### PR TITLE
Show warning on screens which require a current match to be selected

### DIFF
--- a/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
+++ b/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
@@ -11,7 +11,7 @@ using osu.Game.Tournament.IPC;
 
 namespace osu.Game.Tournament.Screens
 {
-    public abstract class BeatmapInfoScreen : TournamentScreen
+    public abstract class BeatmapInfoScreen : TournamentMatchScreen
     {
         protected readonly SongBar SongBar;
 

--- a/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
+++ b/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Tournament.Components;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Tournament.Models;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Screens.Showcase
@@ -38,6 +40,12 @@ namespace osu.Game.Tournament.Screens.Showcase
                     }
                 }
             });
+        }
+
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        {
+            // showcase screen doesn't care about a match being selected.
+            // base call intentionally omitted to not show match warning.
         }
     }
 }

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -18,11 +18,9 @@ using osuTK;
 
 namespace osu.Game.Tournament.Screens.TeamIntro
 {
-    public class SeedingScreen : TournamentScreen, IProvideVideo
+    public class SeedingScreen : TournamentMatchScreen, IProvideVideo
     {
         private Container mainContainer;
-
-        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
 
         private readonly Bindable<TournamentTeam> currentTeam = new Bindable<TournamentTeam>();
 
@@ -50,13 +48,13 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         {
                             RelativeSizeAxes = Axes.X,
                             Text = "Show first team",
-                            Action = () => currentTeam.Value = currentMatch.Value.Team1.Value,
+                            Action = () => currentTeam.Value = CurrentMatch.Value.Team1.Value,
                         },
                         new TourneyButton
                         {
                             RelativeSizeAxes = Axes.X,
                             Text = "Show second team",
-                            Action = () => currentTeam.Value = currentMatch.Value.Team2.Value,
+                            Action = () => currentTeam.Value = CurrentMatch.Value.Team2.Value,
                         },
                         new SettingsTeamDropdown(LadderInfo.Teams)
                         {
@@ -66,9 +64,6 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                     }
                 }
             };
-
-            currentMatch.BindValueChanged(matchChanged);
-            currentMatch.BindTo(LadderInfo.CurrentMatch);
 
             currentTeam.BindValueChanged(teamChanged, true);
         }
@@ -84,8 +79,15 @@ namespace osu.Game.Tournament.Screens.TeamIntro
             showTeam(team.NewValue);
         }
 
-        private void matchChanged(ValueChangedEvent<TournamentMatch> match) =>
-            currentTeam.Value = currentMatch.Value.Team1.Value;
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        {
+            base.CurrentMatchChanged(match);
+
+            if (match.NewValue == null)
+                return;
+
+            currentTeam.Value = match.NewValue.Team1.Value;
+        }
 
         private void showTeam(TournamentTeam team)
         {

--- a/osu.Game.Tournament/Screens/TeamIntro/TeamIntroScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/TeamIntroScreen.cs
@@ -12,11 +12,9 @@ using osuTK;
 
 namespace osu.Game.Tournament.Screens.TeamIntro
 {
-    public class TeamIntroScreen : TournamentScreen, IProvideVideo
+    public class TeamIntroScreen : TournamentMatchScreen, IProvideVideo
     {
         private Container mainContainer;
-
-        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
 
         [BackgroundDependencyLoader]
         private void load(Storage storage)
@@ -35,18 +33,16 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                     RelativeSizeAxes = Axes.Both,
                 }
             };
-
-            currentMatch.BindValueChanged(matchChanged);
-            currentMatch.BindTo(LadderInfo.CurrentMatch);
         }
 
-        private void matchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
         {
+            base.CurrentMatchChanged(match);
+
+            mainContainer.Clear();
+
             if (match.NewValue == null)
-            {
-                mainContainer.Clear();
                 return;
-            }
 
             const float y_flag_offset = 292;
 

--- a/osu.Game.Tournament/Screens/TeamWin/TeamWinScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamWin/TeamWinScreen.cs
@@ -13,11 +13,10 @@ using osuTK;
 
 namespace osu.Game.Tournament.Screens.TeamWin
 {
-    public class TeamWinScreen : TournamentScreen, IProvideVideo
+    public class TeamWinScreen : TournamentMatchScreen, IProvideVideo
     {
         private Container mainContainer;
 
-        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
         private readonly Bindable<bool> currentCompleted = new Bindable<bool>();
 
         private TourneyVideo blueWinVideo;
@@ -48,17 +47,19 @@ namespace osu.Game.Tournament.Screens.TeamWin
                 }
             };
 
-            currentMatch.BindValueChanged(matchChanged);
-            currentMatch.BindTo(ladder.CurrentMatch);
-
             currentCompleted.BindValueChanged(_ => update());
         }
 
-        private void matchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
         {
-            currentCompleted.UnbindBindings();
-            currentCompleted.BindTo(match.NewValue.Completed);
+            base.CurrentMatchChanged(match);
 
+            currentCompleted.UnbindBindings();
+
+            if (match.NewValue == null)
+                return;
+
+            currentCompleted.BindTo(match.NewValue.Completed);
             update();
         }
 
@@ -66,7 +67,7 @@ namespace osu.Game.Tournament.Screens.TeamWin
 
         private void update() => Schedule(() =>
         {
-            var match = currentMatch.Value;
+            var match = CurrentMatch.Value;
 
             if (match.Winner == null)
             {

--- a/osu.Game.Tournament/Screens/TournamentMatchScreen.cs
+++ b/osu.Game.Tournament/Screens/TournamentMatchScreen.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Tournament.Models;
+
+namespace osu.Game.Tournament.Screens
+{
+    public abstract class TournamentMatchScreen : TournamentScreen
+    {
+        protected readonly Bindable<TournamentMatch> CurrentMatch = new Bindable<TournamentMatch>();
+        private WarningBox noMatchWarning;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            CurrentMatch.BindTo(LadderInfo.CurrentMatch);
+            CurrentMatch.BindValueChanged(CurrentMatchChanged, true);
+        }
+
+        protected virtual void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        {
+            if (match.NewValue == null)
+            {
+                AddInternal(noMatchWarning = new WarningBox("Choose a match first from the brackets screen"));
+                return;
+            }
+
+            noMatchWarning?.Expire();
+            noMatchWarning = null;
+        }
+    }
+}

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -97,7 +97,12 @@ namespace osu.Game.Tournament
                         },
                     }
                 },
-                heightWarning = new WarningBox("Please make the window wider"),
+                heightWarning = new WarningBox("Please make the window wider")
+                {
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Margin = new MarginPadding(20),
+                },
                 new OsuContextMenuContainer
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
This is kind of in response to https://github.com/ppy/osu/discussions/13892, which made it clear that there wasn't enough prompting to users to help understand the correct flow of using the tournament client.

In order to avoid overlap with the "make screen wider" warning I moved it to the bottom of the screen.
