### PR TITLE
Add missing accent colour in breadcrumb header item

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbControlHeader.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbControlHeader.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             foreach (var item in items.Reverse().SkipLast(3))
                 AddStep($"Remove {item} item", () => header.RemoveItem(item));
 
-            AddStep("Clear item", () => header.ClearItem());
+            AddStep("Clear items", () => header.ClearItems());
 
             foreach (var item in items)
                 AddStep($"Add {item} item", () => header.AddItem(item));
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Current.Value = TabControl.Items.LastOrDefault();
             }
 
-            public void ClearItem()
+            public void ClearItems()
             {
                 TabControl.Clear();
                 Current.Value = null;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbControlHeader.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbControlHeader.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneBreadcrumbControlHeader : OsuTestScene
+    {
+        private static readonly string[] items = { "first", "second", "third", "fourth", "fifth" };
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Red);
+
+        private TestHeader header;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = header = new TestHeader
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+        });
+
+        [Test]
+        public void TestAddAndRemoveItem()
+        {
+            foreach (var item in items.Skip(1))
+                AddStep($"Add {item} item", () => header.AddItem(item));
+
+            foreach (var item in items.Reverse().SkipLast(3))
+                AddStep($"Remove {item} item", () => header.RemoveItem(item));
+
+            AddStep($"Clear item", () => header.ClearItem());
+
+            foreach (var item in items)
+                AddStep($"Add {item} item", () => header.AddItem(item));
+
+            foreach (var item in items)
+                AddStep($"Remove {item} item", () => header.RemoveItem(item));
+        }
+
+        private class TestHeader : BreadcrumbControlOverlayHeader
+        {
+            public TestHeader()
+            {
+                TabControl.AddItem(items[0]);
+                Current.Value = items[0];
+            }
+
+            public void AddItem(string value)
+            {
+                TabControl.AddItem(value);
+                Current.Value = TabControl.Items.LastOrDefault();
+            }
+
+            public void RemoveItem(string value)
+            {
+                TabControl.RemoveItem(value);
+                Current.Value = TabControl.Items.LastOrDefault();
+            }
+
+            public void ClearItem()
+            {
+                TabControl.Clear();
+                Current.Value = null;
+            }
+
+            protected override OverlayTitle CreateTitle() => new TestTitle();
+        }
+
+        private class TestTitle : OverlayTitle
+        {
+            public TestTitle()
+            {
+                Title = "Test Title";
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbControlHeader.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbControlHeader.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             foreach (var item in items.Reverse().SkipLast(3))
                 AddStep($"Remove {item} item", () => header.RemoveItem(item));
 
-            AddStep($"Clear item", () => header.ClearItem());
+            AddStep("Clear item", () => header.ClearItem());
 
             foreach (var item in items)
                 AddStep($"Add {item} item", () => header.AddItem(item));

--- a/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
+++ b/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
@@ -26,7 +26,10 @@ namespace osu.Game.Overlays
                 AccentColour = colourProvider.Light2;
             }
 
-            protected override TabItem<string> CreateTabItem(string value) => new ControlTabItem(value);
+            protected override TabItem<string> CreateTabItem(string value) => new ControlTabItem(value)
+            {
+                AccentColour = AccentColour,
+            };
 
             private class ControlTabItem : BreadcrumbTabItem
             {


### PR DESCRIPTION
**Before**

![before-accent](https://user-images.githubusercontent.com/4964985/119030517-2fbc3180-b9d4-11eb-9a65-ea5f9d1b0a19.gif)

**After**

![after-accent](https://user-images.githubusercontent.com/4964985/119030533-364aa900-b9d4-11eb-9d06-f75c5102124c.gif)
