### PR TITLE
Localise "Scroll to top" button in overlays

### DIFF
--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 
@@ -118,7 +119,7 @@ namespace osu.Game.Overlays
                     }
                 });
 
-                TooltipText = "Scroll to top";
+                TooltipText = CommonStrings.ButtonsBackToTop;
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
Localises the "scroll to top" button in `OverlayScrollContainer`.

![image](https://user-images.githubusercontent.com/20256717/124082991-a88bc000-da4d-11eb-8965-271a13879b44.png)
