### PR TITLE
Fix judgement processors provided to mods while not completely loaded

### DIFF
--- a/osu.Game/Rulesets/Mods/IApplicableToHealthProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToHealthProcessor.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToHealthProcessor : IApplicableMod
     {
         /// <summary>
-        /// Provides a ready <see cref="HealthProcessor"/> to a mod. Called once on initialisation of a play instance.
+        /// Provides a loaded <see cref="HealthProcessor"/> to a mod. Called once on initialisation of a play instance.
         /// </summary>
         void ApplyToHealthProcessor(HealthProcessor healthProcessor);
     }

--- a/osu.Game/Rulesets/Mods/IApplicableToHealthProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToHealthProcessor.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToHealthProcessor : IApplicableMod
     {
         /// <summary>
-        /// Provide a <see cref="HealthProcessor"/> to a mod. Called once on initialisation of a play instance.
+        /// Provides a ready <see cref="HealthProcessor"/> to a mod. Called once on initialisation of a play instance.
         /// </summary>
         void ApplyToHealthProcessor(HealthProcessor healthProcessor);
     }

--- a/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToScoreProcessor : IApplicableMod
     {
         /// <summary>
-        /// Provide a <see cref="ScoreProcessor"/> to a mod. Called once on initialisation of a play instance.
+        /// Provides a loaded <see cref="ScoreProcessor"/> to a mod. Called once on initialisation of a play instance.
         /// </summary>
         void ApplyToScoreProcessor(ScoreProcessor scoreProcessor);
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -297,6 +297,8 @@ namespace osu.Game.Screens.Play
             ScoreProcessor.HasCompleted.BindValueChanged(scoreCompletionChanged);
             HealthProcessor.Failed += onFail;
 
+            // Provide judgement processors to mods after they're loaded so that they're on the gameplay clock,
+            // this is required for mods that apply transforms to these processors.
             ScoreProcessor.OnLoadComplete += _ =>
             {
                 foreach (var mod in Mods.Value.OfType<IApplicableToScoreProcessor>())

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -297,11 +297,17 @@ namespace osu.Game.Screens.Play
             ScoreProcessor.HasCompleted.BindValueChanged(scoreCompletionChanged);
             HealthProcessor.Failed += onFail;
 
-            foreach (var mod in Mods.Value.OfType<IApplicableToScoreProcessor>())
-                mod.ApplyToScoreProcessor(ScoreProcessor);
+            ScoreProcessor.OnLoadComplete += _ =>
+            {
+                foreach (var mod in Mods.Value.OfType<IApplicableToScoreProcessor>())
+                    mod.ApplyToScoreProcessor(ScoreProcessor);
+            };
 
-            foreach (var mod in Mods.Value.OfType<IApplicableToHealthProcessor>())
-                mod.ApplyToHealthProcessor(HealthProcessor);
+            HealthProcessor.OnLoadComplete += _ =>
+            {
+                foreach (var mod in Mods.Value.OfType<IApplicableToHealthProcessor>())
+                    mod.ApplyToHealthProcessor(HealthProcessor);
+            };
 
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);


### PR DESCRIPTION
This was causing the initial transforms added on `ModMuted` to be populated with an incorrect clock time.

I wasn't sure whether to fix it locally by wrapping the muted logic in `OnLoadComplete`, but I see no reason not to do it for all mods.