### PR TITLE
Revert "Add nested `PlatformActionContainer` to allow testing of platform actions in visual tests"

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.611.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.611.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.614.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input;
 using osu.Framework.Testing.Input;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.Sprites;
@@ -49,7 +48,7 @@ namespace osu.Game.Tests.Visual
                 InputManager = new ManualInputManager
                 {
                     UseParentInput = true,
-                    Child = new PlatformActionContainer().WithChild(mainContent)
+                    Child = mainContent
                 },
                 new Container
                 {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ppy.osu.Framework" Version="2021.611.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.614.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.611.0" />
     <PackageReference Include="Sentry" Version="3.4.0" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.611.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.614.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.611.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.611.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.614.0" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
This reverts commit be91203c92ba7004f0f03b32878b3a4182092584.

This is not handled by `ManualInputManager` itself.

- [x] Depends on https://github.com/ppy/osu-framework/pull/4509.