### PR TITLE
Add support for specifying toolbar-specific overlay names

### DIFF
--- a/osu.Game/Overlays/FullscreenOverlay.cs
+++ b/osu.Game/Overlays/FullscreenOverlay.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Overlays
     {
         public virtual string IconTexture => Header.Title.IconTexture ?? string.Empty;
         public virtual LocalisableString Title => Header.Title.Title;
+        public virtual LocalisableString? ToolbarName => Header.Title.ToolbarName;
         public virtual LocalisableString Description => Header.Title.Description;
 
         public T Header { get; }

--- a/osu.Game/Overlays/INamedOverlayComponent.cs
+++ b/osu.Game/Overlays/INamedOverlayComponent.cs
@@ -11,6 +11,12 @@ namespace osu.Game.Overlays
 
         LocalisableString Title { get; }
 
+        /// <summary>
+        /// An optional name used specifically for toolbar overlay toggle buttons.
+        /// If null, <see cref="Title"/> should be used directly instead.
+        /// </summary>
+        LocalisableString? ToolbarName => null;
+
         LocalisableString Description { get; }
     }
 }

--- a/osu.Game/Overlays/OverlayTitle.cs
+++ b/osu.Game/Overlays/OverlayTitle.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Overlays
             protected set => titleText.Text = title = value;
         }
 
+        public LocalisableString? ToolbarName { get; protected set; }
+
         public LocalisableString Description { get; protected set; }
 
         private string iconTexture;

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Overlays.Rankings
             public RankingsTitle()
             {
                 Title = "ranking";
+                ToolbarName = "rankings";
                 Description = "find out who's the best right now";
                 IconTexture = "Icons/Hexacons/rankings";
             }

--- a/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Toolbar
 
                 if (stateContainer is INamedOverlayComponent named)
                 {
-                    TooltipMain = named.Title;
+                    TooltipMain = named.ToolbarName ?? named.Title;
                     TooltipSub = named.Description;
                     SetIcon(named.IconTexture);
                 }

--- a/osu.Game/Overlays/Wiki/WikiHeader.cs
+++ b/osu.Game/Overlays/Wiki/WikiHeader.cs
@@ -73,7 +73,8 @@ namespace osu.Game.Overlays.Wiki
         {
             public WikiHeaderTitle()
             {
-                Title = "wiki";
+                Title = "knowledge base";
+                ToolbarName = "wiki";
                 Description = "knowledge base";
                 IconTexture = "Icons/Hexacons/wiki";
             }


### PR DESCRIPTION
Prerequisite for #13914 to correctly use the right localisation strings rather than mixing `PageTitleStrings` and `LayoutStrings.Menu*`.

Also fixes:
 - https://github.com/ppy/osu/commit/d23954e340f5c5ce53c940c0ebb4445a06b5dabd: Wiki overlay displaying "wiki" on the overlay header title, rather than "knowledge base" (for matching with osu!web, overlay description may need to be updated though).
 - https://github.com/ppy/osu/commit/9673f3772396b8b9b8cb1d0fac5bbdbaab86b5b7: Rankings overlay displaying "ranking" on the toolbar, rather than "rankings". (considering osu!web's navigation menu as an analogue, can revert if it doesn't sound right, not sure)