### PR TITLE
Fix song progress graph not being correctly hidden

### DIFF
--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Screens.Play
             float barHeight = bottom_bar_height + handle_size.Y;
 
             bar.ResizeHeightTo(ShowGraph.Value ? barHeight + graph_height : barHeight, transition_duration, Easing.In);
-            graph.MoveToY(ShowGraph.Value ? 0 : bottom_bar_height + graph_height, transition_duration, Easing.In);
+            graph.FadeTo(ShowGraph.Value ? 1 : 0, transition_duration, Easing.In);
 
             updateInfoMargin();
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12940. I don't get https://github.com/ppy/osu/issues/12940#issuecomment-847183705 as the current way was recreating the graph every single toggle. A simple fade out does the trick.

Before:
![Kapture 2021-07-29 at 23 44 45](https://user-images.githubusercontent.com/35318437/127612168-4bf359ac-5c1e-4aab-8040-4cf28c235e63.gif)

After:
![Kapture 2021-07-29 at 23 46 42](https://user-images.githubusercontent.com/35318437/127612410-d862383d-fa0e-451a-bcd2-1972d0bee330.gif)