### PR TITLE
Fix wiki image tooltips not showing inside table views

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -143,6 +143,25 @@ Line after image";
             });
         }
 
+        [Test]
+        public void TestTableWithImageContent()
+        {
+            AddStep("Add Table", () =>
+            {
+                markdownContainer.DocumentUrl = "https://dev.ppy.sh";
+                markdownContainer.Text = @"
+| Image | Name | Effect |
+| :-: | :-: | :-- |
+| ![](/wiki/Skinning/Interface/img/hit300.png ""300"") | 300 | A possible score when tapping a hit circle precisely on time, completing a Slider and keeping the cursor over every tick, or completing a Spinner with the Spinner Metre full. A score of 300 appears in an blue score by default. Scoring nothing except 300s in a beatmap will award the player with the SS or SSH grade. |
+| ![](/wiki/Skinning/Interface/img/hit300g.png ""Geki"") | (激) Geki | A term from Ouendan, called Elite Beat! in EBA. Appears when playing the last element in a combo in which the player has scored only 300s. Getting a Geki will give a sizable boost to the Life Bar. By default, it is blue. |
+| ![](/wiki/Skinning/Interface/img/hit100.png ""100"") | 100 | A possible score one can get when tapping a Hit Object slightly late or early, completing a Slider and missing a number of ticks, or completing a Spinner with the Spinner Meter almost full. A score of 100 appears in a green score by default. When very skilled players test a beatmap and they get a lot of 100s, this may mean that the beatmap does not have correct timing. |
+| ![](/wiki/Skinning/Interface/img/hit300k.png ""300 Katu"") ![](/wiki/Skinning/Interface/img/hit100k.png ""100 Katu"") | (喝) Katu or Katsu | A term from Ouendan, called Beat! in EBA. Appears when playing the last element in a combo in which the player has scored at least one 100, but no 50s or misses. Getting a Katu will give a small boost to the Life Bar. By default, it is coloured green or blue depending on whether the Katu itself is a 100 or a 300. |
+| ![](/wiki/Skinning/Interface/img/hit50.png ""50"") | 50 | A possible score one can get when tapping a hit circle rather early or late but not early or late enough to cause a miss, completing a Slider and missing a lot of ticks, or completing a Spinner with the Spinner Metre close to full. A score of 50 appears in a orange score by default. Scoring a 50 in a combo will prevent the appearance of a Katu or a Geki at the combo's end. |
+| ![](/wiki/Skinning/Interface/img/hit0.png ""Miss"") | Miss | A possible score one can get when not tapping a hit circle or too early (based on OD and AR, it may *shake* instead), not tapping or holding the Slider at least once, or completing a Spinner with low Spinner Metre fill. Scoring a Miss will reset the current combo to 0 and will prevent the appearance of a Katu or a Geki at the combo's end. |
+";
+            });
+        }
+
         private class TestMarkdownContainer : WikiMarkdownContainer
         {
             public LinkInline Link;

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Syntax.Inlines;
+using osu.Framework.Graphics.Containers.Markdown;
+using osu.Framework.Graphics.Cursor;
+
+namespace osu.Game.Graphics.Containers.Markdown
+{
+    public class OsuMarkdownImage : MarkdownImage, IHasTooltip
+    {
+        public string TooltipText { get; }
+
+        public OsuMarkdownImage(LinkInline linkInline)
+            : base(linkInline.Url)
+        {
+            TooltipText = linkInline.Title;
+        }
+    }
+}

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Graphics.Containers.Markdown
         protected override void AddLinkText(string text, LinkInline linkInline)
             => AddDrawable(new OsuMarkdownLinkText(text, linkInline));
 
+        protected override void AddImage(LinkInline linkInline) => AddDrawable(new OsuMarkdownImage(linkInline));
+
         // TODO : Change font to monospace
         protected override void AddCodeInLine(CodeInline codeInline) => AddDrawable(new OsuMarkdownInlineCode
         {

--- a/osu.Game/Overlays/Wiki/Markdown/WikiMarkdownImage.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiMarkdownImage.cs
@@ -2,19 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Markdig.Syntax.Inlines;
-using osu.Framework.Graphics.Containers.Markdown;
-using osu.Framework.Graphics.Cursor;
+using osu.Game.Graphics.Containers.Markdown;
 
 namespace osu.Game.Overlays.Wiki.Markdown
 {
-    public class WikiMarkdownImage : MarkdownImage, IHasTooltip
+    public class WikiMarkdownImage : OsuMarkdownImage
     {
-        public string TooltipText { get; }
-
         public WikiMarkdownImage(LinkInline linkInline)
-            : base(linkInline.Url)
+            : base(linkInline)
         {
-            TooltipText = linkInline.Title;
         }
 
         protected override ImageContainer CreateImageContainer(string url)


### PR DESCRIPTION
Closes #13421

![tooltip](https://user-images.githubusercontent.com/4964985/121456760-c1fe9680-c9d0-11eb-8d01-0d34e09bfbcb.gif)

This happened because `TableCellTextFlowContainer` in `OsuMarkdownTableCell` is extending `OsuMarkdownTextFlowContainer`.

https://github.com/ppy/osu/blob/2b4649a3ea2a919f8869a2e66854448b05780d01/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTableCell.cs#L70-L75

While the implementation of tooltip itself is in `WikiMarkdownImage` inside `WikiMarkdownTextFlowContainer`.

https://github.com/ppy/osu/blob/2b4649a3ea2a919f8869a2e66854448b05780d01/osu.Game/Overlays/Wiki/Markdown/WikiMarkdownImage.cs#L14-L18

https://github.com/ppy/osu/blob/2b4649a3ea2a919f8869a2e66854448b05780d01/osu.Game/Overlays/Wiki/Markdown/WikiMarkdownContainer.cs#L50-L53

So in this PR, I decided to lift up the implementation of image tooltip and create `OsuMarkdownImage` inside `OsuMarkdownTextFlowContainer` and make `WikiMarkdownImage` to extends `OsuMarkdownImage`.