### PR TITLE
Add support for song select leaderboard to handle newly imported scores

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
@@ -37,18 +38,37 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Size = new Vector2(550f, 450f),
                 Scope = BeatmapLeaderboardScope.Global,
             });
+        }
 
+        [Test]
+        public void TestScoresDisplay()
+        {
             AddStep(@"New Scores", newScores);
+        }
+
+        [Test]
+        public void TestPersonalBest()
+        {
             AddStep(@"Show personal best", showPersonalBest);
+            AddStep("null personal best position", showPersonalBestWithNullPosition);
+        }
+
+        [Test]
+        public void TestPlaceholderStates()
+        {
             AddStep(@"Empty Scores", () => leaderboard.SetRetrievalState(PlaceholderState.NoScores));
             AddStep(@"Network failure", () => leaderboard.SetRetrievalState(PlaceholderState.NetworkFailure));
             AddStep(@"No supporter", () => leaderboard.SetRetrievalState(PlaceholderState.NotSupporter));
             AddStep(@"Not logged in", () => leaderboard.SetRetrievalState(PlaceholderState.NotLoggedIn));
             AddStep(@"Unavailable", () => leaderboard.SetRetrievalState(PlaceholderState.Unavailable));
             AddStep(@"None selected", () => leaderboard.SetRetrievalState(PlaceholderState.NoneSelected));
+        }
+
+        [Test]
+        public void TestBeatmapStates()
+        {
             foreach (BeatmapSetOnlineStatus status in Enum.GetValues(typeof(BeatmapSetOnlineStatus)))
                 AddStep($"{status} beatmap", () => showBeatmapWithStatus(status));
-            AddStep("null personal best position", showPersonalBestWithNullPosition);
         }
 
         private void showPersonalBestWithNullPosition()

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -2,16 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Graphics;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select.Leaderboards;
+using osu.Game.Tests.Resources;
 using osu.Game.Users;
 using osuTK;
 
@@ -24,26 +30,73 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Cached]
         private readonly DialogOverlay dialogOverlay;
 
+        private ScoreManager scoreManager;
+
+        private RulesetStore rulesetStore;
+        private BeatmapManager beatmapManager;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            dependencies.Cache(rulesetStore = new RulesetStore(ContextFactory));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, null, ContextFactory));
+
+            return dependencies;
+        }
+
         public TestSceneBeatmapLeaderboard()
         {
-            Add(dialogOverlay = new DialogOverlay
+            AddRange(new Drawable[]
             {
-                Depth = -1
-            });
-
-            Add(leaderboard = new FailableLeaderboard
-            {
-                Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-                Size = new Vector2(550f, 450f),
-                Scope = BeatmapLeaderboardScope.Global,
+                dialogOverlay = new DialogOverlay
+                {
+                    Depth = -1
+                },
+                leaderboard = new FailableLeaderboard
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    Size = new Vector2(550f, 450f),
+                    Scope = BeatmapLeaderboardScope.Global,
+                }
             });
         }
 
         [Test]
-        public void TestScoresDisplay()
+        public void TestLocalScoresDisplay()
         {
-            AddStep(@"New Scores", newScores);
+            BeatmapInfo beatmapInfo = null;
+
+            AddStep(@"Set scope", () => leaderboard.Scope = BeatmapLeaderboardScope.Local);
+
+            AddStep(@"Set beatmap", () =>
+            {
+                beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).Wait();
+                beatmapInfo = beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps.First();
+
+                leaderboard.Beatmap = beatmapInfo;
+            });
+
+            clearScores();
+            checkCount(0);
+
+            loadMoreScores(() => beatmapInfo);
+            checkCount(10);
+
+            loadMoreScores(() => beatmapInfo);
+            checkCount(20);
+
+            clearScores();
+            checkCount(0);
+        }
+
+        [Test]
+        public void TestGlobalScoresDisplay()
+        {
+            AddStep(@"Set scope", () => leaderboard.Scope = BeatmapLeaderboardScope.Global);
+            AddStep(@"New Scores", () => leaderboard.Scores = generateSampleScores(null));
         }
 
         [Test]
