### PR TITLE
Fix thread safety of realm `Refresh` operation

### DIFF
--- a/osu.Game/Database/IRealmFactory.cs
+++ b/osu.Game/Database/IRealmFactory.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Database
     {
         /// <summary>
         /// The main realm context, bound to the update thread.
+        /// If querying from a non-update thread is needed, use <see cref="GetForRead"/> or <see cref="GetForWrite"/> to receive a context instead.
         /// </summary>
         Realm Context { get; }
 

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Database
             get
             {
                 if (!ThreadSafety.IsUpdateThread)
-                    throw new InvalidOperationException($"Use {nameof(GetForRead)} when performing realm operations from a non-update thread");
+                    throw new InvalidOperationException($"Use {nameof(GetForRead)} or {nameof(GetForWrite)} when performing realm operations from a non-update thread");
 
                 lock (updateContextLock)
                 {

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Development;
@@ -166,11 +167,15 @@ namespace osu.Game.Database
         private void flushContexts()
         {
             Logger.Log(@"Flushing realm contexts...", LoggingTarget.Database);
+            Debug.Assert(blockingLock.CurrentCount == 0);
 
-            var previousContext = context;
+            Realm previousContext;
 
             lock (updateContextLock)
+            {
+                previousContext = context;
                 context = null;
+            }
 
             // wait for all threaded usages to finish
             while (active_usages.Value > 0)


### PR DESCRIPTION
Due to the lack of locking, there was a chance the the update thread `context` was retrieved just before the `flushContexts` call, followed by `.Refresh()` being run while the blocking behaviour was invoked.

This can be seen in test failures such as https://ci.appveyor.com/project/peppy/osu/builds/39859786/tests.

As an aside, I tried multiple different methods to avoid `lock()` on the update thread but they felt flaky. The overhead of lock when there's no contention is reportedly around 30-50ns, so likely not of concern. We can address it at a later point if it becomes one.