### PR TITLE
Add more correct flip support to skin editor

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -350,5 +350,55 @@ namespace osu.Game.Screens.Edit.Compose.Components
             => Enumerable.Empty<MenuItem>();
 
         #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Given a flip direction, a surrounding quad for all selected objects, and a position,
+        /// will return the flipped position in screen space coordinates.
+        /// </summary>
+        protected static Vector2 GetFlippedPosition(Direction direction, Quad quad, Vector2 position)
+        {
+            var centre = quad.Centre;
+
+            switch (direction)
+            {
+                case Direction.Horizontal:
+                    position.X = centre.X - (position.X - centre.X);
+                    break;
+
+                case Direction.Vertical:
+                    position.Y = centre.Y - (position.Y - centre.Y);
+                    break;
+            }
+
+            return position;
+        }
+
+        /// <summary>
+        /// Returns a quad surrounding the provided points.
+        /// </summary>
+        /// <param name="points">The points to calculate a quad for.</param>
+        protected static Quad GetSurroundingQuad(IEnumerable<Vector2> points)
+        {
+            if (!points.Any())
+                return new Quad();
+
+            Vector2 minPosition = new Vector2(float.MaxValue, float.MaxValue);
+            Vector2 maxPosition = new Vector2(float.MinValue, float.MinValue);
+
+            // Go through all hitobjects to make sure they would remain in the bounds of the editor after movement, before any movement is attempted
+            foreach (var p in points)
+            {
+                minPosition = Vector2.ComponentMin(minPosition, p);
+                maxPosition = Vector2.ComponentMax(maxPosition, p);
+            }
+
+            Vector2 size = maxPosition - minPosition;
+
+            return new Quad(minPosition.X, minPosition.Y, size.X, size.Y);
+        }
+
+        #endregion
     }
 }

--- a/osu.Game/Skinning/Editor/SkinBlueprint.cs
+++ b/osu.Game/Skinning/Editor/SkinBlueprint.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Skinning.Editor
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => drawable.ReceivePositionalInputAt(screenSpacePos);
 
-        public override Vector2 ScreenSpaceSelectionPoint => drawable.ScreenSpaceDrawQuad.Centre;
+        public override Vector2 ScreenSpaceSelectionPoint => drawable.ToScreenSpace(drawable.OriginPosition);
 
         public override Quad SelectionQuad => drawable.ScreenSpaceDrawQuad;
     }

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -43,10 +43,16 @@ namespace osu.Game.Skinning.Editor
 
         public override bool HandleFlip(Direction direction)
         {
-            // TODO: this is temporary as well.
-            foreach (var c in SelectedBlueprints)
+            var selectionQuad = GetSurroundingQuad(SelectedBlueprints.Select(b => b.ScreenSpaceSelectionPoint));
+
+            foreach (var b in SelectedBlueprints)
             {
-                ((Drawable)c.Item).Scale *= new Vector2(
+                var drawableItem = (Drawable)b.Item;
+
+                drawableItem.Position =
+                    drawableItem.Parent.ToLocalSpace(GetFlippedPosition(direction, selectionQuad, b.ScreenSpaceSelectionPoint)) - drawableItem.AnchorPosition;
+
+                drawableItem.Scale *= new Vector2(
                     direction == Direction.Horizontal ? -1 : 1,
                     direction == Direction.Vertical ? -1 : 1
                 );


### PR DESCRIPTION
This is the first of many PRs which will bring the skin editor's selection handling up to par with osu! editor's. I chose to start with flip because it is one of the "easier" operations (although the coordinate management turned out to be a bit complicated).

Before:

![20210518 183726 (dotnet)](https://user-images.githubusercontent.com/191335/118629007-21b9b580-b808-11eb-998e-61dc04659978.gif)

After:

![20210518 183635 (dotnet)](https://user-images.githubusercontent.com/191335/118628915-077fd780-b808-11eb-9a75-ad0900560cc0.gif)
