### PR TITLE
Add localisation license header to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -190,3 +190,6 @@ dotnet_diagnostic.CA2225.severity = none
 
 # Banned APIs
 dotnet_diagnostic.RS0030.severity = error
+
+dotnet_diagnostic.OLOC001.prefix_namespace = osu.Game.Resources.Localisation
+dotnet_diagnostic.OLOC001.license_header = // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.\n// See the LICENCE file in the repository root for full licence text.

--- a/.editorconfig
+++ b/.editorconfig
@@ -191,5 +191,4 @@ dotnet_diagnostic.CA2225.severity = none
 # Banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
-dotnet_diagnostic.OLOC001.prefix_namespace = osu.Game.Resources.Localisation
 dotnet_diagnostic.OLOC001.license_header = // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.\n// See the LICENCE file in the repository root for full licence text.

--- a/osu.Game/.editorconfig
+++ b/osu.Game/.editorconfig
@@ -1,2 +1,3 @@
 [*.cs]
 dotnet_diagnostic.OLOC001.prefix_namespace = osu.Game.Resources.Localisation
+dotnet_diagnostic.OLOC001.license_header = // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.\n// See the LICENCE file in the repository root for full licence text.


### PR DESCRIPTION
See https://github.com/ppy/osu-localisation-analyser/pull/38 for reference (can be merged as is - has no effect until the tool is updated).

I thought about reading the `.licenseheader` file, but I actually don't know what that file even is, and whether it's a format defined somewhere or what.

I've also duplicated it to the sln's own `.editorconfig`, since it should be used for all projects (rulesets), but haven't removed them from the `osu.Game`'s one until the next Rider release as I'm currently working around non-EAP Rider bugs. We probably won't be localising rulesets until the next Rider release anyway, so I didn't bother duplicating into each individual ruleset.