### PR TITLE
Prevent context menu from showing from system messages

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -240,6 +240,9 @@ namespace osu.Game.Overlays.Chat
             {
                 get
                 {
+                    if (sender.Id == User.SYSTEM_USER.Id)
+                        return Array.Empty<MenuItem>();
+
                     List<MenuItem> items = new List<MenuItem>
                     {
                         new OsuMenuItem("View Profile", MenuItemType.Highlighted, Action)

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Overlays.Chat
             {
                 get
                 {
-                    if (sender == User.SYSTEM_USER)
+                    if (sender.Equals(User.SYSTEM_USER))
                         return Array.Empty<MenuItem>();
 
                     List<MenuItem> items = new List<MenuItem>
@@ -248,7 +248,7 @@ namespace osu.Game.Overlays.Chat
                         new OsuMenuItem("View Profile", MenuItemType.Highlighted, Action)
                     };
 
-                    if (sender.Id != api.LocalUser.Value.Id)
+                    if (!sender.Equals(api.LocalUser.Value))
                         items.Add(new OsuMenuItem("Start Chat", MenuItemType.Standard, startChatAction));
 
                     return items.ToArray();

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Overlays.Chat
             {
                 get
                 {
-                    if (sender.Id == User.SYSTEM_USER.Id)
+                    if (sender == User.SYSTEM_USER)
                         return Array.Empty<MenuItem>();
 
                     List<MenuItem> items = new List<MenuItem>


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/13642.

Returns an empty array of menu items when it is a system message.