### PR TITLE
Fix accuracy heatmap points changing colour

### DIFF
--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Osu.Statistics
 
                     var point = new HitPoint(pointType, this)
                     {
-                        Colour = pointType == HitPointType.Hit ? new Color4(102, 255, 204, 255) : new Color4(255, 102, 102, 255)
+                        BaseColour = pointType == HitPointType.Hit ? new Color4(102, 255, 204, 255) : new Color4(255, 102, 102, 255)
                     };
 
                     points[r][c] = point;
@@ -234,6 +234,11 @@ namespace osu.Game.Rulesets.Osu.Statistics
 
         private class HitPoint : Circle
         {
+            /// <summary>
+            /// The base colour which will be lightened/darkened depending on the value of this <see cref="HitPoint"/>.
+            /// </summary>
+            public Color4 BaseColour;
+
             private readonly HitPointType pointType;
             private readonly AccuracyHeatmap heatmap;
 
@@ -284,7 +289,7 @@ namespace osu.Game.Rulesets.Osu.Statistics
 
                 Alpha = Math.Min(amount / lighten_cutoff, 1);
                 if (pointType == HitPointType.Hit)
-                    Colour = ((Color4)Colour).Lighten(Math.Max(0, amount - lighten_cutoff));
+                    Colour = BaseColour.Lighten(Math.Max(0, amount - lighten_cutoff));
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12807

This was hidden since the framebuffer is cached, but hitpoints would continuously re-brighten their own colour.

Admittedly, this shouldn't be adjusting its own alpha/colour, but it's an internal component so...
