### PR TITLE
Set score's rank on a failed submission

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -953,7 +953,11 @@ namespace osu.Game.Screens.Play
 
             // if arriving here and the results screen preparation task hasn't run, it's safe to say the user has not completed the beatmap.
             if (prepareScoreForDisplayTask == null)
+            {
                 Score.ScoreInfo.Passed = false;
+                // potentially should be ScoreRank.F instead? this is the best alternative for now.
+                Score.ScoreInfo.Rank = ScoreRank.D;
+            }
 
             // EndPlaying() is typically called from ReplayRecorder.Dispose(). Disposal is currently asynchronous.
             // To resolve test failures, forcefully end playing synchronously when this screen exits.


### PR DESCRIPTION
As we don't have a `RankInfo.F`, this is the next best choice. I am also adding a check osu-web side for this - this is just to make sure we aren't sending scores with SS when they are not actually completed.

I'm working on a separate PR (#13929) to ensure this does not get mutated during the player exit process.

Closes https://github.com/ppy/osu/issues/13897.