### PR TITLE
Encapsulate check arguments in context object

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Edit.Checks;
@@ -224,12 +225,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOk(IBeatmap beatmap)
         {
-            Assert.That(check.Run(beatmap, new TestWorkingBeatmap(beatmap)), Is.Empty);
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         private void assertOffscreenCircle(IBeatmap beatmap)
         {
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckOffscreenObjects.IssueTemplateOffscreenCircle);
@@ -237,7 +240,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOffscreenSlider(IBeatmap beatmap)
         {
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckOffscreenObjects.IssueTemplateOffscreenSlider);

--- a/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
@@ -225,14 +225,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOk(IBeatmap beatmap)
         {
-            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
-            Assert.That(check.Run(beatmap, context), Is.Empty);
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+            Assert.That(check.Run(context), Is.Empty);
         }
 
         private void assertOffscreenCircle(IBeatmap beatmap)
         {
-            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
-            var issues = check.Run(beatmap, context).ToList();
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckOffscreenObjects.IssueTemplateOffscreenCircle);
@@ -240,8 +240,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOffscreenSlider(IBeatmap beatmap)
         {
-            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
-            var issues = check.Run(beatmap, context).ToList();
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckOffscreenObjects.IssueTemplateOffscreenSlider);

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Checks
             new IssueTemplateOffscreenSlider(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            foreach (var hitobject in playableBeatmap.HitObjects)
+            foreach (var hitobject in beatmap.HitObjects)
             {
                 switch (hitobject)
                 {

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Osu.Objects;
@@ -32,9 +31,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Checks
             new IssueTemplateOffscreenSlider(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            foreach (var hitobject in beatmap.HitObjects)
+            foreach (var hitobject in context.Beatmap.HitObjects)
             {
                 switch (hitobject)
                 {

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
@@ -31,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Checks
             new IssueTemplateOffscreenSlider(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             foreach (var hitobject in playableBeatmap.HitObjects)
             {

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -17,9 +17,9 @@ namespace osu.Game.Rulesets.Osu.Edit
             new CheckOffscreenObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            return checks.SelectMany(check => check.Run(playableBeatmap, context));
+            return checks.SelectMany(check => check.Run(beatmap, context));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Osu.Edit.Checks;
@@ -17,9 +16,9 @@ namespace osu.Game.Rulesets.Osu.Edit
             new CheckOffscreenObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            return checks.SelectMany(check => check.Run(beatmap, context));
+            return checks.SelectMany(check => check.Run(context));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -17,9 +17,9 @@ namespace osu.Game.Rulesets.Osu.Edit
             new CheckOffscreenObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
-            return checks.SelectMany(check => check.Run(playableBeatmap, workingBeatmap));
+            return checks.SelectMany(check => check.Run(playableBeatmap, context));
         }
     }
 }

--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Tests.Editing.Checks
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);
             mock.SetupGet(w => w.Track).Returns((Track)null);
 
-            Assert.That(check.Run(beatmap, new BeatmapVerifierContext(mock.Object)), Is.Empty);
+            Assert.That(check.Run(new BeatmapVerifierContext(beatmap, mock.Object)), Is.Empty);
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(192);
 
-            Assert.That(check.Run(beatmap, context), Is.Empty);
+            Assert.That(check.Run(context), Is.Empty);
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(null);
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateNoBitrate);
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(0);
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateNoBitrate);
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(320);
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooHighBitrate);
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(64);
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run( context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooLowBitrate);
@@ -98,7 +98,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(int? audioBitrate)
         {
-            return new BeatmapVerifierContext(getMockWorkingBeatmap(audioBitrate).Object);
+            return new BeatmapVerifierContext(beatmap, getMockWorkingBeatmap(audioBitrate).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(64);
 
-            var issues = check.Run( context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooLowBitrate);

--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 
@@ -40,23 +41,23 @@ namespace osu.Game.Tests.Editing.Checks
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);
             mock.SetupGet(w => w.Track).Returns((Track)null);
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, new BeatmapVerifierContext(mock.Object)), Is.Empty);
         }
 
         [Test]
         public void TestAcceptable()
         {
-            var mock = getMockWorkingBeatmap(192);
+            var context = getContext(192);
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
         public void TestNullBitrate()
         {
-            var mock = getMockWorkingBeatmap(null);
+            var context = getContext(null);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateNoBitrate);
@@ -65,9 +66,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestZeroBitrate()
         {
-            var mock = getMockWorkingBeatmap(0);
+            var context = getContext(0);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateNoBitrate);
@@ -76,9 +77,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooHighBitrate()
         {
-            var mock = getMockWorkingBeatmap(320);
+            var context = getContext(320);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooHighBitrate);
@@ -87,12 +88,17 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooLowBitrate()
         {
-            var mock = getMockWorkingBeatmap(64);
+            var context = getContext(64);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooLowBitrate);
+        }
+
+        private BeatmapVerifierContext getContext(int? audioBitrate)
+        {
+            return new BeatmapVerifierContext(getMockWorkingBeatmap(audioBitrate).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -9,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 using FileInfo = osu.Game.IO.FileInfo;
@@ -53,25 +54,25 @@ namespace osu.Game.Tests.Editing.Checks
         {
             // While this is a problem, it is out of scope for this check and is caught by a different one.
             beatmap.Metadata.BackgroundFile = null;
-            var mock = getMockWorkingBeatmap(null, System.Array.Empty<byte>());
+            var context = getContext(null, System.Array.Empty<byte>());
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
         public void TestAcceptable()
         {
-            var mock = getMockWorkingBeatmap(new Texture(1920, 1080));
+            var context = getContext(new Texture(1920, 1080));
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
         public void TestTooHighResolution()
         {
-            var mock = getMockWorkingBeatmap(new Texture(3840, 2160));
+            var context = getContext(new Texture(3840, 2160));
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooHighResolution);
@@ -80,9 +81,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestLowResolution()
         {
-            var mock = getMockWorkingBeatmap(new Texture(640, 480));
+            var context = getContext(new Texture(640, 480));
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateLowResolution);
@@ -91,9 +92,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooLowResolution()
         {
-            var mock = getMockWorkingBeatmap(new Texture(100, 100));
+            var context = getContext(new Texture(100, 100));
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooLowResolution);
@@ -102,12 +103,17 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooUncompressed()
         {
-            var mock = getMockWorkingBeatmap(new Texture(1920, 1080), new byte[1024 * 1024 * 3]);
+            var context = getContext(new Texture(1920, 1080), new byte[1024 * 1024 * 3]);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooUncompressed);
+        }
+
+        private BeatmapVerifierContext getContext(Texture background, [CanBeNull] byte[] fileBytes = null)
+        {
+            return new BeatmapVerifierContext(getMockWorkingBeatmap(background, fileBytes).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Tests.Editing.Checks
             beatmap.Metadata.BackgroundFile = null;
             var context = getContext(null, System.Array.Empty<byte>());
 
-            Assert.That(check.Run(beatmap, context), Is.Empty);
+            Assert.That(check.Run(context), Is.Empty);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(new Texture(1920, 1080));
 
-            Assert.That(check.Run(beatmap, context), Is.Empty);
+            Assert.That(check.Run(context), Is.Empty);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(new Texture(3840, 2160));
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooHighResolution);
@@ -83,7 +83,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(new Texture(640, 480));
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateLowResolution);
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(new Texture(100, 100));
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooLowResolution);
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             var context = getContext(new Texture(1920, 1080), new byte[1024 * 1024 * 3]);
 
-            var issues = check.Run(beatmap, context).ToList();
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooUncompressed);
@@ -113,7 +113,7 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(Texture background, [CanBeNull] byte[] fileBytes = null)
         {
-            return new BeatmapVerifierContext(getMockWorkingBeatmap(background, fileBytes).Object);
+            return new BeatmapVerifierContext(beatmap, getMockWorkingBeatmap(background, fileBytes).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Moq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
@@ -105,7 +106,7 @@ namespace osu.Game.Tests.Editing.Checks
                 new HitCircle { StartTime = 300 }
             };
 
-            var issues = check.Run(getPlayableBeatmap(hitobjects), null).ToList();
+            var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(3));
             Assert.That(issues.Where(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentDifferent).ToList(), Has.Count.EqualTo(2));
@@ -164,12 +165,12 @@ namespace osu.Game.Tests.Editing.Checks
 
         private void assertOk(List<HitObject> hitobjects)
         {
-            Assert.That(check.Run(getPlayableBeatmap(hitobjects), null), Is.Empty);
+            Assert.That(check.Run(getContext(hitobjects)), Is.Empty);
         }
 
         private void assertConcurrentSame(List<HitObject> hitobjects, int count = 1)
         {
-            var issues = check.Run(getPlayableBeatmap(hitobjects), null).ToList();
+            var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentSame));
@@ -177,18 +178,18 @@ namespace osu.Game.Tests.Editing.Checks
 
         private void assertConcurrentDifferent(List<HitObject> hitobjects, int count = 1)
         {
-            var issues = check.Run(getPlayableBeatmap(hitobjects), null).ToList();
+            var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckConcurrentObjects.IssueTemplateConcurrentDifferent));
         }
 
