### PR TITLE
Move catcher trail generation logic to `CatcherArea` to remove mutual dependency of `Catcher` and `CatcherTrailDisplay`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Catch.Tests
                 }
             };
 
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 12; i++)
             {
-                float width = (i % 10 + 1) / 20f * CatchPlayfield.WIDTH;
+                float width = (i + 1) / 20f * CatchPlayfield.WIDTH;
 
                 beatmap.HitObjects.Add(new JuiceStream
                 {
@@ -39,8 +39,8 @@ namespace osu.Game.Rulesets.Catch.Tests
                         Vector2.Zero,
                         new Vector2(width, 0)
                     }),
-                    StartTime = i * 2000,
-                    NewCombo = i % 8 == 0,
+                    StartTime = i * 1000,
+                    NewCombo = i % 5 == 0,
                     Samples = new List<HitSampleInfo>(new[]
                     {
                         new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "normal", volume: 100)

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Catch.Tests
                 }
             };
 
-            for (int i = 0; i < 12; i++)
+            for (int i = 0; i < 100; i++)
             {
-                float width = (i + 1) / 20f * CatchPlayfield.WIDTH;
+                float width = (i % 10 + 1) / 20f * CatchPlayfield.WIDTH;
 
                 beatmap.HitObjects.Add(new JuiceStream
                 {
@@ -39,8 +39,8 @@ namespace osu.Game.Rulesets.Catch.Tests
                         Vector2.Zero,
                         new Vector2(width, 0)
                     }),
-                    StartTime = i * 1000,
-                    NewCombo = i % 5 == 0,
+                    StartTime = i * 2000,
+                    NewCombo = i % 8 == 0,
                     Samples = new List<HitSampleInfo>(new[]
                     {
                         new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "normal", volume: 100)

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 var skin = new TestSkin { FlipCatcherPlate = flip };
                 container.Child = new SkinProvidingContainer(skin)
                 {
-                    Child = catcher = new Catcher(new Container(), new DroppedObjectContainer())
+                    Child = catcher = new Catcher(new CatcherTrailDisplay(), new DroppedObjectContainer())
                     {
                         Anchor = Anchor.Centre
                     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 var skin = new TestSkin { FlipCatcherPlate = flip };
                 container.Child = new SkinProvidingContainer(skin)
                 {
-                    Child = catcher = new Catcher(new CatcherTrailDisplay(), new DroppedObjectContainer())
+                    Child = catcher = new Catcher(new DroppedObjectContainer())
                     {
                         Anchor = Anchor.Centre
                     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private Container trailContainer;
+        private CatcherTrailDisplay trailDisplay;
 
         private DroppedObjectContainer droppedObjectContainer;
 
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 CircleSize = 0,
             };
 
-            trailContainer = new Container();
+            trailDisplay = new CatcherTrailDisplay();
             droppedObjectContainer = new DroppedObjectContainer();
 
             Child = new Container
@@ -54,8 +54,8 @@ namespace osu.Game.Rulesets.Catch.Tests
                 Children = new Drawable[]
                 {
                     droppedObjectContainer,
-                    catcher = new TestCatcher(trailContainer, droppedObjectContainer, difficulty),
-                    trailContainer,
+                    catcher = new TestCatcher(trailDisplay, droppedObjectContainer, difficulty),
+                    trailDisplay,
                 }
             };
         });
@@ -294,8 +294,8 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
-            public TestCatcher(Container trailsTarget, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
-                : base(trailsTarget, droppedObjectTarget, difficulty)
+            public TestCatcher(CatcherTrailDisplay trails, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
+                : base(trails, droppedObjectTarget, difficulty)
             {
             }
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private CatcherTrailDisplay trailDisplay;
-
         private DroppedObjectContainer droppedObjectContainer;
 
         private TestCatcher catcher;
@@ -45,7 +43,6 @@ namespace osu.Game.Rulesets.Catch.Tests
                 CircleSize = 0,
             };
 
-            trailDisplay = new CatcherTrailDisplay();
             droppedObjectContainer = new DroppedObjectContainer();
 
             Child = new Container
@@ -54,8 +51,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 Children = new Drawable[]
                 {
                     droppedObjectContainer,
-                    catcher = new TestCatcher(trailDisplay, droppedObjectContainer, difficulty),
-                    trailDisplay,
+                    catcher = new TestCatcher(droppedObjectContainer, difficulty),
                 }
             };
         });
