### PR TITLE
Fix mod selector overflowing from beatmap info overlay

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/LeaderboardModSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/LeaderboardModSelector.cs
@@ -26,12 +26,14 @@ namespace osu.Game.Overlays.BeatmapSet
 
         public LeaderboardModSelector()
         {
-            AutoSizeAxes = Axes.Both;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
             InternalChild = modsContainer = new FillFlowContainer<ModButton>
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                AutoSizeAxes = Axes.Both,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Full,
                 Spacing = new Vector2(4),
             };
@@ -54,7 +56,12 @@ namespace osu.Game.Overlays.BeatmapSet
             modsContainer.Add(new ModButton(new ModNoMod()));
             modsContainer.AddRange(ruleset.NewValue.CreateInstance().GetAllMods().Where(m => m.UserPlayable).Select(m => new ModButton(m)));
 
-            modsContainer.ForEach(button => button.OnSelectionChanged = selectionChanged);
+            modsContainer.ForEach(button =>
+            {
+                button.Anchor = Anchor.TopCentre;
+                button.Origin = Anchor.TopCentre;
+                button.OnSelectionChanged = selectionChanged;
+            });
         }
 
         protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
Before:
<img width="1322" alt="Screen Shot 2021-07-24 at 3 33 37 PM" src="https://user-images.githubusercontent.com/35318437/126882518-54647141-194b-4b9c-82d5-378e10339cbd.png">

After:
<img width="1274" alt="Screen Shot 2021-07-24 at 3 34 44 PM" src="https://user-images.githubusercontent.com/35318437/126882513-2905a95c-418d-4cf8-8f05-8af2746e3f8d.png">
