### PR TITLE
Rewrite `PerformExit` documentation and remove storyboard outro special casing

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -66,12 +66,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestStoryboardExitToSkipOutro()
+        public void TestStoryboardExitDuringOutroStillExits()
         {
             CreateTest(null);
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());
-            AddAssert("score shown", () => Player.IsScoreShown);
+            AddAssert("player exited", () => !Player.IsCurrentScreen() && Player.GetChildScreen() == null);
         }
 
         [TestCase(false)]

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -515,12 +515,14 @@ namespace osu.Game.Screens.Play
         /// Attempts to complete a user request to exit gameplay.
         /// </summary>
         /// <remarks>
-        /// - This should only be called in response to a user interaction. Exiting is not guaranteed.
-        /// - This will interrupt any pending progression to the results screen, even if the transition has begun.
+        /// <list type="bullet">
+        /// <item>This should only be called in response to a user interaction. Exiting is not guaranteed.</item>
+        /// <item>This will interrupt any pending progression to the results screen, even if the transition has begun.</item>
+        /// </list>
         /// </remarks>
         /// <param name="showDialogFirst">
         /// Whether the pause or fail dialog should be shown before performing an exit.
-        /// If <c>true</c> and a dialog is not yet displayed, the exit will be blocked the relevant dialog will display instead.
+        /// If <see langword="true"/> and a dialog is not yet displayed, the exit will be blocked the relevant dialog will display instead.
         /// </param>
         protected void PerformExit(bool showDialogFirst)
         {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -512,19 +512,23 @@ namespace osu.Game.Screens.Play
         }
 
         /// <summary>
-        /// Exits the <see cref="Player"/>.
+        /// Attempts to complete a user request to exit gameplay.
         /// </summary>
+        /// <remarks>
+        /// - This should only be called in response to a user interaction. Exiting is not guaranteed.
+        /// - This will interrupt any pending progression to the results screen, even if the transition has begun.
+        /// </remarks>
         /// <param name="showDialogFirst">
         /// Whether the pause or fail dialog should be shown before performing an exit.
-        /// If true and a dialog is not yet displayed, the exit will be blocked the the relevant dialog will display instead.
+        /// If <c>true</c> and a dialog is not yet displayed, the exit will be blocked the relevant dialog will display instead.
         /// </param>
         protected void PerformExit(bool showDialogFirst)
         {
-            // if a restart has been requested, cancel any pending completion (user has shown intent to restart).
+            // if an exit has been requested, cancel any pending completion (the user has showing intention to exit).
             completionProgressDelegate?.Cancel();
 
-            // there is a chance that the exit was performed after the transition to results has started.
-            // we want to give the user what they want, so forcefully return to this screen (to proceed with the upwards exit process).
+            // there is a chance that an exit request occurs after the transition to results has already started.
+            // even in such a case, the user has shown intent, so forcefully return to this screen (to proceed with the upwards exit process).
             if (!this.IsCurrentScreen())
             {
                 ValidForResume = false;
@@ -547,7 +551,7 @@ namespace osu.Game.Screens.Play
                     return;
                 }
 
-                // there's a chance the pausing is not supported in the current state, at which point immediate exit should be preferred.
+                // even if this call has requested a dialog, there is a chance the current player mode doesn't support pausing.
                 if (pausingSupportedByCurrentState)
                 {
                     // in the case a dialog needs to be shown, attempt to pause and show it.
@@ -563,6 +567,10 @@ namespace osu.Game.Screens.Play
                 }
             }
 
+            // The actual exit is performed if
+            // - the pause / fail dialog was not requested
+            // - the pause / fail dialog was requested but is already displayed (user showing intention to exit).
+            // - the pause / fail dialog was requested but couldn't be displayed due to the type or state of this Player instance.
             this.Exit();
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -559,12 +559,6 @@ namespace osu.Game.Screens.Play
                     Pause();
                     return;
                 }
-
-                // if the score is ready for display but results screen has not been pushed yet (e.g. storyboard is still playing beyond gameplay), then transition to results screen instead of exiting.
-                if (prepareScoreForDisplayTask != null && completionProgressDelegate == null)
-                {
-                    updateCompletionState(true);
-                }
             }
 
             // The actual exit is performed if

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -522,11 +522,11 @@ namespace osu.Game.Screens.Play
         /// </remarks>
         /// <param name="showDialogFirst">
         /// Whether the pause or fail dialog should be shown before performing an exit.
-        /// If <see langword="true"/> and a dialog is not yet displayed, the exit will be blocked the relevant dialog will display instead.
+        /// If <see langword="true"/> and a dialog is not yet displayed, the exit will be blocked and the relevant dialog will display instead.
         /// </param>
         protected void PerformExit(bool showDialogFirst)
         {
-            // if an exit has been requested, cancel any pending completion (the user has showing intention to exit).
+            // if an exit has been requested, cancel any pending completion (the user has shown intention to exit).
             completionProgressDelegate?.Cancel();
 
             // there is a chance that an exit request occurs after the transition to results has already started.


### PR DESCRIPTION
This is the first of a few changes to the `Player` exit/completion flow which I need to make in order to get score submission on exit working correctly. Just trying to get things into a sane state before (potentially) adding more complexity.

Note that this changes the behaviour introduced in https://github.com/ppy/osu/pull/12432 which made the pause/exit key progress to the results screen if pressed during a storyboard outro. This differs from the standard behaviour of returning to song select (for instance, if the same key press occurred during the one second induced delay before the results screen is shown).