### PR TITLE
Set more appropriate time limits for GH Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
             - { prettyname: macOS, fullname: macos-latest }
             - { prettyname: Linux, fullname: ubuntu-latest }
           threadingMode: ['SingleThread', 'MultiThreaded']
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -21,6 +21,7 @@ jobs:
             - { prettyname: macOS }
             - { prettyname: Linux }
           threadingMode: ['SingleThread', 'MultiThreaded']
+    timeout-minutes: 5
     steps:
       - name: Annotate CI run with test results
         uses: dorny/test-reporter@v1.4.2


### PR DESCRIPTION
[Default is 360 minutes](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) which is excessive when deadlocks happen (those happen).

60 minutes for the main job, which matches appveyor and which seems more than ample for now (actions jobs run for 25-ish minutes, so even faster than appveyor, mainly thanks to inspectcode being ran in parallel to the test matrix).

5 minutes for the test report job, which is even more excessive as those usually take half a minute, but I wanted to both give some slack and not have that thing run for 6 hours either.