### PR TITLE
Fix `RulesetSkinProvidingContainer` being potentially late in setting up skin sources

### DIFF
--- a/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
@@ -1,0 +1,100 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+ // See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Skinning;
+using osu.Game.Tests.Testing;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Rulesets
+{
+    public class TestSceneRulesetSkinProvidingContainer : OsuTestScene
+    {
+        [Resolved]
+        private SkinManager skins { get; set; }
+
+        private SkinRequester requester;
+
+        protected override Ruleset CreateRuleset() => new TestRuleset();
+
+        [Test]
+        public void TestEarlyAddedSkinRequester()
+        {
+            ISample transformerSampleOnBdl = null;
+
+            // need a legacy skin to plug the TestRuleset's legacy transformer, which is required for testing this.
+            AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.Info);
+
+            AddStep("setup provider", () =>
+            {
+                var rulesetSkinProvider = new RulesetSkinProvidingContainer(Ruleset.Value.CreateInstance(), Beatmap.Value.Beatmap, Beatmap.Value.Skin);
+
+                rulesetSkinProvider.Add(requester = new SkinRequester());
+
+                requester.OnBdl += () => transformerSampleOnBdl = requester.GetSample(new SampleInfo(TestLegacySkinTransformer.VIRTUAL_SAMPLE_NAME));
+
+                Child = rulesetSkinProvider;
+            });
+
+            AddAssert("requester got correct initial sample", () => transformerSampleOnBdl != null);
+        }
+
+        private class SkinRequester : Drawable, ISkin
+        {
+            private ISkinSource skin;
+
+            public event Action OnBdl;
+
+            [BackgroundDependencyLoader]
+            private void load(ISkinSource skin)
+            {
+                this.skin = skin;
+
+                OnBdl?.Invoke();
+            }
+
+            public Drawable GetDrawableComponent(ISkinComponent component) => skin.GetDrawableComponent(component);
+
+            public Texture GetTexture(string componentName, WrapMode wrapModeS = default, WrapMode wrapModeT = default) => skin.GetTexture(componentName);
+
+            public ISample GetSample(ISampleInfo sampleInfo) => skin.GetSample(sampleInfo);
+
+            public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => skin.GetConfig<TLookup, TValue>(lookup);
+        }
+
+        private class TestRuleset : TestSceneRulesetDependencies.TestRuleset
+        {
+            public override ISkin CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => new TestLegacySkinTransformer(skin);
+        }
+
+        private class TestLegacySkinTransformer : LegacySkinTransformer
+        {
+            public const string VIRTUAL_SAMPLE_NAME = "virtual-test-sample";
+
+            public TestLegacySkinTransformer([NotNull] ISkin skin)
+                : base(skin)
+            {
+            }
+
+            public override ISample GetSample(ISampleInfo sampleInfo)
+            {
+                if (sampleInfo.LookupNames.Single() == VIRTUAL_SAMPLE_NAME)
+                    return new SampleVirtual();
+
+                return base.GetSample(sampleInfo);
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Rulesets
         [Test]
         public void TestEarlyAddedSkinRequester()
         {
-            ISample transformerSampleOnBdl = null;
+            ISample transformerSampleOnLoad = null;
 
             // need a legacy skin to plug the TestRuleset's legacy transformer, which is required for testing this.
             AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.Info);
@@ -43,26 +43,26 @@ namespace osu.Game.Tests.Rulesets
 
                 rulesetSkinProvider.Add(requester = new SkinRequester());
 
-                requester.OnBdl += () => transformerSampleOnBdl = requester.GetSample(new SampleInfo(TestLegacySkinTransformer.VIRTUAL_SAMPLE_NAME));
+                requester.OnLoadAsync += () => transformerSampleOnLoad = requester.GetSample(new SampleInfo(TestLegacySkinTransformer.VIRTUAL_SAMPLE_NAME));
 
                 Child = rulesetSkinProvider;
             });
 
-            AddAssert("requester got correct initial sample", () => transformerSampleOnBdl != null);
+            AddAssert("requester got correct initial sample", () => transformerSampleOnLoad != null);
         }
 
         private class SkinRequester : Drawable, ISkin
         {
             private ISkinSource skin;
 
-            public event Action OnBdl;
+            public event Action OnLoadAsync;
 
             [BackgroundDependencyLoader]
             private void load(ISkinSource skin)
             {
                 this.skin = skin;
 
-                OnBdl?.Invoke();
+                OnLoadAsync?.Invoke();
             }
 
             public Drawable GetDrawableComponent(ISkinComponent component) => skin.GetDrawableComponent(component);

--- a/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
- // See the LICENCE file in the repository root for full licence text.
+// See the LICENCE file in the repository root for full licence text.
 
 using System;
 using NUnit.Framework;

--- a/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
@@ -19,10 +19,10 @@ namespace osu.Game.Tests.Rulesets
 {
     public class TestSceneRulesetSkinProvidingContainer : OsuTestScene
     {
-        [Resolved]
-        private SkinManager skins { get; set; }
-
         private SkinRequester requester;
+
+        [Cached(typeof(ISkin))]
+        private readonly TestSkinProvider testSkin = new TestSkinProvider();
 
         protected override Ruleset CreateRuleset() => new TestSceneRulesetDependencies.TestRuleset();
 
@@ -31,15 +31,13 @@ namespace osu.Game.Tests.Rulesets
         {
             Texture textureOnLoad = null;
 
-            AddStep("set skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.Info);
-
             AddStep("setup provider", () =>
             {
                 var rulesetSkinProvider = new RulesetSkinProvidingContainer(Ruleset.Value.CreateInstance(), Beatmap.Value.Beatmap, Beatmap.Value.Skin);
 
                 rulesetSkinProvider.Add(requester = new SkinRequester());
 
-                requester.OnLoadAsync += () => textureOnLoad = requester.GetTexture("hitcircle");
+                requester.OnLoadAsync += () => textureOnLoad = requester.GetTexture(TestSkinProvider.TEXTURE_NAME);
 
                 Child = rulesetSkinProvider;
             });
@@ -68,6 +66,19 @@ namespace osu.Game.Tests.Rulesets
             public ISample GetSample(ISampleInfo sampleInfo) => skin.GetSample(sampleInfo);
 
             public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => skin.GetConfig<TLookup, TValue>(lookup);
+        }
+
+        private class TestSkinProvider : ISkin
+        {
+            public const string TEXTURE_NAME = "some-texture";
+
+            public Drawable GetDrawableComponent(ISkinComponent component) => throw new NotImplementedException();
+
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => componentName == TEXTURE_NAME ? Texture.WhitePixel : null;
+
+            public ISample GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
+
+            public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new NotImplementedException();
         }
     }
 }

--- a/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
@@ -24,12 +24,8 @@ namespace osu.Game.Tests.Rulesets
 
         protected override Ruleset CreateRuleset() => new TestSceneRulesetDependencies.TestRuleset();
 
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-            dependencies.CacheAs<ISkinSource>(new TestSkinProvider());
-            return dependencies;
-        }
+        [Cached(typeof(ISkinSource))]
+        private readonly ISkinSource testSource = new TestSkinProvider();
 
         [Test]
         public void TestEarlyAddedSkinRequester()

--- a/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
+++ b/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Testing
                 Dependencies.Get<TestRulesetConfigManager>() != null);
         }
 
