### PR TITLE
Increase music volume back to 80% for the time being

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -58,7 +58,7 @@ namespace osu.Game
         /// <summary>
         /// The maximum volume at which audio tracks should playback. This can be set lower than 1 to create some head-room for sound effects.
         /// </summary>
-        internal const double GLOBAL_TRACK_VOLUME_ADJUST = 0.5;
+        internal const double GLOBAL_TRACK_VOLUME_ADJUST = 0.8;
 
         public bool UseDevelopmentServer { get; }
 


### PR DESCRIPTION
Until we get the `BassMix` changes in and reconsider volume normalisation this should be a more user-friendly value.