### PR TITLE
Fix iOS props Newtonsoft.Json version not matching osu.Game

### DIFF
--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -92,7 +92,7 @@
     <PackageReference Include="Humanizer" Version="2.10.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.601.0" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />


### PR DESCRIPTION
Not actually sure a lot of these are still required to be in the props file itself, but for now I'm just looking to get things working again. Tested on sim and device.