### PR TITLE
Adjust user beatmap section naming on profile overlay to match web

### DIFF
--- a/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
@@ -26,9 +26,9 @@ namespace osu.Game.Online.API.Requests
     public enum BeatmapSetType
     {
         Favourite,
-        RankedAndApproved,
+        Ranked,
         Loved,
-        Unranked,
+        Pending,
         Graveyard
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -46,11 +46,11 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
                 case BeatmapSetType.Loved:
                     return user.LovedBeatmapsetCount;
 
-                case BeatmapSetType.RankedAndApproved:
-                    return user.RankedAndApprovedBeatmapsetCount;
+                case BeatmapSetType.Ranked:
+                    return user.RankedBeatmapsetCount;
 
-                case BeatmapSetType.Unranked:
-                    return user.UnrankedBeatmapsetCount;
+                case BeatmapSetType.Pending:
+                    return user.PendingBeatmapsetCount;
 
                 default:
                     return 0;

--- a/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
@@ -19,9 +19,9 @@ namespace osu.Game.Overlays.Profile.Sections
             Children = new[]
             {
                 new PaginatedBeatmapContainer(BeatmapSetType.Favourite, User, UsersStrings.ShowExtraBeatmapsFavouriteTitle),
-                new PaginatedBeatmapContainer(BeatmapSetType.RankedAndApproved, User, UsersStrings.ShowExtraBeatmapsRankedTitle),
+                new PaginatedBeatmapContainer(BeatmapSetType.Ranked, User, UsersStrings.ShowExtraBeatmapsRankedTitle),
                 new PaginatedBeatmapContainer(BeatmapSetType.Loved, User, UsersStrings.ShowExtraBeatmapsLovedTitle),
-                new PaginatedBeatmapContainer(BeatmapSetType.Unranked, User, UsersStrings.ShowExtraBeatmapsPendingTitle),
+                new PaginatedBeatmapContainer(BeatmapSetType.Pending, User, UsersStrings.ShowExtraBeatmapsPendingTitle),
                 new PaginatedBeatmapContainer(BeatmapSetType.Graveyard, User, UsersStrings.ShowExtraBeatmapsGraveyardTitle)
             };
         }

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -138,11 +138,11 @@ namespace osu.Game.Users
         [JsonProperty(@"loved_beatmapset_count")]
         public int LovedBeatmapsetCount;
 
-        [JsonProperty(@"ranked_and_approved_beatmapset_count")]
-        public int RankedAndApprovedBeatmapsetCount;
+        [JsonProperty(@"ranked_beatmapset_count")]
+        public int RankedBeatmapsetCount;
 
-        [JsonProperty(@"unranked_beatmapset_count")]
-        public int UnrankedBeatmapsetCount;
+        [JsonProperty(@"pending_beatmapset_count")]
+        public int PendingBeatmapsetCount;
 
         [JsonProperty(@"scores_best_count")]
         public int ScoresBestCount;


### PR DESCRIPTION
Follow-up item from #13921.

This pull renames some enum members and API request parameter values to adjust to breaking changes introduced in https://github.com/ppy/osu-web/pull/7711.

Reference: [the "breaking changes" API docs section](https://osu.ppy.sh/docs/index.html#breaking-changes) (entry listed under 2021-06-09).