### PR TITLE
Fix right-click placement in taiko editor not correctly updating samples

### DIFF
--- a/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
@@ -14,10 +14,10 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
     {
         private readonly HitPiece piece;
 
-        private static Hit hit;
+        public new Hit HitObject => (Hit)base.HitObject;
 
         public HitPlacementBlueprint()
-            : base(hit = new Hit())
+            : base(new Hit())
         {
             InternalChild = piece = new HitPiece
             {
@@ -30,12 +30,12 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
             switch (e.Button)
             {
                 case MouseButton.Left:
-                    hit.Type = HitType.Centre;
+                    HitObject.Type = HitType.Centre;
                     EndPlacement(true);
                     return true;
 
                 case MouseButton.Right:
-                    hit.Type = HitType.Rim;
+                    HitObject.Type = HitType.Rim;
                     EndPlacement(true);
                     return true;
             }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -52,13 +52,16 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override void OnApply()
         {
             type.BindTo(HitObject.TypeBindable);
-            type.BindValueChanged(_ =>
-            {
-                updateActionsFromType();
-                RecreatePieces();
-            }, true);
+            // this doesn't need to be run inline as RecreatePieces is called by the base call below.
+            type.BindValueChanged(_ => RecreatePieces());
 
             base.OnApply();
+        }
+
+        protected override void RecreatePieces()
+        {
+            updateActionsFromType();
+            base.RecreatePieces();
         }
 
         protected override void OnFree()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -55,16 +55,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             type.BindValueChanged(_ =>
             {
                 updateActionsFromType();
-
-                // will overwrite samples, should only be called on subsequent changes
-                // after the initial application.
-                updateSamplesFromTypeChange();
-
                 RecreatePieces();
-            });
-
-            // action update also has to happen immediately on application.
-            updateActionsFromType();
+            }, true);
 
             base.OnApply();
         }
@@ -90,24 +82,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             base.LoadSamples();
 
             type.Value = getRimSamples().Any() ? HitType.Rim : HitType.Centre;
-        }
-
-        private void updateSamplesFromTypeChange()
-        {
-            var rimSamples = getRimSamples();
-
-            bool isRimType = HitObject.Type == HitType.Rim;
-
-            if (isRimType != rimSamples.Any())
-            {
-                if (isRimType)
-                    HitObject.Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_CLAP));
-                else
-                {
-                    foreach (var sample in rimSamples)
-                        HitObject.Samples.Remove(sample);
-                }
-            }
         }
 
         private void updateActionsFromType()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             type.BindTo(HitObject.TypeBindable);
             // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            type.BindValueChanged(_ => RecreatePieces());
+            type.BindValueChanged(_ => Scheduler.AddOnce(RecreatePieces));
 
             base.OnApply();
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -78,15 +78,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             validActionPressed = pressHandledThisFrame = false;
         }
 
