### PR TITLE
Add fallback-to-default logic for HoverSounds and HoverClickSounds

### DIFF
--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select");
+            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select") ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleClick = audio.Samples.Get($@"UI/generic-select{SampleSet.GetDescription()}");
+            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select");
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, SessionStatics statics)
         {
-            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-hover");
+            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-hover") ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-hover");
         }
 
         public override void PlayHoverSample()
@@ -44,7 +44,7 @@ namespace osu.Game.Graphics.UserInterface
     public enum HoverSampleSet
     {
         [Description("default")]
-        Loud,
+        Default,
 
         [Description("soft")]
         Normal,

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, SessionStatics statics)
         {
-            sampleHover = audio.Samples.Get($@"UI/generic-hover{SampleSet.GetDescription()}");
+            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-hover");
         }
 
         public override void PlayHoverSample()
@@ -43,19 +43,19 @@ namespace osu.Game.Graphics.UserInterface
 
     public enum HoverSampleSet
     {
-        [Description("")]
+        [Description("default")]
         Loud,
 
-        [Description("-soft")]
+        [Description("soft")]
         Normal,
 
-        [Description("-softer")]
+        [Description("softer")]
         Soft,
 
-        [Description("-toolbar")]
+        [Description("toolbar")]
         Toolbar,
 
-        [Description("-songselect")]
+        [Description("songselect")]
         SongSelect
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Graphics.UserInterface
         protected Box Background;
         protected SpriteText SpriteText;
 
-        public OsuButton(HoverSampleSet? hoverSounds = HoverSampleSet.Loud)
+        public OsuButton(HoverSampleSet? hoverSounds = HoverSampleSet.Default)
         {
             Height = 40;
 


### PR DESCRIPTION
Saves having duplicate hover samples on disk when a component only has a unique click sound, for example.

- [ ] depends on #13451