### PR TITLE
Don't invoke "completed" action for test scene virtual track

### DIFF
--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -350,7 +350,7 @@ namespace osu.Game.Tests.Visual
                     if (CurrentTime >= Length)
                     {
                         Stop();
-                        RaiseCompleted();
+                        // `RaiseCompleted` is not called here to prevent transitioning to the next song.
                     }
                 }
             }


### PR DESCRIPTION
`MusicController` tries to play the next music when a track is completed.
In test scenes, we want to keep the virtual track, not random songs.

- Fixes #11301