### PR TITLE
Implement horizontal flipping of hit objects in catch editor 

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectUtils.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectUtils.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
@@ -20,5 +23,41 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
             return new Vector2(hitObject.OriginalX, hitObjectContainer.PositionAtTime(hitObject.StartTime));
         }
+
+        /// <summary>
+        /// Get the range of horizontal position occupied by the hit object.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="TinyDroplet"/>s are excluded and returns <see cref="PositionRange.EMPTY"/>.
+        /// </remarks>
+        public static PositionRange GetPositionRange(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Fruit fruit:
+                    return new PositionRange(fruit.OriginalX);
+
+                case Droplet droplet:
+                    return droplet is TinyDroplet ? PositionRange.EMPTY : new PositionRange(droplet.OriginalX);
+
+                case JuiceStream _:
+                    return GetPositionRange(hitObject.NestedHitObjects);
+
+                case BananaShower _:
+                    // A banana shower occupies the whole screen width.
+                    return new PositionRange(0, CatchPlayfield.WIDTH);
+
+                default:
+                    return PositionRange.EMPTY;
+            }
+        }
+
+        /// <summary>
+        /// Get the range of horizontal position occupied by the hit objects.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="TinyDroplet"/>s are excluded.
+        /// </remarks>
+        public static PositionRange GetPositionRange(IEnumerable<HitObject> hitObjects) => hitObjects.Select(GetPositionRange).Aggregate(PositionRange.EMPTY, PositionRange.Union);
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -40,12 +40,12 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             EditorBeatmap.PerformOnSelection(h =>
             {
-                if (!(h is CatchHitObject hitObject)) return;
+                if (!(h is CatchHitObject catchObject)) return;
 
-                hitObject.OriginalX += deltaX;
+                catchObject.OriginalX += deltaX;
 
                 // Move the nested hit objects to give an instant result before nested objects are recreated.
-                foreach (var nested in hitObject.NestedHitObjects.OfType<CatchHitObject>())
+                foreach (var nested in catchObject.NestedHitObjects.OfType<CatchHitObject>())
                     nested.OriginalX += deltaX;
             });
 
@@ -59,8 +59,8 @@ namespace osu.Game.Rulesets.Catch.Edit
             bool changed = false;
             EditorBeatmap.PerformOnSelection(h =>
             {
-                if (h is CatchHitObject hitObject)
-                    changed |= handleFlip(selectionRange, hitObject);
+                if (h is CatchHitObject catchObject)
+                    changed |= handleFlip(selectionRange, catchObject);
             });
             return changed;
         }

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -69,7 +69,8 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
             base.OnSelectionChanged();
 
-            SelectionBox.CanFlipX = true;
+            var selectionRange = CatchHitObjectUtils.GetPositionRange(EditorBeatmap.SelectedHitObjects);
+            SelectionBox.CanFlipX = selectionRange.Length > 0 && EditorBeatmap.SelectedHitObjects.Any(h => h is CatchHitObject && !(h is BananaShower));
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
+++ b/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Rulesets.Catch.Edit
         public readonly float Min;
         public readonly float Max;
 
+        public float Length => Max - Min;
+
         public PositionRange(float value)
             : this(value, value)
         {

--- a/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
+++ b/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
@@ -8,14 +8,15 @@ using System;
 namespace osu.Game.Rulesets.Catch.Edit
 {
     /// <summary>
-    /// Represents a closed interval of horizontal positions in the playfield.
+    /// Represents either the empty range or a closed interval of horizontal positions in the playfield.
+    /// A <see cref="PositionRange"/> represents a closed interval if it is <see cref="Min"/> &lt;= <see cref="Max"/>, and represents the empty range otherwise.
     /// </summary>
     public readonly struct PositionRange
     {
         public readonly float Min;
         public readonly float Max;
 
-        public float Length => Max - Min;
+        public float Length => Math.Max(0, Max - Min);
 
         public PositionRange(float value)
             : this(value, value)
@@ -30,7 +31,11 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public static PositionRange Union(PositionRange a, PositionRange b) => new PositionRange(Math.Min(a.Min, b.Min), Math.Max(a.Max, b.Max));
 
-        public float GetFlippedPosition(float x) => Max - (x - Min);
+        /// <summary>
+        /// Get the given position flipped (mirrored) for the axis at the center of this range.
+        /// Returns the given position unchanged if the range was empty.
+        /// </summary>
+        public float GetFlippedPosition(float x) => Min <= Max ? Max - (x - Min) : x;
 
         public static readonly PositionRange EMPTY = new PositionRange(float.PositiveInfinity, float.NegativeInfinity);
     }

--- a/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
+++ b/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public static PositionRange Union(PositionRange a, PositionRange b) => new PositionRange(Math.Min(a.Min, b.Min), Math.Max(a.Max, b.Max));
 
+        public float GetFlippedPosition(float x) => Max - (x - Min);
+
         public static readonly PositionRange EMPTY = new PositionRange(float.PositiveInfinity, float.NegativeInfinity);
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
+++ b/osu.Game.Rulesets.Catch/Edit/PositionRange.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+#nullable enable
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    /// <summary>
+    /// Represents a closed interval of horizontal positions in the playfield.
+    /// </summary>
+    public readonly struct PositionRange
+    {
+        public readonly float Min;
+        public readonly float Max;
+
+        public PositionRange(float value)
+            : this(value, value)
+        {
+        }
+
+        public PositionRange(float min, float max)
+        {
+            Min = min;
+            Max = max;
+        }
+
+        public static PositionRange Union(PositionRange a, PositionRange b) => new PositionRange(Math.Min(a.Min, b.Min), Math.Max(a.Max, b.Max));
+
+        public static readonly PositionRange EMPTY = new PositionRange(float.PositiveInfinity, float.NegativeInfinity);
+    }
+}


### PR DESCRIPTION
The logic of computing occupied position range of hit objects is extracted to `CatchHitObjectUtils.GetPositionRange`.
Actual flipping implementation is only in the commit <https://github.com/ppy/osu/commit/d2d3214d47958703be35f6117b15bfd1541d2a1d>.

- [x] Depends on #13960
