### PR TITLE
Fix intermittent ready button test failures

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Client.ChangeUserState(Client.Room?.Users[0].UserID ?? 0, MultiplayerUserState.FinishedPlay);
             });
 
-            AddAssert("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
+            AddUntilStep("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -113,10 +113,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             addClickButtonStep();
-            AddAssert("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
 
             addClickButtonStep();
-            AddAssert("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+            AddUntilStep("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
         }
 
         [TestCase(true)]
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             addClickButtonStep();
-            AddAssert("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
 
             verifyGameplayStartFlow();
         }
@@ -206,8 +206,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void verifyGameplayStartFlow()
         {
+            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
             addClickButtonStep();
-            AddAssert("user waiting for load", () => Client.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
+            AddUntilStep("user waiting for load", () => Client.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
 
             AddAssert("ready button disabled", () => !button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
             AddStep("transitioned to gameplay", () => readyClickOperation.Dispose());


### PR DESCRIPTION
Has been failing ([example](https://github.com/ppy/osu/pull/13795/checks?check_run_id=2997033945)) intermittently for quite some time because the state change is an async operation. Can be tested by adding a `Thread.Sleep(1000)` in `TestMultiplayerClient.ChangeState()`.