### PR TITLE
Fix `DirectorySelector` causing a stack overflow when trying to open an inaccessible directory

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -83,11 +83,17 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             var newDirectory = directory.NewValue;
             bool flashError = false;
+            IEnumerable<DisplayPiece> displayPieces = Array.Empty<DisplayPiece>();
 
-            while (!newDirectoryIsAccessible())
+            while (newDirectory != null)
             {
+                newDirectory.Refresh();
+
+                if (TryGetEntriesForPath(newDirectory, out displayPieces))
+                    break;
+
                 flashError = true;
-                newDirectory = newDirectory?.Parent;
+                newDirectory = newDirectory.Parent;
             }
 
             if (flashError)
@@ -106,18 +112,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             CurrentPath.Value = newDirectory;
 
             directoryFlow.Add(new ParentDirectoryPiece(newDirectory.Parent));
-            if (TryGetEntriesForPath(newDirectory, out var displayPieces))
-                directoryFlow.AddRange(displayPieces);
-
-            bool newDirectoryIsAccessible()
-            {
-                if (newDirectory == null)
-                    return true;
-
-                newDirectory.Refresh();
-
-                return TryGetEntriesForPath(newDirectory, out displayPieces);
-            }
+            directoryFlow.AddRange(displayPieces);
         }
 
         protected virtual bool TryGetEntriesForPath(DirectoryInfo path, out IEnumerable<DisplayPiece> displayPieces)

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -77,8 +77,20 @@ namespace osu.Game.Graphics.UserInterfaceV2
             CurrentPath.BindValueChanged(updateDisplay, true);
         }
 
+        /// <summary>
+        /// Because <see cref="CurrentPath"/> changes may not necessarily lead to directories that exist/are accessible,
+        /// <see cref="updateDisplay"/> may need to change <see cref="CurrentPath"/> again to lead to a directory that is actually accessible.
+        /// This flag intends to prevent recursive <see cref="updateDisplay"/> calls from taking place during the process of finding an accessible directory.
+        /// </summary>
+        private bool directoryChanging;
+
         private void updateDisplay(ValueChangedEvent<DirectoryInfo> directory)
         {
+            if (directoryChanging)
+                return;
+
+            directoryChanging = true;
+
             directoryFlow.Clear();
 
             var newDirectory = directory.NewValue;
@@ -113,6 +125,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             directoryFlow.Add(new ParentDirectoryPiece(newDirectory.Parent));
             directoryFlow.AddRange(displayPieces);
+
+            directoryChanging = false;
         }
 
         protected virtual bool TryGetEntriesForPath(DirectoryInfo path, out ICollection<DisplayPiece> displayPieces)

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -81,8 +81,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             directoryFlow.Clear();
 
-            directory.NewValue?.Refresh();
-
             try
             {
                 if (directory.NewValue == null)
@@ -91,22 +89,24 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                     foreach (var drive in drives)
                         directoryFlow.Add(new DirectoryPiece(drive.RootDirectory));
-                }
-                else if (!directory.NewValue.Exists)
-                {
-                    var newDirectory = directory.NewValue;
 
-                    while (newDirectory != null && !newDirectory.Exists)
-                        newDirectory = newDirectory.Parent;
-
-                    CurrentPath.Value = newDirectory;
+                    return;
                 }
-                else
-                {
-                    directoryFlow.Add(new ParentDirectoryPiece(CurrentPath.Value.Parent));
 
-                    directoryFlow.AddRange(GetEntriesForPath(CurrentPath.Value));
-                }
+                directory.NewValue.Refresh();
+
+                var newDirectory = directory.NewValue;
+
+                while (newDirectory != null && !newDirectory.Exists)
+                    newDirectory = newDirectory.Parent;
+
+                CurrentPath.Value = newDirectory;
+
+                if (newDirectory == null)
+                    return;
+
+                directoryFlow.Add(new ParentDirectoryPiece(newDirectory.Parent));
+                directoryFlow.AddRange(GetEntriesForPath(newDirectory));
             }
             catch (Exception)
             {

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -81,8 +81,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             directoryFlow.Clear();
 
-            directory.NewValue.Refresh();
-
             try
             {
                 if (directory.NewValue == null)
@@ -94,6 +92,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 }
                 else if (!directory.NewValue.Exists)
                 {
+                    directory.NewValue.Refresh();
+
                     var newDirectory = directory.NewValue;
 
                     while (newDirectory != null && !newDirectory.Exists)

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private class CurrentDirectoryDisplay : CompositeDrawable
         {
             [Resolved]
-            public Bindable<DirectoryInfo> CurrentDirectory { get; private set; }
+            private Bindable<DirectoryInfo> currentDirectory { get; set; }
 
             private FillFlowContainer flow;
 
@@ -158,7 +158,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     },
                 };
 
-                CurrentDirectory.BindValueChanged(updateDisplay, true);
+                currentDirectory.BindValueChanged(updateDisplay, true);
             }
 
             private void updateDisplay(ValueChangedEvent<DirectoryInfo> dir)

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -81,6 +81,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             directoryFlow.Clear();
 
