### PR TITLE
Uncouple display logic from text in rankings overlay tables

### DIFF
--- a/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
@@ -19,14 +19,14 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
         }
 
-        protected override TableColumn[] CreateAdditionalHeaders() => new[]
+        protected override RankingsTableColumn[] CreateAdditionalHeaders() => new[]
         {
-            new TableColumn("Active Users", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new TableColumn("Play Count", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new TableColumn("Ranked Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new TableColumn("Avg. Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new TableColumn("Performance", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new TableColumn("Avg. Perf.", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Active Users", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Play Count", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Ranked Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Avg. Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Performance", Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true),
+            new RankingsTableColumn("Avg. Perf.", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
         };
 
         protected override Country GetCountry(CountryStatistics item) => item.Country;

--- a/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
         }
 
-        protected override TableColumn[] CreateUniqueHeaders() => new[]
+        protected override RankingsTableColumn[] CreateUniqueHeaders() => new[]
         {
-            new TableColumn("Performance", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Performance", Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true),
         };
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -55,29 +55,24 @@ namespace osu.Game.Overlays.Rankings.Tables
 
             rankings.ForEach(_ => backgroundFlow.Add(new TableRowBackground { Height = row_height }));
 
-            Columns = mainHeaders.Concat(CreateAdditionalHeaders()).ToArray();
+            Columns = mainHeaders.Concat(CreateAdditionalHeaders()).Cast<TableColumn>().ToArray();
             Content = rankings.Select((s, i) => createContent((page - 1) * items_per_page + i, s)).ToArray().ToRectangular();
         }
 
         private Drawable[] createContent(int index, TModel item) => new Drawable[] { createIndexDrawable(index), createMainContent(item) }.Concat(CreateAdditionalContent(item)).ToArray();
 
-        private static TableColumn[] mainHeaders => new[]
+        private static RankingsTableColumn[] mainHeaders => new[]
         {
-            new TableColumn(string.Empty, Anchor.Centre, new Dimension(GridSizeMode.Absolute, 40)), // place
-            new TableColumn(string.Empty, Anchor.CentreLeft, new Dimension()), // flag and username (country name)
+            new RankingsTableColumn(string.Empty, Anchor.Centre, new Dimension(GridSizeMode.Absolute, 40)), // place
+            new RankingsTableColumn(string.Empty, Anchor.CentreLeft, new Dimension()), // flag and username (country name)
         };
 
-        protected abstract TableColumn[] CreateAdditionalHeaders();
+        protected abstract RankingsTableColumn[] CreateAdditionalHeaders();
 
         protected abstract Drawable[] CreateAdditionalContent(TModel item);
 
-        protected virtual string HighlightedColumn => @"Performance";
-
-        protected override Drawable CreateHeader(int index, TableColumn column)
-        {
-            var title = column?.Header ?? default;
-            return new HeaderText(title, title == HighlightedColumn);
-        }
+        protected sealed override Drawable CreateHeader(int index, TableColumn column)
+            => (column as RankingsTableColumn)?.CreateHeaderText() ?? new HeaderText(column?.Header ?? default, false);
 
         protected abstract Country GetCountry(TModel item);
 
@@ -105,6 +100,19 @@ namespace osu.Game.Overlays.Rankings.Tables
                 CreateFlagContent(item)
             }
         };
+
+        protected class RankingsTableColumn : TableColumn
+        {
+            protected readonly bool Highlighted;
+
+            public RankingsTableColumn(LocalisableString? header = null, Anchor anchor = Anchor.TopLeft, Dimension dimension = null, bool highlighted = false)
+                : base(header, anchor, dimension)
+            {
+                Highlighted = highlighted;
+            }
+
+            public virtual HeaderText CreateHeaderText() => new HeaderText(Header, Highlighted);
+        }
 
         protected class HeaderText : OsuSpriteText
         {

--- a/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
@@ -15,10 +15,10 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
         }
 
-        protected override TableColumn[] CreateUniqueHeaders() => new[]
+        protected override RankingsTableColumn[] CreateUniqueHeaders() => new[]
         {
-            new TableColumn("Total Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new TableColumn("Ranked Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize))
+            new RankingsTableColumn("Total Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn("Ranked Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true)
         };
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]
@@ -32,7 +32,5 @@ namespace osu.Game.Overlays.Rankings.Tables
                 Text = $@"{item.RankedScore:N0}",
             }
         };
-
-        protected override string HighlightedColumn => @"Ranked Score";
     }
 }

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -22,19 +22,13 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected virtual IEnumerable<string> GradeColumns => new List<string> { "SS", "S", "A" };
 
-        protected override TableColumn[] CreateAdditionalHeaders() => new[]
+        protected override RankingsTableColumn[] CreateAdditionalHeaders() => new[]
             {
-                new TableColumn("Accuracy", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-                new TableColumn("Play Count", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+                new RankingsTableColumn("Accuracy", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+                new RankingsTableColumn("Play Count", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
             }.Concat(CreateUniqueHeaders())
-             .Concat(GradeColumns.Select(grade => new TableColumn(grade, Anchor.Centre, new Dimension(GridSizeMode.AutoSize))))
+             .Concat(GradeColumns.Select(grade => new GradeTableColumn(grade, Anchor.Centre, new Dimension(GridSizeMode.AutoSize))))
              .ToArray();
-
-        protected override Drawable CreateHeader(int index, TableColumn column)
-        {
-            var title = column?.Header ?? default;
-            return new UserTableHeaderText(title, HighlightedColumn == title, GradeColumns.Contains(title.ToString()));
-        }
 
         protected sealed override Country GetCountry(UserStatistics item) => item.User.Country;
 
@@ -61,19 +55,29 @@ namespace osu.Game.Overlays.Rankings.Tables
             new ColoredRowText { Text = $@"{item.GradesCount[ScoreRank.A]:N0}", }
         }).ToArray();
 
-        protected abstract TableColumn[] CreateUniqueHeaders();
+        protected abstract RankingsTableColumn[] CreateUniqueHeaders();
 
         protected abstract Drawable[] CreateUniqueContent(UserStatistics item);
 
-        private class UserTableHeaderText : HeaderText
+        private class GradeTableColumn : RankingsTableColumn
         {
-            public UserTableHeaderText(LocalisableString text, bool isHighlighted, bool isGrade)
+            public GradeTableColumn(LocalisableString? header = null, Anchor anchor = Anchor.TopLeft, Dimension dimension = null, bool highlighted = false)
+                : base(header, anchor, dimension, highlighted)
+            {
+            }
+
+            public override HeaderText CreateHeaderText() => new GradeHeaderText(Header, Highlighted);
+        }
+
+        private class GradeHeaderText : HeaderText
+        {
+            public GradeHeaderText(LocalisableString text, bool isHighlighted)
                 : base(text, isHighlighted)
             {
                 Margin = new MarginPadding
                 {
                     // Grade columns have extra horizontal padding for readibility
-                    Horizontal = isGrade ? 20 : 10,
+                    Horizontal = 20,
                     Vertical = 5
                 };
             }


### PR DESCRIPTION
This pull is a proposal on how to avoid rankings table header display logic being dependent on the textual contents of said headers. The way this is done here is by introducing subclasses of `TableColumn` that actually store information as to whether the given column is highlighted in a boolean field.

Note that this isn't a full code quality pass over these tables, they're still quite bad/convoluted in places due to the baroque inheritance hierarchy. But this particular issue is the easily the biggest one there is in that area, and a near-blocker for localisation (which @Game4all was going to apply next, from what I understand).