### PR TITLE
Shorten test beatmap to avoid timeouts in score submission test

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -4,14 +4,18 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Solo;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Ranking;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -24,6 +28,15 @@ namespace osu.Game.Tests.Visual.Gameplay
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
         protected override bool HasCustomSteps => true;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var beatmap = (TestBeatmap)base.CreateBeatmap(ruleset);
+
+            beatmap.HitObjects = beatmap.HitObjects.Take(10).ToList();
+
+            return beatmap;
+        }
 
         protected override TestPlayer CreatePlayer(Ruleset ruleset) => new TestPlayer(false);
 


### PR DESCRIPTION
As seen at https://ci.appveyor.com/project/peppy/osu/builds/39883555/tests.