### PR TITLE
Localise friends view in dashboard overlay

### DIFF
--- a/osu.Game/Overlays/Changelog/ChangelogUpdateStreamItem.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogUpdateStreamItem.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Humanizer;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osuTK.Graphics;
@@ -17,11 +18,11 @@ namespace osu.Game.Overlays.Changelog
                 Width *= 2;
         }
 
-        protected override string MainText => Value.DisplayName;
+        protected override LocalisableString MainText => Value.DisplayName;
 
-        protected override string AdditionalText => Value.LatestBuild.DisplayVersion;
+        protected override LocalisableString AdditionalText => Value.LatestBuild.DisplayVersion;
 
-        protected override string InfoText => Value.LatestBuild.Users > 0 ? $"{"user".ToQuantity(Value.LatestBuild.Users, "N0")} online" : null;
+        protected override LocalisableString InfoText => Value.LatestBuild.Users > 0 ? $"{"user".ToQuantity(Value.LatestBuild.Users, "N0")} online" : null;
 
         protected override Color4 GetBarColour(OsuColour colours) => Value.Colour;
     }

--- a/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
+++ b/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Dashboard
 {
@@ -13,18 +16,37 @@ namespace osu.Game.Overlays.Dashboard
         {
             public DashboardTitle()
             {
-                Title = "dashboard";
+                Title = HomeStrings.UserTitle;
                 Description = "view your friends and other information";
                 IconTexture = "Icons/Hexacons/social";
             }
         }
     }
 
