### PR TITLE
Make osu! auto generator interpolate during key-up frames

### DIFF
--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Rulesets.Osu.Replays
 
                 Vector2 lastPosition = lastFrame.Position;
 
-                // Perform eased movement.
+                // Perform the rest of the eased movement until the target position is reached.
                 for (double time = lastFrame.Time + GetFrameDelay(lastFrame.Time); time < h.StartTime; time += GetFrameDelay(time))
                 {
                     Vector2 currentPosition = Interpolation.ValueAt(time, lastPosition, targetPos, lastFrame.Time, h.StartTime, easing);

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -266,8 +266,8 @@ namespace osu.Game.Rulesets.Osu.Replays
                 }
             }
 
-            // Start alternating once the time separation is too small (equivalent 120BPM @ 1/4 divisor).
-            if (timeDifference > 0 && timeDifference < 125)
+            // Start alternating once the time separation is too small (faster than ~225BPM).
+            if (timeDifference > 0 && timeDifference < 266)
                 buttonIndex++;
             else
                 buttonIndex = 0;

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -248,8 +248,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             if (timeDifference > 0)
             {
                 // If the last frame is a key-up frame and there has been no wait period, adjust the last frame's position such that it begins eased movement instantaneously.
-                if (lastLastFrame != null && lastFrame is OsuKeyUpReplayFrame && !hasWaited
-                    && lastFrame.Time > lastLastFrame.Time) //
+                if (lastLastFrame != null && lastFrame is OsuKeyUpReplayFrame && !hasWaited)
                 {
                     // [lastLastFrame] ... [lastFrame] ... [current frame]
                     // We want to find the cursor position at lastFrame, so interpolate between lastLastFrame and the new target position.

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -240,40 +240,33 @@ namespace osu.Game.Rulesets.Osu.Replays
                 AddFrameToReplay(lastFrame);
             }
 
-            Vector2 lastPosition = lastFrame.Position;
-
             double timeDifference = ApplyModsToTimeDelta(lastFrame.Time, h.StartTime);
 
-            // Only "snap" to hitcircles if they are far enough apart. As the time between hitcircles gets shorter the snapping threshold goes up.
-            if (timeDifference > 0 && // Sanity checks
-                ((lastPosition - targetPos).Length > h.Radius * (1.5 + 100.0 / timeDifference) || // Either the distance is big enough
-                 timeDifference >= 266)) // ... or the beats are slow enough to tap anyway.
+            OsuReplayFrame lastLastFrame = Frames.Count >= 2 ? (OsuReplayFrame)Frames[^2] : null;
+
+            // The last frame may be a key-up frame if it shares a position with the second-last frame.
+            // If it is a key-up frame and its time occurs after the "wait time" (i.e. there was no wait period), adjust its position to begin eased movement instantaneously.
+            if (lastLastFrame?.Position == lastFrame.Position && lastFrame.Time >= waitTime)
             {
-                OsuReplayFrame lastLastFrame = Frames.Count >= 2 ? (OsuReplayFrame)Frames[^2] : null;
-
-                // The last frame may be a key-up frame if it shares a position with the second-last frame.
-                // If it is a key-up frame and its time occurs after the "wait time" (i.e. there was no wait period), adjust its position to begin eased movement instantaneously.
-                if (lastLastFrame?.Position == lastFrame.Position && lastFrame.Time >= waitTime)
-                {
-                    // [lastLastFrame] ... [lastFrame] ... [current frame]
-                    // We want to find the cursor position at lastFrame, so interpolate between lastLastFrame and the new target position.
-                    lastFrame.Position = Interpolation.ValueAt(lastFrame.Time, lastFrame.Position, targetPos, lastLastFrame.Time, h.StartTime, easing);
-                    lastPosition = lastFrame.Position;
-                }
-
-                // Perform eased movement
-                for (double time = lastFrame.Time + GetFrameDelay(lastFrame.Time); time < h.StartTime; time += GetFrameDelay(time))
-                {
-                    Vector2 currentPosition = Interpolation.ValueAt(time, lastPosition, targetPos, lastFrame.Time, h.StartTime, easing);
-                    AddFrameToReplay(new OsuReplayFrame((int)time, new Vector2(currentPosition.X, currentPosition.Y)) { Actions = lastFrame.Actions });
-                }
-
-                buttonIndex = 0;
+                // [lastLastFrame] ... [lastFrame] ... [current frame]
+                // We want to find the cursor position at lastFrame, so interpolate between lastLastFrame and the new target position.
+                lastFrame.Position = Interpolation.ValueAt(lastFrame.Time, lastFrame.Position, targetPos, lastLastFrame.Time, h.StartTime, easing);
             }
-            else
+
+            Vector2 lastPosition = lastFrame.Position;
+
+            // Perform eased movement.
+            for (double time = lastFrame.Time + GetFrameDelay(lastFrame.Time); time < h.StartTime; time += GetFrameDelay(time))
             {
+                Vector2 currentPosition = Interpolation.ValueAt(time, lastPosition, targetPos, lastFrame.Time, h.StartTime, easing);
+                AddFrameToReplay(new OsuReplayFrame((int)time, new Vector2(currentPosition.X, currentPosition.Y)) { Actions = lastFrame.Actions });
+            }
+
+            // Start alternating once the time separation is too small (equivalent 120BPM @ 1/4 divisor).
+            if (timeDifference > 0 && timeDifference < 125)
                 buttonIndex++;
-            }
+            else
+                buttonIndex = 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/13635
Resolves #9341

