### PR TITLE
Move catcher movement logic of `Catcher` to `CatcherArea`

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModRelax.cs
@@ -33,13 +33,13 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         private class MouseInputHelper : Drawable, IKeyBindingHandler<CatchAction>, IRequireHighFrequencyMousePosition
         {
-            private readonly Catcher catcher;
+            private readonly CatcherArea catcherArea;
 
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
             public MouseInputHelper(CatchPlayfield playfield)
             {
-                catcher = playfield.CatcherArea.MovableCatcher;
+                catcherArea = playfield.CatcherArea;
                 RelativeSizeAxes = Axes.Both;
             }
 
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 
             protected override bool OnMouseMove(MouseMoveEvent e)
             {
-                catcher.UpdatePosition(e.MousePosition.X / DrawSize.X * CatchPlayfield.WIDTH);
+                catcherArea.SetCatcherPosition(e.MousePosition.X / DrawSize.X * CatchPlayfield.WIDTH);
                 return base.OnMouseMove(e);
             }
         }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -14,12 +16,19 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class CatcherArea : Container
+    public class CatcherArea : Container, IKeyBindingHandler<CatchAction>
     {
         public const float CATCHER_SIZE = 106.75f;
 
         public readonly Catcher MovableCatcher;
         private readonly CatchComboDisplay comboDisplay;
+
+        /// <summary>
+        /// <c>-1</c> when only left button is pressed.
+        /// <c>1</c> when only right button is pressed.
+        /// <c>0</c> when none or both left and right buttons are pressed.
+        /// </summary>
+        private int currentDirection;
 
         public CatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty difficulty = null)
         {
@@ -63,16 +72,73 @@ namespace osu.Game.Rulesets.Catch.UI
             MovableCatcher.OnRevertResult(hitObject, result);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            var replayState = (GetContainingInputManager().CurrentState as RulesetInputManagerInputState<CatchAction>)?.LastReplayState as CatchFramedReplayInputHandler.CatchReplayState;
+
+            SetCatcherPosition(
+                replayState?.CatcherX ??
+                (float)(MovableCatcher.X + MovableCatcher.Speed * currentDirection * Clock.ElapsedFrameTime));
+        }
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
 
-            var state = (GetContainingInputManager().CurrentState as RulesetInputManagerInputState<CatchAction>)?.LastReplayState as CatchFramedReplayInputHandler.CatchReplayState;
-
-            if (state?.CatcherX != null)
-                MovableCatcher.X = state.CatcherX.Value;
-
             comboDisplay.X = MovableCatcher.X;
+        }
+
+        public void SetCatcherPosition(float X)
+        {
+            float lastPosition = MovableCatcher.X;
+            float newPosition = Math.Clamp(X, 0, CatchPlayfield.WIDTH);
+
+            MovableCatcher.X = newPosition;
+
+            if (lastPosition < newPosition)
+                MovableCatcher.VisualDirection = Direction.Right;
+            else if (lastPosition > newPosition)
+                MovableCatcher.VisualDirection = Direction.Left;
+        }
+
+        public bool OnPressed(CatchAction action)
+        {
+            switch (action)
+            {
+                case CatchAction.MoveLeft:
+                    currentDirection--;
+                    return true;
+
+                case CatchAction.MoveRight:
+                    currentDirection++;
+                    return true;
+
+                case CatchAction.Dash:
+                    MovableCatcher.Dashing = true;
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(CatchAction action)
+        {
+            switch (action)
+            {
+                case CatchAction.MoveLeft:
+                    currentDirection++;
+                    break;
+
+                case CatchAction.MoveRight:
+                    currentDirection--;
+                    break;
+
+                case CatchAction.Dash:
+                    MovableCatcher.Dashing = false;
+                    break;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/Direction.cs
+++ b/osu.Game.Rulesets.Catch/UI/Direction.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    public enum Direction
+    {
+        Right = 1,
+        Left = -1
+    }
+}


### PR DESCRIPTION
It unifies the code of moving the catcher

- While a replay is playing, or when
- No replay is playing, the user is moving the catcher.

The movement of the catcher when a replay is playing was `UpdateAfterChildren` and it is moved to `Update`. This change shouldn't affect normal replay, but it cannot really be tested because the replay playing is already far from perfect for several reasons.