### PR TITLE
Extract `SeedSettingsControl` to `IHasSeed` interface

### DIFF
--- a/osu.Game/Rulesets/Mods/IHasSeed.cs
+++ b/osu.Game/Rulesets/Mods/IHasSeed.cs
@@ -1,0 +1,94 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public interface IHasSeed
+    {
+        public Bindable<int?> Seed { get; }
+    }
+
+    public class SeedSettingsControl : SettingsItem<int?>
+    {
+        protected override Drawable CreateControl() => new SeedControl
+        {
+            RelativeSizeAxes = Axes.X,
+            Margin = new MarginPadding { Top = 5 }
+        };
+
+        private sealed class SeedControl : CompositeDrawable, IHasCurrentValue<int?>
+        {
+            private readonly BindableWithCurrent<int?> current = new BindableWithCurrent<int?>();
+
+            public Bindable<int?> Current
+            {
+                get => current;
+                set
+                {
+                    current.Current = value;
+                    seedNumberBox.Text = value.Value.ToString();
+                }
+            }
+
+            private readonly OsuNumberBox seedNumberBox;
+
+            public SeedControl()
+            {
+                AutoSizeAxes = Axes.Y;
+
+                InternalChildren = new[]
+                {
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.Absolute, 2),
+                            new Dimension(GridSizeMode.Relative, 0.25f)
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize)
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                seedNumberBox = new OsuNumberBox
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    CommitOnFocusLost = true
+                                }
+                            }
+                        }
+                    }
+                };
+
+                seedNumberBox.Current.BindValueChanged(e =>
+                {
+                    int? value = null;
+
+                    if (int.TryParse(e.NewValue, out var intVal))
+                        value = intVal;
+
+                    current.Value = value;
+                });
+            }
+
+            protected override void Update()
+            {
+                if (current.Value == null)
+                    seedNumberBox.Text = current.Current.Value.ToString();
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/IHasSeed.cs
+++ b/osu.Game/Rulesets/Mods/IHasSeed.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
 {
     public interface IHasSeed
     {
-        public Bindable<int?> Seed { get; }
+        Bindable<int?> Seed { get; }
     }
 
     public class SeedSettingsControl : SettingsItem<int?>

--- a/osu.Game/Rulesets/Mods/IHasSeed.cs
+++ b/osu.Game/Rulesets/Mods/IHasSeed.cs
@@ -2,93 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
 {
     public interface IHasSeed
     {
         Bindable<int?> Seed { get; }
-    }
-
-    public class SeedSettingsControl : SettingsItem<int?>
-    {
-        protected override Drawable CreateControl() => new SeedControl
-        {
-            RelativeSizeAxes = Axes.X,
-            Margin = new MarginPadding { Top = 5 }
-        };
-
-        private sealed class SeedControl : CompositeDrawable, IHasCurrentValue<int?>
-        {
-            private readonly BindableWithCurrent<int?> current = new BindableWithCurrent<int?>();
-
-            public Bindable<int?> Current
-            {
-                get => current;
-                set
-                {
-                    current.Current = value;
-                    seedNumberBox.Text = value.Value.ToString();
-                }
-            }
-
-            private readonly OsuNumberBox seedNumberBox;
-
-            public SeedControl()
-            {
-                AutoSizeAxes = Axes.Y;
-
-                InternalChildren = new[]
-                {
-                    new GridContainer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        ColumnDimensions = new[]
-                        {
-                            new Dimension(),
-                            new Dimension(GridSizeMode.Absolute, 2),
-                            new Dimension(GridSizeMode.Relative, 0.25f)
-                        },
-                        RowDimensions = new[]
-                        {
-                            new Dimension(GridSizeMode.AutoSize)
-                        },
-                        Content = new[]
-                        {
-                            new Drawable[]
-                            {
-                                seedNumberBox = new OsuNumberBox
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    CommitOnFocusLost = true
-                                }
-                            }
-                        }
-                    }
-                };
-
-                seedNumberBox.Current.BindValueChanged(e =>
-                {
-                    int? value = null;
-
-                    if (int.TryParse(e.NewValue, out var intVal))
-                        value = intVal;
-
-                    current.Value = value;
-                });
-            }
-
-            protected override void Update()
-            {
-                if (current.Value == null)
-                    seedNumberBox.Text = current.Current.Value.ToString();
-            }
-        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -2,10 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.UserInterface;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -8,11 +8,10 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModRandom : Mod
+    public abstract class ModRandom : Mod, IHasSeed
     {
         public override string Name => "Random";
         public override string Acronym => "RD";
@@ -20,88 +19,11 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.Dice;
         public override double ScoreMultiplier => 1;
 
-        [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(ModRandomSettingsControl))]
+        [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SeedSettingsControl))]
         public Bindable<int?> Seed { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
-
-        private class ModRandomSettingsControl : SettingsItem<int?>
-        {
-            protected override Drawable CreateControl() => new SeedControl
-            {
-                RelativeSizeAxes = Axes.X,
-                Margin = new MarginPadding { Top = 5 }
-            };
-
-            private sealed class SeedControl : CompositeDrawable, IHasCurrentValue<int?>
-            {
-                private readonly BindableWithCurrent<int?> current = new BindableWithCurrent<int?>();
-
-                public Bindable<int?> Current
-                {
-                    get => current;
-                    set
-                    {
-                        current.Current = value;
-                        seedNumberBox.Text = value.Value.ToString();
-                    }
-                }
-
-                private readonly SettingsNumberBox.NumberBox seedNumberBox;
-
-                public SeedControl()
-                {
-                    AutoSizeAxes = Axes.Y;
-
-                    InternalChildren = new[]
-                    {
-                        new GridContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            ColumnDimensions = new[]
-                            {
-                                new Dimension(),
-                                new Dimension(GridSizeMode.Absolute, 2),
-                                new Dimension(GridSizeMode.Relative, 0.25f)
-                            },
-                            RowDimensions = new[]
-                            {
-                                new Dimension(GridSizeMode.AutoSize)
-                            },
-                            Content = new[]
-                            {
-                                new Drawable[]
-                                {
-                                    seedNumberBox = new SettingsNumberBox.NumberBox
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        CommitOnFocusLost = true
-                                    }
-                                }
-                            }
-                        }
-                    };
-
-                    seedNumberBox.Current.BindValueChanged(e =>
-                    {
-                        int? value = null;
-
-                        if (int.TryParse(e.NewValue, out var intVal))
-                            value = intVal;
-
-                        current.Value = value;
-                    });
-                }
-
-                protected override void Update()
-                {
-                    if (current.Value == null)
-                        seedNumberBox.Text = current.Current.Value.ToString();
-                }
-            }
-        }
     }
 }

