### PR TITLE
Add ability to choose Team Versus match type and view / switch teams

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -1,0 +1,138 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens;
+using osu.Game.Screens.OnlinePlay.Components;
+using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+using osu.Game.Tests.Resources;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    public class TestSceneTeamVersus : ScreenTestScene
+    {
+        private BeatmapManager beatmaps;
+        private RulesetStore rulesets;
+        private BeatmapSetInfo importedSet;
+
+        private DependenciesScreen dependenciesScreen;
+        private TestMultiplayer multiplayerScreen;
+        private TestMultiplayerClient client;
+
+        [Cached(typeof(UserLookupCache))]
+        private UserLookupCache lookupCache = new TestUserLookupCache();
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host, AudioManager audio)
+        {
+            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
+        }
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("import beatmap", () =>
+            {
+                beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).Wait();
+                importedSet = beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.All).First();
+            });
+
+            AddStep("create multiplayer screen", () => multiplayerScreen = new TestMultiplayer());
+
+            AddStep("load dependencies", () =>
+            {
+                client = new TestMultiplayerClient(multiplayerScreen.RoomManager);
+
+                // The screen gets suspended so it stops receiving updates.
+                Child = client;
+
+                LoadScreen(dependenciesScreen = new DependenciesScreen(client));
+            });
+
+            AddUntilStep("wait for dependencies to load", () => dependenciesScreen.IsLoaded);
+
+            AddStep("load multiplayer", () => LoadScreen(multiplayerScreen));
+            AddUntilStep("wait for multiplayer to load", () => multiplayerScreen.IsLoaded);
+            AddUntilStep("wait for lounge to load", () => this.ChildrenOfType<MultiplayerLoungeSubScreen>().FirstOrDefault()?.IsLoaded == true);
+        }
+
+        [Test]
+        public void TestChangeTypeViaMatchSettings()
+        {
+            createRoom(() => new Room
+            {
+                Name = { Value = "Test Room" },
+                Playlist =
+                {
+                    new PlaylistItem
+                    {
+                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.RulesetID == 0)).BeatmapInfo },
+                        Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                    }
+                }
+            });
+
+            AddAssert("room type is head to head", () => client.Room?.Settings.MatchType == MatchType.HeadToHead);
+
+            AddStep("change to team vs", () => client.ChangeSettings(matchType: MatchType.TeamVersus));
+
+            AddAssert("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
+        }
+
+        private void createRoom(Func<Room> room)
+        {
+            AddStep("open room", () =>
+            {
+                multiplayerScreen.OpenNewRoom(room());
+            });
+
+            AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
+            AddWaitStep("wait for transition", 2);
+
+            AddStep("create room", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("wait for join", () => client.Room != null);
+        }
+
+        /// <summary>
+        /// Used for the sole purpose of adding <see cref="TestMultiplayerClient"/> as a resolvable dependency.
+        /// </summary>
+        private class DependenciesScreen : OsuScreen
+        {
+            [Cached(typeof(MultiplayerClient))]
+            public readonly TestMultiplayerClient Client;
+
+            public DependenciesScreen(TestMultiplayerClient client)
+            {
+                Client = client;
+            }
+        }
+
+        private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
+        {
+            public new TestRequestHandlingMultiplayerRoomManager RoomManager { get; private set; }
+
+            protected override RoomManager CreateRoomManager() => RoomManager = new TestRequestHandlingMultiplayerRoomManager();
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -19,6 +19,7 @@ using osu.Game.Screens;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Participants;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
 
@@ -92,6 +93,36 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddAssert("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
             AddAssert("user state arrived", () => client.Room?.Users.FirstOrDefault()?.MatchState is TeamVersusUserState);
+        }
+
+        [Test]
+        public void TestChangeTeamsViaButton()
+        {
+            createRoom(() => new Room
+            {
+                Name = { Value = "Test Room" },
+                Type = { Value = MatchType.TeamVersus },
+                Playlist =
+                {
+                    new PlaylistItem
+                    {
+                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.RulesetID == 0)).BeatmapInfo },
+                        Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                    }
+                }
+            });
+
+            AddAssert("user on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
+
+            AddStep("press button", () =>
+            {
+                InputManager.MoveMouseTo(multiplayerScreen.ChildrenOfType<TeamDisplay>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("user on team 1", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 1);
+
+            AddStep("press button", () => InputManager.Click(MouseButton.Left));
+            AddAssert("user on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -11,6 +11,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
@@ -70,6 +71,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("load multiplayer", () => LoadScreen(multiplayerScreen));
             AddUntilStep("wait for multiplayer to load", () => multiplayerScreen.IsLoaded);
             AddUntilStep("wait for lounge to load", () => this.ChildrenOfType<MultiplayerLoungeSubScreen>().FirstOrDefault()?.IsLoaded == true);
+        }
+
+        [Test]
+        public void TestCreateWithType()
+        {
+            createRoom(() => new Room
+            {
+                Name = { Value = "Test Room" },
+                Type = { Value = MatchType.TeamVersus },
+                Playlist =
+                {
+                    new PlaylistItem
+                    {
+                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.RulesetID == 0)).BeatmapInfo },
+                        Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                    }
+                }
+            });
+
+            AddAssert("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
+            AddAssert("user state arrived", () => client.Room?.Users.FirstOrDefault()?.MatchState is TeamVersusUserState);
         }
 
         [Test]

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -142,11 +142,20 @@ namespace osu.Game.Online.Multiplayer
                     APIRoom = room;
                     foreach (var user in joinedRoom.Users)
                         updateUserPlayingState(user.UserID, user.State);
+
+                    OnRoomJoined();
                 }, cancellationSource.Token).ConfigureAwait(false);
 
                 // Update room settings.
                 await updateLocalRoomSettings(joinedRoom.Settings, cancellationSource.Token).ConfigureAwait(false);
             }, cancellationSource.Token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Fired when the room join sequence is complete
