### PR TITLE
Add remaining metadata fields to editor setup screen

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneMetadataSection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneMetadataSection.cs
@@ -1,0 +1,144 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Setup;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneMetadataSection : OsuTestScene
+    {
+        [Cached]
+        private EditorBeatmap editorBeatmap = new EditorBeatmap(new Beatmap());
+
+        private TestMetadataSection metadataSection;
+
+        [Test]
+        public void TestMinimalMetadata()
+        {
+            AddStep("set metadata", () =>
+            {
+                editorBeatmap.Metadata.Artist = "Example Artist";
+                editorBeatmap.Metadata.ArtistUnicode = null;
+
+                editorBeatmap.Metadata.Title = "Example Title";
+                editorBeatmap.Metadata.TitleUnicode = null;
+            });
+
+            createSection();
+
+            assertArtist("Example Artist");
+            assertRomanisedArtist("Example Artist", false);
+
+            assertTitle("Example Title");
+            assertRomanisedTitle("Example Title", false);
+        }
+
+        [Test]
+        public void TestInitialisationFromNonRomanisedVariant()
+        {
+            AddStep("set metadata", () =>
+            {
+                editorBeatmap.Metadata.ArtistUnicode = "＊なみりん";
+                editorBeatmap.Metadata.Artist = null;
+
+                editorBeatmap.Metadata.TitleUnicode = "コイシテイク・プラネット";
+                editorBeatmap.Metadata.Title = null;
+            });
+
+            createSection();
+
+            assertArtist("＊なみりん");
+            assertRomanisedArtist(string.Empty, true);
+
+            assertTitle("コイシテイク・プラネット");
+            assertRomanisedTitle(string.Empty, true);
+        }
+
+        [Test]
+        public void TestInitialisationPreservesOriginalValues()
+        {
+            AddStep("set metadata", () =>
+            {
+                editorBeatmap.Metadata.ArtistUnicode = "＊なみりん";
+                editorBeatmap.Metadata.Artist = "*namirin";
+
+                editorBeatmap.Metadata.TitleUnicode = "コイシテイク・プラネット";
+                editorBeatmap.Metadata.Title = "Koishiteiku Planet";
+            });
+
+            createSection();
+
+            assertArtist("＊なみりん");
+            assertRomanisedArtist("*namirin", true);
+
+            assertTitle("コイシテイク・プラネット");
+            assertRomanisedTitle("Koishiteiku Planet", true);
+        }
+
+        [Test]
+        public void TestValueTransfer()
+        {
+            AddStep("set metadata", () =>
+            {
+                editorBeatmap.Metadata.ArtistUnicode = "＊なみりん";
+                editorBeatmap.Metadata.Artist = null;
+
+                editorBeatmap.Metadata.TitleUnicode = "コイシテイク・プラネット";
+                editorBeatmap.Metadata.Title = null;
+            });
+
+            createSection();
+
+            AddStep("set romanised artist name", () => metadataSection.ArtistTextBox.Current.Value = "*namirin");
+            assertArtist("*namirin");
+            assertRomanisedArtist("*namirin", false);
+
+            AddStep("set native artist name", () => metadataSection.ArtistTextBox.Current.Value = "＊なみりん");
+            assertArtist("＊なみりん");
+            assertRomanisedArtist("*namirin", true);
+
+            AddStep("set romanised title", () => metadataSection.TitleTextBox.Current.Value = "Hitokoto no kyori");
+            assertTitle("Hitokoto no kyori");
+            assertRomanisedTitle("Hitokoto no kyori", false);
+
+            AddStep("set native title", () => metadataSection.TitleTextBox.Current.Value = "ヒトコトの距離");
+            assertTitle("ヒトコトの距離");
+            assertRomanisedTitle("Hitokoto no kyori", true);
+        }
+
+        private void createSection()
+            => AddStep("create metadata section", () => Child = metadataSection = new TestMetadataSection());
+
+        private void assertArtist(string expected)
+            => AddAssert($"artist is {expected}", () => metadataSection.ArtistTextBox.Current.Value == expected);
+
+        private void assertRomanisedArtist(string expected, bool editable)
+        {
+            AddAssert($"romanised artist is {expected}", () => metadataSection.RomanisedArtistTextBox.Current.Value == expected);
+            AddAssert($"romanised artist is {(editable ? "" : "not ")}editable", () => metadataSection.RomanisedArtistTextBox.ReadOnly == !editable);
+        }
+
+        private void assertTitle(string expected)
+            => AddAssert($"title is {expected}", () => metadataSection.TitleTextBox.Current.Value == expected);
+
+        private void assertRomanisedTitle(string expected, bool editable)
+        {
+            AddAssert($"romanised title is {expected}", () => metadataSection.RomanisedTitleTextBox.Current.Value == expected);
+            AddAssert($"romanised title is {(editable ? "" : "not ")}editable", () => metadataSection.RomanisedTitleTextBox.ReadOnly == !editable);
+        }
+
+        private class TestMetadataSection : MetadataSection
+        {
+            public new LabelledTextBox ArtistTextBox => base.ArtistTextBox;
+            public new LabelledTextBox RomanisedArtistTextBox => base.RomanisedArtistTextBox;
+
+            public new LabelledTextBox TitleTextBox => base.TitleTextBox;
+            public new LabelledTextBox RomanisedTitleTextBox => base.RomanisedTitleTextBox;
+        }
+    }
+}

