### PR TITLE
Fix difficulty not being applied to user mods

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -211,7 +211,22 @@ namespace osu.Game.Screens.OnlinePlay.Match
             if (SelectedItem.Value == null)
                 return;
 
+            ApplyToUserMods();
+
             Mods.Value = UserMods.Value.Concat(SelectedItem.Value.RequiredMods).ToList();
+        }
+
+        protected void ApplyToUserMods()
+        {
+            BeatmapDifficulty baseDifficulty = Beatmap.Value.BeatmapInfo.BaseDifficulty;
+
+            if (baseDifficulty != null && UserMods.Value.Any(m => m is IApplicableToDifficulty))
+            {
+                var adjustedDifficulty = baseDifficulty.Clone();
+
+                foreach (var mod in UserMods.Value.OfType<IApplicableToDifficulty>())
+                    mod.ReadFromDifficulty(adjustedDifficulty);
+            }
         }
 
         private void beginHandlingTrack()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -282,6 +282,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             // update local mods based on room's reported status for the local user (omitting the base call implementation).
             // this makes the server authoritative, and avoids the local user potentially setting mods that the server is not aware of (ie. if the match was started during the selection being changed).
+
+            // because we omit the base call, this needs to be called manually to ensure mods are in a good display state for the local user.
+            ApplyToUserMods();
+
             var ruleset = Ruleset.Value.CreateInstance();
             Mods.Value = client.LocalUser.Mods.Select(m => m.ToMod(ruleset)).Concat(SelectedItem.Value.RequiredMods).ToList();
         }


### PR DESCRIPTION
This was causing defaults to not be displayed in the free mod selection for difficulty adjust mods. PRing for discussion.

Another path that can be taken here which may be deemed more correct is moving this logic to within the base `ModSelectOverlay` rather than applying it in each location. This would be mor elegant if we are sure that all `ModSelectOverlay`s are related to their DI available beatmap (I believe this to be the case currently).