### PR TITLE
Fix catch hit lighting not always showing when a replay is rewound

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -216,7 +216,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddStep("enable hit lighting", () => config.SetValue(OsuSetting.HitLighting, true));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             AddAssert("correct hit lighting colour", () =>
-                catcher.ChildrenOfType<HitExplosion>().First()?.ObjectColour == fruitColour);
+                catcher.ChildrenOfType<HitExplosion>().First()?.Entry?.ObjectColour == fruitColour);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -506,7 +506,7 @@ namespace osu.Game.Rulesets.Catch.UI
         }
 
         private void addLighting(CatchHitObject hitObject, float x, Color4 colour) =>
-            hitExplosionContainer.Add(new HitExplosionEntry(Time.Current, x, hitObject.Scale, colour));
+            hitExplosionContainer.Add(new HitExplosionEntry(Time.Current, x, hitObject.Scale, colour, hitObject.RandomSeed));
 
         private CaughtObject getCaughtObject(PalpableCatchHitObject source)
         {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -126,8 +126,7 @@ namespace osu.Game.Rulesets.Catch.UI
         private float hyperDashTargetPosition;
         private Bindable<bool> hitLighting;
 
-        private readonly DrawablePool<HitExplosion> hitExplosionPool;
-        private readonly Container<HitExplosion> hitExplosionContainer;
+        private readonly HitExplosionContainer hitExplosionContainer;
 
         private readonly DrawablePool<CaughtFruit> caughtFruitPool;
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
@@ -148,7 +147,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
             InternalChildren = new Drawable[]
             {
-                hitExplosionPool = new DrawablePool<HitExplosion>(10),
                 caughtFruitPool = new DrawablePool<CaughtFruit>(50),
                 caughtBananaPool = new DrawablePool<CaughtBanana>(100),
                 // less capacity is needed compared to fruit because droplet is not stacked
@@ -173,7 +171,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Anchor = Anchor.TopCentre,
                     Alpha = 0,
                 },
-                hitExplosionContainer = new Container<HitExplosion>
+                hitExplosionContainer = new HitExplosionContainer
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.BottomCentre,
@@ -297,7 +295,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
             caughtObjectContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
             droppedObjectTarget.RemoveAll(d => d.HitObject == drawableObject.HitObject);
-            hitExplosionContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
         }
 
         /// <summary>
@@ -508,15 +505,8 @@ namespace osu.Game.Rulesets.Catch.UI
             return position;
         }
 
-        private void addLighting(CatchHitObject hitObject, float x, Color4 colour)
-        {
-            HitExplosion hitExplosion = hitExplosionPool.Get();
-            hitExplosion.HitObject = hitObject;
-            hitExplosion.X = x;
-            hitExplosion.Scale = new Vector2(hitObject.Scale);
-            hitExplosion.ObjectColour = colour;
-            hitExplosionContainer.Add(hitExplosion);
-        }
+        private void addLighting(CatchHitObject hitObject, float x, Color4 colour) =>
+            hitExplosionContainer.Add(new HitExplosionEntry(Time.Current, x, hitObject.Scale, colour));
 
         private CaughtObject getCaughtObject(PalpableCatchHitObject source)
         {

--- a/osu.Game.Rulesets.Catch/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosion.cs
@@ -5,31 +5,15 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
-using osu.Framework.Graphics.Pooling;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects.Pooling;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class HitExplosion : PoolableDrawable
+    public class HitExplosion : PoolableDrawableWithLifetime<HitExplosionEntry>
     {
-        private Color4 objectColour;
-        public CatchHitObject HitObject;
-
-        public Color4 ObjectColour
-        {
-            get => objectColour;
-            set
-            {
-                if (objectColour == value) return;
-
-                objectColour = value;
-                onColourChanged();
-            }
-        }
-
         private readonly CircularContainer largeFaint;
         private readonly CircularContainer smallFaint;
         private readonly CircularContainer directionalGlow1;
@@ -83,9 +67,19 @@ namespace osu.Game.Rulesets.Catch.UI
             };
         }
 
-        protected override void PrepareForUse()
+        protected override void OnApply(HitExplosionEntry entry)
         {
-            base.PrepareForUse();
+            X = entry.Position;
+            Scale = new Vector2(entry.Scale);
+            setColour(entry.ObjectColour);
+
+            using (BeginAbsoluteSequence(entry.LifetimeStart))
+                applyTransforms();
+        }
+
+        private void applyTransforms()
+        {
+            ClearTransforms(true);
 
             const double duration = 400;
 
@@ -99,11 +93,10 @@ namespace osu.Game.Rulesets.Catch.UI
             directionalGlow1.Rotation = RNG.NextSingle(-angle_variangle, angle_variangle);
             directionalGlow2.Rotation = RNG.NextSingle(-angle_variangle, angle_variangle);
 
-            this.FadeInFromZero(50).Then().FadeOut(duration, Easing.Out);
-            Expire(true);
+            this.FadeInFromZero(50).Then().FadeOut(duration, Easing.Out).Expire();
         }
 
