### PR TITLE
Rename CheckModsAllowFailure and convert it to a property

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
             public new HUDOverlay HUDOverlay => base.HUDOverlay;
 
-            public bool AllowFail => base.CheckModsAllowFailure();
+            public bool AllowFail => base.AllowFailure;
 
             protected override bool PauseOnFocusLost => false;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override bool PauseOnFocusLost => false;
 
         // Disallow fails in multiplayer for now.
-        protected override bool CheckModsAllowFailure() => false;
+        protected override bool AllowFailure => false;
 
         [Resolved]
         private MultiplayerClient client { get; set; }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.Play
         /// Whether failing should be allowed.
         /// By default, this checks whether all selected mods allow failing.
         /// </summary>
-        protected virtual bool CheckModsAllowFailure() => Mods.Value.OfType<IApplicableFailOverride>().All(m => m.PerformFail());
+        protected virtual bool AllowFailure => Mods.Value.OfType<IApplicableFailOverride>().All(m => m.PerformFail());
 
         public readonly PlayerConfiguration Configuration;
 
@@ -770,7 +770,7 @@ namespace osu.Game.Screens.Play
 
         private bool onFail()
         {
-            if (!CheckModsAllowFailure())
+            if (!AllowFailure)
                 return false;
 
             HasFailed = true;

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Play
         private readonly Func<IBeatmap, IReadOnlyList<Mod>, Score> createScore;
 
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
-        protected override bool CheckModsAllowFailure() => false;
+        protected override bool AllowFailure => false;
 
         public ReplayPlayer(Score score, PlayerConfiguration configuration = null)
             : this((_, __) => score, configuration)

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Play
 
         private readonly Score score;
 
-        protected override bool AllowFailure => false;
+        protected override bool AllowFailure => false; // todo: better support starting mid-way through beatmap
 
         public SpectatorPlayer(Score score)
         {

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Play
 
         private readonly Score score;
 
-        protected override bool CheckModsAllowFailure() => false; // todo: better support starting mid-way through beatmap
+        protected override bool AllowFailure => false;
 
         public SpectatorPlayer(Score score)
         {

--- a/osu.Game/Tests/Visual/ModPerfectTestScene.cs
+++ b/osu.Game/Tests/Visual/ModPerfectTestScene.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual
             {
             }
 
-            protected override bool CheckModsAllowFailure() => true;
+            protected override bool AllowFailure => true;
 
             public bool CheckFailed(bool failed)
             {

--- a/osu.Game/Tests/Visual/ModTestScene.cs
+++ b/osu.Game/Tests/Visual/ModTestScene.cs
@@ -54,14 +54,12 @@ namespace osu.Game.Tests.Visual
 
         protected class ModTestPlayer : TestPlayer
         {
-            private readonly bool allowFail;
-
-            protected override bool CheckModsAllowFailure() => allowFail;
+            protected override bool AllowFailure { get; }
 
             public ModTestPlayer(bool allowFail)
                 : base(false, false)
             {
-                this.allowFail = allowFail;
+                AllowFailure = allowFail;
             }
         }
 


### PR DESCRIPTION
`CheckModsAllowFailure` is a function that takes no parameter and returns a `bool`. A property feels more suitable here. As a result of this, the private read-only field `allowFail` is no longer needed in `ModTestPlayer`.

As for naming, the name `CheckModsAllowFailure` is a bit confusing, since only the default implementation actually checks mods for whether failure is allowed. I have renamed it to `AllowFailure` instead.