### PR TITLE
Add storyboards as a main menu background source

### DIFF
--- a/osu.Game/Configuration/BackgroundSource.cs
+++ b/osu.Game/Configuration/BackgroundSource.cs
@@ -1,11 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.ComponentModel;
+
 namespace osu.Game.Configuration
 {
     public enum BackgroundSource
     {
         Skin,
-        Beatmap
+        Beatmap,
+
+        [Description("Beatmap (with storyboard / video)")]
+        BeatmapWithStoryboard,
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
@@ -13,16 +13,21 @@ namespace osu.Game.Graphics.Backgrounds
 
         private readonly string fallbackTextureName;
 
+        [Resolved]
+        private LargeTextureStore textures { get; set; }
+
         public BeatmapBackground(WorkingBeatmap beatmap, string fallbackTextureName = @"Backgrounds/bg1")
         {
             Beatmap = beatmap;
             this.fallbackTextureName = fallbackTextureName;
         }
 
-        [BackgroundDependencyLoader]
-        private void load(LargeTextureStore textures)
+        protected override void LoadComplete()
         {
-            Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
+            base.LoadComplete();
+            Initialize();
         }
+
+        protected virtual void Initialize() => Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
@@ -13,21 +13,16 @@ namespace osu.Game.Graphics.Backgrounds
 
         private readonly string fallbackTextureName;
 
-        [Resolved]
-        private LargeTextureStore textures { get; set; }
-
         public BeatmapBackground(WorkingBeatmap beatmap, string fallbackTextureName = @"Backgrounds/bg1")
         {
             Beatmap = beatmap;
             this.fallbackTextureName = fallbackTextureName;
         }
 
-        protected override void LoadComplete()
+        [BackgroundDependencyLoader]
+        private void load(LargeTextureStore textures)
         {
-            base.LoadComplete();
-            Initialize();
+            Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
         }
-
-        protected virtual void Initialize() => Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -1,7 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Storyboards.Drawables;
@@ -15,21 +16,19 @@ namespace osu.Game.Graphics.Backgrounds
         {
         }
 
-        protected override void Initialize()
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            if (Beatmap.Storyboard.HasDrawable)
-            {
-                LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }, AddInternal);
-            }
-
-            if (Beatmap.Storyboard.ReplacesBackground || Beatmap.Storyboard.Layers.First(l => l.Name == "Video").Elements.Any())
-            {
-                Sprite.Expire();
-            }
-            else
-            {
-                base.Initialize();
-            }
+            LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard)
+                {
+                    Clock = new InterpolatingFramedClock(Beatmap.Track),
+                },
+                loaded =>
+                {
+                    AddInternal(loaded);
+                    if (Beatmap.Storyboard.ReplacesBackground)
+                        Sprite.FadeOut(300, Easing.OutQuint);
+                });
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -26,11 +26,12 @@ namespace osu.Game.Graphics.Backgrounds
             if (Beatmap.Storyboard.ReplacesBackground)
                 Sprite.Alpha = 0;
 
-            var audio = new AudioContainer { RelativeSizeAxes = Axes.Both };
-            audio.Volume.Value = 0;
-
-            AddInternal(audio);
-            LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }, audio.Add);
+            LoadComponentAsync(new AudioContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Volume = { Value = 0 },
+                Child = new DrawableStoryboard(Beatmap.Storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }
+            }, AddInternal);
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -1,8 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
+using System.Linq;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Storyboards.Drawables;
@@ -16,19 +15,21 @@ namespace osu.Game.Graphics.Backgrounds
         {
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override void Initialize()
         {
-            LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard)
-                {
-                    Clock = new InterpolatingFramedClock(Beatmap.Track),
-                },
-                loaded =>
-                {
-                    AddInternal(loaded);
-                    if (Beatmap.Storyboard.ReplacesBackground)
-                        Sprite.FadeOut(300, Easing.OutQuint);
-                });
+            if (Beatmap.Storyboard.HasDrawable)
+            {
+                LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }, AddInternal);
+            }
+
+            if (Beatmap.Storyboard.ReplacesBackground || Beatmap.Storyboard.Layers.First(l => l.Name == "Video").Elements.Any())
+            {
+                Sprite.Expire();
+            }
+            else
+            {
+                base.Initialize();
+            }
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -21,14 +21,11 @@ namespace osu.Game.Graphics.Backgrounds
         {
             LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard)
                 {
-                    Alpha = 0,
                     Clock = new InterpolatingFramedClock(Beatmap.Track),
                 },
                 loaded =>
                 {
                     AddInternal(loaded);
-                    loaded.FadeIn(300, Easing.OutQuint);
-
                     if (Beatmap.Storyboard.ReplacesBackground)
                         Sprite.FadeOut(300, Easing.OutQuint);
                 });

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -1,10 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
+using osu.Game.Storyboards;
 using osu.Game.Storyboards.Drawables;
 
 namespace osu.Game.Graphics.Backgrounds
