### PR TITLE
Fix IApplicableToDifficulty potentially not being consistently applied in all cases

### DIFF
--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    [TestFixture]
+    public class WorkingBeatmapTest
+    {
+        [Test]
+        public void TestModsApplicableToDifficultyReadFromDifficulty()
+        {
+            var beatmap = new TestBeatmap(new OsuRuleset().RulesetInfo)
+            {
+                BeatmapInfo =
+                {
+                    BaseDifficulty =
+                    {
+                        OverallDifficulty = 11,
+                        ApproachRate = 11,
+                        DrainRate = 11,
+                        CircleSize = 11
+                    }
+                }
+            };
+
+            var workingBeatmap = new TestWorkingBeatmap(beatmap);
+
+            var playableBeatmap = workingBeatmap.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, new[]
+            {
+                new OsuModDifficultyAdjust()
+            });
+
+            // Playable beatmap should have read default difficulty settings from beatmap.
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty, Is.EqualTo(11));
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.ApproachRate, Is.EqualTo(11));
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.DrainRate, Is.EqualTo(11));
+            Assert.That(playableBeatmap.BeatmapInfo.BaseDifficulty.CircleSize, Is.EqualTo(11));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -119,14 +119,17 @@ namespace osu.Game.Beatmaps
                 // Apply difficulty mods
                 if (mods.Any(m => m is IApplicableToDifficulty))
                 {
+                    var originalDifficulty = converted.BeatmapInfo.BaseDifficulty;
+
                     converted.BeatmapInfo = converted.BeatmapInfo.Clone();
-                    converted.BeatmapInfo.BaseDifficulty = converted.BeatmapInfo.BaseDifficulty.Clone();
+                    converted.BeatmapInfo.BaseDifficulty = originalDifficulty.Clone();
 
                     foreach (var mod in mods.OfType<IApplicableToDifficulty>())
                     {
                         if (cancellationSource.IsCancellationRequested)
                             throw new BeatmapLoadTimeoutException(BeatmapInfo);
 
+                        mod.ReadFromDifficulty(originalDifficulty);
                         mod.ApplyToDifficulty(converted.BeatmapInfo.BaseDifficulty);
                     }
                 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -525,16 +525,11 @@ namespace osu.Game
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> beatmap)
         {
             beatmap.OldValue?.CancelAsyncLoad();
-
-            updateModDefaults();
-
             beatmap.NewValue?.BeginAsyncLoad();
         }
 
         private void modsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
-            updateModDefaults();
-
             // a lease may be taken on the mods bindable, at which point we can't really ensure valid mods.
             if (SelectedMods.Disabled)
                 return;
@@ -543,19 +538,6 @@ namespace osu.Game
             {
                 // ensure we always have a valid set of mods.
                 SelectedMods.Value = mods.NewValue.Except(invalid).ToArray();
-            }
-        }
-
-        private void updateModDefaults()
-        {
-            BeatmapDifficulty baseDifficulty = Beatmap.Value.BeatmapInfo.BaseDifficulty;
-
-            if (baseDifficulty != null && SelectedMods.Value.Any(m => m is IApplicableToDifficulty))
-            {
-                var adjustedDifficulty = baseDifficulty.Clone();
-
-                foreach (var mod in SelectedMods.Value.OfType<IApplicableToDifficulty>())
-                    mod.ReadFromDifficulty(adjustedDifficulty);
             }
         }
 


### PR DESCRIPTION
- Matches game & test execution by moving the difficulty reading to `OsuGameBase`.
- Adds a last-chance mechanism to `WorkingBeatmap.GetPlayableBeatmap()` to make sure that the mods have read from the beatamp. This covers cases like difficulty calculators which don't always exist inside an `OsuGameBase`.

The `OsuGameBase` change is debatable and I'm willing to go back on that one if it's deemed more correct for this to be handled locally where required (e.g. a `SongSelect` test scene that tries to use the DA mod).

The `WorkingBeatmap` change is required, however.