### PR TITLE
Disable foreign key enforcing at an sqlite level

### DIFF
--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -77,6 +77,9 @@ namespace osu.Game.Database
                 {
                     cmd.CommandText = "PRAGMA journal_mode=WAL;";
                     cmd.ExecuteNonQuery();
+
+                    cmd.CommandText = "PRAGMA foreign_keys=OFF;";
+                    cmd.ExecuteNonQuery();
                 }
             }
             catch


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/13773#issuecomment-873737717.

This may be seen as fixing the problem with fire, and probably is to an extent.

While sqlite *does* support foreign keys seemingly to a decent level, there's a few reasons we probably don't want this:

- We're already doing our own cascade deletion logic (see `AddIncludesForDeletion` and `OsuGameBase`'s special cross-store handling). Maybe not what we want going forward, but is what it is, and does an amicable job of cleaning up. I have tested this with FK disabled.
- The automatic migrations generated by EFcore are haphazardly either `cascade` or `restrict` for foreign key constraints. We don't really support or rely on either of these behaviours, so rather than converting the `restrict` cases (that are causing these exceptions) to instead be `cascade` I think it makes more sense just to disable.
- When we get to refactoring the storage, this whole thing will need to be re-thought anyway. This stops the random startup issues that users are having.
- Foreign key enforcement in sqlite is not guaranteed. For instance, I was testing this with rider's built-in database tools and even when attempting to explicitly set foreign key support on, I couldn't reproduce the errors (likely because the driver version bundled with rider doesn't support them at all). So they aren't offering much by means of "protecting against external database changes" because a user could just disable them (or not enable them in the first place) before manually breaking their database. See https://sqlite.org/foreignkeys.html for details about manual enabling etc.

I've manually tested cases of deletion and import and this doesn't look to regress any behaviour (ie. rows are gone from the database when we expect them to be).