### PR TITLE
Factor out caught object stacking/dropping logic to separate classes

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -50,10 +50,11 @@ namespace osu.Game.Rulesets.Catch.Tests
             Child = new Container
             {
                 Anchor = Anchor.Centre,
-                Children = new Drawable[]
+                Children = new[]
                 {
                     trailContainer,
                     droppedObjectContainer,
+                    catcher.CreateProxiedContent(),
                     catcher
                 }
             };

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -188,8 +188,8 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddStep("catch more fruits", () => attemptCatch(() => new Fruit(), 9));
             checkPlate(10);
             AddAssert("caught objects are stacked", () =>
-                catcher.CaughtObjects.All(obj => obj.Y <= Catcher.CAUGHT_FRUIT_VERTICAL_OFFSET) &&
-                catcher.CaughtObjects.Any(obj => obj.Y == Catcher.CAUGHT_FRUIT_VERTICAL_OFFSET) &&
+                catcher.CaughtObjects.All(obj => obj.Y <= 0) &&
+                catcher.CaughtObjects.Any(obj => obj.Y == 0) &&
                 catcher.CaughtObjects.Any(obj => obj.Y < -25));
         }
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -102,17 +102,20 @@ namespace osu.Game.Rulesets.Catch.Tests
                     RelativeSizeAxes = Axes.Both
                 };
 