-        private IBeatmap getPlayableBeatmap(List<HitObject> hitobjects)
+        private BeatmapVerifierContext getContext(List<HitObject> hitobjects)
         {
-            return new Beatmap<HitObject>
+            return new BeatmapVerifierContext(new Beatmap<HitObject>
             {
                 HitObjects = hitobjects
-            };
+            }, null);
         }
     }
 }

--- a/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckConcurrentObjectsTest.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Editing.Checks
 {
@@ -186,10 +187,8 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(List<HitObject> hitobjects)
         {
-            return new BeatmapVerifierContext(new Beatmap<HitObject>
-            {
-                HitObjects = hitobjects
-            }, null);
+            var beatmap = new Beatmap<HitObject> { HitObjects = hitobjects };
+            return new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
         }
     }
 }

--- a/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestBackgroundSetAndInFiles()
         {
-            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
-            Assert.That(check.Run(beatmap, context), Is.Empty);
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+            Assert.That(check.Run(context), Is.Empty);
         }
 
         [Test]
@@ -55,8 +55,8 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.BeatmapInfo.BeatmapSet.Files.Clear();
 
-            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
-            var issues = check.Run(beatmap, context).ToList();
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckFilePresence.IssueTemplateDoesNotExist);
@@ -67,8 +67,8 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.Metadata.BackgroundFile = null;
 
