### PR TITLE
Remove some mentions of "lazer"

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -5,8 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>A free-to-win rhythm game. Rhythm is just a *click* away!</Description>
     <AssemblyName>osu!</AssemblyName>
-    <Title>osu!lazer</Title>
-    <Product>osu!lazer</Product>
+    <Title>osu!</Title>
+    <Product>osu!</Product>
     <ApplicationIcon>lazer.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Version>0.0.0</Version>

--- a/osu.Desktop/osu.nuspec
+++ b/osu.Desktop/osu.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>osulazer</id>
         <version>0.0.0</version>
-        <title>osu!lazer</title>
+        <title>osu!</title>
         <authors>ppy Pty Ltd</authors>
         <owners>Dean Herbert</owners>
         <projectUrl>https://osu.ppy.sh/</projectUrl>
@@ -20,4 +20,3 @@
       <file src="**.config" target="lib\net45\"/>
     </files>
 </package>
-

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         /// <remarks>
         /// All constants are in osu!stable's gamefield space, which is shifted 16px downwards.
-        /// This offset is negated in both osu!stable and osu!lazer to bring all constants into window-space.
+        /// This offset is negated to bring all constants into window-space.
         /// Note: SPINNER_Y_CENTRE + SPINNER_TOP_OFFSET - Position.Y = 240 (=480/2, or half the window-space in osu!stable)
         /// </remarks>
         protected const float SPINNER_TOP_OFFSET = 45f - 16f;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Version = "All Metrics",
                 Metadata = new BeatmapMetadata
                 {
-                    Source = "osu!lazer",
+                    Source = "osu!",
                     Tags = "this beatmap has all the metrics",
                 },
                 BaseDifficulty = new BeatmapDifficulty
@@ -100,7 +100,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Version = "Only Ratings",
                 Metadata = new BeatmapMetadata
                 {
-                    Source = "osu!lazer",
+                    Source = "osu!",
                     Tags = "this beatmap has ratings metrics but not retries or fails",
                 },
                 BaseDifficulty = new BeatmapDifficulty
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Version = "Only Retries and Fails",
                 Metadata = new BeatmapMetadata
                 {
-                    Source = "osu!lazer",
+                    Source = "osu!",
                     Tags = "this beatmap has retries and fails but no ratings",
                 },
                 BaseDifficulty = new BeatmapDifficulty
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Version = "No Metrics",
                 Metadata = new BeatmapMetadata
                 {
-                    Source = "osu!lazer",
+                    Source = "osu!",
                     Tags = "this beatmap has no metrics",
                 },
                 BaseDifficulty = new BeatmapDifficulty

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -80,7 +80,7 @@ namespace osu.Game
                     return @"local " + (DebugUtils.IsDebugBuild ? @"debug" : @"release");
 
                 var version = AssemblyVersion;
-                return $@"{version.Major}.{version.Minor}.{version.Build}";
+                return $@"{version.Major}.{version.Minor}.{version.Build}-lazer";
             }
         }
 
@@ -162,7 +162,7 @@ namespace osu.Game
         public OsuGameBase()
         {
             UseDevelopmentServer = DebugUtils.IsDebugBuild;
-            Name = @"osu!lazer";
+            Name = @"osu!";
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Scoring
                 }
                 else
                 {
-                    // This score is guaranteed to be an osu!lazer score.
+                    // This is guaranteed to be a non-legacy score.
                     // The combo must be determined through the score's statistics, as both the beatmap's max combo and the difficulty calculator will provide osu!stable combo values.
                     beatmapMaxCombo = Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r.AffectsCombo()).Select(r => score.Statistics.GetOrDefault(r)).Sum();
                 }

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -230,7 +230,7 @@ namespace osu.Game.Screens.Menu
                 "New features are coming online every update. Make sure to stay up-to-date!",
                 "If you find the UI too large or small, try adjusting UI scale in settings!",
                 "Try adjusting the \"Screen Scaling\" mode to change your gameplay or UI area, even in fullscreen!",
-                "For now, what used to be \"osu!direct\" is available to all users on lazer. You can access it anywhere using Ctrl-D!",
+                "What used to be \"osu!direct\" is available to all users just like on the website. You can access it anywhere using Ctrl-D!",
                 "Seeking in replays is available by dragging on the difficulty bar at the bottom of the screen!",
                 "Multithreading support means that even with low \"FPS\" your input and judgements will be accurate!",
                 "Try scrolling down in the mod select panel to find a bunch of new fun mods!",

--- a/osu.Game/Skinning/LegacyColourCompatibility.cs
+++ b/osu.Game/Skinning/LegacyColourCompatibility.cs
@@ -7,7 +7,7 @@ using osuTK.Graphics;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Compatibility methods to convert osu!stable colours to osu!lazer-compatible ones. Should be used for legacy skins only.
+    /// Compatibility methods to apply osu!stable quirks to colours. Should be used for legacy skins only.
     /// </summary>
     public static class LegacyColourCompatibility
     {

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Skinning
         public static SkinInfo Default { get; } = new SkinInfo
         {
             ID = DEFAULT_SKIN,
-            Name = "osu!lazer",
+            Name = "osu! (triangles)",
             Creator = "team osu!",
             InstantiationInfo = typeof(DefaultSkin).GetInvariantInstantiationInfo()
         };

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Updater
             public UpdateCompleteNotification(string version)
             {
                 this.version = version;
-                Text = $"You are now running osu!lazer {version}.\nClick to see what's new!";
+                Text = $"You are now running osu! {version}.\nClick to see what's new!";
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
I am aware there are more throughout the codebase but intentionally left the remaining mentioned for one reason or another. The intention here is to mainly change user-facing versioning to change the positioning of the "lazer" term (to be where we would expect "cuttingedge" or "beta" to be).