@@ -294,8 +290,8 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
-            public TestCatcher(CatcherTrailDisplay trails, DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
-                : base(trails, droppedObjectTarget, difficulty)
+            public TestCatcher(DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty)
+                : base(droppedObjectTarget, difficulty)
             {
             }
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -121,11 +121,13 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
             {
-                var droppedObjectContainer = new DroppedObjectContainer();
+                var trailDisplay = new CatcherTrailDisplay { Depth = -1 };
+                Add(trailDisplay);
 
+                var droppedObjectContainer = new DroppedObjectContainer();
                 Add(droppedObjectContainer);
 
-                Catcher = new Catcher(this, droppedObjectContainer, beatmapDifficulty)
+                Catcher = new Catcher(trailDisplay, droppedObjectContainer, beatmapDifficulty)
                 {
                     X = CatchPlayfield.CENTER_X
                 };

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -121,13 +121,10 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
             {
-                var trailDisplay = new CatcherTrailDisplay { Depth = -1 };
-                Add(trailDisplay);
-
                 var droppedObjectContainer = new DroppedObjectContainer();
                 Add(droppedObjectContainer);
 
-                Catcher = new Catcher(trailDisplay, droppedObjectContainer, beatmapDifficulty)
+                Catcher = new Catcher(droppedObjectContainer, beatmapDifficulty)
                 {
                     X = CatchPlayfield.CENTER_X
                 };

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -118,19 +118,19 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                trails = new CatcherTrailDisplay();
+                CatcherArea catcherArea;
                 Child = setupSkinHierarchy(new Container
                 {
                     Anchor = Anchor.Centre,
-                    Children = new Drawable[]
+                    Child = catcherArea = new CatcherArea
                     {
-                        catcher = new Catcher(trails, new DroppedObjectContainer())
+                        Catcher = catcher = new Catcher(new DroppedObjectContainer())
                         {
                             Scale = new Vector2(4)
-                        },
-                        trails
+                        }
                     }
                 }, skin);
+                trails = catcherArea.CatcherTrails;
             });
 
             AddStep("start hyper-dash", () =>

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -113,30 +113,28 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private void checkHyperDashCatcherColour(ISkin skin, Color4 expectedCatcherColour, Color4? expectedEndGlowColour = null)
         {
-            Container trailsContainer = null;
-            Catcher catcher = null;
             CatcherTrailDisplay trails = null;
+            Catcher catcher = null;
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                trailsContainer = new Container();
+                trails = new CatcherTrailDisplay();
                 Child = setupSkinHierarchy(new Container
                 {
                     Anchor = Anchor.Centre,
                     Children = new Drawable[]
                     {
-                        catcher = new Catcher(trailsContainer, new DroppedObjectContainer())
+                        catcher = new Catcher(trails, new DroppedObjectContainer())
                         {
                             Scale = new Vector2(4)
                         },
-                        trailsContainer
+                        trails
                     }
                 }, skin);
             });
 
-            AddStep("get trails container", () =>
+            AddStep("start hyper-dash", () =>
             {
-                trails = trailsContainer.OfType<CatcherTrailDisplay>().Single();
                 catcher.SetHyperDashState(2);
             });
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                         }
                     }
                 }, skin);
-                trails = catcherArea.CatcherTrails;
+                trails = catcherArea.ChildrenOfType<CatcherTrailDisplay>().Single();
             });
 
             AddStep("start hyper-dash", () =>

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -45,14 +44,14 @@ namespace osu.Game.Rulesets.Catch.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            var trailContainer = new Container
+            var trailDisplay = new CatcherTrailDisplay
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.TopLeft
             };
             var droppedObjectContainer = new DroppedObjectContainer();
 
-            Catcher = new Catcher(trailContainer, droppedObjectContainer, difficulty)
+            Catcher = new Catcher(trailDisplay, droppedObjectContainer, difficulty)
             {
                 X = CENTER_X
             };
@@ -70,7 +69,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Origin = Anchor.TopLeft,
                     Catcher = Catcher,
                 },
-                trailContainer,
+                trailDisplay,
                 HitObjectContainer,
             });
 

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -44,14 +44,9 @@ namespace osu.Game.Rulesets.Catch.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            var trailDisplay = new CatcherTrailDisplay
-            {
-                Anchor = Anchor.BottomLeft,
-                Origin = Anchor.TopLeft
-            };
             var droppedObjectContainer = new DroppedObjectContainer();
 
-            Catcher = new Catcher(trailDisplay, droppedObjectContainer, difficulty)
+            Catcher = new Catcher(droppedObjectContainer, difficulty)
             {
                 X = CENTER_X
             };