--- a/osu.Game/Rulesets/Mods/SeedSettingsControl.cs
+++ b/osu.Game/Rulesets/Mods/SeedSettingsControl.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Rulesets.Mods
+{
+    /// <summary>
+    /// A settings control for use by <see cref="IHasSeed"/> mods which have a customisable seed value.
+    /// </summary>
+    public class SeedSettingsControl : SettingsItem<int?>
+    {
+        protected override Drawable CreateControl() => new SeedControl
+        {
+            RelativeSizeAxes = Axes.X,
+            Margin = new MarginPadding { Top = 5 }
+        };
+
+        private sealed class SeedControl : CompositeDrawable, IHasCurrentValue<int?>
+        {
+            private readonly BindableWithCurrent<int?> current = new BindableWithCurrent<int?>();
+
+            public Bindable<int?> Current
+            {
+                get => current;
+                set
+                {
+                    current.Current = value;
+                    seedNumberBox.Text = value.Value.ToString();
+                }
+            }
+
+            private readonly OsuNumberBox seedNumberBox;
+
+            public SeedControl()
+            {
+                AutoSizeAxes = Axes.Y;
+
+                InternalChildren = new[]
+                {
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.Absolute, 2),
+                            new Dimension(GridSizeMode.Relative, 0.25f)
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize)
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                seedNumberBox = new OsuNumberBox
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    CommitOnFocusLost = true
+                                }
+                            }
+                        }
+                    }
+                };
+
+                seedNumberBox.Current.BindValueChanged(e =>
+                {
+                    int? value = null;
+
+                    if (int.TryParse(e.NewValue, out var intVal))
+                        value = intVal;
+
+                    current.Value = value;
+                });
+            }
+
+            protected override void Update()
+            {
+                if (current.Value == null)
+                    seedNumberBox.Text = current.Current.Value.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Split from #12877 

This PR moves `SeedSettingsControl` from `ModRandom` to `IHasSeed`, so that mods other than random mods can use the control.

Ideally, all mods implementing the `IHasSeed` interface should inherit the `SettingSource` attribute from the interface, but sadly C# doesn't allow that, so there are no attributes in the interface and `SeedSettingsControl` is simply put in the same file instead.