### PR TITLE
Add star rating range display 

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Components;
+using osu.Game.Tests.Visual.OnlinePlay;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    public class TestSceneStarRatingRangeDisplay : OnlinePlayTestScene
+    {
+        [SetUp]
+        public new void Setup() => Schedule(() =>
+        {
+            SelectedRoom.Value = new Room();
+
+            Child = new StarRatingRangeDisplay
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            };
+        });
+
+        [Test]
+        public void TestRange([Values(0, 2, 3, 4, 6, 7)] double min, [Values(0, 2, 3, 4, 6, 7)] double max)
+        {
+            AddStep("set playlist", () =>
+            {
+                SelectedRoom.Value.Playlist.AddRange(new[]
+                {
+                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarDifficulty = min } } },
+                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarDifficulty = max } } },
+                });
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Specialized;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Screens.Ranking.Expanded;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Components
+{
+    public class StarRatingRangeDisplay : OnlinePlayComposite
+    {
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        private StarRatingDisplay minDisplay;
+        private Drawable minBackground;
+        private StarRatingDisplay maxDisplay;
+        private Drawable maxBackground;
+
+        public StarRatingRangeDisplay()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 1,
+                    Children = new[]
+                    {
+                        minBackground = new Box
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(0.5f),
+                        },
+                        maxBackground = new Box
+                        {
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(0.5f),
+                        },
+                    }
+                },
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        minDisplay = new StarRatingDisplay(default),
+                        maxDisplay = new StarRatingDisplay(default)
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Playlist.BindCollectionChanged(updateRange, true);
+        }
+
+        private void updateRange(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            var orderedDifficulties = Playlist.Select(p => p.Beatmap.Value).OrderBy(b => b.StarDifficulty).ToArray();
+
+            StarDifficulty minDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[0].StarDifficulty : 0, 0);
+            StarDifficulty maxDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[^1].StarDifficulty : 0, 0);
+
+            minDisplay.Current.Value = minDifficulty;
+            maxDisplay.Current.Value = maxDifficulty;
+
+            minBackground.Colour = colours.ForDifficultyRating(minDifficulty.DifficultyRating, true);
+            maxBackground.Colour = colours.ForDifficultyRating(maxDifficulty.DifficultyRating, true);
+        }
+    }
+}


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/13724

Will eventually be used in various multiplayer screens to display the SR range of the room. Uses the existing `StarRatingDisplay` component, so the design is slightly different. We'll have to update that component too to follow the latest osu!web design.

Design:
![image](https://user-images.githubusercontent.com/1329837/124118372-38605700-daac-11eb-892b-94d90d1685ff.png)

This PR:
![image](https://user-images.githubusercontent.com/1329837/124118341-2ed6ef00-daac-11eb-8145-b2d0eb399d75.png)