### PR TITLE
Fix some incorrectly invoked `async` calls

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -116,7 +116,7 @@ namespace osu.Desktop.Updater
                 if (scheduleRecheck)
                 {
                     // check again in 30 minutes.
-                    Scheduler.AddDelayed(async () => await checkForUpdateAsync().ConfigureAwait(false), 60000 * 30);
+                    Scheduler.AddDelayed(() => Task.Run(async () => await checkForUpdateAsync().ConfigureAwait(false)), 60000 * 30);
                 }
             }
 
@@ -141,7 +141,7 @@ namespace osu.Desktop.Updater
                 Activated = () =>
                 {
                     updateManager.PrepareUpdateAsync()
-                                 .ContinueWith(_ => updateManager.Schedule(() => game.GracefullyExit()));
+                                 .ContinueWith(_ => updateManager.Schedule(() => game?.GracefullyExit()));
                     return true;
                 };
             }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -66,19 +66,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(200, 50),
-                OnReadyClick = () => Task.Run(async () =>
+                OnReadyClick = () =>
                 {
                     readyClickOperation = OngoingOperationTracker.BeginOperation();
 
-                    if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                    Task.Run(async () =>
                     {
-                        await Client.StartMatch();
-                        return;
-                    }
+                        if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                        {
+                            await Client.StartMatch();
+                            return;
+                        }
 
-                    await Client.ToggleReady();
-                    readyClickOperation.Dispose();
-                })
+                        await Client.ToggleReady();
+
+                        readyClickOperation.Dispose();
+                    });
+                }
             });
         });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -65,7 +66,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(200, 50),
-                OnReadyClick = async () =>
+                OnReadyClick = () => Task.Run(async () =>
                 {
                     readyClickOperation = OngoingOperationTracker.BeginOperation();
 
@@ -77,7 +78,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                     await Client.ToggleReady();
                     readyClickOperation.Dispose();
-                }
+                })
             });
         });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -70,31 +70,39 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(200, 50),
-                        OnSpectateClick = () => Task.Run(async () =>
+                        OnSpectateClick = () =>
                         {
                             readyClickOperation = OngoingOperationTracker.BeginOperation();
-                            await Client.ToggleSpectate();
-                            readyClickOperation.Dispose();
-                        })
+
+                            Task.Run(async () =>
+                            {
+                                await Client.ToggleSpectate();
+                                readyClickOperation.Dispose();
+                            });
+                        }
                     },
                     readyButton = new MultiplayerReadyButton
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(200, 50),
-                        OnReadyClick = () => Task.Run(async () =>
+                        OnReadyClick = () =>
                         {
                             readyClickOperation = OngoingOperationTracker.BeginOperation();
 
-                            if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                            Task.Run(async () =>
                             {
-                                await Client.StartMatch();
-                                return;
-                            }
+                                if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                                {
+                                    await Client.StartMatch();
+                                    return;
+                                }
 
-                            await Client.ToggleReady();
-                            readyClickOperation.Dispose();
-                        })
+                                await Client.ToggleReady();
+
+                                readyClickOperation.Dispose();
+                            });
+                        }
                     }
                 }
             };

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -69,19 +70,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(200, 50),
-                        OnSpectateClick = async () =>
+                        OnSpectateClick = () => Task.Run(async () =>
                         {
                             readyClickOperation = OngoingOperationTracker.BeginOperation();
                             await Client.ToggleSpectate();
                             readyClickOperation.Dispose();
-                        }
+                        })
                     },
                     readyButton = new MultiplayerReadyButton
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(200, 50),
-                        OnReadyClick = async () =>
+                        OnReadyClick = () => Task.Run(async () =>
                         {
                             readyClickOperation = OngoingOperationTracker.BeginOperation();
 
@@ -93,7 +94,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                             await Client.ToggleReady();
                             readyClickOperation.Dispose();
-                        }
+                        })
                     }
                 }
             };

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -491,6 +491,10 @@ namespace osu.Game
         public override Task Import(params ImportTask[] imports)
         {
             // encapsulate task as we don't want to begin the import process until in a ready state.
+
+            // ReSharper disable once AsyncVoidLambda
+            // TODO: This is bad because `new Task` doesn't have a Func<Task?> override.
+            // Only used for android imports and a bit of a mess. Probably needs rethinking overall.
             var importTask = new Task(async () => await base.Import(imports).ConfigureAwait(false));
 
             waitForReady(() => this, _ => importTask.Start());


### PR DESCRIPTION
This is a new inspection introduced in one of the recent r# EAPs, which addresses a best practice of not throwing away the `Task` return of an `async` marked function.

Of note, using `Task.Run` in these cases uses a `Func<Task?>` override which correctly proxies the inner task.
