### PR TITLE
Fix bindable lease failure in editor beatmap creation tests

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -29,13 +29,17 @@ namespace osu.Game.Tests.Visual.Editing
 
         public override void SetUpSteps()
         {
-            AddStep("set dummy", () => Beatmap.Value = new DummyWorkingBeatmap(Audio, null));
-
             base.SetUpSteps();
 
             // if we save a beatmap with a hash collision, things fall over.
             // probably needs a more solid resolution in the future but this will do for now.
             AddStep("make new beatmap unique", () => EditorBeatmap.Metadata.Title = Guid.NewGuid().ToString());
+        }
+
+        protected override void LoadEditor()
+        {
+            Beatmap.Value = new DummyWorkingBeatmap(Audio, null);
+            base.LoadEditor();
         }
 
         [Test]

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -33,10 +33,15 @@ namespace osu.Game.Tests.Visual
         {
             base.SetUpSteps();
 
-            AddStep("load editor", () => LoadScreen(Editor = CreateEditor()));
+            AddStep("load editor", LoadEditor);
             AddUntilStep("wait for editor to load", () => EditorComponentsReady);
             AddStep("get beatmap", () => EditorBeatmap = Editor.ChildrenOfType<EditorBeatmap>().Single());
             AddStep("get clock", () => EditorClock = Editor.ChildrenOfType<EditorClock>().Single());
+        }
+
+        protected virtual void LoadEditor()
+        {
+            LoadScreen(Editor = CreateEditor());
         }
 
         /// <summary>


### PR DESCRIPTION
One remaining failure case which came up:

```csharp
osu.Game.Tests.Visual.Editing.TestSceneEditorBeatmapCreation.TestAddAudioTrack

TearDown : System.InvalidOperationException : Can not set value to "please load a beatmap! - no beatmaps available!" as bindable is disabled.
--TearDown
   at osu.Framework.Bindables.Bindable`1.set_Value(T value)
   at osu.Game.Tests.Visual.Editing.TestSceneEditorBeatmapCreation.<SetUpSteps>b__9_0() in /Users/dean/Projects/osu/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs:line 34
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 366
   at osu.Framework.Testing.TestScene.RunTests()
```

This is due to the "exit all screens" step being added in the same place as the next screen's load being done. I've added a new `virtual` method to allow wedging our beatmap update in between these two calls for the creation tests.