### PR TITLE
Fix song select background not showing in multiplayer/playlists

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("load multiplayer", () => LoadScreen(multiplayerScreen));
             AddUntilStep("wait for multiplayer to load", () => multiplayerScreen.IsLoaded);
+            AddUntilStep("wait for lounge to load", () => this.ChildrenOfType<MultiplayerLoungeSubScreen>().FirstOrDefault()?.IsLoaded == true);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             this.HidePopover();
         }
 
-        public void Join(Room room, string password)
+        public void Join(Room room, string password) => Schedule(() =>
         {
             if (joiningRoomOperation != null)
                 return;
@@ -194,25 +194,22 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 joiningRoomOperation?.Dispose();
                 joiningRoomOperation = null;
             });
-        }
-
-        private void updateLoadingLayer()
-        {
-            if (operationInProgress.Value || !initialRoomsReceived.Value)
-                loadingLayer.Show();
-            else
-                loadingLayer.Hide();
-        }
+        });
 
         /// <summary>
         /// Push a room as a new subscreen.
         /// </summary>
-        public virtual void Open(Room room)
+        public void Open(Room room) => Schedule(() =>
         {
             // Handles the case where a room is clicked 3 times in quick succession
             if (!this.IsCurrentScreen())
                 return;
 
+            OpenNewRoom(room);
+        });
+
+        protected virtual void OpenNewRoom(Room room)
+        {
             selectedRoom.Value = room;
 
             this.Push(CreateRoomSubScreen(room));
@@ -221,5 +218,13 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         protected abstract FilterControl CreateFilterControl();
 
         protected abstract RoomSubScreen CreateRoomSubScreen(Room room);
+
+        private void updateLoadingLayer()
+        {
+            if (operationInProgress.Value || !initialRoomsReceived.Value)
+                loadingLayer.Show();
+            else
+                loadingLayer.Hide();
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerLoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerLoungeSubScreen.cs
@@ -20,15 +20,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
-        public override void Open(Room room)
+        protected override void OpenNewRoom(Room room)
         {
-            if (!client.IsConnected.Value)
+            if (client?.IsConnected.Value != true)
             {
                 Logger.Log("Not currently connected to the multiplayer server.", LoggingTarget.Runtime, LogLevel.Important);
                 return;
             }
 
-            base.Open(room);
+            base.OpenNewRoom(room);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -162,10 +162,6 @@ namespace osu.Game.Screens.OnlinePlay
                     ongoingOperationTracker,
                 }
             };
-
-            // a lot of the functionality in this class depends on loungeSubScreen being in a ready to go state.
-            // as such, we intentionally load this inline so it is ready alongside this screen.
-            LoadComponent(loungeSubScreen = CreateLounge());
         }
 
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>
@@ -184,7 +180,7 @@ namespace osu.Game.Screens.OnlinePlay
             screenStack.ScreenPushed += screenPushed;
             screenStack.ScreenExited += screenExited;
 
-            screenStack.Push(loungeSubScreen);
+            screenStack.Push(loungeSubScreen = CreateLounge());
 
             apiState.BindTo(API.State);
             apiState.BindValueChanged(onlineStateChanged, true);


### PR DESCRIPTION
The screen was now being loaded against incorrect dependencies. I'm not sure why I thought it wasn't possible to just do the `Push` in `LoadComplete` as it seems to work without issue this time...

Closes #13974.
