### PR TITLE
Fix test failures due to logger pollution

### DIFF
--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -102,8 +102,15 @@ namespace osu.Game.IO
 
         protected override void ChangeTargetStorage(Storage newStorage)
         {
+            var lastStorage = UnderlyingStorage;
             base.ChangeTargetStorage(newStorage);
-            Logger.Storage = UnderlyingStorage.GetStorageForDirectory("logs");
+
+            if (lastStorage != null)
+            {
+                // for now we assume that if there was a previous storage, this is a migration operation.
+                // the logger shouldn't be set during initialisation as it can cause cross-talk in tests (due to being static).
+                Logger.Storage = UnderlyingStorage.GetStorageForDirectory("logs");
+            }
         }
 
         public override void Migrate(Storage newStorage)

--- a/osu.Game/Tests/CleanRunHeadlessGameHost.cs
+++ b/osu.Game/Tests/CleanRunHeadlessGameHost.cs
@@ -25,8 +25,11 @@ namespace osu.Game.Tests
 
         protected override void SetupForRun()
         {
-            base.SetupForRun();
             Storage.DeleteDirectory(string.Empty);
+
+            // base call needs to be run *after* storage is emptied, as it updates the (static) logger's storage and may start writing
+            // log entries from another source if a unit test host is shared over multiple tests, causing a file access denied exception.
+            base.SetupForRun();
         }
     }
 }


### PR DESCRIPTION
As seen at https://github.com/ppy/osu/pull/13831/checks?check_run_id=3025050307. I can't confirm that this will fix the issue but it looks like the only plausible reason. I have confirmed that the logging is not coming from the local (first logging is guaranteed to be after `SetupForRun`).