### PR TITLE
Fix potential failure during cleanup of files in migration tests

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
         [Test]
         public void TestDefaultDirectory()
         {
-            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost(nameof(TestDefaultDirectory)))
             {
                 try
                 {
@@ -139,8 +139,13 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 }
                 finally
                 {
-                    host.Storage.Delete("tournament.ini");
-                    host.Storage.DeleteDirectory("tournaments");
+                    try
+                    {
+                        host.Storage.Delete("tournament.ini");
+                        host.Storage.DeleteDirectory("tournaments");
+                    }
+                    catch { }
+
                     host.Exit();
                 }
             }


### PR DESCRIPTION
As seen at https://ci.appveyor.com/project/peppy/osu/builds/39879979. The actual failure there was likely a file IO related one, but hidden by the `host.Exit` call being missed as a result.