### PR TITLE
Remove playlists type select button from multiplayer

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Online.Multiplayer
         public string Password { get; set; } = string.Empty;
 
         [Key(8)]
-        public MatchType MatchType { get; set; }
+        public MatchType MatchType { get; set; } = MatchType.HeadToHead;
 
         public bool Equals(MultiplayerRoomSettings other)
             => BeatmapID == other.BeatmapID

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchTypePicker.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchTypePicker.cs
@@ -30,8 +30,6 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
             AddItem(MatchType.HeadToHead);
             AddItem(MatchType.TeamVersus);
-            // TODO: remove after osu-web is updated to set the correct default type.
-            AddItem(MatchType.Playlists);
         }
 
         private class GameTypePickerItem : DisableableTabItem


### PR DESCRIPTION
Also sets a default `MultiplayerRoomSettings` type to something that isn't playlists. Mostly for server-side usage (so we can remove all the specifications in tests in https://github.com/ppy/osu-server-spectator/pull/77).
