### PR TITLE
Disallow custom rulesets from attempting to submit scores

### DIFF
--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Solo;
+using osu.Game.Rulesets;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play
@@ -27,7 +28,7 @@ namespace osu.Game.Screens.Play
             if (!(Beatmap.Value.BeatmapInfo.OnlineBeatmapID is int beatmapId))
                 return null;
 
-            if (!(Ruleset.Value.ID is int rulesetId))
+            if (!(Ruleset.Value.ID is int rulesetId) || Ruleset.Value.ID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
                 return null;
 
             return new CreateSoloScoreRequest(beatmapId, rulesetId, Game.VersionHash);

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -57,7 +57,9 @@ namespace osu.Game.Tests.Visual
 
         protected void LoadPlayer()
         {
-            var ruleset = Ruleset.Value.CreateInstance();
+            var ruleset = CreatePlayerRuleset();
+            Ruleset.Value = ruleset.RulesetInfo;
+
             var beatmap = CreateBeatmap(ruleset.RulesetInfo);
 
             Beatmap.Value = CreateWorkingBeatmap(beatmap);


### PR DESCRIPTION
Closes #13820 

Have added test coverage for both the `null` online beatmap ID case (which was missing one) and the custom ruleset ID case. That required https://github.com/ppy/osu/commit/f21ea3b790812bf48d108601191b11e1b462f087 for the ruleset to be updated properly per test case, however.