### PR TITLE
Create a deep clone of score for score submission purposes

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -3,6 +3,7 @@ M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Us
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.Nullable`1.Equals(System.Object)~System.Boolean;Use == instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
+T:SixLabors.ImageSharp.IDeepCloneable`1;Use osu.Game.Utils.IDeepCloneable<T> instead.
 M:osu.Framework.Graphics.Sprites.SpriteText.#ctor;Use OsuSpriteText.
 M:osu.Framework.Bindables.IBindableList`1.GetBoundCopy();Fails on iOS. Use manual ctor + BindTo instead. (see https://github.com/mono/mono/issues/19900)
 T:Microsoft.EntityFrameworkCore.Internal.EnumerableExtensions;Don't use internal extension methods.

--- a/osu.Game.Tests/NonVisual/ControlPointInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ControlPointInfoTest.cs
@@ -248,13 +248,13 @@ namespace osu.Game.Tests.NonVisual
         }
 
         [Test]
-        public void TestCreateCopyIsDeepClone()
+        public void TestDeepClone()
         {
             var cpi = new ControlPointInfo();
 
             cpi.Add(1000, new TimingControlPoint { BeatLength = 500 });
 
-            var cpiCopy = cpi.CreateCopy();
+            var cpiCopy = cpi.DeepClone();
 
             cpiCopy.Add(2000, new TimingControlPoint { BeatLength = 500 });
 

--- a/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class ScoreInfoTest
+    {
+        [Test]
+        public void TestDeepClone()
+        {
+            var score = new ScoreInfo();
+
+            score.Statistics.Add(HitResult.Good, 10);
+            score.Rank = ScoreRank.B;
+
+            var scoreCopy = score.DeepClone();
+
+            score.Statistics[HitResult.Good]++;
+            score.Rank = ScoreRank.X;
+
+            Assert.That(scoreCopy.Statistics[HitResult.Good], Is.EqualTo(10));
+            Assert.That(score.Statistics[HitResult.Good], Is.EqualTo(11));
+
+            Assert.That(scoreCopy.Rank, Is.EqualTo(ScoreRank.B));
+            Assert.That(score.Rank, Is.EqualTo(ScoreRank.X));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("create mods", () =>
             {
                 original = new OsuModDoubleTime();
-                copy = (OsuModDoubleTime)original.CreateCopy();
+                copy = (OsuModDoubleTime)original.DeepClone();
             });
 
             AddStep("change property", () => original.SpeedChange.Value = 2);
@@ -106,7 +106,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("create mods", () =>
             {
                 original = new MultiMod(new OsuModDoubleTime());
-                copy = (MultiMod)original.CreateCopy();
+                copy = (MultiMod)original.DeepClone();
             });
 
             AddStep("change property", () => ((OsuModDoubleTime)original.Mods[0]).SpeedChange.Value = 2);

--- a/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
@@ -3,11 +3,12 @@
 
 using System;
 using osu.Game.Graphics;
+using osu.Game.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
-    public abstract class ControlPoint : IComparable<ControlPoint>
+    public abstract class ControlPoint : IComparable<ControlPoint>, IDeepCloneable<ControlPoint>
     {
         /// <summary>
         /// The time at which the control point takes effect.
@@ -32,7 +33,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <summary>
         /// Create an unbound copy of this control point.
         /// </summary>
-        public ControlPoint CreateCopy()
+        public ControlPoint DeepClone()
         {
             var copy = (ControlPoint)Activator.CreateInstance(GetType());
 

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -10,11 +10,12 @@ using osu.Framework.Bindables;
 using osu.Framework.Lists;
 using osu.Framework.Utils;
 using osu.Game.Screens.Edit;
+using osu.Game.Utils;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
     [Serializable]
-    public class ControlPointInfo
+    public class ControlPointInfo : IDeepCloneable<ControlPointInfo>
     {
         /// <summary>
         /// All control points grouped by time.
@@ -350,12 +351,12 @@ namespace osu.Game.Beatmaps.ControlPoints
             }
         }
 
-        public ControlPointInfo CreateCopy()
+        public ControlPointInfo DeepClone()
         {
             var controlPointInfo = new ControlPointInfo();
 
             foreach (var point in AllControlPoints)
-                controlPointInfo.Add(point.Time, point.CreateCopy());
+                controlPointInfo.Add(point.Time, point.DeepClone());
 
             return controlPointInfo;
         }

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -10,10 +10,11 @@ using osu.Game.IO.Serialization.Converters;
 using osu.Game.Online.Rooms.GameTypes;
 using osu.Game.Online.Rooms.RoomStatuses;
 using osu.Game.Users;
+using osu.Game.Utils;
 
 namespace osu.Game.Online.Rooms
 {
-    public class Room
+    public class Room : IDeepCloneable<Room>
     {
         [Cached]
         [JsonProperty("id")]
@@ -120,7 +121,7 @@ namespace osu.Game.Online.Rooms
         /// Create a copy of this room without online information.
         /// Should be used to create a local copy of a room for submitting in the future.
         /// </summary>
-        public Room CreateCopy()
+        public Room DeepClone()
         {
             var copy = new Room();
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -429,7 +429,7 @@ namespace osu.Game.Overlays.Mods
                 if (!Stacked)
                     modEnumeration = ModUtils.FlattenMods(modEnumeration);
 
-                section.Mods = modEnumeration.Select(getValidModOrNull).Where(m => m != null).Select(m => m.CreateCopy());
+                section.Mods = modEnumeration.Select(getValidModOrNull).Where(m => m != null).Select(m => m.DeepClone());
             }
 
             updateSelectedButtons();

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Utils;
 
 namespace osu.Game.Replays
 {
-    public class Replay
+    public class Replay : IDeepCloneable<Replay>
     {
         /// <summary>
         /// Whether all frames for this replay have been received.
@@ -15,5 +17,15 @@ namespace osu.Game.Replays
         public bool HasReceivedAllFrames = true;
 
         public List<ReplayFrame> Frames = new List<ReplayFrame>();
+
+        public Replay DeepClone()
+        {
+            return new Replay
+            {
+                HasReceivedAllFrames = HasReceivedAllFrames,
+                // individual frames are mutable for now but hopefully this will not be a thing in the future.
+                Frames = Frames.ToList(),
+            };
+        }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// <returns>A structure describing the difficulty of the beatmap.</returns>
         public DifficultyAttributes Calculate(params Mod[] mods)
         {
-            mods = mods.Select(m => m.CreateCopy()).ToArray();
+            mods = mods.Select(m => m.DeepClone()).ToArray();
 
             IBeatmap playableBeatmap = beatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
     /// The base class for gameplay modifiers.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public abstract class Mod : IMod, IEquatable<Mod>, IJsonSerializable
+    public abstract class Mod : IMod, IEquatable<Mod>, IJsonSerializable, IDeepCloneable<Mod>
     {
         /// <summary>
         /// The name of this mod.
@@ -132,7 +132,7 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Creates a copy of this <see cref="Mod"/> initialised to a default state.
         /// </summary>
-        public virtual Mod CreateCopy()
+        public virtual Mod DeepClone()
         {
             var result = (Mod)Activator.CreateInstance(GetType());
             result.CopyFrom(this);

--- a/osu.Game/Rulesets/Mods/MultiMod.cs
+++ b/osu.Game/Rulesets/Mods/MultiMod.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
             Mods = mods;
         }
 
-        public override Mod CreateCopy() => new MultiMod(Mods.Select(m => m.CreateCopy()).ToArray());
+        public override Mod DeepClone() => new MultiMod(Mods.Select(m => m.DeepClone()).ToArray());
 
         public override Type[] IncompatibleMods => Mods.SelectMany(m => m.IncompatibleMods).ToArray();
     }

--- a/osu.Game/Scoring/Score.cs
+++ b/osu.Game/Scoring/Score.cs
@@ -2,12 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Replays;
+using osu.Game.Utils;
 
 namespace osu.Game.Scoring
 {
-    public class Score
+    public class Score : IDeepCloneable<Score>
     {
         public ScoreInfo ScoreInfo = new ScoreInfo();
         public Replay Replay = new Replay();
+
+        public Score DeepClone()
+        {
+            return new Score
+            {
+                ScoreInfo = ScoreInfo.DeepClone(),
+                Replay = Replay.DeepClone(),
+            };
+        }
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -18,7 +18,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Scoring
 {
-    public class ScoreInfo : IHasFiles<ScoreFileInfo>, IHasPrimaryKey, ISoftDelete, IEquatable<ScoreInfo>
+    public class ScoreInfo : IHasFiles<ScoreFileInfo>, IHasPrimaryKey, ISoftDelete, IEquatable<ScoreInfo>, IDeepCloneable<ScoreInfo>
     {
         public int ID { get; set; }
 
@@ -240,6 +240,15 @@ namespace osu.Game.Scoring
                         break;
                 }
             }
+        }
+
+        public ScoreInfo DeepClone()
+        {
+            var clone = (ScoreInfo)MemberwiseClone();
+
+            clone.Statistics = new Dictionary<HitResult, int>(clone.Statistics);
+
+            return clone;
         }
 
         public override string ToString() => $"{User} playing {Beatmap}";

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.Edit
 
                 // clone these locally for now to avoid incurring overhead on GetPlayableBeatmap usages.
                 // eventually we will want to improve how/where this is done as there are issues with *not* cloning it in all cases.
-                playableBeatmap.ControlPointInfo = playableBeatmap.ControlPointInfo.CreateCopy();
+                playableBeatmap.ControlPointInfo = playableBeatmap.ControlPointInfo.DeepClone();
             }
             catch (Exception e)
             {

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         {
             new OsuMenuItem("Create copy", MenuItemType.Standard, () =>
             {
-                parentScreen?.OpenNewRoom(Room.CreateCopy());
+                parentScreen?.OpenNewRoom(Room.DeepClone());
             })
         };
     }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -72,8 +72,8 @@ namespace osu.Game.Screens.OnlinePlay
 
             // At this point, Mods contains both the required and allowed mods. For selection purposes, it should only contain the required mods.
             // Similarly, freeMods is currently empty but should only contain the allowed mods.
-            Mods.Value = selectedItem?.Value?.RequiredMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
-            FreeMods.Value = selectedItem?.Value?.AllowedMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
+            Mods.Value = selectedItem?.Value?.RequiredMods.Select(m => m.DeepClone()).ToArray() ?? Array.Empty<Mod>();
+            FreeMods.Value = selectedItem?.Value?.AllowedMods.Select(m => m.DeepClone()).ToArray() ?? Array.Empty<Mod>();
 
             Mods.BindValueChanged(onModsChanged);
             Ruleset.BindValueChanged(onRulesetChanged);
@@ -108,8 +108,8 @@ namespace osu.Game.Screens.OnlinePlay
                 }
             };
 
-            item.RequiredMods.AddRange(Mods.Value.Select(m => m.CreateCopy()));
-            item.AllowedMods.AddRange(FreeMods.Value.Select(m => m.CreateCopy()));
+            item.RequiredMods.AddRange(Mods.Value.Select(m => m.DeepClone()));
+            item.AllowedMods.AddRange(FreeMods.Value.Select(m => m.DeepClone()));
 
             SelectItem(item);
             return true;

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -55,10 +55,10 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             item.Ruleset.Value = Ruleset.Value;
 
             item.RequiredMods.Clear();
-            item.RequiredMods.AddRange(Mods.Value.Select(m => m.CreateCopy()));
+            item.RequiredMods.AddRange(Mods.Value.Select(m => m.DeepClone()));
 
             item.AllowedMods.Clear();
-            item.AllowedMods.AddRange(FreeMods.Value.Select(m => m.CreateCopy()));
+            item.AllowedMods.AddRange(FreeMods.Value.Select(m => m.DeepClone()));
         }
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -694,9 +694,11 @@ namespace osu.Game.Screens.Play
         /// <returns>The final score.</returns>
         private async Task<ScoreInfo> prepareScoreForResults()
         {
+            var scoreCopy = Score.DeepClone();
+
             try
             {
-                await PrepareScoreForResultsAsync(Score).ConfigureAwait(false);
+                await PrepareScoreForResultsAsync(scoreCopy).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -705,14 +707,14 @@ namespace osu.Game.Screens.Play
 
             try
             {
-                await ImportScore(Score).ConfigureAwait(false);
+                await ImportScore(scoreCopy).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, @"Score import failed!");
             }
 
-            return Score.ScoreInfo;
+            return scoreCopy.ScoreInfo;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, OsuConfigManager config, OsuGameBase game)
         {
-            Mods.Value = base.Mods.Value.Select(m => m.CreateCopy()).ToArray();
+            Mods.Value = base.Mods.Value.Select(m => m.DeepClone()).ToArray();
 
             if (Beatmap.Value is DummyWorkingBeatmap)
                 return;

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -38,15 +38,13 @@ namespace osu.Game.Screens.Play
 
         protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token)
         {
-            var scoreCopy = score.DeepClone();
-
-            var beatmap = scoreCopy.ScoreInfo.Beatmap;
+            var beatmap = score.ScoreInfo.Beatmap;
 
             Debug.Assert(beatmap.OnlineBeatmapID != null);
 
             int beatmapId = beatmap.OnlineBeatmapID.Value;
 
-            return new SubmitSoloScoreRequest(beatmapId, token, scoreCopy.ScoreInfo);
+            return new SubmitSoloScoreRequest(beatmapId, token, score.ScoreInfo);
         }
     }
 }

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -38,13 +38,15 @@ namespace osu.Game.Screens.Play
 
         protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token)
         {
-            var beatmap = score.ScoreInfo.Beatmap;
+            var scoreCopy = score.DeepClone();
+
+            var beatmap = scoreCopy.ScoreInfo.Beatmap;
 
             Debug.Assert(beatmap.OnlineBeatmapID != null);
 
             int beatmapId = beatmap.OnlineBeatmapID.Value;
 
-            return new SubmitSoloScoreRequest(beatmapId, token, score.ScoreInfo);
+            return new SubmitSoloScoreRequest(beatmapId, token, scoreCopy.ScoreInfo);
         }
     }
 }

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Play
         {
             var exiting = base.OnExiting(next);
 
-            submitScore(Score);
+            submitScore(Score.DeepClone());
 
             return exiting;
         }

--- a/osu.Game/Utils/IDeepCloneable.cs
+++ b/osu.Game/Utils/IDeepCloneable.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Utils
+{
+    /// <summary>A generic interface for a deeply cloneable type.</summary>
+    /// <typeparam name="T">The type of object to clone.</typeparam>
+    public interface IDeepCloneable<out T> where T : class
+    {
+        /// <summary>
+        /// Creates a new <typeparamref name="T" /> that is a deep copy of the current instance.
+        /// </summary>
+        /// <returns>The <typeparamref name="T" />.</returns>
+        T DeepClone();
+    }
+}


### PR DESCRIPTION
I'm not sure this was happening until now, but felt very unsafe and worthy of an immediate fix.

I've also consolidated all other instances where we are expecting a deep clone operation (ie. `CreateCopy` methods) to use a single interface.
