### PR TITLE
Add hitsound checks

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
@@ -20,10 +20,19 @@ namespace osu.Game.Tests.Editing.Checks
     {
         private CheckFewHitsounds check;
 
+        private List<HitSampleInfo> notHitsounded;
+        private List<HitSampleInfo> hitsounded;
+
         [SetUp]
         public void Setup()
         {
             check = new CheckFewHitsounds();
+            notHitsounded = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+            hitsounded = new List<HitSampleInfo>
+            {
+                new HitSampleInfo(HitSampleInfo.HIT_NORMAL),
+                new HitSampleInfo(HitSampleInfo.HIT_FINISH)
+            };
         }
 
         [Test]
@@ -80,10 +89,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             for (int i = 0; i < 30; ++i)
             {
-                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
-
-                if (i % 8 == 0)
-                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+                var samples = i % 8 == 0 ? hitsounded : notHitsounded;
 
                 hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
             }
@@ -98,10 +104,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             for (int i = 0; i < 30; ++i)
             {
-                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
-
-                if (i == 0 || i == 15)
-                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+                var samples = (i == 0 || i == 15) ? hitsounded : notHitsounded;
 
                 hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
             }
@@ -117,10 +120,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             for (int i = 0; i < 80; ++i)
             {
-                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
-
-                if (i == 40)
-                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+                var samples = i == 40 ? hitsounded : notHitsounded;
 
                 hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
             }
@@ -135,11 +135,7 @@ namespace osu.Game.Tests.Editing.Checks
             var hitObjects = new List<HitObject>();
 
             for (int i = 0; i < 20; ++i)
-            {
-                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
-
-                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
-            }
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = notHitsounded });
 
             assertNoHitsounds(hitObjects);
         }
@@ -148,13 +144,6 @@ namespace osu.Game.Tests.Editing.Checks
         public void TestConcurrentObjects()
         {
             var hitObjects = new List<HitObject>();
-
-            var notHitsounded = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
-            var hitsounded = new List<HitSampleInfo>
-            {
-                new HitSampleInfo(HitSampleInfo.HIT_NORMAL),
-                new HitSampleInfo(HitSampleInfo.HIT_FINISH)
-            };
 
             var ticks = new List<HitObject>();
             for (int i = 1; i < 10; ++i)

--- a/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Editing.Checks
                 hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
             }
 
-            // Should prompt one warning between 1st and 11th, and another between 11th and 20th.
+            // Should prompt one warning between 1st and 16th, and another between 16th and 31st.
             assertLongPeriodWarning(hitObjects, count: 2);
         }
 
@@ -124,7 +124,7 @@ namespace osu.Game.Tests.Editing.Checks
                 hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
             }
 
-            // Should prompt one problem between 1st and 40th, and another between 40th and 80th.
+            // Should prompt one problem between 1st and 41st, and another between 41st and 81st.
             assertLongPeriodProblem(hitObjects, count: 2);
         }
 
@@ -140,7 +140,6 @@ namespace osu.Game.Tests.Editing.Checks
                 hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
             }
 
-            // Should prompt one problem between 1st and 40th, and another between 40th and 80th.
             assertNoHitsounds(hitObjects);
         }
 

