### PR TITLE
Integrate editor colour display with colour picker & popover 

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledColourPalette.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledColourPalette.cs
@@ -53,15 +53,15 @@ namespace osu.Game.Tests.Visual.UserInterface
 
                 component.Colours.AddRange(new[]
                 {
-                    Color4.DarkRed,
-                    Color4.Aquamarine,
-                    Color4.Goldenrod,
-                    Color4.Gainsboro
+                    Colour4.DarkRed,
+                    Colour4.Aquamarine,
+                    Colour4.Goldenrod,
+                    Colour4.Gainsboro
                 });
             });
         }
 
-        private Color4 randomColour() => new Color4(
+        private Colour4 randomColour() => new Color4(
             RNG.NextSingle(),
             RNG.NextSingle(),
             RNG.NextSingle(),

--- a/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
@@ -3,11 +3,14 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 
@@ -16,7 +19,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
     /// <summary>
     /// A component which displays a colour along with related description text.
     /// </summary>
-    public class ColourDisplay : CompositeDrawable, IHasCurrentValue<Colour4>
+    public class ColourDisplay : CompositeDrawable, IHasCurrentValue<Colour4>, IHasPopover
     {
         private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>();
 
@@ -60,10 +63,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Spacing = new Vector2(0, 10),
                 Children = new Drawable[]
                 {
-                    new CircularContainer
+                    new OsuClickableContainer
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = 100,
+                        CornerRadius = 50,
                         Masking = true,
                         Children = new Drawable[]
                         {
@@ -77,7 +81,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                 Origin = Anchor.Centre,
                                 Font = OsuFont.Default.With(size: 12)
                             }
-                        }
+                        },
+                        Action = this.ShowPopover
                     },
                     colourName = new OsuSpriteText
                     {
@@ -101,5 +106,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
             colourHexCode.Text = current.Value.ToHex();
             colourHexCode.Colour = OsuColour.ForegroundTextColourFor(current.Value);
         }
+
+        public Popover GetPopover() => new OsuPopover(false)
+        {
+            Child = new OsuColourPicker
+            {
+                Current = { BindTarget = Current }
+            }
+        };
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -11,22 +10,21 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
     /// <summary>
     /// A component which displays a colour along with related description text.
     /// </summary>
-    public class ColourDisplay : CompositeDrawable, IHasCurrentValue<Color4>
+    public class ColourDisplay : CompositeDrawable, IHasCurrentValue<Colour4>
     {
-        private readonly BindableWithCurrent<Color4> current = new BindableWithCurrent<Color4>();
+        private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>();
 
         private Box fill;
         private OsuSpriteText colourHexCode;
         private OsuSpriteText colourName;
 
-        public Bindable<Color4> Current
+        public Bindable<Colour4> Current
         {
             get => current.Current;
             set => current.Current = value;

--- a/osu.Game/Graphics/UserInterfaceV2/ColourPalette.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ColourPalette.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -17,7 +16,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
     /// </summary>
     public class ColourPalette : CompositeDrawable
     {
-        public BindableList<Color4> Colours { get; } = new BindableList<Color4>();
+        public BindableList<Colour4> Colours { get; } = new BindableList<Colour4>();
 
         private string colourNamePrefix = "Colour";
 

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledColourPalette.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledColourPalette.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osuTK.Graphics;
+using osu.Framework.Graphics;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -13,7 +13,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
         }
 
-        public BindableList<Color4> Colours => Component.Colours;
+        public BindableList<Colour4> Colours => Component.Colours;
 
         public string ColourNamePrefix
         {

--- a/osu.Game/Screens/Edit/Setup/ColoursSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ColoursSection.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -32,7 +33,7 @@ namespace osu.Game.Screens.Edit.Setup
 
             var colours = Beatmap.BeatmapSkin?.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value;
             if (colours != null)
-                comboColours.Colours.AddRange(colours);
+                comboColours.Colours.AddRange(colours.Select(c => (Colour4)c));
         }
     }
 }


### PR DESCRIPTION
Disclaimer right at the start: The colours are not saved yet, purposefully. The "obvious" way of jamming the colours into the skin config works badly - the values do get persisted to the beatmap file, but the rest of the editor knows nothing about that and neither timeline blueprints, nor drawable hitobjects are aware of the change and retain their previous colours. If this is deemed a blocker I can disable editing in-game for now, there is a test scene for the palette component anyways.

This change is just mostly integration of the existing pieces into the editor and I'm PRing it out for my sanity after having it on a loose branch for weeks.

Adding and removing colours I also have ready on a branch, and will PR that after this. I don't have anything for the proper skin-saving flow yet and will have to take a weekend to dig into it most likely.

With that out of the way, here's a video.

https://user-images.githubusercontent.com/20418176/127569053-b33251cb-41d0-4e5a-ac34-0d70de3de25e.mp4