### PR TITLE
Clean up previous sample immediately on skin source change to avoid `Play` after disposal

### DIFF
--- a/osu.Game/Skinning/PoolableSkinnableSample.cs
+++ b/osu.Game/Skinning/PoolableSkinnableSample.cs
@@ -186,7 +186,8 @@ namespace osu.Game.Skinning
         {
             base.Dispose(isDisposing);
 
-            CurrentSkin.SourceChanged -= skinChangedImmediate;
+            if (CurrentSkin != null)
+                CurrentSkin.SourceChanged -= skinChangedImmediate;
         }
 
         #region Re-expose AudioContainer

--- a/osu.Game/Skinning/PoolableSkinnableSample.cs
+++ b/osu.Game/Skinning/PoolableSkinnableSample.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -70,21 +71,47 @@ namespace osu.Game.Skinning
                 updateSample();
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            CurrentSkin.SourceChanged += skinChangedImmediate;
+        }
+
+        private void skinChangedImmediate()
+        {
+            // Clean up the previous sample immediately on a source change.
+            // This avoids a potential call to Play() of an already disposed sample (samples are disposed along with the skin, but SkinChanged is scheduled).
+            clearPreviousSamples();
+        }
+
         protected override void SkinChanged(ISkinSource skin, bool allowFallback)
         {
             base.SkinChanged(skin, allowFallback);
             updateSample();
         }
 
+        /// <summary>
+        /// Whether this sample was playing before a skin source change.
+        /// </summary>
+        private bool wasPlaying;
+
+        private void clearPreviousSamples()
+        {
+            // only run if the samples aren't already cleared.
+            // this ensures the "wasPlaying" state is stored correctly even if multiple clear calls are executed.
+            if (!sampleContainer.Any()) return;
+
+            wasPlaying = Playing;
+
+            sampleContainer.Clear();
+            Sample = null;
+        }
+
         private void updateSample()
         {
             if (sampleInfo == null)
                 return;
-
-            bool wasPlaying = Playing;
-
-            sampleContainer.Clear();
-            Sample = null;
 
             var sample = CurrentSkin.GetSample(sampleInfo);
 
@@ -153,6 +180,13 @@ namespace osu.Game.Skinning
                 if (activeChannel != null)
                     activeChannel.Looping = value;
             }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            CurrentSkin.SourceChanged -= skinChangedImmediate;
         }
 
         #region Re-expose AudioContainer


### PR DESCRIPTION
This seems to be the simplest way to avoid calls to `Play` after the underlying sample may have been disposed. As per the issue thread, a local workaround is acceptable here.

Closes #13223, in theory (hard one to repro in the first place).