### PR TITLE
Fix sliders sometimes being outside of the playfield with osu! random mod enabled

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -173,6 +173,9 @@ namespace osu.Game.Rulesets.Osu.Mods
             pos = slider.Path.PositionAt(1);
             updateMargin();
 
+            minMargin.Left = Math.Min(minMargin.Left, OsuPlayfield.BASE_SIZE.X - minMargin.Right);
+            minMargin.Top = Math.Min(minMargin.Top, OsuPlayfield.BASE_SIZE.Y - minMargin.Bottom);
+
             return minMargin;
 
             void updateMargin()

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "It never gets boring!";
         public override bool Ranked => false;
 
+        private const float slider_path_checking_rate = 10;
+
         // The relative distance to the edge of the playfield before objects' positions should start to "turn around" and curve towards the middle.
         // The closer the hit objects draw to the border, the sharper the turn
         private const float playfield_edge_ratio = 0.375f;
@@ -74,22 +76,8 @@ namespace osu.Game.Rulesets.Osu.Mods
                 // update end position as it may have changed as a result of the position update.
                 current.EndPositionRandomised = current.PositionRandomised;
 
-                switch (hitObject)
-                {
-                    case Slider slider:
-                        // Shift nested objects the same distance as the slider got shifted in the randomisation process
-                        // so that moveSliderIntoPlayfield() can determine their relative distances to slider.Position and thus minMargin
-                        shiftNestedObjects(slider, Vector2.Subtract(slider.Position, current.PositionOriginal));
-
-                        var oldPos = new Vector2(slider.Position.X, slider.Position.Y);
-
-                        moveSliderIntoPlayfield(slider, current);
-
-                        // Shift them again to move them to their final position after the slider got moved into the playfield
-                        shiftNestedObjects(slider, Vector2.Subtract(slider.Position, oldPos));
-
-                        break;
-                }
+                if (hitObject is Slider slider)
+                    moveSliderIntoPlayfield(slider, current);
 
                 previous = current;
             }
@@ -146,34 +134,53 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// </summary>
         private void moveSliderIntoPlayfield(Slider slider, RandomObjectInfo currentObjectInfo)
         {
-            // Min. distances from the slider's position to the playfield border
-            var minMargin = new MarginPadding();
+            var minMargin = getMinSliderMargin(slider);
 
-            foreach (var hitObject in slider.NestedHitObjects.Where(o => o is SliderTick || o is SliderEndCircle))
-            {
-                if (!(hitObject is OsuHitObject osuHitObject))
-                    continue;
-
-                var relativePos = Vector2.Subtract(osuHitObject.Position, slider.Position);
-
-                minMargin.Left = Math.Max(minMargin.Left, -relativePos.X);
-                minMargin.Right = Math.Max(minMargin.Right, relativePos.X);
-                minMargin.Top = Math.Max(minMargin.Top, -relativePos.Y);
-                minMargin.Bottom = Math.Max(minMargin.Bottom, relativePos.Y);
-            }
-
-            if (slider.Position.X < minMargin.Left)
-                slider.Position = new Vector2(minMargin.Left, slider.Position.Y);
-            else if (slider.Position.X + minMargin.Right > OsuPlayfield.BASE_SIZE.X)
-                slider.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - minMargin.Right, slider.Position.Y);
-
-            if (slider.Position.Y < minMargin.Top)
-                slider.Position = new Vector2(slider.Position.X, minMargin.Top);
-            else if (slider.Position.Y + minMargin.Bottom > OsuPlayfield.BASE_SIZE.Y)
-                slider.Position = new Vector2(slider.Position.X, OsuPlayfield.BASE_SIZE.Y - minMargin.Bottom);
+            slider.Position = new Vector2(
+                Math.Clamp(slider.Position.X, minMargin.Left, OsuPlayfield.BASE_SIZE.X - minMargin.Right),
+                Math.Clamp(slider.Position.Y, minMargin.Top, OsuPlayfield.BASE_SIZE.Y - minMargin.Bottom)
+            );
 
             currentObjectInfo.PositionRandomised = slider.Position;
             currentObjectInfo.EndPositionRandomised = slider.EndPosition;
