### PR TITLE
Fix storyboard videos not correctly filling the screen

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -57,9 +57,12 @@ namespace osu.Game.Storyboards.Drawables
         public DrawableStoryboard(Storyboard storyboard)
         {
             Storyboard = storyboard;
+
             Size = new Vector2(640, 480);
 
-            Width = Height * (storyboard.BeatmapInfo.WidescreenStoryboard ? 16 / 9f : 4 / 3f);
+            bool onlyHasVideoElements = !Storyboard.Layers.Any(l => l.Elements.Any(e => !(e is StoryboardVideo)));
+
+            Width = Height * (storyboard.BeatmapInfo.WidescreenStoryboard || onlyHasVideoElements ? 16 / 9f : 4 / 3f);
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -58,6 +58,9 @@ namespace osu.Game.Storyboards.Drawables
         {
             Storyboard = storyboard;
             Size = new Vector2(640, 480);
+
+            Width = Height * (storyboard.BeatmapInfo.WidescreenStoryboard ? 16 / 9f : 4 / 3f);
+
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Storyboards.Drawables
 
             Size = new Vector2(640, 480);
 
-            bool onlyHasVideoElements = !Storyboard.Layers.Any(l => l.Elements.Any(e => !(e is StoryboardVideo)));
+            bool onlyHasVideoElements = Storyboard.Layers.SelectMany(l => l.Elements).Any(e => !(e is StoryboardVideo));
 
             Width = Height * (storyboard.BeatmapInfo.WidescreenStoryboard || onlyHasVideoElements ? 16 / 9f : 4 / 3f);
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardLayer.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardLayer.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osuTK;
 
 namespace osu.Game.Storyboards.Drawables
 {
@@ -15,6 +16,8 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool IsPresent => Enabled && base.IsPresent;
 
+        protected LayerElementContainer ElementContainer { get; }
+
         public DrawableStoryboardLayer(StoryboardLayer layer)
         {
             Layer = layer;
@@ -24,10 +27,10 @@ namespace osu.Game.Storyboards.Drawables
             Enabled = layer.VisibleWhenPassing;
             Masking = layer.Masking;
 
-            InternalChild = new LayerElementContainer(layer);
+            InternalChild = ElementContainer = new LayerElementContainer(layer);
         }
 
-        private class LayerElementContainer : LifetimeManagementContainer
+        protected class LayerElementContainer : LifetimeManagementContainer
         {
             private readonly StoryboardLayer storyboardLayer;
 
@@ -35,8 +38,8 @@ namespace osu.Game.Storyboards.Drawables
             {
                 storyboardLayer = layer;
 
-                Width = 640;
-                Height = 480;
+                Size = new Vector2(640, 480);
+
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
             }

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Storyboards
 
         public Storyboard()
         {
-            layers.Add("Video", new StoryboardLayer("Video", 4, false));
+            layers.Add("Video", new StoryboardLayerVideo("Video", 4, false));
             layers.Add("Background", new StoryboardLayer("Background", 3));
             layers.Add("Fail", new StoryboardLayer("Fail", 2) { VisibleWhenPassing = false, });
             layers.Add("Pass", new StoryboardLayer("Pass", 1) { VisibleWhenFailing = false, });

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Storyboards
 
         public Storyboard()
         {
-            layers.Add("Video", new StoryboardLayerVideo("Video", 4, false));
+            layers.Add("Video", new StoryboardVideoLayer("Video", 4, false));
             layers.Add("Background", new StoryboardLayer("Background", 3));
             layers.Add("Fail", new StoryboardLayer("Fail", 2) { VisibleWhenPassing = false, });
             layers.Add("Pass", new StoryboardLayer("Pass", 1) { VisibleWhenFailing = false, });

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -85,12 +85,8 @@ namespace osu.Game.Storyboards
             }
         }
 
-        public DrawableStoryboard CreateDrawable(WorkingBeatmap working = null)
-        {
-            var drawable = new DrawableStoryboard(this);
-            drawable.Width = drawable.Height * (BeatmapInfo.WidescreenStoryboard ? 16 / 9f : 4 / 3f);
-            return drawable;
-        }
+        public DrawableStoryboard CreateDrawable(WorkingBeatmap working = null) =>
+            new DrawableStoryboard(this);
 
         public Drawable CreateSpriteFromResourcePath(string path, TextureStore textureStore)
         {

--- a/osu.Game/Storyboards/StoryboardLayer.cs
+++ b/osu.Game/Storyboards/StoryboardLayer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Storyboards
             Elements.Add(element);
         }
 
-        public DrawableStoryboardLayer CreateDrawable()
+        public virtual DrawableStoryboardLayer CreateDrawable()
             => new DrawableStoryboardLayer(this) { Depth = Depth, Name = Name };
     }
 }

--- a/osu.Game/Storyboards/StoryboardLayerVideo.cs
+++ b/osu.Game/Storyboards/StoryboardLayerVideo.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Storyboards.Drawables;
+using osuTK;
+
+namespace osu.Game.Storyboards
+{
+    public class StoryboardLayerVideo : StoryboardLayer
+    {
+        public StoryboardLayerVideo(string name, int depth, bool masking)
+            : base(name, depth, masking)
+        {
+        }
+
+        public override DrawableStoryboardLayer CreateDrawable()
+            => new DrawableStoryboardLayerVideo(this) { Depth = Depth, Name = Name };
+
+        public class DrawableStoryboardLayerVideo : DrawableStoryboardLayer
+        {
+            public DrawableStoryboardLayerVideo(StoryboardLayerVideo layer)
+                : base(layer)
+            {
+                // for videos we want to take on the full size of the storyboard container hierarchy
+                // to allow the video to fill the full available region.
+                ElementContainer.RelativeSizeAxes = Axes.Both;
+                ElementContainer.Size = Vector2.One;
+            }
+        }
+    }
+}

--- a/osu.Game/Storyboards/StoryboardVideoLayer.cs
+++ b/osu.Game/Storyboards/StoryboardVideoLayer.cs
@@ -7,19 +7,19 @@ using osuTK;
 
 namespace osu.Game.Storyboards
 {
-    public class StoryboardLayerVideo : StoryboardLayer
+    public class StoryboardVideoLayer : StoryboardLayer
     {
-        public StoryboardLayerVideo(string name, int depth, bool masking)
+        public StoryboardVideoLayer(string name, int depth, bool masking)
             : base(name, depth, masking)
         {
         }
 
         public override DrawableStoryboardLayer CreateDrawable()
-            => new DrawableStoryboardLayerVideo(this) { Depth = Depth, Name = Name };
+            => new DrawableStoryboardVideoLayer(this) { Depth = Depth, Name = Name };
 
-        public class DrawableStoryboardLayerVideo : DrawableStoryboardLayer
+        public class DrawableStoryboardVideoLayer : DrawableStoryboardLayer
         {
-            public DrawableStoryboardLayerVideo(StoryboardLayerVideo layer)
+            public DrawableStoryboardVideoLayer(StoryboardVideoLayer layer)
                 : base(layer)
             {
                 // for videos we want to take on the full size of the storyboard container hierarchy


### PR DESCRIPTION
Storyboard layers were coded in a way to allow correct positioning of elements, where in stable the coordinate space is 640x480 (even in the case of widescreen). This was limiting elements within `StoryboardLayer`s that have `RelativeSize.Both` specification to that 4:3 aspect ratio, which isn't what we want for videos.

In addition, lazer was missing the special case in stable where a storyboard without any actual storyboard elements (ie. only containing video / backgrounds) was set to `WidescreenStoryboard` implicitly.

Closes https://github.com/ppy/osu/issues/12291.