### PR TITLE
Fix default multiplayer lobby name if user's name ends with "s"

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override Room CreateNewRoom() =>
             new Room
             {
-                Name = { Value = $"{API.LocalUser}'s awesome room" },
+                Name = { Value = $"{API.LocalUser}{(API.LocalUser.ToString().ToLower().EndsWith("s") ? "'" : "'s")} awesome room" },
                 Category = { Value = RoomCategory.Realtime }
             };
 


### PR DESCRIPTION
Before, "`'s`" would always be appended to the player's name, which I'm pretty sure isn't correct. This PR creates a check whether the player's name ends on "s" or not, and based on that decides if "`'s`" or "`'`" should be appended.