### PR TITLE
Update hit object lifetime on `HitObject.DefaultsApplied`

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -3,6 +3,8 @@
 
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Tests.Visual;
@@ -68,6 +70,15 @@ namespace osu.Game.Tests.Gameplay
                 entry.KeepAlive = false;
             });
             AddAssert("Lifetime is changed", () => entry.LifetimeStart == double.MinValue && entry.LifetimeEnd == 1000);
+        }
+
+        [Test]
+        public void TestLifetimeUpdatedOnDefaultApplied()
+        {
+            TestLifetimeEntry entry = null;
+            AddStep("Create entry", () => entry = new TestLifetimeEntry(new HitObject()) { LifetimeStart = 1 });
+            AddStep("ApplyDefaults", () => entry.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty()));
+            AddAssert("Lifetime is updated", () => entry.LifetimeStart == -TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
         }
 
         private class TestDrawableHitObject : DrawableHitObject

--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -79,16 +79,38 @@ namespace osu.Game.Tests.Gameplay
             AddStep("Create entry", () => entry = new TestLifetimeEntry(new HitObject()) { LifetimeStart = 1 });
             AddStep("ApplyDefaults", () => entry.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty()));
             AddAssert("Lifetime is updated", () => entry.LifetimeStart == -TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
+
+            TestDrawableHitObject dho = null;
+            AddStep("Create DHO", () =>
+            {
+                dho = new TestDrawableHitObject(null);
+                dho.Apply(entry);
+                Child = dho;
+                dho.SetLifetimeStartOnApply = true;
+            });
+            AddStep("ApplyDefaults", () => entry.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty()));
+            AddAssert("Lifetime is correct", () => dho.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY && entry.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY);
         }
 
         private class TestDrawableHitObject : DrawableHitObject
         {
             public const double INITIAL_LIFETIME_OFFSET = 100;
+            public const double LIFETIME_ON_APPLY = 222;
             protected override double InitialLifetimeOffset => INITIAL_LIFETIME_OFFSET;
+
+            public bool SetLifetimeStartOnApply;
 
             public TestDrawableHitObject(HitObject hitObject)
                 : base(hitObject)
             {
+            }
+
+            protected override void OnApply()
+            {
+                base.OnApply();
+
+                if (SetLifetimeStartOnApply)
+                    LifetimeStart = LIFETIME_ON_APPLY;
             }
         }
 

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -35,7 +35,9 @@ namespace osu.Game.Rulesets.Objects
             HitObject = hitObject;
 
             startTimeBindable.BindTo(HitObject.StartTimeBindable);
-            startTimeBindable.BindValueChanged(onStartTimeChanged, true);
+            startTimeBindable.BindValueChanged(_ => setInitialLifetime(), true);
+
+            HitObject.DefaultsApplied += _ => setInitialLifetime();
         }
 
         // The lifetime, as set by the hitobject.
@@ -89,8 +91,8 @@ namespace osu.Game.Rulesets.Objects
         protected virtual double InitialLifetimeOffset => 10000;
 
         /// <summary>
-        /// Resets <see cref="LifetimeEntry.LifetimeStart"/> according to the change in start time of the <see cref="HitObject"/>.
+        /// Set <see cref="LifetimeEntry.LifetimeStart"/> using <see cref="InitialLifetimeOffset"/>.
         /// </summary>
-        private void onStartTimeChanged(ValueChangedEvent<double> startTime) => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
+        private void setInitialLifetime() => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
     }
 }

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Rulesets.Objects
             startTimeBindable.BindTo(HitObject.StartTimeBindable);
             startTimeBindable.BindValueChanged(_ => setInitialLifetime(), true);
 
-            // It is important to subscribe to this event before applied to a DrawableHitObject.
-            // Otherwise DHO cannot overwrite LifetimeStart set in setInitialLifetime.
+            // Subscribe to this event before the DrawableHitObject so that the local callback is invoked before the entry is re-applied as a result of DefaultsApplied.
+            // This way, the DrawableHitObject can use OnApply() to overwrite the LifetimeStart that was set inside setInitialLifetime().
             HitObject.DefaultsApplied += _ => setInitialLifetime();
         }
 

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Rulesets.Objects
             startTimeBindable.BindTo(HitObject.StartTimeBindable);
             startTimeBindable.BindValueChanged(_ => setInitialLifetime(), true);
 
+            // It is important to subscribe to this event before applied to a DrawableHitObject.
+            // Otherwise DHO cannot overwrite LifetimeStart set in setInitialLifetime.
             HitObject.DefaultsApplied += _ => setInitialLifetime();
         }
 


### PR DESCRIPTION
- Fixes #12972
- See also: #13232

An issue of this implementation is it is relying on the event register ordering of the `DefaultsApplied` event (if `DrawableHitObject` sets `LifetimeStart` on `OnApply`).
PRing to consult if there is a better way.