### PR TITLE
Scale the playfield using the diagonal instead of the max side when barrel roll mod is active

### DIFF
--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -50,8 +50,8 @@ namespace osu.Game.Rulesets.Mods
 
             var playfieldSize = drawableRuleset.Playfield.DrawSize;
             var minSide = MathF.Min(playfieldSize.X, playfieldSize.Y);
-            var maxSide = MathF.Max(playfieldSize.X, playfieldSize.Y);
-            drawableRuleset.Playfield.Scale = new Vector2(minSide / maxSide);
+            var diagonal = MathF.Sqrt(MathF.Pow(playfieldSize.X, 2) + MathF.Pow(playfieldSize.Y, 2));
+            drawableRuleset.Playfield.Scale = new Vector2(minSide / diagonal);
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -50,8 +50,7 @@ namespace osu.Game.Rulesets.Mods
 
             var playfieldSize = drawableRuleset.Playfield.DrawSize;
             var minSide = MathF.Min(playfieldSize.X, playfieldSize.Y);
-            var diagonal = MathF.Sqrt(MathF.Pow(playfieldSize.X, 2) + MathF.Pow(playfieldSize.Y, 2));
-            drawableRuleset.Playfield.Scale = new Vector2(minSide / diagonal);
+            drawableRuleset.Playfield.Scale = new Vector2(minSide / playfieldSize.Length);
         }
     }
 }


### PR DESCRIPTION
Closes #13683.

Example of behavior with changes:

https://user-images.githubusercontent.com/55509723/126569332-e4549ff7-d2ca-4e95-9170-4b3c8456e58b.mp4

