### PR TITLE
Multiple `ScrollingHitObjectContainer` logic simplification

### DIFF
--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
             flipPositionIfRequired(ref position);
 
-            return scrollingInfo.Algorithm.TimeAt(position, Time.Current, scrollingInfo.TimeRange.Value, getLength());
+            return scrollingInfo.Algorithm.TimeAt(position, Time.Current, scrollingInfo.TimeRange.Value, scrollLength);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
         /// </summary>
         public Vector2 ScreenSpacePositionAtTime(double time)
         {
-            var pos = scrollingInfo.Algorithm.PositionAt(time, Time.Current, scrollingInfo.TimeRange.Value, getLength());
+            var pos = scrollingInfo.Algorithm.PositionAt(time, Time.Current, scrollingInfo.TimeRange.Value, scrollLength);
 
             flipPositionIfRequired(ref pos);
 
@@ -100,16 +100,19 @@ namespace osu.Game.Rulesets.UI.Scrolling
             }
         }
 
-        private float getLength()
+        private float scrollLength
         {
-            switch (scrollingInfo.Direction.Value)
+            get
             {
-                case ScrollingDirection.Left:
-                case ScrollingDirection.Right:
-                    return DrawWidth;
+                switch (scrollingInfo.Direction.Value)
+                {
+                    case ScrollingDirection.Left:
+                    case ScrollingDirection.Right:
+                        return DrawWidth;
 
-                default:
-                    return DrawHeight;
+                    default:
+                        return DrawHeight;
+                }
             }
         }
 
@@ -163,8 +166,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
             layoutComputed.Remove(hitObject);
         }
 
-        private float scrollLength;
-
         protected override void Update()
         {
             base.Update();
@@ -178,18 +179,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
             }
 
             scrollingInfo.Algorithm.Reset();
-
-            switch (direction.Value)
-            {
-                case ScrollingDirection.Up:
-                case ScrollingDirection.Down:
-                    scrollLength = DrawSize.Y;
-                    break;
-
-                default:
-                    scrollLength = DrawSize.X;
-                    break;
-            }
 
             layoutCache.Validate();
         }

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
         private readonly HashSet<DrawableHitObject> toComputeLifetime = new HashSet<DrawableHitObject>();
 
         /// <summary>
-        /// A set containing all <see cref="HitObjectContainer.AliveObjects"/> which have an up-to-date layout.
+        /// A set of top-level <see cref="DrawableHitObject"/>s which have an up-to-date layout.
         /// </summary>
         private readonly HashSet<DrawableHitObject> layoutComputed = new HashSet<DrawableHitObject>();
 
@@ -150,29 +150,18 @@ namespace osu.Game.Rulesets.UI.Scrolling
             }
         }
 
-        protected override void OnAdd(DrawableHitObject drawableHitObject) => onAddRecursive(drawableHitObject);
-
-        protected override void OnRemove(DrawableHitObject drawableHitObject) => onRemoveRecursive(drawableHitObject);
-
-        private void onAddRecursive(DrawableHitObject hitObject)
+        protected override void OnAdd(DrawableHitObject drawableHitObject)
         {
-            invalidateHitObject(hitObject);
-
-            hitObject.DefaultsApplied += invalidateHitObject;
-
-            foreach (var nested in hitObject.NestedHitObjects)
-                onAddRecursive(nested);
+            invalidateHitObject(drawableHitObject);
+            drawableHitObject.DefaultsApplied += invalidateHitObject;
         }
 
-        private void onRemoveRecursive(DrawableHitObject hitObject)
+        protected override void OnRemove(DrawableHitObject drawableHitObject)
         {
-            toComputeLifetime.Remove(hitObject);
-            layoutComputed.Remove(hitObject);
+            toComputeLifetime.Remove(drawableHitObject);
+            layoutComputed.Remove(drawableHitObject);
 
-            hitObject.DefaultsApplied -= invalidateHitObject;
-
-            foreach (var nested in hitObject.NestedHitObjects)
-                onRemoveRecursive(nested);
+            drawableHitObject.DefaultsApplied -= invalidateHitObject;
         }
 
         /// <summary>


### PR DESCRIPTION
There are more possibilities of code shrinking (simplifying `switch` statements) but I didn't include those because I want to make a separate PR that contains only syntactical (no semantical) changes.

1. Don't recurse into nested hit objects in `OnAdd` and `OnRemove`.

Only top-level hit objects were/are checked for layout computation caching.
Also, the lifetime of nested hit objects is not managed by the HitObjectContainer.

2. Remove delay of lifetime update.

Because of changes of `HitObjectContainer` (`OnAdd` timing for non-pooled DHOs), it is no longer necessary to manage a set of hit objects that needs lifetime update.

3. Merge duplicated scrolling length computation into one, removing ad-hoc caching of this value.

No noticeable performance difference.