### PR TITLE
Handle link action in `OsuMarkdownLinkText`

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuMarkdownContainer.cs
@@ -87,6 +87,15 @@ _**italic with underscore, bold with asterisk**_";
         }
 
         [Test]
+        public void TestLinkWithTitle()
+        {
+            AddStep("Add Link with title", () =>
+            {
+                markdownContainer.Text = "[wikipedia](https://www.wikipedia.org \"The Free Encyclopedia\")";
+            });
+        }
+
+        [Test]
         public void TestInlineCode()
         {
             AddStep("Add inline code", () =>

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
@@ -23,10 +23,14 @@ namespace osu.Game.Graphics.Containers.Markdown
             LineSpacing = 21;
         }
 
-        [BackgroundDependencyLoader]
-        private void load(IAPIProvider api)
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
+            var api = parent.Get<IAPIProvider>();
+
+            // needs to be set before the base BDL call executes to avoid invalidating any already populated markdown content.
             DocumentUrl = api.WebsiteRootUrl;
+
+            return base.CreateChildDependencies(parent);
         }
 
         protected override void AddMarkdownComponent(IMarkdownObject markdownObject, FillFlowContainer container, int level)

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
@@ -6,11 +6,13 @@ using Markdig.Extensions.AutoIdentifiers;
 using Markdig.Extensions.Tables;
 using Markdig.Extensions.Yaml;
 using Markdig.Syntax;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API;
 
 namespace osu.Game.Graphics.Containers.Markdown
 {
@@ -19,6 +21,12 @@ namespace osu.Game.Graphics.Containers.Markdown
         public OsuMarkdownContainer()
         {
             LineSpacing = 21;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IAPIProvider api)
+        {
+            DocumentUrl = api.WebsiteRootUrl;
         }
 
         protected override void AddMarkdownComponent(IMarkdownObject markdownObject, FillFlowContainer container, int level)

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownLinkText.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownLinkText.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Graphics.Containers.Markdown
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load()
         {
             var textDrawable = CreateSpriteText().With(t => t.Text = text);
 

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownLinkText.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownLinkText.cs
@@ -16,28 +16,29 @@ namespace osu.Game.Graphics.Containers.Markdown
         [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
 
-        protected string Text;
-        protected string Title;
+        private readonly string text;
+        private readonly string title;
 
         public OsuMarkdownLinkText(string text, LinkInline linkInline)
             : base(text, linkInline)
         {
-            Text = text;
-            Title = linkInline.Title;
+            this.text = text;
+            title = linkInline.Title;
         }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            var text = CreateSpriteText().With(t => t.Text = Text);
+            var textDrawable = CreateSpriteText().With(t => t.Text = text);
+
             InternalChildren = new Drawable[]
             {
-                text,
-                new OsuMarkdownLinkCompiler(new[] { text })
+                textDrawable,
+                new OsuMarkdownLinkCompiler(new[] { textDrawable })
                 {
                     RelativeSizeAxes = Axes.Both,
                     Action = OnLinkPressed,
-                    TooltipText = Title ?? Url,
+                    TooltipText = title ?? Url,
                 }
             };
         }


### PR DESCRIPTION
This changes will handle this kind of markdown link.

- `[peppy](/users/2)` will open user profile overlay.
- `[Disco Prince](/beatmapsets/1)` will open beatmapset overlay.
- `[Wikipedia](https://www.wikipedia.org)` will open as external link.