### PR TITLE
Fix osu!(lazer) overwriting osu!(stable) desktop icons by adding back a suffix

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -6,7 +6,7 @@
     <Description>A free-to-win rhythm game. Rhythm is just a *click* away!</Description>
     <AssemblyName>osu!</AssemblyName>
     <Title>osu!</Title>
-    <Product>osu!</Product>
+    <Product>osu!(lazer)</Product>
     <ApplicationIcon>lazer.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Version>0.0.0</Version>


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu/issues/13864, Squirrel will use the product name before the title, allowing us to use this variable to update the icon while not changing the window display title or naming elsewhere.

Closes https://github.com/ppy/osu/issues/13864.
