### PR TITLE
Forcefully trigger EndPlaying() to fix test failures

### DIFF
--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -174,6 +174,9 @@ namespace osu.Game.Online.Spectator
 
         public void EndPlaying()
         {
+            if (!IsPlaying)
+                return;
+
             IsPlaying = false;
             currentBeatmap = null;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -22,6 +22,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
+using osu.Game.Online.Spectator;
 using osu.Game.Overlays;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
@@ -92,6 +93,9 @@ namespace osu.Game.Screens.Play
 
         [Resolved]
         private MusicController musicController { get; set; }
+
+        [Resolved]
+        private SpectatorClient spectatorClient { get; set; }
 
         private Sample sampleRestart;
 
@@ -881,6 +885,11 @@ namespace osu.Game.Screens.Play
                 completionProgressDelegate.RunTask();
                 return true;
             }
+
+            // EndPlaying() is typically called from ReplayRecorder.Dispose(). Disposal is currently asynchronous.
+            // To resolve test failures, forcefully end playing synchronously when this screen exits.
+            // Todo: Replace this with a more permanent solution once osu-framework has a synchronous cleanup method.
+            spectatorClient.EndPlaying();
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.
             // as we are no longer the current screen, we cannot guarantee the track is still usable.


### PR DESCRIPTION
Should resolve some intermittent test failures we've been having.