### PR TITLE
Fix crash when multiplayer server join fails during game creation

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -283,6 +283,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 {
                     // the room has gone away.
                     // this could mean something happened during the join process, or an external connection issue occurred.
+                    // one specific scenario is where the underlying room is created, but the signalr server returns an error during the join process. this triggers a PartRoom operation (see https://github.com/ppy/osu/blob/7654df94f6f37b8382be7dfcb4f674e03bd35427/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs#L97)
                     Schedule(this.Exit);
                 }
             }, true);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -48,6 +48,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private OngoingOperationTracker ongoingOperationTracker { get; set; }
 
+        [Resolved]
+        private Bindable<Room> currentRoom { get; set; }
+
         private MultiplayerMatchSettingsOverlay settingsOverlay;
 
         private readonly IBindable<bool> isConnected = new Bindable<bool>();
@@ -272,6 +275,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             {
                 if (!connected.NewValue)
                     Schedule(this.Exit);
+            }, true);
+
+            currentRoom.BindValueChanged(room =>
+            {
+                if (room.NewValue == null)
+                {
+                    // the room has gone away.
+                    // this could mean something happened during the join process, or an external connection issue occurred.
+                    Schedule(this.Exit);
+                }
             }, true);
         }
 


### PR DESCRIPTION
I think we can probably get some test coverage of this if required, but needs a bit of thought (basically an error needs to be thrown during the multiplayer client portion of the join procedure, after `CurrentRoom` is non-null but before the join completes).

Manual testing on password branch (#13861) is possible since it currently errors due to missing method on the live/dev servers.

- Create game, which will fail with `MethodNotExists`.
- Note the fields on the settings screen are emptied.
- Fill fields again and press create game (crash).

Closes #13847.

