### PR TITLE
Remove `IApplicableToDifficulty.ReadFromDifficulty`

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -525,16 +525,11 @@ namespace osu.Game
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> beatmap)
         {
             beatmap.OldValue?.CancelAsyncLoad();
-
-            updateModDefaults();
-
             beatmap.NewValue?.BeginAsyncLoad();
         }
 
         private void modsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
-            updateModDefaults();
-
             // a lease may be taken on the mods bindable, at which point we can't really ensure valid mods.
             if (SelectedMods.Disabled)
                 return;
@@ -543,19 +538,6 @@ namespace osu.Game
             {
                 // ensure we always have a valid set of mods.
                 SelectedMods.Value = mods.NewValue.Except(invalid).ToArray();
-            }
-        }
-
-        private void updateModDefaults()
-        {
-            BeatmapDifficulty baseDifficulty = Beatmap.Value.BeatmapInfo.BaseDifficulty;
-
-            if (baseDifficulty != null && SelectedMods.Value.Any(m => m is IApplicableToDifficulty))
-            {
-                var adjustedDifficulty = baseDifficulty.Clone();
-
-                foreach (var mod in SelectedMods.Value.OfType<IApplicableToDifficulty>())
-                    mod.ReadFromDifficulty(adjustedDifficulty);
             }
         }
 

--- a/osu.Game/Rulesets/Mods/IApplicableToDifficulty.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToDifficulty.cs
@@ -11,13 +11,6 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToDifficulty : IApplicableMod
     {
         /// <summary>
-        /// Called when a beatmap is changed. Can be used to read default values.
-        /// Any changes made will not be preserved.
-        /// </summary>
-        /// <param name="difficulty">The difficulty to read from.</param>
-        void ReadFromDifficulty(BeatmapDifficulty difficulty);
-
-        /// <summary>
         /// Called post beatmap conversion. Can be used to apply changes to difficulty attributes.
         /// </summary>
         /// <param name="difficulty">The difficulty to mutate.</param>


### PR DESCRIPTION
This was added specifically for `ModDifficultyAdjust`, but turned out to be more of a headache than we expected. We have since removed usage and would hope that this is not required by any other mods.

Opting for complete removal rather than obsoletion, as we discovered this was already broken in multiple cases, with fixes being quite logically complex.

If you happen to be a ruleset developer relying on this, open an issue and we'll talk you through a better approach (or check what `ModDifficultyAdjust` is doing now for an example).
