### PR TITLE
Add multiplayer room music dimming option

### DIFF
--- a/osu.Game/Audio/BackgroundTrackManager.cs
+++ b/osu.Game/Audio/BackgroundTrackManager.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Audio
+{
+    /// <summary>
+    /// Handles volume changes to the global music track.
+    /// </summary>
+    public class BackgroundTrackManager : Component
+    {
+        private readonly BindableDouble muteBindable = new BindableDouble(1);
+
+        private readonly BindableDouble dimBindable = new BindableDouble(1);
+
+        [Resolved]
+        private AudioManager audio { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            audio.Tracks.AddAdjustment(AdjustableProperty.Volume, muteBindable);
+            audio.Tracks.AddAdjustment(AdjustableProperty.Volume, dimBindable);
+        }
+
+        /// <summary>
+        /// Mutes the music track.
+        /// </summary>
+        /// <param name="duration">The duration of the volume transformation.</param>
+        /// <param name="easing">The easing of the volume transformation.</param>
+        public void Mute(double duration = 0D, Easing easing = Easing.None)
+        {
+            this.TransformBindableTo(muteBindable, 0, duration, easing);
+        }
+
+        /// <summary>
+        /// Unmutes the music track.
+        /// </summary>
+        /// <param name="duration">The duration of the volume transformation.</param>
+        /// <param name="easing">The easing of the volume transformation.</param>
+        public void Unmute(double duration = 0D, Easing easing = Easing.None)
+        {
+            this.TransformBindableTo(muteBindable, 1, duration, easing);
+        }
+
+        /// <summary>
+        /// Dims the volume of the music track.
+        /// </summary>
+        /// <param name="volume">The volume adjustment level.</param>
+        /// <param name="duration">The duration of the volume transformation.</param>
+        /// <param name="easing">The easing of the volume transformation.</param>
+        public void SetDimming(double volume, double duration = 0D, Easing easing = Easing.None)
+        {
+            this.TransformBindableTo(dimBindable, volume, duration, easing);
+        }
+
+        /// <summary>
+        /// Removes any volume dimming from the music track.
+        /// </summary>
+        /// <param name="duration">The duration of the volume transformation.</param>
+        /// <param name="easing">The easing of the volume transformation.</param>
+        public void RemoveDimming(double duration = 0D, Easing easing = Easing.None)
+        {
+            SetDimming(1, duration, easing);
+        }
+    }
+}

--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Audio
         [Resolved]
         private AudioManager audio { get; set; }
 
+        [Resolved]
+        private BackgroundTrackManager backgroundTrackManager { get; set; }
+
         private PreviewTrackStore trackStore;
 
         protected TrackManagerPreviewTrack CurrentTrack;
@@ -32,8 +35,6 @@ namespace osu.Game.Audio
         [BackgroundDependencyLoader]
         private void load()
         {
-            // this is a temporary solution to get around muting ourselves.
-            // todo: update this once we have a BackgroundTrackManager or similar.
             trackStore = new PreviewTrackStore(new OnlineStore());
 
             audio.AddItem(trackStore);
@@ -54,7 +55,7 @@ namespace osu.Game.Audio
             {
                 CurrentTrack?.Stop();
                 CurrentTrack = track;
-                audio.Tracks.AddAdjustment(AdjustableProperty.Volume, muteBindable);
+                backgroundTrackManager.Mute(100, Easing.OutQuint);
             });
 
             track.Stopped += () => Schedule(() =>
@@ -63,7 +64,7 @@ namespace osu.Game.Audio
                     return;
 
                 CurrentTrack = null;
-                audio.Tracks.RemoveAdjustment(AdjustableProperty.Volume, muteBindable);
+                backgroundTrackManager.Unmute(100, Easing.OutQuint);
             });
 
             return track;

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Configuration
 
             // Audio
             SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.VolumeMultiplayerRoom, 1, 0, 1, 0.01);
 
             SetDefault(OsuSetting.MenuVoice, true);
             SetDefault(OsuSetting.MenuMusic, true);
@@ -271,5 +272,6 @@ namespace osu.Game.Configuration
         DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
         ShowOnlineExplicitContent,
