### PR TITLE
Swap 'select' sample variants and add hover+select sounds to more components

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.722.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.730.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2021.728.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Graphics/Containers/OsuRearrangeableListItem.cs
+++ b/osu.Game/Graphics/Containers/OsuRearrangeableListItem.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
@@ -59,33 +60,37 @@ namespace osu.Game.Graphics.Containers
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = new GridContainer
+            InternalChildren = new Drawable[]
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Content = new[]
+                new GridContainer
                 {
-                    new[]
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Content = new[]
                     {
-                        handleContainer = new Container
+                        new[]
                         {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            AutoSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Horizontal = 5 },
-                            Child = handle = new PlaylistItemHandle
+                            handleContainer = new Container
                             {
-                                Size = new Vector2(12),
-                                Colour = HandleColour,
-                                AlwaysPresent = true,
-                                Alpha = 0
-                            }
-                        },
-                        CreateContent()
-                    }
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                AutoSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Horizontal = 5 },
+                                Child = handle = new PlaylistItemHandle
+                                {
+                                    Size = new Vector2(12),
+                                    Colour = HandleColour,
+                                    AlwaysPresent = true,
+                                    Alpha = 0
+                                }
+                            },
+                            CreateContent()
+                        }
+                    },
+                    ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
                 },
-                ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
-                RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
+                new HoverClickSounds()
             };
         }
 

--- a/osu.Game/Graphics/UserInterface/BackButton.cs
+++ b/osu.Game/Graphics/UserInterface/BackButton.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             Size = TwoLayerButton.SIZE_EXTENDED;
 
-            Child = button = new TwoLayerButton
+            Child = button = new TwoLayerButton(HoverSampleSet.Submit)
             {
                 Anchor = Anchor.TopLeft,
                 Origin = Anchor.TopLeft,

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Graphics.UserInterface
         private Vector2 hoverSpacing => new Vector2(3f, 0f);
 
         public DialogButton()
+            : base(HoverSampleSet.Submit)
         {
             RelativeSizeAxes = Axes.X;
 

--- a/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
+++ b/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
@@ -23,14 +23,20 @@ namespace osu.Game.Graphics.UserInterface
         [Resolved]
         private GameHost host { get; set; }
 
+        private readonly SpriteIcon linkIcon;
+
         public ExternalLinkButton(string link = null)
         {
             Link = link;
             Size = new Vector2(12);
-            InternalChild = new SpriteIcon
+            InternalChildren = new Drawable[]
             {
-                Icon = FontAwesome.Solid.ExternalLinkAlt,
-                RelativeSizeAxes = Axes.Both
+                linkIcon = new SpriteIcon
+                {
+                    Icon = FontAwesome.Solid.ExternalLinkAlt,
+                    RelativeSizeAxes = Axes.Both
+                },
+                new HoverClickSounds(HoverSampleSet.Submit)
             };
         }
 
@@ -42,13 +48,13 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnHover(HoverEvent e)
         {
-            InternalChild.FadeColour(hoverColour, 500, Easing.OutQuint);
+            linkIcon.FadeColour(hoverColour, 500, Easing.OutQuint);
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            InternalChild.FadeColour(Color4.White, 500, Easing.OutQuint);
+            linkIcon.FadeColour(Color4.White, 500, Easing.OutQuint);
             base.OnHoverLost(e);
         }
 

--- a/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
@@ -10,8 +10,6 @@ namespace osu.Game.Graphics.UserInterface
         [Description("default")]
         Default,
 
-        [Description("soft")]
-        Soft,
 
         [Description("button")]
         Button,

--- a/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Graphics.UserInterface
         [Description("default")]
         Default,
 
+        [Description("submit")]
+        Submit,
 
         [Description("button")]
         Button,

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -71,7 +71,8 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        public TwoLayerButton()
+        public TwoLayerButton(HoverSampleSet sampleSet = HoverSampleSet.Default)
+            : base(sampleSet)
         {
             Size = SIZE_RETRACTED;
             Shear = shear;

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 {
                     Depth = 1
                 },
-                new HoverClickSounds(HoverSampleSet.Soft)
+                new HoverClickSounds()
             });
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     {
                         Depth = 1
                     },
-                    new HoverClickSounds(HoverSampleSet.Soft)
+                    new HoverClickSounds()
                 });
             }
 

