### PR TITLE
Allow running with different game IDs for debug builds of osu!lazer

### DIFF
--- a/.run/Dual client test.run.xml
+++ b/.run/Dual client test.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Dual client test" type="CompoundRunConfigurationType">
+    <toRun name="osu!" type="DotNetProject" />
+    <toRun name="osu! (Second Client)" type="DotNetProject" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/osu! (Second Client).run.xml
+++ b/.run/osu! (Second Client).run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="osu! (Second Client)" type="DotNetProject" factoryName=".NET Project" folderName="osu!" activateToolWindowBeforeRun="false">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/osu.Desktop/bin/Debug/net5.0/osu!.dll" />
+    <option name="PROGRAM_PARAMETERS" value="--debug-client-id=1" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/osu.Desktop/bin/Debug/net5.0" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/osu.Desktop/osu.Desktop.csproj" />
+    <option name="PROJECT_EXE_PATH_TRACKING" value="1" />
+    <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
+    <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
+    <option name="PROJECT_KIND" value="DotNetCore" />
+    <option name="PROJECT_TFM" value="net5.0" />
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -17,18 +17,25 @@ namespace osu.Desktop
 {
     public static class Program
     {
+        private const string base_game_name = @"osu";
+
         [STAThread]
         public static int Main(string[] args)
         {
             // Back up the cwd before DesktopGameHost changes it
             var cwd = Environment.CurrentDirectory;
 
-            string gameName = @"osu";
+            string gameName = base_game_name;
             bool tournamentClient = false;
 
-            foreach (var arg in args.Select(s => s.Split('=')))
+            foreach (var arg in args)
             {
-                switch (arg[0])
+                var split = arg.Split('=');
+
+                var key = split[0];
+                var val = split[1];
+
+                switch (key)
                 {
                     case "--tournament":
                         tournamentClient = true;
@@ -36,9 +43,12 @@ namespace osu.Desktop
 
                     case "--debug-client-id":
                         if (!DebugUtils.IsDebugBuild)
-                            break;
+                            throw new InvalidOperationException("Cannot use this argument in a non-debug build.");
 
-                        gameName = $"{gameName}-{int.Parse(arg[1])}";
+                        if (!int.TryParse(val, out int clientID))
+                            throw new ArgumentException("Provided client ID must be an integer.");
+
+                        gameName = $"{base_game_name}-{clientID}";
                         break;
                 }
             }

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -24,12 +24,23 @@ namespace osu.Desktop
             var cwd = Environment.CurrentDirectory;
 
             string gameName = @"osu";
+            bool tournamentClient = false;
 
-            if (DebugUtils.IsDebugBuild)
+            foreach (var arg in args.Select(s => s.Split('=')))
             {
-                var customNameArg = args.SingleOrDefault(s => s.StartsWith(@"--name=", StringComparison.Ordinal));
-                if (customNameArg != null)
-                    gameName = customNameArg.Replace(@"--name=", string.Empty);
+                switch (arg[0])
+                {
+                    case "--tournament":
+                        tournamentClient = true;
+                        break;
+
+                    case "--debug-client-id":
+                        if (!DebugUtils.IsDebugBuild)
+                            break;
+
+                        gameName = $"{gameName}-{int.Parse(arg[1])}";
+                        break;
+                }
             }
 
             using (DesktopGameHost host = Host.GetSuitableHost(gameName, true))
@@ -57,7 +68,7 @@ namespace osu.Desktop
                         return 0;
                 }
 
-                if (args.Contains("--tournament"))
+                if (tournamentClient)
                     host.Run(new TournamentGame());
                 else
                     host.Run(new OsuGameDesktop(args));

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework;

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -23,7 +23,16 @@ namespace osu.Desktop
             // Back up the cwd before DesktopGameHost changes it
             var cwd = Environment.CurrentDirectory;
 
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            string gameName = @"osu";
+
+            if (DebugUtils.IsDebugBuild)
+            {
+                var customNameArg = args.SingleOrDefault(s => s.StartsWith(@"--name=", StringComparison.Ordinal));
+                if (customNameArg != null)
+                    gameName = customNameArg.Replace(@"--name=", string.Empty);
+            }
+
+            using (DesktopGameHost host = Host.GetSuitableHost(gameName, true))
             {
                 host.ExceptionThrown += handleException;
 
@@ -48,16 +57,10 @@ namespace osu.Desktop
                         return 0;
                 }
 
-                switch (args.FirstOrDefault() ?? string.Empty)
-                {
-                    default:
-                        host.Run(new OsuGameDesktop(args));
-                        break;
-
-                    case "--tournament":
-                        host.Run(new TournamentGame());
-                        break;
-                }
+                if (args.Contains("--tournament"))
+                    host.Run(new TournamentGame());
+                else
+                    host.Run(new OsuGameDesktop(args));
 
                 return 0;
             }


### PR DESCRIPTION
Making things easy to test development server with multiple game instances running simultaneously, without having to log out and in between accounts in each instance, or manually modifying the game name and potentially causing a `BadImageFormatException` in the already running instance.

Of course, this argument should never be accessible by normal users so I've limited access to `DebugUtils.IsDebugBuild` only.