### PR TITLE
Fix incorrect `base` call causing import optimisation to not work

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -324,7 +324,7 @@ namespace osu.Game.Beatmaps
 
         protected override bool CanSkipImport(BeatmapSetInfo existing, BeatmapSetInfo import)
         {
-            if (!base.CanReuseExisting(existing, import))
+            if (!base.CanSkipImport(existing, import))
                 return false;
 
             return existing.Beatmaps.Any(b => b.OnlineBeatmapID != null);

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -353,8 +353,6 @@ namespace osu.Game.Database
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            delayEvents();
-
             bool checkedExisting = false;
             TModel existing = null;
 
@@ -393,6 +391,8 @@ namespace osu.Game.Database
                     Files.Dereference(item.Files.Select(f => f.FileInfo).ToArray());
                 }
             }
+
+            delayEvents();
 
             try
             {


### PR DESCRIPTION
Open to suggestions on how to test this. The current import tests use a full game setup so it's hard to tell the different between an "optimised" reuse and a standard one. I've tested this on a real-world scenario and it's working as expected now, at least.