### PR TITLE
Add more logging to help diagnose realm migration failures

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -422,11 +422,15 @@ namespace osu.Game
 
         public void Migrate(string path)
         {
+            Logger.Log($@"Migrating osu! data from ""{Storage.GetFullPath(string.Empty)}"" to ""{path}""...");
+
             using (realmFactory.BlockAllOperations())
             {
                 contextFactory.FlushConnections();
                 (Storage as OsuStorage)?.Migrate(Host.GetStorage(path));
             }
+
+            Logger.Log(@"Migration complete!");
         }
 
         protected override UserInputManager CreateUserInputManager() => new OsuUserInputManager();


### PR DESCRIPTION
When looking into the test failure at https://github.com/ppy/osu/runs/2940065457, it became apparent that we are not showing the migration process anywhere in logs. It's the cause of many issues, and we would want to see this in CI and user logs when occurring.

I'm going to run these tests locally to try and reproduce the failure, but failing that this may help the next time it occurs.