### PR TITLE
Add background colour for inline code markdown

### DIFF
--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
@@ -14,15 +14,14 @@ namespace osu.Game.Graphics.Containers.Markdown
 {
     public class OsuMarkdownTextFlowContainer : MarkdownTextFlowContainer
     {
-        [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
-
         protected override void AddLinkText(string text, LinkInline linkInline)
             => AddDrawable(new OsuMarkdownLinkText(text, linkInline));
 
-        // TODO : Add background (colour B6) and change font to monospace
-        protected override void AddCodeInLine(CodeInline codeInline)
-            => AddText(codeInline.Content, t => { t.Colour = colourProvider.Light1; });
+        // TODO : Change font to monospace
+        protected override void AddCodeInLine(CodeInline codeInline) => AddDrawable(new OsuMarkdownInlineCode
+        {
+            Text = codeInline.Content
+        });
 
         protected override SpriteText CreateEmphasisedSpriteText(bool bold, bool italic)
             => CreateSpriteText().With(t => t.Font = t.Font.With(weight: bold ? FontWeight.Bold : FontWeight.Regular, italics: italic));

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
@@ -4,7 +4,9 @@
 using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays;
 
@@ -24,5 +26,32 @@ namespace osu.Game.Graphics.Containers.Markdown
 
         protected override SpriteText CreateEmphasisedSpriteText(bool bold, bool italic)
             => CreateSpriteText().With(t => t.Font = t.Font.With(weight: bold ? FontWeight.Bold : FontWeight.Regular, italics: italic));
+
+        private class OsuMarkdownInlineCode : Container
+        {
+            [Resolved]
+            private IMarkdownTextComponent parentTextComponent { get; set; }
+
+            public string Text;
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                AutoSizeAxes = Axes.Both;
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background6,
+                    },
+                    parentTextComponent.CreateSpriteText().With(t =>
+                    {
+                        t.Colour = colourProvider.Light1;
+                        t.Text = Text;
+                    }),
+                };
+            }
+        }
     }
 }

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Graphics.Containers.Markdown
             private void load(OverlayColourProvider colourProvider)
             {
                 AutoSizeAxes = Axes.Both;
+                CornerRadius = 4;
+                Masking = true;
                 Children = new Drawable[]
                 {
                     new Box
@@ -48,6 +50,11 @@ namespace osu.Game.Graphics.Containers.Markdown
                     {
                         t.Colour = colourProvider.Light1;
                         t.Text = Text;
+                        t.Padding = new MarginPadding
+                        {
+                            Vertical = 1,
+                            Horizontal = 4,
+                        };
                     }),
                 };
             }


### PR DESCRIPTION
Part of #13271 

Now it looks better.

![Screenshot from 2021-06-01 14-12-00](https://user-images.githubusercontent.com/4964985/120282175-0a88c680-c2e4-11eb-940f-1379bd68e3c7.png)

![Screenshot from 2021-06-01 14-17-43](https://user-images.githubusercontent.com/4964985/120282316-2ab88580-c2e4-11eb-831f-44a5ab15465d.png)
