### PR TITLE
Fix authentication loss not handled correctly

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -148,6 +148,16 @@ namespace osu.Game.Online.API
 
                         var userReq = new GetUserRequest();
 
+                        userReq.Failure += ex =>
+                        {
+                            if (ex.InnerException is WebException webException && webException.Message == @"Unauthorized")
+                            {
+                                log.Add(@"Login no longer valid");
+                                Logout();
+                            }
+                            else
+                                failConnectionProcess();
+                        };
                         userReq.Success += u =>
                         {
                             localUser.Value = u;
@@ -167,6 +177,7 @@ namespace osu.Game.Online.API
                         // getting user's friends is considered part of the connection process.
                         var friendsReq = new GetFriendsRequest();
 
+                        friendsReq.Failure += _ => failConnectionProcess();
                         friendsReq.Success += res =>
                         {
                             friends.AddRange(res);


### PR DESCRIPTION
Found this while switching the key for the development server endpoint (causing existing "valid" oauth token to no longer be accepted).

This handles the case where on initial API connection, the server responds with an `Unauthorized` response. It doesn't perform this same checking/handling on every API request, which is probably what we want eventually.

Opting to not address the full issue because I know this is going to be a long one (see https://github.com/ppy/osu/blob/05c50c0f6cfafab359963586ec265ad4f143a46c/osu.Game/Online/API/APIAccess.cs#L233). Exception handling in `APIAccess` is a mess and needs proper focus to fix. I see adding this as showing a requirement which was missing until now moreso than being a good fix for the issue.