--- a/osu.Game/Beatmaps/MetadataUtils.cs
+++ b/osu.Game/Beatmaps/MetadataUtils.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System.Linq;
+using System.Text;
+
+namespace osu.Game.Beatmaps
+{
+    /// <summary>
+    /// Groups utility methods used to handle beatmap metadata.
+    /// </summary>
+    public static class MetadataUtils
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> if the character <paramref name="c"/> can be used in <see cref="BeatmapMetadata.Artist"/> and <see cref="BeatmapMetadata.Title"/> fields.
+        /// Characters not matched by this method can be placed in <see cref="BeatmapMetadata.ArtistUnicode"/> and <see cref="BeatmapMetadata.TitleUnicode"/>.
+        /// </summary>
+        public static bool IsRomanised(char c) => c <= 0xFF;
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the string <paramref name="str"/> can be used in <see cref="BeatmapMetadata.Artist"/> and <see cref="BeatmapMetadata.Title"/> fields.
+        /// Strings not matched by this method can be placed in <see cref="BeatmapMetadata.ArtistUnicode"/> and <see cref="BeatmapMetadata.TitleUnicode"/>.
+        /// </summary>
+        public static bool IsRomanised(string? str) => str == null || str.All(IsRomanised);
+
+        /// <summary>
+        /// Returns a copy of <paramref name="str"/> with all characters that do not match <see cref="IsRomanised(char)"/> removed.
+        /// </summary>
+        public static string StripNonRomanisedCharacters(string? str)
+        {
+            if (string.IsNullOrEmpty(str))
+                return string.Empty;
+
+            var stringBuilder = new StringBuilder(str.Length);
+
+            foreach (var c in str)
+            {
+                if (IsRomanised(c))
+                    stringBuilder.Append(c);
+            }
+
+            return stringBuilder.ToString().Trim();
+        }
+    }
+}

--- a/osu.Game/Beatmaps/MetadataUtils.cs
+++ b/osu.Game/Beatmaps/MetadataUtils.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Beatmaps
         /// Returns <see langword="true"/> if the string <paramref name="str"/> can be used in <see cref="BeatmapMetadata.Artist"/> and <see cref="BeatmapMetadata.Title"/> fields.
         /// Strings not matched by this method can be placed in <see cref="BeatmapMetadata.ArtistUnicode"/> and <see cref="BeatmapMetadata.TitleUnicode"/>.
         /// </summary>
-        public static bool IsRomanised(string? str) => str == null || str.All(IsRomanised);
+        public static bool IsRomanised(string? str) => string.IsNullOrEmpty(str) || str.All(IsRomanised);
 
         /// <summary>
         /// Returns a copy of <paramref name="str"/> with all characters that do not match <see cref="IsRomanised(char)"/> removed.

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -45,14 +45,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             Component.BorderColour = colours.Blue;
         }
 
