### PR TITLE
Fix copy-and-paste not working in osu!catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -33,11 +33,11 @@ namespace osu.Game.Rulesets.Catch.Edit
                 if (hitObject is BananaShower) return;
 
                 // TODO: confine in bounds
-                hitObject.OriginalXBindable.Value += deltaX;
+                hitObject.OriginalX += deltaX;
 
                 // Move the nested hit objects to give an instant result before nested objects are recreated.
                 foreach (var nested in hitObject.NestedHitObjects.OfType<CatchHitObject>())
-                    nested.OriginalXBindable.Value += deltaX;
+                    nested.OriginalX += deltaX;
             });
 
             return true;

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -20,6 +21,11 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// <summary>
         /// The horizontal position of the hit object between 0 and <see cref="CatchPlayfield.WIDTH"/>.
         /// </summary>
+        /// <remarks>
+        /// Only setter is exposed.
+        /// Use <see cref="OriginalX"/> or <see cref="EffectiveX"/> to get the horizontal position.
+        /// </remarks>
+        [JsonIgnore]
         public float X
         {
             set => OriginalXBindable.Value = value;
@@ -34,6 +40,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </summary>
         public float XOffset
         {
+            get => XOffsetBindable.Value;
             set => XOffsetBindable.Value = value;
         }
 
@@ -44,7 +51,11 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// This value is the original <see cref="X"/> value specified in the beatmap, not affected by the beatmap processing.
         /// Use <see cref="EffectiveX"/> for a gameplay.
         /// </remarks>
-        public float OriginalX => OriginalXBindable.Value;
+        public float OriginalX
+        {
+            get => OriginalXBindable.Value;
+            set => OriginalXBindable.Value = value;
+        }
 
         /// <summary>
         /// The effective horizontal position of the hit object between 0 and <see cref="CatchPlayfield.WIDTH"/>.
@@ -55,7 +66,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </remarks>
         public float EffectiveX => OriginalXBindable.Value + XOffsetBindable.Value;
 
-        public double TimePreempt = 1000;
+        public double TimePreempt { get; set; } = 1000;
 
         public readonly Bindable<int> IndexInBeatmapBindable = new Bindable<int>();
 

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// This value is the original <see cref="X"/> value plus the offset applied by the beatmap processing.
         /// Use <see cref="OriginalX"/> if a value not affected by the offset is desired.
         /// </remarks>
-        public float EffectiveX => OriginalXBindable.Value + XOffsetBindable.Value;
+        public float EffectiveX => OriginalX + XOffset;
 
         public double TimePreempt { get; set; } = 1000;
 

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Newtonsoft.Json;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -25,7 +26,10 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         public int RepeatCount { get; set; }
 
+        [JsonIgnore]
         public double Velocity { get; private set; }
+
+        [JsonIgnore]
         public double TickDistance { get; private set; }
 
         /// <summary>
@@ -113,6 +117,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         public float EndX => OriginalX + this.CurvePositionAt(1).X;
 
+        [JsonIgnore]
         public double Duration
         {
             get => this.SpanCount() * Path.Distance / Velocity;

--- a/osu.Game.Rulesets.Catch/Objects/PalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/PalpableCatchHitObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK.Graphics;
@@ -33,6 +34,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// <summary>
         /// The target fruit if we are to initiate a hyperdash.
         /// </summary>
+        [JsonIgnore]
         public CatchHitObject HyperDashTarget
         {
             get => hyperDashTarget;


### PR DESCRIPTION
Note that pasting a hit object results in a buggy behavior when the hit object is immediately caught by the catcher and expired, and the selection blueprint is removed. That issue should be fixed separately.
