### PR TITLE
Create base implementations of the two most common `TernaryStateMenuItem`s

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -243,7 +243,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             int totalCount = Pieces.Count(p => p.IsSelected.Value);
             int countOfState = Pieces.Where(p => p.IsSelected.Value).Count(p => p.ControlPoint.Type.Value == type);
 
-            var item = new PathTypeMenuItem(type, () =>
+            var item = new TernaryStateRadioMenuItem(type == null ? "Inherit" : type.ToString().Humanize(), MenuItemType.Standard, _ =>
             {
                 foreach (var p in Pieces.Where(p => p.IsSelected.Value))
                     updatePathType(p, type);
@@ -257,16 +257,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 item.State.Value = TernaryState.False;
 
             return item;
-        }
-
-        private class PathTypeMenuItem : TernaryStateMenuItem
-        {
-            public PathTypeMenuItem(PathType? type, Action action)
-                : base(type == null ? "Inherit" : type.ToString().Humanize(), changeState, MenuItemType.Standard, _ => action?.Invoke())
-            {
-            }
-
-            private static TernaryState changeState(TernaryState state) => TernaryState.True;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -76,10 +76,10 @@ namespace osu.Game.Rulesets.Taiko.Edit
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
         {
             if (selection.All(s => s.Item is Hit))
-                yield return new TernaryStateMenuItem("Rim") { State = { BindTarget = selectionRimState } };
+                yield return new TernaryStateToggleMenuItem("Rim") { State = { BindTarget = selectionRimState } };
 
             if (selection.All(s => s.Item is TaikoHitObject))
-                yield return new TernaryStateMenuItem("Strong") { State = { BindTarget = selectionStrongState } };
+                yield return new TernaryStateToggleMenuItem("Strong") { State = { BindTarget = selectionStrongState } };
 
             foreach (var item in base.GetContextMenuItemsForSelection(selection))
                 yield return item;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneStatefulMenuItem.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneStatefulMenuItem.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Visual.UserInterface
     public class TestSceneStatefulMenuItem : OsuManualInputManagerTestScene
     {
         [Test]
-        public void TestTernaryMenuItem()
+        public void TestTernaryRadioMenuItem()
         {
             OsuMenu menu = null;
 
@@ -30,9 +30,57 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Origin = Anchor.Centre,
                     Items = new[]
                     {
-                        new TernaryStateMenuItem("First"),
-                        new TernaryStateMenuItem("Second") { State = { BindTarget = state } },
-                        new TernaryStateMenuItem("Third") { State = { Value = TernaryState.True } },
+                        new TernaryStateRadioMenuItem("First"),
+                        new TernaryStateRadioMenuItem("Second") { State = { BindTarget = state } },
+                        new TernaryStateRadioMenuItem("Third") { State = { Value = TernaryState.True } },
+                    }
+                };
+            });
+
+            checkState(TernaryState.Indeterminate);
+
+            click();
+            checkState(TernaryState.True);
+
+            click();
+            checkState(TernaryState.True);
+
+            click();
+            checkState(TernaryState.True);
+
+            AddStep("change state via bindable", () => state.Value = TernaryState.True);
+
+            void click() =>
+                AddStep("click", () =>
+                {
+                    InputManager.MoveMouseTo(menu.ScreenSpaceDrawQuad.Centre);
+                    InputManager.Click(MouseButton.Left);
+                });
+
+            void checkState(TernaryState expected)
+                => AddAssert($"state is {expected}", () => state.Value == expected);
+        }
+
+        [Test]
+        public void TestTernaryToggleMenuItem()
+        {
+            OsuMenu menu = null;
+
+            Bindable<TernaryState> state = new Bindable<TernaryState>(TernaryState.Indeterminate);
+
+            AddStep("create menu", () =>
+            {
+                state.Value = TernaryState.Indeterminate;
+
+                Child = menu = new OsuMenu(Direction.Vertical, true)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Items = new[]
+                    {
+                        new TernaryStateToggleMenuItem("First"),
+                        new TernaryStateToggleMenuItem("Second") { State = { BindTarget = state } },
+                        new TernaryStateToggleMenuItem("Third") { State = { Value = TernaryState.True } },
                     }
                 };
             });

--- a/osu.Game/Graphics/UserInterface/TernaryStateMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/TernaryStateMenuItem.cs
@@ -9,28 +9,17 @@ namespace osu.Game.Graphics.UserInterface
     /// <summary>
     /// An <see cref="OsuMenuItem"/> with three possible states.
     /// </summary>
-    public class TernaryStateMenuItem : StatefulMenuItem<TernaryState>
+    public abstract class TernaryStateMenuItem : StatefulMenuItem<TernaryState>
     {
         /// <summary>
         /// Creates a new <see cref="TernaryStateMenuItem"/>.
         /// </summary>
         /// <param name="text">The text to display.</param>
+        /// <param name="nextStateFunction">A function to inform what the next state should be when this item is clicked.</param>
         /// <param name="type">The type of action which this <see cref="TernaryStateMenuItem"/> performs.</param>
         /// <param name="action">A delegate to be invoked when this <see cref="TernaryStateMenuItem"/> is pressed.</param>
-        public TernaryStateMenuItem(string text, MenuItemType type = MenuItemType.Standard, Action<TernaryState> action = null)
-            : this(text, getNextState, type, action)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="TernaryStateMenuItem"/>.
-        /// </summary>
-        /// <param name="text">The text to display.</param>
-        /// <param name="changeStateFunc">A function that mutates a state to another state after this <see cref="TernaryStateMenuItem"/> is pressed.</param>
-        /// <param name="type">The type of action which this <see cref="TernaryStateMenuItem"/> performs.</param>
-        /// <param name="action">A delegate to be invoked when this <see cref="TernaryStateMenuItem"/> is pressed.</param>
-        protected TernaryStateMenuItem(string text, Func<TernaryState, TernaryState> changeStateFunc, MenuItemType type, Action<TernaryState> action)
-            : base(text, changeStateFunc, type, action)
+        protected TernaryStateMenuItem(string text, Func<TernaryState, TernaryState> nextStateFunction, MenuItemType type = MenuItemType.Standard, Action<TernaryState> action = null)
+            : base(text, nextStateFunction, type, action)
         {
         }
 
@@ -46,24 +35,6 @@ namespace osu.Game.Graphics.UserInterface
             }
 
             return null;
-        }
-
-        private static TernaryState getNextState(TernaryState state)
-        {
-            switch (state)
-            {
-                case TernaryState.False:
-                    return TernaryState.True;
-
-                case TernaryState.Indeterminate:
-                    return TernaryState.True;
-
-                case TernaryState.True:
-                    return TernaryState.False;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(state), state, null);
-            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/TernaryStateRadioMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/TernaryStateRadioMenuItem.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class TernaryStateRadioMenuItem : TernaryStateMenuItem
+    {
+        /// <summary>
+        /// Creates a new <see cref="TernaryStateMenuItem"/>.
+        /// </summary>
+        /// <param name="text">The text to display.</param>
+        /// <param name="type">The type of action which this <see cref="TernaryStateMenuItem"/> performs.</param>
+        /// <param name="action">A delegate to be invoked when this <see cref="TernaryStateMenuItem"/> is pressed.</param>
+        public TernaryStateRadioMenuItem(string text, MenuItemType type = MenuItemType.Standard, Action<TernaryState> action = null)
+            : base(text, getNextState, type, action)
+        {
+        }
+
+        private static TernaryState getNextState(TernaryState state) => TernaryState.True;
+    }
+}

--- a/osu.Game/Graphics/UserInterface/TernaryStateRadioMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/TernaryStateRadioMenuItem.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace osu.Game.Graphics.UserInterface
 {
+    /// <summary>
+    /// A ternary state menu item which will always set the item to <c>true</c> on click, even if already <c>true</c>.
+    /// </summary>
     public class TernaryStateRadioMenuItem : TernaryStateMenuItem
     {
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/TernaryStateToggleMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/TernaryStateToggleMenuItem.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    /// <summary>
+    /// A ternary state menu item which toggles the state of this item <c>false</c> if clicked when <c>true</c>.
+    /// </summary>
+    public class TernaryStateToggleMenuItem : TernaryStateMenuItem
+    {
+        /// <summary>
+        /// Creates a new <see cref="TernaryStateToggleMenuItem"/>.
+        /// </summary>
+        /// <param name="text">The text to display.</param>
+        /// <param name="type">The type of action which this <see cref="TernaryStateMenuItem"/> performs.</param>
+        /// <param name="action">A delegate to be invoked when this <see cref="TernaryStateMenuItem"/> is pressed.</param>
+        public TernaryStateToggleMenuItem(string text, MenuItemType type = MenuItemType.Standard, Action<TernaryState> action = null)
+            : base(text, getNextState, type, action)
+        {
+        }
+
+        private static TernaryState getNextState(TernaryState state)
+        {
+            switch (state)
+            {
+                case TernaryState.False:
+                    return TernaryState.True;
+
+                case TernaryState.Indeterminate:
+                    return TernaryState.True;
+
+                case TernaryState.True:
+                    return TernaryState.False;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(state), state, null);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -168,13 +168,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             if (SelectedBlueprints.All(b => b.Item is IHasComboInformation))
             {
-                yield return new TernaryStateMenuItem("New combo") { State = { BindTarget = SelectionNewComboState } };
+                yield return new TernaryStateToggleMenuItem("New combo") { State = { BindTarget = SelectionNewComboState } };
             }
 
             yield return new OsuMenuItem("Sound")
             {
                 Items = SelectionSampleStates.Select(kvp =>
-                    new TernaryStateMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
+                    new TernaryStateToggleMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
             };
         }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Screens.Select.Carousel
             else
                 state = TernaryState.False;
 
-            return new TernaryStateMenuItem(collection.Name.Value, MenuItemType.Standard, s =>
+            return new TernaryStateToggleMenuItem(collection.Name.Value, MenuItemType.Standard, s =>
             {
                 foreach (var b in beatmapSet.Beatmaps)
                 {

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Skinning.Editor
             foreach (var item in base.GetContextMenuItemsForSelection(selection))
                 yield return item;
 
-            IEnumerable<AnchorMenuItem> createAnchorItems(Func<Drawable, Anchor> checkFunction, Action<Anchor> applyFunction)
+            IEnumerable<TernaryStateMenuItem> createAnchorItems(Func<Drawable, Anchor> checkFunction, Action<Anchor> applyFunction)
             {
                 var displayableAnchors = new[]
                 {
@@ -117,7 +117,7 @@ namespace osu.Game.Skinning.Editor
 
                 return displayableAnchors.Select(a =>
                 {
-                    return new AnchorMenuItem(a, selection, _ => applyFunction(a))
+                    return new TernaryStateRadioMenuItem(a.ToString(), MenuItemType.Standard, _ => applyFunction(a))
                     {
                         State = { Value = GetStateFromSelection(selection, c => checkFunction((Drawable)c.Item) == a) }
                     };
@@ -165,16 +165,6 @@ namespace osu.Game.Skinning.Editor
                 // TODO: temporary implementation - only dragging the corner handles across the X axis changes size.
                 scale.Y = scale.X;
             }
-        }
-
-        public class AnchorMenuItem : TernaryStateMenuItem
-        {
-            public AnchorMenuItem(Anchor anchor, IEnumerable<SelectionBlueprint<ISkinnableDrawable>> selection, Action<TernaryState> action)
-                : base(anchor.ToString(), getNextState, MenuItemType.Standard, action)
-            {
-            }
-
-            private static TernaryState getNextState(TernaryState state) => TernaryState.True;
         }
     }
 }


### PR DESCRIPTION
This saves creating a derived version each time we are using these as radio control items.