### PR TITLE
Fix online play subscreens not pushing player loaders when starting gameplay

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
@@ -11,11 +11,13 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Playlists;
+using osu.Game.Screens.Play;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Users;
 using osuTK.Input;
@@ -24,8 +26,6 @@ namespace osu.Game.Tests.Visual.Playlists
 {
     public class TestScenePlaylistsRoomSubScreen : RoomTestScene
     {
-        protected override bool UseOnlineAPI => true;
-
         [Cached(typeof(IRoomManager))]
         private readonly TestRoomManager roomManager = new TestRoomManager();
 
@@ -41,6 +41,18 @@ namespace osu.Game.Tests.Visual.Playlists
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, host, Beatmap.Default));
 
             manager.Import(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet).Wait();
+
+            ((DummyAPIAccess)API).HandleRequest = req =>
+            {
+                switch (req)
+                {
+                    case CreateRoomScoreRequest createRoomScoreRequest:
+                        createRoomScoreRequest.TriggerSuccess(new APIScoreToken { ID = 1 });
+                        return true;
+                }
+
+                return false;
+            };
         }
 
         [SetUpSteps]
@@ -59,12 +71,16 @@ namespace osu.Game.Tests.Visual.Playlists
                 Room.Name.Value = "my awesome room";
                 Room.Host.Value = new User { Id = 2, Username = "peppy" };
                 Room.RecentParticipants.Add(Room.Host.Value);
+                Room.EndDate.Value = DateTimeOffset.Now.AddMinutes(5);
                 Room.Playlist.Add(new PlaylistItem
                 {
                     Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                     Ruleset = { Value = new OsuRuleset().RulesetInfo }
                 });
             });
+
+            AddStep("start match", () => match.ChildrenOfType<PlaylistsReadyButton>().First().Click());
+            AddUntilStep("player loader loaded", () => Stack.CurrentScreen is PlayerLoader);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -150,7 +150,11 @@ namespace osu.Game.Screens.OnlinePlay.Match
         protected void StartPlay()
         {
             sampleStart?.Play();
-            ParentScreen?.Push(CreateGameplayScreen());
+
+            // fallback is to allow this class to operate when there is no parent OnlineScreen (testing purposes).
+            var targetScreen = (Screen)ParentScreen ?? this;
+
+            targetScreen?.Push(CreateGameplayScreen());
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             // fallback is to allow this class to operate when there is no parent OnlineScreen (testing purposes).
             var targetScreen = (Screen)ParentScreen ?? this;
 
-            targetScreen?.Push(CreateGameplayScreen());
+            targetScreen.Push(CreateGameplayScreen());
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -27,6 +27,7 @@ using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Participants;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
+using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
 using osuTK;
@@ -452,7 +453,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     return new MultiSpectatorScreen(userIds);
 
                 default:
-                    return new MultiplayerPlayer(SelectedItem.Value, userIds);
+                    return new PlayerLoader(() => new MultiplayerPlayer(SelectedItem.Value, userIds));
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -13,6 +13,7 @@ using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Match;
 using osu.Game.Screens.OnlinePlay.Match.Components;
+using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
 using osuTK;
@@ -271,9 +272,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             }, true);
         }
 
-        protected override Screen CreateGameplayScreen() => new PlaylistsPlayer(SelectedItem.Value)
+        protected override Screen CreateGameplayScreen() => new PlayerLoader(() => new PlaylistsPlayer(SelectedItem.Value)
         {
             Exited = () => leaderboard.RefreshScores()
-        };
+        });
     }
 }


### PR DESCRIPTION
Closes #12797 
Closes https://github.com/ppy/osu/issues/12790.

This simply regressed in #12538 due to the `CreateGameplayScreen()` overrides not creating a player loader, but instead return the player and push it immediately.