### PR TITLE
Use APIBeatmapSet metadata instead of APIBeatmap

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Beatmaps
                             beatmap.Metadata.AuthorID = res.AuthorID;
 
                         if (beatmap.BeatmapSet.Metadata != null)
-                            beatmap.BeatmapSet.Metadata.AuthorID = res.AuthorID;
+                            beatmap.BeatmapSet.Metadata.AuthorID = res.BeatmapSet.AuthorID;
 
                         LogForModel(set, $"Online retrieval mapped {beatmap} to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.");
                     }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/12965. `APIBeatmap` contains beatmap specific properties however it also contains `APIBeatmapSet` which we want to use for beatmap-wide properties such as the metadata. It may require a hard delete and re-importing of existing beatmaps for the fix to take effect.

Supporting per-difficulty ownership is not included in this PR.