### PR TITLE
Localise user profile overlay

### DIFF
--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osuTK;
 
@@ -119,12 +120,12 @@ namespace osu.Game.Overlays.Profile.Header
                             {
                                 hiddenDetailGlobal = new OverlinedInfoContainer
                                 {
-                                    Title = "Global Ranking",
+                                    Title = UsersStrings.ShowRankGlobalSimple,
                                     LineColour = colourProvider.Highlight1
                                 },
                                 hiddenDetailCountry = new OverlinedInfoContainer
                                 {
-                                    Title = "Country Ranking",
+                                    Title = UsersStrings.ShowRankCountrySimple,
                                     LineColour = colourProvider.Highlight1
                                 },
                             }

--- a/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly BindableBool DetailsVisible = new BindableBool();
 
-        public override LocalisableString TooltipText => DetailsVisible.Value ? "collapse" : "expand";
+        public override LocalisableString TooltipText => DetailsVisible.Value ? CommonStrings.ButtonsCollapse : CommonStrings.ButtonsExpand;
 
         private SpriteIcon icon;
         private Sample sampleOpen;

--- a/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -13,7 +14,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public override LocalisableString TooltipText => "followers";
+        public override LocalisableString TooltipText => FriendsStrings.ButtonsDisabled;
 
         protected override IconUsage Icon => FontAwesome.Solid.User;
 

--- a/osu.Game/Overlays/Profile/Header/Components/LevelBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelBadge.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -19,13 +20,13 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public LocalisableString TooltipText { get; }
+        public LocalisableString TooltipText { get; private set; }
 
         private OsuSpriteText levelText;
 
         public LevelBadge()
         {
-            TooltipText = "level";
+            TooltipText = UsersStrings.ShowStatsLevel("0");
         }
 
         [BackgroundDependencyLoader]
@@ -53,6 +54,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private void updateLevel(User user)
         {
             levelText.Text = user?.Statistics?.Level.Current.ToString() ?? "0";
+            TooltipText = UsersStrings.ShowStatsLevel(user?.Statistics?.Level.Current.ToString());
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
@@ -10,6 +10,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osuTK.Graphics;
 
@@ -26,7 +27,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         public LevelProgressBar()
         {
-            TooltipText = "progress to next level";
+            TooltipText = UsersStrings.ShowStatsLevelProgress;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Profile/Header/Components/MappingSubscribersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MappingSubscribersButton.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -13,7 +14,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public override LocalisableString TooltipText => "mapping subscribers";
+        public override LocalisableString TooltipText => FollowsStrings.MappingFollowers;
 
         protected override IconUsage Icon => FontAwesome.Solid.Bell;
 

--- a/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.Chat;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osuTK;
 
@@ -17,7 +18,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         public readonly Bindable<User> User = new Bindable<User>();
 
-        public override LocalisableString TooltipText => "send message";
+        public override LocalisableString TooltipText => UsersStrings.CardSendMessage;
 
         [Resolved(CanBeNull = true)]
         private ChannelManager channelManager { get; set; }

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK.Graphics;
@@ -16,7 +17,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private readonly OsuSpriteText title;
         private readonly OsuSpriteText content;
 
-        public string Title
+        public LocalisableString Title
         {
             set => title.Text = value;
         }

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -31,7 +32,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             InternalChild = info = new OverlinedInfoContainer
             {
-                Title = "Total Play Time",
+                Title = UsersStrings.ShowStatsPlayTime,
                 LineColour = colourProvider.Highlight1,
             };
 

--- a/osu.Game/Overlays/Profile/Header/Components/PreviousUsernames.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/PreviousUsernames.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osuTK;
 
@@ -68,7 +69,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             {
                                 Anchor = Anchor.BottomLeft,
                                 Origin = Anchor.BottomLeft,
-                                Text = @"formerly known as",
+                                Text = UsersStrings.ShowPreviousUsernames,
                                 Font = OsuFont.GetFont(size: 10, italics: true)
                             }
                         },

--- a/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -27,7 +28,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Text = "No recent plays",
+                Text = UsersStrings.ShowExtraUnranked,
                 Font = OsuFont.GetFont(size: 12, weight: FontWeight.Regular)
             });
         }
