### PR TITLE
Add ability to navigate score panels with left/right arrows

### DIFF
--- a/osu.Game/Screens/Ranking/ScorePanelList.cs
+++ b/osu.Game/Screens/Ranking/ScorePanelList.cs
@@ -8,9 +8,11 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Scoring;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Ranking
 {
@@ -261,6 +263,26 @@ namespace osu.Game.Screens.Ranking
                 throw new InvalidOperationException("Panel is not contained by the score panel list.");
 
             container.Attach();
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            var expandedPanelIndex = flow.GetPanelIndex(expandedPanel.Score);
+
+            switch (e.Key)
+            {
+                case Key.Left:
+                    if (expandedPanelIndex > 0)
+                        SelectedScore.Value = flow.Children[expandedPanelIndex - 1].Panel.Score;
+                    return true;
+
+                case Key.Right:
+                    if (expandedPanelIndex < flow.Count - 1)
+                        SelectedScore.Value = flow.Children[expandedPanelIndex + 1].Panel.Score;
+                    return true;
+            }
+
+            return base.OnKeyDown(e);
         }
 
         private class Flow : FillFlowContainer<ScorePanelTrackingContainer>


### PR DESCRIPTION
Uses `OnKeyDown` like `BeatmapCarousel` as there aren't left and right global actions yet.