@@ -116,9 +169,26 @@ namespace osu.Game.Tests.Visual.SongSelect
             };
         }
 
-        private void newScores()
+        private void loadMoreScores(Func<BeatmapInfo> beatmapInfo)
         {
-            var scores = new[]
+            AddStep(@"Load new scores via manager", () =>
+            {
+                foreach (var score in generateSampleScores(beatmapInfo()))
+                    scoreManager.Import(score).Wait();
+            });
+        }
+
+        private void clearScores()
+        {
+            AddStep("Clear all scores", () => scoreManager.Delete(scoreManager.GetAllUsableScores()));
+        }
+
+        private void checkCount(int expected) =>
+            AddUntilStep("Correct count displayed", () => leaderboard.ChildrenOfType<LeaderboardScore>().Count() == expected);
+
+        private static ScoreInfo[] generateSampleScores(BeatmapInfo beatmap)
+        {
+            return new[]
             {
                 new ScoreInfo
                 {
@@ -127,6 +197,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 6602580,
@@ -145,6 +216,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 4608074,
@@ -163,6 +235,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 1014222,
@@ -181,6 +254,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 1541390,
@@ -199,6 +273,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 2243452,
@@ -217,6 +292,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 2705430,
@@ -235,6 +311,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 7151382,
@@ -253,6 +330,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 2051389,
@@ -271,6 +349,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 6169483,
@@ -289,6 +368,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     MaxCombo = 244,
                     TotalScore = 1707827,
                     //Mods = new Mod[] { new OsuModHidden(), new OsuModHardRock(), },
+                    Beatmap = beatmap,
                     User = new User
                     {
                         Id = 6702666,
@@ -301,8 +381,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                     },
                 },
             };
-
-            leaderboard.Scores = scores;
         }
 
         private void showBeatmapWithStatus(BeatmapSetOnlineStatus status)

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Online.Leaderboards
                     return;
 
                 scope = value;
-                UpdateScores();
+                RefreshScores();
             }
         }
 
@@ -154,7 +154,7 @@ namespace osu.Game.Online.Leaderboards
                     case PlaceholderState.NetworkFailure:
                         replacePlaceholder(new ClickablePlaceholder(@"Couldn't fetch scores!", FontAwesome.Solid.Sync)
                         {
-                            Action = UpdateScores,
+                            Action = RefreshScores
                         });
                         break;
 
@@ -254,8 +254,6 @@ namespace osu.Game.Online.Leaderboards
             apiState.BindValueChanged(onlineStateChanged, true);
         }
 
-        public void RefreshScores() => UpdateScores();
-
         private APIRequest getScoresRequest;
 
         protected abstract bool IsOnlineScope { get; }
@@ -267,11 +265,13 @@ namespace osu.Game.Online.Leaderboards
                 case APIState.Online:
                 case APIState.Offline:
                     if (IsOnlineScope)
-                        UpdateScores();
+                        RefreshScores();
 
                     break;
             }
         });
