### PR TITLE
Ensure `RegenerateAutoplay` is only run once per frame

### DIFF
--- a/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
-        private void updateReplay() => drawableRuleset.RegenerateAutoplay();
+        private void updateReplay() => Scheduler.AddOnce(drawableRuleset.RegenerateAutoplay);
 
         private void addHitObject(HitObject hitObject)
         {


### PR DESCRIPTION
Noticed this in pasing. This isn't too important because in standard operation it's using the `ChangeState` event rather than `HitObjectUpdated`, but I think it's best to limit it for safety.