### PR TITLE
Add the ability to enter and exit the skin editor via on-screen buttons

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -757,7 +757,7 @@ namespace osu.Game
             loadComponentSingleFile(userProfile = new UserProfileOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(beatmapSetOverlay = new BeatmapSetOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(skinEditor = new SkinEditorOverlay(screenContainer), overlayContent.Add);
+            loadComponentSingleFile(skinEditor = new SkinEditorOverlay(screenContainer), overlayContent.Add, true);
 
             loadComponentSingleFile(new LoginOverlay
             {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -13,6 +13,7 @@ using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Skinning;
+using osu.Game.Skinning.Editor;
 using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections
@@ -57,14 +58,19 @@ namespace osu.Game.Overlays.Settings.Sections
         private IBindable<WeakReference<SkinInfo>> managerUpdated;
         private IBindable<WeakReference<SkinInfo>> managerRemoved;
 
-        [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load(OsuConfigManager config, SkinEditorOverlay skinEditor)
         {
             FlowContent.Spacing = new Vector2(0, 5);
 
             Children = new Drawable[]
             {
                 skinDropdown = new SkinSettingsDropdown(),
+                new SettingsButton
+                {
+                    Text = "Skin layout editor",
+                    Action = () => skinEditor?.Toggle(),
+                },
                 new ExportSkinButton(),
                 new SettingsSlider<float, SizeSlider>
                 {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -59,7 +60,7 @@ namespace osu.Game.Overlays.Settings.Sections
         private IBindable<WeakReference<SkinInfo>> managerRemoved;
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(OsuConfigManager config, SkinEditorOverlay skinEditor)
+        private void load(OsuConfigManager config, [CanBeNull] SkinEditorOverlay skinEditor)
         {
             FlowContent.Spacing = new Vector2(0, 5);
 

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Skinning.Editor
@@ -91,7 +92,7 @@ namespace osu.Game.Skinning.Editor
                                         new TriangleButton
                                         {
                                             Margin = new MarginPadding(10),
-                                            Text = "Close",
+                                            Text = CommonStrings.ButtonsClose,
                                             Width = 100,
                                             Action = Hide,
                                         },

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -56,6 +56,13 @@ namespace osu.Game.Skinning.Editor
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
+                    new TriangleButton
+                    {
+                        Margin = new MarginPadding(10),
+                        Text = "Close",
+                        Width = 100,
+                        Action = Hide,
+                    },
                     headerText = new OsuTextFlowContainer
                     {
                         TextAnchor = Anchor.TopCentre,

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -56,13 +56,6 @@ namespace osu.Game.Skinning.Editor
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new TriangleButton
-                    {
-                        Margin = new MarginPadding(10),
-                        Text = "Close",
-                        Width = 100,
-                        Action = Hide,
-                    },
                     headerText = new OsuTextFlowContainer
                     {
                         TextAnchor = Anchor.TopCentre,
@@ -95,6 +88,13 @@ namespace osu.Game.Skinning.Editor
                                     Children = new Drawable[]
                                     {
                                         new SkinBlueprintContainer(targetScreen),
+                                        new TriangleButton
+                                        {
+                                            Margin = new MarginPadding(10),
+                                            Text = "Close",
+                                            Width = 100,
+                                            Action = Hide,
+                                        },
                                         new FillFlowContainer
                                         {
                                             Direction = FillDirection.Horizontal,

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -59,14 +59,13 @@ namespace osu.Game.Skinning.Editor
 
         public override void Hide()
         {
-            base.Hide();
+            // base call intentionally omitted.
             skinEditor.Hide();
         }
 
         public override void Show()
         {
-            base.Show();
-
+            // base call intentionally omitted.
             if (skinEditor == null)
             {
                 LoadComponentAsync(skinEditor = new SkinEditor(target), AddInternal);

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -37,8 +37,10 @@ namespace osu.Game.Skinning.Editor
             switch (action)
             {
                 case GlobalAction.Back:
-                    if (skinEditor?.State.Value == Visibility.Visible)
-                        Hide();
+                    if (skinEditor?.State.Value != Visibility.Visible)
+                        break;
+
+                    Hide();
                     return true;
 
                 case GlobalAction.ToggleSkinEditor:

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -38,26 +38,42 @@ namespace osu.Game.Skinning.Editor
             {
                 case GlobalAction.Back:
                     if (skinEditor?.State.Value == Visibility.Visible)
-                    {
-                        skinEditor.ToggleVisibility();
-                        return true;
-                    }
-
-                    break;
+                        Hide();
+                    return true;
 
                 case GlobalAction.ToggleSkinEditor:
-                    if (skinEditor == null)
-                    {
-                        LoadComponentAsync(skinEditor = new SkinEditor(target), AddInternal);
-                        skinEditor.State.BindValueChanged(editorVisibilityChanged);
-                    }
-                    else
-                        skinEditor.ToggleVisibility();
-
+                    Toggle();
                     return true;
             }
 
             return false;
+        }
+
+        public void Toggle()
+        {
+            if (skinEditor == null)
+                Show();
+            else
+                skinEditor.ToggleVisibility();
+        }
+
+        public override void Hide()
+        {
+            base.Hide();
+            skinEditor.Hide();
+        }
+
+        public override void Show()
+        {
+            base.Show();
+
+            if (skinEditor == null)
+            {
+                LoadComponentAsync(skinEditor = new SkinEditor(target), AddInternal);
+                skinEditor.State.BindValueChanged(editorVisibilityChanged);
+            }
+            else
+                skinEditor.Show();
         }
 
         private void editorVisibilityChanged(ValueChangedEvent<Visibility> visibility)


### PR DESCRIPTION
In response to https://github.com/ppy/osu/discussions/13936.

---

Eventually the skin editor should use the same menu system as the editor, replacing these janky buttons. But I think this is okay until that happens.


https://user-images.githubusercontent.com/191335/126311139-1a9faff5-9011-49d7-be18-d56b72f8f43c.mp4



