### PR TITLE
Fix a potential nullref when starting `Player` with autoplay disabled and beatmap fails to load

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -154,8 +154,7 @@ namespace osu.Game.Screens.Play
         {
             base.LoadComplete();
 
-            // BDL load may have aborted early.
-            if (DrawableRuleset == null)
+            if (!LoadedBeatmapSuccessfully)
                 return;
 
             // replays should never be recorded or played back when autoplay is enabled

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -154,6 +154,10 @@ namespace osu.Game.Screens.Play
         {
             base.LoadComplete();
 
+            // BDL load may have aborted early.
+            if (DrawableRuleset == null)
+                return;
+
             // replays should never be recorded or played back when autoplay is enabled
             if (!Mods.Value.Any(m => m is ModAutoplay))
                 PrepareReplay();


### PR DESCRIPTION
Noticed this while testing test regressions. Failure is on `DrawableRuleset` being `null` when the load process aborts at

https://github.com/ppy/osu/blob/dc576c19b47fa64e74bfb9fd440dfccf345bd195/osu.Game/Screens/Play/Player.cs#L191-L192