### PR TITLE
Reduce boilerplate of `IApplicableToDrawableHitObjects` by taking a single DHO instead of an enumerable

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
@@ -174,8 +174,8 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private void addToPlayfield(DrawableCatchHitObject drawable)
         {
-            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObjects>())
-                mod.ApplyToDrawableHitObjects(new[] { drawable });
+            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
+                mod.ApplyToDrawableHitObject(drawable);
 
             drawableRuleset.Playfield.Add(drawable);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -75,8 +75,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             var drawable = CreateDrawableHitCircle(circle, auto);
 
-            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObjects>())
-                mod.ApplyToDrawableHitObjects(new[] { drawable });
+            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
+                mod.ApplyToDrawableHitObject(drawable);
             return drawable;
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -335,8 +335,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             var drawable = CreateDrawableSlider(slider);
 
-            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObjects>())
-                mod.ApplyToDrawableHitObjects(new[] { drawable });
+            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
+                mod.ApplyToDrawableHitObject(drawable);
 
             drawable.OnNewResult += onNewResult;
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
@@ -85,8 +85,8 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Scale = new Vector2(0.75f)
             };
 
-            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObjects>())
-                mod.ApplyToDrawableHitObjects(new[] { drawableSpinner });
+            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
+                mod.ApplyToDrawableHitObject(drawableSpinner);
 
             return drawableSpinner;
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
@@ -13,7 +11,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModApproachDifferent : Mod, IApplicableToDrawableHitObjects
+    public class OsuModApproachDifferent : Mod, IApplicableToDrawableHitObject
     {
         public override string Name => "Approach Different";
         public override string Acronym => "AD";
@@ -32,22 +30,19 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Style", "Change the animation style of the approach circles.", 1)]
         public Bindable<AnimationStyle> Style { get; } = new Bindable<AnimationStyle>();
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {
-            drawables.ForEach(drawable =>
+            drawable.ApplyCustomUpdateState += (drawableObject, state) =>
             {
-                drawable.ApplyCustomUpdateState += (drawableObject, state) =>
-                {
-                    if (!(drawableObject is DrawableHitCircle drawableHitCircle)) return;
+                if (!(drawableObject is DrawableHitCircle drawableHitCircle)) return;
 
-                    var hitCircle = drawableHitCircle.HitObject;
+                var hitCircle = drawableHitCircle.HitObject;
 
-                    drawableHitCircle.ApproachCircle.ClearTransforms(targetMember: nameof(Scale));
+                drawableHitCircle.ApproachCircle.ClearTransforms(targetMember: nameof(Scale));
 
-                    using (drawableHitCircle.BeginAbsoluteSequence(hitCircle.StartTime - hitCircle.TimePreempt))
-                        drawableHitCircle.ApproachCircle.ScaleTo(Scale.Value).ScaleTo(1f, hitCircle.TimePreempt, getEasing(Style.Value));
-                };
-            });
+                using (drawableHitCircle.BeginAbsoluteSequence(hitCircle.StartTime - hitCircle.TimePreempt))
+                    drawableHitCircle.ApproachCircle.ScaleTo(Scale.Value).ScaleTo(1f, hitCircle.TimePreempt, getEasing(Style.Value));
+            };
         }
 
         private Easing getEasing(AnimationStyle style)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -9,22 +8,19 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModBarrelRoll : ModBarrelRoll<OsuHitObject>, IApplicableToDrawableHitObjects