@@ -74,7 +75,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private class RankGraphTooltip : UserGraphTooltip
         {
             public RankGraphTooltip()
-                : base("Global Ranking")
+                : base(UsersStrings.ShowRankGlobalSimple)
             {
             }
 

--- a/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Header.Components
 {
@@ -19,7 +20,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private readonly FillFlowContainer iconContainer;
         private readonly CircularContainer content;
 
-        public LocalisableString TooltipText => "osu!supporter";
+        public LocalisableString TooltipText => UsersStrings.ShowIsSupporter;
 
         public int SupportLevel
         {

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -11,6 +11,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
 using osu.Game.Users;
 using osuTK;
@@ -100,7 +101,7 @@ namespace osu.Game.Overlays.Profile.Header
                                         },
                                         medalInfo = new OverlinedInfoContainer
                                         {
-                                            Title = "Medals",
+                                            Title = UsersStrings.ShowStatsMedals,
                                             LineColour = colours.GreenLight,
                                         },
                                         ppInfo = new OverlinedInfoContainer
@@ -151,12 +152,12 @@ namespace osu.Game.Overlays.Profile.Header
                                     {
                                         detailGlobalRank = new OverlinedInfoContainer(true, 110)
                                         {
-                                            Title = "Global Ranking",
+                                            Title = UsersStrings.ShowRankGlobalSimple,
                                             LineColour = colourProvider.Highlight1,
                                         },
                                         detailCountryRank = new OverlinedInfoContainer(false, 110)
                                         {
-                                            Title = "Country Ranking",
+                                            Title = UsersStrings.ShowRankCountrySimple,
                                             LineColour = colourProvider.Highlight1,
                                         },
                                     }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -7,11 +7,13 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osu.Game.Users.Drawables;
 using osuTK;
@@ -179,19 +181,19 @@ namespace osu.Game.Overlays.Profile.Header
 
             if (user?.Statistics != null)
             {
-                userStats.Add(new UserStatsLine("Ranked Score", user.Statistics.RankedScore.ToString("#,##0")));
-                userStats.Add(new UserStatsLine("Hit Accuracy", user.Statistics.DisplayAccuracy));
-                userStats.Add(new UserStatsLine("Play Count", user.Statistics.PlayCount.ToString("#,##0")));
-                userStats.Add(new UserStatsLine("Total Score", user.Statistics.TotalScore.ToString("#,##0")));
-                userStats.Add(new UserStatsLine("Total Hits", user.Statistics.TotalHits.ToString("#,##0")));
-                userStats.Add(new UserStatsLine("Maximum Combo", user.Statistics.MaxCombo.ToString("#,##0")));
-                userStats.Add(new UserStatsLine("Replays Watched by Others", user.Statistics.ReplaysWatched.ToString("#,##0")));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsRankedScore, user.Statistics.RankedScore.ToString("#,##0")));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsHitAccuracy, user.Statistics.DisplayAccuracy));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsPlayCount, user.Statistics.PlayCount.ToString("#,##0")));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsTotalScore, user.Statistics.TotalScore.ToString("#,##0")));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsTotalHits, user.Statistics.TotalHits.ToString("#,##0")));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsMaximumCombo, user.Statistics.MaxCombo.ToString("#,##0")));
+                userStats.Add(new UserStatsLine(UsersStrings.ShowStatsReplaysWatchedByOthers, user.Statistics.ReplaysWatched.ToString("#,##0")));
             }
         }
 
         private class UserStatsLine : Container
         {
-            public UserStatsLine(string left, string right)
+            public UserStatsLine(LocalisableString left, string right)
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -15,7 +14,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile
 {
-    public class ProfileHeader : TabControlOverlayHeader<ProfileHeaderTab>
+    public class ProfileHeader : TabControlOverlayHeader<LocalisableString>
     {
         private UserCoverBackground coverContainer;
 
@@ -29,6 +28,9 @@ namespace osu.Game.Overlays.Profile
             ContentSidePadding = UserProfileOverlay.CONTENT_X_MARGIN;
 
             User.ValueChanged += e => updateDisplay(e.NewValue);
+
+            TabControl.AddItem(LayoutStrings.HeaderUsersShow);
+            TabControl.AddItem(LayoutStrings.HeaderUsersModding);
 
 
             centreHeaderContainer.DetailsVisible.BindValueChanged(visible => detailHeaderContainer.Expanded = visible.NewValue, true);
@@ -105,31 +107,6 @@ namespace osu.Game.Overlays.Profile
         private class ProfileCoverBackground : UserCoverBackground
         {
             protected override double LoadDelay => 0;
-        }
-    }
-
-    [LocalisableEnum(typeof(ProfileHeaderTabEnumLocalisationMapper))]
-    public enum ProfileHeaderTab
-    {
-        Info,
-        Modding,
-    }
-
-    public class ProfileHeaderTabEnumLocalisationMapper : EnumLocalisationMapper<ProfileHeaderTab>
-    {
-        public override LocalisableString Map(ProfileHeaderTab value)
-        {
-            switch (value)
-            {
-                case ProfileHeaderTab.Info:
-                    return LayoutStrings.HeaderUsersShow;
-
-                case ProfileHeaderTab.Modding:
-                    return LayoutStrings.HeaderUsersModding;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
-            }
         }
     }
 }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -7,12 +7,14 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Overlays.Profile.Header;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile
 {
-    public class ProfileHeader : TabControlOverlayHeader<string>
+    public class ProfileHeader : TabControlOverlayHeader<ProfileHeaderTab>
     {
         private UserCoverBackground coverContainer;
 
@@ -27,8 +29,6 @@ namespace osu.Game.Overlays.Profile
 
             User.ValueChanged += e => updateDisplay(e.NewValue);
 
-            TabControl.AddItem("info");
-            TabControl.AddItem("modding");
 
             centreHeaderContainer.DetailsVisible.BindValueChanged(visible => detailHeaderContainer.Expanded = visible.NewValue, true);
         }
@@ -96,7 +96,7 @@ namespace osu.Game.Overlays.Profile
         {
             public ProfileHeaderTitle()
             {
-                Title = "player info";
+                Title = PageTitleStrings.MainUsersControllerDefault;
                 IconTexture = "Icons/Hexacons/profile";
             }
         }
@@ -104,6 +104,31 @@ namespace osu.Game.Overlays.Profile
         private class ProfileCoverBackground : UserCoverBackground
         {
             protected override double LoadDelay => 0;
+        }
+    }
+
+    [LocalisableEnum(typeof(ProfileHeaderTabEnumLocalisationMapper))]
+    public enum ProfileHeaderTab
+    {
+        Info,
+        Modding,
+    }
+
+    public class ProfileHeaderTabEnumLocalisationMapper : EnumLocalisationMapper<ProfileHeaderTab>
+    {
+        public override LocalisableString Map(ProfileHeaderTab value)
+        {
+            switch (value)
+            {
+                case ProfileHeaderTab.Info:
+                    return LayoutStrings.HeaderUsersShow;
+
+                case ProfileHeaderTab.Modding:
+                    return LayoutStrings.HeaderUsersModding;
+
+                default:
+                    return string.Empty;
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Overlays.Profile
             TabControl.AddItem(LayoutStrings.HeaderUsersShow);
             TabControl.AddItem(LayoutStrings.HeaderUsersModding);
 
-
             centreHeaderContainer.DetailsVisible.BindValueChanged(visible => detailHeaderContainer.Expanded = visible.NewValue, true);
         }
 

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -127,7 +128,7 @@ namespace osu.Game.Overlays.Profile
                     return LayoutStrings.HeaderUsersModding;
 
                 default:
-                    return string.Empty;
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
             }
         }
     }

