### PR TITLE
Add some tests for catch editor blueprints

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/CatchEditorTestSceneContainer.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/CatchEditorTestSceneContainer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Edit;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public class CatchEditorTestSceneContainer : Container
+    {
+        [Cached(typeof(Playfield))]
+        public readonly ScrollingPlayfield Playfield;
+
+        protected override Container<Drawable> Content { get; }
+
+        public CatchEditorTestSceneContainer()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Width = CatchPlayfield.WIDTH;
+            Height = 1000;
+            Padding = new MarginPadding
+            {
+                Bottom = 100
+            };
+
+            InternalChildren = new Drawable[]
+            {
+                new ScrollingTestContainer(ScrollingDirection.Down)
+                {
+                    TimeRange = 1000,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = Playfield = new TestCatchPlayfield
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    }
+                },
+                new PlayfieldBorder
+                {
+                    PlayfieldBorderStyle = { Value = PlayfieldBorderStyle.Full },
+                    Clock = new FramedClock(new StopwatchClock(true))
+                },
+                Content = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                }
+            };
+        }
+
+        private class TestCatchPlayfield : CatchEditorPlayfield
+        {
+            public TestCatchPlayfield()
+                : base(new BeatmapDifficulty { CircleSize = 0 })
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Editor/CatchPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/CatchPlacementBlueprintTestScene.cs
@@ -1,18 +1,30 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Timing;
+using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Tests.Visual;
+using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Catch.Tests.Editor
 {
     public abstract class CatchPlacementBlueprintTestScene : PlacementBlueprintTestScene
     {
+        protected const double TIME_SNAP = 100;
+
+        protected DrawableCatchHitObject LastObject;
+
         protected new ScrollingHitObjectContainer HitObjectContainer => contentContainer.Playfield.HitObjectContainer;
 
         protected override Container<Drawable> Content => contentContainer;
@@ -27,18 +39,41 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             });
         }
 
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            HitObjectContainer.Clear();
+            ResetPlacement();
+            LastObject = null;
+        });
+
+        protected void AddMoveStep(double time, float x) => AddStep($"move to time={time}, x={x}", () =>
+        {
+            float y = HitObjectContainer.PositionAtTime(time);
+            Vector2 pos = HitObjectContainer.ToScreenSpace(new Vector2(x, y + HitObjectContainer.DrawHeight));
+            InputManager.MoveMouseTo(pos);
+        });
+
+        protected void AddClickStep(MouseButton button) => AddStep($"click {button}", () =>
+        {
+            InputManager.Click(button);
+        });
+
+        protected IEnumerable<FruitOutline> FruitOutlines => Content.ChildrenOfType<FruitOutline>();
+
         // Unused because AddHitObject is overriden
         protected override Container CreateHitObjectContainer() => new Container();
 
         protected override void AddHitObject(DrawableHitObject hitObject)
         {
+            LastObject = (DrawableCatchHitObject)hitObject;
             contentContainer.Playfield.HitObjectContainer.Add(hitObject);
         }
 
         protected override SnapResult SnapForBlueprint(PlacementBlueprint blueprint)
         {
             var result = base.SnapForBlueprint(blueprint);
-            result.Time = HitObjectContainer.TimeAtScreenSpacePosition(result.ScreenSpacePosition);
+            result.Time = Math.Round(HitObjectContainer.TimeAtScreenSpacePosition(result.ScreenSpacePosition) / TIME_SNAP) * TIME_SNAP;
             return result;
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/Editor/CatchPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/CatchPlacementBlueprintTestScene.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public abstract class CatchPlacementBlueprintTestScene : PlacementBlueprintTestScene
+    {
+        protected new ScrollingHitObjectContainer HitObjectContainer => contentContainer.Playfield.HitObjectContainer;
+
+        protected override Container<Drawable> Content => contentContainer;
+
+        private readonly CatchEditorTestSceneContainer contentContainer;
+
+        protected CatchPlacementBlueprintTestScene()
+        {
+            base.Content.Add(contentContainer = new CatchEditorTestSceneContainer
+            {
+                Clock = new FramedClock(new ManualClock())
+            });
+        }
+
+        // Unused because AddHitObject is overriden
+        protected override Container CreateHitObjectContainer() => new Container();
+
+        protected override void AddHitObject(DrawableHitObject hitObject)
+        {
+            contentContainer.Playfield.HitObjectContainer.Add(hitObject);
+        }
+
+        protected override SnapResult SnapForBlueprint(PlacementBlueprint blueprint)
+        {
+            var result = base.SnapForBlueprint(blueprint);
+            result.Time = HitObjectContainer.TimeAtScreenSpacePosition(result.ScreenSpacePosition);
+            return result;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Editor/CatchPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/CatchPlacementBlueprintTestScene.cs
@@ -33,10 +33,9 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
 
         protected CatchPlacementBlueprintTestScene()
         {
-            base.Content.Add(contentContainer = new CatchEditorTestSceneContainer
-            {
-                Clock = new FramedClock(new ManualClock())
-            });
+            base.Content.Add(contentContainer = new CatchEditorTestSceneContainer());
+
+            contentContainer.Playfield.Clock = new FramedClock(new ManualClock());
         }
 
         [SetUp]

--- a/osu.Game.Rulesets.Catch.Tests/Editor/CatchSelectionBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/CatchSelectionBlueprintTestScene.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public abstract class CatchSelectionBlueprintTestScene : SelectionBlueprintTestScene
+    {
+        protected ScrollingHitObjectContainer HitObjectContainer => contentContainer.Playfield.HitObjectContainer;
+
+        protected override Container<Drawable> Content => contentContainer;
+
+        private readonly CatchEditorTestSceneContainer contentContainer;
+
+        protected CatchSelectionBlueprintTestScene()
+        {
+            base.Content.Add(contentContainer = new CatchEditorTestSceneContainer());
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public class TestSceneBananaShowerPlacementBlueprint : CatchPlacementBlueprintTestScene
+    {
+        protected override DrawableHitObject CreateHitObject(HitObject hitObject) => new DrawableBananaShower((BananaShower)hitObject);
+
+        protected override PlacementBlueprint CreateBlueprint() => new BananaShowerPlacementBlueprint();
+
+        protected override void AddHitObject(DrawableHitObject hitObject)
+        {
+            // Create nested bananas (but positions are not randomized because beatmap processing is not done).
+            hitObject.HitObject.ApplyDefaults(new ControlPointInfo(), Beatmap.Value.BeatmapInfo.BaseDifficulty);
+
+            base.AddHitObject(hitObject);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
@@ -75,11 +75,11 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
         {
             AddMoveStep(100, 0);
             AddClickStep(MouseButton.Left);
-            AddAssert("outline is semitransparent", () => timeSpanOutline.Alpha < 1);
+            AddUntilStep("outline is semitransparent", () => Precision.DefinitelyBigger(1, timeSpanOutline.Alpha));
             AddMoveStep(200, 0);
-            AddAssert("outline is opaque", () => Precision.AlmostEquals(timeSpanOutline.Alpha, 1));
+            AddUntilStep("outline is opaque", () => Precision.AlmostEquals(timeSpanOutline.Alpha, 1));
             AddMoveStep(100, 0);
-            AddAssert("outline is semitransparent", () => timeSpanOutline.Alpha < 1);
+            AddUntilStep("outline is semitransparent", () => Precision.DefinitelyBigger(1, timeSpanOutline.Alpha));
         }
 
         private TimeSpanOutline timeSpanOutline => Content.ChildrenOfType<TimeSpanOutline>().Single();

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
@@ -1,13 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Catch.Tests.Editor
 {
@@ -24,5 +30,58 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
 
             base.AddHitObject(hitObject);
         }
+
+        [Test]
+        public void TestBasicPlacement()
+        {
+            const double start_time = 100;
+            const double end_time = 500;
+
+            AddMoveStep(start_time, 0);
+            AddClickStep(MouseButton.Left);
+            AddMoveStep(end_time, 0);
+            AddClickStep(MouseButton.Right);
+            AddAssert("banana shower is placed", () => LastObject is DrawableBananaShower);
+            AddAssert("start time is correct", () => Precision.AlmostEquals(LastObject.HitObject.StartTime, start_time));
+            AddAssert("end time is correct", () => Precision.AlmostEquals(LastObject.HitObject.GetEndTime(), end_time));
+        }
+
+        [Test]
+        public void TestReversePlacement()
+        {
+            const double start_time = 100;
+            const double end_time = 500;
+
+            AddMoveStep(end_time, 0);
+            AddClickStep(MouseButton.Left);
+            AddMoveStep(start_time, 0);
+            AddClickStep(MouseButton.Right);
+            AddAssert("start time is correct", () => Precision.AlmostEquals(LastObject.HitObject.StartTime, start_time));
+            AddAssert("end time is correct", () => Precision.AlmostEquals(LastObject.HitObject.GetEndTime(), end_time));
+        }
+
+        [Test]
+        public void TestFinishWithZeroDuration()
+        {
+            AddMoveStep(100, 0);
+            AddClickStep(MouseButton.Left);
+            AddClickStep(MouseButton.Right);
+            AddAssert("banana shower is not placed", () => LastObject == null);
+            AddAssert("state is waiting", () => CurrentBlueprint?.PlacementActive == PlacementBlueprint.PlacementState.Waiting);
+        }
+
+        [Test]
+        public void TestOpacity()
+        {
+            AddMoveStep(100, 0);
+            AddClickStep(MouseButton.Left);
+            AddAssert("outline is semitransparent", () => timeSpanOutline.Alpha < 1);
+            AddMoveStep(200, 0);
+            AddAssert("outline is opaque", () => Precision.AlmostEquals(timeSpanOutline.Alpha, 1));
+            AddMoveStep(100, 0);
+            AddAssert("outline is semitransparent", () => timeSpanOutline.Alpha < 1);
+        }
+
+        private TimeSpanOutline timeSpanOutline => Content.ChildrenOfType<TimeSpanOutline>().Single();
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneFruitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneFruitPlacementBlueprint.cs
@@ -1,12 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Catch.Tests.Editor
 {
@@ -15,5 +20,25 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
         protected override DrawableHitObject CreateHitObject(HitObject hitObject) => new DrawableFruit((Fruit)hitObject);
 
         protected override PlacementBlueprint CreateBlueprint() => new FruitPlacementBlueprint();
+
+        [Test]
+        public void TestFruitPlacementPosition()
+        {
+            const double time = 300;
+            const float x = CatchPlayfield.CENTER_X;
+
+            AddMoveStep(time, x);
+            AddClickStep(MouseButton.Left);
+
+            AddAssert("outline position is correct", () =>
+            {
+                var outline = FruitOutlines.Single();
+                return Precision.AlmostEquals(outline.X, x) &&
+                       Precision.AlmostEquals(outline.Y, HitObjectContainer.PositionAtTime(time));
+            });
+
+            AddAssert("fruit time is correct", () => Precision.AlmostEquals(LastObject.StartTimeBindable.Value, time));
+            AddAssert("fruit position is correct", () => Precision.AlmostEquals(LastObject.X, x));
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneFruitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneFruitPlacementBlueprint.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public class TestSceneFruitPlacementBlueprint : CatchPlacementBlueprintTestScene
+    {
+        protected override DrawableHitObject CreateHitObject(HitObject hitObject) => new DrawableFruit((Fruit)hitObject);
+
+        protected override PlacementBlueprint CreateBlueprint() => new FruitPlacementBlueprint();
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Catch.Edit.Blueprints;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public class TestSceneJuiceStreamSelectionBlueprint : CatchSelectionBlueprintTestScene
+    {
+        public TestSceneJuiceStreamSelectionBlueprint()
+        {
+            var hitObject = new JuiceStream
+            {
+                OriginalX = 100,
+                StartTime = 100,
+                Path = new SliderPath(PathType.PerfectCurve, new[]
+                {
+                    Vector2.Zero,
+                    new Vector2(200, 100),
+                    new Vector2(0, 200),
+                }),
+            };
+            var controlPoint = new ControlPointInfo();
+            controlPoint.Add(0, new TimingControlPoint
+            {
+                BeatLength = 100
+            });
+            hitObject.ApplyDefaults(controlPoint, new BeatmapDifficulty { CircleSize = 0 });
+            AddBlueprint(new JuiceStreamSelectionBlueprint(hitObject));
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/HitObjectSelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectSelectionBlueprint.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         protected virtual bool AlwaysShowWhenSelected => false;
 
-        protected override bool ShouldBeAlive => (DrawableObject.IsAlive && DrawableObject.IsPresent) || (AlwaysShowWhenSelected && State == SelectionState.Selected);
+        protected override bool ShouldBeAlive => (DrawableObject?.IsAlive == true && DrawableObject.IsPresent) || (AlwaysShowWhenSelected && State == SelectionState.Selected);
 
         protected HitObjectSelectionBlueprint(HitObject hitObject)
             : base(hitObject)

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual
 
         protected PlacementBlueprintTestScene()
         {
-            Add(HitObjectContainer = CreateHitObjectContainer().With(c => c.Clock = new FramedClock(new StopwatchClock())));
+            base.Content.Add(HitObjectContainer = CreateHitObjectContainer().With(c => c.Clock = new FramedClock(new StopwatchClock())));
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual
     public abstract class PlacementBlueprintTestScene : OsuManualInputManagerTestScene, IPlacementHandler
     {
         protected readonly Container HitObjectContainer;
-        private PlacementBlueprint currentBlueprint;
+        protected PlacementBlueprint CurrentBlueprint { get; private set; }
 
         protected PlacementBlueprintTestScene()
         {
@@ -63,9 +63,9 @@ namespace osu.Game.Tests.Visual
 
         protected void ResetPlacement()
         {
-            if (currentBlueprint != null)
-                Remove(currentBlueprint);
-            Add(currentBlueprint = CreateBlueprint());
+            if (CurrentBlueprint != null)
+                Remove(CurrentBlueprint);
+            Add(CurrentBlueprint = CreateBlueprint());
         }
 
         public void Delete(HitObject hitObject)
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual
         {
             base.Update();
 
-            currentBlueprint.UpdateTimeAndPosition(SnapForBlueprint(currentBlueprint));
+            CurrentBlueprint.UpdateTimeAndPosition(SnapForBlueprint(CurrentBlueprint));
         }
 
         protected virtual SnapResult SnapForBlueprint(PlacementBlueprint blueprint) =>

--- a/osu.Game/Tests/Visual/SelectionBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/SelectionBlueprintTestScene.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
@@ -23,7 +24,7 @@ namespace osu.Game.Tests.Visual
             });
         }
 
-        protected void AddBlueprint(HitObjectSelectionBlueprint blueprint, DrawableHitObject drawableObject)
+        protected void AddBlueprint(HitObjectSelectionBlueprint blueprint, [CanBeNull] DrawableHitObject drawableObject = null)
         {
             Add(blueprint.With(d =>
             {


### PR DESCRIPTION
- Some tests of placement blueprints are added.
- `TestSceneJuiceStreamSelectionBlueprint` is just for visual inspections, and no actual test steps are there. I'm not sure what can be tested, and the design is currently changing.
- In selection blueprint test scenes, not DHO is added, and `DrawableObject` is `null`.
- Both selection and placement blueprint test scenes use common `CatchEditorTestSceneContainer`, which provide the necessary dependencies (scrolling playfield).
