### PR TITLE
Ensure run-from-screen song select reaches correct point in execution

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
@@ -58,8 +58,7 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestPerformAtSongSelectFromPlayerLoader()
         {
-            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).Wait());
-            PushAndConfirm(() => new TestPlaySongSelect());
+            importAndWaitForSongSelect();
 
             AddStep("Press enter", () => InputManager.Key(Key.Enter));
             AddUntilStep("Wait for new screen", () => Game.ScreenStack.CurrentScreen is PlayerLoader);
@@ -72,8 +71,7 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestPerformAtMenuFromPlayerLoader()
         {
-            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).Wait());
-            PushAndConfirm(() => new TestPlaySongSelect());
+            importAndWaitForSongSelect();
 
             AddStep("Press enter", () => InputManager.Key(Key.Enter));
             AddUntilStep("Wait for new screen", () => Game.ScreenStack.CurrentScreen is PlayerLoader);
@@ -170,6 +168,13 @@ namespace osu.Game.Tests.Visual.Navigation
                 AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen == blocker);
                 AddAssert("did not perform", () => !actionPerformed);
             }
+        }
+
+        private void importAndWaitForSongSelect()
+        {
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).Wait());
+            PushAndConfirm(() => new TestPlaySongSelect());
+            AddUntilStep("beatmap updated", () => Game.Beatmap.Value.BeatmapSetInfo.OnlineBeatmapSetID == 241526);
         }
 
         public class DialogBlockingScreen : OsuScreen


### PR DESCRIPTION
Fixes issues as seen at https://github.com/ppy/osu/runs/3023581865?check_suite_focus=true. Song select may take a few frames to perform initial selection as there is a bit of internal async logic. This ensures that the beatmap has been updated before continuing with test execution.