@@ -69,7 +64,6 @@ namespace osu.Game.Rulesets.Catch.UI
                     Origin = Anchor.TopLeft,
                     Catcher = Catcher,
                 },
-                trailDisplay,
                 HitObjectContainer,
             });
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -115,7 +115,6 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly SkinnableCatcher body;
 
         private Color4 hyperDashColour = DEFAULT_HYPER_DASH_COLOUR;
-        private Color4 hyperDashEndGlowColour = DEFAULT_HYPER_DASH_COLOUR;
 
         private double hyperDashModifier = 1;
         private int hyperDashDirection;
@@ -322,13 +321,6 @@ namespace osu.Game.Rulesets.Catch.UI
             hyperDashColour =
                 skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value ??
                 DEFAULT_HYPER_DASH_COLOUR;
-
-            hyperDashEndGlowColour =
-                skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value ??
-                hyperDashColour;
-
-            trails.HyperDashTrailsColour = hyperDashColour;
-            trails.EndGlowSpritesColour = hyperDashEndGlowColour;
 
             flipCatcherPlate = skin.GetConfig<CatchSkinConfiguration, bool>(CatchSkinConfiguration.FlipCatcherPlate)?.Value ?? true;
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -92,6 +92,9 @@ namespace osu.Game.Rulesets.Catch.UI
             private set => Body.AnimationState.Value = value;
         }
 
+        /// <summary>
+        /// Whether the catcher is currently dashing.
+        /// </summary>
         public bool Dashing { get; set; }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -88,8 +88,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatcherAnimationState CurrentState
         {
-            get => Body.AnimationState.Value;
-            private set => Body.AnimationState.Value = value;
+            get => body.AnimationState.Value;
+            private set => body.AnimationState.Value = value;
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private readonly float catchWidth;
 
-        internal readonly SkinnableCatcher Body;
+        private readonly SkinnableCatcher body;
 
         private Color4 hyperDashColour = DEFAULT_HYPER_DASH_COLOUR;
         private Color4 hyperDashEndGlowColour = DEFAULT_HYPER_DASH_COLOUR;
@@ -154,7 +154,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     // offset fruit vertically to better place "above" the plate.
                     Y = -5
                 },
-                Body = new SkinnableCatcher(),
+                body = new SkinnableCatcher(),
                 hitExplosionContainer = new HitExplosionContainer
                 {
                     Anchor = Anchor.TopCentre,
@@ -294,7 +294,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 if (!wasHyperDashing)
                 {
-                    trails.DisplayEndGlow(CurrentState, X, Scale * Body.Scale);
+                    trails.DisplayEndGlow(CurrentState, X, Scale * body.Scale);
                     runHyperDashStateTransition(true);
                 }
             }
@@ -340,7 +340,7 @@ namespace osu.Game.Rulesets.Catch.UI
             base.Update();
 
             var scaleFromDirection = new Vector2((int)VisualDirection, 1);
-            Body.Scale = scaleFromDirection;
+            body.Scale = scaleFromDirection;
             caughtObjectContainer.Scale = hitExplosionContainer.Scale = flipCatcherPlate ? scaleFromDirection : Vector2.One;
 
             // Correct overshooting.
@@ -357,7 +357,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 double generationInterval = HyperDashing ? 25 : 50;
 
                 if (Time.Current - lastTrailTime >= generationInterval)
-                    trails.DisplayDashTrail(CurrentState, X, Scale * Body.Scale, HyperDashing);
+                    trails.DisplayDashTrail(CurrentState, X, Scale * body.Scale, HyperDashing);
             }
         }
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -72,11 +72,6 @@ namespace osu.Game.Rulesets.Catch.UI
         private const float caught_fruit_scale_adjust = 0.5f;
 
         /// <summary>
-        /// Contains trails and afterimages (also called "end glow" in code) of the catcher.
-        /// </summary>
-        private readonly CatcherTrailDisplay trails;
-
-        /// <summary>
         /// Contains caught objects on the plate.
         /// </summary>
         private readonly Container<CaughtObject> caughtObjectContainer;
@@ -101,6 +96,8 @@ namespace osu.Game.Rulesets.Catch.UI
         /// The currently facing direction.
         /// </summary>
         public Direction VisualDirection { get; set; } = Direction.Right;
+
+        public Vector2 BodyScale => Scale * body.Scale;
 
         /// <summary>
         /// Whether the contents of the catcher plate should be visually flipped when the catcher direction is changed.
@@ -127,9 +124,8 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
         private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
 
