### PR TITLE
Fix multiple issues with `BeatSyncedContainer`

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             double? lastActuationTime = null;
             TimingControlPoint lastTimingPoint = null;
 
-            AddStep("set mistimed to disallow", () => beatContainer.AllowMistimedEventFiring = allowMistimed);
+            AddStep($"set mistimed to {(allowMistimed ? "allowed" : "disallowed")}", () => beatContainer.AllowMistimedEventFiring = allowMistimed);
 
             AddStep("bind event", () =>
             {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -65,19 +65,16 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep($"set mistimed to {(allowMistimed ? "allowed" : "disallowed")}", () => beatContainer.AllowMistimedEventFiring = allowMistimed);
 
-            AddStep("bind event", () =>
+            AddStep("Set time before zero", () =>
             {
                 beatContainer.NewBeat = (i, timingControlPoint, effectControlPoint, channelAmplitudes) =>
                 {
                     lastActuationTime = gameplayClockContainer.CurrentTime;
                     lastTimingPoint = timingControlPoint;
                     lastBeatIndex = i;
+                    beatContainer.NewBeat = null;
                 };
-            });
 
-            AddStep("Set time before zero", () =>
-            {
-                lastBeatIndex = null;
                 gameplayClockContainer.Seek(-1000);
             });
 
@@ -99,19 +96,14 @@ namespace osu.Game.Tests.Visual.UserInterface
             int? lastBeatIndex = null;
             double? lastBpm = null;
 
-            AddStep("bind event", () =>
+            AddStep("Set time before zero", () =>
             {
                 beatContainer.NewBeat = (i, timingControlPoint, effectControlPoint, channelAmplitudes) =>
                 {
                     lastBeatIndex = i;
                     lastBpm = timingControlPoint.BPM;
                 };
-            });
 
-            AddStep("Set time before zero", () =>
-            {
-                lastBeatIndex = null;
-                lastBpm = null;
                 gameplayClockContainer.Seek(-1000);
             });
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -56,7 +56,34 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestFirstBeatAtFirstTimingPoint()
+        public void TestSeekBackDoesntPlayMidBeat()
+        {
+            int? lastBeatIndex = null;
+            double? lastActuationTime = null;
+            TimingControlPoint lastTimingPoint = null;
+
+            AddStep("bind event", () =>
+            {
+                beatContainer.NewBeat = (i, timingControlPoint, effectControlPoint, channelAmplitudes) =>
+                {
+                    lastActuationTime = gameplayClockContainer.CurrentTime;
+                    lastTimingPoint = timingControlPoint;
+                    lastBeatIndex = i;
+                };
+            });
+
+            AddStep("Set time before zero", () =>
+            {
+                lastBeatIndex = null;
+                gameplayClockContainer.Seek(-1000);
+            });
+
+            AddUntilStep("wait for trigger", () => lastBeatIndex != null);
+            AddAssert("trigger is near beat length", () => lastActuationTime != null && lastBeatIndex != null && Precision.AlmostEquals(lastTimingPoint.Time + lastBeatIndex.Value * lastTimingPoint.BeatLength, lastActuationTime.Value, 32));
+        }
+
+        [Test]
+        public void TestNegativeBeatsStillUsingBeatmapTiming()
         {
             int? lastBeatIndex = null;
             double? lastBpm = null;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddUntilStep("wait for trigger", () => lastBpm != null);
-            AddAssert("bpm is from beatmap", () => lastBpm != null && Precision.AlmostEquals(lastBpm.Value, 60));
+            AddAssert("bpm is default", () => lastBpm != null && Precision.AlmostEquals(lastBpm.Value, 60));
         }
 
         private class TestBeatSyncedContainer : BeatSyncedContainer

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -78,8 +78,31 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddUntilStep("wait for trigger", () => lastBpm != null);
-            AddAssert("bpm is from beatmap", () => lastBpm != null&&Precision.AlmostEquals(lastBpm.Value, 128));
+            AddAssert("bpm is from beatmap", () => lastBpm != null && Precision.AlmostEquals(lastBpm.Value, 128));
             AddAssert("beat index is less than zero", () => lastBeatIndex < 0);
+        }
+
+        [Test]
+        public void TestIdleBeatOnPausedClock()
+        {
+            double? lastBpm = null;
+
+            AddStep("bind event", () =>
+            {
+                beatContainer.NewBeat = (i, timingControlPoint, effectControlPoint, channelAmplitudes) => lastBpm = timingControlPoint.BPM;
+            });
+
+            AddUntilStep("wait for trigger", () => lastBpm != null);
+            AddAssert("bpm is from beatmap", () => lastBpm != null && Precision.AlmostEquals(lastBpm.Value, 128));
+
+            AddStep("pause gameplay clock", () =>
+            {
+                lastBpm = null;
+                gameplayClockContainer.Stop();
+            });
+
+            AddUntilStep("wait for trigger", () => lastBpm != null);
+            AddAssert("bpm is from beatmap", () => lastBpm != null && Precision.AlmostEquals(lastBpm.Value, 60));
         }
 
         private class BeatContainer : BeatSyncedContainer

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Graphics.Containers
                 beatmap = Beatmap.Value.Beatmap;
             }
 
-            if (track != null && beatmap != null && track.IsRunning && track.Length > 0)
+            if (track != null && beatmap != null && clock.IsRunning && track.Length > 0)
             {
                 currentTrackTime = clock.CurrentTime + EarlyActivationMilliseconds;
 

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Graphics.Containers
             if (clock == null)
                 return;
 
-            double currentTrackTime = clock.CurrentTime + EarlyActivationMilliseconds;
+            double currentTrackTime = clock.CurrentTime;
 
             if (Beatmap.Value.TrackLoaded && Beatmap.Value.BeatmapLoaded)
             {
@@ -123,7 +123,7 @@ namespace osu.Game.Graphics.Containers
                 effectPoint = EffectControlPoint.DEFAULT;
             }
 
-            Debug.Assert(timingPoint != null);
+            currentTrackTime += EarlyActivationMilliseconds;
 
             double beatLength = timingPoint.BeatLength / Divisor;
 

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Graphics.Containers
                 beatIndex--;
 
             TimeUntilNextBeat = (timingPoint.Time - currentTrackTime) % beatLength;
-            if (TimeUntilNextBeat < 0)
+            if (TimeUntilNextBeat <= 0)
                 TimeUntilNextBeat += beatLength;
 
             TimeSinceLastBeat = beatLength - TimeUntilNextBeat;

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -72,8 +72,6 @@ namespace osu.Game.Screens.Menu
             set => colourAndTriangles.FadeTo(value ? 1 : 0, transition_length, Easing.OutQuint);
         }
 
-        public bool BeatMatching = true;
-
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => logoContainer.ReceivePositionalInputAt(screenSpacePos);
 
         public bool Ripple
@@ -271,8 +269,6 @@ namespace osu.Game.Screens.Menu
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
             base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
-
-            if (!BeatMatching) return;
 
             lastBeatIndex = beatIndex;
 

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -242,7 +242,6 @@ namespace osu.Game.Screens
             logo.Anchor = Anchor.TopLeft;
             logo.Origin = Anchor.Centre;
             logo.RelativePositionAxes = Axes.Both;
-            logo.BeatMatching = true;
             logo.Triangles = true;
             logo.Ripple = true;
         }


### PR DESCRIPTION
Alternative to / closes https://github.com/ppy/osu/pull/13890 (since I can't understand the logic presented there, nor was it tested)

## Refactored `BeatSyncedContainer` to support `GameplayClock`

Previously this container was reading directly from the beatmap's track in all cases, ignoring any gameplay adjustments / offsets. This isn't the final solution to this problem, but at least provides a bandaid fix for otherwise mistimed beat syncing.

## Fix default timing points being used if "track" is not running

Kind of due to the above refactoring, the beat syncing now correctly uses the beatmap's timing for negative time values. Previously because the track was "not running" due to gameplay being in decoupled playback, the `BeatSyncedContainer` would incorrectly use `DEFAULT` timing data.

## Ensure `EarlyActivationMilliseconds` is applied even in idle state

The intention of this variable was to allow for animations to play a "fade in" state and still roughly be centered on the target beat. Which should also be the case for an idle state (so that multiple `BeatSyncedContainer` are still in sync with each other).

## Add ability to disable mistimed event firings

This resolves the issue that #13890 was attempting to fix. The usage of `BeatSyncedContainer` for anything that isn't an animation (and able to consume `TransformDelay`) would potentially cause completely mistimed actuation. I'm not 100% sure on this solution. If it's deemed unacceptable, some more complex alternatives would be:

- `Schedule`ing the `OnNewBeat` invoke.
- Locally fixing this in implementations using `BeatSyncedContainer` that do anything that isn't an animation. ie. every instance we are calling `sample.Play()` would need to be `this.Schedule(() => sample.Play())` to correctly get the `TransformDelay` consideration.
- Changing `PasusableSkinnableSample` etc. to use `Schedule` for their `Play` calls

All of these will potentially add an unwanted frame delay, though (needs investigation). Maybe scheduling only if `TransformDelay` is non-zero would help? not sure.
