### PR TITLE
Update DHO lifetime on entry lifetime change

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -117,8 +117,12 @@ namespace osu.Game.Tests.Gameplay
             AddStep("Modify start time", () => entry.HitObject.StartTime = 100);
             AddAssert("Drawable lifetime is correct", () => dho.LifetimeStart == double.MinValue);
 
+            AddStep("Set LifetimeEnd", () => dho.LifetimeEnd = 999);
+            AddAssert("Lifetime change is blocked", () => dho.LifetimeEnd == double.MaxValue);
+
             AddStep("KeepAlive = false", () => entry.KeepAlive = false);
-            AddAssert("Drawable lifetime is restored", () => dho.LifetimeStart == 100 - TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
+            AddAssert("Drawable lifetime is restored", () =>
+                dho.LifetimeStart == 100 - TestLifetimeEntry.INITIAL_LIFETIME_OFFSET && dho.LifetimeEnd == 999);
         }
 
         private class TestDrawableHitObject : DrawableHitObject

--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -92,6 +92,35 @@ namespace osu.Game.Tests.Gameplay
             AddAssert("Lifetime is correct", () => dho.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY && entry.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY);
         }
 
+        [Test]
+        public void TestDrawableLifetimeUpdateOnEntryLifetimeChange()
+        {
+            TestDrawableHitObject dho = null;
+            TestLifetimeEntry entry = null;
+            AddStep("Create DHO", () =>
+            {
+                dho = new TestDrawableHitObject(null);
+                dho.Apply(entry = new TestLifetimeEntry(new HitObject()));
+                Child = dho;
+            });
+
+            AddStep("Set entry lifetime", () =>
+            {
+                entry.LifetimeStart = 777;
+                entry.LifetimeEnd = 888;
+            });
+            AddAssert("Drawable lifetime is updated", () => dho.LifetimeStart == 777 && dho.LifetimeEnd == 888);
+
+            AddStep("KeepAlive = true", () => entry.KeepAlive = true);
+            AddAssert("Drawable lifetime is updated", () => dho.LifetimeStart == double.MinValue && dho.LifetimeEnd == double.MaxValue);
+
+            AddStep("Modify start time", () => entry.HitObject.StartTime = 100);
+            AddAssert("Drawable lifetime is correct", () => dho.LifetimeStart == double.MinValue);
+
+            AddStep("KeepAlive = false", () => entry.KeepAlive = false);
+            AddAssert("Drawable lifetime is restored", () => dho.LifetimeStart == 100 - TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
+        }
+
         private class TestDrawableHitObject : DrawableHitObject
         {
             public const double INITIAL_LIFETIME_OFFSET = 100;

--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -117,12 +117,14 @@ namespace osu.Game.Tests.Gameplay
             AddStep("Modify start time", () => entry.HitObject.StartTime = 100);
             AddAssert("Drawable lifetime is correct", () => dho.LifetimeStart == double.MinValue);
 
+            AddStep("Set LifetimeStart", () => dho.LifetimeStart = 666);
+            AddAssert("Lifetime change is blocked", () => dho.LifetimeStart == double.MinValue);
+
             AddStep("Set LifetimeEnd", () => dho.LifetimeEnd = 999);
             AddAssert("Lifetime change is blocked", () => dho.LifetimeEnd == double.MaxValue);
 
             AddStep("KeepAlive = false", () => entry.KeepAlive = false);
-            AddAssert("Drawable lifetime is restored", () =>
-                dho.LifetimeStart == 100 - TestLifetimeEntry.INITIAL_LIFETIME_OFFSET && dho.LifetimeEnd == 999);
+            AddAssert("Drawable lifetime is restored", () => dho.LifetimeStart == 666 && dho.LifetimeEnd == 999);
         }
 
         private class TestDrawableHitObject : DrawableHitObject

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -35,11 +35,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
                 if (Entry == null && LifetimeStart != value)
                     throw new InvalidOperationException($"Cannot modify lifetime of {nameof(PoolableDrawableWithLifetime<TEntry>)} when entry is not set");
 
-                if (Entry == null) return;
-
-                // Cannot write it as `base.LifetimeStart = Entry.LifetimeStart = value` because the change may be blocked (when `HitObjectLifetimeEntry.KeepAlive` is true).
-                Entry.LifetimeStart = value;
-                base.LifetimeStart = Entry.LifetimeStart;
+                if (Entry != null)
+                    Entry.LifetimeStart = value;
             }
         }
 
