### PR TITLE
Fix relax mod still holding key after beatmap ends

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
@@ -13,6 +14,7 @@ using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Scoring;
 using osu.Game.Tests.Visual;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests.Mods
 {
@@ -21,11 +23,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         [Test]
         public void TestKeyUp()
         {
-            var lastObject = new HitCircle
-            {
-                Position = OsuPlayfield.BASE_SIZE / 2,
-                StartTime = 2550
-            };
+            var hitObjects = CreateHitObjects();
+
             CreateModTest(new ModTestData
             {
                 Autoplay = false,
@@ -37,26 +36,48 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                     },
                 Beatmap = new Beatmap
                 {
-                    HitObjects =
-                    {
-                        new HitCircle
-                        {
-                            Position = OsuPlayfield.BASE_SIZE / 2,
-                            StartTime = 2500
-                        },
-                        lastObject
-                    }
+                    HitObjects = hitObjects
                 },
-                PassCondition = () => Player.ScoreProcessor.JudgedHits == 2
+                PassCondition = () => Player.ScoreProcessor.Accuracy.Value == 1
             });
             Replay replay = null;
+            InputManager.UseParentInput = false;
 
-            AddUntilStep("wait for beatmap end", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= lastObject.GetEndTime());
+            AddStep("show key overlay", () => Player.HUDOverlay.KeyCounter.AlwaysVisible.Value = true);
+            AddUntilStep("wait for beatmap end", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= hitObjects.Last().StartTime);
             AddStep("get replay", () => replay = ((ScoreAccessiblePlayer)Player).Score.Replay);
             AddAssert("no key was held", () => replay.Frames.Cast<OsuReplayFrame>().Last().Actions.Count == 0);
         }
 
         protected override TestPlayer CreateModPlayer(Ruleset ruleset) => new ScoreAccessiblePlayer(AllowFail);
