### PR TITLE
Compute scrolling hit object `LifetimeStart` from `HitObjectLifetimeEntry`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
@@ -90,6 +90,20 @@ namespace osu.Game.Tests.Visual.Gameplay
             assertChildPosition(5);
         }
 
+        [TestCase("pooled")]
+        [TestCase("non-pooled")]
+        public void TestLifetimeRecomputedWhenTimeRangeChanges(string pooled)
+        {
+            var beatmap = createBeatmap(_ => pooled == "pooled" ? new TestPooledHitObject() : new TestHitObject());
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = time_range });
+            createTest(beatmap);
+
+            assertDead(3);
+
+            AddStep("increase time range", () => drawableRuleset.TimeRange.Value = 3 * time_range);
+            assertPosition(3, 1);
+        }
+
         [Test]
         public void TestRelativeBeatLengthScaleSingleTimingPoint()
         {

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Judgements;
@@ -23,6 +24,11 @@ namespace osu.Game.Rulesets.Objects
         /// This is set by the accompanying <see cref="DrawableHitObject"/>, and reused when required for rewinding.
         /// </summary>
         internal JudgementResult Result;
+
+        /// <summary>
+        /// Invoked when the start time of <see cref="HitObject"/> is changed.
+        /// </summary>
+        public event Action<HitObjectLifetimeEntry> StartTimeChanged;
 
         public readonly Bindable<double> StartTimeBindable = new Bindable<double>();
 
@@ -91,6 +97,10 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// Resets <see cref="LifetimeEntry.LifetimeStart"/> according to the change in start time of the <see cref="HitObject"/>.
         /// </summary>
-        private void onStartTimeChanged(ValueChangedEvent<double> startTime) => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
+        private void onStartTimeChanged(ValueChangedEvent<double> startTime)
+        {
+            LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
+            StartTimeChanged?.Invoke(this);
+        }
     }
 }

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         internal JudgementResult Result;
 
-        private readonly IBindable<double> startTimeBindable = new BindableDouble();
+        public readonly Bindable<double> StartTimeBindable = new Bindable<double>();
 
         /// <summary>
         /// Creates a new <see cref="HitObjectLifetimeEntry"/>.
@@ -34,8 +34,8 @@ namespace osu.Game.Rulesets.Objects
         {
             HitObject = hitObject;
 
-            startTimeBindable.BindTo(HitObject.StartTimeBindable);
-            startTimeBindable.BindValueChanged(onStartTimeChanged, true);
+            StartTimeBindable.BindTo(HitObject.StartTimeBindable);
+            StartTimeBindable.BindValueChanged(onStartTimeChanged, true);
         }
 
         // The lifetime, as set by the hitobject.

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// Invoked when the start time of <see cref="HitObject"/> is changed.
         /// </summary>
+        /// <remarks>
+        /// It can be used to override the <see cref="LifetimeEntry.LifetimeStart"/> computation based on the start time.
+        /// </remarks>
         public event Action<HitObjectLifetimeEntry> StartTimeChanged;
 
         public readonly Bindable<double> StartTimeBindable = new Bindable<double>();

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         internal double FutureLifetimeExtension { get; set; }
 
-        private readonly Dictionary<DrawableHitObject, IBindable> startTimeMap = new Dictionary<DrawableHitObject, IBindable>();
+        private readonly Dictionary<HitObjectLifetimeEntry, IBindable> startTimeMap = new Dictionary<HitObjectLifetimeEntry, IBindable>();
 
         private readonly Dictionary<HitObjectLifetimeEntry, DrawableHitObject> aliveDrawableMap = new Dictionary<HitObjectLifetimeEntry, DrawableHitObject>();
         private readonly Dictionary<HitObjectLifetimeEntry, DrawableHitObject> nonPooledDrawableMap = new Dictionary<HitObjectLifetimeEntry, DrawableHitObject>();
@@ -101,6 +101,7 @@ namespace osu.Game.Rulesets.UI
 
         public void Add(HitObjectLifetimeEntry entry)
         {
+            bindStartTime(entry);
             allEntries.Add(entry);
             lifetimeManager.AddEntry(entry);
         }
@@ -114,6 +115,7 @@ namespace osu.Game.Rulesets.UI
                 removeDrawable(drawable);
 
             allEntries.Remove(entry);
+            unbindStartTime(entry);
             return true;
         }
 
@@ -160,7 +162,6 @@ namespace osu.Game.Rulesets.UI
             drawable.OnNewResult += onNewResult;
             drawable.OnRevertResult += onRevertResult;
 
-            bindStartTime(drawable);
             AddInternal(drawable);
         }
 
@@ -168,8 +169,6 @@ namespace osu.Game.Rulesets.UI
         {
             drawable.OnNewResult -= onNewResult;
             drawable.OnRevertResult -= onRevertResult;
-
-            unbindStartTime(drawable);
 
             RemoveInternal(drawable);
         }
@@ -251,9 +250,9 @@ namespace osu.Game.Rulesets.UI
 
         #region Comparator + StartTime tracking
 
-        private void bindStartTime(DrawableHitObject hitObject)
+        private void bindStartTime(HitObjectLifetimeEntry entry)
         {
-            var bindable = hitObject.StartTimeBindable.GetBoundCopy();
+            var bindable = entry.StartTimeBindable.GetBoundCopy();
 
             bindable.BindValueChanged(_ =>
             {
@@ -261,13 +260,13 @@ namespace osu.Game.Rulesets.UI
                     SortInternal();
             });
 
-            startTimeMap[hitObject] = bindable;
+            startTimeMap[entry] = bindable;
         }
 
-        private void unbindStartTime(DrawableHitObject hitObject)
+        private void unbindStartTime(HitObjectLifetimeEntry entry)
         {
-            startTimeMap[hitObject].UnbindAll();
-            startTimeMap.Remove(hitObject);
+            startTimeMap[entry].UnbindAll();
+            startTimeMap.Remove(entry);
         }
 
         private void unbindAllStartTimes()


### PR DESCRIPTION
- Fixes #12897
- Split from #12627 and then reimplemented.

To restate, the issue is because DHO is not loaded until entry became alive, there is no way to retrieve DHO's properties in the computation of lifetime. It was a cyclic dependency.
Instead, it is now assuming the DHO is bounded by 200x200 by default, and it should be valid for all default rulesets.

The lifetime has to be recomputed when the `StartTime` of the hit object changes.
`HitObjectLifetimeEntry` also set `LifetimeStart` based on `InitialLifetimeOffset` when start time changes. To prevent binding ordering issue, I added `StartTimeChanged` event to `HitObjectLifetimeEntry`.
The event is subscribed by `HitObjectContainer` and it is used for the logic of sorting children based on the `StartTime` that was using bindables.
I removed `Dispose` override because I think the original issue <https://github.com/ppy/osu/pull/10200> is not applicable but not very sure.

Removal of local cache `scrollLength` is not necessary, but the computation won't be a performance bottleneck, and it is prone to be used before updated.