### PR TITLE
Allow specifying different value of scaling and flipping support for a selection box

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Rulesets.Osu.Edit
             Quad quad = selectedMovableObjects.Length > 0 ? getSurroundingQuad(selectedMovableObjects) : new Quad();
 
             SelectionBox.CanRotate = quad.Width > 0 || quad.Height > 0;
-            SelectionBox.CanScaleX = quad.Width > 0;
-            SelectionBox.CanScaleY = quad.Height > 0;
+            SelectionBox.CanFlipX = SelectionBox.CanScaleX = quad.Width > 0;
+            SelectionBox.CanFlipY = SelectionBox.CanScaleY = quad.Height > 0;
             SelectionBox.CanReverse = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
         }
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Tests.Visual.Editing
                         CanRotate = true,
                         CanScaleX = true,
                         CanScaleY = true,
+                        CanFlipX = true,
+                        CanFlipY = true,
 
                         OnRotation = handleRotation,
                         OnScale = handleScale

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool canScaleX;
 
         /// <summary>
-        /// Whether vertical scale support should be enabled.
+        /// Whether horizontal scaling support should be enabled.
         /// </summary>
         public bool CanScaleX
         {
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool canScaleY;
 
         /// <summary>
-        /// Whether horizontal scale support should be enabled.
+        /// Whether vertical scaling support should be enabled.
         /// </summary>
         public bool CanScaleY
         {
@@ -91,6 +91,40 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (canScaleY == value) return;
 
                 canScaleY = value;
+                recreate();
+            }
+        }
+
+        private bool canFlipX;
+
+        /// <summary>
+        /// Whether horizontal flipping support should be enabled.
+        /// </summary>
+        public bool CanFlipX
+        {
+            get => canFlipX;
+            set
+            {
+                if (canFlipX == value) return;
+
+                canFlipX = value;
+                recreate();
+            }
+        }
+
+        private bool canFlipY;
+
+        /// <summary>
+        /// Whether vertical flipping support should be enabled.
+        /// </summary>
+        public bool CanFlipY
+        {
+            get => canFlipY;
+            set
+            {
+                if (canFlipY == value) return;
+
+                canFlipY = value;
                 recreate();
             }
         }
@@ -142,10 +176,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     return CanReverse && runOperationFromHotkey(OnReverse);
 
                 case Key.H:
-                    return CanScaleX && runOperationFromHotkey(() => OnFlip?.Invoke(Direction.Horizontal) ?? false);
+                    return CanFlipX && runOperationFromHotkey(() => OnFlip?.Invoke(Direction.Horizontal) ?? false);
 
                 case Key.J:
-                    return CanScaleY && runOperationFromHotkey(() => OnFlip?.Invoke(Direction.Vertical) ?? false);
+                    return CanFlipY && runOperationFromHotkey(() => OnFlip?.Invoke(Direction.Vertical) ?? false);
             }
 
             return base.OnKeyDown(e);
@@ -214,6 +248,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (CanScaleX) addXScaleComponents();
             if (CanScaleX && CanScaleY) addFullScaleComponents();
             if (CanScaleY) addYScaleComponents();
+            if (CanFlipX) addXFlipComponents();
+            if (CanFlipY) addYFlipComponents();
             if (CanRotate) addRotationComponents();
             if (CanReverse) addButton(FontAwesome.Solid.Backward, "Reverse pattern (Ctrl-G)", () => OnReverse?.Invoke());
         }
@@ -231,8 +267,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void addYScaleComponents()
         {
-            addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically (Ctrl-J)", () => OnFlip?.Invoke(Direction.Vertical));
-
             addScaleHandle(Anchor.TopCentre);
             addScaleHandle(Anchor.BottomCentre);
         }
@@ -247,10 +281,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void addXScaleComponents()
         {
-            addButton(FontAwesome.Solid.ArrowsAltH, "Flip horizontally (Ctrl-H)", () => OnFlip?.Invoke(Direction.Horizontal));
-
             addScaleHandle(Anchor.CentreLeft);
             addScaleHandle(Anchor.CentreRight);
+        }
+
+        private void addXFlipComponents()
+        {
+            addButton(FontAwesome.Solid.ArrowsAltH, "Flip horizontally (Ctrl-H)", () => OnFlip?.Invoke(Direction.Horizontal));
+        }
+
+        private void addYFlipComponents()
+        {
+            addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically (Ctrl-J)", () => OnFlip?.Invoke(Direction.Vertical));
         }
 
         private void addButton(IconUsage icon, string tooltip, Action action)

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -170,6 +170,8 @@ namespace osu.Game.Skinning.Editor
             SelectionBox.CanRotate = true;
             SelectionBox.CanScaleX = true;
             SelectionBox.CanScaleY = true;
+            SelectionBox.CanFlipX = true;
+            SelectionBox.CanFlipY = true;
             SelectionBox.CanReverse = false;
         }
 


### PR DESCRIPTION
Sometimes scaling doesn't make sense and flipping make sense (e.g. mania).
Also, scaling support requires more code and is less well-defined (has one intuitive meaning) than flipping.