### PR TITLE
Avoid throwing / logging an error when `drawings.txt` is missing

### DIFF
--- a/osu.Game.Tournament/Screens/Drawings/Components/StorageBackedTeamList.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/StorageBackedTeamList.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
             {
                 var teams = new List<TournamentTeam>();
 
+                if (!storage.Exists(teams_filename))
+                    return teams;
+
                 try
                 {
                     using (Stream stream = storage.GetStream(teams_filename, FileAccess.Read, FileMode.Open))

--- a/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
+++ b/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
@@ -9,11 +9,13 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Drawings.Components;
@@ -51,6 +53,29 @@ namespace osu.Game.Tournament.Screens.Drawings
 
             if (!TeamList.Teams.Any())
             {
+                LinkFlowContainer links;
+
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.Black,
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Height = 0.3f,
+                    },
+                    new WarningBox("No drawings.txt file found. Please create one and restart the client."),
+                    links = new LinkFlowContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Y = 60,
+                        AutoSizeAxes = Axes.Both
+                    }
+                };
+
+                links.AddLink("Click for details on the file format", "https://osu.ppy.sh/wiki/en/Tournament_Drawings", t => t.Colour = Color4.White);
                 return;
             }
 

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Framework.Platform;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Users;
 
@@ -24,6 +25,9 @@ namespace osu.Game.Graphics.Containers
 
         [Resolved(CanBeNull = true)]
         private OsuGame game { get; set; }
+
+        [Resolved]
+        private GameHost host { get; set; }
 
         public void AddLinks(string text, List<Link> links)
         {
@@ -91,8 +95,11 @@ namespace osu.Game.Graphics.Containers
                 {
                     if (action != null)
                         action();
-                    else
-                        game?.HandleLink(link);
+                    else if (game != null)
+                        game.HandleLink(link);
+                    // fallback to handle cases where OsuGame is not available, ie. tournament client.
+                    else if (link.Action == LinkAction.External)
+                        host.OpenUrlExternally(link.Argument);
                 },
             });
         }


### PR DESCRIPTION
The exception was already caught, but the error is misleading when the user doesn't even have a `drawings.txt` in their tournament folder.
