### PR TITLE
Bring back skin background source

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Background
         }
 
         [Test]
-        public void TestTogglingStoryboardSwitchesBackgroundType()
+        public void TestBackgroundTypeSwitch()
         {
             setSupporter(true);
 
@@ -44,6 +44,9 @@ namespace osu.Game.Tests.Visual.Background
 
             setSourceMode(BackgroundSource.BeatmapWithStoryboard);
             AddUntilStep("is storyboard background", () => getCurrentBackground() is BeatmapBackgroundWithStoryboard);
+
+            setSourceMode(BackgroundSource.Skin);
+            AddUntilStep("is skin background", () => getCurrentBackground() is SkinBackground);
         }
 
         [Test]
@@ -78,7 +81,7 @@ namespace osu.Game.Tests.Visual.Background
         }
 
         private void setSourceMode(BackgroundSource source) =>
-            AddStep("set background mode to beatmap", () => config.SetValue(OsuSetting.MenuBackgroundSource, source));
+            AddStep($"set background mode to {source}", () => config.SetValue(OsuSetting.MenuBackgroundSource, source));
 
         private void setSupporter(bool isSupporter) =>
             AddStep($"set supporter {isSupporter}", () => ((DummyAPIAccess)API).LocalUser.Value = new User

--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -64,15 +65,17 @@ namespace osu.Game.Tests.Visual.Background
             AddUntilStep("is beatmap background", () => getCurrentBackground() is BeatmapBackground);
         }
 
-        [Test]
-        public void TestBeatmapDoesntReloadOnNoChange()
+        [TestCase(BackgroundSource.Beatmap, typeof(BeatmapBackground))]
+        [TestCase(BackgroundSource.BeatmapWithStoryboard, typeof(BeatmapBackgroundWithStoryboard))]
+        [TestCase(BackgroundSource.Skin, typeof(SkinBackground))]
+        public void TestBackgroundDoesntReloadOnNoChange(BackgroundSource source, Type backgroundType)
         {
-            BeatmapBackground last = null;
+            Graphics.Backgrounds.Background last = null;
 
-            setSourceMode(BackgroundSource.Beatmap);
+            setSourceMode(source);
             setSupporter(true);
 
-            AddUntilStep("wait for beatmap background to be loaded", () => (last = getCurrentBackground() as BeatmapBackground) != null);
+            AddUntilStep("wait for beatmap background to be loaded", () => (last = getCurrentBackground())?.GetType() == backgroundType);
             AddAssert("next doesn't load new background", () => screen.Next() == false);
 
             // doesn't really need to be checked but might as well.

--- a/osu.Game/Graphics/Backgrounds/Background.cs
+++ b/osu.Game/Graphics/Backgrounds/Background.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,7 +15,7 @@ namespace osu.Game.Graphics.Backgrounds
     /// <summary>
     /// A background which offers blurring via a <see cref="BufferedContainer"/> on demand.
     /// </summary>
-    public class Background : CompositeDrawable
+    public class Background : CompositeDrawable, IEquatable<Background>
     {
         private const float blur_scale = 0.5f;
 
@@ -70,6 +71,15 @@ namespace osu.Game.Graphics.Backgrounds
                 bufferedContainer.FrameBufferScale = newBlurSigma == Vector2.Zero ? Vector2.One : new Vector2(blur_scale);
 
             bufferedContainer?.BlurTo(newBlurSigma * blur_scale, duration, easing);
+        }
+
+        public virtual bool Equals(Background other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return other.GetType() == GetType()
+                   && other.textureName == textureName;
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
@@ -24,5 +24,14 @@ namespace osu.Game.Graphics.Backgrounds
         {
             Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
         }
+
+        public override bool Equals(Background other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return other.GetType() == GetType()
+                   && ((BeatmapBackground)other).Beatmap == Beatmap;
+        }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/SkinBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/SkinBackground.cs
@@ -21,5 +21,14 @@ namespace osu.Game.Graphics.Backgrounds
         {
             Sprite.Texture = skin.GetTexture("menu-background") ?? Sprite.Texture;
         }
+
+        public override bool Equals(Background other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return other.GetType() == GetType()
+                   && ((SkinBackground)other).skin.SkinInfo.Equals(skin.SkinInfo);
+        }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/SkinBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/SkinBackground.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Skinning;
+
+namespace osu.Game.Graphics.Backgrounds
+{
+    internal class SkinBackground : Background
+    {
+        private readonly Skin skin;
+
+        public SkinBackground(Skin skin, string fallbackTextureName)
+            : base(fallbackTextureName)
+        {
+            this.skin = skin;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Sprite.Texture = skin.GetTexture("menu-background") ?? Sprite.Texture;
+        }
+    }
+}

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -120,6 +120,10 @@ namespace osu.Game.Screens.Backgrounds
 
                         break;
                     }
+
+                    case BackgroundSource.Skin:
+                        newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
+                        break;
                 }
             }
 

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -112,12 +112,6 @@ namespace osu.Game.Screens.Backgrounds
                             newBackground = new BeatmapBackgroundWithStoryboard(beatmap.Value, getBackgroundTextureName());
                         newBackground ??= new BeatmapBackground(beatmap.Value, getBackgroundTextureName());
 
-                        // this method is called in many cases where the beatmap hasn't changed (ie. on screen transitions).
-                        // if a background is already displayed for the requested beatmap, we don't want to load it again.
-                        if (background?.GetType() == newBackground.GetType() &&
-                            (background as BeatmapBackground)?.Beatmap == beatmap.Value)
-                            return background;
-
                         break;
                     }
 
@@ -126,6 +120,11 @@ namespace osu.Game.Screens.Backgrounds
                         break;
                 }
             }
+
+            // this method is called in many cases where the background might not necessarily need to change.
+            // if an equivalent background is currently being shown, we don't want to load it again.
+            if (newBackground?.Equals(background) == true)
+                return background;
 
             newBackground ??= new Background(getBackgroundTextureName());
             newBackground.Depth = currentDisplay;

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -116,6 +116,10 @@ namespace osu.Game.Screens.Backgrounds
                     }
 
                     case BackgroundSource.Skin:
+                        // default skins should use the default background rotation, which won't be the case if a SkinBackground is created for them.
+                        if (skin.Value is DefaultSkin || skin.Value is DefaultLegacySkin)
+                            break;
+
                         newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
                         break;
                 }

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -140,22 +140,5 @@ namespace osu.Game.Screens.Backgrounds
                     return $@"Menu/menu-background-{currentDisplay % background_count + 1}";
             }
         }
-
-        private class SkinnedBackground : Background
-        {
-            private readonly Skin skin;
-
-            public SkinnedBackground(Skin skin, string fallbackTextureName)
-                : base(fallbackTextureName)
-            {
-                this.skin = skin;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                Sprite.Texture = skin.GetTexture("menu-background") ?? Sprite.Texture;
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes #13388.

In addition to bringing back the source, the optimisation from #13362 is extended onto default and user skin backgrounds via `IEquatable<Background>` implementations, [as suggested in the review of that PR](https://github.com/ppy/osu/pull/13362/files#r646432518).