### PR TITLE
Keep displaying menu items intial state regardless of state changes

### DIFF
--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Graphics.UserInterface
                     stateIcon.Alpha = 0;
                 else
                 {
-                    stateIcon.Alpha = 1;
+                    stateIcon.Alpha = state.NewValue != state.OldValue ? 0 : 1;
                     stateIcon.Icon = icon.Value;
                 }
             }

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -17,17 +17,19 @@ namespace osu.Game.Graphics.UserInterface
         {
         }
 
-        protected override TextContainer CreateTextContainer() => new ToggleTextContainer(Item);
+        protected override TextContainer CreateTextContainer() => new ToggleTextContainer(Item, CloseMenuOnClick);
 
         private class ToggleTextContainer : TextContainer
         {
             private readonly StatefulMenuItem menuItem;
             private readonly Bindable<object> state;
             private readonly SpriteIcon stateIcon;
+            private readonly bool closeMenuOnClick;
 
-            public ToggleTextContainer(StatefulMenuItem menuItem)
+            public ToggleTextContainer(StatefulMenuItem menuItem, bool closeMenuOnClick)
             {
                 this.menuItem = menuItem;
+                this.closeMenuOnClick = closeMenuOnClick;
 
                 state = menuItem.State.GetBoundCopy();
 
@@ -44,7 +46,10 @@ namespace osu.Game.Graphics.UserInterface
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                state.BindValueChanged(updateState, true);
+                updateState(state.Value);
+
+                if (!closeMenuOnClick)
+                    state.BindValueChanged(updateState);
             }
 
             protected override void Update()
@@ -57,13 +62,18 @@ namespace osu.Game.Graphics.UserInterface
 
             private void updateState(ValueChangedEvent<object> state)
             {
-                var icon = menuItem.GetIconForState(state.NewValue);
+                updateState(state.NewValue);
+            }
+
+            private void updateState(object state)
+            {
+                var icon = menuItem.GetIconForState(state);
 
                 if (icon == null)
                     stateIcon.Alpha = 0;
                 else
                 {
-                    stateIcon.Alpha = state.NewValue != state.OldValue ? 0 : 1;
+                    stateIcon.Alpha = 1;
                     stateIcon.Icon = icon.Value;
                 }
             }

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -46,10 +46,10 @@ namespace osu.Game.Graphics.UserInterface
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                updateState(state.Value);
+                updateState();
 
                 if (!closeMenuOnClick)
-                    state.BindValueChanged(updateState);
+                    state.BindValueChanged(_ => updateState());
             }
 
             protected override void Update()
@@ -60,14 +60,9 @@ namespace osu.Game.Graphics.UserInterface
                 stateIcon.X = BoldText.DrawWidth + 10;
             }
 
-            private void updateState(ValueChangedEvent<object> state)
+            private void updateState()
             {
-                updateState(state.NewValue);
-            }
-
-            private void updateState(object state)
-            {
-                var icon = menuItem.GetIconForState(state);
+                var icon = menuItem.GetIconForState(state.Value);
 
                 if (icon == null)
                     stateIcon.Alpha = 0;


### PR DESCRIPTION
Fixes #12894

When selecting a new option on the Anchor/Origin menu on the `SkinSelectionHandler`, two check marks were shown for a brief period of time, as seen on the referenced issue.
Instead of messing with the way the menus are drawn, I propose a simpler change that will make it so that the `alpha` value of the option's check mark is only drawn when the menu is created, not when the option is updated (since the menu will close upon option update anyways).