### PR TITLE
Remove windows-only note from InspectCode section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Before committing your code, please run a code formatter. This can be achieved b
 
 We have adopted some cross-platform, compiler integrated analyzers. They can provide warnings when you are editing, building inside IDE or from command line, as-if they are provided by the compiler itself.
 
-JetBrains ReSharper InspectCode is also used for wider rule sets. You can run it from PowerShell with `.\InspectCode.ps1`, which is [only supported on Windows](https://youtrack.jetbrains.com/issue/RSRP-410004). Alternatively, you can install ReSharper or use Rider to get inline support in your IDE of choice.
+JetBrains ReSharper InspectCode is also used for wider rule sets. You can run it from PowerShell with `.\InspectCode.ps1`. Alternatively, you can install ReSharper or use Rider to get inline support in your IDE of choice.
 
 ## Contributing
 


### PR DESCRIPTION
The linked issue has been fixed (see original as that was a duplicate), and been supported for macOS and Linux for a while now since 2019.2.2.

https://github.com/ppy/osu/blob/8f1e64b606935ab163a995a4b216121cfd4c64fd/.config/dotnet-tools.json#L17-L22