### PR TITLE
Resolve ruleset from store after loading tournament ladder

### DIFF
--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -66,7 +66,9 @@ namespace osu.Game.Tournament
             }
 
             ladder ??= new LadderInfo();
-            ladder.Ruleset.Value ??= RulesetStore.AvailableRulesets.First();
+
+            ladder.Ruleset.Value = RulesetStore.GetRuleset(ladder.Ruleset.Value?.ShortName)
+                                   ?? RulesetStore.AvailableRulesets.First();
 
             bool addedInfo = false;
 


### PR DESCRIPTION
Until now it was haphazardly using an unavailable ruleset. We may have just been lucky that it worked and `CreateInstance()` was never called.