--- a/osu.Game/Online/Chat/DrawableLinkCompiler.cs
+++ b/osu.Game/Online/Chat/DrawableLinkCompiler.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Online.Chat
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new LinkHoverSounds(sampleSet, Parts);
 
         public DrawableLinkCompiler(IEnumerable<Drawable> parts)
+            : base(HoverSampleSet.Submit)
         {
             Parts = parts.ToList();
         }

--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         protected Action ViewBeatmap;
 
         protected BeatmapPanel(BeatmapSetInfo setInfo)
+            : base(HoverSampleSet.Submit)
         {
             Debug.Assert(setInfo.OnlineBeatmapSetID != null);
 

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
@@ -3,6 +3,9 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -13,6 +16,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Chat;
 using osuTK;
 using osuTK.Graphics;
@@ -38,6 +42,8 @@ namespace osu.Game.Overlays.Chat.Tabs
         private readonly Container content;
 
         protected override Container<Drawable> Content => content;
+
+        private Sample sampleTabSwitched;
 
         public ChannelTabItem(Channel value)
             : base(value)
@@ -112,6 +118,7 @@ namespace osu.Game.Overlays.Chat.Tabs
                         },
                     },
                 },
+                new HoverSounds()
             };
         }
 
@@ -152,11 +159,12 @@ namespace osu.Game.Overlays.Chat.Tabs
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, AudioManager audio)
         {
             BackgroundActive = colours.ChatBlue;
             BackgroundInactive = colours.Gray4;
             backgroundHover = colours.Gray7;
+            sampleTabSwitched = audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
 
             highlightBox.Colour = colours.Yellow;
         }
@@ -217,7 +225,14 @@ namespace osu.Game.Overlays.Chat.Tabs
             Text.Font = Text.Font.With(weight: FontWeight.Medium);
         }
 
-        protected override void OnActivated() => updateState();
+        protected override void OnActivated()
+        {
+            if (IsLoaded)
+                sampleTabSwitched?.Play();
+
+            updateState();
+        }
+
         protected override void OnDeactivated() => updateState();
     }
 }

--- a/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.Chat.Tabs
             if (value.Type != ChannelType.PM)
                 throw new ArgumentException("Argument value needs to have the targettype user!");
 
-            ClickableAvatar avatar;
+            DrawableAvatar avatar;
 
             AddRange(new Drawable[]
             {
@@ -48,10 +48,9 @@ namespace osu.Game.Overlays.Chat.Tabs
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Masking = true,
-                            Child = new DelayedLoadWrapper(avatar = new ClickableAvatar(value.Users.First())
+                            Child = new DelayedLoadWrapper(avatar = new DrawableAvatar(value.Users.First())
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                OpenOnClick = false,
+                                RelativeSizeAxes = Axes.Both
                             })
                             {
                                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Overlays/News/NewsCard.cs
+++ b/osu.Game/Overlays/News/NewsCard.cs
@@ -14,6 +14,7 @@ using osu.Framework.Platform;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Overlays.News
@@ -28,6 +29,7 @@ namespace osu.Game.Overlays.News
         private TextFlowContainer main;
 
         public NewsCard(APINewsPost post)
+            : base(HoverSampleSet.Submit)
         {
             this.post = post;
 

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -15,13 +15,18 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using System.Diagnostics;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Platform;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.News.Sidebar
 {
     public class MonthSection : CompositeDrawable
     {
         private const int animation_duration = 250;
+        private Sample sampleOpen;
+        private Sample sampleClose;
 
         public readonly BindableBool Expanded = new BindableBool();
 
@@ -51,6 +56,21 @@ namespace osu.Game.Overlays.News.Sidebar
                     }
                 }
             };
+
+            Expanded.ValueChanged += expanded =>
+            {
+                if (expanded.NewValue)
+                    sampleOpen?.Play();
+                else
+                    sampleClose?.Play();
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
+            sampleClose = audio.Samples.Get(@"UI/dropdown-close");
         }
 
         private class DropdownHeader : OsuClickableContainer
@@ -58,6 +78,8 @@ namespace osu.Game.Overlays.News.Sidebar
             public readonly BindableBool Expanded = new BindableBool();
 
             private readonly SpriteIcon icon;
+
+            protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
 
             public DropdownHeader(int month, int year)
             {
@@ -104,6 +126,7 @@ namespace osu.Game.Overlays.News.Sidebar
             private readonly APINewsPost post;
 
             public PostButton(APINewsPost post)
+                : base(HoverSampleSet.Submit)
             {
                 this.post = post;
 

--- a/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
@@ -17,6 +18,7 @@ namespace osu.Game.Overlays.Profile.Sections
         private readonly BeatmapInfo beatmap;
 
         protected BeatmapMetadataContainer(BeatmapInfo beatmap)
+            : base(HoverSampleSet.Submit)
         {
             this.beatmap = beatmap;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -138,7 +138,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                             },
                         }
                     }
-                }
+                },
+                new HoverClickSounds()
             };
 
             foreach (var b in bindings)