@@ -51,10 +48,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
                 if (Entry == null && LifetimeEnd != value)
                     throw new InvalidOperationException($"Cannot modify lifetime of {nameof(PoolableDrawableWithLifetime<TEntry>)} when entry is not set");
 
-                if (Entry == null) return;
-
-                Entry.LifetimeEnd = value;
-                base.LifetimeEnd = Entry.LifetimeEnd;
+                if (Entry != null)
+                    Entry.LifetimeEnd = value;
             }
         }
 

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
                 // Cannot write it as `base.LifetimeStart = Entry.LifetimeStart = value` because the change may be blocked (when `HitObjectLifetimeEntry.KeepAlive` is true).
                 Entry.LifetimeStart = value;
-                base.LifetimeStart = Entry.LifetimeStart = value;
+                base.LifetimeStart = Entry.LifetimeStart;
             }
         }
 

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -37,8 +37,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
                 if (Entry == null) return;
 
-                Entry.LifetimeStart = value;
-                base.LifetimeStart = Entry.LifetimeStart;
+                base.LifetimeStart = Entry.LifetimeStart = value;
             }
         }
 
@@ -52,8 +51,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
                 if (Entry == null) return;
 
-                Entry.LifetimeEnd = value;
-                base.LifetimeEnd = Entry.LifetimeEnd;
+                base.LifetimeEnd = Entry.LifetimeEnd = value;
             }
         }
 
@@ -84,8 +82,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
                 free();
 
             Entry = entry;
-            entry.LifetimeChanged += entryLifetimeChanged;
-            setLifetimeFromEntry();
+            entry.LifetimeChanged += setLifetimeFromEntry;
+            setLifetimeFromEntry(entry);
 
             OnApply(entry);
 
@@ -121,23 +119,19 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
             OnFree(Entry);
 
-            Entry.LifetimeChanged -= entryLifetimeChanged;
+            Entry.LifetimeChanged -= setLifetimeFromEntry;
             Entry = null;
-            setLifetimeFromEntry();
+            base.LifetimeStart = double.MinValue;
+            base.LifetimeEnd = double.MaxValue;
 
             HasEntryApplied = false;
         }
 
-        private void entryLifetimeChanged(LifetimeEntry entry)
+        private void setLifetimeFromEntry(LifetimeEntry entry)
         {
             Debug.Assert(entry == Entry);
-            setLifetimeFromEntry();
-        }
-
-        private void setLifetimeFromEntry()
-        {
-            base.LifetimeStart = Entry?.LifetimeStart ?? double.MinValue;
-            base.LifetimeEnd = Entry?.LifetimeEnd ?? double.MaxValue;
+            base.LifetimeStart = entry.LifetimeStart;
+            base.LifetimeEnd = entry.LifetimeEnd;
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
                 if (Entry == null) return;
 
+                // Cannot write it as `base.LifetimeStart = Entry.LifetimeStart = value` because the change may be blocked (when `HitObjectLifetimeEntry.KeepAlive` is true).
+                Entry.LifetimeStart = value;
                 base.LifetimeStart = Entry.LifetimeStart = value;
             }
         }
@@ -51,7 +53,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
                 if (Entry == null) return;
 
-                base.LifetimeEnd = Entry.LifetimeEnd = value;
+                Entry.LifetimeEnd = value;
+                base.LifetimeEnd = Entry.LifetimeEnd;
             }
         }
 


### PR DESCRIPTION
Previously, a `DrawableHitObject`'s lifetime can get out of sync with its `HitObjectLifetimeEntry`'s lifetime if the entry lifetime is modified.
The behavior could be observed by using the drawable visualizer to watch `LifetimeStart` and `LifetimeEnd` of a DHO in an editor. The lifetime changes weirdly when the hit object is selected and moved in the timeline. I'm not sure this behavior is noticeable without the draw visualizer.
Also, the behavior was confusing when debugging.

To reset lifetime when the `ScrollingHitObjectContainer` layout changes, it needs to set the lifetime of non-alive hit objects. Without this PR, the lifetime change will be partially ignored when DHO was alive.

This implementation is different from what #12878 has reverted, and is compatible with `LifetimeManagementContainer`.
