### PR TITLE
Fix multiple tests eating host exceptions

### DIFF
--- a/osu.Game.Tests/ImportTest.cs
+++ b/osu.Game.Tests/ImportTest.cs
@@ -17,7 +17,8 @@ namespace osu.Game.Tests
         protected virtual TestOsuGameBase LoadOsuIntoHost(GameHost host, bool withBeatmap = false)
         {
             var osu = new TestOsuGameBase(withBeatmap);
-            Task.Run(() => host.Run(osu));
+            Task.Run(() => host.Run(osu))
+                .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
 
             waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
 

--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -149,7 +149,8 @@ namespace osu.Game.Tournament.Tests.NonVisual
         private TournamentGameBase loadOsu(GameHost host)
         {
             var osu = new TournamentGameBase();
-            Task.Run(() => host.Run(osu));
+            Task.Run(() => host.Run(osu))
+                .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
             waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
             return osu;
         }

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -55,7 +55,8 @@ namespace osu.Game.Tournament.Tests.NonVisual
         private TournamentGameBase loadOsu(GameHost host)
         {
             var osu = new TournamentGameBase();
-            Task.Run(() => host.Run(osu));
+            Task.Run(() => host.Run(osu))
+                .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
             waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
             return osu;
         }


### PR DESCRIPTION
All of the tests using these executions patterns could potentially be throwing on the input or update thread and still return success.

Have locally tested that this works correctly on a failure, but haven't added a test covering this.