### PR TITLE
Fix skin editor context menus not dismissing when clicking away

### DIFF
--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -19,7 +19,7 @@ using osuTK;
 namespace osu.Game.Skinning.Editor
 {
     [Cached(typeof(SkinEditor))]
-    public class SkinEditor : FocusedOverlayContainer
+    public class SkinEditor : VisibilityContainer
     {
         public const double TRANSITION_DURATION = 500;
 


### PR DESCRIPTION
Context menu containers cannot operate correctly when inside a parent that has focus. This will probably need further investigation in the future (as we may want to use context menus inside actual `FullscreenOverlay`s), but for now this is the easy solution.