+        /// </summary>
+        protected virtual void OnRoomJoined()
+        {
         }
 
         /// <summary>

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -192,8 +192,9 @@ namespace osu.Game.Online.Multiplayer
         /// </remarks>
         /// <param name="name">The new room name, if any.</param>
         /// <param name="password">The new password, if any.</param>
+        /// <param name="matchType">The type of the match, if any.</param>
         /// <param name="item">The new room playlist item, if any.</param>
-        public Task ChangeSettings(Optional<string> name = default, Optional<string> password = default, Optional<PlaylistItem> item = default)
+        public Task ChangeSettings(Optional<string> name = default, Optional<string> password = default, Optional<MatchType> matchType = default, Optional<PlaylistItem> item = default)
         {
             if (Room == null)
                 throw new InvalidOperationException("Must be joined to a match to change settings.");
@@ -219,6 +220,7 @@ namespace osu.Game.Online.Multiplayer
                 BeatmapID = item.GetOr(existingPlaylistItem).BeatmapID,
                 BeatmapChecksum = item.GetOr(existingPlaylistItem).Beatmap.Value.MD5Hash,
                 RulesetID = item.GetOr(existingPlaylistItem).RulesetID,
+                MatchType = matchType.GetOr(Room.Settings.MatchType),
                 RequiredMods = item.HasValue ? item.Value.AsNonNull().RequiredMods.Select(m => new APIMod(m)).ToList() : Room.Settings.RequiredMods,
                 AllowedMods = item.HasValue ? item.Value.AsNonNull().AllowedMods.Select(m => new APIMod(m)).ToList() : Room.Settings.AllowedMods,
             });

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.Rooms
         public readonly Bindable<RoomAvailability> Availability = new Bindable<RoomAvailability>();
 
         [Cached]
-        [JsonIgnore]
+        [JsonProperty("type")]
         public readonly Bindable<MatchType> Type = new Bindable<MatchType>();
 
         // Todo: osu-framework bug (https://github.com/ppy/osu-framework/issues/4106)

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.Rooms
         public readonly Bindable<RoomAvailability> Availability = new Bindable<RoomAvailability>();
 
         [Cached]
-        [JsonProperty("type")]
+        [JsonIgnore]
         public readonly Bindable<MatchType> Type = new Bindable<MatchType>();
 
         // Todo: osu-framework bug (https://github.com/ppy/osu-framework/issues/4106)

