### PR TITLE
Don't attempt to submit score when nothing has been hit

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -9,6 +9,8 @@ using osu.Game.Online.Rooms;
 using osu.Game.Online.Solo;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Ranking;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -52,6 +54,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
 
             AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+
+            addFakeHit();
+
             AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
@@ -72,6 +77,21 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestNoSubmissionOnEmptyFail()
+        {
+            prepareTokenResponse(true);
+
+            CreateTest(() => allowFail = true);
+
+            AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddStep("exit", () => Player.Exit());
+
+            AddAssert("ensure no submission", () => Player.SubmittedScore == null);
+        }
+
+        [Test]
         public void TestSubmissionOnFail()
         {
             prepareTokenResponse(true);
@@ -79,10 +99,26 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest(() => allowFail = true);
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            addFakeHit();
+
             AddUntilStep("wait for fail", () => Player.HasFailed);
             AddStep("exit", () => Player.Exit());
 
             AddAssert("ensure failing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == false);
+        }
+
+        [Test]
+        public void TestNoSubmissionOnEmptyExit()
+        {
+            prepareTokenResponse(true);
+
+            CreateTest(() => allowFail = false);
+
+            AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            AddStep("exit", () => Player.Exit());
+            AddAssert("ensure no submission", () => Player.SubmittedScore == null);
         }
 
         [Test]
@@ -93,8 +129,25 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest(() => allowFail = false);
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            addFakeHit();
+
             AddStep("exit", () => Player.Exit());
             AddAssert("ensure failing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == false);
+        }
+
+        private void addFakeHit()
+        {
+            AddUntilStep("wait for first result", () => Player.Results.Count > 0);
+
+            AddStep("force successfuly hit", () =>
+            {
+                Player.ScoreProcessor.RevertResult(Player.Results.First());
+                Player.ScoreProcessor.ApplyResult(new OsuJudgementResult(Beatmap.Value.Beatmap.HitObjects.First(), new OsuJudgement())
+                {
+                    Type = HitResult.Great,
+                });
+            });
         }
 
         private void prepareTokenResponse(bool validToken)

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
 
             AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+
+            addFakeHit();
+
             AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
@@ -71,6 +74,10 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest(() => allowFail = false);
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+
+            addFakeHit();
 
             AddStep("exit", () => Player.Exit());
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play
@@ -143,6 +144,10 @@ namespace osu.Game.Screens.Play
 
             if (scoreSubmissionSource != null)
                 return scoreSubmissionSource.Task;
+
+            // if the user never hit anything, this score should not be counted in any way.
+            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit()))
+                return Task.CompletedTask;
 
             scoreSubmissionSource = new TaskCompletionSource<bool>();
             var request = CreateSubmissionRequest(score, token.Value);

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Screens.Play
                 return scoreSubmissionSource.Task;
 
             // if the user never hit anything, this score should not be counted in any way.
-            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit()))
+            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0))
                 return Task.CompletedTask;
 
             scoreSubmissionSource = new TaskCompletionSource<bool>();


### PR DESCRIPTION
This is already guarded against web-side, but as the client was still submitting such scores would throw an error (ie. when retrying before a beatmap has started):

```csharp
2021-07-03 13:40:48 [verbose]: Request to https://osu.ppy.sh/api/v2/beatmaps/339640/solo/scores/5249156 failed with System.Net.WebException: UnprocessableEntity.
2021-07-03 13:40:48 [verbose]: Response was: {"error":"field cannot be empty: 'statistics'"}
2021-07-03 13:40:48 [verbose]: Failing request osu.Game.Online.Solo.SubmitSoloScoreRequest (osu.Game.Online.API.APIException: field cannot be empty: 'statistics'
2021-07-03 13:40:48 [verbose]: ---> System.Net.WebException: UnprocessableEntity
2021-07-03 13:40:48 [verbose]: --- End of inner exception stack trace ---)
```