### PR TITLE
Change the way position is set for components of catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/CatchSelectionBlueprint.cs
@@ -19,9 +19,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
         {
             get
             {
-                float x = HitObject.OriginalX;
-                float y = HitObjectContainer.PositionAtTime(HitObject.StartTime);
-                return HitObjectContainer.ToScreenSpace(new Vector2(x, y + HitObjectContainer.DrawHeight));
+                Vector2 position = CatchHitObjectUtils.GetStartPosition(HitObjectContainer, HitObject);
+                return HitObjectContainer.ToScreenSpace(position + new Vector2(0, HitObjectContainer.DrawHeight));
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/FruitOutline.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/FruitOutline.cs
@@ -1,14 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Skinning.Default;
-using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
@@ -28,10 +26,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             Colour = osuColour.Yellow;
         }
 
-        public void UpdateFrom(ScrollingHitObjectContainer hitObjectContainer, CatchHitObject hitObject, [CanBeNull] CatchHitObject parent = null)
+        public void UpdateFrom(CatchHitObject hitObject)
         {
-            X = hitObject.EffectiveX - (parent?.OriginalX ?? 0);
-            Y = hitObjectContainer.PositionAtTime(hitObject.StartTime, parent?.StartTime ?? hitObjectContainer.Time.Current);
             Scale = new Vector2(hitObject.Scale);
         }
     }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/NestedOutlineContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/NestedOutlineContainer.cs
@@ -20,12 +20,6 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             Anchor = Anchor.BottomLeft;
         }
 
-        public void UpdatePositionFrom(ScrollingHitObjectContainer hitObjectContainer, CatchHitObject parentHitObject)
-        {
-            X = parentHitObject.OriginalX;
-            Y = hitObjectContainer.PositionAtTime(parentHitObject.StartTime);
-        }
-
         public void UpdateNestedObjectsFrom(ScrollingHitObjectContainer hitObjectContainer, CatchHitObject parentHitObject)
         {
             nestedHitObjects.Clear();
@@ -43,7 +37,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             {
                 var hitObject = nestedHitObjects[i];
                 var outline = (FruitOutline)InternalChildren[i];
-                outline.UpdateFrom(hitObjectContainer, hitObject, parentHitObject);
+                outline.Position = CatchHitObjectUtils.GetStartPosition(hitObjectContainer, hitObject) - Position;
+                outline.UpdateFrom(hitObject);
                 outline.Scale *= hitObject is Droplet ? 0.5f : 1;
             }
         }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/ScrollingPath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/ScrollingPath.cs
@@ -33,12 +33,6 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             };
         }
 
-        public void UpdatePositionFrom(ScrollingHitObjectContainer hitObjectContainer, CatchHitObject hitObject)
-        {
-            X = hitObject.OriginalX;
-            Y = hitObjectContainer.PositionAtTime(hitObject.StartTime);
-        }
-
         public void UpdatePathFrom(ScrollingHitObjectContainer hitObjectContainer, JuiceStream hitObject)
         {
             double distanceToYFactor = -hitObjectContainer.LengthAtTime(hitObject.StartTime, hitObject.StartTime + 1 / hitObject.Velocity);

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitPlacementBlueprint.cs
@@ -29,7 +29,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
         {
             base.Update();
 
-            outline.UpdateFrom(HitObjectContainer, HitObject);
+            outline.Position = CatchHitObjectUtils.GetStartPosition(HitObjectContainer, HitObject);
+            outline.UpdateFrom(HitObject);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitSelectionBlueprint.cs
@@ -20,8 +20,10 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
         {
             base.Update();
 
-            if (IsSelected)
-                outline.UpdateFrom(HitObjectContainer, HitObject);
+            if (!IsSelected) return;
+
+            outline.Position = CatchHitObjectUtils.GetStartPosition(HitObjectContainer, HitObject);
+            outline.UpdateFrom(HitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
@@ -49,8 +49,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 
             if (!IsSelected) return;
 
-            scrollingPath.UpdatePositionFrom(HitObjectContainer, HitObject);
-            nestedOutlineContainer.UpdatePositionFrom(HitObjectContainer, HitObject);
+            nestedOutlineContainer.Position = scrollingPath.Position = CatchHitObjectUtils.GetStartPosition(HitObjectContainer, HitObject);
 
             if (pathCache.IsValid) return;
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectUtils.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectUtils.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    /// <summary>
+    /// Utility functions used by the editor.
+    /// </summary>
+    public static class CatchHitObjectUtils
+    {
+        /// <summary>
+        /// Get the position of the hit object in the playfield based on <see cref="CatchHitObject.OriginalX"/> and <see cref="HitObject.StartTime"/>.
+        /// </summary>
+        public static Vector2 GetStartPosition(ScrollingHitObjectContainer hitObjectContainer, CatchHitObject hitObject)
+        {
+            return new Vector2(hitObject.OriginalX, hitObjectContainer.PositionAtTime(hitObject.StartTime));
+        }
+    }
+}


### PR DESCRIPTION
I changed the way individual components are getting the position, so `Position` is set by users, not in the piece class. It turns out this way makes more sense for nested hit objects.
Previously, `FruitOutline` used `EffectiveX`, but it now uses `OriginalX`. This is not a visible change because only `TinyDroplet` has a non-zero offset with no mod and the outline is not currently used for `TinyDroplet`s.