+    public class OsuModBarrelRoll : ModBarrelRoll<OsuHitObject>, IApplicableToDrawableHitObject
     {
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public void ApplyToDrawableHitObject(DrawableHitObject d)
         {
-            foreach (var d in drawables)
+            d.OnUpdate += _ =>
             {
-                d.OnUpdate += _ =>
+                switch (d)
                 {
-                    switch (d)
-                    {
-                        case DrawableHitCircle circle:
-                            circle.CirclePiece.Rotation = -CurrentRotation;
-                            break;
-                    }
-                };
-            }
+                    case DrawableHitCircle circle:
+                        circle.CirclePiece.Rotation = -CurrentRotation;
+                        break;
+                }
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
@@ -15,7 +14,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModClassic : ModClassic, IApplicableToHitObject, IApplicableToDrawableHitObjects, IApplicableToDrawableRuleset<OsuHitObject>
+    public class OsuModClassic : ModClassic, IApplicableToHitObject, IApplicableToDrawableHitObject, IApplicableToDrawableRuleset<OsuHitObject>
     {
         [SettingSource("No slider head accuracy requirement", "Scores sliders proportionally to the number of ticks hit.")]
         public Bindable<bool> NoSliderHeadAccuracy { get; } = new BindableBool(true);
@@ -54,24 +53,21 @@ namespace osu.Game.Rulesets.Osu.Mods
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
         }
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public void ApplyToDrawableHitObject(DrawableHitObject obj)
         {
-            foreach (var obj in drawables)
+            switch (obj)
             {
-                switch (obj)
-                {
-                    case DrawableSlider slider:
-                        slider.Ball.InputTracksVisualSize = !FixedFollowCircleHitArea.Value;
-                        break;
+                case DrawableSlider slider:
+                    slider.Ball.InputTracksVisualSize = !FixedFollowCircleHitArea.Value;
+                    break;
 
-                    case DrawableSliderHead head:
-                        head.TrackFollowCircle = !NoSliderHeadMovement.Value;
-                        break;
+                case DrawableSliderHead head:
+                    head.TrackFollowCircle = !NoSliderHeadMovement.Value;
+                    break;
 
-                    case DrawableSliderTail tail:
-                        tail.SamplePlaysOnlyOnHit = !AlwaysPlayTailSample.Value;
-                        break;
-                }
+                case DrawableSliderTail tail:
+                    tail.SamplePlaysOnlyOnHit = !AlwaysPlayTailSample.Value;
+                    break;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
@@ -19,7 +17,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModFlashlight : ModFlashlight<OsuHitObject>, IApplicableToDrawableHitObjects
+    public class OsuModFlashlight : ModFlashlight<OsuHitObject>, IApplicableToDrawableHitObject
     {
         public override double ScoreMultiplier => 1.12;
 
@@ -31,12 +29,10 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override Flashlight CreateFlashlight() => flashlight = new OsuFlashlight();
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {
-            foreach (var s in drawables.OfType<DrawableSlider>())
-            {
+            if (drawable is DrawableSlider s)
                 s.Tracking.ValueChanged += flashlight.OnSliderTrackingChange;
-            }
         }
 
         public override void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
@@ -13,7 +12,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModSpunOut : Mod, IApplicableToDrawableHitObjects
+    public class OsuModSpunOut : Mod, IApplicableToDrawableHitObject
     {
         public override string Name => "Spun Out";
         public override string Acronym => "SO";
@@ -23,15 +22,12 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 0.9;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(OsuModAutopilot) };
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public void ApplyToDrawableHitObject(DrawableHitObject hitObject)
         {
-            foreach (var hitObject in drawables)
+            if (hitObject is DrawableSpinner spinner)
             {
-                if (hitObject is DrawableSpinner spinner)
-                {
-                    spinner.HandleUserInput = false;
-                    spinner.OnUpdate += onSpinnerUpdate;
-                }
+                spinner.HandleUserInput = false;
+                spinner.OnUpdate += onSpinnerUpdate;
             }
         }
 

--- a/osu.Game/Rulesets/Mods/IApplicableToDrawableHitObject.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToDrawableHitObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Mods
@@ -9,13 +10,19 @@ namespace osu.Game.Rulesets.Mods
     /// <summary>
     /// An interface for <see cref="Mod"/>s that can be applied to <see cref="DrawableHitObject"/>s.
     /// </summary>
-    public interface IApplicableToDrawableHitObjects : IApplicableMod
+    public interface IApplicableToDrawableHitObject : IApplicableMod
     {
         /// <summary>
-        /// Applies this <see cref="IApplicableToDrawableHitObjects"/> to a list of <see cref="DrawableHitObject"/>s.
+        /// Applies this <see cref="IApplicableToDrawableHitObject"/> to a <see cref="DrawableHitObject"/>.
         /// This will only be invoked with top-level <see cref="DrawableHitObject"/>s. Access <see cref="DrawableHitObject.NestedHitObjects"/> if adjusting nested objects is necessary.
         /// </summary>
-        /// <param name="drawables">The list of <see cref="DrawableHitObject"/>s to apply to.</param>
+        void ApplyToDrawableHitObject(DrawableHitObject drawable);
+    }
+
+    public interface IApplicableToDrawableHitObjects : IApplicableToDrawableHitObject
+    {
         void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables);
+
+        void IApplicableToDrawableHitObject.ApplyToDrawableHitObject(DrawableHitObject drawable) => ApplyToDrawableHitObjects(drawable.Yield());
     }
 }

--- a/osu.Game/Rulesets/Mods/IApplicableToDrawableHitObject.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToDrawableHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -19,6 +20,7 @@ namespace osu.Game.Rulesets.Mods
         void ApplyToDrawableHitObject(DrawableHitObject drawable);
     }
 
+    [Obsolete(@"Use the singular version IApplicableToDrawableHitObject instead.")] // Can be removed 20211216
     public interface IApplicableToDrawableHitObjects : IApplicableToDrawableHitObject
     {
         void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables);

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
     /// A <see cref="Mod"/> which applies visibility adjustments to <see cref="DrawableHitObject"/>s
     /// with an optional increased visibility adjustment depending on the user's "increase first object visibility" setting.
     /// </summary>
-    public abstract class ModWithVisibilityAdjustment : Mod, IReadFromConfig, IApplicableToBeatmap, IApplicableToDrawableHitObjects
+    public abstract class ModWithVisibilityAdjustment : Mod, IReadFromConfig, IApplicableToBeatmap, IApplicableToDrawableHitObject
     {
         /// <summary>
         /// The first adjustable object.
@@ -73,19 +73,16 @@ namespace osu.Game.Rulesets.Mods
             }
         }
 
