### PR TITLE
Localise rankings overlay

### DIFF
--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -5,6 +5,9 @@ using osu.Framework.Graphics;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets;
 using osu.Game.Users;
+using osu.Game.Resources.Localisation.Web;
+using osu.Framework.Localisation;
+using System;
 
 namespace osu.Game.Overlays.Rankings
 {
@@ -29,18 +32,43 @@ namespace osu.Game.Overlays.Rankings
         {
             public RankingsTitle()
             {
-                Title = "ranking";
+                Title = PageTitleStrings.MainRankingControllerDefault;
                 Description = "find out who's the best right now";
                 IconTexture = "Icons/Hexacons/rankings";
             }
         }
     }
 
+    [LocalisableEnum(typeof(RankingsScopeEnumLocalisationMapper))]
     public enum RankingsScope
     {
         Performance,
         Spotlights,
         Score,
         Country
+    }
+
+    public class RankingsScopeEnumLocalisationMapper : EnumLocalisationMapper<RankingsScope>
+    {
+        public override LocalisableString Map(RankingsScope value)
+        {
+            switch (value)
+            {
+                case RankingsScope.Performance:
+                    return RankingsStrings.TypePerformance;
+                    
+                case RankingsScope.Spotlights:
+                    return RankingsStrings.TypeCharts;
+
+                case RankingsScope.Score:
+                    return RankingsStrings.TypeScore;
+
+                case RankingsScope.Country:
+                    return RankingsStrings.TypeCountry;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Rankings
             {
                 case RankingsScope.Performance:
                     return RankingsStrings.TypePerformance;
-                    
+
                 case RankingsScope.Spotlights:
                     return RankingsStrings.TypeCharts;
 

--- a/osu.Game/Overlays/Rankings/RankingsSortTabControl.cs
+++ b/osu.Game/Overlays/Rankings/RankingsSortTabControl.cs
@@ -1,19 +1,42 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
 namespace osu.Game.Overlays.Rankings
 {
     public class RankingsSortTabControl : OverlaySortTabControl<RankingsSortCriteria>
     {
         public RankingsSortTabControl()
         {
-            Title = "Show";
+            Title = RankingsStrings.FilterTitle;
         }
     }
 
+    [LocalisableEnum(typeof(RankingsSortCriteriaEnumLocalisationMapper))]
     public enum RankingsSortCriteria
     {
         All,
         Friends
+    }
+
+    public class RankingsSortCriteriaEnumLocalisationMapper : EnumLocalisationMapper<RankingsSortCriteria>
+    {
+        public override LocalisableString Map(RankingsSortCriteria value)
+        {
+            switch (value)
+            {
+                case RankingsSortCriteria.All:
+                    return SortStrings.All;
+
+                case RankingsSortCriteria.Friends:
+                    return SortStrings.Friends;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/Rankings/RankingsSortTabControl.cs
+++ b/osu.Game/Overlays/Rankings/RankingsSortTabControl.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -11,7 +12,7 @@ namespace osu.Game.Overlays.Rankings
     {
         public RankingsSortTabControl()
         {
-            Title = RankingsStrings.FilterTitle;
+            Title = RankingsStrings.FilterTitle.ToUpper();
         }
     }
 

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -124,11 +124,11 @@ namespace osu.Game.Overlays.Rankings
         {
             startDateColumn.Value = dateToString(response.Spotlight.StartDate);
             endDateColumn.Value = dateToString(response.Spotlight.EndDate);
-            mapCountColumn.Value = response.BeatmapSets.Count.ToLocalisableString("N0");
-            participantsColumn.Value = response.Spotlight.Participants?.ToLocalisableString("N0");
+            mapCountColumn.Value = response.BeatmapSets.Count.ToLocalisableString(@"N0");
+            participantsColumn.Value = response.Spotlight.Participants?.ToLocalisableString(@"N0");
         }
 
-        private LocalisableString dateToString(DateTimeOffset date) => date.ToLocalisableString("yyyy-MM-dd");
+        private LocalisableString dateToString(DateTimeOffset date) => date.ToLocalisableString(@"yyyy-MM-dd");
 
         private class InfoColumn : FillFlowContainer
         {

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -16,6 +16,8 @@ using System.Collections.Generic;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Rankings
 {
@@ -92,10 +94,10 @@ namespace osu.Game.Overlays.Rankings
                                         Margin = new MarginPadding { Bottom = 5 },
                                         Children = new Drawable[]
                                         {
-                                            startDateColumn = new InfoColumn(@"Start Date"),
-                                            endDateColumn = new InfoColumn(@"End Date"),
-                                            mapCountColumn = new InfoColumn(@"Map Count"),
-                                            participantsColumn = new InfoColumn(@"Participants")
+                                            startDateColumn = new InfoColumn(RankingsStrings.SpotlightStartDate),
+                                            endDateColumn = new InfoColumn(RankingsStrings.SpotlightEndDate),
+                                            mapCountColumn = new InfoColumn(RankingsStrings.SpotlightMapCount),
+                                            participantsColumn = new InfoColumn(RankingsStrings.SpotlightParticipants)
                                         }
                                     },
                                     new RankingsSortTabControl
@@ -123,21 +125,21 @@ namespace osu.Game.Overlays.Rankings
             startDateColumn.Value = dateToString(response.Spotlight.StartDate);
             endDateColumn.Value = dateToString(response.Spotlight.EndDate);
             mapCountColumn.Value = response.BeatmapSets.Count.ToString();
-            participantsColumn.Value = response.Spotlight.Participants?.ToString("N0");
+            participantsColumn.Value = response.Spotlight.Participants?.ToLocalisableString("N0");
         }
 
-        private string dateToString(DateTimeOffset date) => date.ToString("yyyy-MM-dd");
+        private LocalisableString dateToString(DateTimeOffset date) => date.ToLocalisableString("yyyy-MM-dd");
 
         private class InfoColumn : FillFlowContainer
         {
-            public string Value
+            public LocalisableString Value
             {
                 set => valueText.Text = value;
             }
 
             private readonly OsuSpriteText valueText;
 
-            public InfoColumn(string name)
+            public InfoColumn(LocalisableString name)
             {
                 AutoSizeAxes = Axes.Both;
                 Direction = FillDirection.Vertical;

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Overlays.Rankings
         {
             startDateColumn.Value = dateToString(response.Spotlight.StartDate);
             endDateColumn.Value = dateToString(response.Spotlight.EndDate);
-            mapCountColumn.Value = response.BeatmapSets.Count.ToString();
+            mapCountColumn.Value = response.BeatmapSets.Count.ToLocalisableString("N0");
             participantsColumn.Value = response.Spotlight.Participants?.ToLocalisableString("N0");
         }
 

--- a/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
@@ -9,6 +9,8 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Game.Resources.Localisation.Web;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays.Rankings.Tables
 {
@@ -21,12 +23,12 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override RankingsTableColumn[] CreateAdditionalHeaders() => new[]
         {
-            new RankingsTableColumn("Active Users", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new RankingsTableColumn("Play Count", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new RankingsTableColumn("Ranked Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new RankingsTableColumn("Avg. Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new RankingsTableColumn("Performance", Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true),
-            new RankingsTableColumn("Avg. Perf.", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.StatActiveUsers, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.StatPlayCount, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.StatRankedScore, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.StatAverageScore, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.StatPerformance, Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true),
+            new RankingsTableColumn(RankingsStrings.StatAveragePerformance, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
         };
 
         protected override Country GetCountry(CountryStatistics item) => item.Country;
@@ -37,27 +39,27 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
             new ColoredRowText
             {
-                Text = $@"{item.ActiveUsers:N0}",
+                Text = item.ActiveUsers.ToLocalisableString("N0")
             },
             new ColoredRowText
             {
-                Text = $@"{item.PlayCount:N0}",
+                Text = item.PlayCount.ToLocalisableString("N0")
             },
             new ColoredRowText
             {
-                Text = $@"{item.RankedScore:N0}",
+                Text = item.RankedScore.ToLocalisableString("N0")
             },
             new ColoredRowText
             {
-                Text = $@"{item.RankedScore / Math.Max(item.ActiveUsers, 1):N0}",
+                Text = (item.RankedScore / Math.Max(item.ActiveUsers, 1)).ToLocalisableString("N0")
             },
             new RowText
             {
-                Text = $@"{item.Performance:N0}",
+                Text = item.Performance.ToLocalisableString("N0")
             },
             new ColoredRowText
             {
-                Text = $@"{item.Performance / Math.Max(item.ActiveUsers, 1):N0}",
+                Text = (item.Performance / Math.Max(item.ActiveUsers, 1)).ToLocalisableString("N0")
             }
         };
 

--- a/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
@@ -37,29 +37,29 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override Drawable[] CreateAdditionalContent(CountryStatistics item) => new Drawable[]
         {
-            new ColoredRowText
+            new ColouredRowText
             {
-                Text = item.ActiveUsers.ToLocalisableString("N0")
+                Text = item.ActiveUsers.ToLocalisableString(@"N0")
             },
-            new ColoredRowText
+            new ColouredRowText
             {
-                Text = item.PlayCount.ToLocalisableString("N0")
+                Text = item.PlayCount.ToLocalisableString(@"N0")
             },
-            new ColoredRowText
+            new ColouredRowText
             {
-                Text = item.RankedScore.ToLocalisableString("N0")
+                Text = item.RankedScore.ToLocalisableString(@"N0")
             },
-            new ColoredRowText
+            new ColouredRowText
             {
-                Text = (item.RankedScore / Math.Max(item.ActiveUsers, 1)).ToLocalisableString("N0")
+                Text = (item.RankedScore / Math.Max(item.ActiveUsers, 1)).ToLocalisableString(@"N0")
             },
             new RowText
             {
-                Text = item.Performance.ToLocalisableString("N0")
+                Text = item.Performance.ToLocalisableString(@"N0")
             },
-            new ColoredRowText
+            new ColouredRowText
             {
-                Text = (item.Performance / Math.Max(item.ActiveUsers, 1)).ToLocalisableString("N0")
+                Text = (item.Performance / Math.Max(item.ActiveUsers, 1)).ToLocalisableString(@"N0")
             }
         };
 

--- a/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]
         {
-            new RowText { Text = item.PP.ToLocalisableString("N0"), }
+            new RowText { Text = item.PP.ToLocalisableString(@"N0"), }
         };
     }
 }

--- a/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Rankings.Tables
@@ -17,12 +19,12 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override RankingsTableColumn[] CreateUniqueHeaders() => new[]
         {
-            new RankingsTableColumn("Performance", Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true),
+            new RankingsTableColumn(RankingsStrings.StatPerformance, Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true),
         };
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]
         {
-            new RowText { Text = $@"{item.PP:N0}", }
+            new RowText { Text = item.PP.ToLocalisableString("N0"), }
         };
     }
 }

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         private OsuSpriteText createIndexDrawable(int index) => new RowText
         {
-            Text = (index + 1).ToLocalisableString("\\##"),
+            Text = (index + 1).ToLocalisableString(@"\##"),
             Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.SemiBold)
         };
 
@@ -144,7 +144,7 @@ namespace osu.Game.Overlays.Rankings.Tables
             }
         }
 
-        protected class ColoredRowText : RowText
+        protected class ColouredRowText : RowText
         {
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         private OsuSpriteText createIndexDrawable(int index) => new RowText
         {
-            Text = $"#{index + 1}",
+            Text = (index + 1).ToLocalisableString("\\##"),
             Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.SemiBold)
         };
 

--- a/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]
         {
-            new ColoredRowText
+            new ColouredRowText
             {
                 Text = item.TotalScore.ToLocalisableString("N0"),
             },

--- a/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
@@ -27,11 +27,11 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
             new ColouredRowText
             {
-                Text = item.TotalScore.ToLocalisableString("N0"),
+                Text = item.TotalScore.ToLocalisableString(@"N0"),
             },
             new RowText
             {
-                Text = item.RankedScore.ToLocalisableString("N0")
+                Text = item.RankedScore.ToLocalisableString(@"N0")
             }
         };
     }

--- a/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/ScoresTable.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Rankings.Tables
@@ -17,19 +19,19 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override RankingsTableColumn[] CreateUniqueHeaders() => new[]
         {
-            new RankingsTableColumn("Total Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-            new RankingsTableColumn("Ranked Score", Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true)
+            new RankingsTableColumn(RankingsStrings.StatTotalScore, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+            new RankingsTableColumn(RankingsStrings.StatRankedScore, Anchor.Centre, new Dimension(GridSizeMode.AutoSize), true)
         };
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]
         {
             new ColoredRowText
             {
-                Text = $@"{item.TotalScore:N0}",
+                Text = item.TotalScore.ToLocalisableString("N0"),
             },
             new RowText
             {
-                Text = $@"{item.RankedScore:N0}",
+                Text = item.RankedScore.ToLocalisableString("N0")
             }
         };
     }

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -10,6 +10,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Users;
 using osu.Game.Scoring;
 using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Rankings.Tables
 {
@@ -20,12 +21,12 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
         }
 
-        protected virtual IEnumerable<string> GradeColumns => new List<string> { "SS", "S", "A" };
+        protected virtual IEnumerable<LocalisableString> GradeColumns => new List<LocalisableString> { RankingsStrings.Statss, RankingsStrings.Stats, RankingsStrings.Stata };
 
         protected override RankingsTableColumn[] CreateAdditionalHeaders() => new[]
             {
-                new RankingsTableColumn("Accuracy", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-                new RankingsTableColumn("Play Count", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+                new RankingsTableColumn(RankingsStrings.StatAccuracy, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
+                new RankingsTableColumn(RankingsStrings.StatPlayCount, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
             }.Concat(CreateUniqueHeaders())
              .Concat(GradeColumns.Select(grade => new GradeTableColumn(grade, Anchor.Centre, new Dimension(GridSizeMode.AutoSize))))
              .ToArray();
@@ -47,12 +48,12 @@ namespace osu.Game.Overlays.Rankings.Tables
         protected sealed override Drawable[] CreateAdditionalContent(UserStatistics item) => new[]
         {
             new ColoredRowText { Text = item.DisplayAccuracy, },
-            new ColoredRowText { Text = $@"{item.PlayCount:N0}", },
+            new ColoredRowText { Text = item.PlayCount.ToLocalisableString("N0") },
         }.Concat(CreateUniqueContent(item)).Concat(new[]
         {
-            new ColoredRowText { Text = $@"{item.GradesCount[ScoreRank.XH] + item.GradesCount[ScoreRank.X]:N0}", },
-            new ColoredRowText { Text = $@"{item.GradesCount[ScoreRank.SH] + item.GradesCount[ScoreRank.S]:N0}", },
-            new ColoredRowText { Text = $@"{item.GradesCount[ScoreRank.A]:N0}", }
+            new ColoredRowText { Text = (item.GradesCount[ScoreRank.XH] + item.GradesCount[ScoreRank.X]).ToLocalisableString("N0"), },
+            new ColoredRowText { Text = (item.GradesCount[ScoreRank.SH] + item.GradesCount[ScoreRank.S]).ToLocalisableString("N0"), },
+            new ColoredRowText { Text = item.GradesCount[ScoreRank.A].ToLocalisableString("N0"), }
         }).ToArray();
 
         protected abstract RankingsTableColumn[] CreateUniqueHeaders();
@@ -78,7 +79,7 @@ namespace osu.Game.Overlays.Rankings.Tables
                 {
                     // Grade columns have extra horizontal padding for readibility
                     Horizontal = 20,
-                    Vertical = 5
+                    Vertical = 150
                 };
             }
         }

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -48,12 +48,12 @@ namespace osu.Game.Overlays.Rankings.Tables
         protected sealed override Drawable[] CreateAdditionalContent(UserStatistics item) => new[]
         {
             new ColouredRowText { Text = item.DisplayAccuracy, },
-            new ColouredRowText { Text = item.PlayCount.ToLocalisableString("N0") },
+            new ColouredRowText { Text = item.PlayCount.ToLocalisableString(@"N0") },
         }.Concat(CreateUniqueContent(item)).Concat(new[]
         {
-            new ColouredRowText { Text = (item.GradesCount[ScoreRank.XH] + item.GradesCount[ScoreRank.X]).ToLocalisableString("N0"), },
-            new ColouredRowText { Text = (item.GradesCount[ScoreRank.SH] + item.GradesCount[ScoreRank.S]).ToLocalisableString("N0"), },
-            new ColouredRowText { Text = item.GradesCount[ScoreRank.A].ToLocalisableString("N0"), }
+            new ColouredRowText { Text = (item.GradesCount[ScoreRank.XH] + item.GradesCount[ScoreRank.X]).ToLocalisableString(@"N0"), },
+            new ColouredRowText { Text = (item.GradesCount[ScoreRank.SH] + item.GradesCount[ScoreRank.S]).ToLocalisableString(@"N0"), },
+            new ColouredRowText { Text = item.GradesCount[ScoreRank.A].ToLocalisableString(@"N0"), }
         }).ToArray();
 
         protected abstract RankingsTableColumn[] CreateUniqueHeaders();

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -47,13 +47,13 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected sealed override Drawable[] CreateAdditionalContent(UserStatistics item) => new[]
         {
-            new ColoredRowText { Text = item.DisplayAccuracy, },
-            new ColoredRowText { Text = item.PlayCount.ToLocalisableString("N0") },
+            new ColouredRowText { Text = item.DisplayAccuracy, },
+            new ColouredRowText { Text = item.PlayCount.ToLocalisableString("N0") },
         }.Concat(CreateUniqueContent(item)).Concat(new[]
         {
-            new ColoredRowText { Text = (item.GradesCount[ScoreRank.XH] + item.GradesCount[ScoreRank.X]).ToLocalisableString("N0"), },
-            new ColoredRowText { Text = (item.GradesCount[ScoreRank.SH] + item.GradesCount[ScoreRank.S]).ToLocalisableString("N0"), },
-            new ColoredRowText { Text = item.GradesCount[ScoreRank.A].ToLocalisableString("N0"), }
+            new ColouredRowText { Text = (item.GradesCount[ScoreRank.XH] + item.GradesCount[ScoreRank.X]).ToLocalisableString("N0"), },
+            new ColouredRowText { Text = (item.GradesCount[ScoreRank.SH] + item.GradesCount[ScoreRank.S]).ToLocalisableString("N0"), },
+            new ColouredRowText { Text = item.GradesCount[ScoreRank.A].ToLocalisableString("N0"), }
         }).ToArray();
 
         protected abstract RankingsTableColumn[] CreateUniqueHeaders();

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Rankings.Tables
                 {
                     // Grade columns have extra horizontal padding for readibility
                     Horizontal = 20,
-                    Vertical = 150
+                    Vertical = 5
                 };
             }
         }


### PR DESCRIPTION
Here is a first pass at localising the rankings overlay.
This should cover next to 98%  of the localisation of the overlay.

A string in the country filter was left unlocalised at it is missing from the web localisation since the design was updated on web to a dropdown whereas lazer still has the pill-based country filter, not sure whether to include it a a localisable string client-side for now or to left it is as it and wait for a design update of the rankings overlay.


---
 ![osu_2021-07-30_15-27-32](https://user-images.githubusercontent.com/20256717/127660471-c69d1d93-6aa6-4772-8ab3-a69e6fa0d72a.jpg)