### PR TITLE
Fix ruleset icons overflowing from settings footer

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsFooter.cs
+++ b/osu.Game/Overlays/Settings/SettingsFooter.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.Settings
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
             Direction = FillDirection.Vertical;
-            Padding = new MarginPadding { Top = 20, Bottom = 30 };
+            Padding = new MarginPadding { Top = 20, Bottom = 30, Horizontal = SettingsPanel.CONTENT_MARGINS };
 
             var modes = new List<Drawable>();
 
@@ -32,6 +32,8 @@ namespace osu.Game.Overlays.Settings
             {
                 var icon = new ConstrainedIconContainer
                 {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
                     Icon = ruleset.CreateInstance().CreateIcon(),
                     Colour = Color4.Gray,
                     Size = new Vector2(20),
@@ -47,7 +49,8 @@ namespace osu.Game.Overlays.Settings
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Direction = FillDirection.Full,
-                    AutoSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Children = modes,
                     Spacing = new Vector2(5),
                     Padding = new MarginPadding { Bottom = 10 },


### PR DESCRIPTION
Fixes one issue from https://github.com/ppy/osu/issues/13339.

Before:
<img width="608" alt="Screen Shot 2021-07-23 at 7 02 00 PM" src="https://user-images.githubusercontent.com/35318437/126854521-963f6a86-2fd1-4a9c-8184-6c6038f926c4.png">

After:
<img width="580" alt="Screen Shot 2021-07-23 at 7 03 26 PM" src="https://user-images.githubusercontent.com/35318437/126854526-5fedd3af-02ff-4898-ae23-bbec7b4abb41.png">
