### PR TITLE
Move legacy `ScoreInfo` to be completely based on presence of classic mod

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
@@ -21,7 +21,12 @@ namespace osu.Game.Online.API.Requests.Responses
         {
             var ruleset = rulesets.GetRuleset(OnlineRulesetID);
 
-            var mods = Mods != null ? ruleset.CreateInstance().GetAllMods().Where(mod => Mods.Contains(mod.Acronym)).ToArray() : Array.Empty<Mod>();
+            var rulesetInstance = ruleset.CreateInstance();
+
+            var mods = Mods != null ? rulesetInstance.GetAllMods().Where(mod => Mods.Contains(mod.Acronym)).ToArray() : Array.Empty<Mod>();
+
+            // all API scores provided by this class are considered to be legacy.
+            mods = mods.Append(rulesetInstance.GetAllMods().OfType<ModClassic>().Single()).ToArray();
 
             var scoreInfo = new ScoreInfo
             {
@@ -38,7 +43,6 @@ namespace osu.Game.Online.API.Requests.Responses
                 Rank = Rank,
                 Ruleset = ruleset,
                 Mods = mods,
-                IsLegacyScore = true
             };
 
             if (Statistics != null)

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -65,6 +65,10 @@ namespace osu.Game.Scoring.Legacy
 
                 scoreInfo.Mods = currentRuleset.ConvertFromLegacyMods((LegacyMods)sr.ReadInt32()).ToArray();
 
+                // lazer replays get a really high version number.
+                if (version < 30000000)
+                    scoreInfo.Mods = scoreInfo.Mods.Append(currentRuleset.GetAllMods().OfType<ModClassic>().Single()).ToArray();
+
                 currentBeatmap = workingBeatmap.GetPlayableBeatmap(currentRuleset.RulesetInfo, scoreInfo.Mods);
                 scoreInfo.Beatmap = currentBeatmap.BeatmapInfo;
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Scoring.Legacy
                 scoreInfo.Mods = currentRuleset.ConvertFromLegacyMods((LegacyMods)sr.ReadInt32()).ToArray();
 
                 // lazer replays get a really high version number.
-                if (version < 30000000)
+                if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
                     scoreInfo.Mods = scoreInfo.Mods.Append(currentRuleset.GetAllMods().OfType<ModClassic>().Single()).ToArray();
 
                 currentBeatmap = workingBeatmap.GetPlayableBeatmap(currentRuleset.RulesetInfo, scoreInfo.Mods);

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -17,8 +17,14 @@ namespace osu.Game.Scoring.Legacy
     {
         /// <summary>
         /// Database version in stable-compatible YYYYMMDD format.
+        /// Should be incremented if any changes are made to the format/usage.
         /// </summary>
-        public const int LATEST_VERSION = 30000000;
+        public const int LATEST_VERSION = FIRST_LAZER_VERSION;
+
+        /// <summary>
+        /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.
+        /// </summary>
+        public const int FIRST_LAZER_VERSION = 30000000;
 
         private readonly Score score;
         private readonly IBeatmap beatmap;

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -15,7 +15,10 @@ namespace osu.Game.Scoring.Legacy
 {
     public class LegacyScoreEncoder
     {
-        public const int LATEST_VERSION = 128;
+        /// <summary>
+        /// Database version in stable-compatible YYYYMMDD format.
+        /// </summary>
+        public const int LATEST_VERSION = 30000000;
 
         private readonly Score score;
         private readonly IBeatmap beatmap;

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -76,9 +76,6 @@ namespace osu.Game.Scoring
                 else if (localAPIMods != null)
                     scoreMods = apiMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
 
-                if (IsLegacyScore)
-                    scoreMods = scoreMods.Append(rulesetInstance.GetAllMods().OfType<ModClassic>().Single()).ToArray();
-
                 return scoreMods;
             }
             set

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -201,33 +201,12 @@ namespace osu.Game.Scoring
         [JsonProperty("position")]
         public int? Position { get; set; }
 
-        private bool isLegacyScore;
-
         /// <summary>
         /// Whether this <see cref="ScoreInfo"/> represents a legacy (osu!stable) score.
         /// </summary>
         [JsonIgnore]
         [NotMapped]
-        public bool IsLegacyScore
-        {
-            get
-            {
-                if (isLegacyScore)
-                    return true;
-
-                // The above check will catch legacy online scores that have an appropriate UserString + UserId.
-                // For non-online scores such as those imported in, a heuristic is used based on the following table:
-                //
-                //       Mode      | UserString | UserId
-                // --------------- | ---------- | ---------
-                // stable          | <username> | 1
-                // lazer           | <username> | <userid>
-                // lazer (offline) | Guest      | 1
-
-                return ID > 0 && UserID == 1 && UserString != "Guest";
-            }
-            set => isLegacyScore = value;
-        }
+        public bool IsLegacyScore => mods.OfType<ModClassic>().Any();
 
         public IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay()
         {

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Scoring
         /// </summary>
         [JsonIgnore]
         [NotMapped]
-        public bool IsLegacyScore => mods.OfType<ModClassic>().Any();
+        public bool IsLegacyScore => Mods.OfType<ModClassic>().Any();
 
         public IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay()
         {


### PR DESCRIPTION
PRing to make sure this is a good direction to go. I'm not quite sure which cases this may break, but it seems like removing the separate `IsLegacyScore` flag should work as long as we apply the classic mod at time of import?

Closes #13361 