### PR TITLE
Add playfield border to catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchPlacementBlueprint.cs
@@ -6,6 +6,7 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 {
@@ -23,5 +24,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             : base(new THitObject())
         {
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
@@ -18,6 +20,16 @@ namespace osu.Game.Rulesets.Catch.Edit
         public CatchHitObjectComposer(CatchRuleset ruleset)
             : base(ruleset)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            LayerBelowRuleset.Add(new PlayfieldBorder
+            {
+                RelativeSizeAxes = Axes.Both,
+                PlayfieldBorderStyle = { Value = PlayfieldBorderStyle.Corners }
+            });
         }
 
         protected override DrawableRuleset<CatchHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null) =>


### PR DESCRIPTION
The border is indicating the screen size when the beatmap is normally played (playfield size).
A TODO is that the scrolling hit object container size should be decoupled from the playfield size, because it is currently loading hit objects in the middle of the screen when the editor is vertically tall.