### PR TITLE
Add `JuiceStreamPath` as alternative representation of `JuiceStream` path for catch editor 

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/JuiceStreamPathTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/JuiceStreamPathTest.cs
@@ -1,0 +1,288 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    [TestFixture]
+    public class JuiceStreamPathTest
+    {
+        [TestCase(1e3, true, false)]
+        // When the coordinates are large, the slope invariant fails within the specified absolute allowance due to the floating-number precision.
+        [TestCase(1e9, false, false)]
+        // Using discrete values sometimes discover more edge cases.
+        [TestCase(10, true, true)]
+        public void TestRandomInsertSetPosition(double scale, bool checkSlope, bool integralValues)
+        {
+            var rng = new Random(1);
+            var path = new JuiceStreamPath();
+
+            for (int iteration = 0; iteration < 100000; iteration++)
+            {
+                if (rng.Next(10) == 0)
+                    path.Clear();
+
+                int vertexCount = path.Vertices.Count;
+
+                switch (rng.Next(2))
+                {
+                    case 0:
+                    {
+                        double distance = rng.NextDouble() * scale * 2 - scale;
+                        if (integralValues)
+                            distance = Math.Round(distance);
+
+                        float oldX = path.PositionAtDistance(distance);
+                        int index = path.InsertVertex(distance);
+                        Assert.That(path.Vertices.Count, Is.EqualTo(vertexCount + 1));
+                        Assert.That(path.Vertices[index].Distance, Is.EqualTo(distance));
+                        Assert.That(path.Vertices[index].X, Is.EqualTo(oldX));
+                        break;
+                    }
+
+                    case 1:
+                    {
+                        int index = rng.Next(path.Vertices.Count);
+                        double distance = path.Vertices[index].Distance;
+                        float newX = (float)(rng.NextDouble() * scale * 2 - scale);
+                        if (integralValues)
+                            newX = MathF.Round(newX);
+
+                        path.SetVertexPosition(index, newX);
+                        Assert.That(path.Vertices.Count, Is.EqualTo(vertexCount));
+                        Assert.That(path.Vertices[index].Distance, Is.EqualTo(distance));
+                        Assert.That(path.Vertices[index].X, Is.EqualTo(newX));
+                        break;
+                    }
+                }
+
+                assertInvariants(path.Vertices, checkSlope);
+            }
+        }
+
+        [Test]
+        public void TestRemoveVertices()
+        {
+            var path = new JuiceStreamPath();
+            path.Add(10, 5);
+            path.Add(20, -5);
+
+            int removeCount = path.RemoveVertices((v, i) => v.Distance == 10 && i == 1);
+            Assert.That(removeCount, Is.EqualTo(1));
+            Assert.That(path.Vertices, Is.EqualTo(new[]
+            {
+                new JuiceStreamPathVertex(0, 0),
+                new JuiceStreamPathVertex(20, -5)
+            }));
+
+            removeCount = path.RemoveVertices((_, i) => i == 0);
+            Assert.That(removeCount, Is.EqualTo(1));
+            Assert.That(path.Vertices, Is.EqualTo(new[]
+            {
+                new JuiceStreamPathVertex(20, -5)
+            }));
+
+            removeCount = path.RemoveVertices((_, i) => true);
+            Assert.That(removeCount, Is.EqualTo(1));
+            Assert.That(path.Vertices, Is.EqualTo(new[]
+            {
+                new JuiceStreamPathVertex()
+            }));
+        }
+
+        [Test]
+        public void TestResampleVertices()
+        {
+            var path = new JuiceStreamPath();
+            path.Add(-100, -10);
+            path.Add(100, 50);
+            path.ResampleVertices(new double[]
+            {
+                -50,
+                0,
+                70,
+                120
+            });
+            Assert.That(path.Vertices, Is.EqualTo(new[]
+            {
+                new JuiceStreamPathVertex(-100, -10),
+                new JuiceStreamPathVertex(-50, -5),
+                new JuiceStreamPathVertex(0, 0),
+                new JuiceStreamPathVertex(70, 35),
+                new JuiceStreamPathVertex(100, 50),
+                new JuiceStreamPathVertex(100, 50),
+            }));
+
+            path.Clear();
+            path.SetVertexPosition(0, 10);
+            path.ResampleVertices(Array.Empty<double>());
+            Assert.That(path.Vertices, Is.EqualTo(new[]
+            {
+                new JuiceStreamPathVertex(0, 10)
+            }));
+        }
+
+        [Test]
+        public void TestRandomConvertFromSliderPath()
+        {
+            var rng = new Random(1);
+            var path = new JuiceStreamPath();
+            var sliderPath = new SliderPath();
+
+            for (int iteration = 0; iteration < 10000; iteration++)
+            {
+                sliderPath.ControlPoints.Clear();
+
+                do
+                {
+                    int start = sliderPath.ControlPoints.Count;
+
+                    do
+                    {
+                        float x = (float)(rng.NextDouble() * 1e3);
+                        float y = (float)(rng.NextDouble() * 1e3);
+                        sliderPath.ControlPoints.Add(new PathControlPoint(new Vector2(x, y)));
+                    } while (rng.Next(2) != 0);
+
+                    int length = sliderPath.ControlPoints.Count - start + 1;
+                    sliderPath.ControlPoints[start].Type.Value = length <= 2 ? PathType.Linear : length == 3 ? PathType.PerfectCurve : PathType.Bezier;
+                } while (rng.Next(3) != 0);
+
+                if (rng.Next(5) == 0)
+                    sliderPath.ExpectedDistance.Value = rng.NextDouble() * 3e3;
+                else
+                    sliderPath.ExpectedDistance.Value = null;
+
+                path.ConvertFromSliderPath(sliderPath);
+                Assert.That(path.Vertices[0].Distance, Is.EqualTo(0));
+                Assert.That(path.Distance, Is.EqualTo(sliderPath.Distance).Within(1e-3));
+                assertInvariants(path.Vertices, true);
+
+                double[] sampleDistances = Enumerable.Range(0, 10)
+                                                     .Select(_ => rng.NextDouble() * sliderPath.Distance)
+                                                     .ToArray();
+
+                foreach (double distance in sampleDistances)
+                {
+                    float expected = sliderPath.PositionAt(distance / sliderPath.Distance).X;
+                    Assert.That(path.PositionAtDistance(distance), Is.EqualTo(expected).Within(1e-3));
+                }
+
+                path.ResampleVertices(sampleDistances);
+                assertInvariants(path.Vertices, true);
+
+                foreach (double distance in sampleDistances)
+                {
+                    float expected = sliderPath.PositionAt(distance / sliderPath.Distance).X;
+                    Assert.That(path.PositionAtDistance(distance), Is.EqualTo(expected).Within(1e-3));
+                }
+            }
+        }
+
+        [Test]
+        public void TestRandomConvertToSliderPath()
+        {
+            var rng = new Random(1);
+            var path = new JuiceStreamPath();
+            var sliderPath = new SliderPath();
+
+            for (int iteration = 0; iteration < 10000; iteration++)
+            {
+                path.Clear();
+
+                do
+                {
+                    double distance = rng.NextDouble() * 1e3;
+                    float x = (float)(rng.NextDouble() * 1e3);
+                    path.Add(distance, x);
+                } while (rng.Next(5) != 0);
+
+                float sliderStartY = (float)(rng.NextDouble() * JuiceStreamPath.OSU_PLAYFIELD_HEIGHT);
+
+                path.ConvertToSliderPath(sliderPath, sliderStartY);
+                Assert.That(sliderPath.Distance, Is.EqualTo(path.Distance).Within(1e-3));
+                Assert.That(sliderPath.ControlPoints[0].Position.Value.X, Is.EqualTo(path.Vertices[0].X));
+                assertInvariants(path.Vertices, true);
+
+                foreach (var point in sliderPath.ControlPoints)
+                {
+                    Assert.That(point.Type.Value, Is.EqualTo(PathType.Linear).Or.Null);
+                    Assert.That(sliderStartY + point.Position.Value.Y, Is.InRange(0, JuiceStreamPath.OSU_PLAYFIELD_HEIGHT));
+                }
+
+                for (int i = 0; i < 10; i++)
+                {
+                    double distance = rng.NextDouble() * path.Distance;
+                    float expected = path.PositionAtDistance(distance);
+                    Assert.That(sliderPath.PositionAt(distance / sliderPath.Distance).X, Is.EqualTo(expected).Within(1e-3));
+                }
+            }
+        }
+
+        [Test]
+        public void TestInvalidation()
+        {
+            var path = new JuiceStreamPath();
+            Assert.That(path.InvalidationID, Is.EqualTo(1));
+            int previousId = path.InvalidationID;
+
+            path.InsertVertex(10);
+            checkNewId();
+
+            path.SetVertexPosition(1, 5);
+            checkNewId();
+
+            path.Add(20, 0);
+            checkNewId();
+
+            path.RemoveVertices((v, _) => v.Distance == 20);
+            checkNewId();
+
+            path.ResampleVertices(new double[] { 5, 10, 15 });
+            checkNewId();
+
+            path.Clear();
+            checkNewId();
+
+            path.ConvertFromSliderPath(new SliderPath());
+            checkNewId();
+
+            void checkNewId()
+            {
+                Assert.That(path.InvalidationID, Is.Not.EqualTo(previousId));
+                previousId = path.InvalidationID;
+            }
+        }
+
+        private void assertInvariants(IReadOnlyList<JuiceStreamPathVertex> vertices, bool checkSlope)
+        {
+            Assert.That(vertices, Is.Not.Empty);
+
+            for (int i = 0; i < vertices.Count; i++)
+            {
+                Assert.That(double.IsFinite(vertices[i].Distance));
+                Assert.That(float.IsFinite(vertices[i].X));
+            }
+
+            for (int i = 1; i < vertices.Count; i++)
+            {
+                Assert.That(vertices[i].Distance, Is.GreaterThanOrEqualTo(vertices[i - 1].Distance));
+
+                if (!checkSlope) continue;
+
+                float xDiff = Math.Abs(vertices[i].X - vertices[i - 1].X);
+                double distanceDiff = vertices[i].Distance - vertices[i - 1].Distance;
+                Assert.That(xDiff, Is.LessThanOrEqualTo(distanceDiff).Within(Precision.FLOAT_EPSILON));
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs
@@ -29,6 +29,12 @@ namespace osu.Game.Rulesets.Catch.Objects
     public class JuiceStreamPath
     {
         /// <summary>
+        /// The height of legacy osu!standard playfield.
+        /// The sliders converted by <see cref="ConvertToSliderPath"/> are vertically contained in this height.
+        /// </summary>
+        internal const float OSU_PLAYFIELD_HEIGHT = 384;
+
+        /// <summary>
         /// The list of vertices of the path, which is represented as a polyline connecting the vertices.
         /// </summary>
         public IReadOnlyList<JuiceStreamPathVertex> Vertices => vertices;
@@ -210,12 +216,6 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             invalidate();
         }
-
-        /// <summary>
-        /// The height of legacy osu!standard playfield.
-        /// The sliders converted by <see cref="ConvertToSliderPath"/> are vertically contained in this height.
-        /// </summary>
-        public const float OSU_PLAYFIELD_HEIGHT = 384;
 
         /// <summary>
         /// Convert the path of this <see cref="JuiceStreamPath"/> to a <see cref="SliderPath"/> and write the result to <paramref name="sliderPath"/>.

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs
@@ -1,0 +1,340 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+
+#nullable enable
+
+namespace osu.Game.Rulesets.Catch.Objects
+{
+    /// <summary>
+    /// Represents the path of a juice stream.
+    /// <para>
+    /// A <see cref="JuiceStream"/> holds a legacy <see cref="SliderPath"/> as the representation of the path.
+    /// However, the <see cref="SliderPath"/> representation is difficult to work with.
+    /// This <see cref="JuiceStreamPath"/> represents the path in a more convenient way, a polyline connecting list of <see cref="JuiceStreamPathVertex"/>s.
+    /// </para>
+    /// <para>
+    /// The path can be regarded as a function from the closed interval <c>[Vertices[0].Distance, Vertices[^1].Distance]</c> to the x position, given by <see cref="PositionAtDistance"/>.
+    /// To ensure the path is convertible to a <see cref="SliderPath"/>, the slope of the function must not be more than <c>1</c> everywhere,
+    /// and this slope condition is always maintained as an invariant.
+    /// </para>
+    /// </summary>
+    public class JuiceStreamPath
+    {
+        /// <summary>
+        /// The list of vertices of the path, which is represented as a polyline connecting the vertices.
+        /// </summary>
+        public IReadOnlyList<JuiceStreamPathVertex> Vertices => vertices;
+
+        /// <summary>
+        /// The current version number.
+        /// This starts from <c>1</c> and incremented whenever this <see cref="JuiceStreamPath"/> is modified.
+        /// </summary>
+        public int InvalidationID { get; private set; } = 1;
+
+        /// <summary>
+        /// The difference between first vertex's <see cref="JuiceStreamPathVertex.Distance"/> and last vertex's <see cref="JuiceStreamPathVertex.Distance"/>.
+        /// </summary>
+        public double Distance => vertices[^1].Distance - vertices[0].Distance;
+
+        /// <remarks>
+        /// This list should always be non-empty.
+        /// </remarks>
+        private readonly List<JuiceStreamPathVertex> vertices = new List<JuiceStreamPathVertex>
+        {
+            new JuiceStreamPathVertex()
+        };
+
+        /// <summary>
+        /// Compute the x-position of the path at the given <paramref name="distance"/>.
+        /// </summary>
+        /// <remarks>
+        /// When the given distance is outside of the path, the x position at the corresponding endpoint is returned,
+        /// </remarks>
+        public float PositionAtDistance(double distance)
+        {
+            int index = vertexIndexAtDistance(distance);
+            return positionAtDistance(distance, index);
+        }
+
+        /// <summary>
+        /// Remove all vertices of this path, then add a new vertex <c>(0, 0)</c>.
+        /// </summary>
+        public void Clear()
+        {
+            vertices.Clear();
+            vertices.Add(new JuiceStreamPathVertex());
+            invalidate();
+        }
+
+        /// <summary>
+        /// Insert a vertex at given <paramref name="distance"/>.
+        /// The <see cref="PositionAtDistance"/> is used as the position of the new vertex.
+        /// Thus, the set of points of the path is not changed (up to floating-point precision).
+        /// </summary>
+        /// <returns>The index of the new vertex.</returns>
+        public int InsertVertex(double distance)
+        {
+            if (!double.IsFinite(distance))
+                throw new ArgumentOutOfRangeException(nameof(distance));
+
+            int index = vertexIndexAtDistance(distance);
+            float x = positionAtDistance(distance, index);
+            vertices.Insert(index, new JuiceStreamPathVertex(distance, x));
+
+            invalidate();
+            return index;
+        }
+
+        /// <summary>
+        /// Move the vertex of given <paramref name="index"/> to the given position <paramref name="newX"/>.
+        /// When the distances between vertices are too small for the new vertex positions, the adjacent vertices are moved towards <paramref name="newX"/>.
+        /// </summary>
+        public void SetVertexPosition(int index, float newX)
+        {
+            if (index < 0 || index >= vertices.Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            if (!float.IsFinite(newX))
+                throw new ArgumentOutOfRangeException(nameof(newX));
+
+            var newVertex = new JuiceStreamPathVertex(vertices[index].Distance, newX);
+
+            for (int i = index - 1; i >= 0 && !canConnect(vertices[i], newVertex); i--)
+            {
+                float clampedX = clampToConnectablePosition(newVertex, vertices[i]);
+                vertices[i] = new JuiceStreamPathVertex(vertices[i].Distance, clampedX);
+            }
+
+            for (int i = index + 1; i < vertices.Count; i++)
+            {
+                float clampedX = clampToConnectablePosition(newVertex, vertices[i]);
+                vertices[i] = new JuiceStreamPathVertex(vertices[i].Distance, clampedX);
+            }
+
+            vertices[index] = newVertex;
+
+            invalidate();
+        }
+
+        /// <summary>
+        /// Add a new vertex at given <paramref name="distance"/> and position.
+        /// Adjacent vertices are moved when necessary in the same way as <see cref="SetVertexPosition"/>.
+        /// </summary>
+        public void Add(double distance, float x)
+        {
+            int index = InsertVertex(distance);
+            SetVertexPosition(index, x);
+        }
+
+        /// <summary>
+        /// Remove all vertices that satisfy the given <paramref name="predicate"/>.
+        /// </summary>
+        /// <remarks>
+        /// If all vertices are removed, a new vertex <c>(0, 0)</c> is added.
+        /// </remarks>
+        /// <param name="predicate">The predicate to determine whether a vertex should be removed given the vertex and its index in the path.</param>
+        /// <returns>The number of removed vertices.</returns>
+        public int RemoveVertices(Func<JuiceStreamPathVertex, int, bool> predicate)
+        {
+            int index = 0;
+            int removeCount = vertices.RemoveAll(vertex => predicate(vertex, index++));
+
+            if (vertices.Count == 0)
+                vertices.Add(new JuiceStreamPathVertex());
+
+            if (removeCount != 0)
+                invalidate();
+
+            return removeCount;
+        }
+
+        /// <summary>
+        /// Recreate this path by using difference set of vertices at given distances.
+        /// In addition to the given <paramref name="sampleDistances"/>, the first vertex and the last vertex are always added to the new path.
+        /// New vertices use the positions on the original path. Thus, <see cref="PositionAtDistance"/>s at <paramref name="sampleDistances"/> are preserved.
+        /// </summary>
+        public void ResampleVertices(IEnumerable<double> sampleDistances)
+        {
+            var sampledVertices = new List<JuiceStreamPathVertex>();
+
+            foreach (double distance in sampleDistances)
+            {
+                if (!double.IsFinite(distance))
+                    throw new ArgumentOutOfRangeException(nameof(sampleDistances));
+
+                double clampedDistance = Math.Clamp(distance, vertices[0].Distance, vertices[^1].Distance);
+                float x = PositionAtDistance(clampedDistance);
+                sampledVertices.Add(new JuiceStreamPathVertex(clampedDistance, x));
+            }
+
+            sampledVertices.Sort();
+
+            // The first vertex and the last vertex are always used in the result.
+            vertices.RemoveRange(1, vertices.Count - (vertices.Count == 1 ? 1 : 2));
+            vertices.InsertRange(1, sampledVertices);
+
+            invalidate();
+        }
+
+        /// <summary>
+        /// Convert a <see cref="SliderPath"/> to list of vertices and write the result to this <see cref="JuiceStreamPath"/>.
+        /// </summary>
+        /// <remarks>
+        /// Duplicated vertices are automatically removed.
+        /// </remarks>
+        public void ConvertFromSliderPath(SliderPath sliderPath)
+        {
+            var sliderPathVertices = new List<Vector2>();
+            sliderPath.GetPathToProgress(sliderPathVertices, 0, 1);
+
+            double distance = 0;
+
+            vertices.Clear();
+            vertices.Add(new JuiceStreamPathVertex(0, sliderPathVertices.FirstOrDefault().X));
+
+            for (int i = 1; i < sliderPathVertices.Count; i++)
+            {
+                distance += Vector2.Distance(sliderPathVertices[i - 1], sliderPathVertices[i]);
+
+                if (!Precision.AlmostEquals(vertices[^1].Distance, distance))
+                    vertices.Add(new JuiceStreamPathVertex(distance, sliderPathVertices[i].X));
+            }
+
+            invalidate();
+        }
+
+        /// <summary>
+        /// The height of legacy osu!standard playfield.
+        /// The sliders converted by <see cref="ConvertToSliderPath"/> are vertically contained in this height.
+        /// </summary>
+        public const float OSU_PLAYFIELD_HEIGHT = 384;
+
+        /// <summary>
+        /// Convert the path of this <see cref="JuiceStreamPath"/> to a <see cref="SliderPath"/> and write the result to <paramref name="sliderPath"/>.
+        /// The resulting slider is "folded" to make it vertically contained in the playfield `(0..<see cref="OSU_PLAYFIELD_HEIGHT"/>)` assuming the slider start position is <paramref name="sliderStartY"/>.
+        /// </summary>
+        public void ConvertToSliderPath(SliderPath sliderPath, float sliderStartY)
+        {
+            const float margin = 1;
+
+            // Note: these two variables and `sliderPath` are modified by the local functions.
+            double currentDistance = 0;
+            Vector2 lastPosition = new Vector2(vertices[0].X, 0);
+
+            sliderPath.ControlPoints.Clear();
+            sliderPath.ControlPoints.Add(new PathControlPoint(lastPosition));
+
+            for (int i = 1; i < vertices.Count; i++)
+            {
+                sliderPath.ControlPoints[^1].Type.Value = PathType.Linear;
+
+                float deltaX = vertices[i].X - lastPosition.X;
+                double length = vertices[i].Distance - currentDistance;
+
+                // Should satisfy `deltaX^2 + deltaY^2 = length^2`.
+                // By invariants, the expression inside the `sqrt` is (almost) non-negative.
+                double deltaY = Math.Sqrt(Math.Max(0, length * length - (double)deltaX * deltaX));
+
+                // When `deltaY` is small, one segment is always enough.
+                // This case is handled separately to prevent divide-by-zero.
+                if (deltaY <= OSU_PLAYFIELD_HEIGHT / 2 - margin)
+                {
+                    float nextX = vertices[i].X;
+                    float nextY = (float)(lastPosition.Y + getYDirection() * deltaY);
+                    addControlPoint(nextX, nextY);
+                    continue;
+                }
+
+                // When `deltaY` is large or when the slider velocity is fast, the segment must be partitioned to subsegments to stay in bounds.
+                for (double currentProgress = 0; currentProgress < deltaY;)
+                {
+                    double nextProgress = Math.Min(currentProgress + getMaxDeltaY(), deltaY);
+                    float nextX = (float)(vertices[i - 1].X + nextProgress / deltaY * deltaX);
+                    float nextY = (float)(lastPosition.Y + getYDirection() * (nextProgress - currentProgress));
+                    addControlPoint(nextX, nextY);
+                    currentProgress = nextProgress;
+                }
+            }
+
+            int getYDirection()
+            {
+                float lastSliderY = sliderStartY + lastPosition.Y;
+                return lastSliderY < OSU_PLAYFIELD_HEIGHT / 2 ? 1 : -1;
+            }
+
+            float getMaxDeltaY()
+            {
+                float lastSliderY = sliderStartY + lastPosition.Y;
+                return Math.Max(lastSliderY, OSU_PLAYFIELD_HEIGHT - lastSliderY) - margin;
+            }
+
+            void addControlPoint(float nextX, float nextY)
+            {
+                Vector2 nextPosition = new Vector2(nextX, nextY);
+                sliderPath.ControlPoints.Add(new PathControlPoint(nextPosition));
+                currentDistance += Vector2.Distance(lastPosition, nextPosition);
+                lastPosition = nextPosition;
+            }
+        }
+
+        /// <summary>
+        /// Find the index at which a new vertex with <paramref name="distance"/> can be inserted.
+        /// </summary>
+        private int vertexIndexAtDistance(double distance)
+        {
+            // The position of `(distance, Infinity)` is uniquely determined because infinite positions are not allowed.
+            int i = vertices.BinarySearch(new JuiceStreamPathVertex(distance, float.PositiveInfinity));
+            return i < 0 ? ~i : i;
+        }
+
+        /// <summary>
+        /// Compute the position at the given <paramref name="distance"/>, assuming <paramref name="index"/> is the vertex index returned by <see cref="vertexIndexAtDistance"/>.
+        /// </summary>
+        private float positionAtDistance(double distance, int index)
+        {
+            if (index <= 0)
+                return vertices[0].X;
+            if (index >= vertices.Count)
+                return vertices[^1].X;
+
+            double length = vertices[index].Distance - vertices[index - 1].Distance;
+            if (Precision.AlmostEquals(length, 0))
+                return vertices[index].X;
+
+            float deltaX = vertices[index].X - vertices[index - 1].X;
+
+            return (float)(vertices[index - 1].X + deltaX * ((distance - vertices[index - 1].Distance) / length));
+        }
+
+        /// <summary>
+        /// Check the two vertices can connected directly while satisfying the slope condition.
+        /// </summary>
+        private bool canConnect(JuiceStreamPathVertex vertex1, JuiceStreamPathVertex vertex2, float allowance = 0)
+        {
+            double xDistance = Math.Abs((double)vertex2.X - vertex1.X);
+            float length = (float)Math.Abs(vertex2.Distance - vertex1.Distance);
+            return xDistance <= length + allowance;
+        }
+
+        /// <summary>
+        /// Move the position of <paramref name="movableVertex"/> towards the position of <paramref name="fixedVertex"/>
+        /// until the vertex pair satisfies the condition <see cref="canConnect"/>.
+        /// </summary>
+        /// <returns>The resulting position of <paramref name="movableVertex"/>.</returns>
+        private float clampToConnectablePosition(JuiceStreamPathVertex fixedVertex, JuiceStreamPathVertex movableVertex)
+        {
+            float length = (float)Math.Abs(movableVertex.Distance - fixedVertex.Distance);
+            return Math.Clamp(movableVertex.X, fixedVertex.X - length, fixedVertex.X + length);
+        }
+
+        private void invalidate() => InvalidationID++;
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStreamPathVertex.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStreamPathVertex.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+#nullable enable
+
+namespace osu.Game.Rulesets.Catch.Objects
+{
+    /// <summary>
+    /// A vertex of a <see cref="JuiceStreamPath"/>.
+    /// </summary>
+    public readonly struct JuiceStreamPathVertex : IComparable<JuiceStreamPathVertex>
+    {
+        public readonly double Distance;
+
+        public readonly float X;
+
+        public JuiceStreamPathVertex(double distance, float x)
+        {
+            Distance = distance;
+            X = x;
+        }
+
+        public int CompareTo(JuiceStreamPathVertex other)
+        {
+            int c = Distance.CompareTo(other.Distance);
+            return c != 0 ? c : X.CompareTo(other.X);
+        }
+
+        public override string ToString() => $"({Distance}, {X})";
+    }
+}


### PR DESCRIPTION
A `JuiceStream` holds a legacy `SliderPath` as the representation of the path.
However, the `SliderPath` representation is difficult to work with because `SliderPath` works in 2D positions, while osu!catch works in `(time, x)` coordinates.
This `JuiceStreamPath` represents the path in a more convenient way, a poly-line connecting list of `(distance, x)` vertices.

The path can be regarded as a function from the closed interval of range to the x position.
To ensure the path is convertible to a `SliderPath`, the slope of the function must not be more than `1` everywhere, and this slope condition is always maintained as an invariant.
As the result of slope invariant, when a vertex is moved, some other vertices may have to be moved as well. This effect can be seen as:
(Actual editor logic is not included in this PR)

https://user-images.githubusercontent.com/32995012/126104601-6a7719bd-f0c0-449f-b10b-4527f23b2be1.mp4

`ResampleVertices` will be used after a `SliderPath` is converted to a `JuiceStreamPath`. The naive way to convert the slider path will result in many vertices. The path can be simplified without changing the generated nested hit object pattern by "resampling" the path at the times of the generated nested hit objects because the times of the nested hit objects only depend on the path length.

`ConvertToSliderPath` implements what I call "folding" of the slider path for compatibility with the stable editor. The method ensures the result slider is contained in the playfield when viewed in the stable editor.

In the test, "property testing" is heavily used. Tests generate random cases and assert some properties.
That gives higher confidence of invariant correctness and round-trip correctness of the `SliderPath` conversion.