### PR TITLE
Fix DT being doubled in multiplayer spectator

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         // Isolates beatmap/ruleset to this screen.
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
+        // We are managing our own adjustments. For now, this happens inside the Player instances themselves.
+        public override bool AllowRateAdjustments => false;
+
         /// <summary>
         /// Whether all spectating players have finished loading.
         /// </summary>


### PR DESCRIPTION
Kinda hard to test this one because the tests aren't linked to the `MusicController`. I also want to move the adjustments to be applied by `MasterGameplayClockContainer`, but that needs a bit more testing.