### PR TITLE
Generalize volume dampening and allow dampening while not playing

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -62,7 +62,9 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ShowOnlineExplicitContent, false);
 
             // Audio
-            SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.VolumeDampened, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.VolumeDampenInactive, true);
+            SetDefault(OsuSetting.VolumeDampenNotPlaying, false);
 
             SetDefault(OsuSetting.MenuVoice, true);
             SetDefault(OsuSetting.MenuMusic, true);
@@ -223,7 +225,9 @@ namespace osu.Game.Configuration
         MouseDisableWheel,
         ConfineMouseMode,
         AudioOffset,
-        VolumeInactive,
+        VolumeDampened,
+        VolumeDampenInactive,
+        VolumeDampenNotPlaying,
         MenuMusic,
         MenuVoice,
         CursorRotation,

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -251,7 +251,7 @@ namespace osu.Game
             LocalUserPlaying.BindValueChanged(_ => updateVolumeDampeningState());
 
             configVolumeDampened = LocalConfig.GetBindable<double>(OsuSetting.VolumeDampened);
-            configVolumeDampened.BindValueChanged(volume => this.TransformBindableTo(this.volumeFade, volume.NewValue), true);
+            configVolumeDampened.BindValueChanged(volume => this.TransformBindableTo(volumeFade, volume.NewValue), true);
 
             configVolumeDampenInactive = LocalConfig.GetBindable<bool>(OsuSetting.VolumeDampenInactive);
             configVolumeDampenInactive.BindValueChanged(_ => updateVolumeDampeningState());

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -26,10 +26,20 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 },
                 new SettingsSlider<double>
                 {
-                    LabelText = "Master (window inactive)",
-                    Current = config.GetBindable<double>(OsuSetting.VolumeInactive),
+                    LabelText = "Master dampening",
+                    Current = config.GetBindable<double>(OsuSetting.VolumeDampened),
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
+                },
+                new SettingsCheckbox
+                {
+                    LabelText = "While window is inactive",
+                    Current = config.GetBindable<bool>(OsuSetting.VolumeDampenInactive)
+                },
+                new SettingsCheckbox
+                {
+                    LabelText = "While not playing",
+                    Current = config.GetBindable<bool>(OsuSetting.VolumeDampenNotPlaying)
                 },
                 new SettingsSlider<double>
                 {


### PR DESCRIPTION
I've wanted the feature described in https://github.com/ppy/osu/issues/11298 for a while, so I made an attempt at implementing the proposed changes.

I'm still never sure of the idiomatic way to implement things, so consider this a first draft. Also, of course, feel free to bikeshed the naming of things (including the user-facing text), since I wasn't sure about a lot of it. I changed "dim" to "dampen" as I felt that it was a term better suited for audio, but if this is disagreeable I am more than happy to use the former.

Of potential concern in this implementation are two things:
(1) a slight lack of DRYness, though the "duplication" didn't seem too unreasonable to me
(2) the way that `volumeFade` is updated when the dampened volume is changed means that it is technically possible for it to conflict with an active transition. If this is an issue, please suggest a preferred way to deal with this, since I am unsure myself.