### PR TITLE
Add HighPerformanceSession and use LowLatency GC in gameplay

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -53,6 +53,7 @@ using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.Localisation;
+using osu.Game.Performance;
 using osu.Game.Skinning.Editor;
 
 namespace osu.Game
@@ -488,6 +489,8 @@ namespace osu.Game
 
         protected virtual UpdateManager CreateUpdateManager() => new UpdateManager();
 
+        protected virtual HighPerformanceSession CreateHighPerformanceSession() => new HighPerformanceSession();
+
         protected override Container CreateScalingContainer() => new ScalingContainer(ScalingMode.Everything);
 
         #region Beatmap progression
@@ -755,6 +758,8 @@ namespace osu.Game
 
             loadComponentSingleFile(new AccountCreationOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(new DialogOverlay(), topMostOverlayContent.Add, true);
+
+            loadComponentSingleFile(CreateHighPerformanceSession(), Add);
 
             chatOverlay.State.ValueChanged += state => channelManager.HighPollRate.Value = state.NewValue == Visibility.Visible;
 

--- a/osu.Game/Performance/HighPerformanceSession.cs
+++ b/osu.Game/Performance/HighPerformanceSession.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Performance
+{
+    public class HighPerformanceSession : Component
+    {
+        private readonly IBindable<bool> localUserPlaying = new Bindable<bool>();
+        private GCLatencyMode originalGCMode;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGame game)
+        {
+            localUserPlaying.BindTo(game.LocalUserPlaying);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            localUserPlaying.BindValueChanged(playing =>
+            {
+                if (playing.NewValue)
+                    EnableHighPerformanceSession();
+                else
+                    DisableHighPerformanceSession();
+            }, true);
+        }
+
+        protected virtual void EnableHighPerformanceSession()
+        {
+            originalGCMode = GCSettings.LatencyMode;
+            GCSettings.LatencyMode = GCLatencyMode.LowLatency;
+        }
+
+        protected virtual void DisableHighPerformanceSession()
+        {
+            if (GCSettings.LatencyMode == GCLatencyMode.LowLatency)
+                GCSettings.LatencyMode = originalGCMode;
+        }
+    }
+}


### PR DESCRIPTION
Slightly adapted from https://github.com/ppy/osu/pull/11996. Exposes virtual methods for the PR to eventually override, and to potentially support different "high performance" profiles on mobile devices.

In debugging GC stutters, I noticed that using `LowLatency` GC mode yields better frame consistency in cases where we're not allocating very much (i.e. basically only in gameplay). This is also what osu!stable does, however it also allocates 10x less than we currently are - a good goal to aim for in any case.
Here's some graphs to look at: https://docs.google.com/spreadsheets/d/1ZJLe61ay_O1JT1EbpphQcGpKdaoYro2jR_WOkecfyB8/edit#gid=0

I'm still following up with the .NET team in https://github.com/dotnet/runtime/issues/48937, but this should serve as a good test for the time being.

Only has an effect if the local user is playing. Has no effect in replays.