### PR TITLE
Fix malformed database test failing in single-threaded mode

### DIFF
--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -113,7 +113,6 @@ namespace osu.Game.Tests.Collections.IO
                         await importCollectionsFromStream(osu, ms);
                     }
 
-                    Assert.That(host.UpdateThread.Running, Is.True);
                     Assert.That(exceptionThrown, Is.False);
                     Assert.That(osu.CollectionManager.Collections.Count, Is.EqualTo(0));
                 }


### PR DESCRIPTION
As seen in https://github.com/smoogipoo/osu/runs/2829956423?check_suite_focus=true

Just removing this assertion, which is pretty weird to have anyway.