### PR TITLE
Add database tracking of beatmap creator `user_id`s

### DIFF
--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -37,12 +37,31 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Helper property to deserialize a username to <see cref="User"/>.
         /// </summary>
+        [JsonProperty(@"user_id")]
+        [Column("AuthorID")]
+        public int AuthorID
+        {
+            get => Author?.Id ?? 1;
+            set
+            {
+                Author ??= new User();
+                Author.Id = value;
+            }
+        }
+
+        /// <summary>
+        /// Helper property to deserialize a username to <see cref="User"/>.
+        /// </summary>
         [JsonProperty(@"creator")]
         [Column("Author")]
         public string AuthorString
         {
             get => Author?.Username;
-            set => Author = new User { Username = value };
+            set
+            {
+                Author ??= new User();
+                Author.Username = value;
+            }
         }
 
         /// <summary>

--- a/osu.Game/Migrations/20210514062639_AddAuthorIdToBeatmapMetadata.Designer.cs
+++ b/osu.Game/Migrations/20210514062639_AddAuthorIdToBeatmapMetadata.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using osu.Game.Database;
 
 namespace osu.Game.Migrations
 {
     [DbContext(typeof(OsuDbContext))]
-    partial class OsuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210514062639_AddAuthorIdToBeatmapMetadata")]
+    partial class AddAuthorIdToBeatmapMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/osu.Game/Migrations/20210514062639_AddAuthorIdToBeatmapMetadata.cs
+++ b/osu.Game/Migrations/20210514062639_AddAuthorIdToBeatmapMetadata.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace osu.Game.Migrations
+{
+    public partial class AddAuthorIdToBeatmapMetadata : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AuthorID",
+                table: "BeatmapMetadata",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AuthorID",
+                table: "BeatmapMetadata");
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12803.

Note that the API response half of this will only work on the dev server (was added as part of https://github.com/ppy/osu-web/pull/7517 which is not yet deployed to production). As per usual, will require a re-import to actually take effect for the time being.