### PR TITLE
Exclude interfaces from skinnable types

### DIFF
--- a/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
+++ b/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
@@ -57,7 +57,10 @@ namespace osu.Game.Skinning.Editor
                 Spacing = new Vector2(20)
             };
 
-            var skinnableTypes = typeof(OsuGame).Assembly.GetTypes().Where(t => typeof(ISkinnableDrawable).IsAssignableFrom(t)).ToArray();
+            var skinnableTypes = typeof(OsuGame).Assembly.GetTypes()
+                                                .Where(t => !t.IsInterface)
+                                                .Where(t => typeof(ISkinnableDrawable).IsAssignableFrom(t))
+                                                .ToArray();
 
             foreach (var type in skinnableTypes)
             {


### PR DESCRIPTION
Would cause the following exception only with debugger attached:
```
System.MissingMethodException: Cannot create an instance of an interface.
   at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean wrapExceptions, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor, Boolean& hasNoDefaultCtor)
   at System.RuntimeType.CreateInstanceDefaultCtorSlow(Boolean publicOnly, Boolean wrapExceptions, Boolean fillCache)
   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, Boolean wrapExceptions)
   at osu.Game.Skinning.Editor.SkinComponentToolbox.attemptAddComponent(Type type) in /home/smgi/Repos/osu/osu.Game/Skinning/Editor/SkinComponentToolbox.cs:line 78
```
Obviously, interface types don't have constructors.

Note: This `try catch` should definitely be logging exceptions:
https://github.com/ppy/osu/blob/7921930a92af4385986f383b8a49e3dec23dc32e/osu.Game/Skinning/Editor/SkinComponentToolbox.cs#L74-L91