### PR TITLE
Add `IApplicableToBeatmapProcessor` mod interface

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.MathUtils;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Rulesets.Catch.Beatmaps
@@ -16,6 +15,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
     public class CatchBeatmapProcessor : BeatmapProcessor
     {
         public const int RNG_SEED = 1337;
+
+        public bool HardRockOffsets { get; set; }
 
         public CatchBeatmapProcessor(IBeatmap beatmap)
             : base(beatmap)
@@ -43,11 +44,10 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             }
         }
 
-        public static void ApplyPositionOffsets(IBeatmap beatmap, params Mod[] mods)
+        public void ApplyPositionOffsets(IBeatmap beatmap)
         {
             var rng = new FastRandom(RNG_SEED);
 
-            bool shouldApplyHardRockOffset = mods.Any(m => m is ModHardRock);
             float? lastPosition = null;
             double lastStartTime = 0;
 
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 switch (obj)
                 {
                     case Fruit fruit:
-                        if (shouldApplyHardRockOffset)
+                        if (HardRockOffsets)
                             applyHardRockOffset(fruit, ref lastPosition, ref lastStartTime, rng);
                         break;
 

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
@@ -7,10 +7,14 @@ using osu.Game.Rulesets.Catch.Beatmaps;
 
 namespace osu.Game.Rulesets.Catch.Mods
 {
-    public class CatchModHardRock : ModHardRock, IApplicableToBeatmap
+    public class CatchModHardRock : ModHardRock, IApplicableToBeatmapProcessor
     {
         public override double ScoreMultiplier => 1.12;
 
-        public void ApplyToBeatmap(IBeatmap beatmap) => CatchBeatmapProcessor.ApplyPositionOffsets(beatmap, this);
+        public void ApplyToBeatmapProcessor(IBeatmapProcessor beatmapProcessor)
+        {
+            var catchProcessor = (CatchBeatmapProcessor)beatmapProcessor;
+            catchProcessor.HardRockOffsets = true;
+        }
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -133,6 +133,9 @@ namespace osu.Game.Beatmaps
 
                 IBeatmapProcessor processor = rulesetInstance.CreateBeatmapProcessor(converted);
 
+                foreach (var mod in mods.OfType<IApplicableToBeatmapProcessor>())
+                    mod.ApplyToBeatmapProcessor(processor);
+
                 processor?.PreProcess();
 
                 // Compute default values for hitobjects, including creating nested hitobjects in-case they're needed

--- a/osu.Game/Rulesets/Mods/IApplicableToBeatmapProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToBeatmapProcessor.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Mods
+{
+    /// <summary>
+    /// Interface for a <see cref="Mod"/> that applies changes to a <see cref="BeatmapProcessor"/>.
+    /// </summary>
+    public interface IApplicableToBeatmapProcessor : IApplicableMod
+    {
+        /// <summary>
+        /// Applies this <see cref="Mod"/> to a <see cref="BeatmapProcessor"/>.
+        /// </summary>
+        void ApplyToBeatmapProcessor(IBeatmapProcessor beatmapProcessor);
+    }
+}


### PR DESCRIPTION
This PR introduces `IApplicableToBeatmapProcessor`. It is similar to the existing `IApplicableToBeatmapConverter` interface in the shape.

I made changes to the `CatchModHardRock` to use the new interface.
Previously, `CatchModHardRock` was calling the beatmap processing method (with hard rock offsets enabled) after the beatmap is already processed (without hard rock offsets).
The second processing just overwrites the first processing, so the result was correct, though.