### PR TITLE
Remove redundant `NotNull` attributes in `nullable` classes

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using MessagePack;
 using osu.Game.Online.API;
 
@@ -28,11 +27,9 @@ namespace osu.Game.Online.Multiplayer
         [Key(3)]
         public string Name { get; set; } = "Unnamed room";
 
-        [NotNull]
         [Key(4)]
         public IEnumerable<APIMod> RequiredMods { get; set; } = Enumerable.Empty<APIMod>();
 
-        [NotNull]
         [Key(5)]
         public IEnumerable<APIMod> AllowedMods { get; set; } = Enumerable.Empty<APIMod>();
 

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using MessagePack;
 using Newtonsoft.Json;
 using osu.Game.Online.API;
@@ -35,7 +34,6 @@ namespace osu.Game.Online.Multiplayer
         /// Any mods applicable only to the local user.
         /// </summary>
         [Key(3)]
-        [NotNull]
         public IEnumerable<APIMod> Mods { get; set; } = Enumerable.Empty<APIMod>();
 
         [IgnoreMember]

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
 
@@ -117,7 +116,7 @@ namespace osu.Game.Rulesets.Replays
             }
         }
 
-        protected virtual bool IsImportant([NotNull] TFrame frame) => false;
+        protected virtual bool IsImportant(TFrame frame) => false;
 
         /// <summary>
         /// Update the current frame based on an incoming time value.


### PR DESCRIPTION
New inspection in 2021.2EAP3 (which is quite stable and usable, for reference).