--- a/osu.Game/Screens/OnlinePlay/Components/DisableableTabControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/DisableableTabControl.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 {
     public abstract class DisableableTabControl<T> : TabControl<T>
     {
-        public readonly BindableBool Enabled = new BindableBool();
+        public readonly BindableBool Enabled = new BindableBool(true);
 
         protected override void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -149,7 +149,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                                 },
                                                                 new Section("Game type")
                                                                 {
-                                                                    Alpha = disabled_alpha,
                                                                     Child = new FillFlowContainer
                                                                     {
                                                                         AutoSizeAxes = Axes.Y,
@@ -161,7 +160,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                                             TypePicker = new MatchTypePicker
                                                                             {
                                                                                 RelativeSizeAxes = Axes.X,
-                                                                                Enabled = { Value = false }
                                                                             },
                                                                             typeLabel = new OsuSpriteText
                                                                             {
@@ -305,7 +303,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 // Otherwise, update the room directly in preparation for it to be submitted to the API on match creation.
                 if (client.Room != null)
                 {
-                    client.ChangeSettings(name: NameField.Text, password: PasswordTextBox.Text).ContinueWith(t => Schedule(() =>
+                    client.ChangeSettings(name: NameField.Text, password: PasswordTextBox.Text, matchType: TypePicker.Current.Value).ContinueWith(t => Schedule(() =>
                     {
                         if (t.IsCompletedSuccessfully)
                             onSuccess(currentRoom.Value);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -58,7 +58,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             new Room
             {
                 Name = { Value = $"{API.LocalUser}'s awesome room" },
-                Category = { Value = RoomCategory.Realtime }
+                Category = { Value = RoomCategory.Realtime },
+                Type = { Value = MatchType.HeadToHead },
             };
 
         protected override string ScreenTitle => "Multiplayer";

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -17,7 +17,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
-using osu.Game.Online.Multiplayer.MatchRulesets.TeamVs;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
@@ -38,7 +37,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private RulesetStore rulesets { get; set; }
 
         private SpriteIcon crown;
-        private Box teamDisplay;
 
         private OsuSpriteText userRankText;
         private ModDisplay userModsDisplay;
@@ -59,106 +57,108 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             var backgroundColour = Color4Extensions.FromHex("#33413C");
 
-            InternalChildren = new Drawable[]
+            InternalChild = new GridContainer
             {
-                crown = new SpriteIcon
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = new[]
                 {
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    Icon = FontAwesome.Solid.Crown,
-                    Size = new Vector2(14),
-                    Colour = Color4Extensions.FromHex("#F7E65D"),
-                    Alpha = 0
+                    new Dimension(GridSizeMode.Absolute, 14),
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension()
                 },
-                teamDisplay = new Box
+                Content = new[]
                 {
-                    Colour = Color4.Black,
-                    RelativeSizeAxes = Axes.Y,
-                    Width = 15,
-                    Alpha = 0,
-                },
-                new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Left = 24 },
-                    Child = new Container
+                    new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Masking = true,
-                        CornerRadius = 5,
-                        Children = new Drawable[]
+                        crown = new SpriteIcon
                         {
-                            new Box
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Icon = FontAwesome.Solid.Crown,
+                            Size = new Vector2(14),
+                            Colour = Color4Extensions.FromHex("#F7E65D"),
+                            Alpha = 0
+                        },
+                        new TeamDisplay(user),
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            CornerRadius = 5,
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = backgroundColour
-                            },
-                            new UserCoverBackground
-                            {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                RelativeSizeAxes = Axes.Both,
-                                Width = 0.75f,
-                                User = user,
-                                Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0), Color4.White.Opacity(0.25f))
-                            },
-                            new FillFlowContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Spacing = new Vector2(10),
-                                Direction = FillDirection.Horizontal,
-                                Children = new Drawable[]
+                                new Box
                                 {
-                                    new UpdateableAvatar
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = backgroundColour
+                                },
+                                new UserCoverBackground
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Width = 0.75f,
+                                    User = user,
+                                    Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0), Color4.White.Opacity(0.25f))
+                                },
+                                new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Spacing = new Vector2(10),
+                                    Direction = FillDirection.Horizontal,
+                                    Children = new Drawable[]
                                     {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        RelativeSizeAxes = Axes.Both,
-                                        FillMode = FillMode.Fit,
-                                        User = user
-                                    },
-                                    new UpdateableFlag
-                                    {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Size = new Vector2(30, 20),
-                                        Country = user?.Country
-                                    },
-                                    new OsuSpriteText
-                                    {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 18),
-                                        Text = user?.Username
-                                    },
-                                    userRankText = new OsuSpriteText
-                                    {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(size: 14),
+                                        new UpdateableAvatar
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            RelativeSizeAxes = Axes.Both,
+                                            FillMode = FillMode.Fit,
+                                            User = user
+                                        },
+                                        new UpdateableFlag
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Size = new Vector2(30, 20),
+                                            Country = user?.Country
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 18),
+                                            Text = user?.Username
+                                        },
+                                        userRankText = new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Font = OsuFont.GetFont(size: 14),
+                                        }
                                     }
