### PR TITLE
Fix multiplayer screen buttons showing no text when local user not available

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -72,25 +71,20 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         {
             var localUser = Client.LocalUser;
 
-            if (localUser == null)
-                return;
+            int newCountReady = Room?.Users.Count(u => u.State == MultiplayerUserState.Ready) ?? 0;
+            int newCountTotal = Room?.Users.Count(u => u.State != MultiplayerUserState.Spectating) ?? 0;
 
-            Debug.Assert(Room != null);
-
-            int newCountReady = Room.Users.Count(u => u.State == MultiplayerUserState.Ready);
-            int newCountTotal = Room.Users.Count(u => u.State != MultiplayerUserState.Spectating);
-
-            string countText = $"({newCountReady} / {newCountTotal} ready)";
-
-            switch (localUser.State)
+            switch (localUser?.State)
             {
-                case MultiplayerUserState.Idle:
+                default:
                     button.Text = "Ready";
                     updateButtonColour(true);
                     break;
 
                 case MultiplayerUserState.Spectating:
                 case MultiplayerUserState.Ready:
+                    string countText = $"({newCountReady} / {newCountTotal} ready)";
+
                     if (Room?.Host?.Equals(localUser) == true)
                     {
                         button.Text = $"Start match {countText}";
@@ -108,7 +102,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             bool enableButton = Client.Room?.State == MultiplayerRoomState.Open && !operationInProgress.Value;
 
             // When the local user is the host and spectating the match, the "start match" state should be enabled if any users are ready.
-            if (localUser.State == MultiplayerUserState.Spectating)
+            if (localUser?.State == MultiplayerUserState.Spectating)
                 enableButton &= Room?.Host?.Equals(localUser) == true && newCountReady > 0;
 
             button.Enabled.Value = enableButton;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -57,14 +56,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
         private void updateState()
         {
-            var localUser = Client.LocalUser;
-
-            if (localUser == null)
-                return;
-
-            Debug.Assert(Room != null);
-
-            switch (localUser.State)
+            switch (Client.LocalUser?.State)
             {
                 default:
                     button.Text = "Spectate";
@@ -81,7 +73,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     break;
             }
 
-            button.Enabled.Value = Client.Room?.State != MultiplayerRoomState.Closed && !operationInProgress.Value;
+            button.Enabled.Value = Client.Room != null
+                                   && Client.Room.State != MultiplayerRoomState.Closed
+                                   && !operationInProgress.Value;
         }
 
         private class ButtonWithTrianglesExposed : TriangleButton


### PR DESCRIPTION
As discussed, this just makes the buttons always display text even when an error has occurred out of their control.

Can be tested by changing line https://github.com/ppy/osu/blob/d197a7f6f5f539ec2e75f1bf2e7935bc8642d9a9/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs#L70 to:

```csharp
        protected override Task<MultiplayerRoom> JoinRoom(long roomId)
        {
            if (!IsConnected.Value)
                return Task.FromCanceled<MultiplayerRoom>(new CancellationToken(true));

            return Task.Delay(3000).ContinueWith(t => new MultiplayerRoom(1));
        }
```

(ie. the local user is not in the room)
