### PR TITLE
Make all localisation class strings verbatim

### DIFF
--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -7,17 +7,17 @@ namespace osu.Game.Localisation
 {
     public static class ChatStrings
     {
-        private const string prefix = "osu.Game.Localisation.Chat";
+        private const string prefix = @"osu.Game.Localisation.Chat";
 
         /// <summary>
         /// "chat"
         /// </summary>
-        public static LocalisableString HeaderTitle => new TranslatableString(getKey("header_title"), "chat");
+        public static LocalisableString HeaderTitle => new TranslatableString(getKey(@"header_title"), @"chat");
 
         /// <summary>
         /// "join the real-time discussion"
         /// </summary>
-        public static LocalisableString HeaderDescription => new TranslatableString(getKey("header_description"), "join the real-time discussion");
+        public static LocalisableString HeaderDescription => new TranslatableString(getKey(@"header_description"), @"join the real-time discussion");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -7,12 +7,12 @@ namespace osu.Game.Localisation
 {
     public static class CommonStrings
     {
-        private const string prefix = "osu.Game.Localisation.Common";
+        private const string prefix = @"osu.Game.Localisation.Common";
 
         /// <summary>
         /// "Cancel"
         /// </summary>
-        public static LocalisableString Cancel => new TranslatableString(getKey("cancel"), "Cancel");
+        public static LocalisableString Cancel => new TranslatableString(getKey(@"cancel"), @"Cancel");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -7,10 +7,10 @@ namespace osu.Game.Localisation
 {
     public enum Language
     {
-        [Description("English")]
+        [Description(@"English")]
         en,
 
-        [Description("日本語")]
+        [Description(@"日本語")]
         ja
     }
 }

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -7,17 +7,17 @@ namespace osu.Game.Localisation
 {
     public static class NotificationsStrings
     {
-        private const string prefix = "osu.Game.Localisation.Notifications";
+        private const string prefix = @"osu.Game.Localisation.Notifications";
 
         /// <summary>
         /// "notifications"
         /// </summary>
-        public static LocalisableString HeaderTitle => new TranslatableString(getKey("header_title"), "notifications");
+        public static LocalisableString HeaderTitle => new TranslatableString(getKey(@"header_title"), @"notifications");
 
         /// <summary>
         /// "waiting for 'ya"
         /// </summary>
-        public static LocalisableString HeaderDescription => new TranslatableString(getKey("header_description"), "waiting for 'ya");
+        public static LocalisableString HeaderDescription => new TranslatableString(getKey(@"header_description"), @"waiting for 'ya");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/NowPlayingStrings.cs
+++ b/osu.Game/Localisation/NowPlayingStrings.cs
@@ -7,17 +7,17 @@ namespace osu.Game.Localisation
 {
     public static class NowPlayingStrings
     {
-        private const string prefix = "osu.Game.Localisation.NowPlaying";
+        private const string prefix = @"osu.Game.Localisation.NowPlaying";
 
         /// <summary>
         /// "now playing"
         /// </summary>
-        public static LocalisableString HeaderTitle => new TranslatableString(getKey("header_title"), "now playing");
+        public static LocalisableString HeaderTitle => new TranslatableString(getKey(@"header_title"), @"now playing");
 
         /// <summary>
         /// "manage the currently playing track"
         /// </summary>
-        public static LocalisableString HeaderDescription => new TranslatableString(getKey("header_description"), "manage the currently playing track");
+        public static LocalisableString HeaderDescription => new TranslatableString(getKey(@"header_description"), @"manage the currently playing track");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/SettingsStrings.cs
+++ b/osu.Game/Localisation/SettingsStrings.cs
@@ -7,17 +7,17 @@ namespace osu.Game.Localisation
 {
     public static class SettingsStrings
     {
-        private const string prefix = "osu.Game.Localisation.Settings";
+        private const string prefix = @"osu.Game.Localisation.Settings";
 
         /// <summary>
         /// "settings"
         /// </summary>
-        public static LocalisableString HeaderTitle => new TranslatableString(getKey("header_title"), "settings");
+        public static LocalisableString HeaderTitle => new TranslatableString(getKey(@"header_title"), @"settings");
 
         /// <summary>
         /// "change the way osu! behaves"
         /// </summary>
-        public static LocalisableString HeaderDescription => new TranslatableString(getKey("header_description"), "change the way osu! behaves");
+        public static LocalisableString HeaderDescription => new TranslatableString(getKey(@"header_description"), @"change the way osu! behaves");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }


### PR DESCRIPTION
Just saw these which are formatted differently than what the Roslyn tool would generate.