### PR TITLE
Fix multiplayer tests intermittently failing on muted player check

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -289,7 +289,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             => AddAssert($"{userId} is {(state ? "paused" : "playing")}", () => getPlayer(userId).ChildrenOfType<GameplayClockContainer>().First().GameplayClock.IsRunning != state);
 
         private void assertMuted(int userId, bool muted)
-            => AddAssert($"{userId} {(muted ? "is" : "is not")} muted", () => getInstance(userId).Mute == muted);
+            => AddUntilStep($"{userId} {(muted ? "is" : "is not")} muted", () => getInstance(userId).Mute == muted);
 
         private void waitForCatchup(int userId)
             => AddUntilStep($"{userId} not catching up", () => !getInstance(userId).GameplayClock.IsCatchingUp);


### PR DESCRIPTION
Looks like this can happen on one of the initial checks, where there's no until step waiting on a catch-up state. I haven't looked into exactly which line was failing, but over multiple runs I can no longer produce the test failure (where it previously happened quite easily).