@@ -19,16 +22,23 @@ namespace osu.Game.Graphics.Backgrounds
         [BackgroundDependencyLoader]
         private void load()
         {
-            LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard)
-                {
-                    Clock = new InterpolatingFramedClock(Beatmap.Track),
-                },
-                loaded =>
-                {
-                    AddInternal(loaded);
-                    if (Beatmap.Storyboard.ReplacesBackground)
-                        Sprite.FadeOut(300, Easing.OutQuint);
-                });
+            if (!Beatmap.Storyboard.HasDrawable)
+                return;
+
+            var storyboard = new Storyboard { BeatmapInfo = Beatmap.BeatmapInfo };
+            foreach (var layer in storyboard.Layers)
+            {
+                if (layer.Name != "Fail")
+                    layer.Elements = Beatmap.Storyboard.GetLayer(layer.Name).Elements.Where(e => !(e is StoryboardSampleInfo)).ToList();
+            }
+
+            if (storyboard.ReplacesBackground)
+            {
+                Sprite.Texture = Texture.WhitePixel;
+                Sprite.Colour = Colour4.Black;
+            }
+
+            LoadComponentAsync(new DrawableStoryboard(storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }, AddInternal);
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -11,8 +11,6 @@ namespace osu.Game.Graphics.Backgrounds
 {
     public class BeatmapBackgroundWithStoryboard : BeatmapBackground
     {
-        private DrawableStoryboard storyboard;
-
         public BeatmapBackgroundWithStoryboard(WorkingBeatmap beatmap, string fallbackTextureName = "Backgrounds/bg1")
             : base(beatmap, fallbackTextureName)
         {
@@ -21,20 +19,19 @@ namespace osu.Game.Graphics.Backgrounds
         [BackgroundDependencyLoader]
         private void load()
         {
-            var clock = new InterpolatingFramedClock(Beatmap.Track);
             LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard)
-            {
-                Alpha = 0,
-                Clock = clock,
-            },
-            loaded =>
-            {
-                AddInternal(storyboard = loaded);
-                storyboard.FadeIn(300, Easing.OutQuint);
+                {
+                    Alpha = 0,
+                    Clock = new InterpolatingFramedClock(Beatmap.Track),
+                },
+                loaded =>
+                {
+                    AddInternal(loaded);
+                    loaded.FadeIn(300, Easing.OutQuint);
 
-                if (Beatmap.Storyboard.ReplacesBackground)
-                    Sprite.FadeOut(300, Easing.OutQuint);
-            });
+                    if (Beatmap.Storyboard.ReplacesBackground)
+                        Sprite.FadeOut(300, Easing.OutQuint);
+                });
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Storyboards.Drawables;
+
+namespace osu.Game.Graphics.Backgrounds
+{
+    public class BeatmapBackgroundWithStoryboard : BeatmapBackground
+    {
+        private DrawableStoryboard storyboard;
+
+        public BeatmapBackgroundWithStoryboard(WorkingBeatmap beatmap, string fallbackTextureName = "Backgrounds/bg1")
+            : base(beatmap, fallbackTextureName)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var clock = new InterpolatingFramedClock(Beatmap.Track);
+            LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard)
+            {
+                Alpha = 0,
+                Clock = clock,
+            },
+            loaded =>
+            {
+                AddInternal(storyboard = loaded);
+                storyboard.FadeIn(300, Easing.OutQuint);
+
+                if (Beatmap.Storyboard.ReplacesBackground)
+                    Sprite.FadeOut(300, Easing.OutQuint);
+            });
+        }
+    }
+}

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
-using osu.Game.Storyboards;
 using osu.Game.Storyboards.Drawables;
 
 namespace osu.Game.Graphics.Backgrounds
