### PR TITLE
Update SR colours to match osu-web

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -32,10 +32,10 @@ namespace osu.Game.Graphics
                     return Pink;
 
                 case DifficultyRating.Expert:
-                    return useLighterColour ? PurpleLight : Purple;
+                    return PurpleLight;
 
                 case DifficultyRating.ExpertPlus:
-                    return useLighterColour ? Gray9 : Gray0;
+                    return useLighterColour ? Gray9 : Color4Extensions.FromHex("#121415");
             }
         }
 

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -4,9 +4,7 @@
 using System.Globalization;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
@@ -111,12 +109,9 @@ namespace osu.Game.Screens.Ranking.Expanded
 
             var rating = Current.Value.DifficultyRating;
 
-            background.Colour = rating == DifficultyRating.ExpertPlus
-                ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
-                : (ColourInfo)colours.ForDifficultyRating(rating);
+            background.Colour = colours.ForDifficultyRating(rating, true);
 
             textFlow.Clear();
-
             textFlow.AddText($"{wholePart}", s =>
             {
                 s.Colour = Color4.Black;


### PR DESCRIPTION
Just unifying these colours, because in particular both osu!web and the new osu!lazer designs use a flat colour for expert-plus difficulty.

Another difference is the removal of the darker purple colour. This also matches osu!web and I don't think it's a huge difference:

Before:
![before](https://user-images.githubusercontent.com/1329837/124116779-4a40fa80-daaa-11eb-9c06-57f23661653a.png)
After:
![after](https://user-images.githubusercontent.com/1329837/124116807-562cbc80-daaa-11eb-911a-be13b5c863c2.png)