The process in the above PR is to keep the key-up frames in an "adjustment" set which it then adjusted the positions of in the next movement sequence. The way it did this is very cryptic and hard to understand, so I took it from the basics understanding this one concept.
I've also noticed that the above PR caused some very bad lag, because it's effectively O(n^2) in removing frames from its "adjustment" set.

This PR works similarly - when moving to the next hitobject, if there has been no "wait time" (i.e. auto must have "seen" the hitobjects), interpolate the position for the last key-up frame.

A few additional changes in this PR:
* Always performs movement easing. The concept of "snapping" doesn't exist anymore, but it still looks very snappy when required.
* Alternating is tied to BPM rather than distance (players don't switch tap vs alt solely based on distance).
* Everything is done in the one `moveToHitObject()` method, unlike the above PR.

Comparisons:
**Tramontane** (https://osu.ppy.sh/beatmapsets/1016398#osu/2127254)
- Master: https://drive.google.com/file/d/18PZKcxWPBDdSHWyHWyQSZHq53KVb1f1E/view?usp=sharing
- Above PR: https://drive.google.com/file/d/1cQw1UWWI5XjxCuN0T1U5PxwEFwSoYdvX/view?usp=sharing
- This PR: https://drive.google.com/file/d/1eNztDt5kfvPp-1wNxsqB9lXA4jjn6MMr/view?usp=sharing

**Aza** (https://osu.ppy.sh/beatmapsets/1384189#osu/2859822)
- Master: https://drive.google.com/file/d/1sqqIAp-Uxn7QABJfnw3lAqh9QNPNmc8i/view?usp=sharing
- Above PR: https://drive.google.com/file/d/15kXsEju4eogp26uF4Lm1fCeIJUcp4q3h/view?usp=sharing
- This PR: https://drive.google.com/file/d/1-rNkUDJlaUktD9xK3ZyjTswALLJGcFv6/view?usp=sharing

**Sidetracked Day** (https://osu.ppy.sh/beatmapsets/767600#osu/1613687)
- Master: https://drive.google.com/file/d/1UDiQ_WP-qxhHQmwJPOFuHdxCW-CTNo1X/view?usp=sharing
- Above PR: https://drive.google.com/file/d/1gb4BKEXWuy_Q_4vlG891bwMW_4Bpq-q6/view?usp=sharing
- This PR: https://drive.google.com/file/d/15CFSYBEMcpMBDYOEFXvhEKIVpQZXO7Z_/view?usp=sharing

Note:
* In **Sidetracked Day**, the jerkyness of streams in master.
* In **Tramontane**, the ugly slider jumps at 1:40 (in-game time) in master.
* In **Aza**, the unreasonably snappy jumps at 0:20 (in-game time) in master.
* This PR looks _similar_ to the above PR, though I'd say something feels wrong about the above PR like it's lagging behind too much.