### PR TITLE
Fix test failures in `TestSceneStoryboardWithOutro`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -53,7 +53,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest(null);
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("skip outro", () => InputManager.Key(osuTK.Input.Key.Space));
-            AddAssert("score shown", () => Player.IsScoreShown);
+            AddUntilStep("wait for score shown", () => Player.IsScoreShown);
+            AddUntilStep("time less than storyboard duration", () => Player.GameplayClockContainer.GameplayClock.CurrentTime < currentStoryboardDuration);
         }
 
         [Test]


### PR DESCRIPTION
As seen https://ci.appveyor.com/project/peppy/osu/builds/39346090/tests.

Test was not accounting for the fact that the results may not have loaded in time.