+            directory.NewValue?.Refresh();
+
             try
             {
                 if (directory.NewValue == null)
@@ -92,8 +94,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 }
                 else if (!directory.NewValue.Exists)
                 {
-                    directory.NewValue.Refresh();
-
                     var newDirectory = directory.NewValue;
 
                     while (newDirectory != null && !newDirectory.Exists)

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             var newDirectory = directory.NewValue;
             bool flashError = false;
-            IEnumerable<DisplayPiece> displayPieces = Array.Empty<DisplayPiece>();
+            ICollection<DisplayPiece> displayPieces = Array.Empty<DisplayPiece>();
 
             while (newDirectory != null)
             {
@@ -115,7 +115,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             directoryFlow.AddRange(displayPieces);
         }
 
-        protected virtual bool TryGetEntriesForPath(DirectoryInfo path, out IEnumerable<DisplayPiece> displayPieces)
+        protected virtual bool TryGetEntriesForPath(DirectoryInfo path, out ICollection<DisplayPiece> displayPieces)
         {
             displayPieces = new List<DisplayPiece>();
 
@@ -124,7 +124,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 foreach (var dir in path.GetDirectories().OrderBy(d => d.Name))
                 {
                     if ((dir.Attributes & FileAttributes.Hidden) == 0)
-                        displayPieces = displayPieces.Append(new DirectoryPiece(dir));
+                        displayPieces.Add(new DirectoryPiece(dir));
                 }
 
                 return true;

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -82,12 +82,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
             directoryFlow.Clear();
 
             var newDirectory = directory.NewValue;
-
-            if (!newDirectoryIsAccessible())
-                this.FlashColour(Color4.Red, 300);
+            bool flashError = false;
 
             while (!newDirectoryIsAccessible())
+            {
+                flashError = true;
                 newDirectory = newDirectory?.Parent;
+            }
+
+            if (flashError)
+                this.FlashColour(Color4.Red, 300);
 
             if (newDirectory == null)
             {

--- a/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/DirectorySelector.cs
@@ -81,6 +81,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             directoryFlow.Clear();
 
+            directory.NewValue.Refresh();
+
             try
             {
                 if (directory.NewValue == null)
@@ -89,6 +91,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                     foreach (var drive in drives)
                         directoryFlow.Add(new DirectoryPiece(drive.RootDirectory));
+                }
+                else if (!directory.NewValue.Exists)
+                {
+                    var newDirectory = directory.NewValue;
+
+                    while (newDirectory != null && !newDirectory.Exists)
+                        newDirectory = newDirectory.Parent;
+
+                    CurrentPath.Value = newDirectory;
                 }
                 else
                 {

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             this.validFileExtensions = validFileExtensions ?? Array.Empty<string>();
         }
 
-        protected override bool TryGetEntriesForPath(DirectoryInfo path, out IEnumerable<DisplayPiece> displayPieces)
+        protected override bool TryGetEntriesForPath(DirectoryInfo path, out ICollection<DisplayPiece> displayPieces)
         {
             displayPieces = new List<DisplayPiece>();
 
@@ -42,7 +42,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             foreach (var file in files.OrderBy(d => d.Name))
             {
                 if ((file.Attributes & FileAttributes.Hidden) == 0)
-                    displayPieces = displayPieces.Append(new FilePiece(file));
+                    displayPieces.Add(new FilePiece(file));
             }
 
             return true;

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
@@ -34,18 +34,25 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             displayPieces = directories;
 
-            IEnumerable<FileInfo> files = path.GetFiles();
-
-            if (validFileExtensions.Length > 0)
-                files = files.Where(f => validFileExtensions.Contains(f.Extension));
-
-            foreach (var file in files.OrderBy(d => d.Name))
+            try
             {
-                if ((file.Attributes & FileAttributes.Hidden) == 0)
-                    displayPieces.Add(new FilePiece(file));
-            }
+                IEnumerable<FileInfo> files = path.GetFiles();
 
-            return true;
+                if (validFileExtensions.Length > 0)
+                    files = files.Where(f => validFileExtensions.Contains(f.Extension));
+
+                foreach (var file in files.OrderBy(d => d.Name))
+                {
+                    if ((file.Attributes & FileAttributes.Hidden) == 0)
+                        displayPieces.Add(new FilePiece(file));
+                }
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         protected class FilePiece : DisplayPiece

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
@@ -25,10 +25,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
             this.validFileExtensions = validFileExtensions ?? Array.Empty<string>();
         }
 
-        protected override IEnumerable<DisplayPiece> GetEntriesForPath(DirectoryInfo path)
+        protected override bool TryGetEntriesForPath(DirectoryInfo path, out IEnumerable<DisplayPiece> displayPieces)
         {
-            foreach (var dir in base.GetEntriesForPath(path))
-                yield return dir;
+            displayPieces = new List<DisplayPiece>();
+
+            if (!base.TryGetEntriesForPath(path, out var directories))
+                return false;
+
+            displayPieces = directories;
 
             IEnumerable<FileInfo> files = path.GetFiles();
 
@@ -38,8 +42,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
             foreach (var file in files.OrderBy(d => d.Name))
             {
                 if ((file.Attributes & FileAttributes.Hidden) == 0)
-                    yield return new FilePiece(file);
+                    displayPieces = displayPieces.Append(new FilePiece(file));
             }
+
+            return true;
         }
 
         protected class FilePiece : DisplayPiece

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 
@@ -43,7 +44,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                 foreach (var file in files.OrderBy(d => d.Name))
                 {
-                    if ((file.Attributes & FileAttributes.Hidden) == 0)
+                    if (!file.Attributes.HasFlagFast(FileAttributes.Hidden))
                         displayPieces.Add(new FilePiece(file));
                 }
 


### PR DESCRIPTION
Fixes #13602 

Attempting to open a nonexistent folder will open the next existing parent directory instead.

