### PR TITLE
Moved DrawableHitObject OnNewResult event invokation before state update

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -699,10 +699,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             Result.TimeOffset = Math.Min(MaximumJudgementOffset, Time.Current - HitObject.GetEndTime());
 
+            OnNewResult?.Invoke(this, Result);
+
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);
-
-            OnNewResult?.Invoke(this, Result);
         }
 
         /// <summary>


### PR DESCRIPTION
I wanted to make a mod similar to McOsu where all 50s / 100s hits are treated as misses, I managed to do it using the OnNewResult event from DrawableHitObject but I had to move the event invokation before the state update.

This way the state is updated after I change the hit result judgement