### PR TITLE
Update usages of `IHasTooltip` in line with framework localisation changes

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.618.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.622.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.628.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mania.Configuration;
@@ -47,7 +48,7 @@ namespace osu.Game.Rulesets.Mania
 
         private class TimeSlider : OsuSliderBar<double>
         {
-            public override string TooltipText => Current.Value.ToString("N0") + "ms";
+            public override LocalisableString TooltipText => Current.Value.ToString(@"N0") + "ms";
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
@@ -283,6 +284,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
         }
 
-        public string TooltipText => ControlPoint.Type.Value.ToString() ?? string.Empty;
+        public LocalisableString TooltipText => ControlPoint.Type.Value.ToString() ?? string.Empty;
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuIcon.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osuTK;
@@ -59,7 +60,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private class Icon : Container, IHasTooltip
         {
-            public string TooltipText { get; }
+            public LocalisableString TooltipText { get; }
 
             public SpriteIcon SpriteIcon { get; }
 

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Configuration
     {
         public LocalisableString Label { get; }
 
-        public string Description { get; }
+        public LocalisableString Description { get; }
 
         public int? OrderPosition { get; }
 

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownImage.cs
@@ -4,12 +4,13 @@
 using Markdig.Syntax.Inlines;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.Containers.Markdown
 {
     public class OsuMarkdownImage : MarkdownImage, IHasTooltip
     {
-        public string TooltipText { get; }
+        public LocalisableString TooltipText { get; }
 
         public OsuMarkdownImage(LinkInline linkInline)
             : base(linkInline.Url)

--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Graphics.Containers
@@ -24,7 +25,7 @@ namespace osu.Game.Graphics.Containers
             this.sampleSet = sampleSet;
         }
 
-        public virtual string TooltipText { get; set; }
+        public virtual LocalisableString TooltipText { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
+++ b/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Graphics.Cursor
@@ -32,7 +33,7 @@ namespace osu.Game.Graphics.Cursor
 
             public override bool SetContent(object content)
             {
-                if (!(content is string contentString))
+                if (!(content is LocalisableString contentString))
                     return false;
 
                 if (contentString == text.Text) return true;

--- a/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
+++ b/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
@@ -58,6 +59,6 @@ namespace osu.Game.Graphics.UserInterface
             return true;
         }
 
-        public string TooltipText => "view in browser";
+        public LocalisableString TooltipText => "view in browser";
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 
 namespace osu.Game.Graphics.UserInterface
@@ -105,7 +106,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private class CapsWarning : SpriteIcon, IHasTooltip
         {
-            public string TooltipText => @"caps lock is active";
+            public LocalisableString TooltipText => "caps lock is active";
 
             public CapsWarning()
             {

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -34,7 +35,7 @@ namespace osu.Game.Graphics.UserInterface
         private readonly Box rightBox;
         private readonly Container nubContainer;
 
-        public virtual string TooltipText { get; private set; }
+        public virtual LocalisableString TooltipText { get; private set; }
 
         /// <summary>
         /// Whether to format the tooltip as a percentage or the actual value.

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -295,7 +296,7 @@ namespace osu.Game.Online.Leaderboards
 
             public override bool Contains(Vector2 screenSpacePos) => content.Contains(screenSpacePos);
 
-            public string TooltipText { get; }
+            public LocalisableString TooltipText { get; }
 
             public ScoreComponentLabel(LeaderboardScoreStatistic statistic)
             {
@@ -365,7 +366,7 @@ namespace osu.Game.Online.Leaderboards
                 };
             }
 
-            public string TooltipText { get; }
+            public LocalisableString TooltipText { get; }
         }
 
         public class LeaderboardScoreStatistic

--- a/osu.Game/Overlays/BeatmapSet/BasicStats.cs
+++ b/osu.Game/Overlays/BeatmapSet/BasicStats.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Overlays.BeatmapSet
         {
             private readonly OsuSpriteText value;
 
-            public string TooltipText { get; }
+            public LocalisableString TooltipText { get; }
 
             public LocalisableString Value
             {

--- a/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
@@ -28,7 +29,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
 
         private readonly IBindable<User> localUser = new Bindable<User>();
 
-        public string TooltipText
+        public LocalisableString TooltipText
         {
             get
             {

--- a/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -26,7 +27,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
 
         private readonly bool noVideo;
 
-        public string TooltipText => button.Enabled.Value ? "download this beatmap" : "login to download";
+        public LocalisableString TooltipText => button.Enabled.Value ? "download this beatmap" : "login to download";
 
         private readonly IBindable<User> localUser = new Bindable<User>();
 

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -20,6 +20,7 @@ using System;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using System.Collections.Specialized;
+using osu.Framework.Localisation;
 using osu.Game.Overlays.Comments.Buttons;
 
 namespace osu.Game.Overlays.Comments
@@ -395,7 +396,7 @@ namespace osu.Game.Overlays.Comments
 
         private class ParentUsername : FillFlowContainer, IHasTooltip
         {
-            public string TooltipText => getParentMessage();
+            public LocalisableString TooltipText => getParentMessage();
 
             private readonly Comment parentComment;
 
@@ -427,7 +428,7 @@ namespace osu.Game.Overlays.Comments
                 if (parentComment == null)
                     return string.Empty;
 
-                return parentComment.HasMessage ? parentComment.Message : parentComment.IsDeleted ? @"deleted" : string.Empty;
+                return parentComment.HasMessage ? parentComment.Message : parentComment.IsDeleted ? "deleted" : string.Empty;
             }
         }
     }

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -14,6 +14,7 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
@@ -34,7 +35,7 @@ namespace osu.Game.Overlays.Mods
         /// </summary>
         public Action<Mod> SelectionChanged;
 
-        public string TooltipText => (SelectedMod?.Description ?? Mods.FirstOrDefault()?.Description) ?? string.Empty;
+        public LocalisableString TooltipText => (SelectedMod?.Description ?? Mods.FirstOrDefault()?.Description) ?? string.Empty;
 
         private const Easing mod_switch_easing = Easing.InOutSine;
         private const double mod_switch_duration = 120;

--- a/osu.Game/Overlays/OverlayPanelDisplayStyleControl.cs
+++ b/osu.Game/Overlays/OverlayPanelDisplayStyleControl.cs
@@ -11,6 +11,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays
 {
@@ -56,7 +57,7 @@ namespace osu.Game.Overlays
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; }
 
-            public string TooltipText => $@"{Value} view";
+            public LocalisableString TooltipText => $@"{Value} view";
 
             private readonly SpriteIcon icon;
 

--- a/osu.Game/Overlays/Profile/Header/Components/DrawableBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DrawableBadge.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Localisation;
 using osu.Game.Users;
 using osuTK;
 
@@ -42,6 +43,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
             InternalChild.FadeInFromZero(200);
         }
 
-        public string TooltipText => badge.Description;
+        public LocalisableString TooltipText => badge.Description;
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osuTK;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -14,7 +15,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly BindableBool DetailsVisible = new BindableBool();
 
-        public override string TooltipText => DetailsVisible.Value ? "collapse" : "expand";
+        public override LocalisableString TooltipText => DetailsVisible.Value ? "collapse" : "expand";
 
         private SpriteIcon icon;
 

--- a/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -12,7 +13,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public override string TooltipText => "followers";
+        public override LocalisableString TooltipText => "followers";
 
         protected override IconUsage Icon => FontAwesome.Solid.User;
 

--- a/osu.Game/Overlays/Profile/Header/Components/LevelBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelBadge.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Users;
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public string TooltipText { get; }
+        public LocalisableString TooltipText { get; }
 
         private OsuSpriteText levelText;
 

--- a/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public string TooltipText { get; }
+        public LocalisableString TooltipText { get; }
 
         private Bar levelProgressBar;
         private OsuSpriteText levelProgressText;

--- a/osu.Game/Overlays/Profile/Header/Components/MappingSubscribersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MappingSubscribersButton.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -12,7 +13,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public override string TooltipText => "mapping subscribers";
+        public override LocalisableString TooltipText => "mapping subscribers";
 
         protected override IconUsage Icon => FontAwesome.Solid.Bell;
 

--- a/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.Chat;
 using osu.Game.Users;
@@ -16,7 +17,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public override string TooltipText => "send message";
+        public override LocalisableString TooltipText => "send message";
 
         [Resolved(CanBeNull = true)]
         private ChannelManager channelManager { get; set; }

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -14,7 +15,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public string TooltipText { get; set; }
+        public LocalisableString TooltipText { get; set; }
 
         private OverlinedInfoContainer info;
 

--- a/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private readonly FillFlowContainer iconContainer;
         private readonly CircularContainer content;
 
-        public string TooltipText => "osu!supporter";
+        public LocalisableString TooltipText => "osu!supporter";
 
         public int SupportLevel
         {

--- a/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedBeatmap.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedBeatmap.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         private class PlayCountText : CompositeDrawable, IHasTooltip
         {
-            public string TooltipText => "times played";
+            public LocalisableString TooltipText => "times played";
 
             public PlayCountText(int playCount)
             {

--- a/osu.Game/Overlays/RestoreDefaultValueButton.cs
+++ b/osu.Game/Overlays/RestoreDefaultValueButton.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
@@ -76,7 +77,7 @@ namespace osu.Game.Overlays
             UpdateState();
         }
 
-        public string TooltipText => "revert to default";
+        public LocalisableString TooltipText => "revert to default";
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 
@@ -32,7 +33,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
         private class OffsetSlider : OsuSliderBar<double>
         {
-            public override string TooltipText => Current.Value.ToString(@"0ms");
+            public override LocalisableString TooltipText => Current.Value.ToString(@"0ms");
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -233,7 +233,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private class UIScaleSlider : OsuSliderBar<float>
         {
-            public override string TooltipText => base.TooltipText + "x";
+            public override LocalisableString TooltipText => base.TooltipText + "x";
         }
 
         private class ResolutionSettingsDropdown : SettingsDropdown<Size>

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
@@ -116,7 +117,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private class SensitivitySlider : OsuSliderBar<double>
         {
-            public override string TooltipText => Current.Disabled ? "enable high precision mouse to adjust sensitivity" : $"{base.TooltipText}x";
+            public override LocalisableString TooltipText => Current.Disabled ? "enable high precision mouse to adjust sensitivity" : $"{base.TooltipText}x";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/SizeSlider.cs
+++ b/osu.Game/Overlays/Settings/Sections/SizeSlider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Settings.Sections
@@ -10,6 +11,6 @@ namespace osu.Game.Overlays.Settings.Sections
     /// </summary>
     internal class SizeSlider : OsuSliderBar<float>
     {
-        public override string TooltipText => Current.Value.ToString(@"0.##x");
+        public override LocalisableString TooltipText => Current.Value.ToString(@"0.##x");
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 
@@ -44,7 +45,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
 
         private class TimeSlider : OsuSliderBar<float>
         {
-            public override string TooltipText => Current.Value.ToString("N0") + "ms";
+            public override LocalisableString TooltipText => Current.Value.ToString(@"N0") + "ms";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 
@@ -62,12 +63,12 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
 
         private class MaximumStarsSlider : StarsSlider
         {
-            public override string TooltipText => Current.IsDefault ? "no limit" : base.TooltipText;
+            public override LocalisableString TooltipText => Current.IsDefault ? "no limit" : base.TooltipText;
         }
 
         private class StarsSlider : OsuSliderBar<double>
         {
-            public override string TooltipText => Current.Value.ToString(@"0.## stars");
+            public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
         }
     }
 }

--- a/osu.Game/Overlays/Settings/SettingsButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsButton.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Settings
@@ -17,14 +18,15 @@ namespace osu.Game.Overlays.Settings
             Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS };
         }
 
-        public string TooltipText { get; set; }
+        public LocalisableString TooltipText { get; set; }
 
         public override IEnumerable<string> FilterTerms
         {
             get
             {
-                if (TooltipText != null)
-                    return base.FilterTerms.Append(TooltipText);
+                if (TooltipText != default)
+                    // TODO: this won't work as intended once the tooltip text is translated.
+                    return base.FilterTerms.Append(TooltipText.ToString());
 
                 return base.FilterTerms;
             }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Settings
 
         public bool ShowsDefaultIndicator = true;
 
-        public string TooltipText { get; set; }
+        public LocalisableString TooltipText { get; set; }
 
         [Resolved]
         private OsuColour colours { get; set; }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 using osu.Framework.Bindables;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -29,7 +30,7 @@ namespace osu.Game.Rulesets.UI
 
         private const float size = 80;
 
-        public virtual string TooltipText => showTooltip ? mod.IconTooltip : null;
+        public virtual LocalisableString TooltipText => showTooltip ? mod.IconTooltip : null;
 
         private Mod mod;
         private readonly bool showTooltip;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osuTK;
 using osuTK.Graphics;
 
@@ -58,6 +59,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             icon.FadeColour(!IsHeld && IsHovered ? Color4.White : Color4.Black, TRANSFORM_DURATION, Easing.OutQuint);
         }
 
-        public string TooltipText { get; }
+        public LocalisableString TooltipText { get; }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Components/DrawableGameType.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/DrawableGameType.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
 
@@ -16,7 +17,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
     {
         private readonly GameType type;
 
-        public string TooltipText => type.Name;
+        public LocalisableString TooltipText => type.Name;
 
         public DrawableGameType(GameType type)
         {

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -431,7 +431,7 @@ namespace osu.Game.Screens.Select
 
             public class InfoLabel : Container, IHasTooltip
             {
-                public string TooltipText { get; }
+                public LocalisableString TooltipText { get; }
 
                 public InfoLabel(BeatmapStatistic statistic)
                 {

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Users.Drawables
@@ -68,11 +69,11 @@ namespace osu.Game.Users.Drawables
 
         private class ClickableArea : OsuClickableContainer
         {
-            private string tooltip = default_tooltip_text;
+            private LocalisableString tooltip = default_tooltip_text;
 
-            public override string TooltipText
+            public override LocalisableString TooltipText
             {
-                get => Enabled.Value ? tooltip : null;
+                get => Enabled.Value ? tooltip : default;
                 set => tooltip = value;
             }
 

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Users.Drawables
 {
@@ -13,7 +14,7 @@ namespace osu.Game.Users.Drawables
     {
         private readonly Country country;
 
-        public string TooltipText => country?.FullName;
+        public LocalisableString TooltipText => country?.FullName;
 
         public DrawableFlag(Country country)
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.2.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.622.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.628.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.618.0" />
     <PackageReference Include="Sentry" Version="3.4.0" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.622.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.628.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.618.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.622.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.628.0" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Companion piece to https://github.com/ppy/osu-framework/pull/4540.

- [x] Depends on framework bump.

The intention of this pull is to make things compile again and not-crash, and not to start migrating existing tooltips to the localisation system. The most I've taken the liberty of doing in that respect is removing/adding some raw string prefixes where applicable. The strings can get localised with the rest of their corresponding views/overlays.