--- a/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
@@ -1,0 +1,166 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    [TestFixture]
+    public class CheckFewHitsoundsTest
+    {
+        private CheckFewHitsounds check;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckFewHitsounds();
+        }
+
+        [Test]
+        public void TestHitsounded()
+        {
+            var hitObjects = new List<HitObject>();
+
+            for (int i = 0; i < 16; ++i)
+            {
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+
+                if ((i + 1) % 2 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_CLAP));
+                if ((i + 1) % 3 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+                if ((i + 1) % 4 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_FINISH));
+
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
+            }
+
+            assertOk(hitObjects);
+        }
+
+        [Test]
+        public void TestLightlyHitsounded()
+        {
+            var hitObjects = new List<HitObject>();
+
+            for (int i = 0; i < 30; ++i)
+            {
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+
+                if (i % 8 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
+            }
+
+            assertLongPeriodNegligible(hitObjects, count: 3);
+        }
+
+        [Test]
+        public void TestRarelyHitsounded()
+        {
+            var hitObjects = new List<HitObject>();
+
+            for (int i = 0; i < 30; ++i)
+            {
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+
+                if (i == 0 || i == 15)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
+            }
+
+            // Should prompt one warning between 1st and 11th, and another between 11th and 20th.
+            assertLongPeriodWarning(hitObjects, count: 2);
+        }
+
+        [Test]
+        public void TestExtremelyRarelyHitsounded()
+        {
+            var hitObjects = new List<HitObject>();
+
+            for (int i = 0; i < 80; ++i)
+            {
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+
+                if (i == 40)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
+            }
+
+            // Should prompt one problem between 1st and 40th, and another between 40th and 80th.
+            assertLongPeriodProblem(hitObjects, count: 2);
+        }
+
+        [Test]
+        public void TestNotHitsounded()
+        {
+            var hitObjects = new List<HitObject>();
+
+            for (int i = 0; i < 20; ++i)
+            {
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
+            }
+
+            // Should prompt one problem between 1st and 40th, and another between 40th and 80th.
+            assertNoHitsounds(hitObjects);
+        }
+
+        private void assertOk(List<HitObject> hitObjects)
+        {
+            Assert.That(check.Run(getContext(hitObjects)), Is.Empty);
+        }
+
+        private void assertLongPeriodProblem(List<HitObject> hitObjects, int count = 1)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(count));
+            Assert.That(issues.All(issue => issue.Template is CheckFewHitsounds.IssueTemplateLongPeriodProblem));
+        }
+
+        private void assertLongPeriodWarning(List<HitObject> hitObjects, int count = 1)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(count));
+            Assert.That(issues.All(issue => issue.Template is CheckFewHitsounds.IssueTemplateLongPeriodWarning));
+        }
+
+        private void assertLongPeriodNegligible(List<HitObject> hitObjects, int count = 1)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(count));
+            Assert.That(issues.All(issue => issue.Template is CheckFewHitsounds.IssueTemplateLongPeriodNegligible));
+        }
+
+        private void assertNoHitsounds(List<HitObject> hitObjects)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Any(issue => issue.Template is CheckFewHitsounds.IssueTemplateNoHitsounds));
+        }
+
+        private BeatmapVerifierContext getContext(List<HitObject> hitObjects)
+        {
+            var beatmap = new Beatmap<HitObject> { HitObjects = hitObjects };
+
+            return new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+        }
+    }
+}

--- a/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
@@ -141,6 +141,38 @@ namespace osu.Game.Tests.Editing.Checks
         }
 
         [Test]
+        public void TestNestedObjectsHitsounded()
+        {
+            var ticks = new List<HitObject>();
+            for (int i = 1; i < 16; ++i)
+                ticks.Add(new SliderTick { StartTime = 1000 * i, Samples = hitsounded });
+
+            var nested = new MockNestableHitObject(ticks.ToList(), 0, 16000)
+            {
+                Samples = hitsounded
+            };
+            nested.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            assertOk(new List<HitObject> { nested });
+        }
+
+        [Test]
+        public void TestNestedObjectsRarelyHitsounded()
+        {
+            var ticks = new List<HitObject>();
+            for (int i = 1; i < 16; ++i)
+                ticks.Add(new SliderTick { StartTime = 1000 * i, Samples = i == 0 ? hitsounded : notHitsounded });
+
+            var nested = new MockNestableHitObject(ticks.ToList(), 0, 16000)
+            {
+                Samples = hitsounded
+            };
+            nested.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            assertLongPeriodWarning(new List<HitObject> { nested });
+        }
+
+        [Test]
         public void TestConcurrentObjects()
         {
             var hitObjects = new List<HitObject>();

--- a/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFewHitsoundsTest.cs
@@ -48,6 +48,31 @@ namespace osu.Game.Tests.Editing.Checks
         }
 
         [Test]