+                var catcherArea = new TestCatcherArea(droppedObjectContainer, beatmapDifficulty)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.TopCentre,
+                };
+
                 return new CatchInputManager(catchRuleset)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Children = new[]
                     {
                         droppedObjectContainer,
-                        new TestCatcherArea(droppedObjectContainer, beatmapDifficulty)
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.TopCentre,
-                        }
+                        catcherArea.MovableCatcher.CreateProxiedContent(),
+                        catcherArea
                     }
                 };
             });

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
@@ -97,12 +96,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             SetContents(_ =>
             {
-                var droppedObjectContainer = new Container<CaughtObject>
-                {
-                    RelativeSizeAxes = Axes.Both
-                };
-
-                var catcherArea = new TestCatcherArea(droppedObjectContainer, beatmapDifficulty)
+                var catcherArea = new TestCatcherArea(beatmapDifficulty)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.TopCentre,
@@ -113,7 +107,6 @@ namespace osu.Game.Rulesets.Catch.Tests
                     RelativeSizeAxes = Axes.Both,
                     Children = new[]
                     {
-                        droppedObjectContainer,
                         catcherArea.MovableCatcher.CreateProxiedContent(),
                         catcherArea
                     }
@@ -129,9 +122,13 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestCatcherArea : CatcherArea
         {
-            public TestCatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
-                : base(droppedObjectContainer, beatmapDifficulty)
+            [Cached]
+            private readonly DroppedObjectContainer droppedObjectContainer;
+
+            public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
+                : base(beatmapDifficulty)
             {
+                AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
 
             public void ToggleHyperDash(bool status) => MovableCatcher.SetHyperDashState(status ? 2 : 1);

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -118,11 +118,10 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new Container<CaughtObject>())
+                Child = setupSkinHierarchy(catcherArea = new TestCatcherArea
                 {
                     Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(4f),
+                    Origin = Anchor.Centre
                 }, skin);
             });
 
@@ -204,6 +203,19 @@ namespace osu.Game.Rulesets.Catch.Tests
             public TestSkin()
                 : base(new SkinInfo(), null, null, string.Empty)
             {
+            }
+        }
+
+        private class TestCatcherArea : CatcherArea
+        {
+            [Cached]
+            private readonly DroppedObjectContainer droppedObjectContainer;
+
+            public TestCatcherArea()
+            {
+                Scale = new Vector2(4f);
+
+                AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -31,6 +30,9 @@ namespace osu.Game.Rulesets.Catch.UI
         [Cached]
         private readonly CaughtObjectPool caughtObjectPool;
 
+        [Cached]
+        private readonly DroppedObjectContainer droppedObjectContainer;
+
         internal readonly CatcherArea CatcherArea;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
@@ -39,12 +41,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation)
         {
-            var droppedObjectContainer = new Container<CaughtObject>
-            {
-                RelativeSizeAxes = Axes.Both,
-            };
-
-            CatcherArea = new CatcherArea(droppedObjectContainer, difficulty)
+            CatcherArea = new CatcherArea(difficulty)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.TopLeft,
@@ -53,7 +50,7 @@ namespace osu.Game.Rulesets.Catch.UI
             InternalChildren = new[]
             {
                 caughtObjectPool = new CaughtObjectPool(),
-                droppedObjectContainer,
+                droppedObjectContainer = new DroppedObjectContainer(),
                 CatcherArea.MovableCatcher.CreateProxiedContent(),
                 HitObjectContainer.CreateProxy(),
                 // This ordering (`CatcherArea` before `HitObjectContainer`) is important to

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public const float CENTER_X = WIDTH / 2;
 
+        [Cached]
+        private readonly CaughtObjectPool caughtObjectPool;
+
         internal readonly CatcherArea CatcherArea;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
@@ -49,6 +52,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             InternalChildren = new[]
             {
+                caughtObjectPool = new CaughtObjectPool(),
                 droppedObjectContainer,
                 CatcherArea.MovableCatcher.CreateProxiedContent(),
                 HitObjectContainer.CreateProxy(),

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public bool CatchFruitOnPlate
         {
-            set => plate.StackCaughtObject.Value = value;
+            set => plate.PlaceCaughtObject.Value = value;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -57,11 +57,6 @@ namespace osu.Game.Rulesets.Catch.UI
         public double Speed => (Dashing ? 1 : 0.5) * BASE_SPEED * hyperDashModifier;
 
         /// <summary>
-        /// The amount by which caught fruit should be offset from the plate surface to make them look visually "caught".
-        /// </summary>
-        public const float CAUGHT_FRUIT_VERTICAL_OFFSET = -5;
-
-        /// <summary>
         /// The amount by which caught fruit should be scaled down to fit on the plate.
         /// </summary>
         private const float caught_fruit_scale_adjust = 0.5f;
@@ -157,6 +152,8 @@ namespace osu.Game.Rulesets.Catch.UI
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.BottomCentre,
+                    // offset fruit vertically to better place "above" the plate.
+                    Y = -5
                 },
                 body = new SkinnableCatcher(),
                 hitExplosionContainer = new HitExplosionContainer
@@ -387,9 +384,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
             float adjustedRadius = displayRadius * lenience_adjust;
             float checkDistance = MathF.Pow(adjustedRadius, 2);
-
-            // offset fruit vertically to better place "above" the plate.
-            position.Y += CAUGHT_FRUIT_VERTICAL_OFFSET;
 
             while (caughtObjectContainer.Any(f => Vector2Extensions.DistanceSquared(f.Position, position) < checkDistance))
             {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Catch.UI
         private int hyperDashDirection;
         private float hyperDashTargetPosition;
 
-        public Catcher([NotNull] Container trailsTarget, [NotNull] Container<CaughtObject> droppedObjectTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] Container trailsTarget, BeatmapDifficulty difficulty = null)
         {
             this.trailsTarget = trailsTarget;
 
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.Catch.UI
             InternalChildren = new Drawable[]
             {
                 body = new SkinnableCatcher(),
-                plate = new CatcherPlate(droppedObjectTarget)
+                plate = new CatcherPlate
                 {
                     Anchor = Anchor.TopCentre
                 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private int currentDirection;
 
-        public CatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty difficulty = null)
+        public CatcherArea(BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
             Children = new Drawable[]
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Margin = new MarginPadding { Bottom = 350f },
                     X = CatchPlayfield.CENTER_X
                 },
-                MovableCatcher = new Catcher(this, droppedObjectContainer, difficulty) { X = CatchPlayfield.CENTER_X },
+                MovableCatcher = new Catcher(this, difficulty) { X = CatchPlayfield.CENTER_X },
             };
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherPlate.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherPlate.cs
@@ -21,9 +21,15 @@ namespace osu.Game.Rulesets.Catch.UI
     /// </summary>
     public class CatcherPlate : CompositeDrawable
     {
+        /// <summary>
+        /// Whether a hit lighting should be generated when a hit object is caught.
+        /// </summary>
         public Bindable<bool> GenerateHitLighting = new Bindable<bool>(true);
 
-        public Bindable<bool> StackCaughtObject = new Bindable<bool>(true);
+        /// <summary>
+        /// Whether caught objects should be placed on the plate (stacked on the plate or immediately dropped).
+        /// </summary>
+        public Bindable<bool> PlaceCaughtObject = new Bindable<bool>(true);
 
         private CaughtObjectPool caughtObjectPool;
 
@@ -77,7 +83,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             var positionInStack = computePositionInStack(new Vector2(drawableHitObject.X - catcherPosition, 0), drawableHitObject.DisplaySize.X);
 
-            if (StackCaughtObject.Value)
+            if (PlaceCaughtObject.Value)
                 placeCaughtObject(drawableHitObject, positionInStack);
 
             if (GenerateHitLighting.Value)
@@ -128,6 +134,9 @@ namespace osu.Game.Rulesets.Catch.UI
 
         #region Caught object dropping
 
+        /// <summary>
+        /// Drop all caught objects on the stack.
+        /// </summary>
         public void DropAll(DropAnimation animation)
         {
             foreach (var caughtObject in caughtObjectContainer)

--- a/osu.Game.Rulesets.Catch/UI/CatcherPlate.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherPlate.cs
@@ -191,9 +191,10 @@ namespace osu.Game.Rulesets.Catch.UI
                     break;
 
                 case DropAnimation.Explode:
-                    var originalX = droppedObjectTarget.ToSpaceOfOtherDrawable(d.DrawPosition, caughtObjectContainer).X * Scale.X;
+                    Vector2 positionInStack = droppedObjectTarget.ToSpaceOfOtherDrawable(d.DrawPosition, caughtObjectContainer);
+                    Vector2 targetPosition = caughtObjectContainer.ToSpaceOfOtherDrawable(positionInStack * new Vector2(7f, 1), droppedObjectTarget);
                     d.MoveToY(d.Y - 50, 250, Easing.OutSine).Then().MoveToY(d.Y + 50, 500, Easing.InSine);
-                    d.MoveToX(d.X + originalX * 6, 1000);
+                    d.MoveToX(targetPosition.X, 1000);
                     d.FadeOut(750);
                     break;
             }

--- a/osu.Game.Rulesets.Catch/UI/CatcherPlate.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherPlate.cs
@@ -1,0 +1,213 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    /// <summary>
+    /// Contains contents of the catcher plate.
+    /// The sprite of the plate is drawn by <see cref="SkinnableCatcher"/>.
+    /// </summary>
+    public class CatcherPlate : CompositeDrawable
+    {
+        public Bindable<bool> GenerateHitLighting = new Bindable<bool>(true);
+
+        public Bindable<bool> StackCaughtObject = new Bindable<bool>(true);
+
+        private readonly DrawablePool<CaughtFruit> caughtFruitPool;
+        private readonly DrawablePool<CaughtBanana> caughtBananaPool;
+        private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
+
+        /// <summary>
+        /// Caught objects stacked on the plate.
+        /// </summary>
+        private readonly Container<CaughtObject> caughtObjectContainer;
+
+        /// <summary>
+        /// Contains <see cref="HitExplosion"/>s (aka. hit lighting).
+        /// </summary>
+        private readonly HitExplosionContainer hitExplosionContainer;
+
+        /// <summary>
+        /// Objects dropped from the plate.
+        /// </summary>
+        private readonly Container<CaughtObject> droppedObjectTarget;
+
+        /// <summary>
+        /// The amount by which caught fruit should be scaled down to fit on the plate.
+        /// </summary>
+        private const float caught_fruit_scale_adjust = 0.5f;
+
+        public CatcherPlate(Container<CaughtObject> droppedObjectTarget)
+        {
+            this.droppedObjectTarget = droppedObjectTarget;
+
+            Origin = Anchor.BottomCentre;
+
+            InternalChildren = new Drawable[]
+            {
+                caughtFruitPool = new DrawablePool<CaughtFruit>(50),
+                caughtBananaPool = new DrawablePool<CaughtBanana>(100),
+                // less capacity is needed compared to fruit because droplet is not stacked
+                caughtDropletPool = new DrawablePool<CaughtDroplet>(25),
+                caughtObjectContainer = new Container<CaughtObject>
+                {
+                    // offset fruit vertically to better place "above" the plate.
+                    Y = -5
+                },
+                hitExplosionContainer = new HitExplosionContainer()
+            };
+        }
+
+        public Drawable CreateBackgroundLayerProxy() => caughtObjectContainer.CreateProxy();
+
+        public void OnHitObjectCaught(DrawablePalpableCatchHitObject drawableHitObject, float catcherPosition)
+        {
+            var positionInStack = computePositionInStack(new Vector2(drawableHitObject.X - catcherPosition, 0), drawableHitObject.DisplaySize.X);
+
+            if (StackCaughtObject.Value)
+                placeCaughtObject(drawableHitObject, positionInStack);
+
+            if (GenerateHitLighting.Value)
+                addHitLighting(drawableHitObject.HitObject, positionInStack.X, drawableHitObject.AccentColour.Value);
+        }
+
+        public void OnRevertResult(DrawableCatchHitObject drawableHitObject)
+        {
+            caughtObjectContainer.RemoveAll(d => d.HitObject == drawableHitObject.HitObject);
+            droppedObjectTarget.RemoveAll(d => d.HitObject == drawableHitObject.HitObject);
+        }
+
+        #region Caught object stacking
+
+        private Vector2 computePositionInStack(Vector2 position, float displayRadius)
+        {
+            // this is taken from osu-stable (lenience should be 10 * 10 at standard scale).
+            const float lenience_adjust = 10 / CatchHitObject.OBJECT_RADIUS;
+
+            float adjustedRadius = displayRadius * lenience_adjust;
+            float checkDistance = MathF.Pow(adjustedRadius, 2);
+
+            while (caughtObjectContainer.Any(f => Vector2Extensions.DistanceSquared(f.Position, position) < checkDistance))
+            {
+                position.X += RNG.NextSingle(-adjustedRadius, adjustedRadius);
+                position.Y -= RNG.NextSingle(0, 5);
+            }
+
+            return position;
+        }
+
+        private void placeCaughtObject(DrawablePalpableCatchHitObject drawableObject, Vector2 position)
+        {
+            var caughtObject = getCaughtObject(drawableObject.HitObject);
+
+            if (caughtObject == null) return;
+
+            caughtObject.CopyStateFrom(drawableObject);
+            caughtObject.Anchor = Anchor.TopCentre;
+            caughtObject.Position = position;
+            caughtObject.Scale *= caught_fruit_scale_adjust;
+
+            caughtObjectContainer.Add(caughtObject);
+
+            if (!caughtObject.StaysOnPlate)
+                removeFromPlate(caughtObject, DropAnimation.Explode);
+        }
+
+        private CaughtObject getCaughtObject(PalpableCatchHitObject source)
+        {
+            switch (source)
+            {
+                case Fruit _:
+                    return caughtFruitPool.Get();
+
+                case Banana _:
+                    return caughtBananaPool.Get();
+
+                case Droplet _:
+                    return caughtDropletPool.Get();
+
+                default:
+                    return null;
+            }
+        }
+
+        #endregion
+
+        #region Caught object dropping
+
+        public void DropAll(DropAnimation animation)
+        {
+            var droppedObjects = caughtObjectContainer.Children.Select(getDroppedObject).ToArray();
+
+            caughtObjectContainer.Clear(false);
+
+            droppedObjectTarget.AddRange(droppedObjects);
+
+            foreach (var droppedObject in droppedObjects)
+                applyDropAnimation(droppedObject, animation);
+        }
+
+        private CaughtObject getDroppedObject(CaughtObject caughtObject)
+        {
+            var droppedObject = getCaughtObject(caughtObject.HitObject);
+
+            droppedObject.CopyStateFrom(caughtObject);
+            droppedObject.Anchor = Anchor.TopLeft;
+            droppedObject.Position = caughtObjectContainer.ToSpaceOfOtherDrawable(caughtObject.DrawPosition, droppedObjectTarget);
+
+            return droppedObject;
+        }
+
+        private void removeFromPlate(CaughtObject caughtObject, DropAnimation animation)
+        {
+            var droppedObject = getDroppedObject(caughtObject);
+
+            caughtObjectContainer.Remove(caughtObject);
+
+            droppedObjectTarget.Add(droppedObject);
+
+            applyDropAnimation(droppedObject, animation);
+        }
+
+        private void applyDropAnimation(Drawable d, DropAnimation animation)
+        {
+            switch (animation)
+            {
+                case DropAnimation.Drop:
+                    d.MoveToY(d.Y + 75, 750, Easing.InSine);
+                    d.FadeOut(750);
+                    break;
+
+                case DropAnimation.Explode:
+                    var originalX = droppedObjectTarget.ToSpaceOfOtherDrawable(d.DrawPosition, caughtObjectContainer).X * Scale.X;
+                    d.MoveToY(d.Y - 50, 250, Easing.OutSine).Then().MoveToY(d.Y + 50, 500, Easing.InSine);
+                    d.MoveToX(d.X + originalX * 6, 1000);
+                    d.FadeOut(750);
+                    break;
+            }
+
+            d.Expire();
+        }
+
+        #endregion
+
+        #region Hit lighting
+
+        private void addHitLighting(CatchHitObject hitObject, float x, Color4 colour) =>
+            hitExplosionContainer.Add(new HitExplosionEntry(Time.Current, x, hitObject.Scale, colour, hitObject.RandomSeed));
+
+        #endregion
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/CaughtObjectPool.cs
+++ b/osu.Game.Rulesets.Catch/UI/CaughtObjectPool.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    public class CaughtObjectPool : CompositeDrawable
+    {
+        private DrawablePool<CaughtFruit> caughtFruitPool;
+        private DrawablePool<CaughtBanana> caughtBananaPool;
+        private DrawablePool<CaughtDroplet> caughtDropletPool;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                caughtFruitPool = new DrawablePool<CaughtFruit>(50),
+                caughtBananaPool = new DrawablePool<CaughtBanana>(100),
+                // less capacity is needed compared to fruit because droplet is not stacked
+                caughtDropletPool = new DrawablePool<CaughtDroplet>(25),
+            };
+        }
+
+        [NotNull]
+        public CaughtObject Get(PalpableCatchHitObject source)
+        {
+            switch (source)
+            {
+                case Fruit _:
+                    return caughtFruitPool.Get();
+
+                case Banana _:
+                    return caughtBananaPool.Get();
+
+                case Droplet _:
+                    return caughtDropletPool.Get();
+
+                default:
+                    throw new InvalidOperationException($"Unexpected {nameof(PalpableCatchHitObject)}: {source.GetType().ReadableName()}.");
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/DropAnimation.cs
+++ b/osu.Game.Rulesets.Catch/UI/DropAnimation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    /// <summary>
+    /// Animation of an object dropped from the catcher plate.
+    /// </summary>
+    public enum DropAnimation
+    {
+        Drop,
+        Explode
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/DroppedObjectContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/DroppedObjectContainer.cs
@@ -29,6 +29,9 @@ namespace osu.Game.Rulesets.Catch.UI
                 AddInternal(caughtObjectPool = new CaughtObjectPool());
         }
 
+        /// <summary>
+        /// Create a dropped object from <paramref name="source"/> and drop it immediately.
+        /// </summary>
         public void Add(CaughtObject source, DropAnimation animation)
         {
             var droppedObject = caughtObjectPool.Get(source.HitObject);

--- a/osu.Game.Rulesets.Catch/UI/DroppedObjectContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/DroppedObjectContainer.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    public class DroppedObjectContainer : CompositeDrawable
+    {
+        private CaughtObjectPool caughtObjectPool;
+
+        private readonly Container<CaughtObject> container;
+
+        public DroppedObjectContainer()
+        {
+            RelativeSizeAxes = Axes.Both;
+            AddInternal(container = new Container<CaughtObject> { RelativeSizeAxes = Axes.Both });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // Create a pool if not provided. It is convenient for testing.
+            if (!Dependencies.TryGet(out caughtObjectPool))
+                AddInternal(caughtObjectPool = new CaughtObjectPool());
+        }
+
+        public void Add(CaughtObject source, DropAnimation animation)
+        {
+            var droppedObject = caughtObjectPool.Get(source.HitObject);
+
+            droppedObject.CopyStateFrom(source);
+            droppedObject.Anchor = Anchor.TopLeft;
+            droppedObject.Position = source.Parent.ToSpaceOfOtherDrawable(source.DrawPosition, container);
+
+            container.Add(droppedObject);
+
+            Vector2 targetPosition = source.Parent.ToSpaceOfOtherDrawable(source.DrawPosition * new Vector2(7f, 1), container);
+            applyDropAnimation(droppedObject, animation, targetPosition);
+        }
+
+        public void OnRevertResult(DrawableCatchHitObject drawableHitObject)
+        {
+            container.RemoveAll(d => d.HitObject == drawableHitObject.HitObject);
+        }
+
+        private void applyDropAnimation(Drawable d, DropAnimation animation, Vector2 targetPosition)
+        {
+            switch (animation)
+            {
+                case DropAnimation.Drop:
+                    d.MoveToY(d.Y + 75, 750, Easing.InSine);
+                    d.FadeOut(750);
+                    break;
+
+                case DropAnimation.Explode:
+                    d.MoveToY(d.Y - 50, 250, Easing.OutSine).Then().MoveToY(d.Y + 50, 500, Easing.InSine);
+                    d.MoveToX(targetPosition.X, 1000);
+                    d.FadeOut(750);
+                    break;
+            }
+
+            d.Expire();
+        }
+    }
+}


### PR DESCRIPTION
Majority of the diff is code moving, but also:

- <https://github.com/ppy/osu/commit/a6f300feb250811abe31277f5727c60d58b206a2> Offset caught object container instead of individual objects.
- <https://github.com/ppy/osu/commit/a51364d85d308bf1ec1b718a6b0413bd1f3743dc> Simplify the object explosion transforming code.
- <https://github.com/ppy/osu/commit/ac143015a3b76266eaaee5c5354f31182cd2c9ac> Instead of passing `droppedObjectTarget` down in constructors, use DI to resolve the new `DroppedObjectContainer` class. Changes in the tests are mostly due to this.
- <https://github.com/ppy/osu/commit/d3b25a4d9d79b7f7d16b151ecd9a55bdd048547e> The default (without creating the proxy) depth relation between the catcher body and caught objects is changed.

Hopefully, this change makes further changes easier to apply (less diff). Namely, maintaining caught objects by lifetime entries.
`Catcher` is still somewhat convoluted, though.