### PR TITLE
Make freemod selection overlay taller in multiplayer room

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -96,7 +96,8 @@ namespace osu.Game.Overlays.Mods
             Waves.ThirdWaveColour = Color4Extensions.FromHex(@"005774");
             Waves.FourthWaveColour = Color4Extensions.FromHex(@"003a4e");
 
-            RelativeSizeAxes = Axes.Both;
+            RelativeSizeAxes = Axes.X;
+            Height = HEIGHT;
 
             Padding = new MarginPadding { Horizontal = -OsuScreen.HORIZONTAL_OVERFLOW_PADDING };
 

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
                     Origin = Anchor.BottomLeft,
                     Depth = float.MinValue,
                     RelativeSizeAxes = Axes.Both,
-                    Height = 0.5f,
+                    Height = 1.0f,
                     Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING },
                     Child = userModsSelectOverlay = new UserModSelectOverlay
                     {

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -72,8 +72,8 @@ namespace osu.Game.Screens.OnlinePlay.Match
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     Depth = float.MinValue,
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 0.7f,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING },
                     Child = userModsSelectOverlay = new UserModSelectOverlay
                     {

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
                     Origin = Anchor.BottomLeft,
                     Depth = float.MinValue,
                     RelativeSizeAxes = Axes.Both,
-                    Height = 1.0f,
+                    Height = 0.7f,
                     Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING },
                     Child = userModsSelectOverlay = new UserModSelectOverlay
                     {


### PR DESCRIPTION
This is something that's really been annoying me and probably others too, there was only space for one row of mods and tiny space for customization. This change makes the mod selection full screen.

P.S. This is my first ever pull request so I hope I did everything correctly.