+        public void TestHitsoundedWithBreak()
+        {
+            var hitObjects = new List<HitObject>();
+
+            for (int i = 0; i < 32; ++i)
+            {
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+
+                if ((i + 1) % 2 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_CLAP));
+                if ((i + 1) % 3 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_WHISTLE));
+                if ((i + 1) % 4 == 0)
+                    samples.Add(new HitSampleInfo(HitSampleInfo.HIT_FINISH));
+                // Leaves a gap in which no hitsounds exist or can be added, and so shouldn't be an issue.
+                if (i > 8 && i < 24)
+                    continue;
+
+                hitObjects.Add(new HitCircle { StartTime = 1000 * i, Samples = samples });
+            }
+
+            assertOk(hitObjects);
+        }
+
+        [Test]
         public void TestLightlyHitsounded()
         {
             var hitObjects = new List<HitObject>();

--- a/osu.Game.Tests/Editing/Checks/CheckMutedObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckMutedObjectsTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using NUnit.Framework;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -11,7 +10,6 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Tests.Beatmaps;
 
@@ -26,32 +24,6 @@ namespace osu.Game.Tests.Editing.Checks
         private const int volume_regular = 50;
         private const int volume_low = 15;
         private const int volume_muted = 5;
-
-        private sealed class MockNestableHitObject : HitObject, IHasDuration
-        {
-            private readonly IEnumerable<HitObject> toBeNested;
-
-            public MockNestableHitObject(IEnumerable<HitObject> toBeNested, double startTime, double endTime)
-            {
-                this.toBeNested = toBeNested;
-                StartTime = startTime;
-                EndTime = endTime;
-            }
-
-            protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
-            {
-                foreach (var hitObject in toBeNested)
-                    AddNested(hitObject);
-            }
-
-            public double EndTime { get; }
-
-            public double Duration
-            {
-                get => EndTime - StartTime;
-                set => throw new System.NotImplementedException();
-            }
-        }
 
         [SetUp]
         public void Setup()

--- a/osu.Game.Tests/Editing/Checks/CheckMutedObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckMutedObjectsTest.cs
@@ -1,0 +1,317 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    [TestFixture]
+    public class CheckMutedObjectsTest
+    {
+        private CheckMutedObjects check;
+        private ControlPointInfo cpi;
+
+        private const int volume_regular = 50;
+        private const int volume_low = 15;
+        private const int volume_muted = 5;
+
+        private sealed class MockNestableHitObject : HitObject, IHasDuration
+        {
+            private readonly IEnumerable<HitObject> toBeNested;
+
+            public MockNestableHitObject(IEnumerable<HitObject> toBeNested, double startTime, double endTime)
+            {
+                this.toBeNested = toBeNested;
+                StartTime = startTime;
+                EndTime = endTime;
+            }
+
+            protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
+            {
+                foreach (var hitObject in toBeNested)
+                    AddNested(hitObject);
+            }
+
+            public double EndTime { get; }
+
+            public double Duration
+            {
+                get => EndTime - StartTime;
+                set => throw new System.NotImplementedException();
+            }
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckMutedObjects();
+
+            cpi = new ControlPointInfo();
+            cpi.Add(0, new SampleControlPoint { SampleVolume = volume_regular });
+            cpi.Add(1000, new SampleControlPoint { SampleVolume = volume_low });
+            cpi.Add(2000, new SampleControlPoint { SampleVolume = volume_muted });
+        }
+
+        [Test]
+        public void TestNormalControlPointVolume()
+        {
+            var hitcircle = new HitCircle
+            {
+                StartTime = 0,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertOk(new List<HitObject> { hitcircle });
+        }
+
+        [Test]
+        public void TestLowControlPointVolume()
+        {
+            var hitcircle = new HitCircle
+            {
+                StartTime = 1000,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertLowVolume(new List<HitObject> { hitcircle });
+        }
+
+        [Test]
+        public void TestMutedControlPointVolume()
+        {
+            var hitcircle = new HitCircle
+            {
+                StartTime = 2000,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertMuted(new List<HitObject> { hitcircle });
+        }
+
+        [Test]
+        public void TestNormalSampleVolume()
+        {
+            // The sample volume should take precedence over the control point volume.
+            var hitcircle = new HitCircle
+            {
+                StartTime = 2000,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_regular) }
+            };
+            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertOk(new List<HitObject> { hitcircle });
+        }
+
+        [Test]
+        public void TestLowSampleVolume()
+        {
+            var hitcircle = new HitCircle
+            {
+                StartTime = 2000,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_low) }
+            };
+            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertLowVolume(new List<HitObject> { hitcircle });
+        }
+
+        [Test]
+        public void TestMutedSampleVolume()
+        {
+            var hitcircle = new HitCircle
+            {
+                StartTime = 0,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_muted) }
+            };
+            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertMuted(new List<HitObject> { hitcircle });
+        }
+
+        [Test]
+        public void TestNormalSampleVolumeSlider()
+        {
+            var sliderHead = new SliderHeadCircle
+            {
+                StartTime = 0,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            sliderHead.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var sliderTick = new SliderTick
+            {
+                StartTime = 250,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo("slidertick", volume: volume_muted) } // Should be fine.
+            };
+            sliderTick.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var slider = new MockNestableHitObject(new List<HitObject> { sliderHead, sliderTick, }, startTime: 0, endTime: 500)
+            {
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            slider.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertOk(new List<HitObject> { slider });
+        }
+
+        [Test]
+        public void TestMutedSampleVolumeSliderHead()
+        {
+            var sliderHead = new SliderHeadCircle
+            {
+                StartTime = 0,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_muted) }
+            };
+            sliderHead.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var sliderTick = new SliderTick
+            {
+                StartTime = 250,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo("slidertick") }
+            };
+            sliderTick.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var slider = new MockNestableHitObject(new List<HitObject> { sliderHead, sliderTick, }, startTime: 0, endTime: 500)
+            {
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) } // Applies to the tail.
+            };
+            slider.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertMuted(new List<HitObject> { slider });
+        }
+
+        [Test]
+        public void TestMutedSampleVolumeSliderTail()
+        {
+            var sliderHead = new SliderHeadCircle
+            {
+                StartTime = 0,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            sliderHead.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var sliderTick = new SliderTick
+            {
+                StartTime = 250,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo("slidertick") }
+            };
+            sliderTick.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var slider = new MockNestableHitObject(new List<HitObject> { sliderHead, sliderTick, }, startTime: 0, endTime: 2500)
+            {
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_muted) } // Applies to the tail.
+            };
+            slider.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertMutedPassive(new List<HitObject> { slider });
+        }
+
+        [Test]
+        public void TestMutedControlPointVolumeSliderHead()
+        {
+            var sliderHead = new SliderHeadCircle
+            {
+                StartTime = 2000,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            sliderHead.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var sliderTick = new SliderTick
+            {
+                StartTime = 2250,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo("slidertick") }
+            };
+            sliderTick.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var slider = new MockNestableHitObject(new List<HitObject> { sliderHead, sliderTick, }, startTime: 2000, endTime: 2500)
+            {
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_regular) }
+            };
+            slider.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertMuted(new List<HitObject> { slider });
+        }
+
+        [Test]
+        public void TestMutedControlPointVolumeSliderTail()
+        {
+            var sliderHead = new SliderHeadCircle
+            {
+                StartTime = 0,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            sliderHead.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            var sliderTick = new SliderTick
+            {
+                StartTime = 250,
+                Samples = new List<HitSampleInfo> { new HitSampleInfo("slidertick") }
+            };
+            sliderTick.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            // Ends after the 5% control point.
+            var slider = new MockNestableHitObject(new List<HitObject> { sliderHead, sliderTick, }, startTime: 0, endTime: 2500)
+            {
+                Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
+            };
+            slider.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            assertMutedPassive(new List<HitObject> { slider });
+        }
+
+        private void assertOk(List<HitObject> hitObjects)
+        {
+            Assert.That(check.Run(getContext(hitObjects)), Is.Empty);
+        }
+
+        private void assertLowVolume(List<HitObject> hitObjects, int count = 1)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(count));
+            Assert.That(issues.All(issue => issue.Template is CheckMutedObjects.IssueTemplateLowVolumeActive));
+        }
+
+        private void assertMuted(List<HitObject> hitObjects, int count = 1)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(count));
+            Assert.That(issues.All(issue => issue.Template is CheckMutedObjects.IssueTemplateMutedActive));
+        }
+
+        private void assertMutedPassive(List<HitObject> hitObjects)
+        {
+            var issues = check.Run(getContext(hitObjects)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Any(issue => issue.Template is CheckMutedObjects.IssueTemplateMutedPassive));
+        }
+
+        private BeatmapVerifierContext getContext(List<HitObject> hitObjects)
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                ControlPointInfo = cpi,
+                HitObjects = hitObjects
+            };
+
+            return new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+        }
+    }
+}

