### PR TITLE
Add new 'soft' select sound variant and use it in some places

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.706.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.722.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2021.721.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
@@ -10,6 +10,9 @@ namespace osu.Game.Graphics.UserInterface
         [Description("default")]
         Default,
 
+        [Description("soft")]
+        Soft,
+
         [Description("button")]
         Button,
 

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -25,9 +26,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
             Flow.AutoSizeAxes = Axes.X;
             Flow.Height = OsuDirectorySelector.ITEM_HEIGHT;
 
-            AddInternal(new Background
+            AddRangeInternal(new Drawable[]
             {
-                Depth = 1
+                new Background
+                {
+                    Depth = 1
+                },
+                new HoverClickSounds(HoverSampleSet.Soft)
             });
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -50,9 +51,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Flow.AutoSizeAxes = Axes.X;
                 Flow.Height = OsuDirectorySelector.ITEM_HEIGHT;
 
-                AddInternal(new OsuDirectorySelectorDirectory.Background
+                AddRangeInternal(new Drawable[]
                 {
-                    Depth = 1
+                    new OsuDirectorySelectorDirectory.Background
+                    {
+                        Depth = 1
+                    },
+                    new HoverClickSounds(HoverSampleSet.Soft)
                 });
             }
 

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -9,6 +9,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK.Graphics;
 
@@ -64,6 +65,7 @@ namespace osu.Game.Screens.Edit
             private EditorClock clock { get; set; }
 
             public RowBackground(object item)
+                : base(HoverSampleSet.Soft)
             {
                 Item = item;
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.3.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.721.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.706.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.722.0" />
     <PackageReference Include="Sentry" Version="3.6.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.721.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.706.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.722.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Not entirely sold on the naming scheme here... also not sure whether this will end up being the default 'select' sound instead (with the current select sound being renamed to something else).

This new 'soft' select sound has been added to:
- `OsuFileSelector`
- `OsuDirectorySelectorDirectory`
- `EditorTable` (replaces previous usage of the default select sound)

Also as an aside, adding hover sounds to the file/directory selector kinda highlights an issue with hover sounds - they'll play when a Drawable with them appears under the cursor, even if the mouse wasn't moved... which results in hover sounds being played (almost) instantly after the select sounds play while drilling down into a folder.

- [x] Depends on ppy/osu-resources#138