### PR TITLE
Increase number of sent frames to prevent timing issues

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             // Send initial frames for both players. A few more for player 1.
             sendFrames(PLAYER_1_ID, 1000);
-            sendFrames(PLAYER_2_ID, 10);
+            sendFrames(PLAYER_2_ID, 30);
             checkPausedInstant(PLAYER_1_ID, false);
             checkPausedInstant(PLAYER_2_ID, false);
 


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/2951403789. Sending one second worth of frames may be too little if the first step takes a bit to complete.