### PR TITLE
Move and merge Overlays.KeyBinding into Overlays.Settings.Sections.Input

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -8,7 +8,7 @@ using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
-using osu.Game.Overlays.KeyBinding;
+using osu.Game.Overlays.Settings.Sections.Input;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Settings

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
@@ -7,7 +7,7 @@ using osu.Framework.Localisation;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays.Settings;
 
-namespace osu.Game.Overlays.KeyBinding
+namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class GlobalKeyBindingsSection : SettingsSection
     {

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
@@ -5,7 +5,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Input.Bindings;
-using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
@@ -4,8 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Input.Bindings;
-using osu.Game.Overlays.Settings;
-using osu.Game.Overlays.Settings.Sections.Input;
 using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.Settings.Sections.Input

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
@@ -4,11 +4,11 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Input.Bindings;
-using osu.Game.Overlays.KeyBinding;
 using osu.Game.Overlays.Settings;
+using osu.Game.Overlays.Settings.Sections.Input;
 using osu.Game.Rulesets;
 
-namespace osu.Game.Overlays
+namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class KeyBindingPanel : SettingsSubPanel
     {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -24,7 +24,7 @@ using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
 
-namespace osu.Game.Overlays.KeyBinding
+namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class KeyBindingRow : Container, IFilterable
     {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -13,7 +13,7 @@ using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 using osuTK;
 
-namespace osu.Game.Overlays.KeyBinding
+namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public abstract class KeyBindingsSubsection : SettingsSubsection
     {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 using osuTK;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.Settings.Sections.Input

--- a/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
@@ -7,7 +7,7 @@ using osu.Game.Graphics;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 
-namespace osu.Game.Overlays.KeyBinding
+namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class RulesetBindingsSection : SettingsSection
     {

--- a/osu.Game/Overlays/Settings/Sections/Input/VariantBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/VariantBindingsSubsection.cs
@@ -4,7 +4,7 @@
 using osu.Framework.Localisation;
 using osu.Game.Rulesets;
 
-namespace osu.Game.Overlays.KeyBinding
+namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class VariantBindingsSubsection : KeyBindingsSubsection
     {

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Settings.Sections;
+using osu.Game.Overlays.Settings.Sections.Input;
 using osuTK.Graphics;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
My first PR in codebase to address issue #12961. 

When looking into code structure I thought it is more reasonable in my opinion to move `osu.Game.Overlays.KeyBinding` and merge with `osu.Game.Overlays.Settings.Sections.Input`. Even though in UI keybindings setup appear as a separate panel to settings, it seems more natural to place code in `osu.Game.Overlays.Settings.Sections.Input`. Let me know if this is unreasonable and I should keep KeyBinding as a separate namespace.

I started to play a few months ago and really love osu! and when I found out there is a new open source version I decided it would be great to make a little contribution in my free time :)

