### PR TITLE
Add `star` keyword to `FilterQueryParser` criteria

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -33,10 +33,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
          * outside of the range.
          */
 
-        [Test]
-        public void TestApplyStarQueries()
+        [TestCase("star")]
+        [TestCase("stars")]
+        public void TestApplyStarQueries(string variant)
         {
-            const string query = "stars<4 easy";
+            string query = $"{variant}<4 easy";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual("easy", filterCriteria.SearchText.Trim());

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Screens.Select
         {
             switch (key)
             {
+                case "star":
                 case "stars":
                     return TryUpdateCriteriaRange(ref criteria.StarDifficulty, op, value, 0.01d / 2);
 


### PR DESCRIPTION
tiny patches, osu!lazer version of https://github.com/ppy/osu-web/pull/7699, I think there should be the same star name at this part too.

There is a [test](https://github.com/ppy/osu/blob/master/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs#L39) about this, but I'm hesitating to add these changes to the test, is it okay to add it?


![image](https://user-images.githubusercontent.com/37479424/121574297-14879380-ca61-11eb-909d-d171339b8ccc.png)

oops, I accidentally renamed the branch and it closed :c