### PR TITLE
Make timeline blueprints outside of TimelineBlueprint boundaries interactable

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -110,9 +110,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             bool selectionPerformed = performMouseDownActions(e);
 
             // even if a selection didn't occur, a drag event may still move the selection.
-            prepareSelectionMovement();
+            bool movementPossible = prepareSelectionMovement();
 
-            return selectionPerformed || e.Button == MouseButton.Left;
+            return selectionPerformed || movementPossible;
         }
 
         protected SelectionBlueprint<T> ClickedBlueprint { get; private set; }
@@ -427,19 +427,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Attempts to begin the movement of any selected blueprints.
         /// </summary>
-        private void prepareSelectionMovement()
+        /// <returns>Whether a movement is possible.</returns>
+        private bool prepareSelectionMovement()
         {
             if (!SelectionHandler.SelectedBlueprints.Any())
-                return;
+                return false;
 
             // Any selected blueprint that is hovered can begin the movement of the group, however only the first item (according to SortForMovement) is used for movement.
             // A special case is added for when a click selection occurred before the drag
             if (!clickSelectionBegan && !SelectionHandler.SelectedBlueprints.Any(b => b.IsHovered))
-                return;
+                return false;
 
             // Movement is tracked from the blueprint of the earliest item, since it only makes sense to distance snap from that item
             movementBlueprints = SortForMovement(SelectionHandler.SelectedBlueprints).ToArray();
             movementBlueprintOriginalPositions = movementBlueprints.Select(m => m.ScreenSpaceSelectionPoint).ToArray();
+            return true;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // even if a selection didn't occur, a drag event may still move the selection.
             bool movementPossible = prepareSelectionMovement();
 
-            return selectionPerformed || movementPossible;
+            return selectionPerformed || (e.Button == MouseButton.Left && movementPossible);
         }
 
         protected SelectionBlueprint<T> ClickedBlueprint { get; private set; }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -35,8 +35,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Bindable<HitObject> placement;
         private SelectionBlueprint<HitObject> placementBlueprint;
 
