### PR TITLE
Fix beatmap discussion links wrongly leading to beatmap page

### DIFF
--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Tests.Chat
         [TestCase(LinkAction.OpenBeatmapSet, "123", "https://dev.ppy.sh/beatmapsets/123")]
         [TestCase(LinkAction.OpenBeatmapSet, "123", "https://dev.ppy.sh/beatmapsets/123/whatever")]
         [TestCase(LinkAction.External, "https://dev.ppy.sh/beatmapsets/abc", "https://dev.ppy.sh/beatmapsets/abc")]
+        [TestCase(LinkAction.External, "https://dev.ppy.sh/beatmapsets/discussions", "https://dev.ppy.sh/beatmapsets/discussions")]
+        [TestCase(LinkAction.External, "https://dev.ppy.sh/beatmapsets/discussions/123", "https://dev.ppy.sh/beatmapsets/discussions/123")]
         public void TestBeatmapLinks(LinkAction expectedAction, string expectedArg, string link)
         {
             MessageFormatter.WebsiteRootUrl = "dev.ppy.sh";

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -154,6 +154,10 @@ namespace osu.Game.Online.Chat
                             case "beatmapsets":
                             case "d":
                             {
+                                if (mainArg == "discussions")
+                                    // handle discussion links externally for now
+                                    return new LinkDetails(LinkAction.External, url);
+
                                 if (args.Length > 4 && int.TryParse(args[4], out var id))
                                     // https://osu.ppy.sh/beatmapsets/1154158#osu/2768184
                                     return new LinkDetails(LinkAction.OpenBeatmap, id.ToString());


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/6747. Since https://github.com/ppy/osu/pull/11757, the reported behavior changed from doing nothing to opening a random beatmap page based on discussion id.