@@ -22,24 +20,17 @@ namespace osu.Game.Graphics.Backgrounds
         [BackgroundDependencyLoader]
         private void load()
         {
-            var storyboard = new Storyboard { BeatmapInfo = Beatmap.BeatmapInfo };
-
-            foreach (var layer in storyboard.Layers)
-            {
-                if (layer.Name != "Fail")
-                    layer.Elements = Beatmap.Storyboard.GetLayer(layer.Name).Elements.Where(e => !(e is StoryboardSampleInfo)).ToList();
-            }
-
-            if (!storyboard.HasDrawable)
+            if (!Beatmap.Storyboard.HasDrawable)
                 return;
 
-            if (storyboard.ReplacesBackground)
-            {
-                Sprite.Texture = Texture.WhitePixel;
-                Sprite.Colour = Colour4.Black;
-            }
+            if (Beatmap.Storyboard.ReplacesBackground)
+                Sprite.Alpha = 0;
 
-            LoadComponentAsync(new DrawableStoryboard(storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }, AddInternal);
+            var audio = new AudioContainer { RelativeSizeAxes = Axes.Both };
+            audio.Volume.Value = 0;
+
+            AddInternal(audio);
+            LoadComponentAsync(new DrawableStoryboard(Beatmap.Storyboard) { Clock = new InterpolatingFramedClock(Beatmap.Track) }, audio.Add);
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackgroundWithStoryboard.cs
@@ -22,15 +22,16 @@ namespace osu.Game.Graphics.Backgrounds
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (!Beatmap.Storyboard.HasDrawable)
-                return;
-
             var storyboard = new Storyboard { BeatmapInfo = Beatmap.BeatmapInfo };
+
             foreach (var layer in storyboard.Layers)
             {
                 if (layer.Name != "Fail")
                     layer.Elements = Beatmap.Storyboard.GetLayer(layer.Name).Elements.Where(e => !(e is StoryboardSampleInfo)).ToList();
             }
+
+            if (!storyboard.HasDrawable)
+                return;
 
             if (storyboard.ReplacesBackground)
             {

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -172,6 +172,8 @@ namespace osu.Game.Graphics.Containers
 
         private class ScalingBackgroundScreen : BackgroundScreenDefault
         {
+            protected override bool AllowStoryboardBackground => false;
+
             public override void OnEntering(IScreen last)
             {
                 this.FadeInFromZero(4000, Easing.OutQuint);

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -110,6 +110,10 @@ namespace osu.Game.Screens.Backgrounds
                         newBackground = new BeatmapBackground(beatmap.Value, backgroundName);
                         break;
 
+                    case BackgroundSource.BeatmapWithStoryboard:
+                        newBackground = new BeatmapBackgroundWithStoryboard(beatmap.Value, backgroundName);
+                        break;
+
                     default:
                         newBackground = new SkinnedBackground(skin.Value, backgroundName);
                         break;

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Screens.Backgrounds
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; }
 
+        protected virtual bool AllowStoryboardBackground => true;
+
         public BackgroundScreenDefault(bool animateOnEnter = true)
             : base(animateOnEnter)
         {
@@ -111,7 +113,9 @@ namespace osu.Game.Screens.Backgrounds
                         break;
 
                     case BackgroundSource.BeatmapWithStoryboard:
-                        newBackground = new BeatmapBackgroundWithStoryboard(beatmap.Value, backgroundName);
+                        newBackground = AllowStoryboardBackground
+                            ? new BeatmapBackgroundWithStoryboard(beatmap.Value, backgroundName)
+                            : new BeatmapBackground(beatmap.Value, backgroundName);
                         break;
 
                     default:


### PR DESCRIPTION
From #13299. Adds beatmap storyboards as a main menu background option.


https://user-images.githubusercontent.com/191335/121237125-acef0e00-c8d1-11eb-8d9c-ee98ca53ada3.mov

