### PR TITLE
Fix intermittent HUD test failure

### DIFF
--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Skinning
 
         private readonly BindableList<ISkinnableDrawable> components = new BindableList<ISkinnableDrawable>();
 
+        public bool ComponentsLoaded { get; private set; }
+
         public SkinnableTargetContainer(SkinnableTarget target)
         {
             Target = target;
@@ -30,6 +32,7 @@ namespace osu.Game.Skinning
         {
             ClearInternal();
             components.Clear();
+            ComponentsLoaded = false;
 
             content = CurrentSkin.GetDrawableComponent(new SkinnableTargetComponent(Target)) as SkinnableTargetComponentsContainer;
 
@@ -39,8 +42,11 @@ namespace osu.Game.Skinning
                 {
                     AddInternal(wrapper);
                     components.AddRange(wrapper.Children.OfType<ISkinnableDrawable>());
+                    ComponentsLoaded = true;
                 });
             }
+            else
+                ComponentsLoaded = true;
         }
 
         /// <inheritdoc cref="ISkinnableTarget"/>

--- a/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -47,6 +48,8 @@ namespace osu.Game.Tests.Visual
                 LegacySkin.ResetDrawableTarget(t);
                 t.Reload();
             }));
+
+            AddUntilStep("wait for components to load", () => this.ChildrenOfType<SkinnableTargetContainer>().All(t => t.ComponentsLoaded));
         }
 
         public class SkinProvidingPlayer : TestPlayer


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/pull/13498/checks?check_run_id=2838194560

Can be tested by adding a `Thread.Sleep(1000)` in `LegacyScoreCounter.load()`.