### PR TITLE
Match osu!stable taiko playfield size at 16:9

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         /// <summary>
         /// Default height of a <see cref="TaikoPlayfield"/> when inside a <see cref="DrawableTaikoRuleset"/>.
         /// </summary>
-        public const float DEFAULT_HEIGHT = 178;
+        public const float DEFAULT_HEIGHT = 212;
 
         private Container<HitExplosion> hitExplosionContainer;
         private Container<KiaiHitExplosion> kiaiExplosionContainer;


### PR DESCRIPTION
Just eyeballed the value.

| old | new |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1329837/127843286-8bc6a514-2dff-4168-98ef-821509584f78.png) | ![res-comparison](https://user-images.githubusercontent.com/1329837/127841850-c9f0792c-f425-4c4c-bbe4-ecc8e99c3e6d.png) |