### PR TITLE
Make taiko classic mod emulate the classic "4:3" scroll speed

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -2,10 +2,30 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.UI;
+using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModClassic : ModClassic
+    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
     {
+        private DrawableTaikoRuleset drawableTaikoRuleset;
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
+        {
+            drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
+        }
+
+        public void Update(Playfield playfield)
+        {
+            // Classic taiko scrolls at a constant 100px per 1000ms. More notes become visible as the playfield is lengthened.
+            const float scroll_rate = 10;
+
+            // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
+            float ratio = drawableTaikoRuleset.DrawHeight / 480;
+
+            drawableTaikoRuleset.TimeRange.Value = (playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate;
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -12,7 +12,7 @@ using osu.Game.Rulesets.Taiko.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModHidden : ModHidden, IApplicableToDifficulty
+    public class TaikoModHidden : ModHidden
     {
         public override string Description => @"Beats fade out before you hit them!";
         public override double ScoreMultiplier => 1.06;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -17,18 +17,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override string Description => @"Beats fade out before you hit them!";
         public override double ScoreMultiplier => 1.06;
 
-        /// <summary>
-        /// In osu-stable, the hit position is 160, so the active playfield is essentially 160 pixels shorter
-        /// than the actual screen width. The normalized playfield height is 480, so on a 4:3 screen the
-        /// playfield ratio of the active area up to the hit position will actually be (640 - 160) / 480 = 1.
-        /// For custom resolutions/aspect ratios (x:y), the screen width given the normalized height becomes 480 * x / y instead,
-        /// and the playfield ratio becomes (480 * x / y - 160) / 480 = x / y - 1/3.
-        /// This constant is equal to the playfield ratio on 4:3 screens divided by the playfield ratio on 16:9 screens.
-        /// </summary>
-        private const double hd_sv_scale = (4.0 / 3.0 - 1.0 / 3.0) / (16.0 / 9.0 - 1.0 / 3.0);
-
-        private double originalSliderMultiplier;
-
         private ControlPointInfo controlPointInfo;
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
@@ -41,7 +29,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
             double beatLength = controlPointInfo.TimingPointAt(position).BeatLength;
             double speedMultiplier = controlPointInfo.DifficultyPointAt(position).SpeedMultiplier;
 
-            return originalSliderMultiplier * speedMultiplier * TimingControlPoint.DEFAULT_BEAT_LENGTH / beatLength;
+            return speedMultiplier * TimingControlPoint.DEFAULT_BEAT_LENGTH / beatLength;
         }
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
@@ -67,22 +55,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
                     break;
             }
-        }
-
-        public void ReadFromDifficulty(BeatmapDifficulty difficulty)
-        {
-        }
-
-        public void ApplyToDifficulty(BeatmapDifficulty difficulty)
-        {
-            // needs to be read after all processing has been run (TaikoBeatmapConverter applies an adjustment which would otherwise be omitted).
-            originalSliderMultiplier = difficulty.SliderMultiplier;
-
-            // osu-stable has an added playfield cover that essentially forces a 4:3 playfield ratio, by cutting off all objects past that size.
-            // This is not yet implemented; instead a playfield adjustment container is present which maintains a 16:9 ratio.
-            // For now, increase the slider multiplier proportionally so that the notes stay on the screen for the same amount of time as on stable.
-            // Note that this means that the notes will scroll faster as they have a longer distance to travel on the screen in that same amount of time.
-            difficulty.SliderMultiplier /= hd_sv_scale;
         }
 
         public override void ApplyToBeatmap(IBeatmap beatmap)

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -24,11 +25,13 @@ namespace osu.Game.Rulesets.Taiko.UI
 {
     public class DrawableTaikoRuleset : DrawableScrollingRuleset<TaikoHitObject>
     {
-        private SkinnableDrawable scroller;
+        public new BindableDouble TimeRange => base.TimeRange;
 
         protected override ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Overlapping;
 
         protected override bool UserScrollSpeedAdjustment => false;
+
+        private SkinnableDrawable scroller;
 
         public DrawableTaikoRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
             : base(ruleset, beatmap, mods)

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
         /// <summary>
         /// The maximum span of time that may be visible by the length of the scrolling axes.
         /// </summary>
-        private const double time_span_max = 10000;
+        private const double time_span_max = 20000;
 
         /// <summary>
         /// The step increase/decrease of the span of time visible by the length of the scrolling axes.


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu/discussions/13047

| | stable | master | This PR |
| --- | --- | --- | ---|
| 4:3 | ![stable-4:3](https://user-images.githubusercontent.com/1329837/127852036-fb6e1ba9-e160-4ab5-8128-5200fb349bbc.png) | ![lazer-master-4:3](https://user-images.githubusercontent.com/1329837/127852050-899839f5-f816-481c-963b-814c5d4e1765.png) | ![lazer-4:3](https://user-images.githubusercontent.com/1329837/127852071-2129371e-45a6-41d5-85a2-5460406c04f1.png) |
| 16:9 | ![stable-16:9](https://user-images.githubusercontent.com/1329837/127852098-0dfe68ec-de60-4fed-8f36-540e5f990ec9.png) | ![lazer-master-16:9](https://user-images.githubusercontent.com/1329837/127852113-40e85f7d-193c-4a95-8987-9d137d928a91.png) | ![lazer-16:9](https://user-images.githubusercontent.com/1329837/127852124-66b3905e-5074-4982-ae00-39d5b80518e1.png) |
| 5:4 | ![stable-5:4](https://user-images.githubusercontent.com/1329837/127852142-543dfb24-5a5a-43b7-8f33-e4ef19122a52.png) | ![lazer-master-5:4](https://user-images.githubusercontent.com/1329837/127852157-d03b4e7c-7ef9-44bf-bc3f-3c42c3e67aae.png) | ![lazer-5:4](https://user-images.githubusercontent.com/1329837/127852168-966a6c79-890b-470d-90ea-b42cb389b80c.png) |

Remaining differences are due to the hit target/`HitObjectContainer` being offset compared to stable.

I haven't taken the HD mod into account beyond removing the existing hackery which would would completely hide the hitobjects at 4:3 resolutions with this mod. I personally don't believe we really need to do this for the classic mod since it's meant more as a stop-gap measure to bring players into familiarity and can have a score/pp/prestige multiplier.