### PR TITLE
Ensure proxied judgement content is correctly depth-ordered

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private void onJudgementLoaded(DrawableOsuJudgement judgement)
         {
-            judgementAboveHitObjectLayer.Add(judgement.GetProxyAboveHitObjectsContent());
+            judgementAboveHitObjectLayer.Add(judgement.ProxiedAboveHitObjectsContent);
         }
 
         [BackgroundDependencyLoader(true)]
@@ -150,6 +150,10 @@ namespace osu.Game.Rulesets.Osu.UI
             DrawableOsuJudgement explosion = poolDictionary[result.Type].Get(doj => doj.Apply(result, judgedObject));
 
             judgementLayer.Add(explosion);
+
+            // the proxied content is added to judgementAboveHitObjectLayer once, on first load, and never removed from it.
+            // ensure that ordering is consistent with expectations (latest judgement should be front-most).
+            judgementAboveHitObjectLayer.ChangeChildDepth(explosion.ProxiedAboveHitObjectsContent, (float)-result.TimeAbsolute);
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => HitObjectContainer.ReceivePositionalInputAt(screenSpacePos);

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -31,6 +32,9 @@ namespace osu.Game.Rulesets.Judgements
 
         private readonly Container aboveHitObjectsContent;
 
+        private readonly Lazy<Drawable> proxiedAboveHitObjectsContent;
+        public Drawable ProxiedAboveHitObjectsContent => proxiedAboveHitObjectsContent.Value;
+
         /// <summary>
         /// Creates a drawable which visualises a <see cref="Judgements.Judgement"/>.
         /// </summary>
@@ -52,6 +56,8 @@ namespace osu.Game.Rulesets.Judgements
                 Depth = float.MinValue,
                 RelativeSizeAxes = Axes.Both
             });
+
+            proxiedAboveHitObjectsContent = new Lazy<Drawable>(() => aboveHitObjectsContent.CreateProxy());
         }
 
         [BackgroundDependencyLoader]
@@ -59,8 +65,6 @@ namespace osu.Game.Rulesets.Judgements
         {
             prepareDrawables();
         }
-
-        public Drawable GetProxyAboveHitObjectsContent() => aboveHitObjectsContent.CreateProxy();
 
         /// <summary>
         /// Apply top-level animations to the current judgement when successfully hit.


### PR DESCRIPTION
Closes #14089.

osu! was using `GetProxyAboveHitObjectsContent()` to proxy things out of the judgements, but the proxied contents were only ever added once to their target container. Due to pooling that meant that their order could look wrong later on after first usage.

This was even visible in test scenes, on the `old-skin` (second-to-last object is wrong):

| `master` | this PR |
| :-: | :-: |
| ![2021-08-01-150758_690x478_scrot](https://user-images.githubusercontent.com/20418176/127772488-8268cee5-0e83-4c9a-b729-424658b9c101.png) | ![2021-08-01-150904_691x478_scrot](https://user-images.githubusercontent.com/20418176/127772492-995bb7fc-b1ae-40d0-8ad0-92f47e35c9da.png) |