### PR TITLE
Limit automatically calculated HUD offsets to keep menu items on screen

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -196,12 +196,12 @@ namespace osu.Game.Screens.Play
             }
 
             if (lowestTopScreenSpace.HasValue)
-                topRightElements.Y = TopScoringElementsHeight = ToLocalSpace(lowestTopScreenSpace.Value).Y;
+                topRightElements.Y = TopScoringElementsHeight = Math.Max(0, ToLocalSpace(lowestTopScreenSpace.Value).Y);
             else
                 topRightElements.Y = 0;
 
             if (highestBottomScreenSpace.HasValue)
-                bottomRightElements.Y = BottomScoringElementsHeight = -(DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y);
+                bottomRightElements.Y = BottomScoringElementsHeight = -Math.Max(0, (DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y));
             else
                 bottomRightElements.Y = 0;
         }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -196,12 +196,12 @@ namespace osu.Game.Screens.Play
             }
 
             if (lowestTopScreenSpace.HasValue)
-                topRightElements.Y = TopScoringElementsHeight = Math.Max(0, ToLocalSpace(lowestTopScreenSpace.Value).Y);
+                topRightElements.Y = TopScoringElementsHeight = MathHelper.Clamp(ToLocalSpace(lowestTopScreenSpace.Value).Y, 0, DrawHeight - topRightElements.DrawHeight);
             else
                 topRightElements.Y = 0;
 
             if (highestBottomScreenSpace.HasValue)
-                bottomRightElements.Y = BottomScoringElementsHeight = -Math.Max(0, (DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y));
+                bottomRightElements.Y = BottomScoringElementsHeight = -MathHelper.Clamp(DrawHeight - ToLocalSpace(highestBottomScreenSpace.Value).Y, 0, DrawHeight - bottomRightElements.DrawHeight);
             else
                 bottomRightElements.Y = 0;
         }


### PR DESCRIPTION
Should stop #12919 from occurring.


https://user-images.githubusercontent.com/191335/119298122-56f65580-bc97-11eb-9e87-1a3784590de7.mp4

Just best effort for now (there's obviously going to be overlap at the extremities).