### PR TITLE
Limit update notifications to once per startup

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -68,6 +68,8 @@ namespace osu.Desktop.Updater
                     return false;
                 }
 
+                scheduleRecheck = false;
+
                 if (notification == null)
                 {
                     notification = new UpdateProgressNotification(this) { State = ProgressNotificationState.Active };
@@ -98,7 +100,6 @@ namespace osu.Desktop.Updater
                         // could fail if deltas are unavailable for full update path (https://github.com/Squirrel/Squirrel.Windows/issues/959)
                         // try again without deltas.
                         await checkForUpdateAsync(false, notification).ConfigureAwait(false);
-                        scheduleRecheck = false;
                     }
                     else
                     {

--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -111,6 +111,7 @@ namespace osu.Desktop.Updater
             catch (Exception)
             {
                 // we'll ignore this and retry later. can be triggered by no internet connection or thread abortion.
+                scheduleRecheck = true;
             }
             finally
             {


### PR DESCRIPTION
This logic was intentionally designed to continue to prompt the user to update if they haven't, but that seems pretty anti-user. The change will stop the update prompts from showing more than once per game startup, unless manually invoked by the user a second time.

Closes https://github.com/ppy/osu/issues/13821.