--- a/osu.Game/Overlays/Profile/ProfileSection.cs
+++ b/osu.Game/Overlays/Profile/ProfileSection.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
@@ -17,7 +18,7 @@ namespace osu.Game.Overlays.Profile
 {
     public abstract class ProfileSection : Container
     {
-        public abstract string Title { get; }
+        public abstract LocalisableString Title { get; }
 
         public abstract string Identifier { get; }
 

--- a/osu.Game/Overlays/Profile/Sections/AboutSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/AboutSection.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class AboutSection : ProfileSection
     {
-        public override string Title => "me!";
+        public override LocalisableString Title => UsersStrings.ShowExtraMeTitle;
 
         public override string Identifier => "me";
     }

--- a/osu.Game/Overlays/Profile/Sections/AboutSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/AboutSection.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraMeTitle;
 
-        public override string Identifier => "me";
+        public override string Identifier => @"me";
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -19,8 +20,8 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
         private const float panel_padding = 10f;
         private readonly BeatmapSetType type;
 
-        public PaginatedBeatmapContainer(BeatmapSetType type, Bindable<User> user, string headerText)
-            : base(user, headerText)
+        public PaginatedBeatmapContainer(BeatmapSetType type, Bindable<User> user, LocalisableString headerText)
+            : base(user, headerText, null)
         {
             this.type = type;
             ItemsPerPage = 6;

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
         private readonly BeatmapSetType type;
 
         public PaginatedBeatmapContainer(BeatmapSetType type, Bindable<User> user, LocalisableString headerText)
-            : base(user, headerText, null)
+            : base(user, headerText)
         {
             this.type = type;
             ItemsPerPage = 6;

--- a/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
@@ -18,11 +18,11 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             Children = new[]
             {
-                new PaginatedBeatmapContainer(BeatmapSetType.Favourite, User, "Favourite Beatmaps"),
-                new PaginatedBeatmapContainer(BeatmapSetType.RankedAndApproved, User, "Ranked & Approved Beatmaps"),
-                new PaginatedBeatmapContainer(BeatmapSetType.Loved, User, "Loved Beatmaps"),
-                new PaginatedBeatmapContainer(BeatmapSetType.Unranked, User, "Pending Beatmaps"),
-                new PaginatedBeatmapContainer(BeatmapSetType.Graveyard, User, "Graveyarded Beatmaps")
+                new PaginatedBeatmapContainer(BeatmapSetType.Favourite, User, UsersStrings.ShowExtraBeatmapsFavouriteTitle),
+                new PaginatedBeatmapContainer(BeatmapSetType.RankedAndApproved, User, UsersStrings.ShowExtraBeatmapsRankedTitle),
+                new PaginatedBeatmapContainer(BeatmapSetType.Loved, User, UsersStrings.ShowExtraBeatmapsLovedTitle),
+                new PaginatedBeatmapContainer(BeatmapSetType.Unranked, User, UsersStrings.ShowExtraBeatmapsPendingTitle),
+                new PaginatedBeatmapContainer(BeatmapSetType.Graveyard, User, UsersStrings.ShowExtraBeatmapsGraveyardTitle)
             };
         }
     }

--- a/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraBeatmapsTitle;
 
-        public override string Identifier => "beatmaps";
+        public override string Identifier => @"beatmaps";
 
         public BeatmapsSection()
         {

--- a/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Profile.Sections.Beatmaps;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class BeatmapsSection : ProfileSection
     {
-        public override string Title => "Beatmaps";
+        public override LocalisableString Title => UsersStrings.ShowExtraBeatmapsTitle;
 
         public override string Identifier => "beatmaps";
 

--- a/osu.Game/Overlays/Profile/Sections/Historical/ChartProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ChartProfileSubsection.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Users;
 using static osu.Game.Users.User;
 
@@ -18,9 +19,9 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
         /// <summary>
         /// Text describing the value being plotted on the graph, which will be displayed as a prefix to the value in the history graph tooltip.
         /// </summary>
-        protected abstract string GraphCounterName { get; }
+        protected abstract LocalisableString GraphCounterName { get; }
 
-        protected ChartProfileSubsection(Bindable<User> user, string headerText)
+        protected ChartProfileSubsection(Bindable<User> user, LocalisableString headerText)
             : base(user, headerText)
         {
         }

--- a/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedBeatmap.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedBeatmap.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections.Historical
 {
@@ -143,7 +144,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         private class PlayCountText : CompositeDrawable, IHasTooltip
         {
-            public LocalisableString TooltipText => "times played";
+            public LocalisableString TooltipText => UsersStrings.ShowExtraHistoricalMostPlayedCount;
 
             public PlayCountText(int playCount)
             {

--- a/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Sections.Historical
@@ -16,7 +17,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
     public class PaginatedMostPlayedBeatmapContainer : PaginatedProfileSubsection<APIUserMostPlayedBeatmap>
     {
         public PaginatedMostPlayedBeatmapContainer(Bindable<User> user)
-            : base(user, "Most Played Beatmaps")
+            : base(user, UsersStrings.ShowExtraHistoricalMostPlayedTitle)
         {
             ItemsPerPage = 5;
         }

--- a/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using static osu.Game.Users.User;
 
@@ -9,10 +11,10 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public class PlayHistorySubsection : ChartProfileSubsection
     {
-        protected override string GraphCounterName => "Plays";
+        protected override LocalisableString GraphCounterName => UsersStrings.ShowExtraHistoricalMonthlyPlaycountsCountLabel;
 
         public PlayHistorySubsection(Bindable<User> user)
-            : base(user, "Play History")
+            : base(user, UsersStrings.ShowExtraHistoricalMonthlyPlaycountsTitle)
         {
         }
 

--- a/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
@@ -12,8 +12,8 @@ using osu.Framework.Allocation;
 using osu.Game.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
-using static osu.Game.Users.User;
 using osu.Framework.Localisation;
+using static osu.Game.Users.User;
 
 namespace osu.Game.Overlays.Profile.Sections.Historical
 {

--- a/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
 using static osu.Game.Users.User;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Profile.Sections.Historical
 {
@@ -42,7 +43,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
         private readonly Container<TickLine> rowLinesContainer;
         private readonly Container<TickLine> columnLinesContainer;
 
-        public ProfileLineChart(string graphCounterName)
+        public ProfileLineChart(LocalisableString graphCounterName)
         {
             RelativeSizeAxes = Axes.X;
             Height = 250;

--- a/osu.Game/Overlays/Profile/Sections/Historical/ReplaysSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ReplaysSubsection.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using static osu.Game.Users.User;
 
@@ -9,10 +11,10 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public class ReplaysSubsection : ChartProfileSubsection
     {
-        protected override string GraphCounterName => "Replays Watched";
+        protected override LocalisableString GraphCounterName => UsersStrings.ShowExtraHistoricalReplaysWatchedCountsCountLabel;
 
         public ReplaysSubsection(Bindable<User> user)
-            : base(user, "Replays Watched History")
+            : base(user, UsersStrings.ShowExtraHistoricalReplaysWatchedCountsTitle)
         {
         }
 

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -5,13 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework.Localisation;
 using static osu.Game.Users.User;
 
 namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public class UserHistoryGraph : UserGraph<DateTime, long>
     {
-        private readonly string tooltipCounterName;
+        private readonly LocalisableString tooltipCounterName;
 
         [CanBeNull]
         public UserHistoryCount[] Values
@@ -19,7 +20,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
             set => Data = value?.Select(v => new KeyValuePair<DateTime, long>(v.Date, v.Count)).ToArray();
         }
 
-        public UserHistoryGraph(string tooltipCounterName)
+        public UserHistoryGraph(LocalisableString tooltipCounterName)
         {
             this.tooltipCounterName = tooltipCounterName;
         }
@@ -40,9 +41,9 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected class HistoryGraphTooltip : UserGraphTooltip
         {
-            private readonly string tooltipCounterName;
+            private readonly LocalisableString tooltipCounterName;
 
-            public HistoryGraphTooltip(string tooltipCounterName)
+            public HistoryGraphTooltip(LocalisableString tooltipCounterName)
                 : base(tooltipCounterName)
             {
                 this.tooltipCounterName = tooltipCounterName;
@@ -61,7 +62,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         private class TooltipDisplayContent
         {
-            public string Name;
+            public LocalisableString Name;
             public string Count;
             public string Date;
         }

--- a/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays.Profile.Sections
             {
                 new PlayHistorySubsection(User),
                 new PaginatedMostPlayedBeatmapContainer(User),
-                new PaginatedScoreContainer(ScoreType.Recent, User, "Recent Plays (24h)"),
+                new PaginatedScoreContainer(ScoreType.Recent, User, UsersStrings.ShowExtraHistoricalRecentPlaysTitle),
                 new ReplaysSubsection(User)
             };
         }

--- a/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
@@ -2,15 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Profile.Sections.Historical;
 using osu.Game.Overlays.Profile.Sections.Ranks;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class HistoricalSection : ProfileSection
     {
-        public override string Title => "Historical";
+        public override LocalisableString Title => UsersStrings.ShowExtraHistoricalTitle;
 
         public override string Identifier => "historical";
 

--- a/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraHistoricalTitle;
 
-        public override string Identifier => "historical";
+        public override string Identifier => @"historical";
 
         public HistoricalSection()
         {

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/KudosuInfo.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/KudosuInfo.cs
@@ -12,6 +12,8 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Users;
 using osu.Framework.Allocation;
+using osu.Game.Resources.Localisation.Web;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Profile.Sections.Kudosu
 {
@@ -37,7 +39,7 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
         private class CountTotal : CountSection
         {
             public CountTotal()
-                : base("Total Kudosu Earned")
+                : base(UsersStrings.ShowExtraKudosuTotal)
             {
                 DescriptionText.AddText("Based on how much of a contribution the user has made to beatmap moderation. See ");
                 DescriptionText.AddLink("this page", "https://osu.ppy.sh/wiki/Kudosu");
@@ -56,7 +58,7 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
                 set => valueText.Text = value.ToString("N0");
             }
 
-            public CountSection(string header)
+            public CountSection(LocalisableString header)
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
@@ -8,13 +8,14 @@ using osu.Framework.Bindables;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.API;
 using System.Collections.Generic;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections.Kudosu
 {
     public class PaginatedKudosuHistoryContainer : PaginatedProfileSubsection<APIKudosuHistory>
     {
         public PaginatedKudosuHistoryContainer(Bindable<User> user)
-            : base(user, missingText: "This user hasn't received any kudosu!")
+            : base(user, missingText: UsersStrings.ShowExtraKudosuEntryEmpty)
         {
             ItemsPerPage = 5;
         }

--- a/osu.Game/Overlays/Profile/Sections/KudosuSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/KudosuSection.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraKudosuTitle;
 
-        public override string Identifier => "kudosu";
+        public override string Identifier => @"kudosu";
 
         public KudosuSection()
         {

--- a/osu.Game/Overlays/Profile/Sections/KudosuSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/KudosuSection.cs
@@ -3,12 +3,14 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Overlays.Profile.Sections.Kudosu;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class KudosuSection : ProfileSection
     {
-        public override string Title => "Kudosu!";
+        public override LocalisableString Title => UsersStrings.ShowExtraKudosuTitle;
 
         public override string Identifier => "kudosu";
 

--- a/osu.Game/Overlays/Profile/Sections/MedalsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/MedalsSection.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraMedalsTitle;
 
-        public override string Identifier => "medals";
+        public override string Identifier => @"medals";
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/MedalsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/MedalsSection.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class MedalsSection : ProfileSection
     {
-        public override string Title => "Medals";
+        public override LocalisableString Title => UsersStrings.ShowExtraMedalsTitle;
 
         public override string Identifier => "medals";
     }

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Profile.Sections
         private OsuSpriteText missing;
         private readonly LocalisableString? missingText;
 
-        protected PaginatedProfileSubsection(Bindable<User> user, LocalisableString headerText, LocalisableString? missingText = null)
+        protected PaginatedProfileSubsection(Bindable<User> user, LocalisableString? headerText = null, LocalisableString? missingText = null)
             : base(user, headerText, CounterVisibilityState.AlwaysVisible)
         {
             this.missingText = missingText;

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Profile.Sections
         private OsuSpriteText missing;
         private readonly LocalisableString? missingText;
 
-        protected PaginatedProfileSubsection(Bindable<User> user, LocalisableString headerText, LocalisableString? missingText)
+        protected PaginatedProfileSubsection(Bindable<User> user, LocalisableString headerText, LocalisableString? missingText = null)
             : base(user, headerText, CounterVisibilityState.AlwaysVisible)
         {
             this.missingText = missingText;

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
@@ -36,9 +37,9 @@ namespace osu.Game.Overlays.Profile.Sections
 
         private ShowMoreButton moreButton;
         private OsuSpriteText missing;
-        private readonly string missingText;
+        private readonly LocalisableString? missingText;
 
-        protected PaginatedProfileSubsection(Bindable<User> user, string headerText = "", string missingText = "")
+        protected PaginatedProfileSubsection(Bindable<User> user, LocalisableString headerText, LocalisableString? missingText)
             : base(user, headerText, CounterVisibilityState.AlwaysVisible)
         {
             this.missingText = missingText;
@@ -68,7 +69,7 @@ namespace osu.Game.Overlays.Profile.Sections
                 missing = new OsuSpriteText
                 {
                     Font = OsuFont.GetFont(size: 15),
-                    Text = missingText,
+                    Text = missingText ?? string.Empty,
                     Alpha = 0,
                 }
             }
@@ -114,7 +115,7 @@ namespace osu.Game.Overlays.Profile.Sections
                 moreButton.Hide();
                 moreButton.IsLoading = false;
 
-                if (!string.IsNullOrEmpty(missingText))
+                if (missingText.HasValue)
                     missing.Show();
 
                 return;

--- a/osu.Game/Overlays/Profile/Sections/ProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileSubsection.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Users;
 using JetBrains.Annotations;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
@@ -14,12 +15,12 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         protected readonly Bindable<User> User = new Bindable<User>();
 
-        private readonly string headerText;
+        private readonly LocalisableString headerText;
         private readonly CounterVisibilityState counterVisibilityState;
 
         private ProfileSubsectionHeader header;
 
-        protected ProfileSubsection(Bindable<User> user, string headerText = "", CounterVisibilityState counterVisibilityState = CounterVisibilityState.AlwaysHidden)
+        protected ProfileSubsection(Bindable<User> user, LocalisableString headerText, CounterVisibilityState counterVisibilityState = CounterVisibilityState.AlwaysHidden)
         {
             this.headerText = headerText;
             this.counterVisibilityState = counterVisibilityState;

--- a/osu.Game/Overlays/Profile/Sections/ProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileSubsection.cs
@@ -20,9 +20,9 @@ namespace osu.Game.Overlays.Profile.Sections
 
         private ProfileSubsectionHeader header;
 
-        protected ProfileSubsection(Bindable<User> user, LocalisableString headerText, CounterVisibilityState counterVisibilityState = CounterVisibilityState.AlwaysHidden)
+        protected ProfileSubsection(Bindable<User> user, LocalisableString? headerText = null, CounterVisibilityState counterVisibilityState = CounterVisibilityState.AlwaysHidden)
         {
-            this.headerText = headerText;
+            this.headerText = headerText ?? string.Empty;
             this.counterVisibilityState = counterVisibilityState;
             User.BindTo(user);
         }
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.Profile.Sections
             {
                 header = new ProfileSubsectionHeader(headerText, counterVisibilityState)
                 {
-                    Alpha = string.IsNullOrEmpty(headerText) ? 0 : 1
+                    Alpha = string.IsNullOrEmpty(headerText.ToString()) ? 0 : 1
                 },
                 CreateContent()
             };

--- a/osu.Game/Overlays/Profile/Sections/ProfileSubsectionHeader.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileSubsectionHeader.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Shapes;
 using osuTK;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
@@ -24,12 +25,12 @@ namespace osu.Game.Overlays.Profile.Sections
             set => current.Current = value;
         }
 
-        private readonly string text;
+        private readonly LocalisableString text;
         private readonly CounterVisibilityState counterState;
 
         private CounterPill counterPill;
 
-        public ProfileSubsectionHeader(string text, CounterVisibilityState counterState)
+        public ProfileSubsectionHeader(LocalisableString text, CounterVisibilityState counterState)
         {
             this.text = text;
             this.counterState = counterState;

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
 using osuTK;
 
@@ -51,7 +52,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                 new OsuSpriteText
                 {
                     Font = OsuFont.GetFont(size: 12),
-                    Text = $@"weighted {weight:0%}"
+                    Text = UsersStrings.ShowExtraTopRanksPpWeight(weight.ToString("0%"))
                 }
             }
         };

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -11,6 +11,7 @@ using osu.Game.Online.API.Requests.Responses;
 using System.Collections.Generic;
 using osu.Game.Online.API;
 using osu.Framework.Allocation;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Profile.Sections.Ranks
 {
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
     {
         private readonly ScoreType type;
 
-        public PaginatedScoreContainer(ScoreType type, Bindable<User> user, string headerText)
+        public PaginatedScoreContainer(ScoreType type, Bindable<User> user, LocalisableString headerText)
             : base(user, headerText)
         {
             this.type = type;

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -18,8 +18,8 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             Children = new[]
             {
-                new PaginatedScoreContainer(ScoreType.Best, User, "Best Performance"),
-                new PaginatedScoreContainer(ScoreType.Firsts, User, "First Place Ranks")
+                new PaginatedScoreContainer(ScoreType.Best, User, UsersStrings.ShowExtraTopRanksBestTitle),
+                new PaginatedScoreContainer(ScoreType.Firsts, User, UsersStrings.ShowExtraTopRanksFirstTitle)
             };
         }
     }

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraTopRanksTitle;
 
-        public override string Identifier => "top_ranks";
+        public override string Identifier => @"top_ranks";
 
         public RanksSection()
         {

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -3,12 +3,14 @@
 
 using osu.Game.Overlays.Profile.Sections.Ranks;
 using osu.Game.Online.API.Requests;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class RanksSection : ProfileSection
     {
-        public override string Title => "Ranks";
+        public override LocalisableString Title => UsersStrings.ShowExtraTopRanksTitle;
 
         public override string Identifier => "top_ranks";
 

--- a/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
     public class PaginatedRecentActivityContainer : PaginatedProfileSubsection<APIRecentActivity>
     {
         public PaginatedRecentActivityContainer(Bindable<User> user)
-            : base(user, string.Empty, EventsStrings.Empty)
+            : base(user, missingText: EventsStrings.Empty)
         {
             ItemsPerPage = 10;
         }

--- a/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
@@ -10,13 +10,14 @@ using osu.Game.Online.API;
 using System.Collections.Generic;
 using osuTK;
 using osu.Framework.Allocation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections.Recent
 {
     public class PaginatedRecentActivityContainer : PaginatedProfileSubsection<APIRecentActivity>
     {
         public PaginatedRecentActivityContainer(Bindable<User> user)
-            : base(user, missingText: "This user hasn't done anything notable recently!")
+            : base(user, string.Empty, EventsStrings.Empty)
         {
             ItemsPerPage = 10;
         }

--- a/osu.Game/Overlays/Profile/Sections/RecentSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RecentSection.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public override LocalisableString Title => UsersStrings.ShowExtraRecentActivityTitle;
 
-        public override string Identifier => "recent_activity";
+        public override string Identifier => @"recent_activity";
 
         public RecentSection()
         {

--- a/osu.Game/Overlays/Profile/Sections/RecentSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RecentSection.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Overlays.Profile.Sections.Recent;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
     public class RecentSection : ProfileSection
     {
-        public override string Title => "Recent";
+        public override LocalisableString Title => UsersStrings.ShowExtraRecentActivityTitle;
 
         public override string Identifier => "recent_activity";
 

--- a/osu.Game/Overlays/Profile/UserGraph.cs
+++ b/osu.Game/Overlays/Profile/UserGraph.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -211,7 +212,7 @@ namespace osu.Game.Overlays.Profile
             protected readonly OsuSpriteText Counter, BottomText;
             private readonly Box background;
 
-            protected UserGraphTooltip(string tooltipCounterName)
+            protected UserGraphTooltip(LocalisableString tooltipCounterName)
             {
                 AutoSizeAxes = Axes.Both;
                 Masking = true;


### PR DESCRIPTION
Here's an initial pass at localising the user profile overlay. A few profile components (namely the recent section, the kudosu info, and the bottom header container) have been left out of localisation for now as they have a framework requirement on `TextFlowContainer` support for localisable strings. I'll get back to localise them once framework support is in place.

## Preview

![osu_2021-07-18_19-20-19](https://user-images.githubusercontent.com/20256717/126076682-6b43af25-d184-4eca-8cd9-bc33de5d37f1.jpg)

