### PR TITLE
Fix screen offsetting logic accounting for not fully loaded overlays

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -833,9 +833,9 @@ namespace osu.Game
             {
                 float offset = 0;
 
-                if (Settings.State.Value == Visibility.Visible)
+                if (Settings.IsLoaded && Settings.State.Value == Visibility.Visible)
                     offset += Toolbar.HEIGHT / 2;
-                if (notifications.State.Value == Visibility.Visible)
+                if (notifications.IsLoaded && notifications.State.Value == Visibility.Visible)
                     offset -= Toolbar.HEIGHT / 2;
 
                 screenOffsetContainer.MoveToX(offset, SettingsPanel.TRANSITION_LENGTH, Easing.OutQuint);


### PR DESCRIPTION
Closes #14081 

Any overlay which hasn't reached a `LoadComplete`'d state can potentially have an invalid `Visibility` state due to the reasons I've mentioned in https://github.com/ppy/osu/issues/14081#issuecomment-890531152.

Therefore I've changed the screen offsetting logic to not account for overlays which are not fully loaded yet. Fixing the `Visibility` state to always respect `OverlayActivationMode` regardless of its load state can come later when deemed required.