### PR TITLE
Fix circle piece animation sometimes not playing when a replay is rewound (again)

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -15,8 +15,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
     public class MainCirclePiece : CompositeDrawable
     {
-        public override bool RemoveCompletedTransforms => false;
-
         private readonly CirclePiece circle;
         private readonly RingPiece ring;
         private readonly FlashPiece flash;
@@ -44,7 +42,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
-        private readonly IBindable<ArmedState> armedState = new Bindable<ArmedState>();
 
         [Resolved]
         private DrawableHitObject drawableObject { get; set; }
@@ -56,7 +53,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             accentColour.BindTo(drawableObject.AccentColour);
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
-            armedState.BindTo(drawableObject.State);
         }
 
         protected override void LoadComplete()
@@ -72,19 +68,18 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
 
-            armedState.BindValueChanged(animate, true);
+            drawableObject.ApplyCustomUpdateState += updateStateTransforms;
+            updateStateTransforms(drawableObject, drawableObject.State.Value);
         }
 
-        private void animate(ValueChangedEvent<ArmedState> state)
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            ClearTransforms(true);
-
             using (BeginAbsoluteSequence(drawableObject.StateUpdateTime))
                 glow.FadeOut(400);
 
             using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
             {
-                switch (state.NewValue)
+                switch (state)
                 {
                     case ArmedState.Hit:
                         const double flash_in = 40;
@@ -110,6 +105,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                         break;
                 }
             }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableObject != null)
+                drawableObject.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -148,8 +148,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             const double legacy_fade_duration = 240;
 
-            ClearTransforms(true);
-
             using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
             {
                 switch (state)


### PR DESCRIPTION
- Fixes #13395

Because DHO clears transforms *propagating children* <https://github.com/ppy/osu/blob/b8df3fff9e26a4454240c2c562c6598d42cdd9bd/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L432>, using `RemoveCompletedTransforms` like the previous PR #13396 is not enough.
Namely, the point only occurs when there are no hit circles after the hit circle because `State` is not modified by another hit object.

Other skinned pieces of the osu! ruleset doing either

1. register to `ApplyCustomUpdateState`
2. block `ClearTransformsAfter`, used by `SliderBall` <https://github.com/ppy/osu/blob/0d0b4ea78a8a07be1ac472641f8123e26f1a4bdf/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs#L79-L84>

I used the first option here.