### PR TITLE
Use DI to resolve "dropped object target" container in `Catcher`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private Container<CaughtObject> droppedObjectContainer;
+        private DroppedObjectContainer droppedObjectContainer;
 
         private TestCatcher catcher;
 
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             };
 
             var trailContainer = new Container();
-            droppedObjectContainer = new Container<CaughtObject>();
+            droppedObjectContainer = new DroppedObjectContainer();
             catcher = new TestCatcher(trailContainer, droppedObjectContainer, difficulty);
 
             Child = new Container
@@ -293,7 +293,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
-            public TestCatcher(Container trailsTarget, Container<CaughtObject> droppedObjectTarget, BeatmapDifficulty difficulty)
+            public TestCatcher(Container trailsTarget, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
                 : base(trailsTarget, droppedObjectTarget, difficulty)
             {
             }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Game.Rulesets.Catch.UI;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -31,9 +31,22 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private DroppedObjectContainer droppedObjectContainer;
+        [Cached]
+        private readonly DroppedObjectContainer droppedObjectContainer;
+
+        private readonly Container trailContainer;
 
         private TestCatcher catcher;
+
+        public TestSceneCatcher()
+        {
+            Add(trailContainer = new Container
+            {
+                Anchor = Anchor.Centre,
+                Depth = -1
+            });
+            Add(droppedObjectContainer = new DroppedObjectContainer());
+        }
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -43,20 +56,13 @@ namespace osu.Game.Rulesets.Catch.Tests
                 CircleSize = 0,
             };
 
-            var trailContainer = new Container();
-            droppedObjectContainer = new DroppedObjectContainer();
-            catcher = new TestCatcher(trailContainer, droppedObjectContainer, difficulty);
+            if (catcher != null)
+                Remove(catcher);
 
-            Child = new Container
+            Add(catcher = new TestCatcher(trailContainer, difficulty)
             {
-                Anchor = Anchor.Centre,
-                Children = new Drawable[]
-                {
-                    trailContainer,
-                    droppedObjectContainer,
-                    catcher
-                }
-            };
+                Anchor = Anchor.Centre
+            });
         });
 
         [Test]
