### PR TITLE
Fix test failure in `TestSceneMultiplayerGameplayLeaderboard`

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -73,8 +73,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 for (int i = 0; i < users; i++)
                     spectatorClient.StartPlay(i, Beatmap.Value.BeatmapInfo.OnlineBeatmapID ?? 0);
 
-                Client.CurrentMatchPlayingUserIds.Clear();
-                Client.CurrentMatchPlayingUserIds.AddRange(spectatorClient.PlayingUsers);
+                spectatorClient.Schedule(() =>
+                {
+                    Client.CurrentMatchPlayingUserIds.Clear();
+                    Client.CurrentMatchPlayingUserIds.AddRange(spectatorClient.PlayingUsers);
+                });
 
                 Children = new Drawable[]
                 {
@@ -91,6 +94,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for load", () => leaderboard.IsLoaded);
+            AddUntilStep("wait for user population", () => Client.CurrentMatchPlayingUserIds.Count > 0);
         }
 
         [Test]

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -52,6 +53,8 @@ namespace osu.Game.Tests.Visual.Spectator
                 RulesetID = 0,
             });
         }
+
+        public new void Schedule(Action action) => base.Schedule(action);
 
         /// <summary>
         /// Sends frames for an arbitrary user.


### PR DESCRIPTION
As seen at https://ci.appveyor.com/project/peppy/osu/builds/39309355/tests and https://ci.appveyor.com/project/peppy/osu/builds/39331673/tests.

The transfer of users was not accounting for the fact that the `StartPlay` calls are now scheduled and not necessarily run in time. Not sure this is the best way to write this, open to suggestion.