### PR TITLE
Fix mod display overflowing on contracted results panels

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneContractedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneContractedPanelMiddleContent.cs
@@ -29,6 +29,12 @@ namespace osu.Game.Tests.Visual.Ranking
             AddStep("show example score", () => showPanel(CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo)), new TestScoreInfo(new OsuRuleset().RulesetInfo)));
         }
 
+        [Test]
+        public void TestExcessMods()
+        {
+            AddStep("show excess mods score", () => showPanel(CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo)), new TestScoreInfo(new OsuRuleset().RulesetInfo, true)));
+        }
+
         private void showPanel(WorkingBeatmap workingBeatmap, ScoreInfo score)
         {
             Child = new ContractedPanelMiddleContentContainer(workingBeatmap, score);

--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -36,6 +36,17 @@ namespace osu.Game.Tests.Visual.Ranking
             {
                 Beatmap = createTestBeatmap(author)
             }));
+        }
+
+        [Test]
+        public void TestExcessMods()
+        {
+            var author = new User { Username = "mapper_name" };
+
+            AddStep("show excess mods score", () => showPanel(new TestScoreInfo(new OsuRuleset().RulesetInfo, true)
+            {
+                Beatmap = createTestBeatmap(author)
+            }));
 
             AddAssert("mapper name present", () => this.ChildrenOfType<OsuSpriteText>().Any(spriteText => spriteText.Current.Value == "mapper_name"));
         }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModFlowDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModFlowDisplay.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Play.HUD;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneModFlowDisplay : OsuTestScene
+    {
+        private ModFlowDisplay modFlow;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = modFlow = new ModFlowDisplay
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Y,
+                RelativeSizeAxes = Axes.None,
+                Width = 200,
+                Current =
+                {
+                    Value = new OsuRuleset().GetAllMods().ToArray(),
+                }
+            };
+        });
+
+        [Test]
+        public void TestWrapping()
+        {
+            AddSliderStep("icon size", 0.1f, 2, 1, val =>
+            {
+                if (modFlow != null)
+                    modFlow.IconScale = val;
+            });
+
+            AddSliderStep("flow width", 100, 500, 200, val =>
+            {
+                if (modFlow != null)
+                    modFlow.Width = val;
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -16,7 +16,7 @@ using osuTK;
 namespace osu.Game.Screens.Play.HUD
 {
     /// <summary>
-    /// Displays a single-line horizontal auto-sized flow of mods.
+    /// Displays a single-line horizontal auto-sized flow of mods. For cases where wrapping is required, use <see cref="ModFlowDisplay"/> instead.
     /// </summary>
     public class ModDisplay : CompositeDrawable, IHasCurrentValue<IReadOnlyList<Mod>>
     {

--- a/osu.Game/Screens/Play/HUD/ModFlowDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModFlowDisplay.cs
@@ -1,0 +1,83 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osuTK;
+
+namespace osu.Game.Screens.Play.HUD
+{
+    /// <summary>
+    /// A horizontally wrapping display of mods. For cases where wrapping is not required, use <see cref="ModDisplay"/> instead.
+    /// </summary>
+    public class ModFlowDisplay : ReverseChildIDFillFlowContainer<ModIcon>, IHasCurrentValue<IReadOnlyList<Mod>>
+    {
+        private const int fade_duration = 1000;
+
+        private readonly BindableWithCurrent<IReadOnlyList<Mod>> current = new BindableWithCurrent<IReadOnlyList<Mod>>();
+
+        public Bindable<IReadOnlyList<Mod>> Current
+        {
+            get => current.Current;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                current.Current = value;
+            }
+        }
+
+        private float iconScale = 1;
+
+        public float IconScale
+        {
+            get => iconScale;
+            set
+            {
+                iconScale = value;
+                updateDisplay();
+            }
+        }
+
+        public ModFlowDisplay()
+        {
+            Direction = FillDirection.Full;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Current.BindValueChanged(_ => updateDisplay(), true);
+
+            this.FadeInFromZero(fade_duration, Easing.OutQuint);
+        }
+
+        private void updateDisplay()
+        {
+            Clear();
+
+            if (current.Value == null) return;
+
+            Spacing = new Vector2(0, -12 * iconScale);
+
+            foreach (Mod mod in current.Value)
+            {
+                Add(new ModIcon(mod)
+                {
+                    Scale = new Vector2(0.6f * iconScale),
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                });
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -131,13 +131,14 @@ namespace osu.Game.Screens.Ranking.Contracted
                                                 createStatistic("Accuracy", $"{score.Accuracy.FormatAccuracy()}"),
                                             }
                                         },
-                                        new ModDisplay
+                                        new ModFlowDisplay
                                         {
                                             Anchor = Anchor.TopCentre,
                                             Origin = Anchor.TopCentre,
-                                            ExpansionMode = ExpansionMode.AlwaysExpanded,
+                                            AutoSizeAxes = Axes.Y,
+                                            RelativeSizeAxes = Axes.X,
                                             Current = { Value = score.Mods },
-                                            Scale = new Vector2(0.5f),
+                                            IconScale = 0.5f,
                                         }
                                     }
                                 }

--- a/osu.Game/Tests/TestScoreInfo.cs
+++ b/osu.Game/Tests/TestScoreInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -13,7 +14,7 @@ namespace osu.Game.Tests
 {
     public class TestScoreInfo : ScoreInfo
     {
-        public TestScoreInfo(RulesetInfo ruleset)
+        public TestScoreInfo(RulesetInfo ruleset, bool excessMods = false)
         {
             User = new User
             {
@@ -25,7 +26,10 @@ namespace osu.Game.Tests
             Beatmap = new TestBeatmap(ruleset).BeatmapInfo;
             Ruleset = ruleset;
             RulesetID = ruleset.ID ?? 0;
-            Mods = new Mod[] { new TestModHardRock(), new TestModDoubleTime() };
+
+            Mods = excessMods
+                ? ruleset.CreateInstance().GetAllMods().ToArray()
+                : new Mod[] { new TestModHardRock(), new TestModDoubleTime() };
 
             TotalScore = 2845370;
             Accuracy = 0.95;


### PR DESCRIPTION
Resolves part (all?) of #13952.

- [x] Depends on #13963.

![20210721 164649 (dotnet)](https://user-images.githubusercontent.com/191335/126451361-fc6fd42a-ea1d-414f-bcaa-e054a14f4cca.png)

Excessive case (not possible in normal conditions) still looks okay:

![20210721 164718 (dotnet)](https://user-images.githubusercontent.com/191335/126451471-00ec2d70-bb9f-4e65-9a96-2237375cbd26.png)
