### PR TITLE
Fix game crashes due to attempting localisation load for unsupported locales

### DIFF
--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -86,8 +86,10 @@ namespace osu.Game.Localisation
         [Description(@"ไทย")]
         th,
 
-        [Description(@"Tagalog")]
-        tl,
+        // Tagalog has no associated localisations yet, and is not supported on Xamarin platforms or Windows versions <10.
+        // Can be revisited if localisations ever arrive.
+        //[Description(@"Tagalog")]
+        //tl,
 
         [Description(@"Türkçe")]
         tr,

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -55,7 +55,6 @@ using osu.Game.IO;
 using osu.Game.Localisation;
 using osu.Game.Performance;
 using osu.Game.Skinning.Editor;
-using osu.Framework.Extensions;
 
 namespace osu.Game
 {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -55,6 +55,7 @@ using osu.Game.IO;
 using osu.Game.Localisation;
 using osu.Game.Performance;
 using osu.Game.Skinning.Editor;
+using osu.Framework.Extensions;
 
 namespace osu.Game
 {
@@ -585,7 +586,15 @@ namespace osu.Game
             foreach (var language in Enum.GetValues(typeof(Language)).OfType<Language>())
             {
                 var cultureCode = language.ToCultureCode();
-                Localisation.AddLanguage(cultureCode, new ResourceManagerLocalisationStore(cultureCode));
+
+                try
+                {
+                    Localisation.AddLanguage(cultureCode, new ResourceManagerLocalisationStore(cultureCode));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, $"Could not load localisations for language \"{cultureCode}\"");
+                }
             }
 
             // The next time this is updated is in UpdateAfterChildren, which occurs too late and results


### PR DESCRIPTION
Closes #13570.

Tested to boot on the android device I have available. Besides disabling the offending language this pull will also log any errors if this happens with another language in the future.

Might be worth running past a Windows 7/8 machine or VM, since these issues also seem to happen there and I do not have such an environment easily available.

Branch is intentionally rooted at the release tag for ease of testing (realm does not work on android).