### PR TITLE
Misc hover/select sound usage updates

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.803.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.808.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2021.807.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -288,7 +288,7 @@ namespace osu.Game.Graphics.UserInterface
                     },
                 };
 
-                AddInternal(new HoverSounds());
+                AddInternal(new HoverClickSounds());
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -13,6 +16,12 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class OsuMenu : Menu
     {
+        private Sample sampleOpen;
+        private Sample sampleClose;
+
+        // todo: this shouldn't be required after https://github.com/ppy/osu-framework/issues/4519 is fixed.
+        private bool wasOpened;
+
         public OsuMenu(Direction direction, bool topLevelMenu = false)
             : base(direction, topLevelMenu)
         {
@@ -22,8 +31,30 @@ namespace osu.Game.Graphics.UserInterface
             ItemsContainer.Padding = new MarginPadding(5);
         }
 
-        protected override void AnimateOpen() => this.FadeIn(300, Easing.OutQuint);
-        protected override void AnimateClose() => this.FadeOut(300, Easing.OutQuint);
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
+            sampleClose = audio.Samples.Get(@"UI/dropdown-close");
+        }
+
+        protected override void AnimateOpen()
+        {
+            if (!wasOpened)
+                sampleOpen?.Play();
+
+            this.FadeIn(300, Easing.OutQuint);
+            wasOpened = true;
+        }
+
+        protected override void AnimateClose()
+        {
+            if (wasOpened)
+                sampleClose?.Play();
+
+            this.FadeOut(300, Easing.OutQuint);
+            wasOpened = false;
+        }
 
         protected override void UpdateSize(Vector2 newSize)
         {

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void AnimateOpen()
         {
-            if (!wasOpened)
+            if (!TopLevelMenu && !wasOpened)
                 sampleOpen?.Play();
 
             this.FadeIn(300, Easing.OutQuint);
@@ -49,7 +49,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void AnimateClose()
         {
-            if (wasOpened)
+            if (!TopLevelMenu && wasOpened)
                 sampleClose?.Play();
 
             this.FadeOut(300, Easing.OutQuint);

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -79,8 +79,6 @@ namespace osu.Game.Overlays.News.Sidebar
 
             private readonly SpriteIcon icon;
 
-            protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
-
             public DropdownHeader(int month, int year)
             {
                 var date = new DateTime(year, month, 1);

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using osu.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
@@ -44,6 +46,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         public event Action<SelectionState> StateChanged;
 
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
+
         private readonly Box selectionBox;
 
         [Resolved(canBeNull: true)]
@@ -61,6 +65,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         public readonly Room Room;
 
         private SelectionState state;
+
+        private Sample sampleSelect;
+        private Sample sampleJoin;
 
         public SelectionState State
         {
@@ -125,7 +132,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, AudioManager audio)
         {
             float stripWidth = side_strip_width * (Room.Category.Value == RoomCategory.Spotlight ? 2 : 1);
 
@@ -221,6 +228,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     },
                 },
             };
+
+            sampleSelect = audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
+            sampleJoin = audio.Samples.Get($@"UI/{HoverSampleSet.Submit.GetDescription()}-select");
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -273,22 +283,25 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         {
         }
 
-        protected override bool ShouldBeConsideredForInput(Drawable child) => state == SelectionState.Selected;
+        protected override bool ShouldBeConsideredForInput(Drawable child) => state == SelectionState.Selected || child is HoverSounds;
 
         protected override bool OnClick(ClickEvent e)
         {
             if (Room != selectedRoom.Value)
             {
+                sampleSelect?.Play();
                 selectedRoom.Value = Room;
                 return true;
             }
 
             if (Room.HasPassword.Value)
             {
+                sampleJoin?.Play();
                 this.ShowPopover();
                 return true;
             }
 
+            sampleJoin?.Play();
             lounge?.Join(Room, null);
 
             return base.OnClick(e);

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.3.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.807.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.803.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.808.0" />
     <PackageReference Include="Sentry" Version="3.8.3" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.807.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.803.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.808.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
A few misc changes:
- Re-adds on-click feedback to the news overlay sidebar (the month headers)
- Re-adds on-click feedback to dropdown headers
- Adds open/close sounds to menus (re-using dropdown sounds... for now?)
- Adds hover/select/join sounds to the multiplayer games listing

partially addresses #14082