-        public Catcher([NotNull] CatcherTrailDisplay trails, [NotNull] DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] DroppedObjectContainer droppedObjectTarget, BeatmapDifficulty difficulty = null)
         {
-            this.trails = trails;
             this.droppedObjectTarget = droppedObjectTarget;
 
             Origin = Anchor.TopCentre;
@@ -292,10 +288,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 hyperDashTargetPosition = targetPosition;
 
                 if (!wasHyperDashing)
-                {
-                    trails.DisplayEndGlow(CurrentState, X, Scale * body.Scale);
                     runHyperDashStateTransition(true);
-                }
             }
         }
 
@@ -341,15 +334,6 @@ namespace osu.Game.Rulesets.Catch.UI
             {
                 X = hyperDashTargetPosition;
                 SetHyperDashState();
-            }
-
-            if (Dashing || HyperDashing)
-            {
-                double lastTrailTime = trails.LastDashTrail?.LifetimeStart ?? double.NegativeInfinity;
-                double generationInterval = HyperDashing ? 25 : 50;
-
-                if (Time.Current - lastTrailTime >= generationInterval)
-                    trails.DisplayDashTrail(CurrentState, X, Scale * body.Scale, HyperDashing);
             }
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -28,11 +28,11 @@ namespace osu.Game.Rulesets.Catch.UI
             set => catcherContainer.Child = catcher = value;
         }
 
-        internal CatcherTrailDisplay CatcherTrails { get; }
-
         private readonly Container<Catcher> catcherContainer;
 
         private readonly CatchComboDisplay comboDisplay;
