### PR TITLE
Fix auto using incorrect position for key up frames

### DIFF
--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                 addHitObjectReplay(h, i);
             }
 
-            //Apply key up frame adjustments
+            //Apply key up frame adjustments at the end to ensure frame order
             framesPendingAdjust.ForEach(f => Frames.Remove(f));
             framesAfterAdjust.ForEach(AddFrameToReplay);
 
@@ -172,15 +172,6 @@ namespace osu.Game.Rulesets.Osu.Replays
                 }
             }
 
-            //Gets the actual next hitobject we should move to
-            var next = Beatmap.HitObjects[index == Beatmap.HitObjects.Count - 1 ? index : index + 1];
-
-            while (next is Spinner { SpinsRequired: 0 } && index < Beatmap.HitObjects.Count - 1)
-            {
-                index++;
-                next = Beatmap.HitObjects[index == Beatmap.HitObjects.Count - 1 ? index : index + 1];
-            }
-
             // Do some nice easing for cursor movements
             if (Frames.Count > 0)
             {
@@ -188,7 +179,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             }
 
             // Add frames to click the hitobject
-            addHitObjectClickFrames(h, next, startPosition, spinnerDirection);
+            addHitObjectClickFrames(h, (OsuHitObject)GetNextObject(index), startPosition, spinnerDirection);
         }
 
         #endregion
@@ -240,6 +231,22 @@ namespace osu.Game.Rulesets.Osu.Replays
                 startPosition = SPINNER_CENTRE + new Vector2(0, -SPIN_RADIUS);
                 spinnerDirection = 1;
             }
+        }
+
+        /// <summary>
+        /// Gets the next hitobect that requires an action
+        /// Returns the same object if currentIndex is the index of the last hitobject
+        /// </summary>
+        protected override HitObject GetNextObject(int currentIndex)
+        {
+            var next = Beatmap.HitObjects[currentIndex == Beatmap.HitObjects.Count - 1 ? currentIndex : currentIndex + 1];
+
+            while (next is Spinner { SpinsRequired: 0 } && currentIndex < Beatmap.HitObjects.Count - 1)
+            {
+                next = Beatmap.HitObjects[++currentIndex];
+            }
+
+            return next;
         }
 
         private void moveToHitObject(OsuHitObject h, Vector2 targetPos, Easing easing)

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -279,8 +279,8 @@ namespace osu.Game.Rulesets.Osu.Replays
                 {
                     Vector2 currentPosition = Interpolation.ValueAt(time, lastPosition, targetPos, lastFrame.Time, h.StartTime, easing);
 
-                    //Search in framesPendingAdjust to see if any frame has time == current time
-                    //If there is, it means the cursor should be at currentPosition if it's still moving during the KEY_UP_DELAY.
+                    //Search in framesPendingAdjust for frames with .Time == current time
+                    //If found, it means the cursor should be at currentPosition assume it's still moving during the KEY_UP_DELAY.
                     var adjustingFrame = framesPendingAdjust.FirstOrDefault(frame => Precision.AlmostEquals(frame.Time, time, GetFrameDelay(time)));
 
                     if (adjustingFrame != null)
@@ -324,11 +324,14 @@ namespace osu.Game.Rulesets.Osu.Replays
 
             var timeDifference = ApplyModsToTimeDelta(endFrame.Time, next.StartTime);
 
-            //We don't know the exact position the cursor will be at end time, so add it to pending adjust
-            if (timeDifference > GetFrameDelay(endFrame.Time)) framesPendingAdjust.Add(endFrame);
+            //We don't know where the cursor should be at end time, so add it to pending adjust
+            if (timeDifference > GetFrameDelay(endFrame.Time))
+                framesPendingAdjust.Add(endFrame);
 
-            //In 2B maps we cant order hitobjects by their start time, so just move on to the next one
-            else if (next != h /* is not the last hitobject */) endFrame.Position = next.StackedPosition;
+            //For 2B maps which we can't order hitobjects by their start time, so just move to the next one
+            //Moving to StackedEndPosition because timeDifference < FrameDelay < KEY_UP_DELAY
+            else
+                endFrame.Position = next.StackedEndPosition;
 
             // Decrement because we want the previous frame, not the next one
             int index = FindInsertionIndex(startFrame) - 1;


### PR DESCRIPTION
Fixes #9341.
Opened a new PR since #11764 is closed(for inactivity?).

This time I tried to make inline comments more clear

Tested with:
Normal ranked maps (can SS):
https://osu.ppy.sh/beatmapsets/767600#osu/1613687
https://osu.ppy.sh/beatmapsets/1384189#osu/2859822
https://osu.ppy.sh/beatmapsets/292301#osu/658127

2B maps(no miss):
https://osu.ppy.sh/beatmapsets/1236988#osu/2573493
https://osu.ppy.sh/beatmapsets/1139945#osu/2381064