-        private void onColourChanged()
+        private void setColour(Color4 objectColour)
         {
             const float roundness = 100;
 

--- a/osu.Game.Rulesets.Catch/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosion.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Pooling;
+using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -74,10 +75,10 @@ namespace osu.Game.Rulesets.Catch.UI
             setColour(entry.ObjectColour);
 
             using (BeginAbsoluteSequence(entry.LifetimeStart))
-                applyTransforms();
+                applyTransforms(entry.RNGSeed);
         }
 
-        private void applyTransforms()
+        private void applyTransforms(int randomSeed)
         {
             ClearTransforms(true);
 
@@ -90,8 +91,8 @@ namespace osu.Game.Rulesets.Catch.UI
                 .FadeOut(duration * 2);
 
             const float angle_variangle = 15; // should be less than 45
-            directionalGlow1.Rotation = RNG.NextSingle(-angle_variangle, angle_variangle);
-            directionalGlow2.Rotation = RNG.NextSingle(-angle_variangle, angle_variangle);
+            directionalGlow1.Rotation = StatelessRNG.NextSingle(-angle_variangle, angle_variangle, randomSeed, 4);
+            directionalGlow2.Rotation = StatelessRNG.NextSingle(-angle_variangle, angle_variangle, randomSeed, 5);
 
             this.FadeInFromZero(50).Then().FadeOut(duration, Easing.Out).Expire();
         }

--- a/osu.Game.Rulesets.Catch/UI/HitExplosionContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosionContainer.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Objects.Pooling;
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    public class HitExplosionContainer : PooledDrawableWithLifetimeContainer<HitExplosionEntry, HitExplosion>
+    {
+        protected override bool RemoveRewoundEntry => true;
+
+        private readonly DrawablePool<HitExplosion> pool;
+
+        public HitExplosionContainer()
+        {
+            AddInternal(pool = new DrawablePool<HitExplosion>(10));
+        }
+
+        protected override HitExplosion GetDrawable(HitExplosionEntry entry) => pool.Get(d => d.Apply(entry));
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Performance;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    public class HitExplosionEntry : LifetimeEntry
+    {
+        public readonly float Position;
+        public readonly float Scale;
+        public readonly Color4 ObjectColour;
+
+        public HitExplosionEntry(double startTime, float position, float scale, Color4 objectColour)
+        {
+            LifetimeStart = startTime;
+            Position = position;
+            Scale = scale;
+            ObjectColour = objectColour;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
@@ -11,13 +11,15 @@ namespace osu.Game.Rulesets.Catch.UI
         public readonly float Position;
         public readonly float Scale;
         public readonly Color4 ObjectColour;
+        public readonly int RNGSeed;
 
-        public HitExplosionEntry(double startTime, float position, float scale, Color4 objectColour)
+        public HitExplosionEntry(double startTime, float position, float scale, Color4 objectColour, int rngSeed)
         {
             LifetimeStart = startTime;
             Position = position;
             Scale = scale;
             ObjectColour = objectColour;
+            RNGSeed = rngSeed;
         }
     }
 }

--- a/osu.Game/Utils/StatelessRNG.cs
+++ b/osu.Game/Utils/StatelessRNG.cs
@@ -75,5 +75,10 @@ namespace osu.Game.Utils
         /// </param>
         public static float NextSingle(int seed, int series = 0) =>
             (float)(NextULong(seed, series) & ((1 << 24) - 1)) / (1 << 24); // float has 24-bit precision
+
+        /// <summary>
+        /// Compute a random floating point value between <paramref name="min"/> and <paramref name="max"/> from given seed and series number.
+        /// </summary>
+        public static float NextSingle(float min, float max, int seed, int series = 0) => min + NextSingle(seed, series) * (max - min);
     }
 }


### PR DESCRIPTION
When a replay is rewound to time to just after a hit object is caught, the hit lightning was not rendered.
This PR fixes that issue by maintaining catch hit lighting (`HitExplosion` in code) by lifetime entries.

Additionally, I made `HitExplosion` to use a seeded RNG so the animation is consistent when a replay is rewound.