+        VolumeMultiplayerRoom,
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Configuration
 
             // Audio
             SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.VolumeMultiplayerRoom, 1, 0, 1, 0.01);
 
             SetDefault(OsuSetting.MenuVoice, true);
             SetDefault(OsuSetting.MenuMusic, true);
@@ -269,5 +270,6 @@ namespace osu.Game.Configuration
         DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
         ShowOnlineExplicitContent,
+        VolumeMultiplayerRoom,
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -334,6 +334,10 @@ namespace osu.Game
             KeyBindingStore.Register(globalBindings);
             dependencies.Cache(globalBindings);
 
+            BackgroundTrackManager backgroundTrackManager;
+            dependencies.Cache(backgroundTrackManager = new BackgroundTrackManager());
+            Add(backgroundTrackManager);
+
             PreviewTrackManager previewTrackManager;
             dependencies.Cache(previewTrackManager = new PreviewTrackManager());
             Add(previewTrackManager);

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -45,6 +45,13 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
                 },
+                new SettingsSlider<double>
+                {
+                    LabelText = "Music (multiplayer room)",
+                    Current = config.GetBindable<double>(OsuSetting.VolumeMultiplayerRoom),
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true
+                },
             };
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Online;
@@ -258,14 +259,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         }
 
         [Resolved]
-        private AudioManager audio { get; set; }
+        private BackgroundTrackManager backgroundTrackManager { get; set; }
 
         [Resolved]
         private OsuConfigManager config { get; set; }
 
         private readonly Bindable<double> volumeMultiplayerRoom = new Bindable<double>();
-
-        private readonly BindableNumber<double> trackVolumeAdjust = new BindableDouble(1);
 
         protected override void LoadComplete()
         {
@@ -291,8 +290,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         public override void OnResuming(IScreen last)
         {
-            this.TransformBindableTo(trackVolumeAdjust, volumeMultiplayerRoom.Value, 1000, Easing.OutQuad);
-            volumeMultiplayerRoom.BindValueChanged(d => trackVolumeAdjust.Set(d.NewValue));
+            backgroundTrackManager.SetDimming(volumeMultiplayerRoom.Value, 1000, Easing.OutQuint);
+            volumeMultiplayerRoom.BindValueChanged(d => backgroundTrackManager.SetDimming(d.NewValue));
 
             base.OnResuming(last);
         }
@@ -300,16 +299,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         public override void OnSuspending(IScreen next)
         {
             volumeMultiplayerRoom.UnbindEvents();
-            this.TransformBindableTo(trackVolumeAdjust, 1, 1000, Easing.OutQuad);
+            backgroundTrackManager.RemoveDimming(1000, Easing.OutQuint);
 
             base.OnSuspending(next);
         }
 
         public override void OnEntering(IScreen last)
         {
-            audio.Tracks.AddAdjustment(AdjustableProperty.Volume, trackVolumeAdjust);
-            this.TransformBindableTo(trackVolumeAdjust, volumeMultiplayerRoom.Value, 1000, Easing.OutQuad);
-            volumeMultiplayerRoom.BindValueChanged(d => trackVolumeAdjust.Set(d.NewValue));
+            backgroundTrackManager.SetDimming(volumeMultiplayerRoom.Value, 1000, Easing.OutQuint);
+            volumeMultiplayerRoom.BindValueChanged(d => backgroundTrackManager.SetDimming(d.NewValue));
 
             base.OnEntering(last);
         }
@@ -317,8 +315,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         public override bool OnExiting(IScreen next)
         {
             volumeMultiplayerRoom.UnbindEvents();
-            var transform = this.TransformBindableTo(trackVolumeAdjust, 1, 1000, Easing.OutQuad);
-            transform.Finally(_ => audio.Tracks.RemoveAdjustment(AdjustableProperty.Volume, trackVolumeAdjust));
+            backgroundTrackManager.RemoveDimming(1000, Easing.OutQuint);
 
             return base.OnExiting(next);
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;


### PR DESCRIPTION
Closes #13173

- Added settings slider "Music (multiplayer room)" (default value is 100%).
- Added a BackgroundTrackManager for handling muting/dimming of the music track.
- The multiplayer room screen now dims the music track by the amount defined in the settings.
- Updated PreviewTrackManager to mute the music track using BackgroundTrackManager and added a 100ms transition.