@@ -293,8 +299,8 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
-            public TestCatcher(Container trailsTarget, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
-                : base(trailsTarget, droppedObjectTarget, difficulty)
+            public TestCatcher(Container trailsTarget, BeatmapDifficulty difficulty)
+                : base(trailsTarget, difficulty)
             {
             }
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
@@ -97,10 +96,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             SetContents(_ =>
             {
-                var droppedObjectContainer = new Container<CaughtObject>
-                {
-                    RelativeSizeAxes = Axes.Both
-                };
+                var droppedObjectContainer = new DroppedObjectContainer();
 
                 return new CatchInputManager(catchRuleset)
                 {
@@ -126,7 +122,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestCatcherArea : CatcherArea
         {
-            public TestCatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
+            public TestCatcherArea(DroppedObjectContainer droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
                 : base(droppedObjectContainer, beatmapDifficulty)
             {
             }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -96,15 +96,12 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             SetContents(_ =>
             {
-                var droppedObjectContainer = new DroppedObjectContainer();
-
                 return new CatchInputManager(catchRuleset)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        droppedObjectContainer,
-                        new TestCatcherArea(droppedObjectContainer, beatmapDifficulty)
+                        new TestCatcherArea(beatmapDifficulty)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.TopCentre,
@@ -122,9 +119,13 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestCatcherArea : CatcherArea
         {
-            public TestCatcherArea(DroppedObjectContainer droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
-                : base(droppedObjectContainer, beatmapDifficulty)
+            [Cached]
+            private readonly DroppedObjectContainer droppedObjectContainer;
+
+            public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
+                : base(beatmapDifficulty)
             {
+                AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
 
             public void ToggleHyperDash(bool status) => MovableCatcher.SetHyperDashState(status ? 2 : 1);

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -118,11 +118,10 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new DroppedObjectContainer())
+                Child = setupSkinHierarchy(catcherArea = new TestCatcherArea
                 {
                     Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(4f),
+                    Origin = Anchor.Centre
                 }, skin);
             });
 
@@ -204,6 +203,19 @@ namespace osu.Game.Rulesets.Catch.Tests
             public TestSkin()
                 : base(new SkinInfo(), null, null, string.Empty)
             {
+            }
+        }
+
+        private class TestCatcherArea : CatcherArea
+        {
+            [Cached]
+            private readonly DroppedObjectContainer droppedObjectContainer;
+
+            public TestCatcherArea()
+            {
+                Scale = new Vector2(4f);
+
+                AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new Container<CaughtObject>())
+                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new DroppedObjectContainer())
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public const float CENTER_X = WIDTH / 2;
 
+        [Cached]
+        private readonly DroppedObjectContainer droppedObjectContainer;
+
         internal readonly CatcherArea CatcherArea;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
@@ -34,9 +37,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty)
         {
-            var droppedObjectContainer = new DroppedObjectContainer();
-
-            CatcherArea = new CatcherArea(droppedObjectContainer, difficulty)
+            CatcherArea = new CatcherArea(difficulty)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.TopLeft,
@@ -44,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             InternalChildren = new[]
             {
-                droppedObjectContainer,
+                droppedObjectContainer = new DroppedObjectContainer(),
                 CatcherArea.MovableCatcher.CreateProxiedContent(),
                 HitObjectContainer.CreateProxy(),
                 // This ordering (`CatcherArea` before `HitObjectContainer`) is important to

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -35,10 +34,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty)
         {
-            var droppedObjectContainer = new Container<CaughtObject>
-            {
-                RelativeSizeAxes = Axes.Both,
-            };
+            var droppedObjectContainer = new DroppedObjectContainer();
 
             CatcherArea = new CatcherArea(droppedObjectContainer, difficulty)
             {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -79,7 +79,8 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Contains objects dropped from the plate.
         /// </summary>
-        private readonly DroppedObjectContainer droppedObjectTarget;
+        [Resolved]
+        private DroppedObjectContainer droppedObjectTarget { get; set; }
 
         public CatcherAnimationState CurrentState
         {
@@ -134,10 +135,9 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
         private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
 
-        public Catcher([NotNull] Container trailsTarget, [NotNull] DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] Container trailsTarget, BeatmapDifficulty difficulty = null)
         {
             this.trailsTarget = trailsTarget;
-            this.droppedObjectTarget = droppedObjectTarget;
 
             Origin = Anchor.TopCentre;
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Contains objects dropped from the plate.
         /// </summary>
-        private readonly Container<CaughtObject> droppedObjectTarget;
+        private readonly DroppedObjectContainer droppedObjectTarget;
 
         public CatcherAnimationState CurrentState
         {
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
         private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
 
-        public Catcher([NotNull] Container trailsTarget, [NotNull] Container<CaughtObject> droppedObjectTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] Container trailsTarget, [NotNull] DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
         {
             this.trailsTarget = trailsTarget;
             this.droppedObjectTarget = droppedObjectTarget;

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private int currentDirection;
 
-        public CatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty difficulty = null)
+        public CatcherArea(DroppedObjectContainer droppedObjectContainer, BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
             Children = new Drawable[]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private int currentDirection;
 
-        public CatcherArea(DroppedObjectContainer droppedObjectContainer, BeatmapDifficulty difficulty = null)
+        public CatcherArea(BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
             Children = new Drawable[]
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Margin = new MarginPadding { Bottom = 350f },
                     X = CatchPlayfield.CENTER_X
                 },
-                MovableCatcher = new Catcher(this, droppedObjectContainer, difficulty) { X = CatchPlayfield.CENTER_X },
+                MovableCatcher = new Catcher(this, difficulty) { X = CatchPlayfield.CENTER_X },
             };
         }
 

--- a/osu.Game.Rulesets.Catch/UI/DroppedObjectContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/DroppedObjectContainer.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Catch.UI
+{
+    public class DroppedObjectContainer : Container<CaughtObject>
+    {
+        public DroppedObjectContainer()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+    }
+}


### PR DESCRIPTION
The `droppedObjectTarget` argument was passed as constructor arguments and ultimately used by the `Catcher`.
It is necessary because the catcher moves during gameplay, and dropped objects shouldn't change position depending on the catcher's position.

The type was just a container, and it was not possible to add more logic (such as the animation of dropped objects) to this class.

This PR adds `DroppedObejctContainer` class. It is cached by `CatchPlayfield` and resolved by `Catcher`.
I didn't include any more changes to this PR for the sake of incremental changes. In particular, `DroppedObejctContainer` just inherits `Container<CaughtObject>`, and no logic is moved to this class yet.

Split off from #13599.