### PR TITLE
Output startup component load start/end times to non-debug logs

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -932,7 +932,7 @@ namespace osu.Game
 
                     try
                     {
-                        Logger.Log($"Loading {component}...", level: LogLevel.Debug);
+                        Logger.Log($"Loading {component}...");
 
                         // Since this is running in a separate thread, it is possible for OsuGame to be disposed after LoadComponentAsync has been called
                         // throwing an exception. To avoid this, the call is scheduled on the update thread, which does not run if IsDisposed = true
@@ -952,7 +952,7 @@ namespace osu.Game
 
                         await task.ConfigureAwait(false);
 
-                        Logger.Log($"Loaded {component}!", level: LogLevel.Debug);
+                        Logger.Log($"Loaded {component}!");
                     }
                     catch (OperationCanceledException)
                     {


### PR DESCRIPTION
Useful for diagnosing issues in cases like #13981.
