### PR TITLE
Refactor DifficultyAttributes to use auto properties over public fields

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -7,6 +7,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 {
     public class CatchDifficultyAttributes : DifficultyAttributes
     {
-        public double ApproachRate;
+        public double ApproachRate { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 {
     public class ManiaDifficultyAttributes : DifficultyAttributes
     {
-        public double GreatHitWindow;
-        public double ScoreMultiplier;
+        public double GreatHitWindow { get; set; }
+        public double ScoreMultiplier { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -7,11 +7,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 {
     public class OsuDifficultyAttributes : DifficultyAttributes
     {
-        public double AimStrain;
-        public double SpeedStrain;
-        public double ApproachRate;
-        public double OverallDifficulty;
-        public int HitCircleCount;
-        public int SpinnerCount;
+        public double AimStrain { get; set; }
+        public double SpeedStrain { get; set; }
+        public double ApproachRate { get; set; }
+        public double OverallDifficulty { get; set; }
+        public int HitCircleCount { get; set; }
+        public int SpinnerCount { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -7,10 +7,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 {
     public class TaikoDifficultyAttributes : DifficultyAttributes
     {
-        public double StaminaStrain;
-        public double RhythmStrain;
-        public double ColourStrain;
-        public double ApproachRate;
-        public double GreatHitWindow;
+        public double StaminaStrain { get; set; }
+        public double RhythmStrain { get; set; }
+        public double ColourStrain { get; set; }
+        public double ApproachRate { get; set; }
+        public double GreatHitWindow { get; set; }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -8,11 +8,11 @@ namespace osu.Game.Rulesets.Difficulty
 {
     public class DifficultyAttributes
     {
-        public Mod[] Mods;
-        public Skill[] Skills;
+        public Mod[] Mods { get; set; }
+        public Skill[] Skills { get; set; }
 
-        public double StarRating;
-        public int MaxCombo;
+        public double StarRating { get; set; }
+        public int MaxCombo { get; set; }
 
         public DifficultyAttributes()
         {


### PR DESCRIPTION
Simply changes DifficultyAttributes to use auto properties instead of public fields.
This has no impact on the codebase as is, but is more convenient for serialisation when using libraries such as `System.Text.Json`.