### PR TITLE
Don't apply visibility increase to first object in osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
@@ -4,10 +4,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -21,12 +19,6 @@ namespace osu.Game.Rulesets.Catch.Tests
 {
     public class TestSceneCatchModHidden : ModTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            LocalConfig.SetValue(OsuSetting.IncreaseFirstObjectVisibility, false);
-        }
-
         [Test]
         public void TestJuiceStream()
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
@@ -29,8 +29,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         }
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
-        {
-        }
+            => ApplyNormalVisibilityState(hitObject, state);
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {


### PR DESCRIPTION
The goal of the visibility increase is to help in cases where timing is an issue (by showing the approach circle etc.). This doesn't need to apply to catch.

@smoogipoo interested as to whether you agree with this one. Visually it looks better to me but it does change the behaviour for only osu!catch, so I'm not 100% confident on it.

Closes #13367.