### PR TITLE
Add a mention that `OnApply/OnFree` is performed after `ApplyDefaults`

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -311,6 +311,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         /// <summary>
         /// Invoked for this <see cref="DrawableHitObject"/> to take on any values from a newly-applied <see cref="HitObject"/>.
+        /// This is also fired after any changes which occurred via an <see cref="osu.Game.Rulesets.Objects.HitObject.ApplyDefaults"/> call.
         /// </summary>
         protected virtual void OnApply()
         {
@@ -318,6 +319,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         /// <summary>
         /// Invoked for this <see cref="DrawableHitObject"/> to revert any values previously taken on from the currently-applied <see cref="HitObject"/>.
+        /// This is also fired after any changes which occurred via an <see cref="osu.Game.Rulesets.Objects.HitObject.ApplyDefaults"/> call.
         /// </summary>
         protected virtual void OnFree()
         {


### PR DESCRIPTION
Added as this is not immediately obvious, given that usually `OnApply` and `OnFree` named methods are (in the `PoolableDrawable` context) only run when the underlying model reference changes.