### PR TITLE
Make "Blinds" and "Barrel Roll" mods incompatible

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -10,6 +11,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModBarrelRoll : ModBarrelRoll<OsuHitObject>, IApplicableToDrawableHitObject
     {
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModBlinds) };
+
         public void ApplyToDrawableHitObject(DrawableHitObject d)
         {
             d.OnUpdate += _ =>

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => FontAwesome.Solid.Adjust;
         public override ModType Type => ModType.DifficultyIncrease;
 
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModBarrelRoll) };
+
         public override double ScoreMultiplier => 1.12;
         private DrawableOsuBlinds blinds;
 


### PR DESCRIPTION
If it is deemed that we want to make blinds decoupled from the playfield instead, I'm willing to look into that. Just not sure what the best path forward here is. I started making this PR thinking "there's no way the blinds are going to display well when rotating with the playfield", but on closer inspection they are screen aligned, so that line of thinking is potentially incorrect.

One could also argue that other mods in the future will break in combination in the future and a local fix in `OsuModBlinds` is a better path forward.

If we go with this hard disable, will require an osu-web change in line with this.

Closes https://github.com/ppy/osu/issues/13477.

