### PR TITLE
Change markdown container font to use inter font

### DIFF
--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Graphics.Containers.Markdown
 
         public override SpriteText CreateSpriteText() => new OsuSpriteText
         {
-            Font = OsuFont.GetFont(size: 14),
+            Font = OsuFont.GetFont(Typeface.Inter, size: 14, weight: FontWeight.Regular),
         };
 
         public override MarkdownTextFlowContainer CreateTextFlow() => new OsuMarkdownTextFlowContainer();

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownHeading.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownHeading.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Graphics.Containers.Markdown
             public FontWeight FontWeight;
 
             protected override SpriteText CreateSpriteText()
-                => base.CreateSpriteText().With(t => t.Font = t.Font.With(size: FontSize, weight: FontWeight));
+                => base.CreateSpriteText().With(t => t.Font = t.Font.With(Typeface.Torus, size: FontSize, weight: FontWeight));
         }
     }
 }

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Graphics
 
         public static FontUsage Torus => GetFont(Typeface.Torus, weight: FontWeight.Regular);
 
+        public static FontUsage Inter => GetFont(Typeface.Inter, weight: FontWeight.Regular);
+
         /// <summary>
         /// Retrieves a <see cref="FontUsage"/>.
         /// </summary>
@@ -54,6 +56,9 @@ namespace osu.Game.Graphics
 
                 case Typeface.Torus:
                     return "Torus";
+
+                case Typeface.Inter:
+                    return "Inter";
             }
 
             return null;
@@ -107,7 +112,8 @@ namespace osu.Game.Graphics
     public enum Typeface
     {
         Venera,
-        Torus
+        Torus,
+        Inter,
     }
 
     public enum FontWeight

--- a/osu.Game/Overlays/Wiki/WikiMainPage.cs
+++ b/osu.Game/Overlays/Wiki/WikiMainPage.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.Wiki
                 Child = new OsuSpriteText
                 {
                     Text = blurbNode.InnerText,
-                    Font = OsuFont.GetFont(size: 12),
+                    Font = OsuFont.GetFont(Typeface.Inter, size: 12, weight: FontWeight.Light),
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                 }

--- a/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
+++ b/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.Wiki
                 DocumentMargin = new MarginPadding(0);
             }
 
-            public override SpriteText CreateSpriteText() => base.CreateSpriteText().With(t => t.Font = t.Font.With(weight: FontWeight.Bold));
+            public override SpriteText CreateSpriteText() => base.CreateSpriteText().With(t => t.Font = t.Font.With(Typeface.Torus, weight: FontWeight.Bold));
 
             public override MarkdownTextFlowContainer CreateTextFlow() => base.CreateTextFlow().With(f => f.TextAnchor = Anchor.TopCentre);
 


### PR DESCRIPTION
- Change markdown container font to inter.
- Heading and main page still use torus font.