### PR TITLE
Add overall difficulty in query search filter

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -91,6 +91,20 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        public void TestApplyOverallDifficultyQueries()
+        {
+            const string query = "od>4 easy od<8";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            Assert.Greater(filterCriteria.OverallDifficulty.Min, 4.0);
+            Assert.Less(filterCriteria.OverallDifficulty.Min, 4.1);
+            Assert.Greater(filterCriteria.OverallDifficulty.Max, 7.9);
+            Assert.Less(filterCriteria.OverallDifficulty.Max, 8.0);
+        }
+
+        [Test]
         public void TestApplyBPMQueries()
         {
             const string query = "bpm>:200 gotta go fast";

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Screens.Select.Carousel
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(Beatmap.BaseDifficulty.ApproachRate);
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(Beatmap.BaseDifficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(Beatmap.BaseDifficulty.CircleSize);
+            match &= !criteria.OverallDifficulty.HasFilter || criteria.OverallDifficulty.IsInRange(Beatmap.BaseDifficulty.OverallDifficulty);
             match &= !criteria.Length.HasFilter || criteria.Length.IsInRange(Beatmap.Length);
             match &= !criteria.BPM.HasFilter || criteria.BPM.IsInRange(Beatmap.BPM);
 

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Screens.Select
         public OptionalRange<float> ApproachRate;
         public OptionalRange<float> DrainRate;
         public OptionalRange<float> CircleSize;
+        public OptionalRange<float> OverallDifficulty;
         public OptionalRange<double> Length;
         public OptionalRange<double> BPM;
         public OptionalRange<int> BeatDivisor;

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Screens.Select
                 case "cs":
                     return TryUpdateCriteriaRange(ref criteria.CircleSize, op, value);
 
+                case "od":
+                    return TryUpdateCriteriaRange(ref criteria.OverallDifficulty, op, value);
+
                 case "bpm":
                     return TryUpdateCriteriaRange(ref criteria.BPM, op, value, 0.01d / 2);
 


### PR DESCRIPTION
I notice lazer doesn't support `od` query in search filter after seeing https://github.com/ppy/osu-web/issues/7783.

I also check stable and confirm it supports `od` query. This is also [documented in wiki](https://osu.ppy.sh/wiki/en/Interface#search).


https://user-images.githubusercontent.com/191335/124297205-cb28f080-db95-11eb-868b-93878220eac0.mp4

