### PR TITLE
Fix approach circle fade not running early on an early user hit

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -114,11 +114,11 @@ namespace osu.Game.Rulesets.Osu.Tests
                 this.hitOffset = hitOffset;
             }
 
-            public void TriggerJudgement() => UpdateResult(true);
+            public void TriggerJudgement() => Schedule(() => UpdateResult(true));
 
             protected override void CheckForResult(bool userTriggered, double timeOffset)
             {
-                if (auto && !userTriggered && timeOffset > hitOffset)
+                if (auto && !userTriggered && timeOffset > hitOffset && CheckHittable?.Invoke(this, Time.Current) != false)
                 {
                     // force success
                     ApplyResult(r => r.Type = HitResult.Great);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -21,17 +21,11 @@ namespace osu.Game.Rulesets.Osu.Tests
         private int depthIndex;
 
         [Test]
-        public void TestVariousHitCircles()
+        public void TestHits()
         {
-            AddStep("Miss Big Single", () => SetContents(_ => testSingle(2)));
-            AddStep("Miss Medium Single", () => SetContents(_ => testSingle(5)));
-            AddStep("Miss Small Single", () => SetContents(_ => testSingle(7)));
             AddStep("Hit Big Single", () => SetContents(_ => testSingle(2, true)));
             AddStep("Hit Medium Single", () => SetContents(_ => testSingle(5, true)));
             AddStep("Hit Small Single", () => SetContents(_ => testSingle(7, true)));
-            AddStep("Miss Big Stream", () => SetContents(_ => testStream(2)));
-            AddStep("Miss Medium Stream", () => SetContents(_ => testStream(5)));
-            AddStep("Miss Small Stream", () => SetContents(_ => testStream(7)));
             AddStep("Hit Big Stream", () => SetContents(_ => testStream(2, true)));
             AddStep("Hit Medium Stream", () => SetContents(_ => testStream(5, true)));
             AddStep("Hit Small Stream", () => SetContents(_ => testStream(7, true)));
@@ -41,6 +35,17 @@ namespace osu.Game.Rulesets.Osu.Tests
         public void TestHittingEarly()
         {
             AddStep("Hit stream early", () => SetContents(_ => testStream(5, true, -150)));
+        }
+
+        [Test]
+        public void TestMisses()
+        {
+            AddStep("Miss Big Single", () => SetContents(_ => testSingle(2)));
+            AddStep("Miss Medium Single", () => SetContents(_ => testSingle(5)));
+            AddStep("Miss Small Single", () => SetContents(_ => testSingle(7)));
+            AddStep("Miss Big Stream", () => SetContents(_ => testStream(2)));
+            AddStep("Miss Medium Stream", () => SetContents(_ => testStream(5)));
+            AddStep("Miss Small Stream", () => SetContents(_ => testStream(7)));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleComboChange.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleComboChange.cs
@@ -16,11 +16,11 @@ namespace osu.Game.Rulesets.Osu.Tests
             Scheduler.AddDelayed(() => comboIndex.Value++, 250, true);
         }
 
-        protected override TestDrawableHitCircle CreateDrawableHitCircle(HitCircle circle, bool auto)
+        protected override TestDrawableHitCircle CreateDrawableHitCircle(HitCircle circle, bool auto, double hitOffset = 0)
         {
             circle.ComboIndexBindable.BindTo(comboIndex);
             circle.IndexInCurrentComboBindable.BindTo(comboIndex);
-            return base.CreateDrawableHitCircle(circle, auto);
+            return base.CreateDrawableHitCircle(circle, auto, hitOffset);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneShaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneShaking.cs
@@ -26,9 +26,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             return base.CreateBeatmapForSkinProvider();
         }
 
-        protected override TestDrawableHitCircle CreateDrawableHitCircle(HitCircle circle, bool auto)
+        protected override TestDrawableHitCircle CreateDrawableHitCircle(HitCircle circle, bool auto, double hitOffset = 0)
         {
-            var drawableHitObject = base.CreateDrawableHitCircle(circle, auto);
+            var drawableHitObject = base.CreateDrawableHitCircle(circle, auto, hitOffset);
 
             Debug.Assert(drawableHitObject.HitObject.HitWindows != null);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -172,6 +172,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateStartTimeStateTransforms();
 
+            // always fade out at the circle's start time (to match user expectations).
             ApproachCircle.FadeOut(50);
         }
 
@@ -181,6 +182,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             // todo: temporary / arbitrary, used for lifetime optimisation.
             this.Delay(800).FadeOut();
+
+            // in the case of an early state change, the fade should be expedited to the current point in time.
+            if (HitStateUpdateTime < HitObject.StartTime)
+                ApproachCircle.FadeOut(50);
 
             switch (state)
             {


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/12153. 
Closes https://github.com/ppy/osu/issues/13531.