### PR TITLE
Fix negative offsets incorrectly wrapping in timing screen

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private EditorClock clock { get; set; }
 
-        public const float TIMING_COLUMN_WIDTH = 220;
+        public const float TIMING_COLUMN_WIDTH = 230;
 
         public IEnumerable<ControlPointGroup> ControlGroups
         {
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Edit.Timing
                         {
                             Text = group.Time.ToEditorFormattedString(),
                             Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.Bold),
-                            Width = 60,
+                            Width = 70,
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                         },


### PR DESCRIPTION
Before:

![20210611 132847 (dotnet)](https://user-images.githubusercontent.com/191335/121630891-f6e61880-cab8-11eb-8e6e-72c1270ee0ce.png)

After:

![20210611 132942 (dotnet)](https://user-images.githubusercontent.com/191335/121630937-167d4100-cab9-11eb-832e-c9af4d833a6d.png)