+    [LocalisableEnum(typeof(DashboardOverlayTabsEnumLocalisationMapper))]
     public enum DashboardOverlayTabs
     {
         Friends,
 
         [Description("Currently Playing")]
         CurrentlyPlaying
+    }
+
+    public class DashboardOverlayTabsEnumLocalisationMapper : EnumLocalisationMapper<DashboardOverlayTabs>
+    {
+        public override LocalisableString Map(DashboardOverlayTabs value)
+        {
+            switch (value)
+            {
+                case DashboardOverlayTabs.Friends:
+                    return FriendsStrings.TitleCompact;                  
+
+                case DashboardOverlayTabs.CurrentlyPlaying:
+                    return @"Currently Playing";
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
+++ b/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Dashboard
             switch (value)
             {
                 case DashboardOverlayTabs.Friends:
-                    return FriendsStrings.TitleCompact;                  
+                    return FriendsStrings.TitleCompact;
 
                 case DashboardOverlayTabs.CurrentlyPlaying:
                     return @"Currently Playing";

--- a/osu.Game/Overlays/Dashboard/Friends/FriendsOnlineStatusItem.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendsOnlineStatusItem.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Extensions;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osuTK.Graphics;
 
@@ -14,9 +16,9 @@ namespace osu.Game.Overlays.Dashboard.Friends
         {
         }
 
-        protected override string MainText => Value.Status.ToString();
+        protected override LocalisableString MainText => Value.Status.GetLocalisableDescription();
 
-        protected override string AdditionalText => Value.Count.ToString();
+        protected override LocalisableString AdditionalText => Value.Count.ToString();
 
         protected override Color4 GetBarColour(OsuColour colours)
         {

--- a/osu.Game/Overlays/Dashboard/Friends/OnlineStatus.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/OnlineStatus.cs
@@ -1,12 +1,38 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
 namespace osu.Game.Overlays.Dashboard.Friends
 {
+    [LocalisableEnum(typeof(OnlineStatusEnumLocalisationMapper))]
     public enum OnlineStatus
     {
         All,
         Online,
         Offline
+    }
+
+    public class OnlineStatusEnumLocalisationMapper : EnumLocalisationMapper<OnlineStatus>
+    {
+        public override LocalisableString Map(OnlineStatus value)
+        {
+            switch (value)
+            {
+                case OnlineStatus.All:
+                    return SortStrings.All;
+
+                case OnlineStatus.Online:
+                    return UsersStrings.StatusOnline;
+
+                case OnlineStatus.Offline:
+                    return UsersStrings.StatusOffline;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/Dashboard/Friends/UserSortTabControl.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/UserSortTabControl.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Dashboard.Friends
 {
@@ -9,11 +12,33 @@ namespace osu.Game.Overlays.Dashboard.Friends
     {
     }
 
+    [LocalisableEnum(typeof(UserSortCriteriaEnumLocalisationMappper))]
     public enum UserSortCriteria
     {
         [Description(@"Recently Active")]
         LastVisit,
         Rank,
         Username
+    }
+
+    public class UserSortCriteriaEnumLocalisationMappper : EnumLocalisationMapper<UserSortCriteria>
+    {
+        public override LocalisableString Map(UserSortCriteria value)
+        {
+            switch (value)
+            {
+                case UserSortCriteria.LastVisit:
+                    return SortStrings.LastVisit;
+
+                case UserSortCriteria.Rank:
+                    return SortStrings.Rank;
+
+                case UserSortCriteria.Username:
+                    return SortStrings.Username;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/OverlayPanelDisplayStyleControl.cs
+++ b/osu.Game/Overlays/OverlayPanelDisplayStyleControl.cs
@@ -12,6 +12,9 @@ using osu.Framework.Allocation;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
+using System;
+using osu.Game.Resources.Localisation.Web;
+using osu.Framework.Extensions;
 
 namespace osu.Game.Overlays
 {
@@ -57,7 +60,7 @@ namespace osu.Game.Overlays
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; }
 
-            public LocalisableString TooltipText => $@"{Value} view";
+            public LocalisableString TooltipText => Value.GetLocalisableDescription();
 
             private readonly SpriteIcon icon;
 
@@ -98,10 +101,32 @@ namespace osu.Game.Overlays
         }
     }
 
+    [LocalisableEnum(typeof(OverlayPanelDisplayStyleEnumLocalisationMapper))]
     public enum OverlayPanelDisplayStyle
     {
         Card,
         List,
         Brick
+    }
+
+    public class OverlayPanelDisplayStyleEnumLocalisationMapper : EnumLocalisationMapper<OverlayPanelDisplayStyle>
+    {
+        public override LocalisableString Map(OverlayPanelDisplayStyle value)
+        {
+            switch (value)
+            {
+                case OverlayPanelDisplayStyle.Card:
+                    return UsersStrings.ViewModeCard;
+
+                case OverlayPanelDisplayStyle.List:
+                    return UsersStrings.ViewModeList;
+
+                case OverlayPanelDisplayStyle.Brick:
+                    return UsersStrings.ViewModeBrick;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/OverlayStreamItem.cs
+++ b/osu.Game/Overlays/OverlayStreamItem.cs
@@ -12,6 +12,7 @@ using osu.Framework.Allocation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics;
 using osuTK.Graphics;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays
 {
@@ -88,11 +89,11 @@ namespace osu.Game.Overlays
             SelectedItem.BindValueChanged(_ => updateState(), true);
         }
 
-        protected abstract string MainText { get; }
+        protected abstract LocalisableString MainText { get; }
 
-        protected abstract string AdditionalText { get; }
+        protected abstract LocalisableString AdditionalText { get; }
 
-        protected virtual string InfoText => string.Empty;
+        protected virtual LocalisableString InfoText => string.Empty;
 
         protected abstract Color4 GetBarColour(OsuColour colours);
 


### PR DESCRIPTION
Here's a first pass at localising the dashboard overlay; this localises the friends view of the dashboard. I intentionally left out a few strings out of localisation as these are lazer-specific strings and this PR mostly touches components that have web translations , so I'll get to localise them in a next PR. 

![Annotation 2021-07-01 091543](https://user-images.githubusercontent.com/20256717/124085370-3ff21280-da50-11eb-9166-d2024719c1a4.png)


Also note that user panels aren't localised yet as they require  support for localising humanizer strings and localisation of `TextFlowContainer`s so this will come along later as well.

---

As a sidenote, I realized that there isn't any issue tracking localisation progress of the web-herited overlays so I guess it may be nice to open one so that people potentially interested in localising lazer can know what web-herited overlay components are left to localize. 


https://user-images.githubusercontent.com/191335/124296936-7be2c000-db95-11eb-9641-eb32026fa87b.mp4

