### PR TITLE
Fix `BeatmapCarousel` accessing `ScreenSpaceDrawQuad` of non-loaded children

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -786,9 +786,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             }
         }
 
-        private void checkVisibleItemCount(bool diff, int count) =>
-            AddAssert($"{count} {(diff ? "diffs" : "sets")} visible", () =>
+        private void checkVisibleItemCount(bool diff, int count)
+        {
+            // until step required as we are querying against alive items, which are loaded asynchronously inside DrawableCarouselBeatmapSet.
+            AddUntilStep($"{count} {(diff ? "diffs" : "sets")} visible", () =>
                 carousel.Items.Count(s => (diff ? s.Item is CarouselBeatmap : s.Item is CarouselBeatmapSet) && s.Item.Visible) == count);
+        }
 
         private void checkNoSelection() => AddAssert("Selection is null", () => currentSelection == null);
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Select.Carousel
         [Resolved(CanBeNull = true)]
         private ManageCollectionsDialog manageCollectionsDialog { get; set; }
 
-        public IEnumerable<DrawableCarouselItem> DrawableBeatmaps => beatmapContainer?.Children ?? Enumerable.Empty<DrawableCarouselItem>();
+        public IEnumerable<DrawableCarouselItem> DrawableBeatmaps => beatmapContainer?.AliveChildren ?? Enumerable.Empty<DrawableCarouselItem>();
 
         [CanBeNull]
         private Container<DrawableCarouselItem> beatmapContainer;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Select.Carousel
         [Resolved(CanBeNull = true)]
         private ManageCollectionsDialog manageCollectionsDialog { get; set; }
 
-        public IEnumerable<DrawableCarouselItem> DrawableBeatmaps => beatmapContainer?.AliveChildren ?? Enumerable.Empty<DrawableCarouselItem>();
+        public IEnumerable<DrawableCarouselItem> DrawableBeatmaps => beatmapContainer?.IsLoaded != true ? Enumerable.Empty<DrawableCarouselItem>() : beatmapContainer.AliveChildren;
 
         [CanBeNull]
         private Container<DrawableCarouselItem> beatmapContainer;


### PR DESCRIPTION
Should fix failure seen at
https://ci.appveyor.com/project/peppy/osu/builds/39302762/tests.