### PR TITLE
Allow mods to specify incompatibility types which they implement themselves

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/IMutateApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IMutateApproachCircles.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    /// <summary>
+    /// Any mod which affects the animation or visibility of approach circles. Should be used for incompatibility purposes.
+    /// </summary>
+    public interface IMutateApproachCircles
+    {
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -11,13 +12,15 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModApproachDifferent : Mod, IApplicableToDrawableHitObject
+    public class OsuModApproachDifferent : Mod, IApplicableToDrawableHitObject, IMutateApproachCircles
     {
         public override string Name => "Approach Different";
         public override string Acronym => "AD";
         public override string Description => "Never trust the approach circles...";
         public override double ScoreMultiplier => 1;
         public override IconUsage? Icon { get; } = FontAwesome.Regular.Circle;
+
+        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
 
         [SettingSource("Initial size", "Change the initial size of the approach circle, relative to hit circles.", 0)]
         public BindableFloat Scale { get; } = new BindableFloat(4)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -14,12 +14,12 @@ using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModHidden : ModHidden
+    public class OsuModHidden : ModHidden, IMutateApproachCircles
     {
         public override string Description => @"Play with no approach circles and fading circles/sliders.";
         public override double ScoreMultiplier => 1.06;
 
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModTraceable), typeof(OsuModSpinIn) };
+        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
 
         private const double fade_in_duration_multiplier = 0.4;
         private const double fade_out_duration_multiplier = 0.3;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     /// <summary>
     /// Adjusts the size of hit objects during their fade in animation.
     /// </summary>
-    public abstract class OsuModObjectScaleTween : ModWithVisibilityAdjustment
+    public abstract class OsuModObjectScaleTween : ModWithVisibilityAdjustment, IMutateApproachCircles
     {
         public override ModType Type => ModType.Fun;
 
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected virtual float EndScale => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModSpinIn), typeof(OsuModTraceable) };
+        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -12,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModSpinIn : ModWithVisibilityAdjustment
+    public class OsuModSpinIn : ModWithVisibilityAdjustment, IMutateApproachCircles
     {
         public override string Name => "Spin In";
         public override string Acronym => "SI";
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1;
 
         // todo: this mod should be able to be compatible with hidden with a bit of further implementation.
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModObjectScaleTween), typeof(OsuModHidden), typeof(OsuModTraceable) };
+        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
 
         private const int rotate_offset = 360;
         private const float rotate_starting_width = 2;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Osu.Skinning.Default;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModTraceable : ModWithVisibilityAdjustment
+    public class OsuModTraceable : ModWithVisibilityAdjustment, IMutateApproachCircles
     {
         public override string Name => "Traceable";
         public override string Acronym => "TC";
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "Put your faith in the approach circles...";
         public override double ScoreMultiplier => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModHidden), typeof(OsuModSpinIn), typeof(OsuModObjectScaleTween) };
+        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -22,12 +22,34 @@ namespace osu.Game.Tests.Mods
         }
 
         [Test]
+        public void TestModIsCompatibleByItselfWithIncompatibleInterface()
+        {
+            var mod = new Mock<CustomMod1>();
+            mod.Setup(m => m.IncompatibleMods).Returns(new[] { typeof(IModCompatibilitySpecification) });
+            Assert.That(ModUtils.CheckCompatibleSet(new[] { mod.Object }));
+        }
+
+        [Test]
         public void TestIncompatibleThroughTopLevel()
         {
             var mod1 = new Mock<CustomMod1>();
             var mod2 = new Mock<CustomMod2>();
 
             mod1.Setup(m => m.IncompatibleMods).Returns(new[] { mod2.Object.GetType() });
+
+            // Test both orderings.
+            Assert.That(ModUtils.CheckCompatibleSet(new Mod[] { mod1.Object, mod2.Object }), Is.False);
+            Assert.That(ModUtils.CheckCompatibleSet(new Mod[] { mod2.Object, mod1.Object }), Is.False);
+        }
+
+        [Test]
+        public void TestIncompatibleThroughInterface()
+        {
+            var mod1 = new Mock<CustomMod1>();
+            var mod2 = new Mock<CustomMod2>();
+
+            mod1.Setup(m => m.IncompatibleMods).Returns(new[] { typeof(IModCompatibilitySpecification) });
+            mod2.Setup(m => m.IncompatibleMods).Returns(new[] { typeof(IModCompatibilitySpecification) });
 
             // Test both orderings.
             Assert.That(ModUtils.CheckCompatibleSet(new Mod[] { mod1.Object, mod2.Object }), Is.False);
@@ -149,11 +171,15 @@ namespace osu.Game.Tests.Mods
                 Assert.That(invalid.Select(t => t.GetType()), Is.EquivalentTo(expectedInvalid));
         }
 
-        public abstract class CustomMod1 : Mod
+        public abstract class CustomMod1 : Mod, IModCompatibilitySpecification
         {
         }
 
-        public abstract class CustomMod2 : Mod
+        public abstract class CustomMod2 : Mod, IModCompatibilitySpecification
+        {
+        }
+
+        public interface IModCompatibilitySpecification
         {
         }
     }

--- a/osu.Game/Overlays/Mods/LocalPlayerModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/LocalPlayerModSelectOverlay.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Mods
             base.OnModSelected(mod);
 
             foreach (var section in ModSectionsContainer.Children)
-                section.DeselectTypes(mod.IncompatibleMods, true);
+                section.DeselectTypes(mod.IncompatibleMods, true, mod);
         }
     }
 }

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -159,11 +159,15 @@ namespace osu.Game.Overlays.Mods
         /// </summary>
         /// <param name="modTypes">The types of <see cref="Mod"/>s which should be deselected.</param>
         /// <param name="immediate">Whether the deselection should happen immediately. Should only be used when required to ensure correct selection flow.</param>
-        public void DeselectTypes(IEnumerable<Type> modTypes, bool immediate = false)
+        /// <param name="newSelection">If this deselection is triggered by a user selection, this should contain the newly selected type. This type will never be deselected, even if it matches one provided in <paramref name="modTypes"/>.</param>
+        public void DeselectTypes(IEnumerable<Type> modTypes, bool immediate = false, Mod newSelection = null)
         {
             foreach (var button in Buttons)
             {
                 if (button.SelectedMod == null) continue;
+
+                if (button.SelectedMod == newSelection)
+                    continue;
 
                 foreach (var type in modTypes)
                 {

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -60,6 +60,9 @@ namespace osu.Game.Utils
                 {
                     foreach (var invalid in combination.Where(m => type.IsInstanceOfType(m)))
                     {
+                        if (invalid == mod)
+                            continue;
+
                         invalidMods ??= new List<Mod>();
                         invalidMods.Add(invalid);
                     }


### PR DESCRIPTION
Closes #13543 (just combined that fix with this change as an example usage). I think there are likely other cases where we can simplify incompatibility specifications remaining.