### PR TITLE
Add screen for downloading missing beatmap when importing score

### DIFF
--- a/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
@@ -1,37 +1,47 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.IO.Network;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
+
+#nullable enable
 
 namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapRequest : APIRequest<APIBeatmap>
     {
-        private readonly BeatmapInfo beatmap;
-        private readonly string beatmapHash;
+        private readonly int? id;
+        private readonly string checksum;
+        private readonly string? filename;
 
         public GetBeatmapRequest(BeatmapInfo beatmap)
         {
-            this.beatmap = beatmap;
+            id = beatmap.OnlineBeatmapID;
+            checksum = beatmap.Hash;
+            filename = beatmap.Path ?? string.Empty;
         }
 
         public GetBeatmapRequest(string beatmapHash)
         {
-            this.beatmapHash = beatmapHash;
+            checksum = beatmapHash;
         }
 
-        protected override string Target
+        protected override WebRequest CreateWebRequest()
         {
-            get
-            {
-                if (beatmap == null)
-                {
-                    return $@"beatmaps/lookup?checksum={beatmapHash}";
-                }
+            var request = base.CreateWebRequest();
 
-                return $@"beatmaps/lookup?id={beatmap.OnlineBeatmapID}&checksum={beatmap.MD5Hash}&filename={System.Uri.EscapeUriString(beatmap.Path ?? string.Empty)}";
-            }
+            request.AddParameter(@"checksum", checksum);
+
+            if (id != null)
+                request.AddParameter(@"id", id.Value.ToString());
+
+            if (filename != null)
+                request.AddParameter(@"filename", filename);
+
+            return request;
         }
+
+        protected override string Target => @"beatmaps/lookup";
     }
 }

--- a/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
@@ -9,12 +9,29 @@ namespace osu.Game.Online.API.Requests
     public class GetBeatmapRequest : APIRequest<APIBeatmap>
     {
         private readonly BeatmapInfo beatmap;
+        private readonly string beatmapHash;
 
         public GetBeatmapRequest(BeatmapInfo beatmap)
         {
             this.beatmap = beatmap;
         }
 
-        protected override string Target => $@"beatmaps/lookup?id={beatmap.OnlineBeatmapID}&checksum={beatmap.MD5Hash}&filename={System.Uri.EscapeUriString(beatmap.Path ?? string.Empty)}";
+        public GetBeatmapRequest(string beatmapHash)
+        {
+            this.beatmapHash = beatmapHash;
+        }
+
+        protected override string Target
+        {
+            get
+            {
+                if (beatmap == null)
+                {
+                    return $@"beatmaps/lookup?checksum={beatmapHash}";
+                }
+
+                return $@"beatmaps/lookup?id={beatmap.OnlineBeatmapID}&checksum={beatmap.MD5Hash}&filename={System.Uri.EscapeUriString(beatmap.Path ?? string.Empty)}";
+            }
+        }
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -269,6 +269,7 @@ namespace osu.Game
             Audio.AddAdjustment(AdjustableProperty.Volume, inactiveVolumeFade);
 
             SelectedMods.BindValueChanged(modsChanged);
+            ScoreManager.RequestShowBeatmap += ShowBeatmap;
             Beatmap.BindValueChanged(beatmapChanged, true);
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -269,7 +269,6 @@ namespace osu.Game
             Audio.AddAdjustment(AdjustableProperty.Volume, inactiveVolumeFade);
 
             SelectedMods.BindValueChanged(modsChanged);
-
             Beatmap.BindValueChanged(beatmapChanged, true);
 
             ScoreManager.PerformFromScreen += action => PerformFromScreen(action);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -269,8 +269,10 @@ namespace osu.Game
             Audio.AddAdjustment(AdjustableProperty.Volume, inactiveVolumeFade);
 
             SelectedMods.BindValueChanged(modsChanged);
-            ScoreManager.RequestShowBeatmap += ShowBeatmap;
+
             Beatmap.BindValueChanged(beatmapChanged, true);
+
+            ScoreManager.PerformFromScreen += action => PerformFromScreen(action);
         }
 
         private ExternalLinkOpener externalLinkOpener;

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -41,9 +41,10 @@ namespace osu.Game.Scoring.Legacy
 
                 var version = sr.ReadInt32();
 
-                workingBeatmap = GetBeatmap(sr.ReadString());
+                string beatmapHash;
+                workingBeatmap = GetBeatmap(beatmapHash = sr.ReadString());
                 if (workingBeatmap is DummyWorkingBeatmap)
-                    throw new BeatmapNotFoundException();
+                    throw new BeatmapNotFoundException(beatmapHash);
 
                 scoreInfo.User = new User { Username = sr.ReadString() };
 