-        private HitSampleInfo[] getRimSamples() => HitObject.Samples.Where(s => s.Name == HitSampleInfo.HIT_CLAP || s.Name == HitSampleInfo.HIT_WHISTLE).ToArray();
-
-        protected override void LoadSamples()
-        {
-            base.LoadSamples();
-
-            type.Value = getRimSamples().Any() ? HitType.Rim : HitType.Centre;
-        }
-
         private void updateActionsFromType()
         {
             HitActions =

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -137,7 +137,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             Size = BaseSize = new Vector2(TaikoHitObject.DEFAULT_SIZE);
 
-            MainPiece?.Expire();
+            if (MainPiece != null)
+                Content.Remove(MainPiece);
+
             Content.Add(MainPiece = CreateMainPiece());
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             isStrong.BindTo(HitObject.IsStrongBindable);
             // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            isStrong.BindValueChanged(_ => RecreatePieces());
+            isStrong.BindValueChanged(_ => Scheduler.AddOnce(RecreatePieces));
 
             base.OnApply();
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Audio;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
@@ -29,14 +27,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override void OnApply()
         {
             isStrong.BindTo(HitObject.IsStrongBindable);
-            isStrong.BindValueChanged(_ =>
-            {
-                // will overwrite samples, should only be called on subsequent changes
-                // after the initial application.
-                updateSamplesFromStrong();
-
-                RecreatePieces();
-            });
+            // this doesn't need to be run inline as RecreatePieces is called by the base call below.
+            isStrong.BindValueChanged(_ => RecreatePieces());
 
             base.OnApply();
         }
@@ -48,30 +40,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             isStrong.UnbindFrom(HitObject.IsStrongBindable);
             // ensure the next application does not accidentally overwrite samples.
             isStrong.UnbindEvents();
-        }
-
-        private HitSampleInfo[] getStrongSamples() => HitObject.Samples.Where(s => s.Name == HitSampleInfo.HIT_FINISH).ToArray();
-
-        protected override void LoadSamples()
-        {
-            base.LoadSamples();
-            isStrong.Value = getStrongSamples().Any();
-        }
-
-        private void updateSamplesFromStrong()
-        {
-            var strongSamples = getStrongSamples();
-
-            if (isStrong.Value != strongSamples.Any())
-            {
-                if (isStrong.Value)
-                    HitObject.Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_FINISH));
-                else
-                {
-                    foreach (var sample in strongSamples)
-                        HitObject.Samples.Remove(sample);
-                }
-            }
         }
 
         protected override void RecreatePieces()

--- a/osu.Game.Rulesets.Taiko/Objects/Hit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Hit.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Bindables;
+using osu.Game.Audio;
 
 namespace osu.Game.Rulesets.Taiko.Objects
 {
@@ -15,8 +17,35 @@ namespace osu.Game.Rulesets.Taiko.Objects
         public HitType Type
         {
             get => TypeBindable.Value;
-            set => TypeBindable.Value = value;
+            set
+            {
+                TypeBindable.Value = value;
+                updateSamplesFromType();
+            }
         }
+
+        private void updateSamplesFromType()
+        {
+            var rimSamples = getRimSamples();
+
+            bool isRimType = Type == HitType.Rim;
+
+            if (isRimType != rimSamples.Any())
+            {
+                if (isRimType)
+                    Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_CLAP));
+                else
+                {
+                    foreach (var sample in rimSamples)
+                        Samples.Remove(sample);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns an array of any samples which would cause this object to be a "rim" type hit.
+        /// </summary>
+        private HitSampleInfo[] getRimSamples() => Samples.Where(s => s.Name == HitSampleInfo.HIT_CLAP || s.Name == HitSampleInfo.HIT_WHISTLE).ToArray();
 
         protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit { StartTime = startTime };
 

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using System.Threading;
 using osu.Framework.Bindables;
+using osu.Game.Audio;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Objects
@@ -31,8 +33,30 @@ namespace osu.Game.Rulesets.Taiko.Objects
         public bool IsStrong
         {
             get => IsStrongBindable.Value;
-            set => IsStrongBindable.Value = value;
+            set
+            {
+                IsStrongBindable.Value = value;
+                updateSamplesFromStrong();
+            }
         }
+
+        private void updateSamplesFromStrong()
+        {
+            var strongSamples = getStrongSamples();
+
+            if (IsStrongBindable.Value != strongSamples.Any())
+            {
+                if (IsStrongBindable.Value)
+                    Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_FINISH));
+                else
+                {
+                    foreach (var sample in strongSamples)
+                        Samples.Remove(sample);
+                }
+            }
+        }
+
+        private HitSampleInfo[] getStrongSamples() => Samples.Where(s => s.Name == HitSampleInfo.HIT_FINISH).ToArray();
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Closes #12870.

---

This in turn would cause the rim/blue hits to look correct, but not save to file as their correct type (since saving and loading is still using the legacy representation where their type is denoted by their samples).