### PR TITLE
Prevent skin editor crash when scaling 0 area drawables

### DIFF
--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -59,6 +59,10 @@ namespace osu.Game.Skinning.Editor
             // the selection quad is always upright, so use an AABB rect to make mutating the values easier.
             var selectionRect = getSelectionQuad().AABBFloat;
 
+            // If the selection has no area we cannot scale it
+            if (selectionRect.Area == 0.0)
+                return false;
+
             // copy to mutate, as we will need to compare to the original later on.
             var adjustedRect = selectionRect;
 

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Skinning.Editor
             var selectionRect = getSelectionQuad().AABBFloat;
 
             // If the selection has no area we cannot scale it
-            if (selectionRect.Area == 0.0)
+            if (selectionRect.Area == 0)
                 return false;
 
             // copy to mutate, as we will need to compare to the original later on.


### PR DESCRIPTION
Some skinnable drawables (i.e. LegacyComboCounter when combo is 0) can have 0 width or height in certain cases, leading to division by 0 and a crash when the position is updated.