### PR TITLE
Fix gameplay tests incorrectly seeking via MusicController

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void addSeekStep(double time)
         {
-            AddStep($"seek to {time}", () => MusicController.SeekTo(time));
+            AddStep($"seek to {time}", () => Player.GameplayClockContainer.Seek(time));
 
             AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, Player.DrawableRuleset.FrameStableClock.CurrentTime, 100));
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void addSeekStep(double time)
         {
-            AddStep($"seek to {time}", () => MusicController.SeekTo(time));
+            AddStep($"seek to {time}", () => Player.GameplayClockContainer.Seek(time));
 
             AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, Player.DrawableRuleset.FrameStableClock.CurrentTime, 100));
         }


### PR DESCRIPTION
This may fix the intermittent failures of the slider snaking and spinner test scenes.

I'm fairly certain seeking via the `MusicController` is incorrect, as it bypasses the seek of the decoupled clock/gameplay clock, which then seeks backwards on `Player.LoadComplete()` (upon calling `GameplayClockContainer.Reset()`).

Note that this would actually silently fail if `PlayerTestScene` loaded via a `PlayerLoader` instead, as `MusicController.SeekTo()` has a check for beatmap being disabled.