### PR TITLE
Fix migration target having left over files potentially causing test failures

### DIFF
--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -184,6 +184,9 @@ namespace osu.Game.Tests.NonVisual
                     Assert.DoesNotThrow(() => osu.Migrate(customPath2));
                     Assert.That(File.Exists(Path.Combine(customPath2, database_filename)));
 
+                    // some files may have been left behind for whatever reason, but that's not what we're testing here.
+                    customPath = prepareCustomPath();
+
                     Assert.DoesNotThrow(() => osu.Migrate(customPath));
                     Assert.That(File.Exists(Path.Combine(customPath, database_filename)));
                 }


### PR DESCRIPTION
As seen at https://github.com/ppy/osu/pull/13831/checks?check_run_id=3025050324.