### PR TITLE
Adapt to framework `PlatformAction` type change

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.706.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.714.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.721.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -129,9 +129,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         public bool OnPressed(PlatformAction action)
         {
-            switch (action.ActionMethod)
+            switch (action)
             {
-                case PlatformActionMethod.Delete:
+                case PlatformAction.Delete:
                     return DeleteSelected();
             }
 

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -330,15 +330,15 @@ namespace osu.Game.Tests.Visual.Online
             InputManager.ReleaseKey(Key.AltLeft);
         }
 
-        private void pressCloseDocumentKeys() => pressKeysFor(PlatformActionType.DocumentClose);
+        private void pressCloseDocumentKeys() => pressKeysFor(PlatformAction.DocumentClose);
 
-        private void pressNewTabKeys() => pressKeysFor(PlatformActionType.TabNew);
+        private void pressNewTabKeys() => pressKeysFor(PlatformAction.TabNew);
 
-        private void pressRestoreTabKeys() => pressKeysFor(PlatformActionType.TabRestore);
+        private void pressRestoreTabKeys() => pressKeysFor(PlatformAction.TabRestore);
 
-        private void pressKeysFor(PlatformActionType type)
+        private void pressKeysFor(PlatformAction type)
         {
-            var binding = host.PlatformKeyBindings.First(b => ((PlatformAction)b.Action).ActionType == type);
+            var binding = host.PlatformKeyBindings.First(b => (PlatformAction)b.Action == type);
 
             foreach (var k in binding.KeyCombination.Keys)
                 InputManager.PressKey((Key)k);

--- a/osu.Game/Graphics/UserInterface/SearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/SearchTextBox.cs
@@ -32,20 +32,15 @@ namespace osu.Game.Graphics.UserInterface
 
         public override bool OnPressed(PlatformAction action)
         {
-            switch (action.ActionType)
+            switch (action)
             {
-                case PlatformActionType.LineEnd:
-                case PlatformActionType.LineStart:
-                    return false;
-
+                case PlatformAction.MoveBackwardLine:
+                case PlatformAction.MoveForwardLine:
                 // Shift+delete is handled via PlatformAction on macOS. this is not so useful in the context of a SearchTextBox
                 // as we do not allow arrow key navigation in the first place (ie. the caret should always be at the end of text)
                 // Avoid handling it here to allow other components to potentially consume the shortcut.
-                case PlatformActionType.CharNext:
-                    if (action.ActionMethod == PlatformActionMethod.Delete)
-                        return false;
-
-                    break;
+                case PlatformAction.DeleteForwardChar:
+                    return false;
             }
 
             return base.OnPressed(action);

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -374,17 +374,17 @@ namespace osu.Game.Overlays
 
         public bool OnPressed(PlatformAction action)
         {
-            switch (action.ActionType)
+            switch (action)
             {
-                case PlatformActionType.TabNew:
+                case PlatformAction.TabNew:
                     ChannelTabControl.SelectChannelSelectorTab();
                     return true;
 
-                case PlatformActionType.TabRestore:
+                case PlatformAction.TabRestore:
                     channelManager.JoinLastClosedChannel();
                     return true;
 
-                case PlatformActionType.DocumentClose:
+                case PlatformAction.DocumentClose:
                     channelManager.LeaveChannel(channelManager.CurrentChannel.Value);
                     return true;
             }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -230,9 +230,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public bool OnPressed(PlatformAction action)
         {
-            switch (action.ActionType)
+            switch (action)
             {
-                case PlatformActionType.SelectAll:
+                case PlatformAction.SelectAll:
                     SelectAll();
                     return true;
             }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -139,9 +139,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public bool OnPressed(PlatformAction action)
         {
-            switch (action.ActionMethod)
+            switch (action)
             {
-                case PlatformActionMethod.Delete:
+                case PlatformAction.Delete:
                     DeleteSelected();
                     return true;
             }

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Compose
 
         public bool OnPressed(PlatformAction action)
         {
-            if (action.ActionType == PlatformActionType.Copy)
+            if (action == PlatformAction.Copy)
                 host.GetClipboard().SetText(formatSelectionAsString());
 
             return false;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -330,29 +330,29 @@ namespace osu.Game.Screens.Edit
 
         public bool OnPressed(PlatformAction action)
         {
-            switch (action.ActionType)
+            switch (action)
             {
-                case PlatformActionType.Cut:
+                case PlatformAction.Cut:
                     Cut();
                     return true;
 
-                case PlatformActionType.Copy:
+                case PlatformAction.Copy:
                     Copy();
                     return true;
 
-                case PlatformActionType.Paste:
+                case PlatformAction.Paste:
                     Paste();
                     return true;
 
-                case PlatformActionType.Undo:
+                case PlatformAction.Undo:
                     Undo();
                     return true;
 
-                case PlatformActionType.Redo:
+                case PlatformAction.Redo:
                     Redo();
                     return true;
 
-                case PlatformActionType.Save:
+                case PlatformAction.Save:
                     Save();
                     return true;
             }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.3.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.714.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.721.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.706.0" />
     <PackageReference Include="Sentry" Version="3.6.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.714.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.721.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.706.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.714.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.721.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- See: ppy/osu-framework#4622
- [x] Pending framework update.

Note that the new `PlatformAction.Delete` is only fired for the `Delete` key, but the previous method of matching `PlatformActionMethod.Delete` (in the editor, delete selected item) was also handling the case of `Backspace`, `Shift+Delete` etc.
The previous behavior could be retained if required but I guess only handling the `Delete` key is what was/is intended.