### PR TITLE
Make collection database even more safe

### DIFF
--- a/osu.Game/Collections/CollectionManager.cs
+++ b/osu.Game/Collections/CollectionManager.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Collections
         [BackgroundDependencyLoader]
         private void load()
         {
+            Collections.CollectionChanged += collectionsChanged;
+
             if (storage.Exists(database_backup_name))
             {
                 // If a backup file exists, it means the previous write operation didn't run to completion.
@@ -65,10 +67,6 @@ namespace osu.Game.Collections
                     storage.Delete(database_name);
                 File.Copy(storage.GetFullPath(database_backup_name), storage.GetFullPath(database_name));
             }
-
-            // Only accept changes after/if the above succeeds to prevent simultaneously accessing either file.
-            // Todo: This really should not be delayed like this, but is unlikely to cause issues because CollectionManager loads very early in execution.
-            Collections.CollectionChanged += collectionsChanged;
 
             if (storage.Exists(database_name))
             {
@@ -82,7 +80,7 @@ namespace osu.Game.Collections
             }
         }
 
-        private void collectionsChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void collectionsChanged(object sender, NotifyCollectionChangedEventArgs e) => Schedule(() =>
         {
             switch (e.Action)
             {
@@ -106,7 +104,7 @@ namespace osu.Game.Collections
             }
 
             backgroundSave();
-        }
+        });
 
         /// <summary>
         /// Set an endpoint for notifications to be posted to.

--- a/osu.Game/IO/Legacy/SerializationWriter.cs
+++ b/osu.Game/IO/Legacy/SerializationWriter.cs
@@ -18,8 +18,8 @@ namespace osu.Game.IO.Legacy
     /// handle null strings and simplify use with ISerializable. </summary>
     public class SerializationWriter : BinaryWriter
     {
-        public SerializationWriter(Stream s)
-            : base(s, Encoding.UTF8)
+        public SerializationWriter(Stream s, bool leaveOpen = false)
+            : base(s, Encoding.UTF8, leaveOpen)
         {
         }
 


### PR DESCRIPTION
We're still getting database corruption reports: https://github.com/ppy/osu/discussions/13620

Attempting to make this safer by saving to a temporary location and performing a final in-place move.

The backup file exists as a last-chance preventative measure for e.g. if the thread gets aborted before the `.Move()`s complete. Since the backup file is deleted on successful save, it is always preferred when loading the database at startup.

I've tested on Linux and Windows, saving every 10ms while also deleting the file externally.