### PR TITLE
Fix potential stack overflow in ruleset change rejection logic

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -1,21 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
-using osu.Game.Tournament.Configuration;
 using osu.Game.Tests;
+using osu.Game.Tournament.Configuration;
 
 namespace osu.Game.Tournament.Tests.NonVisual
 {
     [TestFixture]
-    public class CustomTourneyDirectoryTest
+    public class CustomTourneyDirectoryTest : TournamentHostTest
     {
         [Test]
         public void TestDefaultDirectory()
@@ -24,7 +21,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadTournament(host);
                     var storage = osu.Dependencies.Get<Storage>();
 
                     Assert.That(storage.GetFullPath("."), Is.EqualTo(Path.Combine(host.Storage.GetFullPath("."), "tournaments", "default")));
@@ -54,7 +51,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadTournament(host);
 
                     storage = osu.Dependencies.Get<Storage>();
 
@@ -111,7 +108,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadTournament(host);
 
                     var storage = osu.Dependencies.Get<Storage>();
 
@@ -149,25 +146,6 @@ namespace osu.Game.Tournament.Tests.NonVisual
                     host.Exit();
                 }
             }
-        }
-
-        private TournamentGameBase loadOsu(GameHost host)
-        {
-            var osu = new TournamentGameBase();
-            Task.Run(() => host.Run(osu))
-                .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
-            waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
-            return osu;
-        }
-
-        private static void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 90000)
-        {
-            Task task = Task.Run(() =>
-            {
-                while (!result()) Thread.Sleep(200);
-            });
-
-            Assert.IsTrue(task.Wait(timeout), failureMessage);
         }
 
         private string basePath(string testInstance) => Path.Combine(RuntimeInfo.StartupDirectory, "headless", testInstance);

--- a/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Platform;
+using osu.Game.Rulesets;
+using osu.Game.Tests;
+
+namespace osu.Game.Tournament.Tests.NonVisual
+{
+    public class DataLoadTest : TournamentHostTest
+    {
+        [Test]
+        public void TestUnavailableRuleset()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost(nameof(TestUnavailableRuleset)))
+            {
+                try
+                {
+                    var osu = new TestTournament();
+
+                    LoadTournament(host, osu);
+                    var storage = osu.Dependencies.Get<Storage>();
+
+                    Assert.That(storage.GetFullPath("."), Is.EqualTo(Path.Combine(host.Storage.GetFullPath("."), "tournaments", "default")));
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        public class TestTournament : TournamentGameBase
+        {
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Ruleset.Value = new RulesetInfo(); // not available
+            }
+        }
+    }
+}

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework;
 using osu.Framework.Allocation;
@@ -15,7 +12,7 @@ using osu.Game.Tournament.IPC;
 namespace osu.Game.Tournament.Tests.NonVisual
 {
     [TestFixture]
-    public class IPCLocationTest
+    public class IPCLocationTest : TournamentHostTest
     {
         [Test]
         public void CheckIPCLocation()
@@ -34,11 +31,11 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadTournament(host);
                     TournamentStorage storage = (TournamentStorage)osu.Dependencies.Get<Storage>();
                     FileBasedIPC ipc = null;
 
-                    waitForOrAssert(() => (ipc = osu.Dependencies.Get<MatchIPCInfo>() as FileBasedIPC) != null, @"ipc could not be populated in a reasonable amount of time");
+                    WaitForOrAssert(() => (ipc = osu.Dependencies.Get<MatchIPCInfo>() as FileBasedIPC) != null, @"ipc could not be populated in a reasonable amount of time");
 
                     Assert.True(ipc.SetIPCLocation(testStableInstallDirectory));
                     Assert.True(storage.AllTournaments.Exists("stable.json"));
@@ -50,25 +47,6 @@ namespace osu.Game.Tournament.Tests.NonVisual
                     host.Exit();
                 }
             }
-        }
-
-        private TournamentGameBase loadOsu(GameHost host)
-        {
-            var osu = new TournamentGameBase();
-            Task.Run(() => host.Run(osu))
-                .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
-            waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
-            return osu;
-        }
-
-        private static void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 90000)
-        {
-            Task task = Task.Run(() =>
-            {
-                while (!result()) Thread.Sleep(200);
-            });
-
-            Assert.IsTrue(task.Wait(timeout), failureMessage);
         }
     }
 }

--- a/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Platform;
+
+namespace osu.Game.Tournament.Tests.NonVisual
+{
+    public abstract class TournamentHostTest
+    {
+        public static TournamentGameBase LoadTournament(GameHost host, TournamentGameBase tournament = null)
+        {
+            tournament ??= new TournamentGameBase();
+            Task.Run(() => host.Run(tournament))
+                .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
+            WaitForOrAssert(() => tournament.IsLoaded, @"osu! failed to start in a reasonable amount of time");
+            return tournament;
+        }
+
+        public static void WaitForOrAssert(Func<bool> result, string failureMessage, int timeout = 90000)
+        {
+            Task task = Task.Run(() =>
+            {
+                while (!result()) Thread.Sleep(200);
+            });
+
+            Assert.IsTrue(task.Wait(timeout), failureMessage);
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -479,7 +479,7 @@ namespace osu.Game
             if (r.NewValue?.Available != true)
             {
                 // reject the change if the ruleset is not available.
-                Ruleset.Value = r.OldValue;
+                Ruleset.Value = r.OldValue?.Available == true ? r.OldValue : RulesetStore.AvailableRulesets.First();
                 return;
             }
 


### PR DESCRIPTION
The test has been added in the tournament tests because that's where it came up. osu! startup logic ensures it cannot happen, so it is less valid there.

I have a separate fix to resolve the root issue, which is that the ruleset deserialised from the ladder is never sourced from the `RulesetStore` making it never available. This is just an extra safety to specifically address the stack overflow.