+
+        private readonly CatcherTrailDisplay catcherTrails;
 
         private Catcher catcher;
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Catch.UI
             Children = new Drawable[]
             {
                 catcherContainer = new Container<Catcher> { RelativeSizeAxes = Axes.Both },
-                CatcherTrails = new CatcherTrailDisplay(),
+                catcherTrails = new CatcherTrailDisplay(),
                 comboDisplay = new CatchComboDisplay
                 {
                     RelativeSizeAxes = Axes.None,
@@ -110,14 +110,14 @@ namespace osu.Game.Rulesets.Catch.UI
             comboDisplay.X = Catcher.X;
 
             if (!lastHyperDashState && Catcher.HyperDashing && Time.Elapsed > 0)
-                CatcherTrails.DisplayEndGlow(Catcher.CurrentState, Catcher.X, Catcher.BodyScale);
+                catcherTrails.DisplayEndGlow(Catcher.CurrentState, Catcher.X, Catcher.BodyScale);
 
             if (Catcher.Dashing || Catcher.HyperDashing)
             {
                 double generationInterval = Catcher.HyperDashing ? 25 : 50;
 
-                if (Time.Current - CatcherTrails.LastDashTrailTime >= generationInterval)
-                    CatcherTrails.DisplayDashTrail(Catcher.CurrentState, Catcher.X, Catcher.BodyScale, Catcher.HyperDashing);
+                if (Time.Current - catcherTrails.LastDashTrailTime >= generationInterval)
+                    catcherTrails.DisplayDashTrail(Catcher.CurrentState, Catcher.X, Catcher.BodyScale, Catcher.HyperDashing);
             }
 
             lastHyperDashState = Catcher.HyperDashing;

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -114,10 +114,9 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (Catcher.Dashing || Catcher.HyperDashing)
             {
-                double lastTrailTime = CatcherTrails.LastDashTrail?.LifetimeStart ?? double.NegativeInfinity;
                 double generationInterval = Catcher.HyperDashing ? 25 : 50;
 
-                if (Time.Current - lastTrailTime >= generationInterval)
+                if (Time.Current - CatcherTrails.LastDashTrailTime >= generationInterval)
                     CatcherTrails.DisplayDashTrail(Catcher.CurrentState, Catcher.X, Catcher.BodyScale, Catcher.HyperDashing);
             }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -17,6 +17,10 @@ namespace osu.Game.Rulesets.Catch.UI
     /// </summary>
     public class CatcherTrailDisplay : CompositeDrawable
     {
+        /// <summary>
+        /// The most recent dash trail added in this container.
+        /// Only alive (not faded out) trails are considered.
+        /// </summary>
         [CanBeNull]
         public CatcherTrail LastDashTrail => dashTrails.Concat(hyperDashTrails)
                                                        .OrderByDescending(trail => trail.LifetimeStart)

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -1,8 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
-using JetBrains.Annotations;
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
@@ -20,13 +19,11 @@ namespace osu.Game.Rulesets.Catch.UI
     public class CatcherTrailDisplay : SkinReloadableDrawable
     {
         /// <summary>
-        /// The most recent dash trail added in this container.
+        /// The most recent time a dash trail was added to this container.
         /// Only alive (not faded out) trails are considered.
+        /// Returns <see cref="double.NegativeInfinity"/> if no dash trail is alive.
         /// </summary>
-        [CanBeNull]
-        public CatcherTrail LastDashTrail => dashTrails.Concat(hyperDashTrails)
-                                                       .OrderByDescending(trail => trail.LifetimeStart)
-                                                       .FirstOrDefault();
+        public double LastDashTrailTime => getLastDashTrailTime();
 
         public Color4 HyperDashTrailsColour => hyperDashTrails.Colour;
 
@@ -96,6 +93,19 @@ namespace osu.Game.Rulesets.Catch.UI
             sprite.Position = new Vector2(x, 0);
 
             return sprite;
+        }
+
+        private double getLastDashTrailTime()
+        {
+            double maxTime = double.NegativeInfinity;
+
+            foreach (var trail in dashTrails)
+                maxTime = Math.Max(maxTime, trail.LifetimeStart);
+
+            foreach (var trail in hyperDashTrails)
+                maxTime = Math.Max(maxTime, trail.LifetimeStart);
+
+            return maxTime;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Catch.Skinning;
+using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 
@@ -15,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.UI
     /// Represents a component responsible for displaying
     /// the appropriate catcher trails when requested to.
     /// </summary>
-    public class CatcherTrailDisplay : CompositeDrawable
+    public class CatcherTrailDisplay : SkinReloadableDrawable
     {
         /// <summary>
         /// The most recent dash trail added in this container.
@@ -26,41 +28,15 @@ namespace osu.Game.Rulesets.Catch.UI
                                                        .OrderByDescending(trail => trail.LifetimeStart)
                                                        .FirstOrDefault();
 
+        public Color4 HyperDashTrailsColour => hyperDashTrails.Colour;
+
+        public Color4 EndGlowSpritesColour => endGlowSprites.Colour;
+
         private readonly DrawablePool<CatcherTrail> trailPool;
 
         private readonly Container<CatcherTrail> dashTrails;
         private readonly Container<CatcherTrail> hyperDashTrails;
         private readonly Container<CatcherTrail> endGlowSprites;
-
-        private Color4 hyperDashTrailsColour = Catcher.DEFAULT_HYPER_DASH_COLOUR;
-
-        public Color4 HyperDashTrailsColour
-        {
-            get => hyperDashTrailsColour;
-            set
-            {
-                if (hyperDashTrailsColour == value)
-                    return;
-
-                hyperDashTrailsColour = value;
-                hyperDashTrails.Colour = hyperDashTrailsColour;
-            }
-        }
-
-        private Color4 endGlowSpritesColour = Catcher.DEFAULT_HYPER_DASH_COLOUR;
-
-        public Color4 EndGlowSpritesColour
-        {
-            get => endGlowSpritesColour;
-            set
-            {
-                if (endGlowSpritesColour == value)
-                    return;
-
-                endGlowSpritesColour = value;
-                endGlowSprites.Colour = endGlowSpritesColour;
-            }
-        }
 
         public CatcherTrailDisplay()
         {
@@ -73,6 +49,14 @@ namespace osu.Game.Rulesets.Catch.UI
                 hyperDashTrails = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
                 endGlowSprites = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
             };
+        }
+
+        protected override void SkinChanged(ISkinSource skin)
+        {
+            base.SkinChanged(skin);
+
+            hyperDashTrails.Colour = skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value ?? Catcher.DEFAULT_HYPER_DASH_COLOUR;
+            endGlowSprites.Colour = skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value ?? hyperDashTrails.Colour;
         }
 
         /// <summary>


### PR DESCRIPTION
There was a mutual dependency between `CatcherTrailDisplay` and `Catcher`, resulting in some awkward code (e.g. `Container` passed to the catcher, and the internal `Catcher.Body`).
In this PR, Trail generation logic is moved to `Catcher`. The `CatcherTrailDisplay` is now more passive.
The generation logic no longer uses delayed scheduling because the hidden state is hard to manage.
Instead, the last time a trail is generated is calculated (has to be calculated due to replay rewind) and used.
The new logic has a different behavior when the dash key is pressed in succession under 50ms, but it is not noticeable for normal plays.
<s><https://github.com/ppy/osu/pull/14024/commits/0fbe950a3c452f645f811147d624836c4ca9c996> is just an aid to visually inspect trails (esp. when hyper-dashing) in a replay environment.</s> Edit: reverted.