### PR TITLE
Do not fire `OnNewBeat` if the beat is before track start in `BeatSyncedContainer`

### DIFF
--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -94,6 +94,9 @@ namespace osu.Game.Graphics.Containers
 
             TimeSinceLastBeat = beatLength - TimeUntilNextBeat;
 
+            if (currentTrackTime < TimeSinceLastBeat)
+                return;
+
             if (timingPoint == lastTimingPoint && beatIndex == lastBeat)
                 return;
 


### PR DESCRIPTION
Currently, the `BeatSyncedContainer` is always firing `OnNewBeat` at the start of the track (when `currentTrackTime` is 0), causing the metronome in #12877 to play twice at the start of the map. This PR fixes the issue by checking if the beat precedes track start.