### PR TITLE
Align label widths of editor setup screen controls

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledDrawable.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledDrawable.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -20,6 +23,45 @@ namespace osu.Game.Tests.Visual.UserInterface
         [TestCase(false)]
         [TestCase(true)]
         public void TestNonPadded(bool hasDescription) => createPaddedComponent(hasDescription, false);
+
+        [Test]
+        public void TestFixedWidth()
+        {
+            const float label_width = 200;
+
+            AddStep("create components", () => Child = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 10),
+                Children = new Drawable[]
+                {
+                    new NonPaddedLabelledDrawable
+                    {
+                        Label = "short",
+                        FixedLabelWidth = label_width
+                    },
+                    new NonPaddedLabelledDrawable
+                    {
+                        Label = "very very very very very very very very very very very long",
+                        FixedLabelWidth = label_width
+                    },
+                    new PaddedLabelledDrawable
+                    {
+                        Label = "short",
+                        FixedLabelWidth = label_width
+                    },
+                    new PaddedLabelledDrawable
+                    {
+                        Label = "very very very very very very very very very very very long",
+                        FixedLabelWidth = label_width
+                    }
+                }
+            });
+
+            AddStep("unset label width", () => this.ChildrenOfType<LabelledDrawable<Drawable>>().ForEach(d => d.FixedLabelWidth = null));
+            AddStep("reset label width", () => this.ChildrenOfType<LabelledDrawable<Drawable>>().ForEach(d => d.FixedLabelWidth = label_width));
+        }
 
         private void createPaddedComponent(bool hasDescription = false, bool padded = true)
         {

--- a/osu.Game/Screens/Edit/Setup/ColoursSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ColoursSection.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Screens.Edit.Setup
                 comboColours = new LabelledColourPalette
                 {
                     Label = "Hitcircle / Slider Combos",
+                    FixedLabelWidth = LABEL_WIDTH,
                     ColourNamePrefix = "Combo"
                 }
             };

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Screens.Edit.Setup
                 circleSizeSlider = new LabelledSliderBar<float>
                 {
                     Label = "Object Size",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Description = "The size of all hit objects",
                     Current = new BindableFloat(Beatmap.BeatmapInfo.BaseDifficulty.CircleSize)
                     {
@@ -40,6 +41,7 @@ namespace osu.Game.Screens.Edit.Setup
                 healthDrainSlider = new LabelledSliderBar<float>
                 {
                     Label = "Health Drain",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Description = "The rate of passive health drain throughout playable time",
                     Current = new BindableFloat(Beatmap.BeatmapInfo.BaseDifficulty.DrainRate)
                     {
@@ -52,6 +54,7 @@ namespace osu.Game.Screens.Edit.Setup
                 approachRateSlider = new LabelledSliderBar<float>
                 {
                     Label = "Approach Rate",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Description = "The speed at which objects are presented to the player",
                     Current = new BindableFloat(Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate)
                     {
@@ -64,6 +67,7 @@ namespace osu.Game.Screens.Edit.Setup
                 overallDifficultySlider = new LabelledSliderBar<float>
                 {
                     Label = "Overall Difficulty",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Description = "The harshness of hit windows and difficulty of special objects (ie. spinners)",
                     Current = new BindableFloat(Beatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty)
                     {

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -27,24 +27,28 @@ namespace osu.Game.Screens.Edit.Setup
                 artistTextBox = new LabelledTextBox
                 {
                     Label = "Artist",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Current = { Value = Beatmap.Metadata.Artist },
                     TabbableContentContainer = this
                 },
                 titleTextBox = new LabelledTextBox
                 {
                     Label = "Title",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Current = { Value = Beatmap.Metadata.Title },
                     TabbableContentContainer = this
                 },
                 creatorTextBox = new LabelledTextBox
                 {
                     Label = "Creator",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Current = { Value = Beatmap.Metadata.AuthorString },
                     TabbableContentContainer = this
                 },
                 difficultyTextBox = new LabelledTextBox
                 {
                     Label = "Difficulty Name",
+                    FixedLabelWidth = LABEL_WIDTH,
                     Current = { Value = Beatmap.BeatmapInfo.Version },
                     TabbableContentContainer = this
                 },

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Screens.Edit.Setup
                         backgroundTextBox = new FileChooserLabelledTextBox(".jpg", ".jpeg", ".png")
                         {
                             Label = "Background",
+                            FixedLabelWidth = LABEL_WIDTH,
                             PlaceholderText = "Click to select a background image",
                             Current = { Value = working.Value.Metadata.BackgroundFile },
                             Target = backgroundFileChooserContainer,
@@ -72,6 +73,7 @@ namespace osu.Game.Screens.Edit.Setup
                         audioTrackTextBox = new FileChooserLabelledTextBox(".mp3", ".ogg")
                         {
                             Label = "Audio Track",
+                            FixedLabelWidth = LABEL_WIDTH,
                             PlaceholderText = "Click to select a track",
                             Current = { Value = working.Value.Metadata.AudioFile },
                             Target = audioTrackFileChooserContainer,

--- a/osu.Game/Screens/Edit/Setup/SetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupSection.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
@@ -14,6 +15,11 @@ namespace osu.Game.Screens.Edit.Setup
     internal abstract class SetupSection : Container
     {
         private readonly FillFlowContainer flow;
+
+        /// <summary>
+        /// Used to align some of the child <see cref="LabelledDrawable{T}"/>s together to achieve a grid-like look.
+        /// </summary>
+        protected const float LABEL_WIDTH = 160;
 
         [Resolved]
         protected OsuColour Colours { get; private set; }


### PR DESCRIPTION
An incremental UI improvement of the setup screen before I add more stuff to it.

![osu_2021-06-08_17-19-05](https://user-images.githubusercontent.com/20418176/121212447-a767d880-c87d-11eb-9385-4685c036e3cc.jpg)

I thought about making some sort of container for `LabelledDrawable`s that would automatically match their children label widths but decided to go with the simpler option in the end of a plain property.

Note that while absolutely all of the current labelled components used in the setup screen got this width specification, there will be some that don't need it, as their components will be right-aligned (see e.g. [this design](https://user-images.githubusercontent.com/1329837/42362656-4469bd68-812f-11e8-8f5b-3371d08779be.png)).
