### PR TITLE
Use "hyper-dash after-image" terminology consistently

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestCustomEndGlowColour()
+        public void TestCustomAfterImageColour()
         {
             var skin = new TestSkin
             {
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestCustomEndGlowColourPriority()
+        public void TestCustomAfterImageColourPriority()
         {
             var skin = new TestSkin
             {
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             checkHyperDashFruitColour(skin, skin.HyperDashColour);
         }
 
-        private void checkHyperDashCatcherColour(ISkin skin, Color4 expectedCatcherColour, Color4? expectedEndGlowColour = null)
+        private void checkHyperDashCatcherColour(ISkin skin, Color4 expectedCatcherColour, Color4? expectedAfterImageColour = null)
         {
             CatcherTrailDisplay trails = null;
             Catcher catcher = null;
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddUntilStep("catcher colour is correct", () => catcher.Colour == expectedCatcherColour);
 
             AddAssert("catcher trails colours are correct", () => trails.HyperDashTrailsColour == expectedCatcherColour);
-            AddAssert("catcher end-glow colours are correct", () => trails.EndGlowSpritesColour == (expectedEndGlowColour ?? expectedCatcherColour));
+            AddAssert("catcher after-image colours are correct", () => trails.HyperDashAfterImageColour == (expectedAfterImageColour ?? expectedCatcherColour));
 
             AddStep("finish hyper-dashing", () =>
             {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -36,8 +36,7 @@ namespace osu.Game.Rulesets.Catch.UI
         public const float ALLOWED_CATCH_RANGE = 0.8f;
 
         /// <summary>
-        /// The default colour used to tint hyper-dash fruit, along with the moving catcher, its trail
-        /// and end glow/after-image during a hyper-dash.
+        /// The default colour used to tint hyper-dash fruit, along with the moving catcher, its trail and after-image during a hyper-dash.
         /// </summary>
         public static readonly Color4 DEFAULT_HYPER_DASH_COLOUR = Color4.Red;
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Catch.UI
             comboDisplay.X = Catcher.X;
 
             if (!lastHyperDashState && Catcher.HyperDashing && Time.Elapsed > 0)
-                catcherTrails.DisplayEndGlow(Catcher.CurrentState, Catcher.X, Catcher.BodyScale);
+                catcherTrails.DisplayHyperDashAfterImage(Catcher.CurrentState, Catcher.X, Catcher.BodyScale);
 
             if (Catcher.Dashing || Catcher.HyperDashing)
             {

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -27,13 +27,13 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public Color4 HyperDashTrailsColour => hyperDashTrails.Colour;
 
-        public Color4 EndGlowSpritesColour => endGlowSprites.Colour;
+        public Color4 HyperDashAfterImageColour => hyperDashAfterImages.Colour;
 
         private readonly DrawablePool<CatcherTrail> trailPool;
 
         private readonly Container<CatcherTrail> dashTrails;
         private readonly Container<CatcherTrail> hyperDashTrails;
-        private readonly Container<CatcherTrail> endGlowSprites;
+        private readonly Container<CatcherTrail> hyperDashAfterImages;
 
         public CatcherTrailDisplay()
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 trailPool = new DrawablePool<CatcherTrail>(30),
                 dashTrails = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both },
                 hyperDashTrails = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
-                endGlowSprites = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
+                hyperDashAfterImages = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
             };
         }
 
@@ -53,22 +53,22 @@ namespace osu.Game.Rulesets.Catch.UI
             base.SkinChanged(skin);
 
             hyperDashTrails.Colour = skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value ?? Catcher.DEFAULT_HYPER_DASH_COLOUR;
-            endGlowSprites.Colour = skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value ?? hyperDashTrails.Colour;
+            hyperDashAfterImages.Colour = skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value ?? hyperDashTrails.Colour;
         }
 
         /// <summary>
-        /// Displays a single end-glow catcher sprite.
+        /// Displays a hyper-dash after-image of the catcher.
         /// </summary>
-        public void DisplayEndGlow(CatcherAnimationState animationState, float x, Vector2 scale)
+        public void DisplayHyperDashAfterImage(CatcherAnimationState animationState, float x, Vector2 scale)
         {
-            var endGlow = createTrail(animationState, x, scale);
+            var trail = createTrail(animationState, x, scale);
 
-            endGlowSprites.Add(endGlow);
+            hyperDashAfterImages.Add(trail);
 
-            endGlow.MoveToOffset(new Vector2(0, -10), 1200, Easing.In);
-            endGlow.ScaleTo(endGlow.Scale * 0.95f).ScaleTo(endGlow.Scale * 1.2f, 1200, Easing.In);
-            endGlow.FadeOut(1200);
-            endGlow.Expire(true);
+            trail.MoveToOffset(new Vector2(0, -10), 1200, Easing.In);
+            trail.ScaleTo(trail.Scale * 0.95f).ScaleTo(trail.Scale * 1.2f, 1200, Easing.In);
+            trail.FadeOut(1200);
+            trail.Expire(true);
         }
 
         public void DisplayDashTrail(CatcherAnimationState animationState, float x, Vector2 scale, bool hyperDashing)

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -73,26 +73,26 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void DisplayDashTrail(CatcherAnimationState animationState, float x, Vector2 scale, bool hyperDashing)
         {
-            var sprite = createTrail(animationState, x, scale);
+            var trail = createTrail(animationState, x, scale);
 
             if (hyperDashing)
-                hyperDashTrails.Add(sprite);
+                hyperDashTrails.Add(trail);
             else
-                dashTrails.Add(sprite);
+                dashTrails.Add(trail);
 
-            sprite.FadeTo(0.4f).FadeOut(800, Easing.OutQuint);
-            sprite.Expire(true);
+            trail.FadeTo(0.4f).FadeOut(800, Easing.OutQuint);
+            trail.Expire(true);
         }
 
         private CatcherTrail createTrail(CatcherAnimationState animationState, float x, Vector2 scale)
         {
-            CatcherTrail sprite = trailPool.Get();
+            CatcherTrail trail = trailPool.Get();
 
-            sprite.AnimationState = animationState;
-            sprite.Scale = scale;
-            sprite.Position = new Vector2(x, 0);
+            trail.AnimationState = animationState;
+            trail.Scale = scale;
+            trail.Position = new Vector2(x, 0);
 
-            return sprite;
+            return trail;
         }
 
         private double getLastDashTrailTime()


### PR DESCRIPTION
The *end glow* name and *after-image* names were used in code inconsistently.
Because the is "end glow" is when a hyper-dash is *started*, the name was confusing. The *afterimage* terminology is more descriptive and also used in wiki <https://osu.ppy.sh/wiki/en/Game_mode/osu!catch#hyperfruits>.
The "after-image" spelling instead of the "afterimage" spelling is used because there was existing usage of "after-image" in code.