### PR TITLE
Fix wrong language codes

### DIFF
--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Localisation
         sk,
 
         [Description(@"Svenska")]
-        se,
+        sv,
 
         [Description(@"ไทย")]
         th,
@@ -99,7 +99,7 @@ namespace osu.Game.Localisation
         // uk,
 
         [Description(@"Tiếng Việt")]
-        vn,
+        vi,
 
         [Description(@"简体中文")]
         zh,


### PR DESCRIPTION
Confused them with the flag/country codes from the [web-side source used](https://github.com/ppy/osu-web/blob/28bb42f994996bcf31c97e6d6ebb195a6a94c034/app/Libraries/LocaleMeta.php).

Tagalog (`tl`) still has no discernible effect, but that's because there are actually no localisation files in `osu-resources` for that language. Left it be for now, as web has that entry, so it might mean that translations might be coming at some point in the future.