-            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
-            var issues = check.Run(beatmap, context).ToList();
+            var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckFilePresence.IssueTemplateNoneSet);

--- a/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.IO;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Tests.Beatmaps;
@@ -45,7 +46,8 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestBackgroundSetAndInFiles()
         {
-            Assert.That(check.Run(beatmap, new TestWorkingBeatmap(beatmap)), Is.Empty);
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
@@ -53,7 +55,8 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.BeatmapInfo.BeatmapSet.Files.Clear();
 
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckFilePresence.IssueTemplateDoesNotExist);
@@ -64,7 +67,8 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.Metadata.BackgroundFile = null;
 
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckFilePresence.IssueTemplateNoneSet);

--- a/osu.Game.Tests/Editing/Checks/CheckUnsnappedObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckUnsnappedObjectsTest.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -105,7 +106,7 @@ namespace osu.Game.Tests.Editing.Checks
                 getSliderMock(startTime: 98, endTime: 398.75d).Object
             };
 
-            var issues = check.Run(getPlayableBeatmap(hitobjects), null).ToList();
+            var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(2));
             Assert.That(issues.Any(issue => issue.Template is CheckUnsnappedObjects.IssueTemplateSmallUnsnap));
@@ -124,12 +125,12 @@ namespace osu.Game.Tests.Editing.Checks
 
         private void assertOk(List<HitObject> hitobjects)
         {
-            Assert.That(check.Run(getPlayableBeatmap(hitobjects), null), Is.Empty);
+            Assert.That(check.Run(getContext(hitobjects)), Is.Empty);
         }
 
         private void assert1Ms(List<HitObject> hitobjects, int count = 1)
         {
-            var issues = check.Run(getPlayableBeatmap(hitobjects), null).ToList();
+            var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckUnsnappedObjects.IssueTemplateSmallUnsnap));
@@ -137,19 +138,19 @@ namespace osu.Game.Tests.Editing.Checks
 
         private void assert2Ms(List<HitObject> hitobjects, int count = 1)
         {
-            var issues = check.Run(getPlayableBeatmap(hitobjects), null).ToList();
+            var issues = check.Run(getContext(hitobjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckUnsnappedObjects.IssueTemplateLargeUnsnap));
         }
 
