### PR TITLE
Ensure online play subscreen is loaded before forwarding `OnExiting`

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -105,6 +105,36 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestExitMidJoin()
+        {
+            Room room = null;
+
+            AddStep("create room", () =>
+            {
+                room = new Room
+                {
+                    Name = { Value = "Test Room" },
+                    Playlist =
+                    {
+                        new PlaylistItem
+                        {
+                            Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.RulesetID == 0)).BeatmapInfo },
+                            Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                        }
+                    }
+                };
+            });
+
+            AddStep("refresh rooms", () => multiplayerScreen.RoomManager.Filter.Value = new FilterCriteria());
+            AddStep("select room", () => InputManager.Key(Key.Down));
+            AddStep("join room and immediately exit", () =>
+            {
+                multiplayerScreen.ChildrenOfType<LoungeSubScreen>().Single().Open(room);
+                Schedule(() => Stack.CurrentScreen.Exit());
+            });
+        }
+
+        [Test]
         public void TestJoinRoomWithoutPassword()
         {
             AddStep("create room", () =>
@@ -179,9 +209,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("password prompt appeared", () => (passwordEntryPopover = InputManager.ChildrenOfType<DrawableRoom.PasswordEntryPopover>().FirstOrDefault()) != null);
             AddStep("enter password in text box", () => passwordEntryPopover.ChildrenOfType<TextBox>().First().Text = "password");
             AddStep("press join room button", () => passwordEntryPopover.ChildrenOfType<OsuButton>().First().Click());
-
-            AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => client.Room != null);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -209,6 +209,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("password prompt appeared", () => (passwordEntryPopover = InputManager.ChildrenOfType<DrawableRoom.PasswordEntryPopover>().FirstOrDefault()) != null);
             AddStep("enter password in text box", () => passwordEntryPopover.ChildrenOfType<TextBox>().First().Text = "password");
             AddStep("press join room button", () => passwordEntryPopover.ChildrenOfType<OsuButton>().First().Click());
+
+            AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
+            AddUntilStep("wait for join", () => client.Room != null);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -222,7 +223,9 @@ namespace osu.Game.Screens.OnlinePlay
             this.FadeIn(250);
             this.ScaleTo(1, 250, Easing.OutSine);
 
-            screenStack.CurrentScreen?.OnResuming(last);
+            Debug.Assert(screenStack.CurrentScreen != null);
+            screenStack.CurrentScreen.OnResuming(last);
+
             base.OnResuming(last);
 
             UpdatePollingRate(isIdle.Value);
@@ -233,14 +236,16 @@ namespace osu.Game.Screens.OnlinePlay
             this.ScaleTo(1.1f, 250, Easing.InSine);
             this.FadeOut(250);
 
-            screenStack.CurrentScreen?.OnSuspending(next);
+            Debug.Assert(screenStack.CurrentScreen != null);
+            screenStack.CurrentScreen.OnSuspending(next);
 
             UpdatePollingRate(isIdle.Value);
         }
 
         public override bool OnExiting(IScreen next)
         {
-            if (screenStack.CurrentScreen?.OnExiting(next) == true)
+            var subScreen = screenStack.CurrentScreen as Drawable;
+            if (subScreen?.IsLoaded == true && screenStack.CurrentScreen.OnExiting(next))
                 return true;
 
             RoomManager.PartRoom();


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/4619.

Turns out this is actually not a framework issue; the framework correctly guards against this scenario, see https://github.com/ppy/osu-framework/blob/4e29504384bb78bbccc0d492de58124f17270eb2/osu.Framework/Screens/ScreenStack.cs#L277.

Added the assertions to be very explicit about the nested stack's state at this point. Both of those events can only be triggered if the stack has a loaded screen (as far as I can tell), making this check unnecessary in those cases.
