### PR TITLE
Use general lifetime container for follow point container 

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Pooling;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
@@ -12,37 +13,30 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
     /// <summary>
     /// Visualises the <see cref="FollowPoint"/>s between two <see cref="DrawableOsuHitObject"/>s.
     /// </summary>
-    public class FollowPointConnection : PoolableDrawable
+    public class FollowPointConnection : PoolableDrawableWithLifetime<FollowPointLifetimeEntry>
     {
         // Todo: These shouldn't be constants
         public const int SPACING = 32;
         public const double PREEMPT = 800;
 
-        public FollowPointLifetimeEntry Entry;
         public DrawablePool<FollowPoint> Pool;
 
-        protected override void PrepareForUse()
+        protected override void OnApply(FollowPointLifetimeEntry entry)
         {
-            base.PrepareForUse();
+            base.OnApply(entry);
 
-            Entry.Invalidated += onEntryInvalidated;
-
+            entry.Invalidated += refreshPoints;
             refreshPoints();
         }
 
-        protected override void FreeAfterUse()
+        protected override void OnFree(FollowPointLifetimeEntry entry)
         {
-            base.FreeAfterUse();
+            base.OnFree(entry);
 
-            Entry.Invalidated -= onEntryInvalidated;
-
+            entry.Invalidated -= refreshPoints;
             // Return points to the pool.
             ClearInternal(false);
-
-            Entry = null;
         }
-
-        private void onEntryInvalidated() => Scheduler.AddOnce(refreshPoints);
 
         private void refreshPoints()
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
@@ -26,26 +25,30 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         {
             base.OnApply(entry);
 
-            entry.Invalidated += refreshPoints;
-            refreshPoints(entry);
+            entry.Invalidated += onEntryInvalidated;
+            refreshPoints();
         }
 
         protected override void OnFree(FollowPointLifetimeEntry entry)
         {
             base.OnFree(entry);
 
-            entry.Invalidated -= refreshPoints;
+            entry.Invalidated -= onEntryInvalidated;
             // Return points to the pool.
             ClearInternal(false);
         }
 
-        private void refreshPoints(FollowPointLifetimeEntry entry)
+        private void onEntryInvalidated() => Scheduler.AddOnce(refreshPoints);
+
+        private void refreshPoints()
         {
             ClearInternal(false);
 
+            var entry = Entry;
+            if (entry?.End == null) return;
+
             OsuHitObject start = entry.Start;
             OsuHitObject end = entry.End;
-            Debug.Assert(end != null, $"{nameof(FollowPointLifetimeEntry)} without end hit object should never be alive");
 
             double startTime = start.GetEndTime();
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             base.OnApply(entry);
 
             entry.Invalidated += refreshPoints;
-            refreshPoints();
+            refreshPoints(entry);
         }
 
         protected override void OnFree(FollowPointLifetimeEntry entry)
@@ -38,12 +39,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             ClearInternal(false);
         }
 
-        private void refreshPoints()
+        private void refreshPoints(FollowPointLifetimeEntry entry)
         {
             ClearInternal(false);
 
-            OsuHitObject start = Entry.Start;
-            OsuHitObject end = Entry.End;
+            OsuHitObject start = entry.Start;
+            OsuHitObject end = entry.End;
+            Debug.Assert(end != null, $"{nameof(FollowPointLifetimeEntry)} without end hit object should never be alive");
 
             double startTime = start.GetEndTime();
 
@@ -88,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             }
 
             // todo: use Expire() on FollowPoints and take lifetime from them when https://github.com/ppy/osu-framework/issues/3300 is fixed.
-            Entry.LifetimeEnd = finalTransformEndTime;
+            entry.LifetimeEnd = finalTransformEndTime;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -83,13 +83,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                     fp.FadeIn(end.TimeFadeIn);
                     fp.ScaleTo(end.Scale, end.TimeFadeIn, Easing.Out);
                     fp.MoveTo(pointEndPosition, end.TimeFadeIn, Easing.Out);
-                    fp.Delay(fadeOutTime - fadeInTime).FadeOut(end.TimeFadeIn);
+                    fp.Delay(fadeOutTime - fadeInTime).FadeOut(end.TimeFadeIn).Expire();
 
-                    finalTransformEndTime = fadeOutTime + end.TimeFadeIn;
+                    finalTransformEndTime = fp.LifetimeEnd;
                 }
             }
 
-            // todo: use Expire() on FollowPoints and take lifetime from them when https://github.com/ppy/osu-framework/issues/3300 is fixed.
             entry.LifetimeEnd = finalTransformEndTime;
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
@@ -11,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
     public class FollowPointLifetimeEntry : LifetimeEntry
     {
-        public event Action Invalidated;
+        public event Action<FollowPointLifetimeEntry>? Invalidated;
         public readonly OsuHitObject Start;
 
         public FollowPointLifetimeEntry(OsuHitObject start)
@@ -22,9 +24,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             bindEvents();
         }
 
-        private OsuHitObject end;
+        private OsuHitObject? end;
 
-        public OsuHitObject End
+        public OsuHitObject? End
         {
             get => end;
             set
@@ -56,11 +58,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
         public void UnbindEvents()
         {
-            if (Start != null)
-            {
-                Start.DefaultsApplied -= onDefaultsApplied;
-                Start.PositionBindable.ValueChanged -= onPositionChanged;
-            }
+            Start.DefaultsApplied -= onDefaultsApplied;
+            Start.PositionBindable.ValueChanged -= onPositionChanged;
 
             if (End != null)
             {
@@ -92,7 +91,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             LifetimeStart = fadeInTime;
             LifetimeEnd = double.MaxValue; // This will be set by the connection.
 
-            Invalidated?.Invoke();
+            Invalidated?.Invoke(this);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
     public class FollowPointLifetimeEntry : LifetimeEntry
     {
-        public event Action<FollowPointLifetimeEntry>? Invalidated;
+        public event Action? Invalidated;
         public readonly OsuHitObject Start;
 
         public FollowPointLifetimeEntry(OsuHitObject start)
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             LifetimeStart = fadeInTime;
             LifetimeEnd = double.MaxValue; // This will be set by the connection.
 
-            Invalidated?.Invoke(this);
+            Invalidated?.Invoke();
         }
     }
 }


### PR DESCRIPTION
Uses the class introduced in #13313.

- Some code removal is unrelated to the base class change. The code could be removed after started using `DrawablePool`.
- `#nullable enable` on the base class file causing "`Entry` can be null" inspection even though the file of the derived class has not enabled nullable. It is not too bad but something to consider when enabling nullable.
- The scheduling was potentially unsafe (entry can be freed in that frame) so I added a guard.