### PR TITLE
Fix rooms in online-play longue screen no longer scrollable by dragging

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
@@ -10,6 +10,7 @@ using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Tests.Visual.OnlinePlay;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Playlists
 {
@@ -31,16 +32,34 @@ namespace osu.Game.Tests.Visual.Playlists
         private RoomsContainer roomsContainer => loungeScreen.ChildrenOfType<RoomsContainer>().First();
 
         [Test]
+        public void TestScrollByDraggingRooms()
+        {
+            AddStep("reset mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("add rooms", () => RoomManager.AddRooms(30));
+
+            AddUntilStep("first room is not masked", () => checkRoomVisible(roomsContainer.Rooms[0]));
+
+            AddStep("move mouse to third room", () => InputManager.MoveMouseTo(roomsContainer.Rooms[2]));
+            AddStep("hold down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("drag to top", () => InputManager.MoveMouseTo(roomsContainer.Rooms[0]));
+
+            AddAssert("first and second room masked", ()
+                => !checkRoomVisible(roomsContainer.Rooms[0]) &&
+                   !checkRoomVisible(roomsContainer.Rooms[1]));
+        }
+
+        [Test]
         public void TestScrollSelectedIntoView()
         {
             AddStep("add rooms", () => RoomManager.AddRooms(30));
 
-            AddUntilStep("first room is not masked", () => checkRoomVisible(roomsContainer.Rooms.First()));
+            AddUntilStep("first room is not masked", () => checkRoomVisible(roomsContainer.Rooms[0]));
 
-            AddStep("select last room", () => roomsContainer.Rooms.Last().Click());
+            AddStep("select last room", () => roomsContainer.Rooms[^1].Click());
 
-            AddUntilStep("first room is masked", () => !checkRoomVisible(roomsContainer.Rooms.First()));
-            AddUntilStep("last room is not masked", () => checkRoomVisible(roomsContainer.Rooms.Last()));
+            AddUntilStep("first room is masked", () => !checkRoomVisible(roomsContainer.Rooms[0]));
+            AddUntilStep("last room is not masked", () => checkRoomVisible(roomsContainer.Rooms[^1]));
         }
 
         private bool checkRoomVisible(DrawableRoom room) =>

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -275,14 +275,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         protected override bool ShouldBeConsideredForInput(Drawable child) => state == SelectionState.Selected;
 
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            if (selectedRoom.Value != Room)
-                return true;
-
-            return base.OnMouseDown(e);
-        }
-
         protected override bool OnClick(ClickEvent e)
         {
             if (Room != selectedRoom.Value)


### PR DESCRIPTION
Closes #14015 

This was regressed by #13861, on this commit specifically https://github.com/ppy/osu/pull/13861/commits/b4ca6b6188d90c4db0436a19ec57364b6942ac41.

Once a drawable under a scroll container handles a `OnMouseDown` event, the scroll container will no longer be in the input queue to receive drags on that specific mouse holding.

Therefore in order to still be draggable, the drawable must only handle `OnClick` without `OnMouseDown`.

@peppy requesting your review to confirm I'm not missing something with this, tested both multiplayer longue with protected rooms and playlists longue, and everything is working as it should be.