-        private SelectableAreaBackground backgroundBox;
-
         // We want children to be able to be clicked and dragged, regardless of this drawable's size
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
@@ -53,7 +51,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(backgroundBox = new SelectableAreaBackground
+            AddInternal(new SelectableAreaBackground
             {
                 Colour = Color4.Black,
                 Depth = float.MaxValue,
@@ -91,15 +89,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         }
 
         protected override Container<SelectionBlueprint<HitObject>> CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
-
-        protected override bool OnDragStart(DragStartEvent e)
-        {
-            // We should only allow BlueprintContainer to create a drag box if the mouse is within selection bounds
-            if (backgroundBox.ReceivePositionalInputAt(e.ScreenSpaceMouseDownPosition))
-                return base.OnDragStart(e);
-
-            return false;
-        }
 
         protected override void OnDrag(DragEvent e)
         {
@@ -319,6 +308,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             public override bool HandleDrag(MouseButtonEvent e)
             {
+                // The dragbox should only be active if the mouseDownPosition.Y is within this drawable's bounds.
+                if (DrawRectangle.Top > e.MouseDownPosition.Y || DrawRectangle.Bottom < e.MouseDownPosition.Y)
+                    return false;
+
                 selectionStart ??= e.MouseDownPosition.X / timeline.CurrentZoom;
 
                 // only calculate end when a transition is not in progress to avoid bouncing.

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -238,6 +238,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         internal class TimelineSelectionHandler : EditorSelectionHandler, IKeyBindingHandler<GlobalAction>
         {
+            [Resolved]
+            private Timeline timeline { get; set; }
+
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => timeline.ScreenSpaceDrawQuad.Contains(screenSpacePos);
+
             // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
             public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Bindable<HitObject> placement;
         private SelectionBlueprint<HitObject> placementBlueprint;
 
-        // We want children to be able to be clicked and dragged, regardless of this drawable's size
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+        // We want children within the timeline to be interactable
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => timeline.ScreenSpaceDrawQuad.Contains(screenSpacePos);
 
         public TimelineBlueprintContainer(HitObjectComposer composer)
             : base(composer)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -309,7 +309,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             public override bool HandleDrag(MouseButtonEvent e)
             {
                 // The dragbox should only be active if the mouseDownPosition.Y is within this drawable's bounds.
-                if (DrawRectangle.Top > e.MouseDownPosition.Y || DrawRectangle.Bottom < e.MouseDownPosition.Y)
+                float localY = ToLocalSpace(e.ScreenSpaceMouseDownPosition).Y;
+                if (DrawRectangle.Top > localY || DrawRectangle.Bottom < localY)
                     return false;
 
                 selectionStart ??= e.MouseDownPosition.X / timeline.CurrentZoom;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -97,6 +97,19 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         protected override Container<SelectionBlueprint<HitObject>> CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
 
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            int selectionCount = SelectedItems.Count;
+
+            // We let BlueprintContainer attempt a HitObject selection
+            // If it fails, we'll pass it this input back to the timeline so it can be dragged
+            // We know it failed if the selection count is unchanged after the selection attempt
+            if (base.OnMouseDown(e) && selectionCount != SelectedItems.Count)
+                return true;
+
+            return false;
+        }
+
         protected override bool OnDragStart(DragStartEvent e)
         {
             if (!shouldHandleInputAt(e.ScreenSpaceMouseDownPosition))

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -13,11 +13,9 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
-using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
@@ -233,125 +231,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 this.FadeColour(Color4.Black, 600, Easing.OutQuint);
                 base.OnHoverLost(e);
-            }
-        }
-
-        internal class TimelineSelectionHandler : EditorSelectionHandler, IKeyBindingHandler<GlobalAction>
-        {
-            [Resolved]
-            private Timeline timeline { get; set; }
-
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => timeline.ScreenSpaceDrawQuad.Contains(screenSpacePos);
-
-            // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
-            public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;
-
-            public bool OnPressed(GlobalAction action)
-            {
-                switch (action)
-                {
-                    case GlobalAction.EditorNudgeLeft:
-                        nudgeSelection(-1);
-                        return true;
-
-                    case GlobalAction.EditorNudgeRight:
-                        nudgeSelection(1);
-                        return true;
-                }
-
-                return false;
-            }
-
-            public void OnReleased(GlobalAction action)
-            {
-            }
-
-            /// <summary>
-            /// Nudge the current selection by the specified multiple of beat divisor lengths,
-            /// based on the timing at the first object in the selection.
-            /// </summary>
-            /// <param name="amount">The direction and count of beat divisor lengths to adjust.</param>
-            private void nudgeSelection(int amount)
-            {
-                var selected = EditorBeatmap.SelectedHitObjects;
-
-                if (selected.Count == 0)
-                    return;
-
-                var timingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(selected.First().StartTime);
-                double adjustment = timingPoint.BeatLength / EditorBeatmap.BeatDivisor * amount;
-
-                EditorBeatmap.PerformOnSelection(h =>
-                {
-                    h.StartTime += adjustment;
-                    EditorBeatmap.Update(h);
-                });
-            }
-        }
-
-        private class TimelineDragBox : DragBox
-        {
-            // the following values hold the start and end X positions of the drag box in the timeline's local space,
-            // but with zoom unapplied in order to be able to compensate for positional changes
-            // while the timeline is being zoomed in/out.
-            private float? selectionStart;
-            private float selectionEnd;
-
-            [Resolved]
-            private Timeline timeline { get; set; }
-
-            public TimelineDragBox(Action<RectangleF> performSelect)
-                : base(performSelect)
-            {
-            }
-
-            protected override Drawable CreateBox() => new Box
-            {
-                RelativeSizeAxes = Axes.Y,
-                Alpha = 0.3f
-            };
-
-            public override bool HandleDrag(MouseButtonEvent e)
-            {
-                // The dragbox should only be active if the mouseDownPosition.Y is within this drawable's bounds.
-                float localY = ToLocalSpace(e.ScreenSpaceMouseDownPosition).Y;
-                if (DrawRectangle.Top > localY || DrawRectangle.Bottom < localY)
-                    return false;
-
-                selectionStart ??= e.MouseDownPosition.X / timeline.CurrentZoom;
-
-                // only calculate end when a transition is not in progress to avoid bouncing.
-                if (Precision.AlmostEquals(timeline.CurrentZoom, timeline.Zoom))
-                    selectionEnd = e.MousePosition.X / timeline.CurrentZoom;
-
-                updateDragBoxPosition();
-                return true;
-            }
-
-            private void updateDragBoxPosition()
-            {
-                if (selectionStart == null)
-                    return;
-
-                float rescaledStart = selectionStart.Value * timeline.CurrentZoom;
-                float rescaledEnd = selectionEnd * timeline.CurrentZoom;
-
-                Box.X = Math.Min(rescaledStart, rescaledEnd);
-                Box.Width = Math.Abs(rescaledStart - rescaledEnd);
-
-                var boxScreenRect = Box.ScreenSpaceDrawQuad.AABBFloat;
-
-                // we don't care about where the hitobjects are vertically. in cases like stacking display, they may be outside the box without this adjustment.
-                boxScreenRect.Y -= boxScreenRect.Height;
-                boxScreenRect.Height *= 2;
-
-                PerformSelection?.Invoke(boxScreenRect);
-            }
-
-            public override void Hide()
-            {
-                base.Hide();
-                selectionStart = null;
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -190,6 +190,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private class SelectableAreaBackground : CompositeDrawable
         {
+            [Resolved]
+            private OsuColour colours { get; set; }
+
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
             {
                 float localY = ToLocalSpace(screenSpacePos).Y;
@@ -219,9 +222,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     }
                 });
             }
-
-            [Resolved]
-            private OsuColour colours { get; set; }
 
             protected override bool OnHover(HoverEvent e)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineDragBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineDragBox.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+
+namespace osu.Game.Screens.Edit.Compose.Components.Timeline
+{
+    public class TimelineDragBox : DragBox
+    {
+        // the following values hold the start and end X positions of the drag box in the timeline's local space,
+        // but with zoom unapplied in order to be able to compensate for positional changes
+        // while the timeline is being zoomed in/out.
+        private float? selectionStart;
+        private float selectionEnd;
+
+        [Resolved]
+        private Timeline timeline { get; set; }
+
+        public TimelineDragBox(Action<RectangleF> performSelect)
+            : base(performSelect)
+        {
+        }
+
+        protected override Drawable CreateBox() => new Box
+        {
+            RelativeSizeAxes = Axes.Y,
+            Alpha = 0.3f
+        };
+
+        public override bool HandleDrag(MouseButtonEvent e)
+        {
+            // The dragbox should only be active if the mouseDownPosition.Y is within this drawable's bounds.
+            float localY = ToLocalSpace(e.ScreenSpaceMouseDownPosition).Y;
+            if (DrawRectangle.Top > localY || DrawRectangle.Bottom < localY)
+                return false;
+
+            selectionStart ??= e.MouseDownPosition.X / timeline.CurrentZoom;
+
+            // only calculate end when a transition is not in progress to avoid bouncing.
+            if (Precision.AlmostEquals(timeline.CurrentZoom, timeline.Zoom))
+                selectionEnd = e.MousePosition.X / timeline.CurrentZoom;
+
+            updateDragBoxPosition();
+            return true;
+        }
+
+        private void updateDragBoxPosition()
+        {
+            if (selectionStart == null)
+                return;
+
+            float rescaledStart = selectionStart.Value * timeline.CurrentZoom;
+            float rescaledEnd = selectionEnd * timeline.CurrentZoom;
+
+            Box.X = Math.Min(rescaledStart, rescaledEnd);
+            Box.Width = Math.Abs(rescaledStart - rescaledEnd);
+
+            var boxScreenRect = Box.ScreenSpaceDrawQuad.AABBFloat;
+
+            // we don't care about where the hitobjects are vertically. in cases like stacking display, they may be outside the box without this adjustment.
+            boxScreenRect.Y -= boxScreenRect.Height;
+            boxScreenRect.Height *= 2;
+
+            PerformSelection?.Invoke(boxScreenRect);
+        }
+
+        public override void Hide()
+        {
+            base.Hide();
+            selectionStart = null;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Input.Bindings;
+using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.Objects;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Compose.Components.Timeline
+{
+    internal class TimelineSelectionHandler : EditorSelectionHandler, IKeyBindingHandler<GlobalAction>
+    {
+        [Resolved]
+        private Timeline timeline { get; set; }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => timeline.ScreenSpaceDrawQuad.Contains(screenSpacePos);
+
+        // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
+        public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;
+
+        public bool OnPressed(GlobalAction action)
+        {
+            switch (action)
+            {
+                case GlobalAction.EditorNudgeLeft:
+                    nudgeSelection(-1);
+                    return true;
+
+                case GlobalAction.EditorNudgeRight:
+                    nudgeSelection(1);
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(GlobalAction action)
+        {
+        }
+
+        /// <summary>
+        /// Nudge the current selection by the specified multiple of beat divisor lengths,
+        /// based on the timing at the first object in the selection.
+        /// </summary>
+        /// <param name="amount">The direction and count of beat divisor lengths to adjust.</param>
+        private void nudgeSelection(int amount)
+        {
+            var selected = EditorBeatmap.SelectedHitObjects;
+
+            if (selected.Count == 0)
+                return;
+
+            var timingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(selected.First().StartTime);
+            double adjustment = timingPoint.BeatLength / EditorBeatmap.BeatDivisor * amount;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                h.StartTime += adjustment;
+                EditorBeatmap.Update(h);
+            });
+        }
+    }
+}


### PR DESCRIPTION
When the timeline blueprints stacked high enough, it is not possible for the user to be able to interact with the blueprints that stick out beyond the container. 

This PR makes it so that users can select blueprints that exceed container bounds, while retaining existing functionality.


https://user-images.githubusercontent.com/12001167/126356119-d3356a51-9ba7-4a7f-a2a2-00c8296b0ec0.mp4


https://user-images.githubusercontent.com/12001167/126356128-0c7fd570-b0b9-493e-942b-09105160e359.mp4