@@ -458,6 +459,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         Origin = Anchor.Centre,
                         Text = keyBinding.KeyCombination.ReadableString(),
                     },
+                    new HoverSounds()
                 };
             }
 

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -67,7 +67,6 @@ namespace osu.Game.Screens.Edit
             private EditorClock clock { get; set; }
 
             public RowBackground(object item)
-                : base(HoverSampleSet.Soft)
             {
                 Item = item;
 

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -11,7 +11,6 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK.Graphics;
 

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Screens.Select.Options
 {
@@ -76,6 +77,7 @@ namespace osu.Game.Screens.Select.Options
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
         public BeatmapOptionsButton()
+            : base(HoverSampleSet.Submit)
         {
             Width = width;
             RelativeSizeAxes = Axes.Y;

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Users.Drawables
 {
@@ -70,6 +71,11 @@ namespace osu.Game.Users.Drawables
         private class ClickableArea : OsuClickableContainer
         {
             private LocalisableString tooltip = default_tooltip_text;
+
+            public ClickableArea()
+                : base(HoverSampleSet.Submit)
+            {
+            }
 
             public override LocalisableString TooltipText
             {

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 
 namespace osu.Game.Users.Drawables
@@ -32,9 +33,17 @@ namespace osu.Game.Users.Drawables
             if (country == null && !ShowPlaceholderOnNull)
                 return null;
 
-            return new DrawableFlag(country)
+            return new Container
             {
                 RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new DrawableFlag(country)
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    new HoverClickSounds(HoverSampleSet.Submit)
+                }
             };
         }
 

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Users
         protected Drawable Background { get; private set; }
 
         protected UserPanel(User user)
+            : base(HoverSampleSet.Submit)
         {
             if (user == null)
                 throw new ArgumentNullException(nameof(user));

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.3.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.728.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.722.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.730.0" />
     <PackageReference Include="Sentry" Version="3.8.2" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.728.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.722.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.730.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
This takes the previous 'default' and 'soft' selection samples (from #13967) and swaps their usages, with the 'soft' variant becoming the new default.

As part of this, the new non-default variant has been renamed 'submit' (i.e. `HoverSampleSet.Submit`). I'm open to suggestions if anyone has a better name for this though, as 'submit' is kinda ehh?

The general idea behind the distinction is that anything that triggers a 'navigation' (between screens or triggering overlays/popups/etc) will use the 'submit' variant when clicked/selected instead of the default sample.

This PR both updates components to use the new 'submit' variant where appropriate, while additionally adding sounds to more components that were missing them completely, namely:
- Rearrangeable lists (`OsuRearrangeableListItem`)
- The little external-link icon thing (`ExternalLinkButton`)
- Chat tabs (`ChannelTabItem` and `PrivateChannelTabItem`)
- Keybinding panel (`KeyBindingRow`)
- Flags (`UpdatableFlag`)

There's likely more components that are still missing hover/select sounds, but this is a first pass at least.

- [x] depends on ppy/osu-resources#140