### PR TITLE
Remove Traditional Chinese (HK) language option due to no actual existing translations

### DIFF
--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -103,8 +103,11 @@ namespace osu.Game.Localisation
         [Description(@"简体中文")]
         zh,
 
-        [Description(@"繁體中文（香港）")]
-        zh_hk,
+        // Traditional Chinese (Hong Kong) is listed in web sources but has no associated localisations,
+        // and was wrongly falling back to Simplified Chinese.
+        // Can be revisited if localisations ever arrive.
+        // [Description(@"繁體中文（香港）")]
+        // zh_hk,
 
         [Description(@"繁體中文（台灣）")]
         zh_tw


### PR DESCRIPTION
It was falling back to Simplified Chinese instead, making the option actively wrong/confusing.

To make sure I've double-checked the others and as far as my ability to read ideographics goes (which, to be fair, is basically nil), the remaining two dialects look to be correct.

Closes #13650.