### PR TITLE
Fix multiplayer leave dialog not working on all exit operations

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -55,7 +55,12 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestExitWithoutSave()
         {
-            AddStep("exit without save", () => Editor.Exit());
+            AddStep("exit without save", () =>
+            {
+                Editor.Exit();
+                DialogOverlay.CurrentDialog.PerformOkAction();
+            });
+
             AddUntilStep("wait for exit", () => !Editor.IsCurrentScreen());
             AddAssert("new beatmap not persisted", () => beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID)?.DeletePending == true);
         }

--- a/osu.Game/Graphics/UserInterface/ScreenBreadcrumbControl.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenBreadcrumbControl.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
 
 namespace osu.Game.Graphics.UserInterface
@@ -19,8 +20,13 @@ namespace osu.Game.Graphics.UserInterface
 
             if (stack.CurrentScreen != null)
                 onPushed(null, stack.CurrentScreen);
+        }
 
-            Current.ValueChanged += current => current.NewValue.MakeCurrent();
+        protected override void SelectTab(TabItem<IScreen> tab)
+        {
+            // override base method to prevent current item from being changed on click.
+            // depend on screen push/exit to change current item instead.
+            tab.Value.MakeCurrent();
         }
 
         private void onPushed(IScreen lastScreen, IScreen newScreen)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -318,11 +318,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             if (!exitConfirmed && dialogOverlay != null)
             {
-                dialogOverlay.Push(new ConfirmDialog("Are you sure you want to leave this multiplayer match?", () =>
+                if (dialogOverlay.CurrentDialog is ConfirmDialog confirmDialog)
+                    confirmDialog.PerformOkAction();
+                else
                 {
-                    exitConfirmed = true;
-                    this.Exit();
-                }));
+                    dialogOverlay.Push(new ConfirmDialog("Are you sure you want to leave this multiplayer match?", () =>
+                    {
+                        exitConfirmed = true;
+                        this.Exit();
+                    }));
+                }
 
                 return true;
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -305,6 +305,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return true;
             }
 
+            return base.OnBackButton();
+        }
+
+        public override bool OnExiting(IScreen next)
+        {
+            if (client.Room == null)
+            {
+                // room has not been created yet; exit immediately.
+                return base.OnExiting(next);
+            }
+
             if (!exitConfirmed && dialogOverlay != null)
             {
                 dialogOverlay.Push(new ConfirmDialog("Are you sure you want to leave this multiplayer match?", () =>
@@ -316,7 +327,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return true;
             }
 
-            return base.OnBackButton();
+            return base.OnExiting(next);
         }
 
         private ModSettingChangeTracker modSettingChangeTracker;

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -240,13 +240,15 @@ namespace osu.Game.Screens.OnlinePlay
 
         public override bool OnExiting(IScreen next)
         {
+            if (screenStack.CurrentScreen?.OnExiting(next) == true)
+                return true;
+
             RoomManager.PartRoom();
 
             waves.Hide();
 
             this.Delay(WaveContainer.DISAPPEAR_DURATION).FadeOut();
 
-            screenStack.CurrentScreen?.OnExiting(next);
             base.OnExiting(next);
             return false;
         }

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Overlays;
 using osu.Game.Screens;
 
 namespace osu.Game.Tests.Visual
@@ -19,12 +21,16 @@ namespace osu.Game.Tests.Visual
 
         protected override Container<Drawable> Content => content;
 
+        [Cached]
+        protected DialogOverlay DialogOverlay { get; private set; }
+
         protected ScreenTestScene()
         {
             base.Content.AddRange(new Drawable[]
             {
                 Stack = new OsuScreenStack { RelativeSizeAxes = Axes.Both },
-                content = new Container { RelativeSizeAxes = Axes.Both }
+                content = new Container { RelativeSizeAxes = Axes.Both },
+                DialogOverlay = new DialogOverlay()
             });
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/13608 and fixes https://github.com/ppy/osu/issues/13609.

Not sure about the tests. I feel like the back button / home & os close tests are too indirect because there is no `OsuGame`. I didn't do it in `TestSceneScreenNavigation` as it didn't have an existing way to create rooms and I can't seem to make it work. Either way, I thought it would bloat up that global test even more.