### PR TITLE
Serialise and send ruleset ID as part of score submission

### DIFF
--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Scoring
         [JsonIgnore]
         public int Combo { get; set; } // Todo: Shouldn't exist in here
 
-        [JsonIgnore]
+        [JsonProperty("ruleset_id")]
         public int RulesetID { get; set; }
 
         [JsonProperty("passed")]


### PR DESCRIPTION
This is currently sent as part of the token request but not submission. In discussion with the osu-web team it may make more sense to consume it at a later point (token storage is currently undergoing some changes infrastructure side).

For now we will still consume the one sent in the initial request, but I don't think there's harm in sending it twice for verification at very least.