### PR TITLE
Fix `Player` potentially running `MakeCurrent` when already removed from the screen stack

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -519,7 +519,7 @@ namespace osu.Game.Screens.Play
 
             // there is a chance that the exit was performed after the transition to results has started.
             // we want to give the user what they want, so forcefully return to this screen (to proceed with the upwards exit process).
-            if (!this.IsCurrentScreen())
+            if (!this.IsCurrentScreen() && this.GetChildScreen() != null)
             {
                 ValidForResume = false;
                 this.MakeCurrent();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -519,10 +519,13 @@ namespace osu.Game.Screens.Play
 
             // there is a chance that the exit was performed after the transition to results has started.
             // we want to give the user what they want, so forcefully return to this screen (to proceed with the upwards exit process).
-            if (!this.IsCurrentScreen() && this.GetChildScreen() != null)
+            if (!this.IsCurrentScreen())
             {
                 ValidForResume = false;
-                this.MakeCurrent();
+
+                // in the potential case that this instance has already been exited, this is required to avoid a crash.
+                if (this.GetChildScreen() != null)
+                    this.MakeCurrent();
                 return;
             }
 


### PR DESCRIPTION
Closes #12919.

Is pretty race-y so not sure figuring out a test setup is worthwhile.