### PR TITLE
Fix rotation handle visibility logic not handling two handles hovered at one point

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
@@ -167,5 +167,21 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("move mouse away", () => InputManager.MoveMouseTo(selectionBox, new Vector2(20)));
             AddUntilStep("rotation handle hidden", () => rotationHandle.Alpha == 0);
         }
+
+        /// <summary>
+        /// Tests that hovering over two handles instantaneously from one to another does not crash or cause issues to the visibility state.
+        /// </summary>
+        [Test]
+        public void TestHoverOverTwoHandlesInstantaneously()
+        {
+            AddStep("hover over top-left scale handle", () =>
+                InputManager.MoveMouseTo(this.ChildrenOfType<SelectionBoxScaleHandle>().Single(s => s.Anchor == Anchor.TopLeft)));
+            AddStep("hover over top-right scale handle", () =>
+                InputManager.MoveMouseTo(this.ChildrenOfType<SelectionBoxScaleHandle>().Single(s => s.Anchor == Anchor.TopRight)));
+            AddUntilStep("top-left rotation handle hidden", () =>
+                this.ChildrenOfType<SelectionBoxRotationHandle>().Single(r => r.Anchor == Anchor.TopLeft).Alpha == 0);
+            AddUntilStep("top-right rotation handle shown", () =>
+                this.ChildrenOfType<SelectionBoxRotationHandle>().Single(r => r.Anchor == Anchor.TopRight).Alpha == 1);
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxDragHandleContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxDragHandleContainer.cs
@@ -84,8 +84,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (activeHandle?.IsHeld == true)
                 return;
 
-            activeHandle = rotationHandles.SingleOrDefault(h => h.IsHeld || h.IsHovered);
-            activeHandle ??= allDragHandles.SingleOrDefault(h => h.IsHovered);
+            activeHandle = rotationHandles.FirstOrDefault(h => h.IsHeld || h.IsHovered);
+            activeHandle ??= allDragHandles.FirstOrDefault(h => h.IsHovered);
 
             if (activeHandle != null)
             {


### PR DESCRIPTION
Fixes it by using `FirstOrDefault` instead of `SingleOrDefault` as a temporary workaround, the only case where this could happen is when tapping between each handle via touch or on a tiny selection box where two handles can potentially be hovered at one point (which is possible with skin editor blueprints).

A more proper way to fix this would be to separate each anchor to handle its own drag handles, which can add more flexibility to this (i.e. allow centred anchors to display rotation handles on the closest corners), I have already worked on that and I'll look at PR'ing it in some form later on.