### PR TITLE
Update hue of certain colour schemes

### DIFF
--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Overlays
                     return 333 / 360f;
 
                 case OverlayColourScheme.Orange:
-                    return 46 / 360f;
+                    return 45 / 360f;
 
                 case OverlayColourScheme.Green:
                     return 115 / 360f;

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -12,12 +12,11 @@ namespace osu.Game.Overlays
         private readonly OverlayColourScheme colourScheme;
 
         public static OverlayColourProvider Red { get; } = new OverlayColourProvider(OverlayColourScheme.Red);
-        public static OverlayColourProvider DarkOrange { get; } = new OverlayColourProvider(OverlayColourScheme.DarkOrange);
+        public static OverlayColourProvider Pink { get; } = new OverlayColourProvider(OverlayColourScheme.Pink);
         public static OverlayColourProvider Orange { get; } = new OverlayColourProvider(OverlayColourScheme.Orange);
         public static OverlayColourProvider Green { get; } = new OverlayColourProvider(OverlayColourScheme.Green);
-        public static OverlayColourProvider Blue { get; } = new OverlayColourProvider(OverlayColourScheme.Blue);
         public static OverlayColourProvider Purple { get; } = new OverlayColourProvider(OverlayColourScheme.Purple);
-        public static OverlayColourProvider Pink { get; } = new OverlayColourProvider(OverlayColourScheme.Pink);
+        public static OverlayColourProvider Blue { get; } = new OverlayColourProvider(OverlayColourScheme.Blue);
 
         public OverlayColourProvider(OverlayColourScheme colourScheme)
         {
@@ -63,8 +62,8 @@ namespace osu.Game.Overlays
                 case OverlayColourScheme.Red:
                     return 0;
 
-                case OverlayColourScheme.DarkOrange:
-                    return 20 / 360f;
+                case OverlayColourScheme.Pink:
+                    return 333 / 360f;
 
                 case OverlayColourScheme.Orange:
                     return 45 / 360f;
@@ -72,17 +71,11 @@ namespace osu.Game.Overlays
                 case OverlayColourScheme.Green:
                     return 115 / 360f;
 
-                case OverlayColourScheme.Cyan:
-                    return 160 / 360f;
-
-                case OverlayColourScheme.Blue:
-                    return 200 / 360f;
-
                 case OverlayColourScheme.Purple:
                     return 255 / 360f;
 
-                case OverlayColourScheme.Pink:
-                    return 333 / 360f;
+                case OverlayColourScheme.Blue:
+                    return 200 / 360f;
             }
         }
     }
@@ -91,11 +84,9 @@ namespace osu.Game.Overlays
     {
         Red,
         Pink,
-        DarkOrange,
         Orange,
         Green,
         Purple,
-        Blue,
-        Cyan,
+        Blue
     }
 }

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -12,11 +12,12 @@ namespace osu.Game.Overlays
         private readonly OverlayColourScheme colourScheme;
 
         public static OverlayColourProvider Red { get; } = new OverlayColourProvider(OverlayColourScheme.Red);
-        public static OverlayColourProvider Pink { get; } = new OverlayColourProvider(OverlayColourScheme.Pink);
+        public static OverlayColourProvider DarkOrange { get; } = new OverlayColourProvider(OverlayColourScheme.DarkOrange);
         public static OverlayColourProvider Orange { get; } = new OverlayColourProvider(OverlayColourScheme.Orange);
         public static OverlayColourProvider Green { get; } = new OverlayColourProvider(OverlayColourScheme.Green);
-        public static OverlayColourProvider Purple { get; } = new OverlayColourProvider(OverlayColourScheme.Purple);
         public static OverlayColourProvider Blue { get; } = new OverlayColourProvider(OverlayColourScheme.Blue);
+        public static OverlayColourProvider Purple { get; } = new OverlayColourProvider(OverlayColourScheme.Purple);
+        public static OverlayColourProvider Pink { get; } = new OverlayColourProvider(OverlayColourScheme.Pink);
 
         public OverlayColourProvider(OverlayColourScheme colourScheme)
         {
@@ -62,8 +63,8 @@ namespace osu.Game.Overlays
                 case OverlayColourScheme.Red:
                     return 0;
 
-                case OverlayColourScheme.Pink:
-                    return 333 / 360f;
+                case OverlayColourScheme.DarkOrange:
+                    return 20 / 360f;
 
                 case OverlayColourScheme.Orange:
                     return 45 / 360f;
@@ -71,11 +72,17 @@ namespace osu.Game.Overlays
                 case OverlayColourScheme.Green:
                     return 115 / 360f;
 
-                case OverlayColourScheme.Purple:
-                    return 255 / 360f;
+                case OverlayColourScheme.Cyan:
+                    return 160 / 360f;
 
                 case OverlayColourScheme.Blue:
                     return 200 / 360f;
+
+                case OverlayColourScheme.Purple:
+                    return 255 / 360f;
+
+                case OverlayColourScheme.Pink:
+                    return 333 / 360f;
             }
         }
     }
@@ -84,9 +91,11 @@ namespace osu.Game.Overlays
     {
         Red,
         Pink,
+        DarkOrange,
         Orange,
         Green,
         Purple,
-        Blue
+        Blue,
+        Cyan,
     }
 }

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays
                     return 45 / 360f;
 
                 case OverlayColourScheme.Green:
-                    return 115 / 360f;
+                    return 125 / 360f;
 
                 case OverlayColourScheme.Purple:
                     return 255 / 360f;

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Overlays
 
         private Color4 getColour(float saturation, float lightness) => Color4.FromHsl(new Vector4(getBaseHue(colourScheme), saturation, lightness, 1));
 
-        // See https://github.com/ppy/osu-web/blob/4218c288292d7c810b619075471eaea8bbb8f9d8/app/helpers.php#L1463
+        // See https://github.com/ppy/osu-web/blob/5a536d217a21582aad999db50a981003d3ad5659/app/helpers.php#L1620-L1628
         private static float getBaseHue(OverlayColourScheme colourScheme)
         {
             switch (colourScheme)


### PR DESCRIPTION
Noticed while going through this, the [original palette in the figma designs](https://user-images.githubusercontent.com/22781491/125310750-8a6e6b80-e33b-11eb-95a0-7d1e0682d3fd.png) show that hue of `Orange` (aka "Custard") is 45°, and osu!web seems to have updated to that in https://github.com/ppy/osu-web/commit/2a2337ebf74ad0df7e69ae750ba8f7d9c2f586fb.

Also updated the attached link inline with the latest commit (permalink).