### PR TITLE
Fix derived API request types firing success when they shouldn't

### DIFF
--- a/osu.Game/Online/API/APIDownloadRequest.cs
+++ b/osu.Game/Online/API/APIDownloadRequest.cs
@@ -16,6 +16,11 @@ namespace osu.Game.Online.API
         /// </summary>
         protected virtual string FileExtension { get; } = @".tmp";
 
+        protected APIDownloadRequest()
+        {
+            base.Success += () => Success?.Invoke(filename);
+        }
+
         protected override WebRequest CreateWebRequest()
         {
             var file = Path.GetTempFileName();
@@ -37,12 +42,6 @@ namespace osu.Game.Online.API
             this.filename = filename;
 
             TriggerSuccess();
-        }
-
-        internal override void TriggerSuccess()
-        {
-            base.TriggerSuccess();
-            Success?.Invoke(filename);
         }
 
         public event APIProgressHandler Progressed;

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Online.API
         /// </summary>
         public new event APISuccessHandler<T> Success;
 
+        protected APIRequest()
+        {
+            base.Success += () => Success?.Invoke(Result);
+        }
+
         protected override void PostProcess()
         {
             base.PostProcess();
@@ -39,12 +44,6 @@ namespace osu.Game.Online.API
             Result = result;
 
             TriggerSuccess();
-        }
-
-        internal override void TriggerSuccess()
-        {
-            base.TriggerSuccess();
-            Success?.Invoke(Result);
         }
     }
 
@@ -132,7 +131,7 @@ namespace osu.Game.Online.API
         {
         }
 
-        internal virtual void TriggerSuccess()
+        internal void TriggerSuccess()
         {
             lock (completionStateLock)
             {


### PR DESCRIPTION
The usual case of `virtual`/`override` being dangerous when logic is added to the base implementation. As such, I've removed this completely.

Closes #13976.
Closes #13975.
