### PR TITLE
Fix registered event not unregistered on dispose

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
@@ -128,5 +128,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                     spmContainer.FadeIn(drawableSpinner.HitObject.TimeFadeIn);
             }
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableSpinner != null)
+                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+        }
     }
 }


### PR DESCRIPTION
I searched other usage of `ApplyCustomUpdateState +=` and it was the only instance of the missing disposal.