### PR TITLE
Fix intermittent `PerformFromScreen` test failures due to incorrect screen sequence

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
@@ -11,6 +11,7 @@ using osu.Game.Overlays;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
+using osu.Game.Tests.Beatmaps.IO;
 using osuTK.Input;
 using static osu.Game.Tests.Visual.Navigation.TestSceneScreenNavigation;
 
@@ -57,8 +58,11 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestPerformAtSongSelectFromPlayerLoader()
         {
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).Wait());
             PushAndConfirm(() => new TestPlaySongSelect());
-            PushAndConfirm(() => new PlayerLoader(() => new SoloPlayer()));
+
+            AddStep("Press enter", () => InputManager.Key(Key.Enter));
+            AddUntilStep("Wait for new screen", () => Game.ScreenStack.CurrentScreen is PlayerLoader);
 
             AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true, new[] { typeof(TestPlaySongSelect) }));
             AddUntilStep("returned to song select", () => Game.ScreenStack.CurrentScreen is TestPlaySongSelect);
@@ -68,8 +72,11 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestPerformAtMenuFromPlayerLoader()
         {
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).Wait());
             PushAndConfirm(() => new TestPlaySongSelect());
-            PushAndConfirm(() => new PlayerLoader(() => new SoloPlayer()));
+
+            AddStep("Press enter", () => InputManager.Key(Key.Enter));
+            AddUntilStep("Wait for new screen", () => Game.ScreenStack.CurrentScreen is PlayerLoader);
 
             AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
             AddUntilStep("returned to song select", () => Game.ScreenStack.CurrentScreen is MainMenu);


### PR DESCRIPTION
These tests were manually pushing the `PlayerLoader` / `Player` instances to `SongSelect`, which bypasses safeties in place which avoid the exact issue that came up in https://github.com/ppy/osu/runs/2951759236 (see `AllowSelection` flag specifically).

Test failures can be tested by changing the schedule call at
https://github.com/ppy/osu/blob/7c4a07256827bcbb900691c356165844b4525dee/osu.Game/Screens/Select/BeatmapCarousel.cs#L124
to have a high delay (200 worked well for me).