### PR TITLE
Toggle the expanded state of the multiplayer leaderboard with the user's HUD

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            ((IBindable<bool>)leaderboard.Expanded).BindTo(IsBreakTime);
+            ((IBindable<bool>)leaderboard.Expanded).BindTo(HUDOverlay.ShowHud);
         }
 
         protected override void StartGameplay()


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/14140.

---

Until now, the multiplayer leaderboard would expand during break time.  Now, it respects the user's HUD visibility status (which can be toggled using Shift+Tab).
