### PR TITLE
Fix keyboard navigation at multiplayer lounge not iterating in correct order

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Osu;
@@ -60,6 +62,31 @@ namespace osu.Game.Tests.Visual.Multiplayer
             press(Key.Down);
             press(Key.Down);
             AddAssert("last room selected", () => checkRoomSelected(RoomManager.Rooms.Last()));
+        }
+
+        [Test]
+        public void TestKeyboardNavigationAfterOrderChange()
+        {
+            AddStep("add rooms", () => RoomManager.AddRooms(3));
+
+            AddStep("reorder rooms", () =>
+            {
+                var room = RoomManager.Rooms[1];
+
+                RoomManager.RemoveRoom(room);
+                RoomManager.AddRoom(room);
+            });
+
+            AddAssert("no selection", () => checkRoomSelected(null));
+
+            press(Key.Down);
+            AddAssert("first room selected", () => checkRoomSelected(getRoomInFlow(0)));
+
+            press(Key.Down);
+            AddAssert("second room selected", () => checkRoomSelected(getRoomInFlow(1)));
+
+            press(Key.Down);
+            AddAssert("third room selected", () => checkRoomSelected(getRoomInFlow(2)));
         }
 
         [Test]
@@ -121,5 +148,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         private bool checkRoomSelected(Room room) => SelectedRoom.Value == room;
+
+        private Room getRoomInFlow(int index) =>
+            (container.ChildrenOfType<FillFlowContainer<DrawableRoom>>().First().FlowingChildren.ElementAt(index) as DrawableRoom)?.Room;
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private readonly IBindableList<Room> rooms = new BindableList<Room>();
 
         private readonly FillFlowContainer<DrawableRoom> roomFlow;
-        public IReadOnlyList<DrawableRoom> Rooms => roomFlow;
+
+        public IReadOnlyList<DrawableRoom> Rooms => roomFlow.FlowingChildren.Cast<DrawableRoom>().ToArray();
 
         [Resolved(CanBeNull = true)]
         private Bindable<FilterCriteria> filter { get; set; }

--- a/osu.Game/Tests/Visual/OnlinePlay/BasicTestRoomManager.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/BasicTestRoomManager.cs
@@ -18,11 +18,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
     /// </summary>
     public class BasicTestRoomManager : IRoomManager
     {
-        public event Action RoomsUpdated
-        {
-            add { }
-            remove { }
-        }
+        public event Action RoomsUpdated;
 
         public readonly BindableList<Room> Rooms = new BindableList<Room>();
 
@@ -35,8 +31,21 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
         {
             room.RoomID.Value ??= Rooms.Select(r => r.RoomID.Value).Where(id => id != null).Select(id => id.Value).DefaultIfEmpty().Max() + 1;
-            Rooms.Add(room);
             onSuccess?.Invoke(room);
+
+            AddRoom(room);
+        }
+
+        public void AddRoom(Room room)
+        {
+            Rooms.Add(room);
+            RoomsUpdated?.Invoke();
+        }
+
+        public void RemoveRoom(Room room)
+        {
+            Rooms.Remove(room);
+            RoomsUpdated?.Invoke();
         }
 
         public void JoinRoom(Room room, string password, Action<Room> onSuccess = null, Action<string> onError = null)
@@ -56,6 +65,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                 var room = new Room
                 {
                     RoomID = { Value = i },
+                    Position = { Value = i },
                     Name = { Value = $"Room {i}" },
                     Host = { Value = new User { Username = "Host" } },
                     EndDate = { Value = DateTimeOffset.Now + TimeSpan.FromSeconds(10) },


### PR DESCRIPTION
Keyboard iteration was not considering the flowing order of the drawables. In the case where a room was removed and then readded (as is the case when leaving a room as a non-host) this would cause incorrect keyboard navigation order.
