### PR TITLE
Add audio adjustment support for `Metronome`s

### DIFF
--- a/osu.Game/Rulesets/Mods/Metronome.cs
+++ b/osu.Game/Rulesets/Mods/Metronome.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
-using osu.Framework.Graphics;
+using osu.Framework.Bindables;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
@@ -11,11 +11,11 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public class Metronome : BeatSyncedContainer
+    public class Metronome : BeatSyncedContainer, IAdjustableAudioComponent
     {
         private readonly double firstHitTime;
 
-        private PausableSkinnableSound sample;
+        private readonly PausableSkinnableSound sample;
 
         /// <param name="firstHitTime">Start time of the first hit object, used for providing a count down.</param>
         public Metronome(double firstHitTime)
@@ -23,15 +23,8 @@ namespace osu.Game.Rulesets.Mods
             this.firstHitTime = firstHitTime;
             AllowMistimedEventFiring = false;
             Divisor = 1;
-        }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            InternalChildren = new Drawable[]
-            {
-                sample = new PausableSkinnableSound(new SampleInfo("Gameplay/catch-banana"))
-            };
+            InternalChild = sample = new PausableSkinnableSound(new SampleInfo("Gameplay/catch-banana"));
         }
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
@@ -49,5 +42,50 @@ namespace osu.Game.Rulesets.Mods
             sample.Frequency.Value = beatIndex % timeSignature == 0 ? 1 : 0.5f;
             sample.Play();
         }
+
+        #region IAdjustableAudioComponent
+
+        public IBindable<double> AggregateVolume => sample.AggregateVolume;
+
+        public IBindable<double> AggregateBalance => sample.AggregateBalance;
+
+        public IBindable<double> AggregateFrequency => sample.AggregateFrequency;
+
+        public IBindable<double> AggregateTempo => sample.AggregateTempo;
+
+        public BindableNumber<double> Volume => sample.Volume;
+
+        public BindableNumber<double> Balance => sample.Balance;
+
+        public BindableNumber<double> Frequency => sample.Frequency;
+
+        public BindableNumber<double> Tempo => sample.Tempo;
+
+        public void BindAdjustments(IAggregateAudioAdjustment component)
+        {
+            sample.BindAdjustments(component);
+        }
+
+        public void UnbindAdjustments(IAggregateAudioAdjustment component)
+        {
+            sample.UnbindAdjustments(component);
+        }
+
+        public void AddAdjustment(AdjustableProperty type, IBindable<double> adjustBindable)
+        {
+            sample.AddAdjustment(type, adjustBindable);
+        }
+
+        public void RemoveAdjustment(AdjustableProperty type, IBindable<double> adjustBindable)
+        {
+            sample.RemoveAdjustment(type, adjustBindable);
+        }
+
+        public void RemoveAllAdjustments(AdjustableProperty type)
+        {
+            sample.RemoveAllAdjustments(type);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
For use in #14064 (or after it gets merged), see https://github.com/ppy/osu/pull/14064#discussion_r679795568.

The sample was moved to being initialised in constructor instead for cases where adjustment is applied before the component is loaded.