### PR TITLE
Remove comparison of online beatmap IDs during dedupe checks

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -439,41 +439,6 @@ namespace osu.Game.Tests.Beatmaps.IO
             }
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task TestImportThenDeleteThenImportWithOnlineIDMismatch(bool set)
-        {
-            // unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
-            using (HeadlessGameHost host = new CleanRunHeadlessGameHost($"{nameof(ImportBeatmapTest)}-{set}"))
-            {
-                try
-                {
-                    var osu = LoadOsuIntoHost(host);
-
-                    var imported = await LoadOszIntoOsu(osu);
-
-                    if (set)
-                        imported.OnlineBeatmapSetID = 1234;
-                    else
-                        imported.Beatmaps.First().OnlineBeatmapID = 1234;
-
-                    osu.Dependencies.Get<BeatmapManager>().Update(imported);
-
-                    deleteBeatmapSet(imported, osu);
-
-                    var importedSecondTime = await LoadOszIntoOsu(osu);
-
-                    // check the newly "imported" beatmap has been reimported due to mismatch (even though hashes matched)
-                    Assert.IsTrue(imported.ID != importedSecondTime.ID);
-                    Assert.IsTrue(imported.Beatmaps.First().ID != importedSecondTime.Beatmaps.First().ID);
-                }
-                finally
-                {
-                    host.Exit();
-                }
-            }
-        }
-
         [Test]
         public async Task TestImportWithDuplicateBeatmapIDs()
         {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -319,18 +319,6 @@ namespace osu.Game.Beatmaps
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public BeatmapSetInfo QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.ConsumableItems.AsNoTracking().FirstOrDefault(query);
 
-        protected override bool CanReuseExisting(BeatmapSetInfo existing, BeatmapSetInfo import)
-        {
-            if (!base.CanReuseExisting(existing, import))
-                return false;
-
-            var existingIds = existing.Beatmaps.Select(b => b.OnlineBeatmapID).OrderBy(i => i);
-            var importIds = import.Beatmaps.Select(b => b.OnlineBeatmapID).OrderBy(i => i);
-
-            // force re-import if we are not in a sane state.
-            return existing.OnlineBeatmapSetID == import.OnlineBeatmapSetID && existingIds.SequenceEqual(importIds);
-        }
-
         /// <summary>
         /// Returns a list of all usable <see cref="BeatmapSetInfo"/>s.
         /// </summary>

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -377,7 +377,7 @@ namespace osu.Game.Database
 
                         if (existing != null)
                         {
-                            if (CanReuseExisting(existing, item))
+                            if (canReuseExisting(existing, item))
                             {
                                 Undelete(existing);
                                 LogForModel(item, $"Found existing {HumanisedModelName} for {item} (ID {existing.ID}) – skipping import.");
@@ -751,7 +751,7 @@ namespace osu.Game.Database
         /// <param name="existing">The existing model.</param>
         /// <param name="import">The newly imported model.</param>
         /// <returns>Whether the existing model should be restored and used. Returning false will delete the existing and force a re-import.</returns>
-        protected virtual bool CanReuseExisting(TModel existing, TModel import) =>
+        private bool canReuseExisting(TModel existing, TModel import) =>
             // for the best or worst, we copy and import files of a new import before checking whether
             // it is a duplicate. so to check if anything has changed, we can just compare all FileInfo IDs.
             getIDs(existing.Files).SequenceEqual(getIDs(import.Files)) &&


### PR DESCRIPTION
This is a prerequisite that is required to shortcut the existing beatmap check (for performance reasons). PRing separate in the interest of keeping individual changes small.

This was added to handle "re-fetching" online IDs on re-import, but if we are to be shortcutting the process before doing any `Populate()` logic (where online population may happen) this will never be reached.

Before: importing a second time would run `Populate()`, re-fetch online IDs and decide to reimport
After: importing a second time will not re-fetch online IDs, even if they are not present

The edge case is if a user imports from stable without an internet connection, they will not get online IDs populated. If they then import a second time, this will not resolve the issue. If this is seen is deemed as a regression in expected behaviour then (at very least) shortcutting import would need to be bypased when existing beatmaps have no onlineID. This is a feasible direction which can be considered at the cost of import performance, make sure you state an opinion on this when reviewing.

If this raises any question or doubt (ie. more than 5 minutes of review time) please throw me a voice call and I'll talk through it.