### PR TITLE
Fix avatars missing in private message channel tabs / local leaderboards

### DIFF
--- a/osu.Game/Users/Drawables/DrawableAvatar.cs
+++ b/osu.Game/Users/Drawables/DrawableAvatar.cs
@@ -31,7 +31,9 @@ namespace osu.Game.Users.Drawables
         private void load(LargeTextureStore textures)
         {
             if (user != null && user.Id > 1)
-                Texture = textures.Get(user.AvatarUrl);
+                // TODO: The fallback here should not need to exist. Users should be looked up and populated via UserLookupCache or otherwise
+                // in remaining cases where this is required (chat tabs, local leaderboard), at which point this should be removed.
+                Texture = textures.Get(user.AvatarUrl ?? $@"https://a.ppy.sh/{user.Id}");
 
             Texture ??= textures.Get(@"Online/avatar-guest");
         }


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/12204.

Closes #13387.

Adding this back in a central location for now, as each of the remaining cases will need a local solution.

For private message tabs, there is apparently an `icon` in the `channel`/`presence` API response which can serve this purpose, but as the chat API is currently in the middle of a refactor I'm not sure it's worth consuming that.

For local leaderboards, we should be using `UserLookupCache`, but this is a bit non-trivial.