### PR TITLE
Move `Catcher` from `CatcherArea` to `CatchPlayfield`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -24,16 +23,12 @@ namespace osu.Game.Rulesets.Catch.Tests
 {
     public class TestSceneCatchSkinConfiguration : OsuTestScene
     {
-        [Cached]
-        private readonly DroppedObjectContainer droppedObjectContainer;
-
         private Catcher catcher;
 
         private readonly Container container;
 
         public TestSceneCatchSkinConfiguration()
         {
-            Add(droppedObjectContainer = new DroppedObjectContainer());
             Add(container = new Container { RelativeSizeAxes = Axes.Both });
         }
 
@@ -46,7 +41,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 var skin = new TestSkin { FlipCatcherPlate = flip };
                 container.Child = new SkinProvidingContainer(skin)
                 {
-                    Child = catcher = new Catcher(new Container())
+                    Child = catcher = new Catcher(new Container(), new DroppedObjectContainer())
                     {
                         Anchor = Anchor.Centre
                     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -31,22 +31,11 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        [Cached]
-        private readonly DroppedObjectContainer droppedObjectContainer;
+        private Container trailContainer;
 
-        private readonly Container trailContainer;
+        private DroppedObjectContainer droppedObjectContainer;
 
         private TestCatcher catcher;
-
-        public TestSceneCatcher()
-        {
-            Add(trailContainer = new Container
-            {
-                Anchor = Anchor.Centre,
-                Depth = -1
-            });
-            Add(droppedObjectContainer = new DroppedObjectContainer());
-        }
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -56,13 +45,19 @@ namespace osu.Game.Rulesets.Catch.Tests
                 CircleSize = 0,
             };
 
-            if (catcher != null)
-                Remove(catcher);
+            trailContainer = new Container();
+            droppedObjectContainer = new DroppedObjectContainer();
 
-            Add(catcher = new TestCatcher(trailContainer, difficulty)
+            Child = new Container
             {
-                Anchor = Anchor.Centre
-            });
+                Anchor = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    droppedObjectContainer,
+                    catcher = new TestCatcher(trailContainer, droppedObjectContainer, difficulty),
+                    trailContainer,
+                }
+            };
         });
 
         [Test]
