### PR TITLE
Add a convenient way to provide ad-hoc dependency to children in visual test

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -31,22 +31,9 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        [Cached]
-        private readonly DroppedObjectContainer droppedObjectContainer;
-
-        private readonly Container trailContainer;
-
         private TestCatcher catcher;
 
-        public TestSceneCatcher()
-        {
-            Add(trailContainer = new Container
-            {
-                Anchor = Anchor.Centre,
-                Depth = -1
-            });
-            Add(droppedObjectContainer = new DroppedObjectContainer());
-        }
+        private DroppedObjectContainer droppedObjectContainer;
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -56,13 +43,24 @@ namespace osu.Game.Rulesets.Catch.Tests
                 CircleSize = 0,
             };
 
-            if (catcher != null)
-                Remove(catcher);
-
-            Add(catcher = new TestCatcher(trailContainer, difficulty)
+            var trailContainer = new Container
             {
+                Anchor = Anchor.Centre,
+            };
+            Child = new DependencyProvidingContainer
+            {
+                Types = new[]
+                {
+                    typeof(DroppedObjectContainer),
+                },
+                Children = new Drawable[]
+                {
+                    droppedObjectContainer = new DroppedObjectContainer(),
+                    catcher = new TestCatcher(trailContainer, difficulty),
+                    trailContainer
+                },
                 Anchor = Anchor.Centre
-            });
+            };
         });
 
         [Test]

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -47,15 +47,16 @@ namespace osu.Game.Rulesets.Catch.Tests
             {
                 Anchor = Anchor.Centre,
             };
+            droppedObjectContainer = new DroppedObjectContainer();
             Child = new DependencyProvidingContainer
             {
-                Types = new[]
+                CachedDependencies = new (Type, object)[]
                 {
-                    typeof(DroppedObjectContainer),
+                    (typeof(DroppedObjectContainer), droppedObjectContainer),
                 },
                 Children = new Drawable[]
                 {
-                    droppedObjectContainer = new DroppedObjectContainer(),
+                    droppedObjectContainer,
                     catcher = new TestCatcher(trailContainer, difficulty),
                     trailContainer
                 },

--- a/osu.Game/Tests/Visual/DependencyProvidingContainer.cs
+++ b/osu.Game/Tests/Visual/DependencyProvidingContainer.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Tests.Visual
+{
+    /// <summary>
+    /// A <see cref="Container"/> which providing ad-hoc dependencies to the child drawables.
+    /// <para>
+    /// To provide a dependency, specify the dependency type to <see cref="Types"/>, then specify the dependency value to either <see cref="Values"/> or <see cref="Container{Drawable}.Children"/>.
+    /// For each type specified in <see cref="Types"/>, the first value compatible with the type is selected and provided to the children.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Types"/> and values of the dependencies must be set while this <see cref="DependencyProvidingContainer"/> is not loaded.
+    /// </remarks>
+    public class DependencyProvidingContainer : Container
+    {
+        /// <summary>
+        /// The types of the dependencies provided to the children.
+        /// </summary>
+        // TODO: should be an init-only property when C# 9
+        public Type[] Types { get; set; } = Array.Empty<Type>();
+
+        /// <summary>
+        /// The dependency values provided to the children.
+        /// </summary>
+        public object[] Values { get; set; } = Array.Empty<object>();
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencyContainer = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            foreach (var type in Types)
+            {
+                object value = Values.FirstOrDefault(v => type.IsInstanceOfType(v)) ??
+                               Children.FirstOrDefault(d => type.IsInstanceOfType(d)) ??
+                               throw new InvalidOperationException($"The type {type} is specified in this {nameof(DependencyProvidingContainer)}, but no corresponding value is provided.");
+
+                dependencyContainer.CacheAs(type, value);
+            }
+
+            return dependencyContainer;
+        }
+    }
+}

--- a/osu.Game/Tests/Visual/DependencyProvidingContainer.cs
+++ b/osu.Game/Tests/Visual/DependencyProvidingContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 
@@ -10,39 +9,24 @@ namespace osu.Game.Tests.Visual
 {
     /// <summary>
     /// A <see cref="Container"/> which providing ad-hoc dependencies to the child drawables.
-    /// <para>
-    /// To provide a dependency, specify the dependency type to <see cref="Types"/>, then specify the dependency value to either <see cref="Values"/> or <see cref="Container{Drawable}.Children"/>.
-    /// For each type specified in <see cref="Types"/>, the first value compatible with the type is selected and provided to the children.
-    /// </para>
     /// </summary>
     /// <remarks>
-    /// The <see cref="Types"/> and values of the dependencies must be set while this <see cref="DependencyProvidingContainer"/> is not loaded.
+    /// The <see cref="CachedDependencies"/> must be set while this <see cref="DependencyProvidingContainer"/> is not loaded.
     /// </remarks>
     public class DependencyProvidingContainer : Container
     {
         /// <summary>
-        /// The types of the dependencies provided to the children.
+        /// The dependencies provided to the children.
         /// </summary>
         // TODO: should be an init-only property when C# 9
-        public Type[] Types { get; set; } = Array.Empty<Type>();
-
-        /// <summary>
-        /// The dependency values provided to the children.
-        /// </summary>
-        public object[] Values { get; set; } = Array.Empty<object>();
+        public (Type, object)[] CachedDependencies { get; set; } = Array.Empty<(Type, object)>();
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             var dependencyContainer = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            foreach (var type in Types)
-            {
-                object value = Values.FirstOrDefault(v => type.IsInstanceOfType(v)) ??
-                               Children.FirstOrDefault(d => type.IsInstanceOfType(d)) ??
-                               throw new InvalidOperationException($"The type {type} is specified in this {nameof(DependencyProvidingContainer)}, but no corresponding value is provided.");
-
+            foreach (var (type, value) in CachedDependencies)
                 dependencyContainer.CacheAs(type, value);
-            }
 
             return dependencyContainer;
         }


### PR DESCRIPTION
Usage:
```csharp
new DependencyProvidingContainer {
    CachedDependencies = new (Type, object)[] {
        (typeof(IFoo), dependencyDrawable),
        (typeof(Bar), dependencyBar),
    },
    Children = new[] {
        dependencyDrawable,
        mainContent = ...,
    }
}
```

Does not support mutation of dependencies after loaded to keep it simple (I felt it is a can of worms).