### PR TITLE
Fix incorrect authorisation loss exception handling with recent changes

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Online.API
 
                         userReq.Failure += ex =>
                         {
-                            if (ex.InnerException is WebException webException && webException.Message == @"Unauthorized")
+                            if (ex is WebException webException && webException.Message == @"Unauthorized")
                             {
                                 log.Add(@"Login no longer valid");
                                 Logout();


### PR DESCRIPTION
I'm guessing something I did with the new failure flow changed this to no longer be an inner exception.
