### PR TITLE
Add "placeholder" (pre-MVP) implementation of osu!catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneEditor.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneEditor.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    [TestFixture]
+    public class TestSceneEditor : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new CatchRuleset();
+    }
+}

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -22,7 +22,9 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using System;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Game.Rulesets.Catch.Edit;
 using osu.Game.Rulesets.Catch.Skinning.Legacy;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch
@@ -182,5 +184,7 @@ namespace osu.Game.Rulesets.Catch
         public int LegacyID => 2;
 
         public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new CatchReplayFrame();
+
+        public override HitObjectComposer CreateHitObjectComposer() => new CatchHitObjectComposer(this);
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
@@ -14,6 +16,8 @@ namespace osu.Game.Rulesets.Catch.Edit
             : base(nameof(BananaShower))
         {
         }
+
+        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners);
 
         public override PlacementBlueprint CreatePlacementBlueprint() => new BananaShowerPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/BananaShowerCompositionTool.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class BananaShowerCompositionTool : HitObjectCompositionTool
+    {
+        public BananaShowerCompositionTool()
+            : base(nameof(BananaShower))
+        {
+        }
+
+        public override PlacementBlueprint CreatePlacementBlueprint() => new BananaShowerPlacementBlueprint();
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
                 case PlacementState.Active:
                     if (e.Button != MouseButton.Right) break;
 
+                    // If the duration is negative, swap the start and the end time to make the duration positive.
                     if (HitObject.Duration < 0)
                     {
                         HitObject.StartTime = HitObject.EndTime;

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public class BananaShowerPlacementBlueprint : CatchPlacementBlueprint<BananaShower>
+    {
+        private readonly TimeSpanOutline outline;
+
+        public BananaShowerPlacementBlueprint()
+        {
+            InternalChild = outline = new TimeSpanOutline();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            outline.UpdateFrom(HitObjectContainer, HitObject);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            switch (PlacementActive)
+            {
+                case PlacementState.Waiting:
+                    if (e.Button != MouseButton.Left) break;
+
+                    BeginPlacement(true);
+                    return true;
+
+                case PlacementState.Active:
+                    if (e.Button != MouseButton.Right) break;
+
+                    if (HitObject.Duration < 0)
+                    {
+                        HitObject.StartTime = HitObject.EndTime;
+                        HitObject.Duration = -HitObject.Duration;
+                    }
+
+                    EndPlacement(HitObject.Duration > 0);
+                    return true;
+            }
+
+            return base.OnMouseDown(e);
+        }
+
+        public override void UpdateTimeAndPosition(SnapResult result)
+        {
+            base.UpdateTimeAndPosition(result);
+
+            if (!(result.Time is double time)) return;
+
+            switch (PlacementActive)
+            {
+                case PlacementState.Waiting:
+                    HitObject.StartTime = time;
+                    break;
+
+                case PlacementState.Active:
+                    HitObject.EndTime = time;
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerSelectionBlueprint.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Objects;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public class BananaShowerSelectionBlueprint : CatchSelectionBlueprint<BananaShower>
+    {
+        public BananaShowerSelectionBlueprint(BananaShower hitObject)
+            : base(hitObject)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchPlacementBlueprint.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public class CatchPlacementBlueprint<THitObject> : PlacementBlueprint
+        where THitObject : CatchHitObject, new()
+    {
+        protected new THitObject HitObject => (THitObject)base.HitObject;
+
+        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
+
+        [Resolved]
+        private Playfield playfield { get; set; }
+
+        public CatchPlacementBlueprint()
+            : base(new THitObject())
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public abstract class CatchSelectionBlueprint<THitObject> : HitObjectSelectionBlueprint<THitObject>
+        where THitObject : CatchHitObject
+    {
+        [Resolved]
+        private Playfield playfield { get; set; }
+
+        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
+
+        public override Vector2 ScreenSpaceSelectionPoint
+        {
+            get
+            {
+                float x = HitObject.OriginalX;
+                float y = HitObjectContainer.PositionAtTime(HitObject.StartTime);
+                return HitObjectContainer.ToScreenSpace(new Vector2(x, y + HitObjectContainer.DrawHeight));
+            }
+        }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => SelectionQuad.Contains(screenSpacePos);
+
+        protected CatchSelectionBlueprint(THitObject hitObject)
+            : base(hitObject)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
@@ -13,11 +13,6 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
     public abstract class CatchSelectionBlueprint<THitObject> : HitObjectSelectionBlueprint<THitObject>
         where THitObject : CatchHitObject
     {
-        [Resolved]
-        private Playfield playfield { get; set; }
-
-        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
-
         public override Vector2 ScreenSpaceSelectionPoint
         {
             get
@@ -29,6 +24,11 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => SelectionQuad.Contains(screenSpacePos);
+
+        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
+
+        [Resolved]
+        private Playfield playfield { get; set; }
 
         protected CatchSelectionBlueprint(THitObject hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/FruitOutline.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/FruitOutline.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             Anchor = Anchor.BottomLeft;
             Origin = Anchor.Centre;
             Size = new Vector2(2 * CatchHitObject.OBJECT_RADIUS);
-            // TODO: use skinned component?
             InternalChild = new BorderPiece();
         }
 

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/FruitOutline.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/FruitOutline.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Skinning.Default;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
+{
+    public class FruitOutline : CompositeDrawable
+    {
+        public FruitOutline()
+        {
+            Anchor = Anchor.BottomLeft;
+            Origin = Anchor.Centre;
+            Size = new Vector2(2 * CatchHitObject.OBJECT_RADIUS);
+            // TODO: use skinned component?
+            InternalChild = new BorderPiece();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour osuColour)
+        {
+            Colour = osuColour.Yellow;
+        }
+
+        public void UpdateFrom(ScrollingHitObjectContainer hitObjectContainer, CatchHitObject hitObject)
+        {
+            X = hitObject.EffectiveX;
+            Y = hitObjectContainer.PositionAtTime(hitObject.StartTime);
+            Scale = new Vector2(hitObject.Scale);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/TimeSpanOutline.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/TimeSpanOutline.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
     {
         private const float border_width = 4;
 
+        private const float opacity_when_empty = 0.5f;
+
         private bool isEmpty = true;
 
         public TimeSpanOutline()
@@ -26,6 +28,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
             Masking = true;
             BorderThickness = border_width;
+            Alpha = opacity_when_empty;
 
             // A box is needed to make the border visible.
             InternalChild = new Box
@@ -52,7 +55,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             bool wasEmpty = isEmpty;
             isEmpty = height == 0;
             if (wasEmpty != isEmpty)
-                this.FadeTo(isEmpty ? 0.5f : 1f, 150);
+                this.FadeTo(isEmpty ? opacity_when_empty : 1f, 150);
 
             Height = Math.Max(height, border_width);
         }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/TimeSpanOutline.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/TimeSpanOutline.cs
@@ -21,14 +21,13 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         public TimeSpanOutline()
         {
-            Anchor = Anchor.BottomLeft;
-            Origin = Anchor.BottomLeft;
+            Anchor = Origin = Anchor.BottomLeft;
             RelativeSizeAxes = Axes.X;
 
             Masking = true;
             BorderThickness = border_width;
 
-            // a box is needed to make edge visible
+            // A box is needed to make the border visible.
             InternalChild = new Box
             {
                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/TimeSpanOutline.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/TimeSpanOutline.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
+{
+    public class TimeSpanOutline : CompositeDrawable
+    {
+        private const float border_width = 4;
+
+        private bool isEmpty = true;
+
+        public TimeSpanOutline()
+        {
+            Anchor = Anchor.BottomLeft;
+            Origin = Anchor.BottomLeft;
+            RelativeSizeAxes = Axes.X;
+
+            Masking = true;
+            BorderThickness = border_width;
+
+            // a box is needed to make edge visible
+            InternalChild = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4.Transparent
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour osuColour)
+        {
+            BorderColour = osuColour.Yellow;
+        }
+
+        public void UpdateFrom(ScrollingHitObjectContainer hitObjectContainer, BananaShower hitObject)
+        {
+            float startY = hitObjectContainer.PositionAtTime(hitObject.StartTime);
+            float endY = hitObjectContainer.PositionAtTime(hitObject.EndTime);
+
+            Y = Math.Max(startY, endY);
+            float height = Math.Abs(startY - endY);
+
+            bool wasEmpty = isEmpty;
+            isEmpty = height == 0;
+            if (wasEmpty != isEmpty)
+                this.FadeTo(isEmpty ? 0.5f : 1f, 150);
+
+            Height = Math.Max(height, border_width);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitPlacementBlueprint.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public class FruitPlacementBlueprint : CatchPlacementBlueprint<Fruit>
+    {
+        private readonly FruitOutline outline;
+
+        public FruitPlacementBlueprint()
+        {
+            InternalChild = outline = new FruitOutline();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            BeginPlacement();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            outline.UpdateFrom(HitObjectContainer, HitObject);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (e.Button != MouseButton.Left) return base.OnMouseDown(e);
+
+            EndPlacement(true);
+            return true;
+        }
+
+        public override void UpdateTimeAndPosition(SnapResult result)
+        {
+            base.UpdateTimeAndPosition(result);
+
+            HitObject.X = ToLocalSpace(result.ScreenSpacePosition).X;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitSelectionBlueprint.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Objects;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public class FruitSelectionBlueprint : CatchSelectionBlueprint<Fruit>
+    {
+        public FruitSelectionBlueprint(Fruit hitObject)
+            : base(hitObject)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitSelectionBlueprint.cs
@@ -1,15 +1,27 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Catch.Objects;
 
 namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 {
     public class FruitSelectionBlueprint : CatchSelectionBlueprint<Fruit>
     {
+        private readonly FruitOutline outline;
+
         public FruitSelectionBlueprint(Fruit hitObject)
             : base(hitObject)
         {
+            InternalChild = outline = new FruitOutline();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (IsSelected)
+                outline.UpdateFrom(HitObjectContainer, HitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 {
     public class JuiceStreamSelectionBlueprint : CatchSelectionBlueprint<JuiceStream>
     {
-        public override Quad SelectionQuad => HitObjectContainer.ToScreenSpace(computeBoundingBox().Offset(new Vector2(0, HitObjectContainer.DrawHeight)));
+        public override Quad SelectionQuad => HitObjectContainer.ToScreenSpace(getBoundingBox().Offset(new Vector2(0, HitObjectContainer.DrawHeight)));
 
         private float minNestedX;
         private float maxNestedX;
@@ -26,18 +26,18 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
         private void load()
         {
             HitObject.DefaultsApplied += onDefaultsApplied;
-            calculateObjectBounds();
+            computeObjectBounds();
         }
 
-        private void onDefaultsApplied(HitObject _) => calculateObjectBounds();
+        private void onDefaultsApplied(HitObject _) => computeObjectBounds();
 
-        private void calculateObjectBounds()
+        private void computeObjectBounds()
         {
             minNestedX = HitObject.NestedHitObjects.OfType<CatchHitObject>().Min(nested => nested.OriginalX) - HitObject.OriginalX;
             maxNestedX = HitObject.NestedHitObjects.OfType<CatchHitObject>().Max(nested => nested.OriginalX) - HitObject.OriginalX;
         }
 
-        private RectangleF computeBoundingBox()
+        private RectangleF getBoundingBox()
         {
             float left = HitObject.OriginalX + minNestedX;
             float right = HitObject.OriginalX + maxNestedX;

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit.Blueprints
+{
+    public class JuiceStreamSelectionBlueprint : CatchSelectionBlueprint<JuiceStream>
+    {
+        public override Quad SelectionQuad => HitObjectContainer.ToScreenSpace(computeBoundingBox().Offset(new Vector2(0, HitObjectContainer.DrawHeight)));
+
+        private float minNestedX;
+        private float maxNestedX;
+
+        public JuiceStreamSelectionBlueprint(JuiceStream hitObject)
+            : base(hitObject)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            HitObject.DefaultsApplied += onDefaultsApplied;
+            calculateObjectBounds();
+        }
+
+        private void onDefaultsApplied(HitObject _) => calculateObjectBounds();
+
+        private void calculateObjectBounds()
+        {
+            minNestedX = HitObject.NestedHitObjects.OfType<CatchHitObject>().Min(nested => nested.OriginalX) - HitObject.OriginalX;
+            maxNestedX = HitObject.NestedHitObjects.OfType<CatchHitObject>().Max(nested => nested.OriginalX) - HitObject.OriginalX;
+        }
+
+        private RectangleF computeBoundingBox()
+        {
+            float left = HitObject.OriginalX + minNestedX;
+            float right = HitObject.OriginalX + maxNestedX;
+            float top = HitObjectContainer.PositionAtTime(HitObject.EndTime);
+            float bottom = HitObjectContainer.PositionAtTime(HitObject.StartTime);
+            float objectRadius = CatchHitObject.OBJECT_RADIUS * HitObject.Scale;
+            return new RectangleF(left, top, right - left, bottom - top).Inflate(objectRadius);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            HitObject.DefaultsApplied -= onDefaultsApplied;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class CatchBlueprintContainer : ComposeBlueprintContainer
+    {
+        public CatchBlueprintContainer(CatchHitObjectComposer composer)
+            : base(composer)
+        {
+        }
+
+        protected override SelectionHandler<HitObject> CreateSelectionHandler() => new CatchSelectionHandler();
+
+        public override HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Fruit fruit:
+                    return new FruitSelectionBlueprint(fruit);
+
+                case BananaShower bananaShower:
+                    return new BananaShowerSelectionBlueprint(bananaShower);
+            }
+
+            return base.CreateHitObjectBlueprintFor(hitObject);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
@@ -25,6 +25,9 @@ namespace osu.Game.Rulesets.Catch.Edit
                 case Fruit fruit:
                     return new FruitSelectionBlueprint(fruit);
 
+                case JuiceStream juiceStream:
+                    return new JuiceStreamSelectionBlueprint(juiceStream);
+
                 case BananaShower bananaShower:
                     return new BananaShowerSelectionBlueprint(bananaShower);
             }

--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.UI;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class CatchEditorPlayfield : CatchPlayfield
+    {
+        // TODO fixme: the size of the catcher is not changed when circle size is changed in setup screen.
+        public CatchEditorPlayfield(BeatmapDifficulty difficulty)
+            : base(difficulty)
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // TODO: honor "hit animation" setting?
+            CatcherArea.MovableCatcher.CatchFruitOnPlate = false;
+
+            // TODO: disable hit lighting as well
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -17,7 +17,10 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
-        protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => System.Array.Empty<HitObjectCompositionTool>();
+        protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]
+        {
+            new FruitCompositionTool(),
+        };
 
         public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -2,9 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -16,6 +19,9 @@ namespace osu.Game.Rulesets.Catch.Edit
             : base(ruleset)
         {
         }
+
+        protected override DrawableRuleset<CatchHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null) =>
+            new DrawableCatchEditorRuleset(ruleset, beatmap, mods);
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]
         {

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Edit
 {
@@ -16,5 +18,15 @@ namespace osu.Game.Rulesets.Catch.Edit
         }
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => System.Array.Empty<HitObjectCompositionTool>();
+
+        public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
+        {
+            var result = base.SnapScreenSpacePositionToValidTime(screenSpacePosition);
+            // TODO: implement position snap
+            result.ScreenSpacePosition.X = screenSpacePosition.X;
+            return result;
+        }
+
+        protected override ComposeBlueprintContainer CreateBlueprintContainer() => new CatchBlueprintContainer(this);
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Catch.Edit
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]
         {
             new FruitCompositionTool(),
+            new BananaShowerCompositionTool()
         };
 
         public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class CatchHitObjectComposer : HitObjectComposer<CatchHitObject>
+    {
+        public CatchHitObjectComposer(CatchRuleset ruleset)
+            : base(ruleset)
+        {
+        }
+
+        protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => System.Array.Empty<HitObjectCompositionTool>();
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Objects;
@@ -33,6 +34,9 @@ namespace osu.Game.Rulesets.Catch.Edit
 
                 // TODO: confine in bounds
                 hitObject.OriginalXBindable.Value += deltaX;
+
+                foreach (var nested in hitObject.NestedHitObjects.OfType<CatchHitObject>())
+                    nested.OriginalXBindable.Value += deltaX;
             });
 
             return true;

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -14,10 +14,10 @@ namespace osu.Game.Rulesets.Catch.Edit
 {
     public class CatchSelectionHandler : EditorSelectionHandler
     {
+        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
+
         [Resolved]
         private Playfield playfield { get; set; }
-
-        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
 
         public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent)
         {

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class CatchSelectionHandler : EditorSelectionHandler
+    {
+        [Resolved]
+        private Playfield playfield { get; set; }
+
+        protected ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
+
+        public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent)
+        {
+            var blueprint = moveEvent.Blueprint;
+            Vector2 originalPosition = HitObjectContainer.ToLocalSpace(blueprint.ScreenSpaceSelectionPoint);
+            Vector2 targetPosition = HitObjectContainer.ToLocalSpace(blueprint.ScreenSpaceSelectionPoint + moveEvent.ScreenSpaceDelta);
+            float deltaX = targetPosition.X - originalPosition.X;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (!(h is CatchHitObject hitObject)) return;
+
+                if (hitObject is BananaShower) return;
+
+                // TODO: confine in bounds
+                hitObject.OriginalXBindable.Value += deltaX;
+            });
+
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                 // TODO: confine in bounds
                 hitObject.OriginalXBindable.Value += deltaX;
 
+                // Move the nested hit objects to give an instant result before nested objects are recreated.
                 foreach (var nested in hitObject.NestedHitObjects.OfType<CatchHitObject>())
                     nested.OriginalXBindable.Value += deltaX;
             });

--- a/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
+++ b/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class DrawableCatchEditorRuleset : DrawableCatchRuleset
+    {
+        public DrawableCatchEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
+            : base(ruleset, beatmap, mods)
+        {
+        }
+
+        protected override Playfield CreatePlayfield() => new CatchEditorPlayfield(Beatmap.BeatmapInfo.BaseDifficulty);
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/FruitCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/FruitCompositionTool.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
@@ -14,6 +16,8 @@ namespace osu.Game.Rulesets.Catch.Edit
             : base(nameof(Fruit))
         {
         }
+
+        public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
 
         public override PlacementBlueprint CreatePlacementBlueprint() => new FruitPlacementBlueprint();
     }

--- a/osu.Game.Rulesets.Catch/Edit/FruitCompositionTool.cs
+++ b/osu.Game.Rulesets.Catch/Edit/FruitCompositionTool.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class FruitCompositionTool : HitObjectCompositionTool
+    {
+        public FruitCompositionTool()
+            : base(nameof(Fruit))
+        {
+        }
+
+        public override PlacementBlueprint CreatePlacementBlueprint() => new FruitPlacementBlueprint();
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -94,6 +95,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Creates a <see cref="SelectionBlueprint{T}"/> for a specific item.
         /// </summary>
         /// <param name="item">The item to create the overlay for.</param>
+        [CanBeNull]
         protected virtual SelectionBlueprint<T> CreateBlueprintFor(T item) => null;
 
         protected virtual DragBox CreateDragBox(Action<RectangleF> performSelect) => new DragBox(performSelect);

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -259,6 +260,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return CreateHitObjectBlueprintFor(item)?.With(b => b.DrawableObject = drawable);
         }
 
+        [CanBeNull]
         public virtual HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject) => null;
 
         private void hitObjectAdded(HitObject obj)

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -256,7 +256,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (drawable == null)
                 return null;
 
-            return CreateHitObjectBlueprintFor(item).With(b => b.DrawableObject = drawable);
+            return CreateHitObjectBlueprintFor(item)?.With(b => b.DrawableObject = drawable);
         }
 
         public virtual HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject) => null;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -89,7 +90,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
             else
             {
-                placementBlueprint = CreateBlueprintFor(obj.NewValue);
+                placementBlueprint = CreateBlueprintFor(obj.NewValue).AsNonNull();
 
                 placementBlueprint.Colour = Color4.MediumPurple;
 


### PR DESCRIPTION
It is a set of files that are needed for any plan of the catch editor anyway.
Due to complexity, juice stream editing/placement is not implemented in this PR.

### Known bugs (I expect this PR to be merged with known issues)

- Catcher size is not changed when the circle size is changed
- Scrolling speed is not changed when the approach rate is changed
- Objects can go out of bounds (only tiny droplets are confined to the playfield)
- Catcher trails/hit lighting are duplicated. Catcher animation is not rewound correctly.
- Fruit outline is always a circle even with a non-default skin.

Fixes to some issues are not included in this PR because that requires changes to the `osu.Game` code or non-editor parts.
Others are not implemented yet due to complexity.

### Not implemented (features needed even for basic editing)

- Editing/placement of juice streams
  - At least piecewise-linear ones.
- Position snapping
- Copy/paste (serialization)
- Probably a lot more
- Hyper state of hit objects should be updated real-time when position is changed <https://github.com/ppy/osu/pull/13617#issuecomment-865827951>
- Hit object shouldn't be expired when caught by the catcher <https://github.com/ppy/osu/pull/13617#issuecomment-866247870>



https://user-images.githubusercontent.com/191335/124296661-2e665300-db95-11eb-8da5-ad34241a6e19.mp4

