### PR TITLE
Change approach rate bonuses to be less punishing on mid-length maps

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -102,7 +102,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             else if (Attributes.ApproachRate < 8.0)
                 approachRateFactor = 0.025 * (8.0 - Attributes.ApproachRate);
 
-            aimValue *= 1.0 + (0.03 + 0.37 * (1.0 / Math.Exp(-(0.0007 * (totalHits - 400))))) * approachRateFactor;
+            double approachRateTotalHitsFactor = 1.0 / (1.0 + Math.Exp(-(0.007 * (totalHits - 400))));
+
+            aimValue *= 1.0 + (0.03 + 0.37 * approachRateTotalHitsFactor) * approachRateFactor;
 
             // We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
             if (mods.Any(h => h is OsuModHidden))
@@ -147,7 +149,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (Attributes.ApproachRate > 10.33)
                 approachRateFactor = Attributes.ApproachRate - 10.33;
 
-            speedValue *= 1.0 + (0.03 + 0.37 * (1.0 / Math.Exp(-(0.0007 * (totalHits - 400))))) * approachRateFactor;
+            double approachRateTotalHitsFactor = 1.0 / (1.0 + Math.Exp(-(0.007 * (totalHits - 400))));
+
+            speedValue *= 1.0 + (0.03 + 0.37 * approachRateTotalHitsFactor) * approachRateFactor;
 
             if (mods.Any(m => m is OsuModHidden))
                 speedValue *= 1.0 + 0.04 * (12.0 - Attributes.ApproachRate);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -98,11 +98,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
-                approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
+                approachRateFactor += Attributes.ApproachRate - 10.33;
             else if (Attributes.ApproachRate < 8.0)
-                approachRateFactor += 0.01 * (8.0 - Attributes.ApproachRate);
+                approachRateFactor += 0.025 * (8.0 - Attributes.ApproachRate);
 
-            aimValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
+            aimValue *= 1.0 + (0.03 + 0.37 * (1.0 / Math.Exp(-(0.0007 * (totalHits - 400))))) * approachRateFactor;
 
             // We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
             if (mods.Any(h => h is OsuModHidden))
@@ -145,9 +145,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
-                approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
+                approachRateFactor = Attributes.ApproachRate - 10.33;
 
             speedValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
+
+            double approachRateFactor = 0.0;
+            if (Attributes.ApproachRate > 10.33)
+                approachRateFactor += Attributes.ApproachRate - 10.33;
+
+            speedValue *= 1.0 + (0.03 + 0.37 * (1.0 / Math.Exp(-(0.0007 * (totalHits - 400))))) * approachRateFactor;
 
             if (mods.Any(m => m is OsuModHidden))
                 speedValue *= 1.0 + 0.04 * (12.0 - Attributes.ApproachRate);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -98,9 +98,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
-                approachRateFactor += Attributes.ApproachRate - 10.33;
+                approachRateFactor = Attributes.ApproachRate - 10.33;
             else if (Attributes.ApproachRate < 8.0)
-                approachRateFactor += 0.025 * (8.0 - Attributes.ApproachRate);
+                approachRateFactor = 0.025 * (8.0 - Attributes.ApproachRate);
 
             aimValue *= 1.0 + (0.03 + 0.37 * (1.0 / Math.Exp(-(0.0007 * (totalHits - 400))))) * approachRateFactor;
 
@@ -146,12 +146,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
                 approachRateFactor = Attributes.ApproachRate - 10.33;
-
-            speedValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
-
-            double approachRateFactor = 0.0;
-            if (Attributes.ApproachRate > 10.33)
-                approachRateFactor += Attributes.ApproachRate - 10.33;
 
             speedValue *= 1.0 + (0.03 + 0.37 * (1.0 / Math.Exp(-(0.0007 * (totalHits - 400))))) * approachRateFactor;
 


### PR DESCRIPTION
After implementing Xexxar's AR11 short map nerf (#11107) there were a lot of complaints from AR11 players about how it unfairly nerfed mid-length (about ~600 objects) maps and even made 3-mod plays on some maps reward less pp than 2-mod plays. This change addresses that by making AR bonus marginally bigger on mid-length maps and slightly bigger on short maps.

![image](https://user-images.githubusercontent.com/8269193/124894183-1868f000-dfe4-11eb-93bd-98bd90612695.png)
X is object count, blue is live, red is new
Interactive desmos graph: https://www.desmos.com/calculator/3es80hz1mm

This also slightly buffs low-AR due to how AR bonus is structured.

Profiles: 
[whitecat.txt](https://github.com/ppy/osu/files/6787249/whitecat.txt)
[mrekk.txt](https://github.com/ppy/osu/files/6787250/mrekk.txt)
[monk.txt](https://github.com/ppy/osu/files/6787251/monk.txt)
[matrix.txt](https://github.com/ppy/osu/files/6787279/matrix.txt)
[suurii.txt](https://github.com/ppy/osu/files/6787280/suurii.txt)
[badeu.txt](https://github.com/ppy/osu/files/6787281/badeu.txt)
[geuse.txt](https://github.com/ppy/osu/files/6787282/geuse.txt)
[sarah.txt](https://github.com/ppy/osu/files/6787283/sarah.txt)
