### PR TITLE
Add localisation coverage of `MouseSettings`

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Mania
 {
     public class ManiaSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override string Header => "osu!mania";
+        protected override LocalisableString Header => "osu!mania";
 
         public ManiaSettingsSubsection(ManiaRuleset ruleset)
             : base(ruleset)

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.UI;
@@ -11,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.UI
 {
     public class OsuSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override string Header => "osu!";
+        protected override LocalisableString Header => "osu!";
 
         public OsuSettingsSubsection(Ruleset ruleset)
             : base(ruleset)

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Cancel => new TranslatableString(getKey(@"cancel"), @"Cancel");
 
-        private static string getKey(string key) => $"{prefix}:{key}";
+        private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class MouseSettingsStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.MouseSettings";
+
+        /// <summary>
+        /// "Mouse"
+        /// </summary>
+        public static LocalisableString Mouse => new TranslatableString(getKey(@"mouse"), @"Mouse");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -14,6 +14,46 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Mouse => new TranslatableString(getKey(@"mouse"), @"Mouse");
 
+        /// <summary>
+        /// "Not applicable in full screen mode"
+        /// </summary>
+        public static LocalisableString NotApplicableFullscreen => new TranslatableString(getKey(@"not_applicable_full_screen"), @"Not applicable in full screen mode");
+
+        /// <summary>
+        /// "High precision mouse"
+        /// </summary>
+        public static LocalisableString HighPrecisionMouse => new TranslatableString(getKey(@"high_precision_mouse"), @"High precision mouse");
+
+        /// <summary>
+        /// "Attempts to bypass any operation system mouse acceleration. On windows, this is equivalent to what used to be known as &quot;Raw Input&quot;."
+        /// </summary>
+        public static LocalisableString HighPrecisionMouseTooltip => new TranslatableString(getKey(@"high_precision_mouse_tooltip"), @"Attempts to bypass any operation system mouse acceleration. On windows, this is equivalent to what used to be known as ""Raw Input"".");
+
+        /// <summary>
+        /// "Confine mouse cursor to window"
+        /// </summary>
+        public static LocalisableString ConfineMouseMode => new TranslatableString(getKey(@"confine_mouse_mode"), @"Confine mouse cursor to window");
+
+        /// <summary>
+        /// "Disable mouse wheel during gameplay"
+        /// </summary>
+        public static LocalisableString DisableMouseWheel => new TranslatableString(getKey(@"disable_mouse_wheel"), @"Disable mouse wheel during gameplay");
+
+        /// <summary>
+        /// "Disable mouse buttons during gameplay"
+        /// </summary>
+        public static LocalisableString DisableMouseButtons => new TranslatableString(getKey(@"disable_mouse_buttons"), @"Disable mouse buttons during gameplay");
+
+        /// <summary>
+        /// "Enable high precision mouse to adjust sensitivity"
+        /// </summary>
+        public static LocalisableString EnableHighPrecisionForSensitivityAdjust => new TranslatableString(getKey(@"enable_high_precision_for_sensitivity_adjust"), @"Enable high precision mouse to adjust sensitivity");
+
+        /// <summary>
+        /// "Cursor sensitivity"
+        /// </summary>
+        public static LocalisableString CursorSensitivity => new TranslatableString(getKey(@"cursor_sensitivity"), @"Cursor sensitivity");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays.Settings;
 
@@ -28,7 +29,7 @@ namespace osu.Game.Overlays.KeyBinding
 
         private class DefaultBindingsSubsection : KeyBindingsSubsection
         {
-            protected override string Header => string.Empty;
+            protected override LocalisableString Header => string.Empty;
 
             public DefaultBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
@@ -39,7 +40,7 @@ namespace osu.Game.Overlays.KeyBinding
 
         private class SongSelectKeyBindingSubsection : KeyBindingsSubsection
         {
-            protected override string Header => "Song Select";
+            protected override LocalisableString Header => "Song Select";
 
             public SongSelectKeyBindingSubsection(GlobalActionContainer manager)
                 : base(null)
@@ -50,7 +51,7 @@ namespace osu.Game.Overlays.KeyBinding
 
         private class InGameKeyBindingsSubsection : KeyBindingsSubsection
         {
-            protected override string Header => "In Game";
+            protected override LocalisableString Header => "In Game";
 
             public InGameKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
@@ -61,7 +62,7 @@ namespace osu.Game.Overlays.KeyBinding
 
         private class AudioControlKeyBindingsSubsection : KeyBindingsSubsection
         {
-            protected override string Header => "Audio";
+            protected override LocalisableString Header => "Audio";
 
             public AudioControlKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
@@ -72,7 +73,7 @@ namespace osu.Game.Overlays.KeyBinding
 
         private class EditorKeyBindingsSubsection : KeyBindingsSubsection
         {
-            protected override string Header => "Editor";
+            protected override LocalisableString Header => "Editor";
 
             public EditorKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)

--- a/osu.Game/Overlays/KeyBinding/VariantBindingsSubsection.cs
+++ b/osu.Game/Overlays/KeyBinding/VariantBindingsSubsection.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.KeyBinding
 {
     public class VariantBindingsSubsection : KeyBindingsSubsection
     {
-        protected override string Header { get; }
+        protected override LocalisableString Header { get; }
 
         public VariantBindingsSubsection(RulesetInfo ruleset, int variant)
             : base(variant)

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 {
     public class AudioDevicesSettings : SettingsSubsection
     {
-        protected override string Header => "Devices";
+        protected override LocalisableString Header => "Devices";
 
         [Resolved]
         private AudioManager audio { get; set; }

--- a/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/OffsetSettings.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 {
     public class OffsetSettings : SettingsSubsection
     {
-        protected override string Header => "Offset Adjustment";
+        protected override LocalisableString Header => "Offset Adjustment";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -4,13 +4,14 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections.Audio
 {
     public class VolumeSettings : SettingsSubsection
     {
-        protected override string Header => "Volume";
+        protected override LocalisableString Header => "Volume";
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/Debug/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Debug/GeneralSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Framework.Screens;
 using osu.Game.Screens.Import;
 
@@ -11,7 +12,7 @@ namespace osu.Game.Overlays.Settings.Sections.Debug
 {
     public class GeneralSettings : SettingsSubsection
     {
-        protected override string Header => "General";
+        protected override LocalisableString Header => "General";
 
         [BackgroundDependencyLoader(true)]
         private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig, OsuGame game)

--- a/osu.Game/Overlays/Settings/Sections/Debug/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Debug/MemorySettings.cs
@@ -4,13 +4,14 @@
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 
 namespace osu.Game.Overlays.Settings.Sections.Debug
 {
     public class MemorySettings : SettingsSubsection
     {
-        protected override string Header => "Memory";
+        protected override LocalisableString Header => "Memory";
 
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager config, GameHost host)

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Scoring;
 
@@ -11,7 +12,7 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
 {
     public class GeneralSettings : SettingsSubsection
     {
-        protected override string Header => "General";
+        protected override LocalisableString Header => "General";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
@@ -4,13 +4,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections.Gameplay
 {
     public class ModsSettings : SettingsSubsection
     {
-        protected override string Header => "Mods";
+        protected override LocalisableString Header => "Mods";
 
         public override IEnumerable<string> FilterTerms => base.FilterTerms.Concat(new[] { "mod" });
 

--- a/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Extensions;
 using osu.Game.Localisation;
 
@@ -15,7 +16,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
         private SettingsDropdown<Language> languageSelection;
         private Bindable<string> frameworkLocale;
 
-        protected override string Header => "Language";
+        protected override LocalisableString Header => "Language";
 
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager frameworkConfig)

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Configuration;
@@ -19,7 +20,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
         [Resolved(CanBeNull = true)]
         private UpdateManager updateManager { get; set; }
 
-        protected override string Header => "Updates";
+        protected override LocalisableString Header => "Updates";
 
         private SettingsButton checkForUpdatesButton;
 

--- a/osu.Game/Overlays/Settings/Sections/Graphics/DetailSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/DetailSettings.cs
@@ -3,13 +3,14 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections.Graphics
 {
     public class DetailSettings : SettingsSubsection
     {
-        protected override string Header => "Detail Settings";
+        protected override LocalisableString Header => "Detail Settings";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 {
     public class LayoutSettings : SettingsSubsection
     {
-        protected override string Header => "Layout";
+        protected override LocalisableString Header => "Layout";
 
         private FillFlowContainer<SettingsSlider<float>> scalingSettings;
 

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
 
@@ -11,7 +12,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 {
     public class RendererSettings : SettingsSubsection
     {
-        protected override string Header => "Renderer";
+        protected override LocalisableString Header => "Renderer";
 
         private SettingsEnumDropdown<FrameSync> frameLimiterDropdown;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
@@ -2,12 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class BindingSettings : SettingsSubsection
     {
-        protected override string Header => "Shortcut and gameplay bindings";
+        protected override LocalisableString Header => "Shortcut and gameplay bindings";
 
         public BindingSettings(KeyBindingPanel keyConfig)
         {

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -47,29 +47,29 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 new SettingsCheckbox
                 {
-                    LabelText = "High precision mouse",
-                    TooltipText = "Attempts to bypass any operation system mouse acceleration. On windows, this is equivalent to what used to be known as \"Raw Input\".",
+                    LabelText = MouseSettingsStrings.HighPrecisionMouse,
+                    TooltipText = MouseSettingsStrings.HighPrecisionMouseTooltip,
                     Current = relativeMode,
-                    Keywords = new[] { "raw", "input", "relative", "cursor" }
+                    Keywords = new[] { @"raw", @"input", @"relative", @"cursor" }
                 },
                 new SensitivitySetting
                 {
-                    LabelText = "Cursor sensitivity",
+                    LabelText = MouseSettingsStrings.CursorSensitivity,
                     Current = localSensitivity
                 },
                 confineMouseModeSetting = new SettingsEnumDropdown<OsuConfineMouseMode>
                 {
-                    LabelText = "Confine mouse cursor to window",
+                    LabelText = MouseSettingsStrings.ConfineMouseMode,
                     Current = osuConfig.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode)
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Disable mouse wheel during gameplay",
+                    LabelText = MouseSettingsStrings.DisableMouseWheel,
                     Current = osuConfig.GetBindable<bool>(OsuSetting.MouseDisableWheel)
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Disable mouse buttons during gameplay",
+                    LabelText = MouseSettingsStrings.DisableMouseButtons,
                     Current = osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons)
                 },
             };
@@ -99,7 +99,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 if (isFullscreen)
                 {
                     confineMouseModeSetting.Current.Disabled = true;
-                    confineMouseModeSetting.TooltipText = "Not applicable in full screen mode";
+                    confineMouseModeSetting.TooltipText = MouseSettingsStrings.NotApplicableFullscreen;
                 }
                 else
                 {
@@ -120,7 +120,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private class SensitivitySlider : OsuSliderBar<double>
         {
-            public override LocalisableString TooltipText => Current.Disabled ? "enable high precision mouse to adjust sensitivity" : $"{base.TooltipText}x";
+            public override LocalisableString TooltipText => Current.Disabled ? MouseSettingsStrings.EnableHighPrecisionForSensitivityAdjust : $"{base.TooltipText}x";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -47,7 +47,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 new SettingsCheckbox
                 {
                     LabelText = "High precision mouse",
-                    Current = relativeMode
+                    TooltipText = "Attempts to bypass any operation system mouse acceleration. On windows, this is equivalent to what used to be known as \"Raw Input\".",
+                    Current = relativeMode,
+                    Keywords = new[] { "raw", "input", "relative", "cursor" }
                 },
                 new SensitivitySetting
                 {

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -10,6 +10,7 @@ using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {
@@ -17,7 +18,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
     {
         private readonly MouseHandler mouseHandler;
 
-        protected override string Header => "Mouse";
+        protected override LocalisableString Header => MouseSettingsStrings.Mouse;
 
         private Bindable<double> handlerSensitivity;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Handlers.Tablet;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Graphics.Sprites;
@@ -52,7 +53,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private OsuSpriteText noTabletMessage;
 
-        protected override string Header => "Tablet";
+        protected override LocalisableString Header => "Tablet";
 
         public TabletSettings(ITabletHandler tabletHandler)
         {

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -9,6 +9,7 @@ using osu.Framework.Input.Handlers.Joystick;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.Handlers.Tablet;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Overlays.Settings.Sections.Input;
 
@@ -100,7 +101,7 @@ namespace osu.Game.Overlays.Settings.Sections
                 };
             }
 
-            protected override string Header => handler.Description;
+            protected override LocalisableString Header => handler.Description;
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Database;
@@ -17,7 +18,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 {
     public class GeneralSettings : SettingsSubsection
     {
-        protected override string Header => "General";
+        protected override LocalisableString Header => "General";
 
         private TriangleButton importBeatmapsButton;
         private TriangleButton importScoresButton;

--- a/osu.Game/Overlays/Settings/Sections/Online/AlertsAndPrivacySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/AlertsAndPrivacySettings.cs
@@ -3,13 +3,14 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections.Online
 {
     public class AlertsAndPrivacySettings : SettingsSubsection
     {
-        protected override string Header => "Alerts and Privacy";
+        protected override LocalisableString Header => "Alerts and Privacy";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/Online/IntegrationSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/IntegrationSettings.cs
@@ -3,13 +3,14 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections.Online
 {
     public class IntegrationSettings : SettingsSubsection
     {
-        protected override string Header => "Integrations";
+        protected override LocalisableString Header => "Integrations";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
@@ -3,13 +3,14 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections.Online
 {
     public class WebSettings : SettingsSubsection
     {
-        protected override string Header => "Web";
+        protected override LocalisableString Header => "Web";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
     public class GeneralSettings : SettingsSubsection
     {
-        protected override string Header => "General";
+        protected override LocalisableString Header => "General";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Users;
@@ -12,7 +13,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
     public class MainMenuSettings : SettingsSubsection
     {
-        protected override string Header => "Main Menu";
+        protected override LocalisableString Header => "Main Menu";
 
         private IBindable<User> user;
 

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
         private Bindable<double> minStars;
         private Bindable<double> maxStars;
 
-        protected override string Header => "Song Select";
+        protected override LocalisableString Header => "Song Select";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -8,6 +8,7 @@ using osu.Game.Graphics.Sprites;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.Graphics;
 
@@ -20,10 +21,10 @@ namespace osu.Game.Overlays.Settings
 
         protected readonly FillFlowContainer FlowContent;
 
-        protected abstract string Header { get; }
+        protected abstract LocalisableString Header { get; }
 
         public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
-        public virtual IEnumerable<string> FilterTerms => new[] { Header };
+        public virtual IEnumerable<string> FilterTerms => new[] { Header.ToString() };
 
         public bool MatchingFilter
         {
@@ -54,7 +55,7 @@ namespace osu.Game.Overlays.Settings
             {
                 new OsuSpriteText
                 {
-                    Text = Header.ToUpperInvariant(),
+                    Text = Header.ToString().ToUpper(), // TODO: Add localisation support after https://github.com/ppy/osu-framework/pull/4603 is merged.
                     Margin = new MarginPadding { Vertical = 30, Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS },
                     Font = OsuFont.GetFont(weight: FontWeight.Bold),
                 },


### PR DESCRIPTION
Also:

- Updates `SettingsSubsection.Header` to accept a `LocalisableString` (but doesn't consume localisations, pending https://github.com/ppy/osu-framework/pull/4603)
- Updates `CommonStrings` to latest localiser tools output