-        public virtual void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        public virtual void ApplyToDrawableHitObject(DrawableHitObject dho)
         {
-            foreach (var dho in drawables)
+            dho.ApplyCustomUpdateState += (o, state) =>
             {
-                dho.ApplyCustomUpdateState += (o, state) =>
-                {
-                    // Increased visibility is applied to the entire first object, including all of its nested hitobjects.
-                    if (IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject))
-                        ApplyIncreasedVisibilityState(o, state);
-                    else
-                        ApplyNormalVisibilityState(o, state);
-                };
-            }
+                // Increased visibility is applied to the entire first object, including all of its nested hitobjects.
+                if (IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject))
+                    ApplyIncreasedVisibilityState(o, state);
+                else
+                    ApplyNormalVisibilityState(o, state);
+            };
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -199,8 +199,11 @@ namespace osu.Game.Rulesets.UI
 
             Playfield.PostProcess();
 
-            foreach (var mod in Mods.OfType<IApplicableToDrawableHitObjects>())
-                mod.ApplyToDrawableHitObjects(Playfield.AllHitObjects);
+            foreach (var mod in Mods.OfType<IApplicableToDrawableHitObject>())
+            {
+                foreach (var drawableHitObject in Playfield.AllHitObjects)
+                    mod.ApplyToDrawableHitObject(drawableHitObject);
+            }
         }
 
         public override void RequestResume(Action continueResume)

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -356,8 +356,8 @@ namespace osu.Game.Rulesets.UI
                     // This is done before Apply() so that the state is updated once when the hitobject is applied.
                     if (mods != null)
                     {
-                        foreach (var m in mods.OfType<IApplicableToDrawableHitObjects>())
-                            m.ApplyToDrawableHitObjects(dho.Yield());
+                        foreach (var m in mods.OfType<IApplicableToDrawableHitObject>())
+                            m.ApplyToDrawableHitObject(dho);
                     }
                 }
 


### PR DESCRIPTION
In the old interface, all implementations were iterating over the enumerable to apply the logic to individual DHOs.
It was not useful to consumers either because all but one use is passing single DHO, like `mod.ApplyToDrawableHitObjects(new[] { drawable });`.

A new interface was required (besides the name difference) because obsoleting an interface method is not a thing.
Thanks to a default implementation in the interface, this change is backward compatible with the implementations of the old interface.

It is known #13301 that the doc comment of the interface is out of date, but this PR doesn't address that issue.