### PR TITLE
Fix seeding screen crashing on seedings with null mod

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
@@ -1,9 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Tournament.Models;
+using osu.Game.Tournament.Screens.Ladder.Components;
 using osu.Game.Tournament.Screens.TeamIntro;
 
 namespace osu.Game.Tournament.Tests.Screens
@@ -11,16 +15,41 @@ namespace osu.Game.Tournament.Tests.Screens
     public class TestSceneSeedingScreen : TournamentTestScene
     {
         [Cached]
-        private readonly LadderInfo ladder = new LadderInfo();
-
-        [BackgroundDependencyLoader]
-        private void load()
+        private readonly LadderInfo ladder = new LadderInfo
         {
-            Add(new SeedingScreen
+            Teams =
+            {
+                new TournamentTeam
+                {
+                    FullName = { Value = @"Japan" },
+                    Acronym = { Value = "JPN" },
+                    SeedingResults =
+                    {
+                        new SeedingResult
+                        {
+                            // Mod intentionally left blank.
+                            Seed = { Value = 4 }
+                        },
+                        new SeedingResult
+                        {
+                            Mod = { Value = "DT" },
+                            Seed = { Value = 8 }
+                        }
+                    }
+                }
+            }
+        };
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("create seeding screen", () => Add(new SeedingScreen
             {
                 FillMode = FillMode.Fit,
                 FillAspectRatio = 16 / 9f
-            });
+            }));
+
+            AddStep("set team to Japan", () => this.ChildrenOfType<SettingsTeamDropdown>().Single().Current.Value = ladder.Teams.Single());
         }
     }
 }

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -179,44 +179,48 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                 [BackgroundDependencyLoader]
                 private void load(TextureStore textures)
                 {
+                    FillFlowContainer row;
+
                     InternalChildren = new Drawable[]
                     {
-                        new FillFlowContainer
+                        row = new FillFlowContainer
                         {
                             AutoSizeAxes = Axes.Both,
                             Direction = FillDirection.Horizontal,
                             Spacing = new Vector2(5),
-                            Children = new Drawable[]
-                            {
-                                new Sprite
-                                {
-                                    Texture = textures.Get($"mods/{mods.ToLower()}"),
-                                    Scale = new Vector2(0.5f)
-                                },
-                                new Container
-                                {
-                                    Size = new Vector2(50, 16),
-                                    CornerRadius = 10,
-                                    Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = TournamentGame.ELEMENT_BACKGROUND_COLOUR,
-                                        },
-                                        new TournamentSpriteText
-                                        {
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Text = seeding.ToString("#,0"),
-                                            Colour = TournamentGame.ELEMENT_FOREGROUND_COLOUR
-                                        },
-                                    }
-                                },
-                            }
                         },
                     };
+
+                    if (!string.IsNullOrEmpty(mods))
+                    {
+                        row.Add(new Sprite
+                        {
+                            Texture = textures.Get($"mods/{mods.ToLower()}"),
+                            Scale = new Vector2(0.5f)
+                        });
+                    }
+
+                    row.Add(new Container
+                    {
+                        Size = new Vector2(50, 16),
+                        CornerRadius = 10,
+                        Masking = true,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = TournamentGame.ELEMENT_BACKGROUND_COLOUR,
+                            },
+                            new TournamentSpriteText
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Text = seeding.ToString("#,0"),
+                                Colour = TournamentGame.ELEMENT_FOREGROUND_COLOUR
+                            },
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
Closes #13912.

Test is a bit janky because the "DT" case only displays slightly differently (has a 5-unit indent on it). That in turn is because there are no mod icon resources for testing. Can try and add on request if needed, but it may be a touch complicated given the tournament client storage structure.