+
+        public void RefreshScores() => Scheduler.AddOnce(UpdateScores);
 
         protected void UpdateScores()
         {

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -44,9 +44,9 @@ namespace osu.Game.Online.Leaderboards
 
         protected override Container<Drawable> Content => content;
 
-        private IEnumerable<TScoreInfo> scores;
+        private ICollection<TScoreInfo> scores;
 
-        public IEnumerable<TScoreInfo> Scores
+        public ICollection<TScoreInfo> Scores
         {
             get => scores;
             set
@@ -290,7 +290,7 @@ namespace osu.Game.Online.Leaderboards
 
                 getScoresRequest = FetchScores(scores => Schedule(() =>
                 {
-                    Scores = scores;
+                    Scores = scores.ToArray();
                     PlaceholderState = Scores.Any() ? PlaceholderState.Successful : PlaceholderState.NoScores;
                 }));
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (Scope != BeatmapLeaderboardScope.Local)
                 return;
 
-            Scheduler.AddOnce(RefreshScores);
+            RefreshScores();
         }
 
         private void onScoreAdded(ValueChangedEvent<WeakReference<ScoreInfo>> score)
@@ -111,7 +111,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (Scope != BeatmapLeaderboardScope.Local)
                 return;
 
-            Scheduler.AddOnce(RefreshScores);
+            RefreshScores();
         }
 
         protected override bool IsOnlineScope => Scope != BeatmapLeaderboardScope.Local;

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (score.NewValue.TryGetTarget(out var scoreInfo))
             {
-                if (Beatmap.ID != scoreInfo.BeatmapInfoID)
+                if (Beatmap?.ID != scoreInfo.BeatmapInfoID)
                     return;
             }
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private IBindable<WeakReference<ScoreInfo>> itemRemoved;
 
+        private IBindable<WeakReference<ScoreInfo>> itemAdded;
+
         /// <summary>
         /// Whether to apply the game's currently selected mods as a filter when retrieving scores.
         /// </summary>
@@ -85,6 +87,9 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             itemRemoved = scoreManager.ItemRemoved.GetBoundCopy();
             itemRemoved.BindValueChanged(onScoreRemoved);
+
+            itemAdded = scoreManager.ItemUpdated.GetBoundCopy();
+            itemAdded.BindValueChanged(onScoreAdded);
         }
 
         protected override void Reset()
@@ -93,7 +98,21 @@ namespace osu.Game.Screens.Select.Leaderboards
             TopScore = null;
         }
 
-        private void onScoreRemoved(ValueChangedEvent<WeakReference<ScoreInfo>> score) => Schedule(RefreshScores);
+        private void onScoreRemoved(ValueChangedEvent<WeakReference<ScoreInfo>> score)
+        {
+            if (Scope != BeatmapLeaderboardScope.Local)
+                return;
+
+            Scheduler.AddOnce(RefreshScores);
+        }
+
+        private void onScoreAdded(ValueChangedEvent<WeakReference<ScoreInfo>> score)
+        {
+            if (Scope != BeatmapLeaderboardScope.Local)
+                return;
+
+            Scheduler.AddOnce(RefreshScores);
+        }
 
         protected override bool IsOnlineScope => Scope != BeatmapLeaderboardScope.Local;
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -98,18 +98,22 @@ namespace osu.Game.Screens.Select.Leaderboards
             TopScore = null;
         }
 
-        private void onScoreRemoved(ValueChangedEvent<WeakReference<ScoreInfo>> score)
+        private void onScoreRemoved(ValueChangedEvent<WeakReference<ScoreInfo>> score) =>
+            scoreStoreChanged(score);
+
+        private void onScoreAdded(ValueChangedEvent<WeakReference<ScoreInfo>> score) =>
+            scoreStoreChanged(score);
+
+        private void scoreStoreChanged(ValueChangedEvent<WeakReference<ScoreInfo>> score)
         {
             if (Scope != BeatmapLeaderboardScope.Local)
                 return;
 
-            RefreshScores();
-        }
-
-        private void onScoreAdded(ValueChangedEvent<WeakReference<ScoreInfo>> score)
-        {
-            if (Scope != BeatmapLeaderboardScope.Local)
-                return;
+            if (score.NewValue.TryGetTarget(out var scoreInfo))
+            {
+                if (Beatmap.ID != scoreInfo.BeatmapInfoID)
+                    return;
+            }
 
             RefreshScores();
         }


### PR DESCRIPTION
Also generally improves the debounce logic to (potentially?) fix other edge cases.

- Closes https://github.com/ppy/osu/issues/13465 (as much as we are going to close it without database refactors)
- Closes https://github.com/ppy/osu/issues/13376