### PR TITLE
Remove high performance GC setting

### DIFF
--- a/osu.Game/Performance/HighPerformanceSession.cs
+++ b/osu.Game/Performance/HighPerformanceSession.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Runtime;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -11,7 +10,6 @@ namespace osu.Game.Performance
     public class HighPerformanceSession : Component
     {
         private readonly IBindable<bool> localUserPlaying = new Bindable<bool>();
-        private GCLatencyMode originalGCMode;
 
         [BackgroundDependencyLoader]
         private void load(OsuGame game)
@@ -34,14 +32,10 @@ namespace osu.Game.Performance
 
         protected virtual void EnableHighPerformanceSession()
         {
-            originalGCMode = GCSettings.LatencyMode;
-            GCSettings.LatencyMode = GCLatencyMode.LowLatency;
         }
 
         protected virtual void DisableHighPerformanceSession()
         {
-            if (GCSettings.LatencyMode == GCLatencyMode.LowLatency)
-                GCSettings.LatencyMode = originalGCMode;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/13558
Reverts the GC part of https://github.com/ppy/osu/pull/13525

I suspect what's going on here is a mix of two things:
1. There's a few high allocations at the start of maps - first time DHO loads and PoolableSkinnableSamples. This causes the initial stutter.
2. Since we have more gen0/1s happening, a lot more data is being promoted to gen2 which would have otherwise died in gen0/1 previously. Later on in the map, this causes a big blocking gen2 collection.

It seems like gen1 size has been reduced to ~500KB which is a little too small for us at this point. Needs more investigation.