### PR TITLE
Make flipping in the skin editor reflect across the axes of the selection box

### DIFF
--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -127,6 +127,7 @@ namespace osu.Game.Skinning.Editor
         public override bool HandleFlip(Direction direction)
         {
             var selectionQuad = getSelectionQuad();
+            Vector2 scaleFactor = direction == Direction.Horizontal ? new Vector2(-1, 1) : new Vector2(1, -1);
 
             foreach (var b in SelectedBlueprints)
             {
@@ -136,10 +137,8 @@ namespace osu.Game.Skinning.Editor
 
                 updateDrawablePosition(drawableItem, flippedPosition);
 
-                drawableItem.Scale *= new Vector2(
-                    direction == Direction.Horizontal ? -1 : 1,
-                    direction == Direction.Vertical ? -1 : 1
-                );
+                drawableItem.Scale *= scaleFactor;
+                drawableItem.Rotation -= drawableItem.Rotation % 180 * 2;
             }
 
             return true;


### PR DESCRIPTION
Closes #13507.

Flipping in the skin editor will now reflect items across the x-axis of the selection box in the case of a vertical flip and across the y-axis in the case of a horizontal flip.

Example of behavior with changes:
https://user-images.githubusercontent.com/55509723/124198327-43ec5780-da85-11eb-97ca-c9d1cd5c256f.mp4



