### PR TITLE
Localise beatmap panels status pills

### DIFF
--- a/osu.Game/Beatmaps/BeatmapSetOnlineStatus.cs
+++ b/osu.Game/Beatmaps/BeatmapSetOnlineStatus.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
 namespace osu.Game.Beatmaps
 {
+    [LocalisableEnum(typeof(BeatmapSetOnlineStatusEnumLocalisationMapper))]
     public enum BeatmapSetOnlineStatus
     {
         None = -3,
@@ -19,5 +24,41 @@ namespace osu.Game.Beatmaps
     {
         public static bool GrantsPerformancePoints(this BeatmapSetOnlineStatus status)
             => status == BeatmapSetOnlineStatus.Ranked || status == BeatmapSetOnlineStatus.Approved;
+    }
+
+    public class BeatmapSetOnlineStatusEnumLocalisationMapper : EnumLocalisationMapper<BeatmapSetOnlineStatus>
+    {
+        public override LocalisableString Map(BeatmapSetOnlineStatus value)
+        {
+            switch (value)
+            {
+                case BeatmapSetOnlineStatus.None:
+                    return string.Empty;
+
+                case BeatmapSetOnlineStatus.Graveyard:
+                    return BeatmapsetsStrings.ShowStatusGraveyard;
+
+                case BeatmapSetOnlineStatus.WIP:
+                    return BeatmapsetsStrings.ShowStatusWip;
+
+                case BeatmapSetOnlineStatus.Pending:
+                    return BeatmapsetsStrings.ShowStatusPending;
+
+                case BeatmapSetOnlineStatus.Ranked:
+                    return BeatmapsetsStrings.ShowStatusRanked;
+
+                case BeatmapSetOnlineStatus.Approved:
+                    return BeatmapsetsStrings.ShowStatusApproved;
+
+                case BeatmapSetOnlineStatus.Qualified:
+                    return BeatmapsetsStrings.ShowStatusQualified;
+
+                case BeatmapSetOnlineStatus.Loved:
+                    return BeatmapsetsStrings.ShowStatusLoved;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -28,7 +30,7 @@ namespace osu.Game.Beatmaps.Drawables
                 status = value;
 
                 Alpha = value == BeatmapSetOnlineStatus.None ? 0 : 1;
-                statusText.Text = value.ToString().ToUpperInvariant();
+                statusText.Text = value.GetLocalisableDescription().ToUpper();
             }
         }
 

--- a/osu.Game/Overlays/BeatmapSet/ExplicitContentBeatmapPill.cs
+++ b/osu.Game/Overlays/BeatmapSet/ExplicitContentBeatmapPill.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.BeatmapSet
 {
@@ -34,7 +36,7 @@ namespace osu.Game.Overlays.BeatmapSet
                     new OsuSpriteText
                     {
                         Margin = new MarginPadding { Horizontal = 10f, Vertical = 2f },
-                        Text = "EXPLICIT",
+                        Text = BeatmapsetsStrings.NsfwBadgeLabel.ToUpper(),
                         Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
                         Colour = OverlayColourProvider.Orange.Colour2,
                     }


### PR DESCRIPTION
This localises the beatmap panel status pills. Remaining places pending localisation in the beatmap listing overlay are mainly TFC usages

![osu_2021-07-21_13-19-39](https://user-images.githubusercontent.com/20256717/126481836-a73a363f-3c7a-46d4-987f-5226ec673b39.jpg)
