### PR TITLE
Rebalance FL bonus, add HDFL bonus

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -114,11 +114,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (mods.Any(h => h is OsuModFlashlight))
             {
                 // Apply object-based bonus for flashlight.
-                flashlightBonus = 1.0 + 0.35 * Math.Min(1.0, totalHits / 200.0) +
-                                  (totalHits > 200
-                                      ? 0.3 * Math.Min(1.0, (totalHits - 200) / 300.0) +
-                                        (totalHits > 500 ? (totalHits - 500) / 1200.0 : 0.0)
-                                      : 0.0);
+                var hitsOver200Bonus = totalHits > 200 ? 0.3 * Math.Min(1.0, (totalHits - 200) / 300.0) : 0.0;
+                var hitsOver500Bonus = totalHits > 500 ? Math.Min(1.0, (totalHits - 500) / 1500.0) : 0.0;
+                var hitsOver2000Bonus = totalHits > 2000 ? (totalHits - 2000) / 1700.0 : 0.0;
+
+                flashlightBonus = 1.0 + 0.35 * Math.Min(1.0, totalHits / 200.0) + hitsOver200Bonus + hitsOver500Bonus + hitsOver2000Bonus;
+
+                if (mods.Any(h => h is OsuModHidden))
+                    flashlightBonus *= 1.1;
             }
 
             aimValue *= Math.Max(flashlightBonus, approachRateBonus);


### PR DESCRIPTION
This nerfs FL scores with more than 500 hits and adds a new bonus when HD is applied which were requested by FL community for a long time.

![image](https://user-images.githubusercontent.com/8269193/127752443-36dbf443-104f-405a-8d8d-771b47bab35d.png)
X is object count, Y is bonus, red is live, blue is new, green is new with HD

Interactive graph: https://www.desmos.com/calculator/trrdjye53b

[fgsky.txt](https://github.com/ppy/osu/files/6911833/fgsky.txt)
[kalanluu.txt](https://github.com/ppy/osu/files/6911834/kalanluu.txt)
[gn.txt](https://github.com/ppy/osu/files/6911835/gn.txt)
[mbmasher.txt](https://github.com/ppy/osu/files/6911836/mbmasher.txt)

<sup>You might wanna lock this pr as too heated immediately, since it's a very very controversial change for the general community.</sup>