### PR TITLE
Add support for overlay-coloured links

### DIFF
--- a/osu.Game/Online/Chat/DrawableLinkCompiler.cs
+++ b/osu.Game/Online/Chat/DrawableLinkCompiler.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Online.Chat
@@ -20,7 +21,10 @@ namespace osu.Game.Online.Chat
         /// <summary>
         /// Each word part of a chat link (split for word-wrap support).
         /// </summary>
-        public List<Drawable> Parts;
+        public readonly List<Drawable> Parts;
+
+        [Resolved(CanBeNull = true)]
+        private OverlayColourProvider overlayColourProvider { get; set; }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parts.Any(d => d.ReceivePositionalInputAt(screenSpacePos));
 
@@ -34,7 +38,7 @@ namespace osu.Game.Online.Chat
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            IdleColour = colours.Blue;
+            IdleColour = overlayColourProvider?.Light2 ?? colours.Blue;
         }
 
         protected override IEnumerable<Drawable> EffectTargets => Parts;


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/7822
Alternative to / closes https://github.com/ppy/osu/pull/8042

I've kept the yellow hover colour because that looks better for the time being - web has underlines to identify hovered links but the link colour only changes lightness by 5% when hovered which is almost indistinguishable by itself.

| old | new |
| --- | --- |
| ![changelog-old](https://user-images.githubusercontent.com/1329837/118452599-47c05680-b731-11eb-99c7-e393cca1da30.png) ![comments-old](https://user-images.githubusercontent.com/1329837/118452618-4d1da100-b731-11eb-97ce-0878a8368d7b.png) ![profile-old](https://user-images.githubusercontent.com/1329837/118452630-50189180-b731-11eb-9087-bdb4a1dfbf05.png) ![rankings-old](https://user-images.githubusercontent.com/1329837/118452672-5a3a9000-b731-11eb-9fcb-73e0c457cf3c.png) | ![changelog-new](https://user-images.githubusercontent.com/1329837/118452737-67f01580-b731-11eb-8f45-1eeff2e4a3fd.png) ![comments-new](https://user-images.githubusercontent.com/1329837/118452748-6a526f80-b731-11eb-993b-b885b7932102.png) ![profile-new](https://user-images.githubusercontent.com/1329837/118452760-6d4d6000-b731-11eb-914e-3038d4598e56.png) ![rankings-new](https://user-images.githubusercontent.com/1329837/118452770-6fafba00-b731-11eb-8737-755dfc8c7743.png) |