### PR TITLE
Add "Mirror" mod

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -10,13 +10,9 @@ using osu.Game.Rulesets.Mania.Beatmaps;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModMirror : Mod, IApplicableToBeatmap
+    public class ManiaModMirror : ModMirror, IApplicableToBeatmap
     {
-        public override string Name => "Mirror";
-        public override string Acronym => "MR";
-        public override ModType Type => ModType.Conversion;
         public override string Description => "Notes are flipped horizontally.";
-        public override double ScoreMultiplier => 1;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -17,13 +17,13 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override double ScoreMultiplier => 1.06;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust), typeof(ModMirror) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModMirror)).ToArray();
 
         public void ApplyToHitObject(HitObject hitObject)
         {
             var osuObject = (OsuHitObject)hitObject;
 
-            OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
+            OsuHitObjectGenerationUtils.ReflectVertically(osuObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Osu.Utils;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Mods;
@@ -15,6 +16,8 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModHardRock : ModHardRock, IApplicableToHitObject
     {
         public override double ScoreMultiplier => 1.06;
+
+        public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust), typeof(ModMirror) };
 
         public void ApplyToHitObject(HitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Osu.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
@@ -19,19 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var osuObject = (OsuHitObject)hitObject;
 
-            osuObject.Position = new Vector2(osuObject.Position.X, OsuPlayfield.BASE_SIZE.Y - osuObject.Y);
-
-            if (!(hitObject is Slider slider))
-                return;
-
-            slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
-            slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
-
-            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
-            foreach (var point in controlPoints)
-                point.Position.Value = new Vector2(point.Position.Value.X, -point.Position.Value.Y);
-
-            slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
+            OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -2,16 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Osu.Utils;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -26,6 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToHitObject(HitObject hitObject)
         {
             var osuObject = (OsuHitObject)hitObject;
+
             switch (Reflection.Value)
             {
                 case MirrorType.Horizontal:

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "Reflect the playfield.";
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock) };
 
-        [SettingSource("Reflection", "Change the type of reflection.")]
+        [SettingSource("Mirrored axes", "Choose which of the playfield's axes are mirrored.")]
         public Bindable<MirrorType> Reflection { get; } = new Bindable<MirrorType>();
 
         public void ApplyToHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -13,10 +13,10 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModMirror : ModMirror, IApplicableToHitObject
     {
-        public override string Description => "Reflect the playfield.";
+        public override string Description => "Flip objects on the chosen axes.";
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock) };
 
-        [SettingSource("Mirrored axes", "Choose which of the playfield's axes are mirrored.")]
+        [SettingSource("Mirrored axes", "Choose which axes objects are mirrored over.")]
         public Bindable<MirrorType> Reflection { get; } = new Bindable<MirrorType>();
 
         public void ApplyToHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModMirror : ModMirror, IApplicableToHitObject
+    {
+        public void ApplyToHitObject(HitObject hitObject)
+        {
+            var osuObject = (OsuHitObject)hitObject;
+
+            osuObject.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - osuObject.X, osuObject.Position.Y);
+
+            if (!(hitObject is Slider slider))
+                return;
+
+            slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
+            slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
+
+            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
+            foreach (var point in controlPoints)
+                point.Position.Value = new Vector2(-point.Position.Value.X, point.Position.Value.Y);
+
+            slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
@@ -17,21 +18,34 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModMirror : ModMirror, IApplicableToHitObject
     {
         public override string Description => "Reflect the playfield.";
+        public override Type[] IncompatibleMods => new[] { typeof(ModHardRock) };
 
-        [SettingSource("Reflect Horizontally", "Reflect the playfield horizontally.")]
-        public Bindable<bool> ReflectY { get; } = new BindableBool(true);
-        [SettingSource("Reflect Vertically", "Reflect the playfield vertically.")]
-        public Bindable<bool> ReflectX { get; } = new BindableBool(false);
+        [SettingSource("Reflection", "Change the type of reflection.")]
+        public Bindable<MirrorType> Reflection { get; } = new Bindable<MirrorType>();
 
         public void ApplyToHitObject(HitObject hitObject)
         {
-            if (!(ReflectY.Value || ReflectX.Value))
-                return; // TODO deselect the mod if possible so replays and submissions don't have purposeless mods attached.
             var osuObject = (OsuHitObject)hitObject;
-            if (ReflectY.Value)
-                OsuHitObjectGenerationUtils.ReflectOsuHitObjectHorizontally(osuObject);
-            if (ReflectX.Value)
-                OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
+            switch (Reflection.Value)
+            {
+                case MirrorType.Horizontal:
+                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectHorizontally(osuObject);
+                    break;
+                case MirrorType.Vertical:
+                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
+                    break;
+                case MirrorType.Both:
+                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectHorizontally(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
+                    break;
+            }
+        }
+
+        public enum MirrorType
+        {
+            Horizontal,
+            Vertical,
+            Both
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -29,14 +29,16 @@ namespace osu.Game.Rulesets.Osu.Mods
             switch (Reflection.Value)
             {
                 case MirrorType.Horizontal:
-                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectHorizontally(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectHorizontally(osuObject);
                     break;
+
                 case MirrorType.Vertical:
-                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectVertically(osuObject);
                     break;
+
                 case MirrorType.Both:
-                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectHorizontally(osuObject);
-                    OsuHitObjectGenerationUtils.ReflectOsuHitObjectVertically(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectHorizontally(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectVertically(osuObject);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -166,6 +166,7 @@ namespace osu.Game.Rulesets.Osu
                         new OsuModDifficultyAdjust(),
                         new OsuModClassic(),
                         new OsuModRandom(),
+                        new OsuModMirror(),
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Utils
         }
 
         /// <summary>
-        /// Reflects an OsuHitObject's position horizontally (over the 'y axis').
+        /// Reflects an OsuHitObject's position horizontally.
         /// </summary>
         /// <param name="osuObject">The OsuHitObject to be reflected.</param>
         /// <returns>The reflected OsuHitObject.</returns>
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Utils
         }
 
         /// <summary>
-        /// Reflects an OsuHitObject's position vertically (over the 'x axis').
+        /// Reflects an OsuHitObject's position vertically.
         /// </summary>
         /// <param name="osuObject">The OsuHitObject to be reflected.</param>
         /// <returns>The reflected OsuHitObject.</returns>

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -2,7 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Utils
@@ -99,6 +103,54 @@ namespace osu.Game.Rulesets.Osu.Utils
                 initial.Length * MathF.Cos(finalAngleRad),
                 initial.Length * MathF.Sin(finalAngleRad)
             );
+        }
+
+        /// <summary>
+        /// Reflects an OsuHitObject's position horizontally (over the 'y axis').
+        /// </summary>
+        /// <param name="osuObject">The OsuHitObject to be reflected.</param>
+        /// <returns>The reflected OsuHitObject.</returns>
+        public static OsuHitObject ReflectOsuHitObjectHorizontally(OsuHitObject osuObject)
+        {
+            osuObject.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - osuObject.X, osuObject.Position.Y);
+
+            if (!(osuObject is Slider slider))
+                return osuObject;
+
+            slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
+            slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
+
+            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
+            foreach (var point in controlPoints)
+                point.Position.Value = new Vector2(-point.Position.Value.X, point.Position.Value.Y);
+
+            slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
+
+            return osuObject;
+        }
+
+        /// <summary>
+        /// Reflects an OsuHitObject's position vertically (over the 'x axis').
+        /// </summary>
+        /// <param name="osuObject">The OsuHitObject to be reflected.</param>
+        /// <returns>The reflected OsuHitObject.</returns>
+        public static OsuHitObject ReflectOsuHitObjectVertically(OsuHitObject osuObject)
+        {
+            osuObject.Position = new Vector2(osuObject.Position.X, OsuPlayfield.BASE_SIZE.Y - osuObject.Y);
+
+            if (!(osuObject is Slider slider))
+                return osuObject;
+
+            slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
+            slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
+
+            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
+            foreach (var point in controlPoints)
+                point.Position.Value = new Vector2(point.Position.Value.X, -point.Position.Value.Y);
+
+            slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
+
+            return osuObject;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -106,16 +106,15 @@ namespace osu.Game.Rulesets.Osu.Utils
         }
 
         /// <summary>
-        /// Reflects an OsuHitObject's position horizontally.
+        /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield vertically.
         /// </summary>
-        /// <param name="osuObject">The OsuHitObject to be reflected.</param>
-        /// <returns>The reflected OsuHitObject.</returns>
-        public static OsuHitObject ReflectOsuHitObjectHorizontally(OsuHitObject osuObject)
+        /// <param name="osuObject">The object to reflect.</param>
+        public static void ReflectHorizontally(OsuHitObject osuObject)
         {
             osuObject.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - osuObject.X, osuObject.Position.Y);
 
             if (!(osuObject is Slider slider))
-                return osuObject;
+                return;
 
             slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
             slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
@@ -125,21 +124,18 @@ namespace osu.Game.Rulesets.Osu.Utils
                 point.Position.Value = new Vector2(-point.Position.Value.X, point.Position.Value.Y);
 
             slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
-
-            return osuObject;
         }
 
         /// <summary>
-        /// Reflects an OsuHitObject's position vertically.
+        /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield horizontally.
         /// </summary>
-        /// <param name="osuObject">The OsuHitObject to be reflected.</param>
-        /// <returns>The reflected OsuHitObject.</returns>
-        public static OsuHitObject ReflectOsuHitObjectVertically(OsuHitObject osuObject)
+        /// <param name="osuObject">The object to reflect.</param>
+        public static void ReflectVertically(OsuHitObject osuObject)
         {
             osuObject.Position = new Vector2(osuObject.Position.X, OsuPlayfield.BASE_SIZE.Y - osuObject.Y);
 
             if (!(osuObject is Slider slider))
-                return osuObject;
+                return;
 
             slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
             slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
@@ -149,8 +145,6 @@ namespace osu.Game.Rulesets.Osu.Utils
                 point.Position.Value = new Vector2(point.Position.Value.X, -point.Position.Value.Y);
 
             slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
-
-            return osuObject;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Utils
         }
 
         /// <summary>
-        /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield vertically.
+        /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield horizontally.
         /// </summary>
         /// <param name="osuObject">The object to reflect.</param>
         public static void ReflectHorizontally(OsuHitObject osuObject)
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Utils
         }
 
         /// <summary>
-        /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield horizontally.
+        /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield vertically.
         /// </summary>
         /// <param name="osuObject">The object to reflect.</param>
         public static void ReflectVertically(OsuHitObject osuObject)

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -9,6 +9,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "MR";
         public override ModType Type => ModType.Conversion;
         public override string Description => "Flips the beatmap horizontally.";
-		public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Mirror";
         public override string Acronym => "MR";
         public override ModType Type => ModType.Conversion;
-        public override string Description => "Flips the beatmap horizontally.";
         public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModMirror : Mod
+    {
+        public override string Name => "Mirror";
+        public override string Acronym => "MR";
+        public override ModType Type => ModType.Conversion;
+        public override string Description => "Flips the beatmap horizontally.";
+		public override double ScoreMultiplier => 1;
+    }
+}


### PR DESCRIPTION
Previously discussed in #7334 and #6954. I'm opening a new pull request purely for osu! standard to avoid the issues peppy had with the old one futzing around with things outside of the `Mod` class.

Rationale:
- Allow beatmaps that may favor one laterality over another to maintain a neutral difficulty regardless of handedness.
- Provide a mod to help players overcome mindblocks.

`OsuModMirror` is modified from `OsuModHardRock`.