### PR TITLE
Fix editor hit circle animation toggle not working

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorHitAnimations.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorHitAnimations.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    [TestFixture]
+    public class TestSceneOsuEditorHitAnimations : TestSceneOsuEditor
+    {
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        [Test]
+        public void TestHitCircleAnimationDisable()
+        {
+            HitCircle hitCircle = null;
+
+            AddStep("retrieve first hit circle", () => hitCircle = getHitCircle(0));
+            toggleAnimations(true);
+            seekSmoothlyTo(() => hitCircle.StartTime + 10);
+
+            AddAssert("hit circle piece has transforms", () =>
+            {
+                var drawableHitCircle = (DrawableHitCircle)getDrawableObjectFor(hitCircle);
+                return getTransformsRecursively(drawableHitCircle.CirclePiece).Any(t => t.EndTime > EditorClock.CurrentTime);
+            });
+
+            AddStep("retrieve second hit circle", () => hitCircle = getHitCircle(1));
+            toggleAnimations(false);
+            seekSmoothlyTo(() => hitCircle.StartTime + 10);
+
+            AddAssert("hit circle piece has no transforms", () =>
+            {
+                var drawableHitCircle = (DrawableHitCircle)getDrawableObjectFor(hitCircle);
+                return getTransformsRecursively(drawableHitCircle.CirclePiece).All(t => t.EndTime <= EditorClock.CurrentTime);
+            });
+        }
+
+        private HitCircle getHitCircle(int index)
+            => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(index);
+
+        private DrawableHitObject getDrawableObjectFor(HitObject hitObject)
+            => this.ChildrenOfType<DrawableHitObject>().Single(ho => ho.HitObject == hitObject);
+
+        private IEnumerable<Transform> getTransformsRecursively(Drawable drawable)
+            => drawable.ChildrenOfType<Drawable>().SelectMany(d => d.Transforms);
+
+        private void toggleAnimations(bool enabled)
+            => AddStep($"toggle animations {(enabled ? "on" : "off")}", () => config.SetValue(OsuSetting.EditorHitAnimations, enabled));
+
+        private void seekSmoothlyTo(Func<double> targetTime)
+        {
+            AddStep("seek smoothly", () => EditorClock.SeekSmoothlyTo(targetTime.Invoke()));
+            AddUntilStep("wait for seek", () => Precision.AlmostEquals(targetTime.Invoke(), EditorClock.CurrentTime));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -74,15 +74,15 @@ namespace osu.Game.Rulesets.Osu.Edit
                     {
                         if (hitObject.HitObject == null) return;
 
-                        mainPieceContainer.CirclePiece.ApplyTransformsAt(hitObject.HitStateUpdateTime, true);
-                        mainPieceContainer.CirclePiece.ClearTransformsAfter(hitObject.HitStateUpdateTime, true);
+                        mainPieceContainer.CirclePiece.ApplyTransformsAt(hitObject.StateUpdateTime, true);
+                        mainPieceContainer.CirclePiece.ClearTransformsAfter(hitObject.StateUpdateTime, true);
                     });
                 }
 
                 if (hitObject is DrawableSliderRepeat repeat)
                 {
-                    repeat.Arrow.ApplyTransformsAt(hitObject.HitStateUpdateTime, true);
-                    repeat.Arrow.ClearTransformsAfter(hitObject.HitStateUpdateTime, true);
+                    repeat.Arrow.ApplyTransformsAt(hitObject.StateUpdateTime, true);
+                    repeat.Arrow.ClearTransformsAfter(hitObject.StateUpdateTime, true);
                 }
 
                 // adjust the visuals of top-level object types to make them stay on screen for longer than usual.

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -69,8 +69,14 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (hitObject is IHasMainCirclePiece mainPieceContainer)
                 {
                     // clear any explode animation logic.
-                    mainPieceContainer.CirclePiece.ApplyTransformsAt(hitObject.HitStateUpdateTime, true);
-                    mainPieceContainer.CirclePiece.ClearTransformsAfter(hitObject.HitStateUpdateTime, true);
+                    // this is scheduled after children to ensure that the clear happens after invocations of ApplyCustomUpdateState on the circle piece's nested skinnables.
+                    ScheduleAfterChildren(() =>
+                    {
+                        if (hitObject.HitObject == null) return;
+
+                        mainPieceContainer.CirclePiece.ApplyTransformsAt(hitObject.HitStateUpdateTime, true);
+                        mainPieceContainer.CirclePiece.ClearTransformsAfter(hitObject.HitStateUpdateTime, true);
+                    });
                 }
 
                 if (hitObject is DrawableSliderRepeat repeat)

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -20,6 +20,12 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public class DrawableOsuEditorRuleset : DrawableOsuRuleset
     {
+        /// <summary>
+        /// Hit objects are intentionally made to fade out at a constant slower rate than in gameplay.
+        /// This allows a mapper to gain better historical context and use recent hitobjects as reference / snap points.
+        /// </summary>
+        public const double EDITOR_HIT_OBJECT_FADE_OUT_EXTENSION = 700;
+
         public DrawableOsuEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
@@ -46,12 +52,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                 d.ApplyCustomUpdateState += updateState;
             }
 
-            /// <summary>
-            /// Hit objects are intentionally made to fade out at a constant slower rate than in gameplay.
-            /// This allows a mapper to gain better historical context and use recent hitobjects as reference / snap points.
-            /// </summary>
-            private const double editor_hit_object_fade_out_extension = 700;
-
             private void updateState(DrawableHitObject hitObject, ArmedState state)
             {
                 if (state == ArmedState.Idle || hitAnimations.Value)
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (hitObject is DrawableHitCircle circle)
                 {
                     circle.ApproachCircle
-                          .FadeOutFromOne(editor_hit_object_fade_out_extension * 4)
+                          .FadeOutFromOne(EDITOR_HIT_OBJECT_FADE_OUT_EXTENSION * 4)
                           .Expire();
 
                     circle.ApproachCircle.ScaleTo(1.1f, 300, Easing.OutQuint);
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                         hitObject.RemoveTransform(existing);
 
                         using (hitObject.BeginAbsoluteSequence(hitObject.HitStateUpdateTime))
-                            hitObject.FadeOut(editor_hit_object_fade_out_extension).Expire();
+                            hitObject.FadeOut(EDITOR_HIT_OBJECT_FADE_OUT_EXTENSION).Expire();
                         break;
                 }
             }


### PR DESCRIPTION
Closes #13466.

Most of the diff is the test scene. The fix for the issue is mostly as described in the issue thread (delaying the editor's transform clear until after the skinnables' `ApplyCustomUpdateState` callbacks have run), with an added guard to prevent accidentally trying to do stuff to DHOs without an applied hit object.

There's another change in here that fell out upon writing the test - in the clear transform logic, `HitStateUpdateTime` was swapped out for `StateUpdateTime`, because `MainCirclePiece` was doing this:

https://github.com/ppy/osu/blob/58974757083b61337fcfa8f7fbc831d5f782ccae/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs#L77-L78

Not sure whether it was left intentionally, but "no animations" for me should mean that that one should also be gone. If that doesn't make sense, then I'll revert those changes and modify the asserts to exclude the glow.