### PR TITLE
Fix playlist item displays empty string if no unicode title is present

### DIFF
--- a/osu.Game.Tests/Localisation/BeatmapMetadataRomanisationTest.cs
+++ b/osu.Game.Tests/Localisation/BeatmapMetadataRomanisationTest.cs
@@ -10,20 +10,30 @@ namespace osu.Game.Tests.Localisation
     public class BeatmapMetadataRomanisationTest
     {
         [Test]
-        public void TestNoUnicode()
+        public void TestRomanisation()
         {
-            var beatmap = new Beatmap
+            var metadata = new BeatmapMetadata
             {
-                BeatmapInfo = new BeatmapInfo
-                {
-                    Metadata = new BeatmapMetadata
-                    {
-                        Artist = "Artist",
-                        Title = "Romanised title"
-                    }
-                }
+                Artist = "Romanised Artist",
+                ArtistUnicode = "Unicode Artist",
+                Title = "Romanised title",
+                TitleUnicode = "Unicode Title"
             };
-            var romanisableString = beatmap.Metadata.ToRomanisableString();
+            var romanisableString = metadata.ToRomanisableString();
+
+            Assert.AreEqual(metadata.ToString(), romanisableString.Romanised);
+            Assert.AreEqual($"{metadata.ArtistUnicode} - {metadata.TitleUnicode}", romanisableString.Original);
+        }
+
+        [Test]
+        public void TestRomanisationNoUnicode()
+        {
+            var metadata = new BeatmapMetadata
+            {
+                Artist = "Romanised Artist",
+                Title = "Romanised title"
+            };
+            var romanisableString = metadata.ToRomanisableString();
 
             Assert.AreEqual(romanisableString.Romanised, romanisableString.Original);
         }

--- a/osu.Game.Tests/Localisation/BeatmapMetadataRomanisationTest.cs
+++ b/osu.Game.Tests/Localisation/BeatmapMetadataRomanisationTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Tests.Localisation
+{
+    [TestFixture]
+    public class BeatmapMetadataRomanisationTest
+    {
+        [Test]
+        public void TestNoUnicode()
+        {
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Metadata = new BeatmapMetadata
+                    {
+                        Artist = "Artist",
+                        Title = "Romanised title"
+                    }
+                }
+            };
+            var romanisableString = beatmap.Metadata.ToRomanisableString();
+
+            Assert.AreEqual(romanisableString.Romanised, romanisableString.Original);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -94,7 +94,10 @@ namespace osu.Game.Beatmaps
         public RomanisableString ToRomanisableString()
         {
             string author = Author == null ? string.Empty : $"({Author})";
-            return new RomanisableString($"{ArtistUnicode} - {TitleUnicode} {author}".Trim(), $"{Artist} - {Title} {author}".Trim());
+            var artistUnicode = string.IsNullOrEmpty(ArtistUnicode) ? Artist : ArtistUnicode;
+            var titleUnicode = string.IsNullOrEmpty(TitleUnicode) ? Title : TitleUnicode;
+
+            return new RomanisableString($"{artistUnicode} - {titleUnicode} {author}".Trim(), $"{Artist} - {Title} {author}".Trim());
         }
 
         [JsonIgnore]


### PR DESCRIPTION
Fixes this stupid mistake regressed in #12464:
![动画](https://user-images.githubusercontent.com/50285552/124350975-4805aa00-dc2a-11eb-99f4-0ccf162912f3.gif)