+
+        protected List<HitObject> CreateHitObjects()
+        {
+            const int start = 500;
+            var list = new List<HitObject>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                list.Add(new HitCircle
+                {
+                    StartTime = start + (i - 1) * 50,
+                    Position = new Vector2((i + 1) * 32, OsuPlayfield.BASE_SIZE.Y / 2)
+                });
+            }
+
+            var lastPos = ((HitCircle)list.Last()).Position + new Vector2(32, 0);
+
+            for (int i = 0; i < 5; i++)
+            {
+                list.Add(new HitCircle
+                {
+                    StartTime = list.Last().StartTime,
+                    Position = lastPos
+                });
+            }
+
+            return list;
+        }
 
         protected class ScoreAccessiblePlayer : ModTestPlayer
         {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Scoring;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Osu.Tests.Mods
+{
+    public class TestSceneOsuModRelax : OsuModTestScene
+    {
+        [Test]
+        public void Test()
+        {
+            var lastObject = new HitCircle()
+            {
+                Position = OsuPlayfield.BASE_SIZE / 2,
+                StartTime = 2550
+            };
+            CreateModTest(new ModTestData
+            {
+                Autoplay = false,
+                Mods =
+                    new Mod[]
+                    {
+                        new OsuModRelax(),
+                        new OsuModAutopilot()
+                    },
+                Beatmap = new Beatmap
+                {
+                    HitObjects =
+                    {
+                        new HitCircle()
+                        {
+                            Position = OsuPlayfield.BASE_SIZE / 2,
+                            StartTime = 2500
+                        },
+                        lastObject
+                    }
+                },
+                PassCondition = () => Player.ScoreProcessor.JudgedHits == 2
+            });
+            Score score = null;
+
+            AddUntilStep("wait for beatmap end", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= lastObject.GetEndTime());
+            AddStep("get score", () => score = ((ScoreAccessiblePlayer)Player).Score);
+            AddAssert("no key was held", () => score.Replay.Frames.Cast<OsuReplayFrame>().TakeLast(2).FirstOrDefault().Actions.Count == 0);
+        }
+
+        protected override TestPlayer CreateModPlayer(Ruleset ruleset) => new ScoreAccessiblePlayer(AllowFail);
+
+        protected class ScoreAccessiblePlayer : ModTestPlayer
+        {
+            public ScoreAccessiblePlayer(bool allowFail)
+                : base(allowFail)
+            {
+            }
+
+            public new Score Score => base.Score;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 {
                     HitObjects = hitObjects
                 },
-                PassCondition = () => Player.ScoreProcessor.Accuracy.Value == 1
+                PassCondition = () => Player.ScoreProcessor.Combo.Value == 15
             });
             Replay replay = null;
             InputManager.UseParentInput = false;
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 list.Add(new HitCircle
                 {
-                    StartTime = start + (i - 1) * 50,
+                    StartTime = start + i * 50,
                     Position = new Vector2((i + 1) * 32, OsuPlayfield.BASE_SIZE.Y / 2)
                 });
             }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
-using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Mods;
@@ -20,11 +19,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
 {
     public class TestSceneOsuModRelax : OsuModTestScene
     {
+        protected new ScoreAccessiblePlayer Player => (ScoreAccessiblePlayer)base.Player;
+
         [Test]
         public void TestKeyUp()
         {
-            var hitObjects = CreateHitObjects();
-
             CreateModTest(new ModTestData
             {
                 Autoplay = false,
@@ -36,17 +35,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                     },
                 Beatmap = new Beatmap
                 {
-                    HitObjects = hitObjects
+                    HitObjects = CreateHitObjects()
                 },
                 PassCondition = () => Player.ScoreProcessor.Combo.Value == 15
             });
-            Replay replay = null;
-            InputManager.UseParentInput = false;
 
-            AddStep("show key overlay", () => Player.HUDOverlay.KeyCounter.AlwaysVisible.Value = true);
-            AddUntilStep("wait for beatmap end", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= hitObjects.Last().StartTime);
-            AddStep("get replay", () => replay = ((ScoreAccessiblePlayer)Player).Score.Replay);
-            AddAssert("no key was held", () => replay.Frames.Cast<OsuReplayFrame>().Last().Actions.Count == 0);
+            AddUntilStep("wait for beatmap end", () => Player.ScoreProcessor.HasCompleted.Value);
+            AddAssert("no key was held", () => Player.Score.Replay.Frames
+                                                     .Cast<OsuReplayFrame>().Last().Actions.Count == 0);
         }
 
         protected override TestPlayer CreateModPlayer(Ruleset ruleset) => new ScoreAccessiblePlayer(AllowFail);

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRelax.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Mods;
@@ -18,9 +19,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
     public class TestSceneOsuModRelax : OsuModTestScene
     {
         [Test]
-        public void Test()
+        public void TestKeyUp()
         {
-            var lastObject = new HitCircle()
+            var lastObject = new HitCircle
             {
                 Position = OsuPlayfield.BASE_SIZE / 2,
                 StartTime = 2550
@@ -38,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 {
                     HitObjects =
                     {
-                        new HitCircle()
+                        new HitCircle
                         {
                             Position = OsuPlayfield.BASE_SIZE / 2,
                             StartTime = 2500
@@ -48,11 +49,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 PassCondition = () => Player.ScoreProcessor.JudgedHits == 2
             });
-            Score score = null;
+            Replay replay = null;
 
             AddUntilStep("wait for beatmap end", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= lastObject.GetEndTime());
-            AddStep("get score", () => score = ((ScoreAccessiblePlayer)Player).Score);
-            AddAssert("no key was held", () => score.Replay.Frames.Cast<OsuReplayFrame>().TakeLast(2).FirstOrDefault().Actions.Count == 0);
+            AddStep("get replay", () => replay = ((ScoreAccessiblePlayer)Player).Score.Replay);
+            AddAssert("no key was held", () => replay.Frames.Cast<OsuReplayFrame>().Last().Actions.Count == 0);
         }
 
         protected override TestPlayer CreateModPlayer(Ruleset ruleset) => new ScoreAccessiblePlayer(AllowFail);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private ReplayState<OsuAction> state;
         private double lastStateChangeTime;
+        private double beatmapLength;
 
         private bool hasReplay;
 
@@ -40,6 +41,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             // grab the input manager for future use.
             osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
+            beatmapLength = drawableRuleset.Beatmap.BeatmapInfo.Length;
         }
 
         public void ApplyToPlayer(Player player)
@@ -101,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             if (requiresHold)
                 changeState(true);
-            else if (isDownState && time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY)
+            else if (isDownState && time >= beatmapLength || time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY)
                 changeState(false);
 
             void handleHitCircle(DrawableHitCircle circle)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             if (requiresHold)
                 changeState(true);
-            else if (isDownState && time >= beatmapLength || time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY)
+            else if ((isDownState && time + AutoGenerator.KEY_UP_DELAY >= beatmapLength) || time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY)
                 changeState(false);
 
             void handleHitCircle(DrawableHitCircle circle)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             // grab the input manager for future use.
             osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
-            lastHitTime = drawableRuleset.Beatmap.HitObjects.Max(h => h.GetEndTime());
+            lastHitTime = drawableRuleset.Objects.Max(h => h.GetEndTime());
         }
 
         public void ApplyToPlayer(Player player)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 changeState(true);
             else
             {
-                bool hasCompleted = time >= lastHitTime - AutoGenerator.KEY_UP_DELAY;
+                bool hasCompleted = time > lastHitTime;
                 bool shouldRelease = isDownState && (time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY || hasCompleted);
 
                 if (shouldRelease)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 changeState(true);
             else
             {
-                bool hasCompleted = time >= lastHitTime;
+                bool hasCompleted = time >= lastHitTime - AutoGenerator.KEY_UP_DELAY;
                 bool shouldRelease = isDownState && (time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY || hasCompleted);
 
                 if (shouldRelease)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 changeState(true);
             else
             {
-                bool hasCompleted = time > lastHitTime;
+                bool hasCompleted = time >= lastHitTime - relax_leniency;
                 bool shouldRelease = isDownState && (time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY || hasCompleted);
 
                 if (shouldRelease)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -41,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             // grab the input manager for future use.
             osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
-            beatmapLength = drawableRuleset.Beatmap.BeatmapInfo.Length;
+            beatmapLength = drawableRuleset.Beatmap.HitObjects.LastOrDefault()?.GetEndTime() ?? 0;
         }
 
         public void ApplyToPlayer(Player player)


### PR DESCRIPTION
Currently relax mod only raise up the key if `time - lastStateChangeTime > AutoGenerator.KEY_UP_DELAY`
But there's no check about `time + AutoGenerator.KEY_UP_DELAY < beatmapLength`
![osu_2021-07-15_11-06-21](https://user-images.githubusercontent.com/50285552/125721721-99ed7bf7-92f1-4a88-8499-d22b78ce12b0.jpg)

You can reproduce it with a quick beatmap:
https://osu.ppy.sh/beatmapsets/757146#osu/1592913

Note that you have to view the replay for this issue, the key counter during gameplay does not show any issue

Replay showing this issue:
[PercyDan playing Tanaka Hirokazu - C-TYPE (Arf) [A-TYPE].zip](https://github.com/ppy/osu/files/6834747/PercyDan.playing.Tanaka.Hirokazu.-.C-TYPE.Arf.A-TYPE.zip)
