### PR TITLE
Fix seasonal backgrounds not cycling

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
@@ -161,15 +161,18 @@ namespace osu.Game.Tests.Visual.Background
 
         private void loadNextBackground()
         {
+            SeasonalBackground previousBackground = null;
             SeasonalBackground background = null;
 
             AddStep("create next background", () =>
             {
+                previousBackground = (SeasonalBackground)backgroundContainer.SingleOrDefault();
                 background = backgroundLoader.LoadNextBackground();
                 LoadComponentAsync(background, bg => backgroundContainer.Child = bg);
             });
 
             AddUntilStep("background loaded", () => background.IsLoaded);
+            AddAssert("background is different", () => !background.Equals(previousBackground));
         }
 
         private void assertAnyBackground()

--- a/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
+++ b/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
@@ -99,5 +99,14 @@ namespace osu.Game.Graphics.Backgrounds
             // ensure we're not loading in without a transition.
             this.FadeInFromZero(200, Easing.InOutSine);
         }
+
+        public override bool Equals(Background other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return other.GetType() == GetType()
+                   && ((SeasonalBackground)other).url == url;
+        }
     }
 }


### PR DESCRIPTION
Closes #13508.

Regressed in #13393. Forgot about seasonal backgrounds... Should have checked all inheritors. Thankfully there are no more now.

The testing is a little indirect (doesn't reside in `TestSceneBackgroundScreenDefault`) but I didn't really want to duplicate the existing testing setup from `TestSceneSeasonalBackgroundLoader`.