### PR TITLE
Fix DHOs not receiving initial skin changed events

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
@@ -5,12 +5,14 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -30,6 +32,16 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep($"{term} Big", () => SetContents(() => testSingle(2, autoplay)));
             AddStep($"{term} Medium", () => SetContents(() => testSingle(5, autoplay)));
             AddStep($"{term} Small", () => SetContents(() => testSingle(7, autoplay)));
+        }
+
+        [Test]
+        public void TestSpinningSamplePitchShift()
+        {
+            AddStep("Add spinner", () => SetContents(() => testSingle(5, true, 4000)));
+            AddUntilStep("Pitch starts low", () => getSpinningSample().Frequency.Value < 0.8);
+            AddUntilStep("Pitch increases", () => getSpinningSample().Frequency.Value > 0.8);
+
+            PausableSkinnableSound getSpinningSample() => drawableSpinner.ChildrenOfType<PausableSkinnableSound>().FirstOrDefault(s => s.Samples.Any(i => i.LookupNames.Any(l => l.Contains("spinnerspin"))));
         }
 
         [TestCase(false)]
@@ -93,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 base.Update();
                 if (auto)
-                    RotationTracker.AddRotation((float)(Clock.ElapsedFrameTime * 3));
+                    RotationTracker.AddRotation((float)(Clock.ElapsedFrameTime * 2));
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -39,6 +39,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private Bindable<bool> isSpinning;
         private bool spinnerFrequencyModulate;
 
+        private const float spinning_sample_initial_frequency = 1.0f;
+        private const float spinning_sample_modulated_base_frequency = 0.5f;
+
         /// <summary>
         /// The amount of bonus score gained from spinning after the required number of spins, for display purposes.
         /// </summary>
@@ -105,9 +108,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             isSpinning = RotationTracker.IsSpinning.GetBoundCopy();
             isSpinning.BindValueChanged(updateSpinningSample);
         }
-
-        private const float spinning_sample_initial_frequency = 1.0f;
-        private const float spinning_sample_modulated_base_frequency = 0.5f;
 
         protected override void OnFree()
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -172,7 +172,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
             base.AddInternal(Samples = new PausableSkinnableSound());
 
             CurrentSkin = skinSource;
-            CurrentSkin.SourceChanged += onSkinSourceChanged;
+            CurrentSkin.SourceChanged += skinSourceChanged;
+        }
+
+        protected override void LoadAsyncComplete()
+        {
+            base.LoadAsyncComplete();
+            skinChanged();
         }
 
         protected override void LoadComplete()
@@ -495,7 +501,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         protected ISkinSource CurrentSkin { get; private set; }
 
-        private void onSkinSourceChanged() => Scheduler.AddOnce(() =>
+        private void skinSourceChanged() => Scheduler.AddOnce(skinChanged);
+
+        private void skinChanged()
         {
             UpdateComboColour();
 
@@ -503,7 +511,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             if (IsLoaded)
                 updateState(State.Value, true);
-        });
+        }
 
         protected void UpdateComboColour()
         {
@@ -747,7 +755,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (HitObject != null)
                 HitObject.DefaultsApplied -= onDefaultsApplied;
 
-            CurrentSkin.SourceChanged -= onSkinSourceChanged;
+            CurrentSkin.SourceChanged -= skinSourceChanged;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12923

Regressed in https://github.com/ppy/osu/pull/12500 where DHO was changed to not inherit `SkinnableDrawable` anymore.