### PR TITLE
Fix `LegacySkinPlayerTestScene` overriden by default beatmap skin

### DIFF
--- a/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
@@ -1,11 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Tests.Visual
 {
@@ -16,11 +22,22 @@ namespace osu.Game.Tests.Visual
 
         protected override TestPlayer CreatePlayer(Ruleset ruleset) => new SkinProvidingPlayer(legacySkinSource);
 
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+            => new LegacySkinWorkingBeatmap(beatmap, storyboard, Clock, Audio);
+
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game, SkinManager skins)
         {
             var legacySkin = new DefaultLegacySkin(new NamespacedResourceStore<byte[]>(game.Resources, "Skins/Legacy"), skins);
             legacySkinSource = new SkinProvidingContainer(legacySkin);
+        }
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            // check presence of a random legacy HUD component to ensure this is using legacy skin.
+            AddAssert("using legacy skin", () => this.ChildrenOfType<LegacyScoreCounter>().Any());
         }
 
         public class SkinProvidingPlayer : TestPlayer
@@ -32,6 +49,16 @@ namespace osu.Game.Tests.Visual
             {
                 this.skinSource = skinSource;
             }
+        }
+
+        private class LegacySkinWorkingBeatmap : ClockBackedTestWorkingBeatmap
+        {
+            public LegacySkinWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard, IFrameBasedClock frameBasedClock, AudioManager audio)
+                : base(beatmap, storyboard, frameBasedClock, audio)
+            {
+            }
+
+            protected override ISkin GetSkin() => new LegacyBeatmapSkin(BeatmapInfo, null, null);
         }
     }
 }


### PR DESCRIPTION
With the new changes in `DefaultSkin`, any test scene that cache a legacy skin on top of a player which uses a `WorkingBeatmap` with a [default skin](https://github.com/ppy/osu/blob/77e422409cdc9e6b216724f778c2b32617878ebf/osu.Game/Beatmaps/WorkingBeatmap.cs#L327) will result in the HUD components being overridden by that beatmap default skin.

The above behaviour sounds like it's in the correct direction, as beatmap skins should override the parent skins, so if starting `Player` with a `WorkingBeatmap` that has a modern lazer skin, it should override a currently selected legacy skin on `SkinManager` if beatmap skins are enabled.

Therefore all test scenes that cache a legacy skin should also use a working beatmap that has a `LegacyBeatmapSkin` instead, could also make that working beatmap internal to all tests as a `LegacySkinWorkingBeatmap` or `LegacyWorkingBeatmap` in general, or put it in `TestWorkingBeatmap`. (alternative way would be to disable beatmap skins in here, but that sounded nastier than just creating the correct legacy beatmap skin instead)