### PR TITLE
Only ignore online score id for database import

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -929,11 +929,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         /// <param name="score">The <see cref="Score"/> to import.</param>
         /// <returns>The imported score.</returns>
-        protected virtual Task ImportScore(Score score)
+        protected virtual async Task ImportScore(Score score)
         {
             // Replays are already populated and present in the game's database, so should not be re-imported.
             if (DrawableRuleset.ReplayScore != null)
-                return Task.CompletedTask;
+                return;
 
             LegacyByteArrayReader replayReader;
 
@@ -943,7 +943,18 @@ namespace osu.Game.Screens.Play
                 replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
             }
 
-            return scoreManager.Import(score.ScoreInfo, replayReader);
+            // For the time being, online ID responses are not really useful for anything.
+            // In addition, the IDs provided via new (lazer) endpoints are based on a different autoincrement from legacy (stable) scores.
+            //
+            // Until we better define the server-side logic behind this, let's not store the online ID to avoid potential unique constraint
+            // conflicts across various systems (ie. solo and multiplayer).
+            long? onlineScoreId = score.ScoreInfo.OnlineScoreID;
+            score.ScoreInfo.OnlineScoreID = null;
+
+            await scoreManager.Import(score.ScoreInfo, replayReader).ConfigureAwait(false);
+
+            // ... And restore the online ID for other processes to handle correctly (e.g. de-duplication for the results screen).
+            score.ScoreInfo.OnlineScoreID = onlineScoreId;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -116,12 +116,7 @@ namespace osu.Game.Screens.Play
 
             request.Success += s =>
             {
-                // For the time being, online ID responses are not really useful for anything.
-                // In addition, the IDs provided via new (lazer) endpoints are based on a different autoincrement from legacy (stable) scores.
-                //
-                // Until we better define the server-side logic behind this, let's not store the online ID to avoid potential unique constraint
-                // conflicts across various systems (ie. solo and multiplayer).
-                // score.ScoreInfo.OnlineScoreID = s.ID;
+                score.ScoreInfo.OnlineScoreID = s.ID;
                 tcs.SetResult(true);
             };
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12798

`OnlineScoreId` is used for de-duplication, and is the only thing that can be used for such a thing.