### PR TITLE
Fix DHO state overwritten at `LoadComplete` if it is already changed

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -190,9 +190,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             comboIndexBindable.BindValueChanged(_ => UpdateComboColour());
             comboIndexWithOffsetsBindable.BindValueChanged(_ => UpdateComboColour(), true);
 
-            // If the state is changed, transforms are already initialized.
-            if (state.Value == ArmedState.Idle)
-                updateState(ArmedState.Idle, true);
+            // Apply transforms
+            updateState(State.Value, true);
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -190,7 +190,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
             comboIndexBindable.BindValueChanged(_ => UpdateComboColour());
             comboIndexWithOffsetsBindable.BindValueChanged(_ => UpdateComboColour(), true);
 
-            updateState(ArmedState.Idle, true);
+            // If the state is changed, transforms are already initialized.
+            if (state.Value == ArmedState.Idle)
+                updateState(ArmedState.Idle, true);
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixes #14126 (see my comment)

Note: frame-unstable seek (used by the spectator) will load many hit objects in one frame, causes a massive lag. But that is separate from the linked issue, as the linked issue is persistent after seek, not just one frame.