### PR TITLE
Fix editor placement ending early if a blueprint becomes alive from a pool

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -61,6 +61,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             inputManager = GetContainingInputManager();
 
+            Beatmap.HitObjectAdded += hitObjectAdded;
+
             // updates to selected are handled for us by SelectionHandler.
             NewCombo.BindTo(SelectionHandler.SelectionNewComboState);
 
@@ -259,10 +261,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public virtual HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject) => null;
 
-        protected override void OnBlueprintAdded(HitObject item)
+        private void hitObjectAdded(HitObject obj)
         {
-            base.OnBlueprintAdded(item);
-
+            // refresh the tool to handle the case of placement completing.
             refreshTool();
 
             // on successful placement, the new combo button should be reset as this is the most common user interaction.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12630.

The base methods `OnBlueprintAdded`/`OnBlueprintRemoved` are not used anywhere, but I've left them in place for now.