-        private class TestRuleset : Ruleset
+        public class TestRuleset : Ruleset
         {
             public override string Description => string.Empty;
             public override string ShortName => string.Empty;

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -42,27 +42,30 @@ namespace osu.Game.Skinning
             };
         }
 
-        [Resolved]
-        private ISkinSource skinSource { get; set; }
+        private ISkinSource parentSource;
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
-            UpdateSkins();
-            skinSource.SourceChanged += OnSourceChanged;
+            parentSource = parent.Get<ISkinSource>();
+
+            UpdateSkinSources();
+
+            parentSource.SourceChanged += OnSourceChanged;
+
+            return base.CreateChildDependencies(parent);
         }
 
         protected override void OnSourceChanged()
         {
-            UpdateSkins();
+            UpdateSkinSources();
             base.OnSourceChanged();
         }
 
-        protected virtual void UpdateSkins()
+        protected virtual void UpdateSkinSources()
         {
             SkinSources.Clear();
 
-            foreach (var skin in skinSource.AllSources)
+            foreach (var skin in parentSource.AllSources)
             {
                 switch (skin)
                 {
@@ -93,8 +96,8 @@ namespace osu.Game.Skinning
         {
             base.Dispose(isDisposing);
 
-            if (skinSource != null)
-                skinSource.SourceChanged -= OnSourceChanged;
+            if (parentSource != null)
+                parentSource.SourceChanged -= OnSourceChanged;
         }
     }
 }

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -47,10 +47,10 @@ namespace osu.Game.Skinning
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             parentSource = parent.Get<ISkinSource>();
-
-            UpdateSkinSources();
-
             parentSource.SourceChanged += OnSourceChanged;
+
+            // ensure sources are populated and ready for use before childrens' asynchronous load flow.
+            UpdateSkinSources();
 
             return base.CreateChildDependencies(parent);
         }


### PR DESCRIPTION
Closes #13646 

If there were children added to `RulesetSkinProvidingContainer` before it's loaded itself, then the children will get loaded before the initial `UpdateSkin()` call at BDL and `SkinReloadableDrawable`s inside them may potentially retrieve incorrect skin resources.

This moves the placement of the `UpdateSkin()` call to be at `CreateChildDependencies` instead, same as where `SkinProvidingContainer` retrieves the `fallbackSource`, and where `BeatmapSkinProvidingContainer` sets up the beatmap config bindables.

Added test coverage for it while at it.