### PR TITLE
Fix catch selection blueprint not displayed after copy-pasted

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
     public abstract class CatchSelectionBlueprint<THitObject> : HitObjectSelectionBlueprint<THitObject>
         where THitObject : CatchHitObject
     {
+        protected override bool AlwaysShowWhenSelected => true;
+
         public override Vector2 ScreenSpaceSelectionPoint
         {
             get


### PR DESCRIPTION
Fix issue described in #13793.