### PR TITLE
Ignore .idea/discord.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,6 +265,7 @@ __pycache__/
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/**/discord.xml
 
 # Generated files
 .idea/**/contentModel.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,1 @@
+discord.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,1 +1,0 @@
-discord.xml


### PR DESCRIPTION
`discord.xml` is a file generated by the [Discord Integration plugin for JetBrains Rider](https://plugins.jetbrains.com/plugin/10233-discord-integration) when the user is asked upon a project's first load whether they want to show their rich presence status for that particular project.

Since this choice (and thus the entire file) is entirely personal preference it shouldn't be committed to the repository.