### PR TITLE
Guard against `IndexOutOfRangeException` when parsing launch arguments

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -32,7 +32,7 @@ namespace osu.Desktop
                 var split = arg.Split('=');
 
                 var key = split[0];
-                var val = split[1];
+                var val = split.Length > 1 ? split[1] : string.Empty;
 
                 switch (key)
                 {


### PR DESCRIPTION
Not every launch argument has an additional `=` parameter, so a guard is needed after splitting by `=`.