### PR TITLE
Adjust mania speed range

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -22,6 +22,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected readonly IBindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
 
+        // Leaving the default (10s) makes hitobjects not appear, as this offset is used for the initial state transforms.
+        // Calculated as DrawableManiaRuleset.MAX_TIME_RANGE + some additional allowance for velocity < 1.
+        protected override double InitialLifetimeOffset => 30000;
+
         [Resolved(canBeNull: true)]
         private ManiaPlayfield playfield { get; set; }
 

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override ScrollVisualisationMethod VisualisationMethod => scrollMethod;
 
         private readonly Bindable<ManiaScrollingDirection> configDirection = new Bindable<ManiaScrollingDirection>();
-        private readonly Bindable<double> configTimeRange = new BindableDouble();
+        private readonly BindableDouble configTimeRange = new BindableDouble();
 
         // Stores the current speed adjustment active in gameplay.
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
@@ -103,6 +103,8 @@ namespace osu.Game.Rulesets.Mania.UI
             configDirection.BindValueChanged(direction => Direction.Value = (ScrollingDirection)direction.NewValue, true);
 
             Config.BindWith(ManiaRulesetSetting.ScrollTime, configTimeRange);
+            TimeRange.MinValue = configTimeRange.MinValue;
+            TimeRange.MaxValue = configTimeRange.MaxValue;
         }
 
         protected override void AdjustScrollSpeed(int amount)

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -33,12 +33,12 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// The minimum time range. This occurs at a <see cref="relativeTimeRange"/> of 40.
         /// </summary>
-        public const double MIN_TIME_RANGE = 340;
+        public const double MIN_TIME_RANGE = 290;
 
         /// <summary>
         /// The maximum time range. This occurs at a <see cref="relativeTimeRange"/> of 1.
         /// </summary>
-        public const double MAX_TIME_RANGE = 13720;
+        public const double MAX_TIME_RANGE = 11485;
 
         protected new ManiaPlayfield Playfield => (ManiaPlayfield)base.Playfield;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/13900

As I mentioned in https://github.com/ppy/osu/discussions/13896#discussioncomment-1012208, my original calculations assumed a scroll distance of 480px. But hitobjects only scroll to the hit position, which is 402px.

Comparison vs stable values:
```
SpeedMania.RelativeSpeed = 40 * 100 / (60000 / speedChanges[0].BeatLength)
28.5714285714286
SpeedMania.TimeAt(speedChanges[0].BeatLength, 402)
287.14285714285711

SpeedMania.RelativeSpeed = 1 * 100 / (60000 / speedChanges[0].BeatLength)
0.714285714285715
SpeedMania.TimeAt(speedChanges[0].BeatLength, 402)
11485.714285714286
```

Or can be calculated manually by `402 * (60000 / 100) / 21 / 40` (explained previously in https://github.com/ppy/osu/issues/9868#issuecomment-675327188).

Comparison:
| stable | lazer |
| --- | --- |
| ![Screenshot_2021-07-16_19-49-10](https://user-images.githubusercontent.com/1329837/125936690-122a040b-d1e5-45e1-a9ab-c5525642b2aa.png) | ![Screenshot_2021-07-16_19-48-57](https://user-images.githubusercontent.com/1329837/125936698-f7b381b9-69d2-4720-bb7a-e0a4d0ecec74.png) |
| ![Screenshot_2021-07-16_19-40-55](https://user-images.githubusercontent.com/1329837/125935809-9fa382ae-2ca3-4cea-80ce-230e92ae6adf.png) | ![Screenshot_2021-07-16_19-40-29](https://user-images.githubusercontent.com/1329837/125935821-18841fd4-6caf-4630-b7ac-1c62db1eebb6.png) |