+
+            shiftNestedObjects(slider, Vector2.Subtract(currentObjectInfo.PositionRandomised, currentObjectInfo.PositionOriginal));
+        }
+
+        /// <summary>
+        /// Calculates the min. distances from the <see cref="Slider"/>'s position to the playfield border for the slider to be fully inside of the playfield.
+        /// </summary>
+        private MarginPadding getMinSliderMargin(Slider slider)
+        {
+            var minMargin = new MarginPadding();
+            Vector2 pos;
+
+            for (double j = 0; j <= 1; j += 1 / (slider_path_checking_rate / 1000 * (slider.EndTime - slider.StartTime)))
+            {
+                pos = slider.Path.PositionAt(j);
+                updateMargin();
+            }
+
+            var repeat = (SliderRepeat)slider.NestedHitObjects.FirstOrDefault(o => o is SliderRepeat);
+
+            if (repeat != null)
+            {
+                pos = repeat.Position - slider.Position;
+                updateMargin();
+            }
+
+            pos = slider.Path.PositionAt(1);
+            updateMargin();
+
+            return minMargin;
+
+            void updateMargin()
+            {
+                minMargin.Left = Math.Max(minMargin.Left, -pos.X);
+                minMargin.Right = Math.Max(minMargin.Right, pos.X);
+                minMargin.Top = Math.Max(minMargin.Top, -pos.Y);
+                minMargin.Bottom = Math.Max(minMargin.Bottom, pos.Y);
+            }
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -151,31 +151,23 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// </summary>
         private MarginPadding getMinSliderMargin(Slider slider)
         {
-            var minMargin = new MarginPadding();
-
             var pathPositions = new List<Vector2>();
             slider.Path.GetPathToProgress(pathPositions, 0, 1);
 
+            var minMargin = new MarginPadding();
+
             foreach (var pos in pathPositions)
-                updateMargin(pos);
-
-            var repeat = (SliderRepeat)slider.NestedHitObjects.FirstOrDefault(o => o is SliderRepeat);
-
-            if (repeat != null)
-                updateMargin(repeat.Position - slider.Position);
-
-            minMargin.Left = Math.Min(minMargin.Left, OsuPlayfield.BASE_SIZE.X - minMargin.Right);
-            minMargin.Top = Math.Min(minMargin.Top, OsuPlayfield.BASE_SIZE.Y - minMargin.Bottom);
-
-            return minMargin;
-
-            void updateMargin(Vector2 pos)
             {
                 minMargin.Left = Math.Max(minMargin.Left, -pos.X);
                 minMargin.Right = Math.Max(minMargin.Right, pos.X);
                 minMargin.Top = Math.Max(minMargin.Top, -pos.Y);
                 minMargin.Bottom = Math.Max(minMargin.Bottom, pos.Y);
             }
+
+            minMargin.Left = Math.Min(minMargin.Left, OsuPlayfield.BASE_SIZE.X - minMargin.Right);
+            minMargin.Top = Math.Min(minMargin.Top, OsuPlayfield.BASE_SIZE.Y - minMargin.Bottom);
+
+            return minMargin;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "It never gets boring!";
         public override bool Ranked => false;
 
+        // How often per second getMinSliderMargin() checks if the slider is outside of the playfield
         private const float slider_path_checking_rate = 10;
 
         // The relative distance to the edge of the playfield before objects' positions should start to "turn around" and curve towards the middle.

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -156,9 +156,9 @@ namespace osu.Game.Rulesets.Osu.Mods
             var minMargin = new MarginPadding();
             Vector2 pos;
 
-            for (double j = 0; j <= 1; j += 1 / (slider_path_checking_rate / 1000 * (slider.EndTime - slider.StartTime)))
+            for (double i = 0; i <= 1; i += 1 / (slider_path_checking_rate / 1000 * (slider.EndTime - slider.StartTime)))
             {
-                pos = slider.Path.PositionAt(j);
+                pos = slider.Path.PositionAt(i);
                 updateMargin();
             }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         private static readonly float border_distance_x = OsuPlayfield.BASE_SIZE.X * playfield_edge_ratio;
         private static readonly float border_distance_y = OsuPlayfield.BASE_SIZE.Y * playfield_edge_ratio;
 
-        private static readonly Vector2 playfield_middle = Vector2.Divide(OsuPlayfield.BASE_SIZE, 2);
+        private static readonly Vector2 playfield_middle = OsuPlayfield.BASE_SIZE / 2;
 
         private static readonly float playfield_diagonal = OsuPlayfield.BASE_SIZE.LengthFast;
 
@@ -119,7 +119,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             current.AngleRad = (float)Math.Atan2(posRelativeToPrev.Y, posRelativeToPrev.X);
 
-            var position = Vector2.Add(previous.EndPositionRandomised, posRelativeToPrev);
+            var position = previous.EndPositionRandomised + posRelativeToPrev;
 
             // Move hit objects back into the playfield if they are outside of it,
             // which would sometimes happen during big jumps otherwise.
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             currentObjectInfo.PositionRandomised = slider.Position;
             currentObjectInfo.EndPositionRandomised = slider.EndPosition;
 
-            shiftNestedObjects(slider, Vector2.Subtract(currentObjectInfo.PositionRandomised, currentObjectInfo.PositionOriginal));
+            shiftNestedObjects(slider, currentObjectInfo.PositionRandomised - currentObjectInfo.PositionOriginal);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 if (!(hitObject is OsuHitObject osuHitObject))
                     continue;
 
-                osuHitObject.Position = Vector2.Add(osuHitObject.Position, shift);
+                osuHitObject.Position += shift;
             }
         }
 


### PR DESCRIPTION
Currently sliders are still outside of the playfield in some cases when using the osu! random mod.
This is because the nested `SliderTick`s are used to determine whether or not and how far a slider is off screen, but even if not a single slider tick is off the playfield, parts of the slider might still be (That's why maps with a low slider tick rate and big sliders like [this one](https://osu.ppy.sh/beatmapsets/996745#osu/2084845) are especially prone to this issue).

![Screenshot_81](https://user-images.githubusercontent.com/47356629/120824267-92770680-c558-11eb-8617-dd9a7c02519d.png)
Beatmap: https://osu.ppy.sh/beatmapsets/996745#osu/2084845 | Seed: 1042387904

Now instead of the `SliderTick`s' positions I'm using `slider.Path.PositionAt(i)` and increase `i` `slider_path_checking_rate` times for every second of a slider's duration (Currently `slider_path_checking_rate` is set to 10).

I tested it on a good amount of maps and didn't come across this issue again.