--- a/osu.Game.Tests/Editing/Checks/MockNestableHitObject.cs
+++ b/osu.Game.Tests/Editing/Checks/MockNestableHitObject.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Threading;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    public sealed class MockNestableHitObject : HitObject, IHasDuration
+    {
+        private readonly IEnumerable<HitObject> toBeNested;
+
+        public MockNestableHitObject(IEnumerable<HitObject> toBeNested, double startTime, double endTime)
+        {
+            this.toBeNested = toBeNested;
+            StartTime = startTime;
+            EndTime = endTime;
+        }
+
+        protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
+        {
+            foreach (var hitObject in toBeNested)
+                AddNested(hitObject);
+        }
+
+        public double EndTime { get; }
+
+        public double Duration
+        {
+            get => EndTime - StartTime;
+            set => throw new System.NotImplementedException();
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Edit
             // Audio
             new CheckAudioPresence(),
             new CheckAudioQuality(),
+            new CheckMutedObjects(),
 
             // Compose
             new CheckUnsnappedObjects(),

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Edit
             new CheckAudioPresence(),
             new CheckAudioQuality(),
             new CheckMutedObjects(),
+            new CheckFewHitsounds(),
 
             // Compose
             new CheckUnsnappedObjects(),

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         {
             new IssueTemplateLongPeriodProblem(this),
             new IssueTemplateLongPeriodWarning(this),
+            new IssueTemplateLongPeriodNegligible(this),
             new IssueTemplateNoHitsounds(this)
         };
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             // Only generating issues on hitsounded or last objects ensures we get one issue per long period.
             // If there are no hitsounds we let the "No hitsounds" template take precedence.
-            if (hasHitsound(hitObject) || isLastObject && hasHitsounds)
+            if (hasHitsound(hitObject) || (isLastObject && hasHitsounds))
             {
                 var timeWithoutHitsounds = time - lastHitsoundTime;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -1,0 +1,161 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Audio;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckFewHitsounds : ICheck
+    {
+        /// <summary>
+        /// 2 measures (4/4) of 120 BPM, typically makes up a few patterns in the map.
+        /// This is almost always ok, but can still be useful for the mapper to make sure hitsounding coverage is good.
+        /// </summary>
+        private const int negligible_threshold_time = 4000;
+
+        /// <summary>
+        /// 4 measures (4/4) of 120 BPM, typically makes up a large portion of a section in the song.
+        /// This is ok if the section is a quiet intro, for example.
+        /// </summary>
+        private const int warning_threshold_time = 8000;
+
+        /// <summary>
+        /// 12 measures (4/4) of 120 BPM, typically makes up multiple sections in the song.
+        /// </summary>
+        private const int problem_threshold_time = 24000;
+
+        // Should pass at least this many objects without hitsounds to be considered an issue (should work for Easy diffs too).
+        private const int warning_threshold_objects = 4;
+        private const int problem_threshold_objects = 16;
+
+        private static readonly string[] hitsound_types = { HitSampleInfo.HIT_CLAP, HitSampleInfo.HIT_WHISTLE, HitSampleInfo.HIT_FINISH };
+
+        public CheckMetadata Metadata { get; } = new CheckMetadata(CheckCategory.Audio, "Few or no hitsounds");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateLongPeriodProblem(this),
+            new IssueTemplateLongPeriodWarning(this),
+            new IssueTemplateNoHitsounds(this)
+        };
+
+        private bool hasHitsounds;
+        private int objectsWithoutHitsounds;
+        private double lastHitsoundTime;
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            if (!context.Beatmap.HitObjects.Any())
+                yield break;
+
+            hasHitsounds = false;
+            objectsWithoutHitsounds = 0;
+            lastHitsoundTime = context.Beatmap.HitObjects.First().StartTime;
+
+            var hitObjectCount = context.Beatmap.HitObjects.Count;
+
+            for (int i = 0; i < hitObjectCount; ++i)
+            {
+                var hitObject = context.Beatmap.HitObjects[i];
+
+                // Samples play on the end of objects. Some objects have nested objects to accomplish playing them elsewhere (e.g. slider head/repeat).
+                foreach (var nestedHitObject in hitObject.NestedHitObjects)
+                {
+                    foreach (var issue in applyHitsoundUpdate(nestedHitObject))
+                        yield return issue;
+                }
+
+                // This is used to perform an update at the end so that the period after the last hitsounded object can be an issue.
+                bool isLastObject = i == hitObjectCount - 1;
+
+                foreach (var issue in applyHitsoundUpdate(hitObject, isLastObject))
+                    yield return issue;
+            }
+
+            if (!hasHitsounds)
+                yield return new IssueTemplateNoHitsounds(this).Create();
+        }
+
+        private IEnumerable<Issue> applyHitsoundUpdate(HitObject hitObject, bool isLastObject = false)
+        {
+            var time = hitObject.GetEndTime();
+
+            // Only generating issues on hitsounded or last objects ensures we get one issue per long period.
+            // If there are no hitsounds we let the "No hitsounds" template take precedence.
+            if (hasHitsound(hitObject) || isLastObject && hasHitsounds)
+            {
+                var timeWithoutHitsounds = time - lastHitsoundTime;
+
+                if (timeWithoutHitsounds > problem_threshold_time && objectsWithoutHitsounds > problem_threshold_objects)
+                    yield return new IssueTemplateLongPeriodProblem(this).Create(lastHitsoundTime, timeWithoutHitsounds);
+                else if (timeWithoutHitsounds > warning_threshold_time && objectsWithoutHitsounds > warning_threshold_objects)
+                    yield return new IssueTemplateLongPeriodWarning(this).Create(lastHitsoundTime, timeWithoutHitsounds);
+                else if (timeWithoutHitsounds > negligible_threshold_time && objectsWithoutHitsounds > warning_threshold_objects)
+                    yield return new IssueTemplateLongPeriodNegligible(this).Create(lastHitsoundTime, timeWithoutHitsounds);
+            }
+
+            if (hasHitsound(hitObject))
+            {
+                hasHitsounds = true;
+                objectsWithoutHitsounds = 0;
+                lastHitsoundTime = time;
+            }
+            else if (couldHaveHitsound(hitObject))
+                ++objectsWithoutHitsounds;
+        }
+
+        private bool hasHitsound(HitObject hitObject) => hitObject.Samples.Any(isHitsound);
+        private bool couldHaveHitsound(HitObject hitObject) => hitObject.Samples.Any(isHitnormal);
+
+        private bool isHitsound(HitSampleInfo sample) => hitsound_types.Any(sample.Name.Contains);
+        private bool isHitnormal(HitSampleInfo sample) => sample.Name.Contains(HitSampleInfo.HIT_NORMAL);
+
+        public abstract class IssueTemplateLongPeriod : IssueTemplate
+        {
+            protected IssueTemplateLongPeriod(ICheck check, IssueType type)
+                : base(check, type, "Long period without hitsounds ({0:F1} seconds).")
+            {
+            }
+
+            public Issue Create(double time, double duration) => new Issue(this, duration / 1000f) { Time = time };
+        }
+
+        public class IssueTemplateLongPeriodProblem : IssueTemplateLongPeriod
+        {
+            public IssueTemplateLongPeriodProblem(ICheck check)
+                : base(check, IssueType.Problem)
+            {
+            }
+        }
+
+        public class IssueTemplateLongPeriodWarning : IssueTemplateLongPeriod
+        {
+            public IssueTemplateLongPeriodWarning(ICheck check)
+                : base(check, IssueType.Warning)
+            {
+            }
+        }
+
+        public class IssueTemplateLongPeriodNegligible : IssueTemplateLongPeriod
+        {
+            public IssueTemplateLongPeriodNegligible(ICheck check)
+                : base(check, IssueType.Negligible)
+            {
+            }
+        }
+
+        public class IssueTemplateNoHitsounds : IssueTemplate
+        {
+            public IssueTemplateNoHitsounds(ICheck check)
+                : base(check, IssueType.Problem, "There are no hitsounds.")
+            {
+            }
+
+            public Issue Create() => new Issue(this);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -82,10 +82,12 @@ namespace osu.Game.Rulesets.Edit.Checks
         private IEnumerable<Issue> applyHitsoundUpdate(HitObject hitObject, bool isLastObject = false)
         {
             var time = hitObject.GetEndTime();
+            bool hasHitsound = hitObject.Samples.Any(isHitsound);
+            bool couldHaveHitsound = hitObject.Samples.Any(isHitnormal);
 
             // Only generating issues on hitsounded or last objects ensures we get one issue per long period.
             // If there are no hitsounds we let the "No hitsounds" template take precedence.
-            if (hasHitsound(hitObject) || (isLastObject && mapHasHitsounds))
+            if (hasHitsound || (isLastObject && mapHasHitsounds))
             {
                 var timeWithoutHitsounds = time - lastHitsoundTime;
 
@@ -97,18 +99,15 @@ namespace osu.Game.Rulesets.Edit.Checks
                     yield return new IssueTemplateLongPeriodNegligible(this).Create(lastHitsoundTime, timeWithoutHitsounds);
             }
 
-            if (hasHitsound(hitObject))
+            if (hasHitsound)
             {
                 mapHasHitsounds = true;
                 objectsWithoutHitsounds = 0;
                 lastHitsoundTime = time;
             }
-            else if (couldHaveHitsound(hitObject))
+            else if (couldHaveHitsound)
                 ++objectsWithoutHitsounds;
         }
-
-        private bool hasHitsound(HitObject hitObject) => hitObject.Samples.Any(isHitsound);
-        private bool couldHaveHitsound(HitObject hitObject) => hitObject.Samples.Any(isHitnormal);
 
         private bool isHitsound(HitSampleInfo sample) => HitSampleInfo.AllAdditions.Any(sample.Name.Contains);
         private bool isHitnormal(HitSampleInfo sample) => sample.Name.Contains(HitSampleInfo.HIT_NORMAL);

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -32,8 +32,6 @@ namespace osu.Game.Rulesets.Edit.Checks
         private const int warning_threshold_objects = 4;
         private const int problem_threshold_objects = 16;
 
-        private static readonly string[] hitsound_types = { HitSampleInfo.HIT_CLAP, HitSampleInfo.HIT_WHISTLE, HitSampleInfo.HIT_FINISH };
-
         public CheckMetadata Metadata { get; } = new CheckMetadata(CheckCategory.Audio, "Few or no hitsounds");
 
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
@@ -111,7 +109,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         private bool hasHitsound(HitObject hitObject) => hitObject.Samples.Any(isHitsound);
         private bool couldHaveHitsound(HitObject hitObject) => hitObject.Samples.Any(isHitnormal);
 
-        private bool isHitsound(HitSampleInfo sample) => hitsound_types.Any(sample.Name.Contains);
+        private bool isHitsound(HitSampleInfo sample) => HitSampleInfo.AllAdditions.Any(sample.Name.Contains);
         private bool isHitnormal(HitSampleInfo sample) => sample.Name.Contains(HitSampleInfo.HIT_NORMAL);
 
         public abstract class IssueTemplateLongPeriod : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateNoHitsounds(this)
         };
 
-        private bool hasHitsounds;
+        private bool mapHasHitsounds;
         private int objectsWithoutHitsounds;
         private double lastHitsoundTime;
 
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (!context.Beatmap.HitObjects.Any())
                 yield break;
 
-            hasHitsounds = false;
+            mapHasHitsounds = false;
             objectsWithoutHitsounds = 0;
             lastHitsoundTime = context.Beatmap.HitObjects.First().StartTime;
 
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                     yield return issue;
             }
 
-            if (!hasHitsounds)
+            if (!mapHasHitsounds)
                 yield return new IssueTemplateNoHitsounds(this).Create();
         }
 
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             // Only generating issues on hitsounded or last objects ensures we get one issue per long period.
             // If there are no hitsounds we let the "No hitsounds" template take precedence.
