### PR TITLE
Fix edges of participant tiles showing incorrect tooltip

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/AuthorInfo.cs
+++ b/osu.Game/Overlays/BeatmapSet/AuthorInfo.cs
@@ -81,9 +81,8 @@ namespace osu.Game.Overlays.BeatmapSet
                     AutoSizeAxes = Axes.Both,
                     CornerRadius = 4,
                     Masking = true,
-                    Child = avatar = new UpdateableAvatar
+                    Child = avatar = new UpdateableAvatar(showGuestOnNull: false)
                     {
-                        ShowGuestOnNull = false,
                         Size = new Vector2(height),
                     },
                     EdgeEffect = new EdgeEffectParameters

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                             },
                         }
                     },
-                    avatar = new UpdateableAvatar
+                    avatar = new UpdateableAvatar(showGuestOnNull: false)
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -75,7 +75,6 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                             Offset = new Vector2(0, 2),
                             Radius = 1,
                         },
-                        ShowGuestOnNull = false,
                     },
                     new FillFlowContainer
                     {

--- a/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Overlays.Chat.Tabs
                             Child = new DelayedLoadWrapper(avatar = new ClickableAvatar(value.Users.First())
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                OpenOnClick = { Value = false },
+                                OpenOnClick = false,
                             })
                             {
                                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -58,12 +58,11 @@ namespace osu.Game.Overlays.Profile.Header
                     Origin = Anchor.CentreLeft,
                     Children = new Drawable[]
                     {
-                        avatar = new UpdateableAvatar
+                        avatar = new UpdateableAvatar(openOnClick: false)
                         {
                             Size = new Vector2(avatar_size),
                             Masking = true,
                             CornerRadius = avatar_size * 0.25f,
-                            OpenOnClick = { Value = false },
                             ShowGuestOnNull = false,
                         },
                         new Container

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -58,12 +58,11 @@ namespace osu.Game.Overlays.Profile.Header
                     Origin = Anchor.CentreLeft,
                     Children = new Drawable[]
                     {
-                        avatar = new UpdateableAvatar(openOnClick: false)
+                        avatar = new UpdateableAvatar(openOnClick: false, showGuestOnNull: false)
                         {
                             Size = new Vector2(avatar_size),
                             Masking = true,
                             CornerRadius = avatar_size * 0.25f,
-                            ShowGuestOnNull = false,
                         },
                         new Container
                         {

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -32,14 +32,13 @@ namespace osu.Game.Overlays.Toolbar
 
             Add(new OpaqueBackground { Depth = 1 });
 
-            Flow.Add(avatar = new UpdateableAvatar
+            Flow.Add(avatar = new UpdateableAvatar(openOnClick: false)
             {
                 Masking = true,
                 Size = new Vector2(32),
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
                 CornerRadius = 4,
-                OpenOnClick = { Value = false },
                 EdgeEffect = new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Shadow,

--- a/osu.Game/Screens/OnlinePlay/Components/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/ParticipantsList.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Threading;
 using osu.Game.Users;
@@ -91,15 +90,13 @@ namespace osu.Game.Screens.OnlinePlay.Components
             });
         }
 
-        private class UserTile : CompositeDrawable, IHasTooltip
+        private class UserTile : CompositeDrawable
         {
             public User User
             {
                 get => avatar.User;
                 set => avatar.User = value;
             }
-
-            public string TooltipText => User?.Username ?? string.Empty;
 
             private readonly UpdateableAvatar avatar;
 
@@ -116,7 +113,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4Extensions.FromHex(@"27252d"),
                     },
-                    avatar = new UpdateableAvatar { RelativeSizeAxes = Axes.Both },
+                    avatar = new UpdateableAvatar(showUsernameTooltip: true) { RelativeSizeAxes = Axes.Both },
                 };
             }
         }

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -45,32 +44,37 @@ namespace osu.Game.Users.Drawables
 
         protected override double LoadDelay => 200;
 
-        /// <summary>
-        /// Whether to show a default guest representation on null user (as opposed to nothing).
-        /// </summary>
-        public bool ShowGuestOnNull = true;
+        private readonly bool openOnClick;
+        private readonly bool showUsernameTooltip;
+        private readonly bool showGuestOnNull;
 
         /// <summary>
-        /// Whether to open the user's profile when clicked.
+        /// Construct a new UpdateableAvatar.
         /// </summary>
-        public readonly BindableBool OpenOnClick = new BindableBool(true);
-
-        public UpdateableAvatar(User user = null)
+        /// <param name="user">The initial user to display.</param>
+        /// <param name="openOnClick">Whether to open the user's profile when clicked.</param>
+        /// <param name="showUsernameTooltip">Whether to show the username rather than "view profile" on the tooltip.</param>
+        /// <param name="showGuestOnNull">Whether to show a default guest representation on null user (as opposed to nothing).</param>
+        public UpdateableAvatar(User user = null, bool openOnClick = true, bool showUsernameTooltip = false, bool showGuestOnNull = true)
         {
+            this.openOnClick = openOnClick;
+            this.showUsernameTooltip = showUsernameTooltip;
+            this.showGuestOnNull = showGuestOnNull;
+
             User = user;
         }
 
         protected override Drawable CreateDrawable(User user)
         {
-            if (user == null && !ShowGuestOnNull)
+            if (user == null && !showGuestOnNull)
                 return null;
 
             var avatar = new ClickableAvatar(user)
             {
+                OpenOnClick = openOnClick,
+                ShowUsernameTooltip = showUsernameTooltip,
                 RelativeSizeAxes = Axes.Both,
             };
-
-            avatar.OpenOnClick.BindTo(OpenOnClick);
 
             return avatar;
         }

--- a/osu.Game/Users/ExtendedUserPanel.cs
+++ b/osu.Game/Users/ExtendedUserPanel.cs
@@ -48,11 +48,7 @@ namespace osu.Game.Users
             statusIcon.FinishTransforms();
         }
 
-        protected UpdateableAvatar CreateAvatar() => new UpdateableAvatar
-        {
-            User = User,
-            OpenOnClick = { Value = false }
-        };
+        protected UpdateableAvatar CreateAvatar() => new UpdateableAvatar(User, false);
 
         protected UpdateableFlag CreateFlag() => new UpdateableFlag(User.Country)
         {


### PR DESCRIPTION
I've opted to remove the bindable flow here as these variables should never change post-construction. Optionally, I can also update `CliakableAvatar` to move the properties into the `ctor` on request. The main reason for not using properties in `UpdateableAvatar` is they don't make sense inside the `ModelBackedDrawable` context (which is why bindables were used instead I guess? but that is unnecessary complexity in this case).