### PR TITLE
Preserve Y position of hit objects in osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
         protected override IEnumerable<CatchHitObject> ConvertHitObject(HitObject obj, IBeatmap beatmap, CancellationToken cancellationToken)
         {
-            var positionData = obj as IHasXPosition;
+            var xPositionData = obj as IHasXPosition;
+            var yPositionData = obj as IHasYPosition;
             var comboData = obj as IHasCombo;
 
             switch (obj)
@@ -36,10 +37,11 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                         Path = curveData.Path,
                         NodeSamples = curveData.NodeSamples,
                         RepeatCount = curveData.RepeatCount,
-                        X = positionData?.X ?? 0,
+                        X = xPositionData?.X ?? 0,
                         NewCombo = comboData?.NewCombo ?? false,
                         ComboOffset = comboData?.ComboOffset ?? 0,
-                        LegacyLastTickOffset = (obj as IHasLegacyLastTickOffset)?.LegacyLastTickOffset ?? 0
+                        LegacyLastTickOffset = (obj as IHasLegacyLastTickOffset)?.LegacyLastTickOffset ?? 0,
+                        LegacyConvertedY = yPositionData?.Y ?? CatchHitObject.DEFAULT_LEGACY_CONVERT_Y
                     }.Yield();
 
                 case IHasDuration endTime:
@@ -59,7 +61,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                         Samples = obj.Samples,
                         NewCombo = comboData?.NewCombo ?? false,
                         ComboOffset = comboData?.ComboOffset ?? 0,
-                        X = positionData?.X ?? 0
+                        X = xPositionData?.X ?? 0,
+                        LegacyConvertedY = yPositionData?.Y ?? CatchHitObject.DEFAULT_LEGACY_CONVERT_Y
                     }.Yield();
             }
         }

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -9,10 +9,11 @@ using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
-    public abstract class CatchHitObject : HitObject, IHasXPosition, IHasComboInformation
+    public abstract class CatchHitObject : HitObject, IHasPosition, IHasComboInformation
     {
         public const float OBJECT_RADIUS = 64;
 
@@ -30,8 +31,6 @@ namespace osu.Game.Rulesets.Catch.Objects
         {
             set => OriginalXBindable.Value = value;
         }
-
-        float IHasXPosition.X => OriginalXBindable.Value;
 
         public readonly Bindable<float> XOffsetBindable = new Bindable<float>();
 
@@ -131,5 +130,24 @@ namespace osu.Game.Rulesets.Catch.Objects
         }
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+
+        #region Hit object conversion
+
+        // The half of the height of the osu! playfield.
+        public const float DEFAULT_LEGACY_CONVERT_Y = 192;
+
+        /// <summary>
+        /// The Y position of the hit object is not used in the normal osu!catch gameplay.
+        /// It is preserved to maximize the backward compatibility with the legacy editor, in which the mappers use the Y position to organize the patterns.
+        /// </summary>
+        public float LegacyConvertedY { get; set; } = DEFAULT_LEGACY_CONVERT_Y;
+
+        float IHasXPosition.X => OriginalX;
+
+        float IHasYPosition.Y => LegacyConvertedY;
+
+        Vector2 IHasPosition.Position => new Vector2(OriginalX, LegacyConvertedY);
+
+        #endregion
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -251,11 +251,8 @@ namespace osu.Game.Beatmaps.Formats
             switch (beatmap.BeatmapInfo.RulesetID)
             {
                 case 0:
-                    position = ((IHasPosition)hitObject).Position;
-                    break;
-
                 case 2:
-                    position.X = ((IHasXPosition)hitObject).X;
+                    position = ((IHasPosition)hitObject).Position;
                     break;
 
                 case 3:

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHit.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHit.cs
@@ -2,15 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Objects.Types;
+using osuTK;
 
 namespace osu.Game.Rulesets.Objects.Legacy.Catch
 {
     /// <summary>
     /// Legacy osu!catch Hit-type, used for parsing Beatmaps.
     /// </summary>
-    internal sealed class ConvertHit : ConvertHitObject, IHasCombo, IHasXPosition
+    internal sealed class ConvertHit : ConvertHitObject, IHasPosition, IHasCombo
     {
-        public float X { get; set; }
+        public float X => Position.X;
+
+        public float Y => Position.Y;
+
+        public Vector2 Position { get; set; }
 
         public bool NewCombo { get; set; }
 

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
 
             return new ConvertHit
             {
-                X = position.X,
+                Position = position,
                 NewCombo = newCombo,
                 ComboOffset = comboOffset
             };
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
 
             return new ConvertSlider
             {
-                X = position.X,
+                Position = position,
                 NewCombo = FirstObject || newCombo,
                 ComboOffset = comboOffset,
                 Path = new SliderPath(controlPoints, length),

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSlider.cs
@@ -2,15 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Objects.Types;
+using osuTK;
 
 namespace osu.Game.Rulesets.Objects.Legacy.Catch
 {
     /// <summary>
     /// Legacy osu!catch Slider-type, used for parsing Beatmaps.
     /// </summary>
-    internal sealed class ConvertSlider : Legacy.ConvertSlider, IHasXPosition, IHasCombo
+    internal sealed class ConvertSlider : Legacy.ConvertSlider, IHasPosition, IHasCombo
     {
-        public float X { get; set; }
+        public float X => Position.X;
+
+        public float Y => Position.Y;
+
+        public Vector2 Position { get; set; }
 
         public bool NewCombo { get; set; }
 


### PR DESCRIPTION
The Y positions of the hit objects are stored in the beatmap but not used in the normal osu!catch gameplay.
In the current lazer, the Y positions are just ignored when a legacy beatmap is decoded, and the fixed value `192` is used when a beatmap is encoded.
However, the mappers use the 2D playfield in the stable editor to organize the hit objects, and it is undesirable to lose the Y position information when a beatmap is just imported and exported.
I think this behavior will discourage the usage of the new lazer editor.
In this PR, I made the catch hit object to store the original Y position when a beatmap is converted. When the beatmap is exported, the stored Y position is written without change.

Also, I imagine some conversion mods want to use the Y position to calculate the actual jump distance in standard maps, to improve the conversion quality.