-            if (hasHitsound(hitObject) || (isLastObject && hasHitsounds))
+            if (hasHitsound(hitObject) || (isLastObject && mapHasHitsounds))
             {
                 var timeWithoutHitsounds = time - lastHitsoundTime;
 
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 
             if (hasHitsound(hitObject))
             {
-                hasHitsounds = true;
+                mapHasHitsounds = true;
                 objectsWithoutHitsounds = 0;
                 lastHitsoundTime = time;
             }

--- a/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
@@ -13,12 +13,12 @@ namespace osu.Game.Rulesets.Edit.Checks
     public class CheckMutedObjects : ICheck
     {
         /// <summary>
-        /// Volume percentages lower than this are typically inaudible.
+        /// Volume percentages lower than or equal to this are typically inaudible.
         /// </summary>
         private const int muted_threshold = 5;
 
         /// <summary>
-        /// Volume percentages lower than this can sometimes be inaudible depending on sample used and music volume.
+        /// Volume percentages lower than or equal to this can sometimes be inaudible depending on sample used and music volume.
         /// </summary>
         private const int low_volume_threshold = 20;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckMutedObjects : ICheck
+    {
+        /// <summary>
+        /// Volume percentages lower than this are typically inaudible.
+        /// </summary>
+        private const int muted_threshold = 5;
+
+        /// <summary>
+        /// Volume percentages lower than this can sometimes be inaudible depending on sample used and music volume.
+        /// </summary>
+        private const int low_volume_threshold = 20;
+
+        public CheckMetadata Metadata { get; } = new CheckMetadata(CheckCategory.Audio, "Low volume hitobjects");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateMutedActive(this),
+            new IssueTemplateLowVolumeActive(this),
+            new IssueTemplateMutedPassive(this)
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            foreach (var hitObject in context.Beatmap.HitObjects)
+            {
+                // Worth keeping in mind: The samples of an object always play at its end time.
+                // Objects like spinners have no sound at its start because of this, while hold notes have nested objects to accomplish this.
+                foreach (var nestedHitObject in hitObject.NestedHitObjects)
+                {
+                    foreach (var issue in getVolumeIssues(hitObject, nestedHitObject))
+                        yield return issue;
+                }
+
+                foreach (var issue in getVolumeIssues(hitObject))
+                    yield return issue;
+            }
+        }
+
+        private IEnumerable<Issue> getVolumeIssues(HitObject hitObject, HitObject sampledHitObject = null)
+        {
+            sampledHitObject ??= hitObject;
+            if (!sampledHitObject.Samples.Any())
+                yield break;
+
+            // Samples that allow themselves to be overridden by control points have a volume of 0.
+            int maxVolume = sampledHitObject.Samples.Max(sample => sample.Volume > 0 ? sample.Volume : sampledHitObject.SampleControlPoint.SampleVolume);
+            double samplePlayTime = sampledHitObject.GetEndTime();
+
+            bool head = Precision.AlmostEquals(samplePlayTime, hitObject.StartTime, 1f);
+            bool tail = Precision.AlmostEquals(samplePlayTime, hitObject.GetEndTime(), 1f);
+            bool repeat = false;
+
+            if (hitObject is IHasRepeats hasRepeats && !head && !tail)
+            {
+                double spanDuration = hasRepeats.Duration / hasRepeats.SpanCount();
+                repeat = Precision.AlmostEquals((samplePlayTime - hitObject.StartTime) % spanDuration, 0f, 1f);
+            }
+
+            // We only care about samples played on the edges of objects, not ones like spinnerspin or slidertick.
+            if (!head && !tail && !repeat)
+                yield break;
+
+            string postfix = null;
+            if (hitObject is IHasDuration)
+                postfix = head ? "head" : tail ? "tail" : "repeat";
+
+            if (maxVolume <= muted_threshold)
+            {
+                if (head)
+                    yield return new IssueTemplateMutedActive(this).Create(hitObject, maxVolume / 100f, sampledHitObject.GetEndTime(), postfix);
+                else
+                    yield return new IssueTemplateMutedPassive(this).Create(hitObject, maxVolume / 100f, sampledHitObject.GetEndTime(), postfix);
+            }
+            else if (maxVolume <= low_volume_threshold && head)
+            {
+                yield return new IssueTemplateLowVolumeActive(this).Create(hitObject, maxVolume / 100f, sampledHitObject.GetEndTime(), postfix);
+            }
+        }
+
+        public abstract class IssueTemplateMuted : IssueTemplate
+        {
+            protected IssueTemplateMuted(ICheck check, IssueType type, string unformattedMessage)
+                : base(check, type, unformattedMessage)
+            {
+            }
+
+            public Issue Create(HitObject hitobject, double volume, double time, string postfix = "")
+            {
+                string objectName = hitobject.GetType().Name;
+                if (!string.IsNullOrEmpty(postfix))
+                    objectName += " " + postfix;
+
+                return new Issue(hitobject, this, objectName, volume) { Time = time };
+            }
+        }
+
+        public class IssueTemplateMutedActive : IssueTemplateMuted
+        {
+            public IssueTemplateMutedActive(ICheck check)
+                : base(check, IssueType.Problem, "{0} has a volume of {1:0%}. Clickable objects must have clearly audible feedback.")
+            {
+            }
+        }
+
+        public class IssueTemplateLowVolumeActive : IssueTemplateMuted
+        {
+            public IssueTemplateLowVolumeActive(ICheck check)
+                : base(check, IssueType.Warning, "{0} has a volume of {1:0%}, ensure this is audible.")
+            {
+            }
+        }
+
+        public class IssueTemplateMutedPassive : IssueTemplateMuted
+        {
+            public IssueTemplateMutedPassive(ICheck check)
+                : base(check, IssueType.Negligible, "{0} has a volume of {1:0%}, ensure there is no distinct sound here in the song if inaudible.")
+            {
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
@@ -98,9 +98,13 @@ namespace osu.Game.Rulesets.Edit.Checks
             {
                 double spanDuration = hasRepeats.Duration / hasRepeats.SpanCount();
                 double spans = (time - hitObject.StartTime) / spanDuration;
+                double acceptableDifference = 1 / spanDuration; // 1 ms of acceptable difference, as with head/tail above.
 
-                if (Precision.AlmostEquals(spans, Math.Ceiling(spans)) || Precision.AlmostEquals(spans, Math.Floor(spans)))
+                if (Precision.AlmostEquals(spans, Math.Ceiling(spans), acceptableDifference) ||
+                    Precision.AlmostEquals(spans, Math.Floor(spans), acceptableDifference))
+                {
                     return EdgeType.Repeat;
+                }
             }
 
             return EdgeType.None;

--- a/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Utils;
@@ -96,7 +97,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (hitObject is IHasRepeats hasRepeats)
             {
                 double spanDuration = hasRepeats.Duration / hasRepeats.SpanCount();
-                if (Precision.AlmostEquals((time - hitObject.StartTime) % spanDuration, 0f, 1f))
+                double spans = (time - hitObject.StartTime) / spanDuration;
+
+                if (Precision.AlmostEquals(spans, Math.Ceiling(spans)) || Precision.AlmostEquals(spans, Math.Floor(spans)))
                     return EdgeType.Repeat;
             }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
@@ -97,6 +97,10 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (hitObject is IHasRepeats hasRepeats)
             {
                 double spanDuration = hasRepeats.Duration / hasRepeats.SpanCount();
+                if (spanDuration <= 0)
+                    // Prevents undefined behaviour in cases like where zero/negative-length sliders/hold notes exist.
+                    return EdgeType.None;
+
                 double spans = (time - hitObject.StartTime) / spanDuration;
                 double acceptableDifference = 1 / spanDuration; // 1 ms of acceptable difference, as with head/tail above.
 


### PR DESCRIPTION
Makes further progress towards resolving https://github.com/ppy/osu/issues/12091.

Adds
- `CheckMutedObjects`
    - Ensures clickable objects have audible feedback.
    - Also adds a negligible check for muted non-clickable edges (e.g. slider repeats/tails).
- `CheckFewHitsounds`
    - Ensures that beatmaps are hitsounded (claps, whistles, finishes) and don't have long periods of no hitsounds.
    - Only points out periods in which there could be hitsounds added (i.e. where there are hitnormals).
- Tests for those checks

https://user-images.githubusercontent.com/30292137/123521124-f81c6580-d6b4-11eb-9d97-287026e0d03f.mp4

---
These were difficult to test and show in-game due to hitsound controls being lacking; mainly the ability to add/remove samples to/from nested hitobjects like slider heads. The `MockNestableHitObject` class (name could probably be better) in `CheckMutedObjectsTest` and its respective tests hopefully help make sure that works properly.