### PR TITLE
Allow `Player` to proceed to results screen after failing

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public bool RestartOnFail => false;
 
+        public bool DisplayResultsOnFail => false;
+
         private OsuInputManager inputManager;
 
         private IFrameStableClock gameplayClock;

--- a/osu.Game/Rulesets/Mods/IApplicableFailOverride.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableFailOverride.cs
@@ -18,5 +18,10 @@ namespace osu.Game.Rulesets.Mods
         /// Whether we want to restart on fail. Only used if <see cref="PerformFail"/> returns true.
         /// </summary>
         bool RestartOnFail { get; }
+
+        /// <summary>
+        /// Whether to proceed to results screen on fail. Only used if <see cref="PerformFail"/> returns true and <see cref="RestartOnFail"/> is false.
+        /// </summary>
+        bool DisplayResultsOnFail { get; }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Rulesets.Mods
 
         public bool RestartOnFail => false;
 
+        public bool DisplayResultsOnFail => false;
+
         public override bool UserPlayable => false;
 
         public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail) };

--- a/osu.Game/Rulesets/Mods/ModBlockFail.cs
+++ b/osu.Game/Rulesets/Mods/ModBlockFail.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Mods
 
         public bool RestartOnFail => false;
 
+        public bool DisplayResultsOnFail => false;
+
         public void ReadFromConfig(OsuConfigManager config)
         {
             showHealthBar = config.GetBindable<bool>(OsuSetting.ShowHealthDisplayWhenCantFail);

--- a/osu.Game/Rulesets/Mods/ModEasyWithExtraLives.cs
+++ b/osu.Game/Rulesets/Mods/ModEasyWithExtraLives.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Rulesets.Mods
 
         public bool RestartOnFail => false;
 
+        public bool DisplayResultsOnFail => false;
+
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
         {
             health = healthProcessor.Health.GetBoundCopy();

--- a/osu.Game/Rulesets/Mods/ModFailCondition.cs
+++ b/osu.Game/Rulesets/Mods/ModFailCondition.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Rulesets.Mods
 
         public virtual bool RestartOnFail => true;
 
+        public virtual bool DisplayResultsOnFail => false;
+
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
         {
             healthProcessor.FailConditions += FailCondition;

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Play
 
         private readonly DrawableRuleset drawableRuleset;
 
-        private BindableDouble trackFreq;
+        private readonly BindableDouble trackFreq = new BindableDouble(1);
 
         private Track track;
 
@@ -65,8 +65,6 @@ namespace osu.Game.Screens.Play
 
             if (adjustTrackFrequency)
             {
-                trackFreq = new BindableDouble(1);
-
                 this.TransformBindableTo(trackFreq, 0, duration).OnComplete(_ =>
                 {
                     OnComplete?.Invoke();
@@ -131,8 +129,7 @@ namespace osu.Game.Screens.Play
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            if (trackFreq != null)
-                track?.RemoveAdjustment(AdjustableProperty.Frequency, trackFreq);
+            track?.RemoveAdjustment(AdjustableProperty.Frequency, trackFreq);
         }
     }
 }

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Start the fail animation playing.
         /// </summary>
+        /// <param name="adjustTrackFrequency">Whether to apply frequency adjustment to the track.</param>
         /// <exception cref="InvalidOperationException">Thrown if started more than once.</exception>
         public void Start(bool adjustTrackFrequency)
         {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual bool CheckModsAllowFailure() => Mods.Value.OfType<IApplicableFailOverride>().All(m => m.PerformFail());
 
-        private bool displayResultsOnFail => Mods.Value.OfType<IApplicableFailOverride>().Any(m => m.DisplayResultsOnFail);
+        private bool displayResultsOnFail() => Mods.Value.OfType<IApplicableFailOverride>().Any(m => m.DisplayResultsOnFail);
 
         public readonly PlayerConfiguration Configuration;
 
@@ -668,7 +668,7 @@ namespace osu.Game.Screens.Play
             }
 
             // Only show the completion screen if the player hasn't failed
-            if (HealthProcessor.HasFailed && !displayResultsOnFail)
+            if (HealthProcessor.HasFailed && !displayResultsOnFail())
                 return;
 
             // Setting this early in the process means that even if something were to go wrong in the order of events following, there
@@ -685,7 +685,7 @@ namespace osu.Game.Screens.Play
 
             bool storyboardHasOutro = DimmableStoryboard.ContentDisplayed && !DimmableStoryboard.HasStoryboardEnded.Value;
 
-            if (storyboardHasOutro && !displayResultsOnFail)
+            if (storyboardHasOutro && !displayResultsOnFail())
             {
                 // if the current beatmap has a storyboard, the progression to results will be handled by the storyboard ending
                 // or the user pressing the skip outro button.
@@ -786,12 +786,12 @@ namespace osu.Game.Screens.Play
             if (PauseOverlay.State.Value == Visibility.Visible)
                 PauseOverlay.Hide();
 
-            failAnimation.Start(!displayResultsOnFail);
+            failAnimation.Start(!displayResultsOnFail());
 
             if (Mods.Value.OfType<IApplicableFailOverride>().Any(m => m.RestartOnFail))
                 Restart();
 
-            if (displayResultsOnFail)
+            if (displayResultsOnFail())
             {
                 scoreCompletionChanged(new ValueChangedEvent<bool>(false, true));
             }
@@ -802,7 +802,7 @@ namespace osu.Game.Screens.Play
         // Called back when the transform finishes
         private void onFailComplete()
         {
-            if (displayResultsOnFail)
+            if (displayResultsOnFail())
                 return;
 
             GameplayClockContainer.Stop();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual bool CheckModsAllowFailure() => Mods.Value.OfType<IApplicableFailOverride>().All(m => m.PerformFail());
 
-        private bool displayResultsOnFail() => Mods.Value.OfType<IApplicableFailOverride>().Any(m => m.DisplayResultsOnFail);
+        protected virtual bool CheckModsDisplayResultsOnFail() => Mods.Value.OfType<IApplicableFailOverride>().Any(m => m.DisplayResultsOnFail);
 
         public readonly PlayerConfiguration Configuration;
 
@@ -668,7 +668,7 @@ namespace osu.Game.Screens.Play
             }
 
             // Only show the completion screen if the player hasn't failed
-            if (HealthProcessor.HasFailed && !displayResultsOnFail())
+            if (HealthProcessor.HasFailed && !CheckModsDisplayResultsOnFail())
                 return;
 
             // Setting this early in the process means that even if something were to go wrong in the order of events following, there
@@ -685,7 +685,7 @@ namespace osu.Game.Screens.Play
 
             bool storyboardHasOutro = DimmableStoryboard.ContentDisplayed && !DimmableStoryboard.HasStoryboardEnded.Value;
 
-            if (storyboardHasOutro && !displayResultsOnFail())
+            if (storyboardHasOutro && !CheckModsDisplayResultsOnFail())
             {
                 // if the current beatmap has a storyboard, the progression to results will be handled by the storyboard ending
                 // or the user pressing the skip outro button.
@@ -786,12 +786,12 @@ namespace osu.Game.Screens.Play
             if (PauseOverlay.State.Value == Visibility.Visible)
                 PauseOverlay.Hide();
 
-            failAnimation.Start(!displayResultsOnFail());
+            failAnimation.Start(!CheckModsDisplayResultsOnFail());
 
             if (Mods.Value.OfType<IApplicableFailOverride>().Any(m => m.RestartOnFail))
                 Restart();
 
-            if (displayResultsOnFail())
+            if (CheckModsDisplayResultsOnFail())
             {
                 scoreCompletionChanged(new ValueChangedEvent<bool>(false, true));
             }
@@ -802,7 +802,7 @@ namespace osu.Game.Screens.Play
         // Called back when the transform finishes
         private void onFailComplete()
         {
-            if (displayResultsOnFail())
+            if (CheckModsDisplayResultsOnFail())
                 return;
 
             GameplayClockContainer.Stop();


### PR DESCRIPTION
Split from #12877 , but rewritten to fit the new `Player`.

This PR adds a bool property `DisplayResultsOnFail` in `IApplicableFailOverride`, which instructs the `Player` to proceed to the results screen after failing, instead of showing the fail overlay.

When proceeding to the results screen after failing:
- The fail animation is played without frequency adjustments.
- The results screen is displayed after a short delay upon failing. It does not wait for the fail animation to complete.
- The music continues to play on the results screen.