### PR TITLE
Fix progression lines getting stuck after removing a match in ladder editor screen

### DIFF
--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -303,6 +303,15 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             Match.LosersProgression.Value = null;
 
             ladderInfo.Matches.Remove(Match);
+
+            foreach (var m in ladderInfo.Matches)
+            {
+                if (m.Progression.Value == Match)
+                    m.Progression.Value = null;
+
+                if (m.LosersProgression.Value == Match)
+                    m.LosersProgression.Value = null;
+            }
         }
     }
 }


### PR DESCRIPTION
Just noticed this in passing.

- Add two matches and connect them
- Remove the second (destination) match

Observe that the progression line remains even after the match is removed.


https://user-images.githubusercontent.com/191335/125967177-0ce44646-70bb-4017-aec8-5d9445138ecf.mp4

