### PR TITLE
Temporarily disable `dotnet format` to unblock CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,11 @@ build:
   publish_nuget: true
 after_build:
   - ps: dotnet tool restore
-  - ps: dotnet format --dry-run --check
+
+  # Temporarily disabled until the tool is upgraded to 5.0.
+  # The version specified in .config/dotnet-tools.json (3.1.37601) won't run on .NET hosts >=5.0.7.
+  # - ps: dotnet format --dry-run --check
+
   - ps: .\InspectCode.ps1
 test:
   assemblies:


### PR DESCRIPTION
It looks as if the issue that impacted github actions in framework (see https://github.com/ppy/osu-framework/pull/4468) has finally hit appveyor, as well - see failing builds [no. 1](https://ci.appveyor.com/project/peppy/osu/builds/39595110), [no. 2](https://ci.appveyor.com/project/peppy/osu/builds/39597030), [no. 3 (on my fork)](https://ci.appveyor.com/project/bdach/osu/builds/39597313).

From the build output it looks like the root cause/breaking environment change is a .NET SDK/host version upgrade on the appveyor machines. A build on SDK 5.0.203 + host 5.0.6 [worked just fine](https://ci.appveyor.com/project/peppy/osu/builds/39590250), the broken builds all have SDK 5.0.301 + host 5.0.7.

PRing for visibility/ease of unblocking; bumping the tool is also an option, but as is the case on the framework side, will require fixing new inspections, including `using` sort order in particular.