### PR TITLE
Implement "reverse pattern" in catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -65,12 +65,33 @@ namespace osu.Game.Rulesets.Catch.Edit
             return changed;
         }
 
+        public override bool HandleReverse()
+        {
+            double selectionStartTime = SelectedItems.Min(h => h.StartTime);
+            double selectionEndTime = SelectedItems.Max(h => h.GetEndTime());
+
+            EditorBeatmap.PerformOnSelection(hitObject =>
+            {
+                hitObject.StartTime = selectionEndTime - (hitObject.GetEndTime() - selectionStartTime);
+
+                if (hitObject is JuiceStream juiceStream)
+                {
+                    juiceStream.Path.Reverse(out Vector2 positionalOffset);
+                    juiceStream.OriginalX += positionalOffset.X;
+                    juiceStream.LegacyConvertedY += positionalOffset.Y;
+                    EditorBeatmap.Update(juiceStream);
+                }
+            });
+            return true;
+        }
+
         protected override void OnSelectionChanged()
         {
             base.OnSelectionChanged();
 
             var selectionRange = CatchHitObjectUtils.GetPositionRange(SelectedItems);
             SelectionBox.CanFlipX = selectionRange.Length > 0 && SelectedItems.Any(h => h is CatchHitObject && !(h is BananaShower));
+            SelectionBox.CanReverse = SelectedItems.Count > 1 || SelectedItems.Any(h => h is JuiceStream);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             Vector2 targetPosition = HitObjectContainer.ToLocalSpace(blueprint.ScreenSpaceSelectionPoint + moveEvent.ScreenSpaceDelta);
 
             float deltaX = targetPosition.X - originalPosition.X;
-            deltaX = limitMovement(deltaX, EditorBeatmap.SelectedHitObjects);
+            deltaX = limitMovement(deltaX, SelectedItems);
 
             if (deltaX == 0)
             {
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public override bool HandleFlip(Direction direction)
         {
-            var selectionRange = CatchHitObjectUtils.GetPositionRange(EditorBeatmap.SelectedHitObjects);
+            var selectionRange = CatchHitObjectUtils.GetPositionRange(SelectedItems);
 
             bool changed = false;
             EditorBeatmap.PerformOnSelection(h =>
@@ -69,8 +69,8 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
             base.OnSelectionChanged();
 
-            var selectionRange = CatchHitObjectUtils.GetPositionRange(EditorBeatmap.SelectedHitObjects);
-            SelectionBox.CanFlipX = selectionRange.Length > 0 && EditorBeatmap.SelectedHitObjects.Any(h => h is CatchHitObject && !(h is BananaShower));
+            var selectionRange = CatchHitObjectUtils.GetPositionRange(SelectedItems);
+            SelectionBox.CanFlipX = selectionRange.Length > 0 && SelectedItems.Any(h => h is CatchHitObject && !(h is BananaShower));
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -76,32 +76,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 if (h is Slider slider)
                 {
-                    var points = slider.Path.ControlPoints.ToArray();
-                    Vector2 endPos = points.Last().Position.Value;
-
-                    slider.Path.ControlPoints.Clear();
-
-                    slider.Position += endPos;
-
-                    PathType? lastType = null;
-
-                    for (var i = 0; i < points.Length; i++)
-                    {
-                        var p = points[i];
-                        p.Position.Value -= endPos;
-
-                        // propagate types forwards to last null type
-                        if (i == points.Length - 1)
-                            p.Type.Value = lastType;
-                        else if (p.Type.Value != null)
-                        {
-                            var newType = p.Type.Value;
-                            p.Type.Value = lastType;
-                            lastType = newType;
-                        }
-
-                        slider.Path.ControlPoints.Insert(0, p);
-                    }
+                    slider.Path.Reverse(out Vector2 offset);
+                    slider.Position += offset;
                 }
             }
 

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+
+#nullable enable
+
+namespace osu.Game.Rulesets.Objects
+{
+    public static class SliderPathExtensions
+    {
+        /// <summary>
+        /// Reverse the direction of this path.
+        /// </summary>
+        /// <param name="sliderPath">The <see cref="SliderPath"/>.</param>
+        /// <param name="positionalOffset">The positional offset of the resulting path. It should be added to the start position of this path.</param>
+        public static void Reverse(this SliderPath sliderPath, out Vector2 positionalOffset)
+        {
+            var points = sliderPath.ControlPoints.ToArray();
+            positionalOffset = points.Last().Position.Value;
+
+            sliderPath.ControlPoints.Clear();
+
+            PathType? lastType = null;
+
+            for (var i = 0; i < points.Length; i++)
+            {
+                var p = points[i];
+                p.Position.Value -= positionalOffset;
+
+                // propagate types forwards to last null type
+                if (i == points.Length - 1)
+                    p.Type.Value = lastType;
+                else if (p.Type.Value != null)
+                {
+                    var newType = p.Type.Value;
+                    p.Type.Value = lastType;
+                    lastType = newType;
+                }
+
+                sliderPath.ControlPoints.Insert(0, p);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The implementation of `SliderPath` reversing is reusing the standard editor code.