@@ -299,9 +300,12 @@ namespace osu.Game.Scoring.Legacy
 
         public class BeatmapNotFoundException : Exception
         {
-            public BeatmapNotFoundException()
+            public string BeatmapHash;
+
+            public BeatmapNotFoundException(string beatmapHash)
                 : base("No corresponding beatmap for the score could be found.")
             {
+                BeatmapHash = beatmapHash;
             }
         }
     }

--- a/osu.Game/Screens/Import/ReplayImportScreen.cs
+++ b/osu.Game/Screens/Import/ReplayImportScreen.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.IO.Archives;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.BeatmapListing.Panels;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Screens.OnlinePlay.Match.Components;
+using osu.Game.Screens.Ranking;
+using osuTK;
+
+namespace osu.Game.Screens.Import
+{
+    public class ReplayImportScreen : OsuScreen
+    {
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
+        private BeatmapSetInfo onlineBeatmap;
+        private Container container;
+        private Container beatmapPanelContainer;
+        private SettingsCheckbox automaticDownload;
+        private ScorePanel scorePanel;
+        private PurpleTriangleButton watchButton;
+
+        private readonly APIBeatmap beatmap;
+        private readonly ArchiveReader archive;
+        private readonly Score score;
+
+        public ReplayImportScreen(Score score, APIBeatmap beatmap, ArchiveReader archive)
+        {
+            this.score = score;
+            this.beatmap = beatmap;
+            this.archive = archive;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGame game, ScoreManager scoreManager, OsuColour colours, OsuConfigManager config)
+        {
+            InternalChildren = new Drawable[]
+            {
+                scorePanel = new ScorePanel(score.ScoreInfo)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.X,
+                    Position = new Vector2(-0.25f, 0)
+                },
+                container = new Container
+                {
+                    Masking = true,
+                    CornerRadius = 20,
+                    AutoSizeAxes = Axes.Both,
+                    AutoSizeDuration = 500,
+                    AutoSizeEasing = Easing.OutQuint,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = colours.GreySeafoamDark,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new FillFlowContainer
+                        {
+                            Margin = new MarginPadding(20),
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Vertical,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Spacing = new Vector2(15),
+                            Children = new Drawable[]
+                            {
+                                new OsuSpriteText
+                                {
+                                    Text = "Beatmap info",
+                                    Font = OsuFont.Default.With(size: 30),
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                },
+                                new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Spacing = new Vector2(15),
+                                    Children = new Drawable[]
+                                    {
+                                        beatmapPanelContainer = new Container
+                                        {
+                                            AutoSizeAxes = Axes.Both,
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                        }
+                                    }
+                                },
+                                automaticDownload = new SettingsCheckbox
+                                {
+                                    LabelText = "Automatically download beatmaps",
+                                    Current = config.GetBindable<bool>(OsuSetting.AutomaticallyDownloadWhenSpectating),
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                },
+                                watchButton = new PurpleTriangleButton
+                                {
+                                    Text = "Start Watching",
+                                    Width = 250,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Action = () =>
+                                    {
+                                        game.PresentScore(scoreManager.Import(archive).Result, ScorePresentType.Gameplay);
+                                    },
+                                    Enabled = { Value = false }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            scorePanel.StateChanged += state => container.MoveToX(scorePanel.Size.X / 2, 500, Easing.OutQuint);
+
+            var onlineBeatmapRequest = new GetBeatmapSetRequest(beatmap.OnlineBeatmapSetID);
+
+            onlineBeatmapRequest.Success += res => Schedule(() =>
+            {
+                onlineBeatmap = res.ToBeatmapSet(rulesets);
+                score.ScoreInfo.Beatmap = beatmap.ToBeatmap(rulesets);
+                score.ScoreInfo.BeatmapInfoID = beatmap.ToBeatmap(rulesets).OnlineBeatmapID ?? 0;
+                beatmapPanelContainer.Child = new GridBeatmapPanel(onlineBeatmap);
+            });
+
+            api.Queue(onlineBeatmapRequest);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            checkForAutomaticDownload();
+        }
+
+        private void checkForAutomaticDownload()
+        {
+            if (onlineBeatmap == null)
+                return;
+
+            if (beatmaps.IsAvailableLocally(onlineBeatmap))
+            {
+                watchButton.Enabled.Value = true;
+                return;
+            }
+
+            if (!automaticDownload.Current.Value)
+                return;
+
+            beatmaps.Download(onlineBeatmap);
+        }
+    }
+}


### PR DESCRIPTION
Discussed in #14029

May need to do a cleanup since there's a lot of copy-pasting from the spectator screen
And I have no idea which namespace should I put it

![osu_2021-07-28_18-33-41](https://user-images.githubusercontent.com/50285552/127308346-96aaf109-e3f0-4437-b9e0-9bcc265b80d5.jpg)
