### PR TITLE
Fix settings panel hide animation looking wrong when a sub-panel is visible when hidden

### DIFF
--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
@@ -49,8 +50,6 @@ namespace osu.Game.Overlays
 
         private readonly bool showSidebar;
 
-        protected Box Background;
-
         protected SettingsPanel(bool showSidebar)
         {
             this.showSidebar = showSidebar;
@@ -63,13 +62,13 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = ContentContainer = new Container
+            InternalChild = ContentContainer = new NonMaskedContent
             {
                 Width = WIDTH,
                 RelativeSizeAxes = Axes.Y,
                 Children = new Drawable[]
                 {
-                    Background = new Box
+                    new Box
                     {
                         Anchor = Anchor.TopRight,
                         Origin = Anchor.TopRight,
@@ -165,7 +164,7 @@ namespace osu.Game.Overlays
         {
             base.PopOut();
 
-            ContentContainer.MoveToX(-WIDTH, TRANSITION_LENGTH, Easing.OutQuint);
+            ContentContainer.MoveToX(-WIDTH + ExpandedPosition, TRANSITION_LENGTH, Easing.OutQuint);
 
             Sidebar?.MoveToX(-sidebar_width, TRANSITION_LENGTH, Easing.OutQuint);
             this.FadeTo(0, TRANSITION_LENGTH, Easing.OutQuint);
@@ -189,6 +188,12 @@ namespace osu.Game.Overlays
 
             ContentContainer.Margin = new MarginPadding { Left = Sidebar?.DrawWidth ?? 0 };
             Padding = new MarginPadding { Top = GetToolbarHeight?.Invoke() ?? 0 };
+        }
+
+        private class NonMaskedContent : Container<Drawable>
+        {
+            // masking breaks the pan-out transform with nested sub-settings panels.
+            protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
         }
 
         public class SettingsSectionsContainer : SectionsContainer<SettingsSection>


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/191335/119644907-696bbd00-be58-11eb-8fa4-20c65491893a.mp4


After:

https://user-images.githubusercontent.com/191335/119644823-4e994880-be58-11eb-967d-6bee91a48dc5.mp4

