### PR TITLE
Add proper scaling support to skin editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -225,26 +225,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         private void scaleHitObjects(OsuHitObject[] hitObjects, Anchor reference, Vector2 scale)
         {
             scale = getClampedScale(hitObjects, reference, scale);
-
-            // move the selection before scaling if dragging from top or left anchors.
-            float xOffset = ((reference & Anchor.x0) > 0) ? -scale.X : 0;
-            float yOffset = ((reference & Anchor.y0) > 0) ? -scale.Y : 0;
-
             Quad selectionQuad = getSurroundingQuad(hitObjects);
 
             foreach (var h in hitObjects)
-            {
-                var newPosition = h.Position;
-
-                // guard against no-ops and NaN.
-                if (scale.X != 0 && selectionQuad.Width > 0)
-                    newPosition.X = selectionQuad.TopLeft.X + xOffset + (h.X - selectionQuad.TopLeft.X) / selectionQuad.Width * (selectionQuad.Width + scale.X);
-
-                if (scale.Y != 0 && selectionQuad.Height > 0)
-                    newPosition.Y = selectionQuad.TopLeft.Y + yOffset + (h.Y - selectionQuad.TopLeft.Y) / selectionQuad.Height * (selectionQuad.Height + scale.Y);
-
-                h.Position = newPosition;
-            }
+                h.Position = GetScaledPosition(reference, scale, selectionQuad, h.Position);
         }
 
         private (bool X, bool Y) isQuadInBounds(Quad quad)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -376,6 +376,26 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         /// <summary>
+        /// Given a scale vector, a surrounding quad for all selected objects, and a position,
+        /// will return the scaled position in screen space coordinates.
+        /// </summary>
+        protected static Vector2 GetScaledPosition(Anchor reference, Vector2 scale, Quad selectionQuad, Vector2 position)
+        {
+            // adjust the direction of scale depending on which side the user is dragging.
+            float xOffset = ((reference & Anchor.x0) > 0) ? -scale.X : 0;
+            float yOffset = ((reference & Anchor.y0) > 0) ? -scale.Y : 0;
+
+            // guard against no-ops and NaN.
+            if (scale.X != 0 && selectionQuad.Width > 0)
+                position.X = selectionQuad.TopLeft.X + xOffset + (position.X - selectionQuad.TopLeft.X) / selectionQuad.Width * (selectionQuad.Width + scale.X);
+
+            if (scale.Y != 0 && selectionQuad.Height > 0)
+                position.Y = selectionQuad.TopLeft.Y + yOffset + (position.Y - selectionQuad.TopLeft.Y) / selectionQuad.Height * (selectionQuad.Height + scale.Y);
+
+            return position;
+        }
+
+        /// <summary>
         /// Returns a quad surrounding the provided points.
         /// </summary>
         /// <param name="points">The points to calculate a quad for.</param>

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Skinning.Editor
                 (!anchor.HasFlagFast(Anchor.x1) && !anchor.HasFlagFast(Anchor.y1))
                 // ..or if any of the selection have been rotated.
                 // this is to avoid requiring skew logic (which would likely not be the user's expected transform anyway).
