### PR TITLE
Hide unexpected hit results from appearing on the hit error meter

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -109,6 +109,34 @@ namespace osu.Game.Tests.Visual.Gameplay
                     meter => meter.ChildrenOfType<ColourHitErrorMeter.HitErrorCircle>().Count() == 2));
         }
 
+        [Test]
+        public void TestBonus()
+        {
+            AddStep("OD 1", () => recreateDisplay(new OsuHitWindows(), 1));
+
+            AddStep("small bonus", () => newJudgement(result: HitResult.SmallBonus));
+            AddAssert("no bars added", () => !this.ChildrenOfType<BarHitErrorMeter.JudgementLine>().Any());
+            AddAssert("no circle added", () => !this.ChildrenOfType<ColourHitErrorMeter.HitErrorCircle>().Any());
+
+            AddStep("large bonus", () => newJudgement(result: HitResult.LargeBonus));
+            AddAssert("no bars added", () => !this.ChildrenOfType<BarHitErrorMeter.JudgementLine>().Any());
+            AddAssert("no circle added", () => !this.ChildrenOfType<ColourHitErrorMeter.HitErrorCircle>().Any());
+        }
+
+        [Test]
+        public void TestIgnore()
+        {
+            AddStep("OD 1", () => recreateDisplay(new OsuHitWindows(), 1));
+
+            AddStep("ignore hit", () => newJudgement(result: HitResult.IgnoreHit));
+            AddAssert("no bars added", () => !this.ChildrenOfType<BarHitErrorMeter.JudgementLine>().Any());
+            AddAssert("no circle added", () => !this.ChildrenOfType<ColourHitErrorMeter.HitErrorCircle>().Any());
+
+            AddStep("ignore miss", () => newJudgement(result: HitResult.IgnoreMiss));
+            AddAssert("no bars added", () => !this.ChildrenOfType<BarHitErrorMeter.JudgementLine>().Any());
+            AddAssert("no circle added", () => !this.ChildrenOfType<ColourHitErrorMeter.HitErrorCircle>().Any());
+        }
+
         private void recreateDisplay(HitWindows hitWindows, float overallDifficulty)
         {
             hitWindows?.SetDifficulty(overallDifficulty);

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -217,6 +217,9 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             if (!judgement.IsHit || judgement.HitObject.HitWindows?.WindowFor(HitResult.Miss) == 0)
                 return;
 
+            if (!judgement.Type.IsScorable() || judgement.Type.IsBonus())
+                return;
+
             if (judgementsContainer.Count > max_concurrent_judgements)
             {
                 const double quick_fade_time = 100;

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 using osuTK;
 using osuTK.Graphics;
 
@@ -24,7 +25,13 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             InternalChild = judgementsFlow = new JudgementFlow();
         }
 
-        protected override void OnNewJudgement(JudgementResult judgement) => judgementsFlow.Push(GetColourForHitResult(judgement.Type));
+        protected override void OnNewJudgement(JudgementResult judgement)
+        {
+            if (!judgement.Type.IsScorable() || judgement.Type.IsBonus())
+                return;
+
+            judgementsFlow.Push(GetColourForHitResult(judgement.Type));
+        }
 
         private class JudgementFlow : FillFlowContainer<HitErrorCircle>
         {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
@@ -41,6 +41,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         {
             switch (result)
             {
+                case HitResult.SmallTickMiss:
+                case HitResult.LargeTickMiss:
                 case HitResult.Miss:
                     return colours.Red;
 
@@ -53,6 +55,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 case HitResult.Good:
                     return colours.GreenLight;
 
+                case HitResult.SmallTickHit:
+                case HitResult.LargeTickHit:
                 case HitResult.Great:
                     return colours.Blue;
 


### PR DESCRIPTION
Just a few things I noticed - ignore and bonus judgements were included, tick misses were non-red, and tick hits were the default lighter-blue colour.

I think this makes more sense? Alternative I contemplated is to make ticks white.