### PR TITLE
Don't generate hit lighting in catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         public void TestHitLightingColour()
         {
             var fruitColour = SkinConfiguration.DefaultComboColours[1];
-            AddStep("enable hit lighting", () => config.SetValue(OsuSetting.HitLighting, true));
+            AddStep("enable hit lighting", () => catcher.GenerateHitLighting = true);
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             AddAssert("correct hit lighting colour", () =>
                 catcher.ChildrenOfType<HitExplosion>().First()?.Entry?.ObjectColour == fruitColour);
@@ -228,7 +228,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Test]
         public void TestHitLightingDisabled()
         {
-            AddStep("disable hit lighting", () => config.SetValue(OsuSetting.HitLighting, false));
+            AddStep("disable hit lighting", () => catcher.GenerateHitLighting = false);
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             AddAssert("no hit lighting", () => !catcher.ChildrenOfType<HitExplosion>().Any());
         }

--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -21,8 +21,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             // TODO: honor "hit animation" setting?
             CatcherArea.MovableCatcher.CatchFruitOnPlate = false;
 
-            CatcherArea.MovableCatcher.GenerateHitLighting.UnbindBindings();
-            CatcherArea.MovableCatcher.GenerateHitLighting.Value = false;
+            CatcherArea.MovableCatcher.GenerateHitLighting = false;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -21,7 +21,8 @@ namespace osu.Game.Rulesets.Catch.Edit
             // TODO: honor "hit animation" setting?
             CatcherArea.MovableCatcher.CatchFruitOnPlate = false;
 
-            // TODO: disable hit lighting as well
+            CatcherArea.MovableCatcher.GenerateHitLighting.UnbindBindings();
+            CatcherArea.MovableCatcher.GenerateHitLighting.Value = false;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -47,6 +47,11 @@ namespace osu.Game.Rulesets.Catch.UI
         public bool CatchFruitOnPlate { get; set; } = true;
 
         /// <summary>
+        /// Whether <see cref="HitExplosion"/>s should be generated on the catcher plate when a hit object is caught.
+        /// </summary>
+        public readonly Bindable<bool> GenerateHitLighting = new Bindable<bool>(true);
+
+        /// <summary>
         /// The relative space to cover in 1 millisecond. based on 1 game pixel per millisecond as in osu-stable.
         /// </summary>
         public const double BASE_SPEED = 1.0;
@@ -126,7 +131,6 @@ namespace osu.Game.Rulesets.Catch.UI
         private double hyperDashModifier = 1;
         private int hyperDashDirection;
         private float hyperDashTargetPosition;
-        private Bindable<bool> hitLighting;
 
         private readonly HitExplosionContainer hitExplosionContainer;
 
@@ -171,7 +175,7 @@ namespace osu.Game.Rulesets.Catch.UI
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            hitLighting = config.GetBindable<bool>(OsuSetting.HitLighting);
+            GenerateHitLighting.BindTo(config.GetBindable<bool>(OsuSetting.HitLighting));
             trails = new CatcherTrailDisplay(this);
         }
 
@@ -240,7 +244,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 if (CatchFruitOnPlate)
                     placeCaughtObject(palpableObject, positionInStack);
 
-                if (hitLighting.Value)
+                if (GenerateHitLighting.Value)
                     addLighting(hitObject, positionInStack.X, drawableObject.AccentColour.Value);
             }
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
@@ -49,7 +48,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Whether <see cref="HitExplosion"/>s should be generated on the catcher plate when a hit object is caught.
         /// </summary>
-        public readonly Bindable<bool> GenerateHitLighting = new Bindable<bool>(true);
+        public bool GenerateHitLighting { get; set; } = true;
 
         /// <summary>
         /// The relative space to cover in 1 millisecond. based on 1 game pixel per millisecond as in osu-stable.
@@ -175,7 +174,7 @@ namespace osu.Game.Rulesets.Catch.UI
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            GenerateHitLighting.BindTo(config.GetBindable<bool>(OsuSetting.HitLighting));
+            GenerateHitLighting = config.GetBindable<bool>(OsuSetting.HitLighting).Value;
             trails = new CatcherTrailDisplay(this);
         }
 
@@ -244,7 +243,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 if (CatchFruitOnPlate)
                     placeCaughtObject(palpableObject, positionInStack);
 
-                if (GenerateHitLighting.Value)
+                if (GenerateHitLighting)
                     addLighting(hitObject, positionInStack.X, drawableObject.AccentColour.Value);
             }
 


### PR DESCRIPTION
Whether there should be a setting for this is an answered question, but it is also temporary mitigation of the issue that a hit lighting is duplicated when a juice stream is edited and nested hit objects are recreated (when implemented).