### PR TITLE
Improve compatibility between mods which mutate approach circles

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/IHidesApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IHidesApproachCircles.cs
@@ -4,8 +4,12 @@
 namespace osu.Game.Rulesets.Osu.Mods
 {
     /// <summary>
-    /// Marker interface for any mod which completely hides the approach circles. Used for incompatibility with <see cref="IRequiresApproachCircles"/>.
+    /// Marker interface for any mod which completely hides the approach circles.
+    /// Used for incompatibility with <see cref="IRequiresApproachCircles"/>.
     /// </summary>
+    /// <remarks>
+    /// Note that this is only a marker interface for incompatibility purposes, it does not change any gameplay behaviour.
+    /// </remarks>
     public interface IHidesApproachCircles
     {
     }

--- a/osu.Game.Rulesets.Osu/Mods/IHidesApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IHidesApproachCircles.cs
@@ -4,7 +4,7 @@
 namespace osu.Game.Rulesets.Osu.Mods
 {
     /// <summary>
-    /// Any mod which completely hides the approach circles. Used for incompatibility with <see cref="IRequiresApproachCircles"/>.
+    /// Marker interface for any mod which completely hides the approach circles. Used for incompatibility with <see cref="IRequiresApproachCircles"/>.
     /// </summary>
     public interface IHidesApproachCircles
     {

--- a/osu.Game.Rulesets.Osu/Mods/IHidesApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IHidesApproachCircles.cs
@@ -4,9 +4,9 @@
 namespace osu.Game.Rulesets.Osu.Mods
 {
     /// <summary>
-    /// Any mod which affects the animation or visibility of approach circles. Should be used for incompatibility purposes.
+    /// Any mod which completely hides the approach circles. Used for incompatibility with <see cref="IRequiresApproachCircles"/>.
     /// </summary>
-    public interface IMutateApproachCircles
+    public interface IHidesApproachCircles
     {
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/IRequiresApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IRequiresApproachCircles.cs
@@ -4,8 +4,12 @@
 namespace osu.Game.Rulesets.Osu.Mods
 {
     /// <summary>
-    /// Marker interface for any mod which requires the approach circles to be visible. Used for incompatibility with <see cref="IHidesApproachCircles"/>.
+    /// Marker interface for any mod which requires the approach circles to be visible.
+    /// Used for incompatibility with <see cref="IHidesApproachCircles"/>.
     /// </summary>
+    /// <remarks>
+    /// Note that this is only a marker interface for incompatibility purposes, it does not change any gameplay behaviour.
+    /// </remarks>
     public interface IRequiresApproachCircles
     {
     }

--- a/osu.Game.Rulesets.Osu/Mods/IRequiresApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IRequiresApproachCircles.cs
@@ -4,7 +4,7 @@
 namespace osu.Game.Rulesets.Osu.Mods
 {
     /// <summary>
-    /// Any mod which requires the approach circles to be visible. Used for incompatibility with <see cref="IHidesApproachCircles"/>.
+    /// Marker interface for any mod which requires the approach circles to be visible. Used for incompatibility with <see cref="IHidesApproachCircles"/>.
     /// </summary>
     public interface IRequiresApproachCircles
     {

--- a/osu.Game.Rulesets.Osu/Mods/IRequiresApproachCircles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/IRequiresApproachCircles.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    /// <summary>
+    /// Any mod which requires the approach circles to be visible. Used for incompatibility with <see cref="IHidesApproachCircles"/>.
+    /// </summary>
+    public interface IRequiresApproachCircles
+    {
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -12,7 +12,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModApproachDifferent : Mod, IApplicableToDrawableHitObject, IMutateApproachCircles
+    public class OsuModApproachDifferent : Mod, IApplicableToDrawableHitObject, IRequiresApproachCircles
     {
         public override string Name => "Approach Different";
         public override string Acronym => "AD";
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1;
         public override IconUsage? Icon { get; } = FontAwesome.Regular.Circle;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles) };
 
         [SettingSource("Initial size", "Change the initial size of the approach circle, relative to hit circles.", 0)]
         public BindableFloat Scale { get; } = new BindableFloat(4)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -15,12 +15,12 @@ using osu.Game.Rulesets.Osu.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModHidden : ModHidden, IMutateApproachCircles
+    public class OsuModHidden : ModHidden, IHidesApproachCircles
     {
         public override string Description => @"Play with no approach circles and fading circles/sliders.";
         public override double ScoreMultiplier => 1.06;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
 
         private const double fade_in_duration_multiplier = 0.4;
         private const double fade_out_duration_multiplier = 0.3;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => @"Play with no approach circles and fading circles/sliders.";
         public override double ScoreMultiplier => 1.06;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn) };
 
         private const double fade_in_duration_multiplier = 0.4;
         private const double fade_out_duration_multiplier = 0.3;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected virtual float EndScale => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn) };
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     /// <summary>
     /// Adjusts the size of hit objects during their fade in animation.
     /// </summary>
-    public abstract class OsuModObjectScaleTween : ModWithVisibilityAdjustment, IMutateApproachCircles
+    public abstract class OsuModObjectScaleTween : ModWithVisibilityAdjustment, IHidesApproachCircles
     {
         public override ModType Type => ModType.Fun;
 
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected virtual float EndScale => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1;
 
         // todo: this mod should be able to be compatible with hidden with a bit of further implementation.
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(IHidesApproachCircles) };
 
         private const int rotate_offset = 360;
         private const float rotate_starting_width = 2;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -12,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModSpinIn : ModWithVisibilityAdjustment, IMutateApproachCircles
+    public class OsuModSpinIn : ModWithVisibilityAdjustment, IHidesApproachCircles
     {
         public override string Name => "Spin In";
         public override string Acronym => "SI";
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1;
 
         // todo: this mod should be able to be compatible with hidden with a bit of further implementation.
-        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
 
         private const int rotate_offset = 360;
         private const float rotate_starting_width = 2;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -50,6 +50,10 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                         circle.RotateTo(rotate_offset).Then().RotateTo(0, h.TimePreempt, Easing.InOutSine);
                         circle.ScaleTo(new Vector2(rotate_starting_width, 0)).Then().ScaleTo(1, h.TimePreempt, Easing.InOutSine);
+
+                        // bypass fade in.
+                        if (state == ArmedState.Idle)
+                            circle.FadeIn();
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -21,8 +21,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "Circles spin in. No approach circles.";
         public override double ScoreMultiplier => 1;
 
-        // todo: this mod should be able to be compatible with hidden with a bit of further implementation.
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(IHidesApproachCircles) };
+        // todo: this mod needs to be incompatible with "hidden" due to forcing the circle to remain opaque,
+        // further implementation will be required for supporting that.
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModObjectScaleTween), typeof(OsuModHidden) };
 
         private const int rotate_offset = 360;
         private const float rotate_starting_width = 2;
@@ -49,10 +50,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                         circle.RotateTo(rotate_offset).Then().RotateTo(0, h.TimePreempt, Easing.InOutSine);
                         circle.ScaleTo(new Vector2(rotate_starting_width, 0)).Then().ScaleTo(1, h.TimePreempt, Easing.InOutSine);
-
-                        // bypass fade in.
-                        if (state == ArmedState.Idle)
-                            circle.FadeIn();
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Osu.Skinning.Default;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModTraceable : ModWithVisibilityAdjustment, IMutateApproachCircles
+    public class OsuModTraceable : ModWithVisibilityAdjustment, IRequiresApproachCircles
     {
         public override string Name => "Traceable";
         public override string Acronym => "TC";
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "Put your faith in the approach circles...";
         public override double ScoreMultiplier => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IMutateApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles) };
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {


### PR DESCRIPTION
Resolves #13581 and [the other issue mentioned in it](https://github.com/ppy/osu/issues/13581#issuecomment-866822078).

This breaks down `IMutateApproachCircle` to:
 - `IRequiresApproachCircle`, implemented by Traceable and Approach Different, which require the approach circle for the mod to be effective. 
 - `IHidesApproachCircle`, implemented by Hidden, Spin In, Grow/Deflate, which hide the approach circle.

Both designed to be incompatible with each other, and in turn resolving the issues mentioned in the linked thread (Hidden being incompatible with Grow/Deflate, and Approach Different being incompatible with Traceable).

- Note that in https://github.com/ppy/osu/commit/23e2684b5bc2dda38d5592ea2d62b4e8b2cc7ab7, "Spin In" is still incompatible with other `IHidesApproachCircles` mods as per the TODO comment.