### PR TITLE
Don't move selected objects outside the playfield in catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             if (deltaX == 0)
             {
-                // Returns true: even there is no positional change, there may be a time change.
+                // Even there is no positional change, there may be a time change.
                 return true;
             }
 
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                 case JuiceStream juiceStream:
                     foreach (var nested in juiceStream.NestedHitObjects.OfType<CatchHitObject>())
                     {
-                        // Exclude tiny droplets: even if `OriginalX` is outside the playfield, it can be moved inside the playfield after the random offset application.
+                        // Even if `OriginalX` is outside the playfield, tiny droplets can be moved inside the playfield after the random offset application.
                         if (!(nested is TinyDroplet))
                             yield return nested.OriginalX;
                     }

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             float upperBound = CatchPlayfield.WIDTH - maxX;
             // The inequality may be unsatisfiable if the objects were already out of bounds.
             // In that case, don't move objects at all.
-            if (!(lowerBound <= upperBound))
+            if (lowerBound > upperBound)
                 return 0;
 
             return Math.Clamp(deltaX, lowerBound, upperBound);

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -1,9 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -26,13 +29,19 @@ namespace osu.Game.Rulesets.Catch.Edit
             Vector2 targetPosition = HitObjectContainer.ToLocalSpace(blueprint.ScreenSpaceSelectionPoint + moveEvent.ScreenSpaceDelta);
             float deltaX = targetPosition.X - originalPosition.X;
 
+            foreach (float x in EditorBeatmap.SelectedHitObjects.SelectMany(getOriginalPositions))
+                deltaX = Math.Clamp(deltaX, -x, CatchPlayfield.WIDTH - x);
+
+            if (deltaX == 0)
+            {
+                // Returns true: even there is no positional change, there may be a time change.
+                return true;
+            }
+
             EditorBeatmap.PerformOnSelection(h =>
             {
                 if (!(h is CatchHitObject hitObject)) return;
 
-                if (hitObject is BananaShower) return;
-
-                // TODO: confine in bounds
                 hitObject.OriginalX += deltaX;
 
                 // Move the nested hit objects to give an instant result before nested objects are recreated.
@@ -41,6 +50,38 @@ namespace osu.Game.Rulesets.Catch.Edit
             });
 
             return true;
+        }
+
+        /// <summary>
+        /// Enumerate X positions that should be contained in-bounds after move offset is applied.
+        /// </summary>
+        private IEnumerable<float> getOriginalPositions(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Fruit fruit:
+                    yield return fruit.OriginalX;
+
+                    break;
+
+                case JuiceStream juiceStream:
+                    foreach (var nested in juiceStream.NestedHitObjects.OfType<CatchHitObject>())
+                    {
+                        // Exclude tiny droplets: even if `OriginalX` is outside the playfield, it can be moved inside the playfield after the random offset application.
+                        if (!(nested is TinyDroplet))
+                            yield return nested.OriginalX;
+                    }
+
+                    break;
+
+                case BananaShower _:
+                    // A banana shower occupies the whole screen width.
+                    // If the selection contains a banana shower, the selection cannot be moved horizontally.
+                    yield return 0;
+                    yield return CatchPlayfield.WIDTH;
+
+                    break;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             if (deltaX == 0)
             {
-                // Even there is no positional change, there may be a time change.
+                // Even if there is no positional change, there may be a time change.
                 return true;
             }
 


### PR DESCRIPTION
Movement restriction is applied to all selected hit objects, so relative positions of the selected hit objects don't change.