### PR TITLE
Add more languages to settings dropdown

### DIFF
--- a/osu.Game/Extensions/LanguageExtensions.cs
+++ b/osu.Game/Extensions/LanguageExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using osu.Game.Localisation;
+
+namespace osu.Game.Extensions
+{
+    /// <summary>
+    /// Conversion utilities for the <see cref="Language"/> enum.
+    /// </summary>
+    public static class LanguageExtensions
+    {
+        /// <summary>
+        /// Returns the culture code of the <see cref="CultureInfo"/> that corresponds to the supplied <paramref name="language"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is required as enum member names are not allowed to contain hyphens.
+        /// </remarks>
+        public static string ToCultureCode(this Language language)
+            => language.ToString().Replace("_", "-");
+
+        /// <summary>
+        /// Attempts to parse the supplied <paramref name="cultureCode"/> to a <see cref="Language"/> value.
+        /// </summary>
+        /// <param name="cultureCode">The code of the culture to parse.</param>
+        /// <param name="language">The parsed <see cref="Language"/>. Valid only if the return value of the method is <see langword="true" />.</param>
+        /// <returns>Whether the parsing succeeded.</returns>
+        public static bool TryParseCultureCode(string cultureCode, out Language language)
+            => Enum.TryParse(cultureCode.Replace("-", "_"), out language);
+    }
+}

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -10,7 +10,104 @@ namespace osu.Game.Localisation
         [Description(@"English")]
         en,
 
+        // TODO: Requires Arabic glyphs to be added to resources (and possibly also RTL support).
+        // [Description(@"اَلْعَرَبِيَّةُ")]
+        // ar,
+
+        // TODO: Some accented glyphs are missing. Revisit when adding Inter.
+        // [Description(@"Беларуская мова")]
+        // be,
+
+        [Description(@"Български")]
+        bg,
+
+        [Description(@"Česky")]
+        cs,
+
+        [Description(@"Dansk")]
+        da,
+
+        [Description(@"Deutsch")]
+        de,
+
+        // TODO: Some accented glyphs are missing. Revisit when adding Inter.
+        // [Description(@"Ελληνικά")]
+        // el,
+
+        [Description(@"español")]
+        es,
+
+        [Description(@"Suomi")]
+        fi,
+
+        [Description(@"français")]
+        fr,
+
+        [Description(@"Magyar")]
+        hu,
+
+        [Description(@"Bahasa Indonesia")]
+        id,
+
+        [Description(@"Italiano")]
+        it,
+
         [Description(@"日本語")]
-        ja
+        ja,
+
+        [Description(@"한국어")]
+        ko,
+
+        [Description(@"Nederlands")]
+        nl,
+
+        [Description(@"Norsk")]
+        no,
+
+        [Description(@"polski")]
+        pl,
+
+        [Description(@"Português")]
+        pt,
+
+        [Description(@"Português (Brasil)")]
+        pt_br,
+
+        [Description(@"Română")]
+        ro,
+
+        [Description(@"Русский")]
+        ru,
+
+        [Description(@"Slovenčina")]
+        sk,
+
+        [Description(@"Svenska")]
+        se,
+
+        [Description(@"ไทย")]
+        th,
+
+        [Description(@"Tagalog")]
+        tl,
+
+        [Description(@"Türkçe")]
+        tr,
+
+        // TODO: Some accented glyphs are missing. Revisit when adding Inter.
+        // [Description(@"Українська мова")]
+        // uk,
+
+        [Description(@"Tiếng Việt")]
+        vn,
+
+        [Description(@"简体中文")]
+        zh,
+
+        [Description(@"繁體中文（香港）")]
+        zh_hk,
+
+        [Description(@"繁體中文（台灣）")]
+        zh_tw
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -50,6 +50,7 @@ using osu.Game.Updater;
 using osu.Game.Utils;
 using LogLevel = osu.Framework.Logging.LogLevel;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.Localisation;
 using osu.Game.Skinning.Editor;
@@ -580,7 +581,7 @@ namespace osu.Game
 
             foreach (var language in Enum.GetValues(typeof(Language)).OfType<Language>())
             {
-                var cultureCode = language.ToString();
+                var cultureCode = language.ToCultureCode();
                 Localisation.AddLanguage(cultureCode, new ResourceManagerLocalisationStore(cultureCode));
             }
 

--- a/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Game.Extensions;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.General
@@ -35,11 +35,11 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 },
             };
 
-            if (!Enum.TryParse<Language>(frameworkLocale.Value, out var locale))
+            if (!LanguageExtensions.TryParseCultureCode(frameworkLocale.Value, out var locale))
                 locale = Language.en;
             languageSelection.Current.Value = locale;
 
-            languageSelection.Current.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToString());
+            languageSelection.Current.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToCultureCode());
         }
     }
 }

--- a/osu.Game/Overlays/Settings/SettingsEnumDropdown.cs
+++ b/osu.Game/Overlays/Settings/SettingsEnumDropdown.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Overlays.Settings
                 Margin = new MarginPadding { Top = 5 };
                 RelativeSizeAxes = Axes.X;
             }
+
+            protected override DropdownMenu CreateMenu() => base.CreateMenu().With(m => m.MaxHeight = 200);
         }
     }
 }


### PR DESCRIPTION


https://user-images.githubusercontent.com/191335/122596094-59847900-d0a4-11eb-9593-7eadfcfb0755.mp4



[Reference for languages.](https://github.com/ppy/osu-web/blob/28bb42f994996bcf31c97e6d6ebb195a6a94c034/app/Libraries/LocaleMeta.php)

Some caveats:

* Some Latin/Cyrilic languages, as well as Arabic, are still commented out due to missing glyphs. May be a thing to revisit with #12739 with regard to the former; the latter is more complex (need a separate Arabic font and possibly support RTL text).
* On some languages, the beatmap listing filter labels overflow. This is not simple to fix as `TextFlowContainer` (which should be used there as per web) has no support for localisation.
* I needed to limit the dropdown height as it was too tall to see in full with all the values. [The non-enum settings dropdown already has this set globally](https://github.com/ppy/osu/blob/cb9db0da0ab84c8a082410fae451ca96b1b14295/osu.Game/Overlays/Settings/SettingsDropdown.cs#L42) so I just matched that.
* Languages with subtags were *not* supported correctly and needed some retouching in the end. Recommend testing on Portuguese and Brazilian Portuguese; one place that changes between the two is the placeholder text on the search box in the beatmap listing overlay. One of the labels there (rank achieved) also changes.
* The `ja`/Japanese reordering value is not breaking wrt user settings because string values of the enum are persisted to `framework.ini` and that string value did not change.