### PR TITLE
Fix loading a ruleset with an updated internal name causing a potential startup crash

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Internal;
 using osu.Framework;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Logging;

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
 using osu.Framework;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Logging;
@@ -96,13 +97,25 @@ namespace osu.Game.Rulesets
 
                 context.SaveChanges();
 
-                // add any other modes
                 var existingRulesets = context.RulesetInfo.ToList();
 
+                // add any other rulesets which have assemblies present but are not yet in the database.
                 foreach (var r in instances.Where(r => !(r is ILegacyRuleset)))
                 {
                     if (existingRulesets.FirstOrDefault(ri => ri.InstantiationInfo.Equals(r.RulesetInfo.InstantiationInfo, StringComparison.Ordinal)) == null)
-                        context.RulesetInfo.Add(r.RulesetInfo);
+                    {
+                        var existingSameShortName = existingRulesets.FirstOrDefault(ri => ri.ShortName == r.RulesetInfo.ShortName);
+
+                        if (existingSameShortName != null)
+                        {
+                            // even if a matching InstantiationInfo was not found, there may be an existing ruleset with the same ShortName.
+                            // this generally means the user or ruleset provider has renamed their dll but the underlying ruleset is *likely* the same one.
+                            // in such cases, update the instantiation info of the existing entry to point to the new one.
+                            existingSameShortName.InstantiationInfo = r.RulesetInfo.InstantiationInfo;
+                        }
+                        else
+                            context.RulesetInfo.Add(r.RulesetInfo);
+                    }
                 }
 
                 context.SaveChanges();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11727. Not adding tests because I hope we are going to be rewriting this code in the near future against a different database backing.

To test, load the first ruleset from the attached archive, let osu! start, quit, replace with the second and then start again. Both ruleset DLLs have the same `ShortName` but a different `InstantiationInfo` (the ruleset class is renamed).

[rulesets.zip](https://github.com/ppy/osu/files/6676455/rulesets.zip)