-        protected virtual OsuTextBox CreateTextBox() => new OsuTextBox
-        {
-            CommitOnFocusLost = true,
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            RelativeSizeAxes = Axes.X,
-            CornerRadius = CORNER_RADIUS,
-        };
+        protected virtual OsuTextBox CreateTextBox() => new OsuTextBox();
 
         public override bool AcceptsFocus => true;
 
@@ -64,6 +57,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         protected override OsuTextBox CreateComponent() => CreateTextBox().With(t =>
         {
+            t.CommitOnFocusLost = true;
+            t.Anchor = Anchor.Centre;
+            t.Origin = Anchor.Centre;
+            t.RelativeSizeAxes = Axes.X;
+            t.CornerRadius = CORNER_RADIUS;
+
             t.OnCommit += (sender, newText) => OnCommit?.Invoke(sender, newText);
         });
     }

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public bool ReadOnly
         {
+            get => Component.ReadOnly;
             set => Component.ReadOnly = value;
         }
 

--- a/osu.Game/Screens/Edit/Setup/LabelledRomanisedTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledRomanisedTextBox.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    internal class LabelledRomanisedTextBox : LabelledTextBox
+    {
+        protected override OsuTextBox CreateTextBox() => new RomanisedTextBox();
+
+        private class RomanisedTextBox : OsuTextBox
+        {
+            protected override bool CanAddCharacter(char character)
+                => MetadataUtils.IsRomanised(character);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -24,39 +24,23 @@ namespace osu.Game.Screens.Edit.Setup
         {
             Children = new Drawable[]
             {
-                artistTextBox = new LabelledTextBox
-                {
-                    Label = "Artist",
-                    FixedLabelWidth = LABEL_WIDTH,
-                    Current = { Value = Beatmap.Metadata.Artist },
-                    TabbableContentContainer = this
-                },
-                titleTextBox = new LabelledTextBox
-                {
-                    Label = "Title",
-                    FixedLabelWidth = LABEL_WIDTH,
-                    Current = { Value = Beatmap.Metadata.Title },
-                    TabbableContentContainer = this
-                },
-                creatorTextBox = new LabelledTextBox
-                {
-                    Label = "Creator",
-                    FixedLabelWidth = LABEL_WIDTH,
-                    Current = { Value = Beatmap.Metadata.AuthorString },
-                    TabbableContentContainer = this
-                },
-                difficultyTextBox = new LabelledTextBox
-                {
-                    Label = "Difficulty Name",
-                    FixedLabelWidth = LABEL_WIDTH,
-                    Current = { Value = Beatmap.BeatmapInfo.Version },
-                    TabbableContentContainer = this
-                },
+                artistTextBox = createTextBox("Artist", Beatmap.Metadata.Artist),
+                titleTextBox = createTextBox("Title", Beatmap.Metadata.Title),
+                creatorTextBox = createTextBox("Creator", Beatmap.Metadata.AuthorString),
+                difficultyTextBox = createTextBox("Difficulty Name", Beatmap.BeatmapInfo.Version)
             };
 
             foreach (var item in Children.OfType<LabelledTextBox>())
                 item.OnCommit += onCommit;
         }
+
+        private LabelledTextBox createTextBox(string label, string initialValue) => new LabelledTextBox
+        {
+            Label = label,
+            FixedLabelWidth = LABEL_WIDTH,
+            Current = { Value = initialValue },
+            TabbableContentContainer = this
+        };
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -14,20 +13,26 @@ namespace osu.Game.Screens.Edit.Setup
     {
         private LabelledTextBox artistTextBox;
         private LabelledTextBox titleTextBox;
+
         private LabelledTextBox creatorTextBox;
         private LabelledTextBox difficultyTextBox;
+        private LabelledTextBox sourceTextBox;
+        private LabelledTextBox tagsTextBox;
 
         public override LocalisableString Title => "Metadata";
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Children = new Drawable[]
+            Children = new[]
             {
                 artistTextBox = createTextBox("Artist", Beatmap.Metadata.Artist),
                 titleTextBox = createTextBox("Title", Beatmap.Metadata.Title),
+                Empty(),
                 creatorTextBox = createTextBox("Creator", Beatmap.Metadata.AuthorString),
-                difficultyTextBox = createTextBox("Difficulty Name", Beatmap.BeatmapInfo.Version)
+                difficultyTextBox = createTextBox("Difficulty Name", Beatmap.BeatmapInfo.Version),
+                sourceTextBox = createTextBox("Source", Beatmap.Metadata.Source),
+                tagsTextBox = createTextBox("Tags", Beatmap.Metadata.Tags)
             };
 
             foreach (var item in Children.OfType<LabelledTextBox>())
@@ -58,8 +63,11 @@ namespace osu.Game.Screens.Edit.Setup
             // after switching database engines we can reconsider if switching to bindables is a good direction.
             Beatmap.Metadata.Artist = artistTextBox.Current.Value;
             Beatmap.Metadata.Title = titleTextBox.Current.Value;
+
             Beatmap.Metadata.AuthorString = creatorTextBox.Current.Value;
             Beatmap.BeatmapInfo.Version = difficultyTextBox.Current.Value;
+            Beatmap.Metadata.Source = sourceTextBox.Current.Value;
+            Beatmap.Metadata.Tags = tagsTextBox.Current.Value;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -12,11 +12,11 @@ namespace osu.Game.Screens.Edit.Setup
 {
     internal class MetadataSection : SetupSection
     {
-        private LabelledTextBox artistTextBox;
-        private LabelledTextBox romanisedArtistTextBox;
+        protected LabelledTextBox ArtistTextBox;
+        protected LabelledTextBox RomanisedArtistTextBox;
 
-        private LabelledTextBox titleTextBox;
-        private LabelledTextBox romanisedTitleTextBox;
+        protected LabelledTextBox TitleTextBox;
+        protected LabelledTextBox RomanisedTitleTextBox;
 
         private LabelledTextBox creatorTextBox;
         private LabelledTextBox difficultyTextBox;
@@ -32,16 +32,16 @@ namespace osu.Game.Screens.Edit.Setup
 
             Children = new[]
             {
-                artistTextBox = createTextBox<LabelledTextBox>("Artist",
+                ArtistTextBox = createTextBox<LabelledTextBox>("Artist",
                     !string.IsNullOrEmpty(metadata.ArtistUnicode) ? metadata.ArtistUnicode : metadata.Artist),
-                romanisedArtistTextBox = createTextBox<LabelledRomanisedTextBox>("Romanised Artist",
+                RomanisedArtistTextBox = createTextBox<LabelledRomanisedTextBox>("Romanised Artist",
                     !string.IsNullOrEmpty(metadata.Artist) ? metadata.Artist : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode)),
 
                 Empty(),
 
-                titleTextBox = createTextBox<LabelledTextBox>("Title",
+                TitleTextBox = createTextBox<LabelledTextBox>("Title",
                     !string.IsNullOrEmpty(metadata.TitleUnicode) ? metadata.TitleUnicode : metadata.Title),
-                romanisedTitleTextBox = createTextBox<LabelledRomanisedTextBox>("Romanised Title",
+                RomanisedTitleTextBox = createTextBox<LabelledRomanisedTextBox>("Romanised Title",
                     !string.IsNullOrEmpty(metadata.Title) ? metadata.Title : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode)),
 
                 Empty(),
@@ -70,11 +70,11 @@ namespace osu.Game.Screens.Edit.Setup
         {
             base.LoadComplete();
 
-            if (string.IsNullOrEmpty(artistTextBox.Current.Value))
-                GetContainingInputManager().ChangeFocus(artistTextBox);
+            if (string.IsNullOrEmpty(ArtistTextBox.Current.Value))
+                GetContainingInputManager().ChangeFocus(ArtistTextBox);
 
-            artistTextBox.Current.BindValueChanged(artist => transferIfRomanised(artist.NewValue, romanisedArtistTextBox));
-            titleTextBox.Current.BindValueChanged(title => transferIfRomanised(title.NewValue, romanisedTitleTextBox));
+            ArtistTextBox.Current.BindValueChanged(artist => transferIfRomanised(artist.NewValue, RomanisedArtistTextBox));
+            TitleTextBox.Current.BindValueChanged(title => transferIfRomanised(title.NewValue, RomanisedTitleTextBox));
             updateReadOnlyState();
         }
 
@@ -89,8 +89,8 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void updateReadOnlyState()
         {
-            romanisedArtistTextBox.ReadOnly = MetadataUtils.IsRomanised(artistTextBox.Current.Value);
-            romanisedTitleTextBox.ReadOnly = MetadataUtils.IsRomanised(titleTextBox.Current.Value);
+            RomanisedArtistTextBox.ReadOnly = MetadataUtils.IsRomanised(ArtistTextBox.Current.Value);
+            RomanisedTitleTextBox.ReadOnly = MetadataUtils.IsRomanised(TitleTextBox.Current.Value);
         }
 
         private void onCommit(TextBox sender, bool newText)
@@ -104,11 +104,11 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void updateMetadata()
         {
-            Beatmap.Metadata.ArtistUnicode = artistTextBox.Current.Value;
-            Beatmap.Metadata.Artist = romanisedArtistTextBox.Current.Value;
+            Beatmap.Metadata.ArtistUnicode = ArtistTextBox.Current.Value;
+            Beatmap.Metadata.Artist = RomanisedArtistTextBox.Current.Value;
 
-            Beatmap.Metadata.TitleUnicode = titleTextBox.Current.Value;
-            Beatmap.Metadata.Title = romanisedTitleTextBox.Current.Value;
+            Beatmap.Metadata.TitleUnicode = TitleTextBox.Current.Value;
+            Beatmap.Metadata.Title = RomanisedTitleTextBox.Current.Value;
 
             Beatmap.Metadata.AuthorString = creatorTextBox.Current.Value;
             Beatmap.BeatmapInfo.Version = difficultyTextBox.Current.Value;

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Screens.Edit.Setup
@@ -12,7 +13,10 @@ namespace osu.Game.Screens.Edit.Setup
     internal class MetadataSection : SetupSection
     {
         private LabelledTextBox artistTextBox;
+        private LabelledTextBox romanisedArtistTextBox;
+
         private LabelledTextBox titleTextBox;
+        private LabelledTextBox romanisedTitleTextBox;
 
         private LabelledTextBox creatorTextBox;
         private LabelledTextBox difficultyTextBox;
@@ -24,28 +28,43 @@ namespace osu.Game.Screens.Edit.Setup
         [BackgroundDependencyLoader]
         private void load()
         {
+            var metadata = Beatmap.Metadata;
+
             Children = new[]
             {
-                artistTextBox = createTextBox("Artist", Beatmap.Metadata.Artist),
-                titleTextBox = createTextBox("Title", Beatmap.Metadata.Title),
+                artistTextBox = createTextBox<LabelledTextBox>("Artist",
+                    !string.IsNullOrEmpty(metadata.ArtistUnicode) ? metadata.ArtistUnicode : metadata.Artist),
+                romanisedArtistTextBox = createTextBox<LabelledRomanisedTextBox>("Romanised Artist",
+                    !string.IsNullOrEmpty(metadata.Artist) ? metadata.Artist : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode)),
+
                 Empty(),
-                creatorTextBox = createTextBox("Creator", Beatmap.Metadata.AuthorString),
-                difficultyTextBox = createTextBox("Difficulty Name", Beatmap.BeatmapInfo.Version),
-                sourceTextBox = createTextBox("Source", Beatmap.Metadata.Source),
-                tagsTextBox = createTextBox("Tags", Beatmap.Metadata.Tags)
+
+                titleTextBox = createTextBox<LabelledTextBox>("Title",
+                    !string.IsNullOrEmpty(metadata.TitleUnicode) ? metadata.TitleUnicode : metadata.Title),
+                romanisedTitleTextBox = createTextBox<LabelledRomanisedTextBox>("Romanised Title",
+                    !string.IsNullOrEmpty(metadata.Title) ? metadata.Title : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode)),
+
+                Empty(),
+
+                creatorTextBox = createTextBox<LabelledTextBox>("Creator", metadata.AuthorString),
+                difficultyTextBox = createTextBox<LabelledTextBox>("Difficulty Name", Beatmap.BeatmapInfo.Version),
+                sourceTextBox = createTextBox<LabelledTextBox>("Source", metadata.Source),
+                tagsTextBox = createTextBox<LabelledTextBox>("Tags", metadata.Tags)
             };
 
             foreach (var item in Children.OfType<LabelledTextBox>())
                 item.OnCommit += onCommit;
         }
 
-        private LabelledTextBox createTextBox(string label, string initialValue) => new LabelledTextBox
-        {
-            Label = label,
-            FixedLabelWidth = LABEL_WIDTH,
-            Current = { Value = initialValue },
-            TabbableContentContainer = this
-        };
+        private TTextBox createTextBox<TTextBox>(string label, string initialValue)
+            where TTextBox : LabelledTextBox, new()
+            => new TTextBox
+            {
+                Label = label,
+                FixedLabelWidth = LABEL_WIDTH,
+                Current = { Value = initialValue },
+                TabbableContentContainer = this
+            };
 
         protected override void LoadComplete()
         {
@@ -53,16 +72,43 @@ namespace osu.Game.Screens.Edit.Setup
 
             if (string.IsNullOrEmpty(artistTextBox.Current.Value))
                 GetContainingInputManager().ChangeFocus(artistTextBox);
+
+            artistTextBox.Current.BindValueChanged(artist => transferIfRomanised(artist.NewValue, romanisedArtistTextBox));
+            titleTextBox.Current.BindValueChanged(title => transferIfRomanised(title.NewValue, romanisedTitleTextBox));
+            updateReadOnlyState();
+        }
+
+        private void transferIfRomanised(string value, LabelledTextBox target)
+        {
+            if (MetadataUtils.IsRomanised(value))
+                target.Current.Value = value;
+
+            updateReadOnlyState();
+            updateMetadata();
+        }
+
+        private void updateReadOnlyState()
+        {
+            romanisedArtistTextBox.ReadOnly = MetadataUtils.IsRomanised(artistTextBox.Current.Value);
+            romanisedTitleTextBox.ReadOnly = MetadataUtils.IsRomanised(titleTextBox.Current.Value);
         }
 
         private void onCommit(TextBox sender, bool newText)
         {
             if (!newText) return;
 
-            // for now, update these on commit rather than making BeatmapMetadata bindables.
+            // for now, update on commit rather than making BeatmapMetadata bindables.
             // after switching database engines we can reconsider if switching to bindables is a good direction.
-            Beatmap.Metadata.Artist = artistTextBox.Current.Value;
-            Beatmap.Metadata.Title = titleTextBox.Current.Value;
+            updateMetadata();
+        }
+
+        private void updateMetadata()
+        {
+            Beatmap.Metadata.ArtistUnicode = artistTextBox.Current.Value;
+            Beatmap.Metadata.Artist = romanisedArtistTextBox.Current.Value;
+
+            Beatmap.Metadata.TitleUnicode = titleTextBox.Current.Value;
+            Beatmap.Metadata.Title = romanisedTitleTextBox.Current.Value;
 
             Beatmap.Metadata.AuthorString = creatorTextBox.Current.Value;
             Beatmap.BeatmapInfo.Version = difficultyTextBox.Current.Value;

--- a/osu.Game/Screens/Edit/Setup/SetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupSection.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Edit.Setup
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Spacing = new Vector2(20),
+                        Spacing = new Vector2(10),
                         Direction = FillDirection.Vertical,
                     }
                 }


### PR DESCRIPTION
...and by remaining, I mean "remaining to reach parity with stable".

![osu_2021-06-10_21-29-43](https://user-images.githubusercontent.com/20418176/121589998-0f621e80-ca38-11eb-9bc7-042b5cbf7045.jpg)

Not much in this diff, except for the romanised fields. The update logic is lifted almost verbatim from stable. I'll be adding a few self-comments on this PR to provide commentary on some things.