### PR TITLE
Fix focused overlays playing their "appear" sound when not necessarily changing state

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -107,10 +107,10 @@ namespace osu.Game.Graphics.Containers
         {
         }
 
-        private bool playedPopInSound;
-
         protected override void UpdateState(ValueChangedEvent<Visibility> state)
         {
+            bool didChange = state.NewValue != state.OldValue;
+
             switch (state.NewValue)
             {
                 case Visibility.Visible:
@@ -121,18 +121,15 @@ namespace osu.Game.Graphics.Containers
                         return;
                     }
 
-                    samplePopIn?.Play();
-                    playedPopInSound = true;
+                    if (didChange)
+                        samplePopIn?.Play();
 
                     if (BlockScreenWideMouse && DimMainContent) game?.AddBlockingOverlay(this);
                     break;
 
                 case Visibility.Hidden:
-                    if (playedPopInSound)
-                    {
+                    if (didChange)
                         samplePopOut?.Play();
-                        playedPopInSound = false;
-                    }
 
                     if (BlockScreenWideMouse) game?.RemoveBlockingOverlay(this);
                     break;


### PR DESCRIPTION
Many overlays call `Show()` when presenting new information, even when they are already on the screen. This is done to bring them to the front, but happened to also play the "pop-in" sample each time.

This fixes that oversight by only playing samples when an actual state transition occurs.

Can be tested by clicking through different builds at the changelog overlay.