### PR TITLE
Specify legacy skin version of `old-skin` test skin

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Resources/old-skin/skin.ini
+++ b/osu.Game.Rulesets.Catch.Tests/Resources/old-skin/skin.ini
@@ -1,0 +1,2 @@
+[General]
+Version: 1.0

--- a/osu.Game.Rulesets.Catch.Tests/Resources/old-skin/skin.ini
+++ b/osu.Game.Rulesets.Catch.Tests/Resources/old-skin/skin.ini
@@ -1,2 +1,2 @@
 [General]
-Version: 1.0
+// no version specified means v1

--- a/osu.Game.Rulesets.Osu.Tests/Resources/old-skin/skin.ini
+++ b/osu.Game.Rulesets.Osu.Tests/Resources/old-skin/skin.ini
@@ -1,5 +1,5 @@
 [General]
-Version: 1.0
+// no version specified means v1
 
 [Fonts]
 HitCircleOverlap: 3

--- a/osu.Game.Tests/Resources/old-skin/skin.ini
+++ b/osu.Game.Tests/Resources/old-skin/skin.ini
@@ -1,2 +1,2 @@
 [General]
-Version: 1.0
+// no version specified means v1


### PR DESCRIPTION
Fix catcher sprite of the `old-skin` is not used in `CatcherArea` test scene.