### PR TITLE
Fix osu!stable directory selection failing if no `Songs` folder is present at install location

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -57,7 +57,7 @@ namespace osu.Desktop
 
         private string getStableInstallPath()
         {
-            static bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs")) || File.Exists("osu!.cfg");
+            static bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs")) || File.Exists(Path.Combine(p, "osu!.cfg"));
 
             string stableInstallPath;
 

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -57,7 +57,7 @@ namespace osu.Desktop
 
         private string getStableInstallPath()
         {
-            static bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs"));
+            static bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs")) || File.Exists("osu!.cfg");
 
             string stableInstallPath;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/13292.

As mentioned in the thread, there is a possibility that the `Songs` folder doesn't exist if the user has set a custom one in their configuration file then deleted the local one.

Testing setup:

```csharp
~/.osu/osu!.cfg <- exists
~/.osu/osu!.dean.cfg <- contains `BeatmapDirectory=/Users/Dean/.custom-osu/Songs`
// importantly, Songs folder is missing from this install

~/.custom-osu/Songs <- contains beatmaps
```