### PR TITLE
Always apply DA mod settings

### DIFF
--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    [TestFixture]
+    public class WorkingBeatmapTest
+    {
+        [Test]
+        public void TestModsApplicableToDifficultyReadFromDifficulty()
+        {
+            var beatmap = new TestBeatmap(new OsuRuleset().RulesetInfo)
+            {
+                BeatmapInfo =
+                {
+                    BaseDifficulty =
+                    {
+                        OverallDifficulty = 11,
+                        ApproachRate = 11,
+                        DrainRate = 11,
+                        CircleSize = 11
+                    }
+                }
+            };
+
+            var workingBeatmap = new TestWorkingBeatmap(beatmap);
+
+            var playableBeatmap = workingBeatmap.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, new[]
+            {
+                new OsuModDifficultyAdjust()
+            });
+
+            // Playable beatmap should have read default difficulty settings from beatmap.
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty, Is.EqualTo(11));
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.ApproachRate, Is.EqualTo(11));
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.DrainRate, Is.EqualTo(11));
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.CircleSize, Is.EqualTo(11));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -119,14 +119,17 @@ namespace osu.Game.Beatmaps
                 // Apply difficulty mods
                 if (mods.Any(m => m is IApplicableToDifficulty))
                 {
+                    var originalDifficulty = converted.BeatmapInfo.BaseDifficulty;
+
                     converted.BeatmapInfo = converted.BeatmapInfo.Clone();
-                    converted.BeatmapInfo.BaseDifficulty = converted.BeatmapInfo.BaseDifficulty.Clone();
+                    converted.BeatmapInfo.BaseDifficulty = originalDifficulty.Clone();
 
                     foreach (var mod in mods.OfType<IApplicableToDifficulty>())
                     {
                         if (cancellationSource.IsCancellationRequested)
                             throw new BeatmapLoadTimeoutException(BeatmapInfo);
 
+                        mod.ReadFromDifficulty(originalDifficulty);
                         mod.ApplyToDifficulty(converted.BeatmapInfo.BaseDifficulty);
                     }
                 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -525,16 +525,11 @@ namespace osu.Game
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> beatmap)
         {
             beatmap.OldValue?.CancelAsyncLoad();
-
-            updateModDefaults();
-
             beatmap.NewValue?.BeginAsyncLoad();
         }
 
         private void modsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
-            updateModDefaults();
-
             // a lease may be taken on the mods bindable, at which point we can't really ensure valid mods.
             if (SelectedMods.Disabled)
                 return;
@@ -543,19 +538,6 @@ namespace osu.Game
             {
                 // ensure we always have a valid set of mods.
                 SelectedMods.Value = mods.NewValue.Except(invalid).ToArray();
-            }
-        }
-
-        private void updateModDefaults()
-        {
-            BeatmapDifficulty baseDifficulty = Beatmap.Value.BeatmapInfo.BaseDifficulty;
-
-            if (baseDifficulty != null && SelectedMods.Value.Any(m => m is IApplicableToDifficulty))
-            {
-                var adjustedDifficulty = baseDifficulty.Clone();
-
-                foreach (var mod in SelectedMods.Value.OfType<IApplicableToDifficulty>())
-                    mod.ReadFromDifficulty(adjustedDifficulty);
             }
         }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -361,6 +361,7 @@ namespace osu.Game
             dependencies.CacheAs(MusicController);
 
             Ruleset.BindValueChanged(onRulesetChanged);
+            SelectedMods.BindValueChanged(onModsChanged);
         }
 
         private IDisposable blocking;
@@ -483,6 +484,19 @@ namespace osu.Game
                 SelectedMods.Value = Array.Empty<Mod>();
 
             AvailableMods.Value = dict;
+        }
+
+        private void onModsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        {
+            BeatmapDifficulty baseDifficulty = Beatmap.Value.BeatmapInfo.BaseDifficulty;
+
+            if (baseDifficulty != null && SelectedMods.Value.Any(m => m is IApplicableToDifficulty))
+            {
+                var adjustedDifficulty = baseDifficulty.Clone();
+
+                foreach (var mod in SelectedMods.Value.OfType<IApplicableToDifficulty>())
+                    mod.ReadFromDifficulty(adjustedDifficulty);
+            }
         }
 
         private void runMigrations()

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -141,13 +141,12 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
-        /// Applies a setting from a configuration bindable using <paramref name="applyFunc"/>, if it has been changed by the user.
+        /// Applies a setting from a configuration bindable using <paramref name="applyFunc"/>.
         /// </summary>
         protected void ApplySetting<T>(BindableNumber<T> setting, Action<T> applyFunc)
             where T : struct, IComparable<T>, IConvertible, IEquatable<T>
         {
-            if (userChangedSettings.TryGetValue(setting, out bool userChangedSetting) && userChangedSetting)
-                applyFunc.Invoke(setting.Value);
+            applyFunc.Invoke(setting.Value);
         }
 
         /// <summary>


### PR DESCRIPTION
The only reason I can come up with for this being a thing is to make it compatible with HR. But HR and DA are incompatible with each other anyway.

Resolves two tests in https://github.com/ppy/osu/pull/13814:
![image](https://user-images.githubusercontent.com/1329837/124766840-3c8be900-df72-11eb-9782-22d9fc7400c9.png)

The reason for test fixes is because sequences like the following now pass:
```
var mod = new SomeModDifficultyAdjust();
mod.ReadFromDifficulty(new BeatmapDifficulty { OverallDifficulty = 10 });

var diff = new BeatmapDifficulty();
mod.ApplyToDifficulty(diff);

Assert.That(diff.OverallDifficulty, Is.EqualTo(10));
```