-        private IBeatmap getPlayableBeatmap(List<HitObject> hitobjects)
+        private BeatmapVerifierContext getContext(List<HitObject> hitobjects)
         {
-            return new Beatmap<HitObject>
+            return new BeatmapVerifierContext(new Beatmap<HitObject>
             {
                 ControlPointInfo = cpi,
                 HitObjects = hitobjects
-            };
+            }, null);
         }
     }
 }

--- a/osu.Game.Tests/Editing/Checks/CheckUnsnappedObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckUnsnappedObjectsTest.cs
@@ -102,12 +102,12 @@ namespace osu.Game.Tests.Editing.Checks
             }, count: 2);
 
             // Start and end are 2 ms and 1.25 ms off respectively, hence two different issues in one object.
-            var hitobjects = new List<HitObject>
+            var hitObjects = new List<HitObject>
             {
                 getSliderMock(startTime: 98, endTime: 398.75d).Object
             };
 
-            var issues = check.Run(getContext(hitobjects)).ToList();
+            var issues = check.Run(getContext(hitObjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(2));
             Assert.That(issues.Any(issue => issue.Template is CheckUnsnappedObjects.IssueTemplateSmallUnsnap));
@@ -124,33 +124,33 @@ namespace osu.Game.Tests.Editing.Checks
             return mockSlider;
         }
 
-        private void assertOk(List<HitObject> hitobjects)
+        private void assertOk(List<HitObject> hitObjects)
         {
-            Assert.That(check.Run(getContext(hitobjects)), Is.Empty);
+            Assert.That(check.Run(getContext(hitObjects)), Is.Empty);
         }
 
-        private void assert1Ms(List<HitObject> hitobjects, int count = 1)
+        private void assert1Ms(List<HitObject> hitObjects, int count = 1)
         {
-            var issues = check.Run(getContext(hitobjects)).ToList();
+            var issues = check.Run(getContext(hitObjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckUnsnappedObjects.IssueTemplateSmallUnsnap));
         }
 
-        private void assert2Ms(List<HitObject> hitobjects, int count = 1)
+        private void assert2Ms(List<HitObject> hitObjects, int count = 1)
         {
-            var issues = check.Run(getContext(hitobjects)).ToList();
+            var issues = check.Run(getContext(hitObjects)).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(count));
             Assert.That(issues.All(issue => issue.Template is CheckUnsnappedObjects.IssueTemplateLargeUnsnap));
         }
 
-        private BeatmapVerifierContext getContext(List<HitObject> hitobjects)
+        private BeatmapVerifierContext getContext(List<HitObject> hitObjects)
         {
             var beatmap = new Beatmap<HitObject>
             {
                 ControlPointInfo = cpi,
-                HitObjects = hitobjects
+                HitObjects = hitObjects
             };
 
             return new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));