-                                }
-                            },
-                            new Container
-                            {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                AutoSizeAxes = Axes.Both,
-                                Margin = new MarginPadding { Right = 70 },
-                                Child = userModsDisplay = new ModDisplay
+                                },
+                                new Container
                                 {
-                                    Scale = new Vector2(0.5f),
-                                    ExpansionMode = ExpansionMode.AlwaysContracted,
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    AutoSizeAxes = Axes.Both,
+                                    Margin = new MarginPadding { Right = 70 },
+                                    Child = userModsDisplay = new ModDisplay
+                                    {
+                                        Scale = new Vector2(0.5f),
+                                        ExpansionMode = ExpansionMode.AlwaysContracted,
+                                    }
+                                },
+                                userStateDisplay = new StateDisplay
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    Margin = new MarginPadding { Right = 10 },
                                 }
-                            },
-                            userStateDisplay = new StateDisplay
-                            {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                Margin = new MarginPadding { Right = 10 },
                             }
                         }
-                    }
+                    },
                 }
             };
         }
@@ -184,34 +184,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             else
                 crown.FadeOut(fade_time);
 
-            if (User.MatchRulesetState is TeamVsMatchUserState teamState)
-            {
-                teamDisplay.Show();
-                teamDisplay.FadeColour(getColourForTeam(teamState.TeamID), 100, Easing.OutQuint);
-            }
-            else
-            {
-                teamDisplay.Hide();
-            }
-
             // If the mods are updated at the end of the frame, the flow container will skip a reflow cycle: https://github.com/ppy/osu-framework/issues/4187
             // This looks particularly jarring here, so re-schedule the update to that start of our frame as a fix.
             Schedule(() => userModsDisplay.Current.Value = User.Mods.Select(m => m.ToMod(ruleset)).ToList());
-        }
-
-        [Resolved]
-        private OsuColour colours { get; set; }
-
-        private ColourInfo getColourForTeam(int id)
-        {
-            switch (id)
-            {
-                default:
-                    return colours.Red;
-
-                case 1:
-                    return colours.Blue;
-            }
         }
 
         public MenuItem[] ContextMenuItems

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -17,6 +17,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchRulesets.TeamVs;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
@@ -37,6 +38,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private RulesetStore rulesets { get; set; }
 
         private SpriteIcon crown;
+        private Box teamDisplay;
+
         private OsuSpriteText userRankText;
         private ModDisplay userModsDisplay;
         private StateDisplay userStateDisplay;
@@ -66,6 +69,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     Size = new Vector2(14),
                     Colour = Color4Extensions.FromHex("#F7E65D"),
                     Alpha = 0
+                },
+                teamDisplay = new Box
+                {
+                    Colour = Color4.Black,
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 15,
+                    Alpha = 0,
                 },
                 new Container
                 {
@@ -174,9 +184,34 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             else
                 crown.FadeOut(fade_time);
 
+            if (User.MatchRulesetState is TeamVsMatchUserState teamState)
+            {
+                teamDisplay.Show();
+                teamDisplay.FadeColour(getColourForTeam(teamState.TeamID), 100, Easing.OutQuint);
+            }
+            else
+            {
+                teamDisplay.Hide();
+            }
+
             // If the mods are updated at the end of the frame, the flow container will skip a reflow cycle: https://github.com/ppy/osu-framework/issues/4187
             // This looks particularly jarring here, so re-schedule the update to that start of our frame as a fix.
             Schedule(() => userModsDisplay.Current.Value = User.Mods.Select(m => m.ToMod(ruleset)).ToList());
+        }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        private ColourInfo getColourForTeam(int id)
+        {
+            switch (id)
+            {
+                default:
+                    return colours.Red;
+
+                case 1:
+                    return colours.Blue;
+            }
         }
 
         public MenuItem[] ContextMenuItems

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 RelativeSizeAxes = Axes.Both,
                 ColumnDimensions = new[]
                 {
-                    new Dimension(GridSizeMode.Absolute, 14),
+                    new Dimension(GridSizeMode.Absolute, 18),
                     new Dimension(GridSizeMode.AutoSize),
                     new Dimension()
                 },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             Width = 15;
 
             Margin = new MarginPadding { Horizontal = 3 };
+
+            Alpha = 0;
+            Scale = new Vector2(0, 1);
         }
 
         [BackgroundDependencyLoader]