@@ -299,8 +294,8 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
-            public TestCatcher(Container trailsTarget, BeatmapDifficulty difficulty)
-                : base(trailsTarget, difficulty)
+            public TestCatcher(Container trailsTarget, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
+                : base(trailsTarget, droppedObjectTarget, difficulty)
             {
             }
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -119,16 +119,16 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestCatcherArea : CatcherArea
         {
-            [Cached]
-            private readonly DroppedObjectContainer droppedObjectContainer;
-
             public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
             {
-                MovableCatcher = new Catcher(this, beatmapDifficulty)
+                var droppedObjectContainer = new DroppedObjectContainer();
+
+                Add(droppedObjectContainer);
+
+                MovableCatcher = new Catcher(this, droppedObjectContainer, beatmapDifficulty)
                 {
                     X = CatchPlayfield.CENTER_X
                 };
-                AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
 
             public void ToggleHyperDash(bool status) => MovableCatcher.SetHyperDashState(status ? 2 : 1);

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 {
                     area.OnNewResult(drawable, new CatchJudgementResult(fruit, new CatchJudgement())
                     {
-                        Type = area.MovableCatcher.CanCatch(fruit) ? HitResult.Great : HitResult.Miss
+                        Type = area.Catcher.CanCatch(fruit) ? HitResult.Great : HitResult.Miss
                     });
 
                     drawable.Expire();
@@ -125,13 +125,13 @@ namespace osu.Game.Rulesets.Catch.Tests
 
                 Add(droppedObjectContainer);
 
-                MovableCatcher = new Catcher(this, droppedObjectContainer, beatmapDifficulty)
+                Catcher = new Catcher(this, droppedObjectContainer, beatmapDifficulty)
                 {
                     X = CatchPlayfield.CENTER_X
                 };
             }
 
-            public void ToggleHyperDash(bool status) => MovableCatcher.SetHyperDashState(status ? 2 : 1);
+            public void ToggleHyperDash(bool status) => Catcher.SetHyperDashState(status ? 2 : 1);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -123,8 +123,11 @@ namespace osu.Game.Rulesets.Catch.Tests
             private readonly DroppedObjectContainer droppedObjectContainer;
 
             public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
-                : base(beatmapDifficulty)
             {
+                MovableCatcher = new Catcher(this, beatmapDifficulty)
+                {
+                    X = CatchPlayfield.CENTER_X
+                };
                 AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private bool playfieldIsEmpty => !((CatchPlayfield)drawableRuleset.Playfield).AllHitObjects.Any(h => h.IsAlive);
 
-        private CatcherAnimationState catcherState => ((CatchPlayfield)drawableRuleset.Playfield).CatcherArea.MovableCatcher.CurrentState;
+        private CatcherAnimationState catcherState => ((CatchPlayfield)drawableRuleset.Playfield).Catcher.CurrentState;
 
         private void spawnFruits(bool hit = false)
         {
@@ -162,7 +162,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             float xCoords = CatchPlayfield.CENTER_X;
 
             if (drawableRuleset.Playfield is CatchPlayfield catchPlayfield)
-                catchPlayfield.CatcherArea.MovableCatcher.X = xCoords - x_offset;
+                catchPlayfield.Catcher.X = xCoords - x_offset;
 
             if (hit)
                 xCoords -= x_offset;

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 // this needs to be done within the frame stable context due to how quickly hyperdash state changes occur.
                 Player.DrawableRuleset.FrameStableComponents.OnUpdate += d =>
                 {
-                    var catcher = Player.ChildrenOfType<CatcherArea>().FirstOrDefault()?.MovableCatcher;
+                    var catcher = Player.ChildrenOfType<Catcher>().FirstOrDefault();
 
                     if (catcher == null)
                         return;

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -213,8 +213,11 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             public TestCatcherArea()
             {
-                Scale = new Vector2(4f);
-
+                MovableCatcher = new Catcher(this, new BeatmapDifficulty())
+                {
+                    X = CatchPlayfield.CENTER_X,
+                    Scale = new Vector2(4)
+                };
                 AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -113,36 +113,45 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private void checkHyperDashCatcherColour(ISkin skin, Color4 expectedCatcherColour, Color4? expectedEndGlowColour = null)
         {
-            CatcherArea catcherArea = null;
+            Container trailsContainer = null;
+            Catcher catcher = null;
             CatcherTrailDisplay trails = null;
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                Child = setupSkinHierarchy(catcherArea = new TestCatcherArea
+                trailsContainer = new Container();
+                Child = setupSkinHierarchy(new Container
                 {
                     Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
+                    Children = new Drawable[]
+                    {
+                        catcher = new Catcher(trailsContainer, new DroppedObjectContainer())
+                        {
+                            Scale = new Vector2(4)
+                        },
+                        trailsContainer
+                    }
                 }, skin);
             });
 
             AddStep("get trails container", () =>
             {
-                trails = catcherArea.OfType<CatcherTrailDisplay>().Single();
-                catcherArea.MovableCatcher.SetHyperDashState(2);
+                trails = trailsContainer.OfType<CatcherTrailDisplay>().Single();
+                catcher.SetHyperDashState(2);
             });
 
-            AddUntilStep("catcher colour is correct", () => catcherArea.MovableCatcher.Colour == expectedCatcherColour);
+            AddUntilStep("catcher colour is correct", () => catcher.Colour == expectedCatcherColour);
 
             AddAssert("catcher trails colours are correct", () => trails.HyperDashTrailsColour == expectedCatcherColour);
             AddAssert("catcher end-glow colours are correct", () => trails.EndGlowSpritesColour == (expectedEndGlowColour ?? expectedCatcherColour));
 
             AddStep("finish hyper-dashing", () =>
             {
-                catcherArea.MovableCatcher.SetHyperDashState();
-                catcherArea.MovableCatcher.FinishTransforms();
+                catcher.SetHyperDashState();
+                catcher.FinishTransforms();
             });
 
-            AddAssert("catcher colour returned to white", () => catcherArea.MovableCatcher.Colour == Color4.White);
+            AddAssert("catcher colour returned to white", () => catcher.Colour == Color4.White);
         }
 
         private void checkHyperDashFruitColour(ISkin skin, Color4 expectedColour)
@@ -203,22 +212,6 @@ namespace osu.Game.Rulesets.Catch.Tests
             public TestSkin()
                 : base(new SkinInfo(), null, null, string.Empty)
             {
-            }
-        }
-
-        private class TestCatcherArea : CatcherArea
-        {
-            [Cached]
-            private readonly DroppedObjectContainer droppedObjectContainer;
-
-            public TestCatcherArea()
-            {
-                MovableCatcher = new Catcher(this, new BeatmapDifficulty())
-                {
-                    X = CatchPlayfield.CENTER_X,
-                    Scale = new Vector2(4)
-                };
-                AddInternal(droppedObjectContainer = new DroppedObjectContainer());
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             base.LoadComplete();
 
             // TODO: honor "hit animation" setting?
-            CatcherArea.MovableCatcher.CatchFruitOnPlate = false;
+            Catcher.CatchFruitOnPlate = false;
 
             // TODO: disable hit lighting as well
         }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -41,9 +41,7 @@ namespace osu.Game.Rulesets.Catch.Mods
             {
                 base.Update();
 
-                var catcherArea = playfield.CatcherArea;
-
-                FlashlightPosition = catcherArea.ToSpaceOfOtherDrawable(catcherArea.MovableCatcher.DrawPosition, this);
+                FlashlightPosition = playfield.CatcherArea.ToSpaceOfOtherDrawable(playfield.Catcher.DrawPosition, this);
             }
 
             private float getSizeFor(int combo)

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Catch.Mods
             var drawableCatchRuleset = (DrawableCatchRuleset)drawableRuleset;
             var catchPlayfield = (CatchPlayfield)drawableCatchRuleset.Playfield;
 
-            catchPlayfield.CatcherArea.MovableCatcher.CatchFruitOnPlate = false;
+            catchPlayfield.Catcher.CatchFruitOnPlate = false;
         }
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 bool impossibleJump = speedRequired > movement_speed * 2;
 
                 // todo: get correct catcher size, based on difficulty CS.
-                const float catcher_width_half = CatcherArea.CATCHER_SIZE * 0.3f * 0.5f;
+                const float catcher_width_half = Catcher.BASE_SIZE * 0.3f * 0.5f;
 
                 if (lastPosition - catcher_width_half < h.EffectiveX && lastPosition + catcher_width_half > h.EffectiveX)
                 {

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Catch.UI
             ((DrawableCatchHitObject)d).CheckPosition = checkIfWeCanCatch;
         }
 
-        private bool checkIfWeCanCatch(CatchHitObject obj) => CatcherArea.MovableCatcher.CanCatch(obj);
+        private bool checkIfWeCanCatch(CatchHitObject obj) => Catcher.CanCatch(obj);
 
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
             => CatcherArea.OnNewResult((DrawableCatchHitObject)judgedObject, result);

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Catch.UI
 {
     public class CatchPlayfield : ScrollingPlayfield
     {
+        private readonly BeatmapDifficulty difficulty;
+
         /// <summary>
         /// The width of the playfield.
         /// The horizontal movement of the catcher is confined in the area of this width.
@@ -31,11 +33,17 @@ namespace osu.Game.Rulesets.Catch.UI
             // only check the X position; handle all vertical space.
             base.ReceivePositionalInputAt(new Vector2(screenSpacePos.X, ScreenSpaceDrawQuad.Centre.Y));
 
-        internal readonly Catcher Catcher;
+        internal Catcher Catcher { get; private set; }
 
-        internal readonly CatcherArea CatcherArea;
+        internal CatcherArea CatcherArea { get; private set; }
 
         public CatchPlayfield(BeatmapDifficulty difficulty)
+        {
+            this.difficulty = difficulty;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
         {
             var trailContainer = new Container
             {
@@ -49,7 +57,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 X = CENTER_X
             };
 
-            InternalChildren = new[]
+            AddRangeInternal(new[]
             {
                 droppedObjectContainer,
                 Catcher.CreateProxiedContent(),
@@ -64,12 +72,8 @@ namespace osu.Game.Rulesets.Catch.UI
                 },
                 trailContainer,
                 HitObjectContainer,
-            };
-        }
+            });
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
             RegisterPool<Droplet, DrawableDroplet>(50);
             RegisterPool<TinyDroplet, DrawableTinyDroplet>(50);
             RegisterPool<Fruit, DrawableFruit>(100);

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -26,31 +27,40 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public const float CENTER_X = WIDTH / 2;
 
-        [Cached]
-        private readonly DroppedObjectContainer droppedObjectContainer;
-
-        internal readonly CatcherArea CatcherArea;
-
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
             // only check the X position; handle all vertical space.
             base.ReceivePositionalInputAt(new Vector2(screenSpacePos.X, ScreenSpaceDrawQuad.Centre.Y));
 
+        internal readonly Catcher Catcher;
+
+        internal readonly CatcherArea CatcherArea;
+
+        [Cached]
+        private readonly DroppedObjectContainer droppedObjectContainer;
+
         public CatchPlayfield(BeatmapDifficulty difficulty)
         {
-            CatcherArea = new CatcherArea(difficulty)
+            var trailContainer = new Container();
+
+            Catcher = new Catcher(trailContainer, difficulty)
             {
-                Anchor = Anchor.BottomLeft,
-                Origin = Anchor.TopLeft,
+                X = CENTER_X
             };
 
             InternalChildren = new[]
             {
                 droppedObjectContainer = new DroppedObjectContainer(),
-                CatcherArea.MovableCatcher.CreateProxiedContent(),
+                Catcher.CreateProxiedContent(),
                 HitObjectContainer.CreateProxy(),
                 // This ordering (`CatcherArea` before `HitObjectContainer`) is important to
                 // make sure the up-to-date catcher position is used for the catcher catching logic of hit objects.
-                CatcherArea,
+                CatcherArea = new CatcherArea
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.TopLeft,
+                    MovableCatcher = Catcher
+                },
+                trailContainer,
                 HitObjectContainer,
             };
         }

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -35,21 +35,19 @@ namespace osu.Game.Rulesets.Catch.UI
 
         internal readonly CatcherArea CatcherArea;
 
-        [Cached]
-        private readonly DroppedObjectContainer droppedObjectContainer;
-
         public CatchPlayfield(BeatmapDifficulty difficulty)
         {
             var trailContainer = new Container();
+            var droppedObjectContainer = new DroppedObjectContainer();
 
-            Catcher = new Catcher(trailContainer, difficulty)
+            Catcher = new Catcher(trailContainer, droppedObjectContainer, difficulty)
             {
                 X = CENTER_X
             };
 
             InternalChildren = new[]
             {
-                droppedObjectContainer = new DroppedObjectContainer(),
+                droppedObjectContainer,
                 Catcher.CreateProxiedContent(),
                 HitObjectContainer.CreateProxy(),
                 // This ordering (`CatcherArea` before `HitObjectContainer`) is important to
@@ -58,7 +56,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.TopLeft,
-                    MovableCatcher = Catcher
+                    MovableCatcher = Catcher,
                 },
                 trailContainer,
                 HitObjectContainer,

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -37,7 +37,11 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty)
         {
-            var trailContainer = new Container();
+            var trailContainer = new Container
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.TopLeft
+            };
             var droppedObjectContainer = new DroppedObjectContainer();
 
             Catcher = new Catcher(trailContainer, droppedObjectContainer, difficulty)

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.TopLeft,
-                    MovableCatcher = Catcher,
+                    Catcher = Catcher,
                 },
                 trailContainer,
                 HitObjectContainer,

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Catch.UI
 {
     public class CatchPlayfield : ScrollingPlayfield
     {
-        private readonly BeatmapDifficulty difficulty;
-
         /// <summary>
         /// The width of the playfield.
         /// The horizontal movement of the catcher is confined in the area of this width.
@@ -36,6 +34,8 @@ namespace osu.Game.Rulesets.Catch.UI
         internal Catcher Catcher { get; private set; }
 
         internal CatcherArea CatcherArea { get; private set; }
+
+        private readonly BeatmapDifficulty difficulty;
 
         public CatchPlayfield(BeatmapDifficulty difficulty)
         {

--- a/osu.Game.Rulesets.Catch/UI/CatchReplayRecorder.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchReplayRecorder.cs
@@ -21,6 +21,6 @@ namespace osu.Game.Rulesets.Catch.UI
         }
 
         protected override ReplayFrame HandleFrame(Vector2 mousePosition, List<CatchAction> actions, ReplayFrame previousFrame)
-            => new CatchReplayFrame(Time.Current, playfield.CatcherArea.MovableCatcher.X, actions.Contains(CatchAction.Dash), previousFrame as CatchReplayFrame);
+            => new CatchReplayFrame(Time.Current, playfield.Catcher.X, actions.Contains(CatchAction.Dash), previousFrame as CatchReplayFrame);
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
         private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
 
-        public Catcher([NotNull] Container trailsTarget, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] Container trailsTarget, [NotNull] DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
         {
             this.trailsTarget = trailsTarget;
             this.droppedObjectTarget = droppedObjectTarget;

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -26,6 +26,16 @@ namespace osu.Game.Rulesets.Catch.UI
     public class Catcher : SkinReloadableDrawable
     {
         /// <summary>
+        /// The size of the catcher at 1x scale.
+        /// </summary>
+        public const float BASE_SIZE = 106.75f;
+
+        /// <summary>
+        /// The width of the catcher which can receive fruit. Equivalent to "catchMargin" in osu-stable.
+        /// </summary>
+        public const float ALLOWED_CATCH_RANGE = 0.8f;
+
+        /// <summary>
         /// The default colour used to tint hyper-dash fruit, along with the moving catcher, its trail
         /// and end glow/after-image during a hyper-dash.
         /// </summary>
@@ -82,11 +92,6 @@ namespace osu.Game.Rulesets.Catch.UI
             private set => Body.AnimationState.Value = value;
         }
 
-        /// <summary>
-        /// The width of the catcher which can receive fruit. Equivalent to "catchMargin" in osu-stable.
-        /// </summary>
-        public const float ALLOWED_CATCH_RANGE = 0.8f;
-
         private bool dashing;
 
         public bool Dashing
@@ -140,7 +145,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             Origin = Anchor.TopCentre;
 
-            Size = new Vector2(CatcherArea.CATCHER_SIZE);
+            Size = new Vector2(BASE_SIZE);
             if (difficulty != null)
                 Scale = calculateScale(difficulty);
 
@@ -197,7 +202,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// Calculates the width of the area used for attempting catches in gameplay.
         /// </summary>
         /// <param name="scale">The scale of the catcher.</param>
-        public static float CalculateCatchWidth(Vector2 scale) => CatcherArea.CATCHER_SIZE * Math.Abs(scale.X) * ALLOWED_CATCH_RANGE;
+        public static float CalculateCatchWidth(Vector2 scale) => BASE_SIZE * Math.Abs(scale.X) * ALLOWED_CATCH_RANGE;
 
         /// <summary>
         /// Calculates the width of the area used for attempting catches in gameplay.

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -74,8 +74,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Contains objects dropped from the plate.
         /// </summary>
-        [Resolved]
-        private DroppedObjectContainer droppedObjectTarget { get; set; }
+        private readonly DroppedObjectContainer droppedObjectTarget;
 
         public CatcherAnimationState CurrentState
         {
@@ -134,9 +133,10 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
         private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
 
-        public Catcher([NotNull] Container trailsTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] Container trailsTarget, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
         {
             this.trailsTarget = trailsTarget;
+            this.droppedObjectTarget = droppedObjectTarget;
 
             Origin = Anchor.TopCentre;
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -15,6 +15,11 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
+    /// <summary>
+    /// The horizontal band at the bottom of the playfield the catcher is moving on.
+    /// It holds a <see cref="Catcher"/> as a child and translates input to the catcher movement.
+    /// It also holds a combo display that is above the catcher, and judgment results are translated to the catcher and the combo display.
+    /// </summary>
     public class CatcherArea : Container, IKeyBindingHandler<CatchAction>
     {
         public const float CATCHER_SIZE = 106.75f;
@@ -42,6 +47,9 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private int currentDirection;
 
+        /// <remarks>
+        /// <see cref="Catcher"/> must be set before loading.
+        /// </remarks>
         public CatcherArea()
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -22,8 +22,6 @@ namespace osu.Game.Rulesets.Catch.UI
     /// </summary>
     public class CatcherArea : Container, IKeyBindingHandler<CatchAction>
     {
-        public const float CATCHER_SIZE = 106.75f;
-
         public Catcher Catcher
         {
             get => catcher;
@@ -52,7 +50,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </remarks>
         public CatcherArea()
         {
-            Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
+            Size = new Vector2(CatchPlayfield.WIDTH, Catcher.BASE_SIZE);
             Child = comboDisplay = new CatchComboDisplay
             {
                 RelativeSizeAxes = Axes.None,

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Catch.UI
     {
         public const float CATCHER_SIZE = 106.75f;
 
-        public Catcher MovableCatcher
+        public Catcher Catcher
         {
             get => catcher;
             set
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnNewResult(DrawableCatchHitObject hitObject, JudgementResult result)
         {
-            MovableCatcher.OnNewResult(hitObject, result);
+            Catcher.OnNewResult(hitObject, result);
 
             if (!result.Type.IsScorable())
                 return;
@@ -66,9 +66,9 @@ namespace osu.Game.Rulesets.Catch.UI
             if (hitObject.HitObject.LastInCombo)
             {
                 if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
-                    MovableCatcher.Explode();
+                    Catcher.Explode();
                 else
-                    MovableCatcher.Drop();
+                    Catcher.Drop();
             }
 
             comboDisplay.OnNewResult(hitObject, result);
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Catch.UI
         public void OnRevertResult(DrawableCatchHitObject hitObject, JudgementResult result)
         {
             comboDisplay.OnRevertResult(hitObject, result);
-            MovableCatcher.OnRevertResult(hitObject, result);
+            Catcher.OnRevertResult(hitObject, result);
         }
 
         protected override void Update()
@@ -88,27 +88,27 @@ namespace osu.Game.Rulesets.Catch.UI
 
             SetCatcherPosition(
                 replayState?.CatcherX ??
-                (float)(MovableCatcher.X + MovableCatcher.Speed * currentDirection * Clock.ElapsedFrameTime));
+                (float)(Catcher.X + Catcher.Speed * currentDirection * Clock.ElapsedFrameTime));
         }
 
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
 
-            comboDisplay.X = MovableCatcher.X;
+            comboDisplay.X = Catcher.X;
         }
 
         public void SetCatcherPosition(float X)
         {
-            float lastPosition = MovableCatcher.X;
+            float lastPosition = Catcher.X;
             float newPosition = Math.Clamp(X, 0, CatchPlayfield.WIDTH);
 
-            MovableCatcher.X = newPosition;
+            Catcher.X = newPosition;
 
             if (lastPosition < newPosition)
-                MovableCatcher.VisualDirection = Direction.Right;
+                Catcher.VisualDirection = Direction.Right;
             else if (lastPosition > newPosition)
-                MovableCatcher.VisualDirection = Direction.Left;
+                Catcher.VisualDirection = Direction.Left;
         }
 
         public bool OnPressed(CatchAction action)
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     return true;
 
                 case CatchAction.Dash:
-                    MovableCatcher.Dashing = true;
+                    Catcher.Dashing = true;
                     return true;
             }
 
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     break;
 
                 case CatchAction.Dash:
-                    MovableCatcher.Dashing = false;
+                    Catcher.Dashing = false;
                     break;
             }
         }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
@@ -20,8 +19,21 @@ namespace osu.Game.Rulesets.Catch.UI
     {
         public const float CATCHER_SIZE = 106.75f;
 
-        public readonly Catcher MovableCatcher;
+        public Catcher MovableCatcher
+        {
+            get => catcher;
+            set
+            {
+                if (catcher != null)
+                    Remove(catcher);
+
+                Add(catcher = value);
+            }
+        }
+
         private readonly CatchComboDisplay comboDisplay;
+
+        private Catcher catcher;
 
         /// <summary>
         /// <c>-1</c> when only left button is pressed.
@@ -30,21 +42,17 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private int currentDirection;
 
-        public CatcherArea(BeatmapDifficulty difficulty = null)
+        public CatcherArea()
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
-            Children = new Drawable[]
+            Child = comboDisplay = new CatchComboDisplay
             {
-                comboDisplay = new CatchComboDisplay
-                {
-                    RelativeSizeAxes = Axes.None,
-                    AutoSizeAxes = Axes.Both,
-                    Anchor = Anchor.TopLeft,
-                    Origin = Anchor.Centre,
-                    Margin = new MarginPadding { Bottom = 350f },
-                    X = CatchPlayfield.CENTER_X
-                },
-                MovableCatcher = new Catcher(this, difficulty) { X = CatchPlayfield.CENTER_X },
+                RelativeSizeAxes = Axes.None,
+                AutoSizeAxes = Axes.Both,
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.Centre,
+                Margin = new MarginPadding { Bottom = 350f },
+                X = CatchPlayfield.CENTER_X
             };
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrail.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrail.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatcherTrail()
         {
-            Size = new Vector2(CatcherArea.CATCHER_SIZE);
+            Size = new Vector2(Catcher.BASE_SIZE);
             Origin = Anchor.TopCentre;
             Blending = BlendingParameters.Additive;
             InternalChild = body = new SkinnableCatcher

--- a/osu.Game.Rulesets.Catch/UI/SkinnableCatcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/SkinnableCatcher.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             Anchor = Anchor.TopCentre;
             // Sets the origin roughly to the centre of the catcher's plate to allow for correct scaling.
-            OriginPosition = new Vector2(0.5f, 0.06f) * CatcherArea.CATCHER_SIZE;
+            OriginPosition = new Vector2(0.5f, 0.06f) * Catcher.BASE_SIZE;
         }
     }
 }

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -19,8 +19,8 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignedValueIsNeverUsed/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignmentIsFullyDiscarded/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignNullToNotNullAttribute/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002EGlobal/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002ELocal/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002EGlobal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BadAttributeBracketsSpaces/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BadBracesSpaces/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BadChildStatementIndent/@EntryIndexedValue">WARNING</s:String>


### PR DESCRIPTION
In my view, the `CatcherArea` type is only a "container" type, and should only weakly coupled to the contents (the catcher).
The extra constructor chain was always a bit cumbersome when writing testing for example.

`DroppedObjectContainer` is passed via constructor instead of DI. This effectively reverts my PR #13648.
It is now just one level deep, so it is not beneficial to use DI here anymore.