### PR TITLE
Add support for markdown in comments

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Tests.Visual.Online
         private static object[] comments =
         {
             new[] { "Plain", "This is plain comment" },
+            new[] { "Link", "Please visit https://osu.ppy.sh" },
 
             new[]
             {

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
@@ -59,6 +59,17 @@ namespace osu.Game.Tests.Visual.Online
         private static object[] comments =
         {
             new[] { "Plain", "This is plain comment" },
+
+            new[]
+            {
+                "Heading", @"# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6"
+            },
+
             // Taken from https://github.com/ppy/osu/issues/13993#issuecomment-885994077
             new[]
             {

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Comments;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public class TestSceneDrawableComment : OsuTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        private Container container;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background4,
+                },
+                container = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                },
+            };
+        });
+
+        [TestCaseSource(nameof(comments))]
+        public void TestComment(string description, string text)
+        {
+            AddStep(description, () =>
+            {
+                comment.Message = text;
+                container.Add(new DrawableComment(comment));
+            });
+        }
+
+        private static readonly Comment comment = new Comment
+        {
+            Id = 1,
+            LegacyName = "Test User",
+            CreatedAt = DateTimeOffset.Now,
+            VotesCount = 0,
+        };
+
+        private static object[] comments =
+        {
+            new[] { "Plain", "This is plain comment" },
+            // Taken from https://github.com/ppy/osu/issues/13993#issuecomment-885994077
+            new[]
+            {
+                "Problematic", @"My tablet doesn't work :(
+It's a Huion 420 and it's apparently incompatible with OpenTablet Driver. The warning I get is: ""DeviceInUseException: Device is currently in use by another kernel module. To fix this issue, please follow the instructions from https://github.com/OpenTabletDriver/OpenTabletDriver/wiki/Linux-FAQ#arg    umentoutofrangeexception-value-0-15"" and it repeats 4 times on the notification before logging subsequent warnings.
+Checking the logs, it looks for other Huion tablets before sending the notification (e.g.
+ ""2021-07-23 03:52:33 [verbose]: Detect: Searching for tablet 'Huion WH1409 V2'
+ 20 2021-07-23 03:52:33 [error]: DeviceInUseException: Device is currently in use by another kernel module. To fix this     issue, please follow the instructions from https://github.com/OpenTabletDriver/OpenTabletDriver/wiki/Linux-FAQ#arg    umentoutofrangeexception-value-0-15"")
+I use an Arch based installation of Linux and the tablet runs perfectly with Digimend kernel driver, with area configuration, pen pressure, etc. On osu!lazer the cursor disappears until I set it to ""Borderless"" instead of ""Fullscreen"" and even after it shows up, it goes to the bottom left corner as soon as a map starts.
+I have honestly 0 idea of whats going on at this point."
+            }
+        };
+    }
+}

--- a/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Game.Graphics.Containers.Markdown;
@@ -11,10 +12,37 @@ namespace osu.Game.Overlays.Comments
     {
         public override MarkdownTextFlowContainer CreateTextFlow() => new CommentMarkdownTextFlowContainer();
 
+        protected override MarkdownHeading CreateHeading(HeadingBlock headingBlock) => new CommentMarkdownHeading(headingBlock);
+
         private class CommentMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer
         {
             // Don't render image in comment for now
             protected override void AddImage(LinkInline linkInline) { }
+        }
+
+        private class CommentMarkdownHeading : OsuMarkdownHeading
+        {
+            public CommentMarkdownHeading(HeadingBlock headingBlock)
+                : base(headingBlock)
+            {
+            }
+
+            protected override float GetFontSizeByLevel(int level)
+            {
+                var defaultFontSize = base.GetFontSizeByLevel(6);
+
+                switch (level)
+                {
+                    case 1:
+                        return 1.2f * defaultFontSize;
+
+                    case 2:
+                        return 1.1f * defaultFontSize;
+
+                    default:
+                        return defaultFontSize;
+                }
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Syntax.Inlines;
+using osu.Framework.Graphics.Containers.Markdown;
+using osu.Game.Graphics.Containers.Markdown;
+
+namespace osu.Game.Overlays.Comments
+{
+    public class CommentMarkdownContainer : OsuMarkdownContainer
+    {
+        public override MarkdownTextFlowContainer CreateTextFlow() => new CommentMarkdownTextFlowContainer();
+
+        private class CommentMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer
+        {
+            // Don't render image in comment for now
+            protected override void AddImage(LinkInline linkInline) { }
+        }
+    }
+}

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Bindables;
 using System.Linq;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Online.Chat;
 using osu.Framework.Allocation;
 using System.Collections.Generic;
 using System;
@@ -61,7 +60,7 @@ namespace osu.Game.Overlays.Comments
         {
             LinkFlowContainer username;
             FillFlowContainer info;
-            LinkFlowContainer message;
+            CommentMarkdownContainer message;
             GridContainer content;
             VotePill votePill;
 
@@ -153,10 +152,12 @@ namespace osu.Game.Overlays.Comments
                                                         }
                                                     }
                                                 },
-                                                message = new LinkFlowContainer(s => s.Font = OsuFont.GetFont(size: 14))
+                                                message = new CommentMarkdownContainer
                                                 {
                                                     RelativeSizeAxes = Axes.X,
-                                                    AutoSizeAxes = Axes.Y
+                                                    AutoSizeAxes = Axes.Y,
+                                                    DocumentMargin = new MarginPadding(0),
+                                                    DocumentPadding = new MarginPadding(0),
                                                 },
                                                 info = new FillFlowContainer
                                                 {
@@ -275,10 +276,7 @@ namespace osu.Game.Overlays.Comments
             }
 
             if (Comment.HasMessage)
-            {
-                var formattedSource = MessageFormatter.FormatText(Comment.Message);
-                message.AddLinks(formattedSource.Text, formattedSource.Links);
-            }
+                message.Text = Comment.Message;
 
             if (Comment.IsDeleted)
             {


### PR DESCRIPTION
close #13993

Looks like the problematic comment from https://github.com/ppy/osu/issues/13993#issuecomment-885994077 can be showed using this.

Not render the image in the comment yet because the sizing is a bit complex. It has [max-height and min-height in web-side](https://github.com/ppy/osu-web/blob/51cc353f3064d61f74d3862392c69d3b18b360ee/resources/assets/less/bem/osu-md.less#L31-L35.). 