### PR TITLE
Allow setting `Entry` of `PoolableDrawableWithLifetime` (including `DrawableHitObject`)

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -44,11 +44,9 @@ namespace osu.Game.Tests.Gameplay
         {
             TestDrawableHitObject dho = null;
             TestLifetimeEntry entry = null;
-            AddStep("Create DHO", () =>
+            AddStep("Create DHO", () => Child = dho = new TestDrawableHitObject
             {
-                dho = new TestDrawableHitObject(null);
-                dho.Apply(entry = new TestLifetimeEntry(new HitObject()));
-                Child = dho;
+                Entry = entry = new TestLifetimeEntry(new HitObject())
             });
 
             AddStep("KeepAlive = true", () =>
@@ -81,12 +79,10 @@ namespace osu.Game.Tests.Gameplay
             AddAssert("Lifetime is updated", () => entry.LifetimeStart == -TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
 
             TestDrawableHitObject dho = null;
-            AddStep("Create DHO", () =>
+            AddStep("Create DHO", () => Child = dho = new TestDrawableHitObject
             {
-                dho = new TestDrawableHitObject(null);
-                dho.Apply(entry);
-                Child = dho;
-                dho.SetLifetimeStartOnApply = true;
+                Entry = entry,
+                SetLifetimeStartOnApply = true
             });
             AddStep("ApplyDefaults", () => entry.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty()));
             AddAssert("Lifetime is correct", () => dho.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY && entry.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY);
@@ -97,11 +93,9 @@ namespace osu.Game.Tests.Gameplay
         {
             TestDrawableHitObject dho = null;
             TestLifetimeEntry entry = null;
-            AddStep("Create DHO", () =>
+            AddStep("Create DHO", () => Child = dho = new TestDrawableHitObject
             {
-                dho = new TestDrawableHitObject(null);
-                dho.Apply(entry = new TestLifetimeEntry(new HitObject()));
-                Child = dho;
+                Entry = entry = new TestLifetimeEntry(new HitObject())
             });
 
             AddStep("Set entry lifetime", () =>
@@ -135,7 +129,7 @@ namespace osu.Game.Tests.Gameplay
 
             public bool SetLifetimeStartOnApply;
 
-            public TestDrawableHitObject(HitObject hitObject)
+            public TestDrawableHitObject(HitObject hitObject = null)
                 : base(hitObject)
             {
             }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -156,10 +156,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// If <c>null</c>, a hitobject is expected to be later applied via <see cref="PoolableDrawableWithLifetime{TEntry}.Apply"/> (or automatically via pooling).
         /// </param>
         protected DrawableHitObject([CanBeNull] HitObject initialHitObject = null)
-            : base(initialHitObject != null ? new SyntheticHitObjectEntry(initialHitObject) : null)
         {
-            if (Entry != null)
-                ensureEntryHasResult();
+            if (initialHitObject == null) return;
+
+            Entry = new SyntheticHitObjectEntry(initialHitObject);
+            ensureEntryHasResult();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </summary>
         /// <remarks>
         /// If a non-null value is set before loading is started, the entry is applied when the loading is completed.
+        /// It is not valid to set an entry while this <see cref="PoolableDrawableWithLifetime{TEntry}"/> is loading.
         /// </remarks>
         public TEntry? Entry
         {

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -30,7 +30,9 @@ namespace osu.Game.Rulesets.Objects.Pooling
             get => entry;
             set
             {
-                if (value != null)
+                if (LoadState == LoadState.NotLoaded)
+                    entry = value;
+                else if (value != null)
                     Apply(value);
                 else if (HasEntryApplied)
                     free();

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -132,11 +132,11 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
         private void free()
         {
-            Debug.Assert(entry != null && HasEntryApplied);
+            Debug.Assert(Entry != null && HasEntryApplied);
 
-            OnFree(entry);
+            OnFree(Entry);
 
-            entry.LifetimeChanged -= setLifetimeFromEntry;
+            Entry.LifetimeChanged -= setLifetimeFromEntry;
             entry = null;
             base.LifetimeStart = double.MinValue;
             base.LifetimeEnd = double.MaxValue;


### PR DESCRIPTION
It is more convenient than using the constructor because the only limited kind of expression is allowed in a base constructor call.
Also, it allows the object initialization syntax.