### PR TITLE
Add a few cases of missing `ConfigureAwait` calls in tests project

### DIFF
--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -168,8 +168,8 @@ namespace osu.Game.Tests.Online
 
             public override async Task<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
             {
-                await AllowImport.Task;
-                return await (CurrentImportTask = base.Import(item, archive, lowPriority, cancellationToken));
+                await AllowImport.Task.ConfigureAwait(false);
+                return await (CurrentImportTask = base.Import(item, archive, lowPriority, cancellationToken)).ConfigureAwait(false);
             }
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
@@ -143,9 +143,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             public override async Task<StarDifficulty> GetDifficultyAsync(BeatmapInfo beatmapInfo, RulesetInfo rulesetInfo = null, IEnumerable<Mod> mods = null, CancellationToken cancellationToken = default)
             {
                 if (blockCalculation)
-                    await calculationBlocker.Task;
+                    await calculationBlocker.Task.ConfigureAwait(false);
 
-                return await base.GetDifficultyAsync(beatmapInfo, rulesetInfo, mods, cancellationToken);
+                return await base.GetDifficultyAsync(beatmapInfo, rulesetInfo, mods, cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
The test project has the [ConfigureAwait inspection disabled](https://github.com/ppy/osu/blob/master/osu.Game.Tests/tests.ruleset) (probably correctly?) because it's mostly testing existing flows. Issues still arise if there is "library" test code, like the cases which are fixed in this PR, where we may be calling `.Wait()` on a misconfigured `await`. These were causing deadlocks with https://github.com/ppy/osu-framework/pull/4149.