--- a/osu.Game.Tests/Editing/Checks/CheckUnsnappedObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckUnsnappedObjectsTest.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Editing.Checks
 {
@@ -146,11 +147,13 @@ namespace osu.Game.Tests.Editing.Checks
 
         private BeatmapVerifierContext getContext(List<HitObject> hitobjects)
         {
-            return new BeatmapVerifierContext(new Beatmap<HitObject>
+            var beatmap = new Beatmap<HitObject>
             {
                 ControlPointInfo = cpi,
                 HitObjects = hitobjects
-            }, null);
+            };
+
+            return new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
@@ -29,9 +28,9 @@ namespace osu.Game.Rulesets.Edit
             new CheckConcurrentObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            return checks.SelectMany(check => check.Run(beatmap, context));
+            return checks.SelectMany(check => check.Run(context));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -29,9 +29,9 @@ namespace osu.Game.Rulesets.Edit
             new CheckConcurrentObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            return checks.SelectMany(check => check.Run(playableBeatmap, context));
+            return checks.SelectMany(check => check.Run(beatmap, context));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -29,9 +29,9 @@ namespace osu.Game.Rulesets.Edit
             new CheckConcurrentObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
-            return checks.SelectMany(check => check.Run(playableBeatmap, workingBeatmap));
+            return checks.SelectMany(check => check.Run(playableBeatmap, context));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -12,6 +12,11 @@ namespace osu.Game.Rulesets.Edit
     public class BeatmapVerifierContext
     {
         /// <summary>
+        /// The playable beatmap instance of the current beatmap.
+        /// </summary>
+        public readonly IBeatmap Beatmap;
+
+        /// <summary>
         /// The working beatmap instance of the current beatmap.
         /// </summary>
         public readonly IWorkingBeatmap WorkingBeatmap;
@@ -21,8 +26,9 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         public DifficultyRating InterpretedDifficulty;
 
-        public BeatmapVerifierContext(IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
+        public BeatmapVerifierContext(IBeatmap beatmap, IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
         {
+            Beatmap = beatmap;
             WorkingBeatmap = workingBeatmap;
             InterpretedDifficulty = difficultyRating;
         }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 
 namespace osu.Game.Rulesets.Edit
@@ -20,12 +19,12 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// The difficulty level which the current beatmap is considered to be.
         /// </summary>
-        public readonly Bindable<DifficultyRating> InterpretedDifficulty;
+        public DifficultyRating InterpretedDifficulty;
 
         public BeatmapVerifierContext(IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
         {
             WorkingBeatmap = workingBeatmap;
-            InterpretedDifficulty = new Bindable<DifficultyRating>(difficultyRating);
+            InterpretedDifficulty = difficultyRating;
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Beatmaps;
- #nullable enable
+
+#nullable enable
+
 namespace osu.Game.Rulesets.Edit
 {
     /// <summary>

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Beatmaps;
-
+ #nullable enable
 namespace osu.Game.Rulesets.Edit
 {
     /// <summary>

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Edit
+{
+    /// <summary>
+    /// Represents the context provided by the beatmap verifier to the checks it runs.
+    /// Contains information about what is being checked and how it should be checked.
+    /// </summary>
+    public class BeatmapVerifierContext
+    {
+        /// <summary>
+        /// The working beatmap instance of the current beatmap.
+        /// </summary>
+        public readonly IWorkingBeatmap WorkingBeatmap;
+
+        public BeatmapVerifierContext(IWorkingBeatmap workingBeatmap)
+        {
+            WorkingBeatmap = workingBeatmap;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -17,9 +17,15 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         public readonly IWorkingBeatmap WorkingBeatmap;
 
-        public BeatmapVerifierContext(IWorkingBeatmap workingBeatmap)
+        /// <summary>
+        /// The difficulty level which the current beatmap is considered to be.
+        /// </summary>
+        public readonly Bindable<DifficultyRating> InterpretedDifficulty;
+
+        public BeatmapVerifierContext(IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
         {
             WorkingBeatmap = workingBeatmap;
+            InterpretedDifficulty = new Bindable<DifficultyRating>(difficultyRating);
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioPresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioPresence.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Edit.Checks
     {
         protected override CheckCategory Category => CheckCategory.Audio;
         protected override string TypeOfFile => "audio";
-        protected override string GetFilename(IBeatmap playableBeatmap) => playableBeatmap.Metadata?.AudioFile;
+        protected override string GetFilename(IBeatmap beatmap) => beatmap.Metadata?.AudioFile;
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
@@ -26,9 +25,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateNoBitrate(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            var audioFile = beatmap.Metadata?.AudioFile;
+            var audioFile = context.Beatmap.Metadata?.AudioFile;
             if (audioFile == null)
                 yield break;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -26,9 +26,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateNoBitrate(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            var audioFile = playableBeatmap.Metadata?.AudioFile;
+            var audioFile = beatmap.Metadata?.AudioFile;
             if (audioFile == null)
                 yield break;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -26,13 +26,13 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateNoBitrate(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             var audioFile = playableBeatmap.Metadata?.AudioFile;
             if (audioFile == null)
                 yield break;
 
-            var track = workingBeatmap.Track;
+            var track = context.WorkingBeatmap.Track;
 
             if (track?.Bitrate == null || track.Bitrate.Value == 0)
                 yield return new IssueTemplateNoBitrate(this).Create();

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundPresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundPresence.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Edit.Checks
     {
         protected override CheckCategory Category => CheckCategory.Resources;
         protected override string TypeOfFile => "background";
-        protected override string GetFilename(IBeatmap playableBeatmap) => playableBeatmap.Metadata?.BackgroundFile;
+        protected override string GetFilename(IBeatmap beatmap) => beatmap.Metadata?.BackgroundFile;
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -30,9 +30,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateTooUncompressed(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            var backgroundFile = playableBeatmap.Metadata?.BackgroundFile;
+            var backgroundFile = beatmap.Metadata?.BackgroundFile;
             if (backgroundFile == null)
                 yield break;
 
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             else if (texture.Width < low_width || texture.Height < low_height)
                 yield return new IssueTemplateLowResolution(this).Create(texture.Width, texture.Height);
 
-            string storagePath = playableBeatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
+            string storagePath = beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
             double filesizeMb = context.WorkingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
 
             if (filesizeMb > max_filesize_mb)

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
@@ -30,9 +29,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateTooUncompressed(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            var backgroundFile = beatmap.Metadata?.BackgroundFile;
+            var backgroundFile = context.Beatmap.Metadata?.BackgroundFile;
             if (backgroundFile == null)
                 yield break;
 
@@ -48,7 +47,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             else if (texture.Width < low_width || texture.Height < low_height)
                 yield return new IssueTemplateLowResolution(this).Create(texture.Width, texture.Height);
 
-            string storagePath = beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
+            string storagePath = context.Beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
             double filesizeMb = context.WorkingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
 
             if (filesizeMb > max_filesize_mb)

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateTooUncompressed(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             var backgroundFile = playableBeatmap.Metadata?.BackgroundFile;
             if (backgroundFile == null)
                 yield break;
 
-            var texture = workingBeatmap.Background;
+            var texture = context.WorkingBeatmap.Background;
             if (texture == null)
                 yield break;
 
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                 yield return new IssueTemplateLowResolution(this).Create(texture.Width, texture.Height);
 
             string storagePath = playableBeatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
-            double filesizeMb = workingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
+            double filesizeMb = context.WorkingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
 
             if (filesizeMb > max_filesize_mb)
                 yield return new IssueTemplateTooUncompressed(this).Create(filesizeMb);

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -22,15 +21,15 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            for (int i = 0; i < beatmap.HitObjects.Count - 1; ++i)
+            for (int i = 0; i < context.Beatmap.HitObjects.Count - 1; ++i)
             {
-                var hitobject = beatmap.HitObjects[i];
+                var hitobject = context.Beatmap.HitObjects[i];
 
-                for (int j = i + 1; j < beatmap.HitObjects.Count; ++j)
+                for (int j = i + 1; j < context.Beatmap.HitObjects.Count; ++j)
                 {
-                    var nextHitobject = beatmap.HitObjects[j];
+                    var nextHitobject = context.Beatmap.HitObjects[j];
 
                     // Accounts for rulesets with hitobjects separated by columns, such as Mania.
                     // In these cases we only care about concurrent objects within the same column.

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -23,13 +23,15 @@ namespace osu.Game.Rulesets.Edit.Checks
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            for (int i = 0; i < context.Beatmap.HitObjects.Count - 1; ++i)
-            {
-                var hitobject = context.Beatmap.HitObjects[i];
+            var hitObjects = context.Beatmap.HitObjects;
 
-                for (int j = i + 1; j < context.Beatmap.HitObjects.Count; ++j)
+            for (int i = 0; i < hitObjects.Count - 1; ++i)
+            {
+                var hitobject = hitObjects[i];
+
+                for (int j = i + 1; j < hitObjects.Count; ++j)
                 {
-                    var nextHitobject = context.Beatmap.HitObjects[j];
+                    var nextHitobject = hitObjects[j];
 
                     // Accounts for rulesets with hitobjects separated by columns, such as Mania.
                     // In these cases we only care about concurrent objects within the same column.

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             for (int i = 0; i < playableBeatmap.HitObjects.Count - 1; ++i)
             {

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -22,15 +22,15 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            for (int i = 0; i < playableBeatmap.HitObjects.Count - 1; ++i)
+            for (int i = 0; i < beatmap.HitObjects.Count - 1; ++i)
             {
-                var hitobject = playableBeatmap.HitObjects[i];
+                var hitobject = beatmap.HitObjects[i];
 
-                for (int j = i + 1; j < playableBeatmap.HitObjects.Count; ++j)
+                for (int j = i + 1; j < beatmap.HitObjects.Count; ++j)
                 {
-                    var nextHitobject = playableBeatmap.HitObjects[j];
+                    var nextHitobject = beatmap.HitObjects[j];
 
                     // Accounts for rulesets with hitobjects separated by columns, such as Mania.
                     // In these cases we only care about concurrent objects within the same column.

--- a/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Edit.Checks
     {
         protected abstract CheckCategory Category { get; }
         protected abstract string TypeOfFile { get; }
-        protected abstract string GetFilename(IBeatmap playableBeatmap);
+        protected abstract string GetFilename(IBeatmap beatmap);
 
         public CheckMetadata Metadata => new CheckMetadata(Category, $"Missing {TypeOfFile}");
 
@@ -21,9 +21,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateDoesNotExist(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            var filename = GetFilename(playableBeatmap);
+            var filename = GetFilename(beatmap);
 
             if (filename == null)
             {
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             }
 
             // If the file is set, also make sure it still exists.
-            var storagePath = playableBeatmap.BeatmapInfo.BeatmapSet.GetPathForFile(filename);
+            var storagePath = beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(filename);
             if (storagePath != null)
                 yield break;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateDoesNotExist(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             var filename = GetFilename(playableBeatmap);
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
@@ -21,9 +21,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateDoesNotExist(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            var filename = GetFilename(beatmap);
+            var filename = GetFilename(context.Beatmap);
 
             if (filename == null)
             {
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             }
 
             // If the file is set, also make sure it still exists.
-            var storagePath = beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(filename);
+            var storagePath = context.Beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(filename);
             if (storagePath != null)
                 yield break;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateSmallUnsnap(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             var controlPointInfo = playableBeatmap.ControlPointInfo;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -22,11 +21,11 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateSmallUnsnap(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            var controlPointInfo = beatmap.ControlPointInfo;
+            var controlPointInfo = context.Beatmap.ControlPointInfo;
 
-            foreach (var hitobject in beatmap.HitObjects)
+            foreach (var hitobject in context.Beatmap.HitObjects)
             {
                 double startUnsnap = hitobject.StartTime - controlPointInfo.GetClosestSnappedTime(hitobject.StartTime);
                 string startPostfix = hitobject is IHasDuration ? "start" : "";

--- a/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
@@ -22,11 +22,11 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateSmallUnsnap(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
-            var controlPointInfo = playableBeatmap.ControlPointInfo;
+            var controlPointInfo = beatmap.ControlPointInfo;
 
-            foreach (var hitobject in playableBeatmap.HitObjects)
+            foreach (var hitobject in beatmap.HitObjects)
             {
                 double startUnsnap = hitobject.StartTime - controlPointInfo.GetClosestSnappedTime(hitobject.StartTime);
                 string startPostfix = hitobject is IHasDuration ? "start" : "";

--- a/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 
 namespace osu.Game.Rulesets.Edit.Checks.Components
 {
@@ -24,8 +23,7 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// <summary>
         /// Runs this check and returns any issues detected for the provided beatmap.
         /// </summary>
-        /// <param name="beatmap">The playable beatmap of the beatmap to run the check on.</param>
         /// <param name="context">The beatmap verifier context associated with the beatmap.</param>
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context);
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
@@ -24,8 +24,8 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// <summary>
         /// Runs this check and returns any issues detected for the provided beatmap.
         /// </summary>
-        /// <param name="playableBeatmap">The playable beatmap of the beatmap to run the check on.</param>
+        /// <param name="beatmap">The playable beatmap of the beatmap to run the check on.</param>
         /// <param name="context">The beatmap verifier context associated with the beatmap.</param>
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context);
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// Runs this check and returns any issues detected for the provided beatmap.
         /// </summary>
         /// <param name="playableBeatmap">The playable beatmap of the beatmap to run the check on.</param>
-        /// <param name="workingBeatmap">The working beatmap of the beatmap to run the check on.</param>
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap);
+        /// <param name="context">The beatmap verifier context associated with the beatmap.</param>
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     public interface IBeatmapVerifier
     {
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap);
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit
@@ -12,6 +11,6 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     public interface IBeatmapVerifier
     {
-        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context);
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     public interface IBeatmapVerifier
     {
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context);
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Screens.Edit.Verify
 
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
+        private BeatmapVerifierContext context;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
@@ -56,6 +57,8 @@ namespace osu.Game.Screens.Edit.Verify
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
             InterpretedDifficulty = new Bindable<DifficultyRating>(beatmap.BeatmapInfo.DifficultyRating);
+
+            context = new BeatmapVerifierContext(workingBeatmap.Value);
 
             RelativeSizeAxes = Axes.Both;
 
@@ -101,10 +104,10 @@ namespace osu.Game.Screens.Edit.Verify
 
         public void Refresh()
         {
-            var issues = generalVerifier.Run(beatmap, workingBeatmap.Value);
+            var issues = generalVerifier.Run(beatmap, context);
 
             if (rulesetVerifier != null)
-                issues = issues.Concat(rulesetVerifier.Run(beatmap, workingBeatmap.Value));
+                issues = issues.Concat(rulesetVerifier.Run(beatmap, context));
 
             issues = filter(issues);
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -35,8 +35,6 @@ namespace osu.Game.Screens.Edit.Verify
         [Resolved]
         private VerifyScreen verify { get; set; }
 
-        private Bindable<DifficultyRating> interpretedDifficulty;
-
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
         private BeatmapVerifierContext context;
@@ -47,10 +45,11 @@ namespace osu.Game.Screens.Edit.Verify
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
-            interpretedDifficulty = verify.InterpretedDifficulty.GetBoundCopy();
-
-            context = new BeatmapVerifierContext(workingBeatmap.Value);
-            context.InterpretedDifficulty.BindTo(interpretedDifficulty);
+            context = new BeatmapVerifierContext(workingBeatmap.Value, verify.InterpretedDifficulty.Value);
+            verify.InterpretedDifficulty.BindValueChanged(change =>
+            {
+                context.InterpretedDifficulty = change.NewValue;
+            });
 
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Edit.Verify
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
-            context = new BeatmapVerifierContext(workingBeatmap.Value, verify.InterpretedDifficulty.Value);
+            context = new BeatmapVerifierContext(beatmap, workingBeatmap.Value, verify.InterpretedDifficulty.Value);
             verify.InterpretedDifficulty.BindValueChanged(change =>
             {
                 context.InterpretedDifficulty = change.NewValue;
@@ -98,10 +98,10 @@ namespace osu.Game.Screens.Edit.Verify
 
         private void refresh()
         {
-            var issues = generalVerifier.Run(beatmap, context);
+            var issues = generalVerifier.Run(context);
 
             if (rulesetVerifier != null)
-                issues = issues.Concat(rulesetVerifier.Run(beatmap, context));
+                issues = issues.Concat(rulesetVerifier.Run(context));
 
             issues = filter(issues);
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Screens.Edit.Verify
             InterpretedDifficulty = new Bindable<DifficultyRating>(beatmap.BeatmapInfo.DifficultyRating);
 
             context = new BeatmapVerifierContext(workingBeatmap.Value);
+            context.InterpretedDifficulty.BindTo(InterpretedDifficulty);
 
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -46,10 +46,7 @@ namespace osu.Game.Screens.Edit.Verify
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
             context = new BeatmapVerifierContext(beatmap, workingBeatmap.Value, verify.InterpretedDifficulty.Value);
-            verify.InterpretedDifficulty.BindValueChanged(change =>
-            {
-                context.InterpretedDifficulty = change.NewValue;
-            });
+            verify.InterpretedDifficulty.BindValueChanged(difficulty => context.InterpretedDifficulty = difficulty.NewValue);
 
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Screens.Edit.Verify
         [Resolved]
         private VerifyScreen verify { get; set; }
 
+        private Bindable<DifficultyRating> interpretedDifficulty;
+
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
         private BeatmapVerifierContext context;
@@ -45,8 +47,10 @@ namespace osu.Game.Screens.Edit.Verify
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
+            interpretedDifficulty = verify.InterpretedDifficulty.GetBoundCopy();
+
             context = new BeatmapVerifierContext(workingBeatmap.Value);
-            context.InterpretedDifficulty.BindTo(verify.InterpretedDifficulty.GetBoundCopy());
+            context.InterpretedDifficulty.BindTo(interpretedDifficulty);
 
             RelativeSizeAxes = Axes.Both;
 


### PR DESCRIPTION
Split off from #12751, related to #12091.

- [x] depends on https://github.com/ppy/osu/pull/12758

Refactors checks such that
- `ICheck.Run` takes a new `BeatmapVerifierContext` instead of its previous arguments
- `BeatmapVerifierContext` contains those previous arguments and more:
    - The `IBeatmap` instance
    - The `IWorkingBeatmap` instance
    - The new `InterpretedDifficulty` setting added by https://github.com/ppy/osu/pull/12758

This makes it easier to add new contextual information for use in checks (such as the new `InterpretedDifficulty` setting), as we can add it to this context instead of as new arguments to every check.

---

The other alternative we considered was DI, but it seemed wrong to make the verifiers and checks visual components, as they should not be dependent on a visual flow existing in my opinion.