@@ -46,7 +49,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 RelativeSizeAxes = Axes.Both,
                 CornerRadius = 5,
                 Masking = true,
-                Alpha = 0,
                 Scale = new Vector2(0, 1),
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -104,14 +106,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             if (displayedTeam != null)
             {
-                box.FadeIn(duration);
                 box.FadeColour(getColourForTeam(displayedTeam.Value), duration, Easing.OutQuint);
                 box.ScaleTo(new Vector2(box.Scale.X < 0 ? 1 : -1, 1), duration, Easing.OutQuint);
+
+                this.ScaleTo(Vector2.One, duration, Easing.OutQuint);
+                this.FadeIn(duration);
             }
             else
             {
-                box.ScaleTo(new Vector2(0, 1), duration, Easing.OutQuint);
-                box.FadeOut(duration);
+                this.ScaleTo(new Vector2(0, 1), duration, Easing.OutQuint);
+                this.FadeOut(duration);
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
+using osu.Game.Users;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
+{
+    internal class TeamDisplay : MultiplayerRoomComposite
+    {
+        private readonly User user;
+        private Drawable box;
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        [Resolved]
+        private MultiplayerClient client { get; set; }
+
+        public TeamDisplay(User user)
+        {
+            this.user = user;
+
+            RelativeSizeAxes = Axes.Y;
+            Width = 15;
+
+            Margin = new MarginPadding { Horizontal = 3 };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            box = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                CornerRadius = 5,
+                Masking = true,
+                Alpha = 0,
+                Scale = new Vector2(0, 1),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Child = new Box
+                {
+                    Colour = Color4.White,
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+
+            if (user.Id == client.LocalUser?.UserID)
+            {
+                InternalChild = new OsuClickableContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    TooltipText = "Change team",
+                    Action = changeTeam,
+                    Child = box
+                };
+            }
+            else
+            {
+                InternalChild = box;
+            }
+        }
+
+        private void changeTeam()
+        {
+            client.SendMatchRequest(new ChangeTeamRequest
+            {
+                TeamID = ((client.LocalUser?.MatchState as TeamVersusUserState)?.TeamID + 1) % 2 ?? 0,
+            });
+        }
+
+        private int? displayedTeam;
+
+        protected override void OnRoomUpdated()
+        {
+            base.OnRoomUpdated();
+
+            // we don't have a way of knowing when an individual user's state has updated, so just handle on RoomUpdated for now.
+
+            var userRoomState = Room?.Users.FirstOrDefault(u => u.UserID == user.Id)?.MatchState;
+
+            const double duration = 400;
+
+            int? newTeam = (userRoomState as TeamVersusUserState)?.TeamID;
+
+            if (newTeam == displayedTeam)
+                return;
+
+            displayedTeam = newTeam;
+
+            if (displayedTeam != null)
+            {
+                box.FadeIn(duration);
+                box.FadeColour(getColourForTeam(displayedTeam.Value), duration, Easing.OutQuint);
+                box.ScaleTo(new Vector2(box.Scale.X < 0 ? 1 : -1, 1), duration, Easing.OutQuint);
+            }
+            else
+            {
+                box.ScaleTo(new Vector2(0, 1), duration, Easing.OutQuint);
+                box.FadeOut(duration);
+            }
+        }
+
+        private ColourInfo getColourForTeam(int id)
+        {
+            switch (id)
+            {
+                default:
+                    return colours.Red;
+
+                case 1:
+                    return colours.Blue;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Playlists/Playlists.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/Playlists.cs
@@ -48,7 +48,11 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override Room CreateNewRoom()
         {
-            return new Room { Name = { Value = $"{API.LocalUser}'s awesome playlist" } };
+            return new Room
+            {
+                Name = { Value = $"{API.LocalUser}'s awesome playlist" },
+                Type = { Value = MatchType.Playlists }
+            };
         }
 
         protected override string ScreenTitle => "Playlists";


### PR DESCRIPTION
Adds required UI components for changing match type and selecting your own team. Basic tests are in place, but I will look to hopefully add some more coverage tomorrow.

This has been full-flow tested with https://github.com/ppy/osu-web/pull/7965 and https://github.com/ppy/osu-server-spectator/pull/75 to work as one would expect.

Note that this doesn't yet show changes in gameplay or results. That will come later. Even so, I think this is in a mergeable state as if we did need to do a release the button to enable Team Versus could be temporarily disabled.

- [x] Depends on https://github.com/ppy/osu/pull/14104.

