### PR TITLE
Factor out entry management logic of `HitObjectContainer` to the new base class

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/DrumRollHitContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumRollHitContainer.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Performance;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 
@@ -11,6 +8,11 @@ namespace osu.Game.Rulesets.Taiko.UI
 {
     internal class DrumRollHitContainer : ScrollingHitObjectContainer
     {
+        // TODO: this usage is buggy.
+        // Because `LifetimeStart` is set based on scrolling, lifetime is not same as the time when the object is created.
+        // If the `Update` override is removed, it breaks in an obscure way.
+        protected override bool RemoveRewoundEntry => true;
+
         protected override void Update()
         {
             base.Update();
@@ -22,15 +24,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                 if (Time.Current <= flyingHit.HitObject.StartTime)
                     Remove(flyingHit);
             }
-        }
-
-        protected override void OnChildLifetimeBoundaryCrossed(LifetimeBoundaryCrossedEvent e)
-        {
-            base.OnChildLifetimeBoundaryCrossed(e);
-
-            // ensure all old hits are removed on becoming alive (may miss being in the AliveInternalChildren list above).
-            if (e.Kind == LifetimeBoundaryKind.Start && e.Direction == LifetimeBoundaryCrossingDirection.Backward)
-                Remove((DrawableHitObject)e.Child);
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -1,0 +1,157 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Performance;
+
+namespace osu.Game.Rulesets.Objects.Pooling
+{
+    /// <summary>
+    /// A container of <typeparamref name="TDrawable"/>s dynamically added/removed by model <typeparamref name="TEntry"/>s.
+    /// When an entry became alive, a drawable corresponding to the entry is obtained (potentially pooled), and added to this container.
+    /// The drawable is removed when the entry became dead.
+    /// </summary>
+    /// <typeparam name="TEntry">The type of entries managed by this container.</typeparam>
+    /// <typeparam name="TDrawable">The type of drawables corresponding to the entries.</typeparam>
+    public abstract class PooledDrawableWithLifetimeContainer<TEntry, TDrawable> : CompositeDrawable
+        where TEntry : LifetimeEntry
+        where TDrawable : Drawable
+    {
+        /// <summary>
+        /// All entries added to this container, including dead entries.
+        /// </summary>
+        /// <remarks>
+        /// The enumeration order is undefined.
+        /// </remarks>
+        public IEnumerable<TEntry> Entries => allEntries;
+
+        /// <summary>
+        /// All alive entries and drawables corresponding to the entries.
+        /// </summary>
+        /// <remarks>
+        /// The enumeration order is undefined.
+        /// </remarks>
+        public IEnumerable<(TEntry Entry, TDrawable Drawable)> AliveEntries => aliveDrawableMap.Select(x => (x.Key, x.Value));
+
+        /// <summary>
+        /// The amount of time prior to the current time within which entries should be considered alive.
+        /// </summary>
+        internal double PastLifetimeExtension { get; set; }
+
+        /// <summary>
+        /// The amount of time after the current time within which entries should be considered alive.
+        /// </summary>
+        internal double FutureLifetimeExtension { get; set; }
+
+        private readonly Dictionary<TEntry, TDrawable> aliveDrawableMap = new Dictionary<TEntry, TDrawable>();
+        private readonly HashSet<TEntry> allEntries = new HashSet<TEntry>();
+
+        private readonly LifetimeEntryManager lifetimeManager = new LifetimeEntryManager();
+
+        protected PooledDrawableWithLifetimeContainer()
+        {
+            lifetimeManager.EntryBecameAlive += entryBecameAlive;
+            lifetimeManager.EntryBecameDead += entryBecameDead;
+            lifetimeManager.EntryCrossedBoundary += entryCrossedBoundary;
+        }
+
+        /// <summary>
+        /// Add a <typeparamref name="TEntry"/> to be managed by this container.
+        /// </summary>
+        /// <remarks>
+        /// The aliveness of the entry is not updated until <see cref="CheckChildrenLife"/>.
+        /// </remarks>
+        public virtual void Add(TEntry entry)
+        {
+            allEntries.Add(entry);
+            lifetimeManager.AddEntry(entry);
+        }
+
+        /// <summary>
+        /// Remove a <typeparamref name="TEntry"/> from this container.
+        /// </summary>
+        /// <remarks>
+        /// If the entry was alive, the corresponding drawable is removed.
+        /// </remarks>
+        /// <returns>Whether the entry was in this container.</returns>
+        public virtual bool Remove(TEntry entry)
+        {
+            if (!lifetimeManager.RemoveEntry(entry)) return false;
+
+            allEntries.Remove(entry);
+            return true;
+        }
+
+        /// <summary>
+        /// Initialize new <typeparamref name="TDrawable"/> corresponding <paramref name="entry"/>.
+        /// </summary>
+        /// <returns>The <typeparamref name="TDrawable"/> corresponding to the entry.</returns>
+        protected abstract TDrawable GetDrawable(TEntry entry);
+
+        private void entryBecameAlive(LifetimeEntry lifetimeEntry)
+        {
+            var entry = (TEntry)lifetimeEntry;
+            Debug.Assert(!aliveDrawableMap.ContainsKey(entry));
+
+            TDrawable drawable = GetDrawable(entry);
+            aliveDrawableMap[entry] = drawable;
+            AddDrawable(entry, drawable);
+        }
+
+        /// <summary>
+        /// Add a <typeparamref name="TDrawable"/> corresponding to <paramref name="entry"/> to this container.
+        /// </summary>
+        /// <remarks>
+        /// Invoked when the entry became alive and a <typeparamref name="TDrawable"/> is obtained by <see cref="GetDrawable"/>.
+        /// </remarks>
+        protected virtual void AddDrawable(TEntry entry, TDrawable drawable) => AddInternal(drawable);
+
+        private void entryBecameDead(LifetimeEntry lifetimeEntry)
+        {
+            var entry = (TEntry)lifetimeEntry;
+            Debug.Assert(aliveDrawableMap.ContainsKey(entry));
+
+            TDrawable drawable = aliveDrawableMap[entry];
+            aliveDrawableMap.Remove(entry);
+            RemoveDrawable(entry, drawable);
+        }
+
+        /// <summary>
+        /// Remove a <typeparamref name="TDrawable"/> corresponding to <paramref name="entry"/> from this container.
+        /// </summary>
+        /// <remarks>
+        /// Invoked when the entry became dead.
+        /// </remarks>
+        protected virtual void RemoveDrawable(TEntry entry, TDrawable drawable) => RemoveInternal(drawable);
+
+        private void entryCrossedBoundary(LifetimeEntry lifetimeEntry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction) =>
+            OnEntryCrossedBoundary((TEntry)lifetimeEntry, kind, direction);
+
+        protected virtual void OnEntryCrossedBoundary(TEntry entry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
+        {
+        }
+
+        /// <summary>
+        /// Remove all <typeparamref name="TEntry"/>s.
+        /// </summary>
+        public virtual void Clear()
+        {
+            foreach (var entry in Entries.ToArray())
+                Remove(entry);
+            Debug.Assert(aliveDrawableMap.Count == 0);
+        }
+
+        protected override bool CheckChildrenLife()
+        {
+            bool aliveChanged = base.CheckChildrenLife();
+            aliveChanged |= lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
+            return aliveChanged;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -145,10 +145,11 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// <summary>
         /// Remove all <typeparamref name="TEntry"/>s.
         /// </summary>
-        public virtual void Clear()
+        public void Clear()
         {
             foreach (var entry in Entries.ToArray())
                 Remove(entry);
+
             Debug.Assert(aliveDrawableMap.Count == 0);
         }
 

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -40,6 +40,12 @@ namespace osu.Game.Rulesets.Objects.Pooling
         public IEnumerable<(TEntry Entry, TDrawable Drawable)> AliveEntries => aliveDrawableMap.Select(x => (x.Key, x.Value));
 
         /// <summary>
+        /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntry.LifetimeStart"/>.
+        /// Used when entries are dynamically added at its <see cref="LifetimeEntry.LifetimeStart"/> to prevent duplicated entries.
+        /// </summary>
+        protected virtual bool RemoveRewoundEntry => false;
+
+        /// <summary>
         /// The amount of time prior to the current time within which entries should be considered alive.
         /// </summary>
         internal double PastLifetimeExtension { get; set; }
@@ -130,11 +136,10 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </remarks>
         protected virtual void RemoveDrawable(TEntry entry, TDrawable drawable) => RemoveInternal(drawable);
 
-        private void entryCrossedBoundary(LifetimeEntry lifetimeEntry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction) =>
-            OnEntryCrossedBoundary((TEntry)lifetimeEntry, kind, direction);
-
-        protected virtual void OnEntryCrossedBoundary(TEntry entry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
+        private void entryCrossedBoundary(LifetimeEntry lifetimeEntry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
         {
+            if (RemoveRewoundEntry && kind == LifetimeBoundaryKind.Start && direction == LifetimeBoundaryCrossingDirection.Backward)
+                Remove((TEntry)lifetimeEntry);
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -92,26 +91,19 @@ namespace osu.Game.Rulesets.UI
 
         protected override void AddDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
         {
-            if (!nonPooledDrawableMap.ContainsKey(entry))
-            {
-                addDrawable(drawable);
-                HitObjectUsageBegan?.Invoke(entry.HitObject);
-            }
+            if (nonPooledDrawableMap.ContainsKey(entry)) return;
 
-            OnAdd(drawable);
+            addDrawable(drawable);
+            HitObjectUsageBegan?.Invoke(entry.HitObject);
         }
 
         protected override void RemoveDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
         {
             drawable.OnKilled();
+            if (nonPooledDrawableMap.ContainsKey(entry)) return;
 
-            if (!nonPooledDrawableMap.ContainsKey(entry))
-            {
-                removeDrawable(drawable);
-                HitObjectUsageFinished?.Invoke(entry.HitObject);
-            }
-
-            OnRemove(drawable);
+            removeDrawable(drawable);
+            HitObjectUsageFinished?.Invoke(entry.HitObject);
         }
 
         private void addDrawable(DrawableHitObject drawable)
@@ -158,21 +150,6 @@ namespace osu.Game.Rulesets.UI
         public int IndexOf(DrawableHitObject hitObject) => IndexOfInternal(hitObject);
 
         #endregion
-
-        /// <summary>
-        /// Invoked after a <see cref="DrawableHitObject"/> is added to this container.
-        /// </summary>
-        protected virtual void OnAdd(DrawableHitObject drawableHitObject)
-        {
-            Debug.Assert(drawableHitObject.LoadState >= LoadState.Ready);
-        }
-
-        /// <summary>
-        /// Invoked after a <see cref="DrawableHitObject"/> is removed from this container.
-        /// </summary>
-        protected virtual void OnRemove(DrawableHitObject drawableHitObject)
-        {
-        }
 
         private void onNewResult(DrawableHitObject d, JudgementResult r) => NewResult?.Invoke(d, r);
         private void onRevertResult(DrawableHitObject d, JudgementResult r) => RevertResult?.Invoke(d, r);

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -9,8 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -158,16 +156,6 @@ namespace osu.Game.Rulesets.UI
         }
 
         public int IndexOf(DrawableHitObject hitObject) => IndexOfInternal(hitObject);
-
-        protected override void OnEntryCrossedBoundary(HitObjectLifetimeEntry entry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
-        {
-            if (nonPooledDrawableMap.TryGetValue(entry, out var drawable))
-                OnChildLifetimeBoundaryCrossed(new LifetimeBoundaryCrossedEvent(drawable, kind, direction));
-        }
-
-        protected virtual void OnChildLifetimeBoundaryCrossed(LifetimeBoundaryCrossedEvent e)
-        {
-        }
 
         #endregion
 

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -14,24 +14,15 @@ using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Pooling;
 
 namespace osu.Game.Rulesets.UI
 {
-    public class HitObjectContainer : CompositeDrawable, IHitObjectContainer
+    public class HitObjectContainer : PooledDrawableWithLifetimeContainer<HitObjectLifetimeEntry, DrawableHitObject>, IHitObjectContainer
     {
-        /// <summary>
-        /// All entries in this <see cref="HitObjectContainer"/> including dead entries.
-        /// </summary>
-        public IEnumerable<HitObjectLifetimeEntry> Entries => allEntries;
-
-        /// <summary>
-        /// All alive entries and <see cref="DrawableHitObject"/>s used by the entries.
-        /// </summary>
-        public IEnumerable<(HitObjectLifetimeEntry Entry, DrawableHitObject Drawable)> AliveEntries => aliveDrawableMap.Select(x => (x.Key, x.Value));
-
         public IEnumerable<DrawableHitObject> Objects => InternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
 
-        public IEnumerable<DrawableHitObject> AliveObjects => AliveInternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
+        public IEnumerable<DrawableHitObject> AliveObjects => AliveEntries.Select(pair => pair.Drawable).OrderBy(h => h.HitObject.StartTime);
 
         /// <summary>
         /// Invoked when a <see cref="DrawableHitObject"/> is judged.
@@ -59,23 +50,9 @@ namespace osu.Game.Rulesets.UI
         /// </remarks>
         internal event Action<HitObject> HitObjectUsageFinished;
 
-        /// <summary>
-        /// The amount of time prior to the current time within which <see cref="HitObject"/>s should be considered alive.
-        /// </summary>
-        internal double PastLifetimeExtension { get; set; }
-
-        /// <summary>
-        /// The amount of time after the current time within which <see cref="HitObject"/>s should be considered alive.
-        /// </summary>
-        internal double FutureLifetimeExtension { get; set; }
-
         private readonly Dictionary<DrawableHitObject, IBindable> startTimeMap = new Dictionary<DrawableHitObject, IBindable>();
 
-        private readonly Dictionary<HitObjectLifetimeEntry, DrawableHitObject> aliveDrawableMap = new Dictionary<HitObjectLifetimeEntry, DrawableHitObject>();
         private readonly Dictionary<HitObjectLifetimeEntry, DrawableHitObject> nonPooledDrawableMap = new Dictionary<HitObjectLifetimeEntry, DrawableHitObject>();
-
-        private readonly LifetimeEntryManager lifetimeManager = new LifetimeEntryManager();
-        private readonly HashSet<HitObjectLifetimeEntry> allEntries = new HashSet<HitObjectLifetimeEntry>();
 
         [Resolved(CanBeNull = true)]
         private IPooledHitObjectProvider pooledObjectProvider { get; set; }
@@ -83,10 +60,6 @@ namespace osu.Game.Rulesets.UI
         public HitObjectContainer()
         {
             RelativeSizeAxes = Axes.Both;
-
-            lifetimeManager.EntryBecameAlive += entryBecameAlive;
-            lifetimeManager.EntryBecameDead += entryBecameDead;
-            lifetimeManager.EntryCrossedBoundary += entryCrossedBoundary;
         }
 
         protected override void LoadAsyncComplete()
@@ -99,37 +72,29 @@ namespace osu.Game.Rulesets.UI
 
         #region Pooling support
 
-        public void Add(HitObjectLifetimeEntry entry)
+        public override bool Remove(HitObjectLifetimeEntry entry)
         {
-            allEntries.Add(entry);
-            lifetimeManager.AddEntry(entry);
-        }
-
-        public bool Remove(HitObjectLifetimeEntry entry)
-        {
-            if (!lifetimeManager.RemoveEntry(entry)) return false;
+            if (!base.Remove(entry)) return false;
 
             // This logic is not in `Remove(DrawableHitObject)` because a non-pooled drawable may be removed by specifying its entry.
             if (nonPooledDrawableMap.Remove(entry, out var drawable))
                 removeDrawable(drawable);
 
-            allEntries.Remove(entry);
             return true;
         }
 
-        private void entryBecameAlive(LifetimeEntry lifetimeEntry)
+        protected sealed override DrawableHitObject GetDrawable(HitObjectLifetimeEntry entry)
         {
-            var entry = (HitObjectLifetimeEntry)lifetimeEntry;
-            Debug.Assert(!aliveDrawableMap.ContainsKey(entry));
+            if (nonPooledDrawableMap.TryGetValue(entry, out var drawable))
+                return drawable;
 
-            bool isPooled = !nonPooledDrawableMap.TryGetValue(entry, out var drawable);
-            drawable ??= pooledObjectProvider?.GetPooledDrawableRepresentation(entry.HitObject, null);
-            if (drawable == null)
-                throw new InvalidOperationException($"A drawable representation could not be retrieved for hitobject type: {entry.HitObject.GetType().ReadableName()}.");
+            return pooledObjectProvider?.GetPooledDrawableRepresentation(entry.HitObject, null) ??
+                   throw new InvalidOperationException($"A drawable representation could not be retrieved for hitobject type: {entry.HitObject.GetType().ReadableName()}.");
+        }
 
-            aliveDrawableMap[entry] = drawable;
-
-            if (isPooled)
+        protected override void AddDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
+        {
+            if (!nonPooledDrawableMap.ContainsKey(entry))
             {
                 addDrawable(drawable);
                 HitObjectUsageBegan?.Invoke(entry.HitObject);
@@ -138,18 +103,11 @@ namespace osu.Game.Rulesets.UI
             OnAdd(drawable);
         }
 
-        private void entryBecameDead(LifetimeEntry lifetimeEntry)
+        protected override void RemoveDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
         {
-            var entry = (HitObjectLifetimeEntry)lifetimeEntry;
-            Debug.Assert(aliveDrawableMap.ContainsKey(entry));
-
-            var drawable = aliveDrawableMap[entry];
-            bool isPooled = !nonPooledDrawableMap.ContainsKey(entry);
-
             drawable.OnKilled();
-            aliveDrawableMap.Remove(entry);
 
-            if (isPooled)
+            if (!nonPooledDrawableMap.ContainsKey(entry))
             {
                 removeDrawable(drawable);
                 HitObjectUsageFinished?.Invoke(entry.HitObject);
@@ -201,9 +159,9 @@ namespace osu.Game.Rulesets.UI
 
         public int IndexOf(DrawableHitObject hitObject) => IndexOfInternal(hitObject);
 
-        private void entryCrossedBoundary(LifetimeEntry entry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
+        protected override void OnEntryCrossedBoundary(HitObjectLifetimeEntry entry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
         {
-            if (nonPooledDrawableMap.TryGetValue((HitObjectLifetimeEntry)entry, out var drawable))
+            if (nonPooledDrawableMap.TryGetValue(entry, out var drawable))
                 OnChildLifetimeBoundaryCrossed(new LifetimeBoundaryCrossedEvent(drawable, kind, direction));
         }
 
@@ -226,22 +184,6 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         protected virtual void OnRemove(DrawableHitObject drawableHitObject)
         {
-        }
-
-        public virtual void Clear()
-        {
-            lifetimeManager.ClearEntries();
-            foreach (var drawable in nonPooledDrawableMap.Values)
-                removeDrawable(drawable);
-            nonPooledDrawableMap.Clear();
-            Debug.Assert(InternalChildren.Count == 0 && startTimeMap.Count == 0 && aliveDrawableMap.Count == 0, "All hit objects should have been removed");
-        }
-
-        protected override bool CheckChildrenLife()
-        {
-            bool aliveChanged = base.CheckChildrenLife();
-            aliveChanged |= lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
-            return aliveChanged;
         }
 
         private void onNewResult(DrawableHitObject d, JudgementResult r) => NewResult?.Invoke(d, r);

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK;
@@ -140,17 +142,20 @@ namespace osu.Game.Rulesets.UI.Scrolling
             }
         }
 
-        protected override void OnAdd(DrawableHitObject drawableHitObject)
+        protected override void AddDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
         {
-            invalidateHitObject(drawableHitObject);
-            drawableHitObject.DefaultsApplied += invalidateHitObject;
+            base.AddDrawable(entry, drawable);
+
+            invalidateHitObject(drawable);
+            drawable.DefaultsApplied += invalidateHitObject;
         }
 
-        protected override void OnRemove(DrawableHitObject drawableHitObject)
+        protected override void RemoveDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
         {
-            layoutComputed.Remove(drawableHitObject);
+            base.RemoveDrawable(entry, drawable);
 
-            drawableHitObject.DefaultsApplied -= invalidateHitObject;
+            drawable.DefaultsApplied -= invalidateHitObject;
+            layoutComputed.Remove(drawable);
         }
 
         private void invalidateHitObject(DrawableHitObject hitObject)
@@ -199,6 +204,9 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
         private double computeOriginAdjustedLifetimeStart(DrawableHitObject hitObject)
         {
+            // Origin position may be relative to the parent size
+            Debug.Assert(hitObject.Parent != null);
+
             float originAdjustment = 0.0f;
 
             // calculate the dimension of the part of the hitobject that should already be visible

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -45,13 +45,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
             timeRange.ValueChanged += _ => layoutCache.Invalidate();
         }
 
-        public override void Clear()
-        {
-            base.Clear();
-
-            layoutComputed.Clear();
-        }
-
         /// <summary>
         /// Given a position in screen space, return the time within this column.
         /// </summary>


### PR DESCRIPTION
For motivation, see #12500.
That is, this lifetime management logic can be used to manage gameplay effects that is not exactly corresponding to a "hit obejct", such as hit explosion or bar lines.

Breaking changes are:

- `OnAdd`, `OnRemove`, and `Clear` overriding of `HitObjectContainer`. Those methods are added only for `ScrollingHitObjectContainer` in the ad-hoc way, and not really used by rulesets.
- `EntryCrossedBoundary`: already broken by pooling. The only usage in taiko was also broken in another way. New `RemoveRewoundEntry` convers the most useful usage.