-                || SelectedBlueprints.Any(b => !Precision.AlmostEquals(((Drawable)b.Item).Rotation % 90, 0));
+                || SelectedBlueprints.Any(b => !Precision.AlmostEquals(((Drawable)b.Item).Rotation, 0));
 
             if (shouldAspectLock)
             {

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Skinning.Editor
 
         public override bool HandleScale(Vector2 scale, Anchor anchor)
         {
+            // convert scale to screen space
+            scale = ToScreenSpace(scale) - ToScreenSpace(Vector2.Zero);
+
             adjustScaleFromAnchor(ref scale, anchor);
 
             var selectionQuad = GetSurroundingQuad(SelectedBlueprints.SelectMany(b =>
@@ -66,8 +69,8 @@ namespace osu.Game.Skinning.Editor
 
             // scale adjust should match that of the quad itself.
             var scaledDelta = new Vector2(
-                adjustedRect.Width / selectionQuad.Width - 1,
-                adjustedRect.Height / selectionQuad.Height - 1
+                adjustedRect.Width / selectionQuad.Width,
+                adjustedRect.Height / selectionQuad.Height
             );
 
             foreach (var b in SelectedBlueprints)
@@ -89,7 +92,7 @@ namespace osu.Game.Skinning.Editor
                 );
 
                 drawableItem.Position = drawableItem.Parent.ToLocalSpace(newPositionInAdjusted) - drawableItem.AnchorPosition;
-                drawableItem.Scale += scaledDelta;
+                drawableItem.Scale *= scaledDelta;
             }
 
             return true;

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -34,9 +34,94 @@ namespace osu.Game.Skinning.Editor
         {
             adjustScaleFromAnchor(ref scale, anchor);
 
-            foreach (var c in SelectedBlueprints)
-                // TODO: this is temporary and will be fixed with a separate refactor of selection transform logic.
-                ((Drawable)c.Item).Scale += scale * 0.02f;
+            if (SelectedBlueprints.Count > 1)
+            {
+                var selectionQuad = GetSurroundingQuad(SelectedBlueprints.SelectMany(b =>
+                    b.Item.ScreenSpaceDrawQuad.GetVertices().ToArray()));
+
+                // the selection quad is always upright, so use a rect to make mutating the values easier.
+                var adjustedRect = selectionQuad.AABBFloat;
+
+                // for now aspect lock scale adjustments that occur at corners.
+                if (!anchor.HasFlagFast(Anchor.x1) && !anchor.HasFlagFast(Anchor.y1))
+                    scale.Y = scale.X / selectionQuad.Width * selectionQuad.Height;
+
+                if (anchor.HasFlagFast(Anchor.x0))
+                {
+                    adjustedRect.X -= scale.X;
+                    adjustedRect.Width += scale.X;
+                }
+                else if (anchor.HasFlagFast(Anchor.x2))
+                {
+                    adjustedRect.Width += scale.X;
+                }
+
+                if (anchor.HasFlagFast(Anchor.y0))
+                {
+                    adjustedRect.Y -= scale.Y;
+                    adjustedRect.Height += scale.Y;
+                }
+                else if (anchor.HasFlagFast(Anchor.y2))
+                {
+                    adjustedRect.Height += scale.Y;
+                }
+
+                // scale adjust should match that of the quad itself.
+                var scaledDelta = new Vector2(
+                    adjustedRect.Width / selectionQuad.Width - 1,
+                    adjustedRect.Height / selectionQuad.Height - 1
+                );
+
+                foreach (var b in SelectedBlueprints)
+                {
+                    var drawableItem = (Drawable)b.Item;
+
+                    if (SelectedBlueprints.Count > 1)
+                    {
+                        // each drawable's relative position should be maintained in the scaled quad.
+                        var screenPosition = b.ScreenSpaceSelectionPoint;
+
+                        var relativePositionInOriginal =
+                            new Vector2(
+                                (screenPosition.X - selectionQuad.TopLeft.X) / selectionQuad.Width,
+                                (screenPosition.Y - selectionQuad.TopLeft.Y) / selectionQuad.Height
+                            );
+
+                        var newPositionInAdjusted = new Vector2(
+                            adjustedRect.TopLeft.X + adjustedRect.Width * relativePositionInOriginal.X,
+                            adjustedRect.TopLeft.Y + adjustedRect.Height * relativePositionInOriginal.Y
+                        );
+
+                        drawableItem.Position = drawableItem.Parent.ToLocalSpace(newPositionInAdjusted) - drawableItem.AnchorPosition;
+                        drawableItem.Scale += scaledDelta;
+                    }
+                }
+            }
+            else
+            {
+                var blueprint = SelectedBlueprints.First();
+                var drawableItem = (Drawable)blueprint.Item;
+
+                // the number of local "pixels" the drag operation resulted in.
+                // our goal is to increase the drawable's draw size by this amount.
+                var scaledDelta = drawableItem.ScreenSpaceDeltaToParentSpace(scale);
+
+                scaledDelta = new Vector2(
+                    scaledDelta.X / drawableItem.DrawWidth,
+                    scaledDelta.Y / drawableItem.DrawHeight
+                );
+
+                // handle the case where scaling with a centre origin needs double the adjustments to match
+                // user cursor movement.
+                if (drawableItem.Origin.HasFlagFast(Anchor.x1)) scaledDelta.X *= 2;
+                if (drawableItem.Origin.HasFlagFast(Anchor.y1)) scaledDelta.Y *= 2;
+
+                // for now aspect lock scale adjustments that occur at corners.
+                if (!anchor.HasFlagFast(Anchor.x1) && !anchor.HasFlagFast(Anchor.y1))
+                    scaledDelta.Y = scaledDelta.X;
+
+                drawableItem.Scale += scaledDelta;
+            }
 
             return true;
         }
@@ -158,13 +243,6 @@ namespace osu.Game.Skinning.Editor
             // reverse the scale direction if dragging from top or left.
             if ((reference & Anchor.x0) > 0) scale.X = -scale.X;
             if ((reference & Anchor.y0) > 0) scale.Y = -scale.Y;
-
-            // for now aspect lock scale adjustments that occur at corners.
-            if (!reference.HasFlagFast(Anchor.x1) && !reference.HasFlagFast(Anchor.y1))
-            {
-                // TODO: temporary implementation - only dragging the corner handles across the X axis changes size.
-                scale.Y = scale.X;
-            }
         }
 
         public class AnchorMenuItem : TernaryStateMenuItem


### PR DESCRIPTION
Handles selections roughly as expected, adjusting each item relative to the bounding box of all items. Code can probably be further optimised but I'm keeping it quite verbose for readability for the time being.


https://user-images.githubusercontent.com/191335/118852210-8874c700-b90d-11eb-9ab1-feba6fc54cbc.mp4

