### PR TITLE
Add open/close sounds to context menus

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -68,13 +70,40 @@ namespace osu.Game.Tests.Visual.UserInterface
             );
         }
 
-        private class MyContextMenuContainer : Container, IHasContextMenu
+        private static MenuItem[] makeMenu()
         {
-            public MenuItem[] ContextMenuItems => new MenuItem[]
+            return new MenuItem[]
             {
                 new OsuMenuItem(@"Some option"),
                 new OsuMenuItem(@"Highlighted option", MenuItemType.Highlighted),
                 new OsuMenuItem(@"Another option"),
+                new OsuMenuItem(@"Nested option >")
+                {
+                    Items = new MenuItem[]
+                    {
+                        new OsuMenuItem(@"Sub-One"),
+                        new OsuMenuItem(@"Sub-Two"),
+                        new OsuMenuItem(@"Sub-Three"),
+                        new OsuMenuItem(@"Sub-Nested option >")
+                        {
+                            Items = new MenuItem[]
+                            {
+                                new OsuMenuItem(@"Double Sub-One"),
+                                new OsuMenuItem(@"Double Sub-Two"),
+                                new OsuMenuItem(@"Double Sub-Three"),
+                                new OsuMenuItem(@"Sub-Sub-Nested option >")
+                                {
+                                    Items = new MenuItem[]
+                                    {
+                                        new OsuMenuItem(@"Too Deep One"),
+                                        new OsuMenuItem(@"Too Deep Two"),
+                                        new OsuMenuItem(@"Too Deep Three"),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 new OsuMenuItem(@"Choose me please"),
                 new OsuMenuItem(@"And me too"),
                 new OsuMenuItem(@"Trying to fill"),
@@ -82,17 +111,29 @@ namespace osu.Game.Tests.Visual.UserInterface
             };
         }
 
+        private class MyContextMenuContainer : Container, IHasContextMenu
+        {
+            public MenuItem[] ContextMenuItems => makeMenu();
+        }
+
         private class AnotherContextMenuContainer : Container, IHasContextMenu
         {
-            public MenuItem[] ContextMenuItems => new MenuItem[]
+            public MenuItem[] ContextMenuItems
             {
-                new OsuMenuItem(@"Simple option"),
-                new OsuMenuItem(@"Simple very very long option"),
-                new OsuMenuItem(@"Change width", MenuItemType.Highlighted, () => this.ResizeWidthTo(Width * 2, 100, Easing.OutQuint)),
-                new OsuMenuItem(@"Change height", MenuItemType.Highlighted, () => this.ResizeHeightTo(Height * 2, 100, Easing.OutQuint)),
-                new OsuMenuItem(@"Change width back", MenuItemType.Destructive, () => this.ResizeWidthTo(Width / 2, 100, Easing.OutQuint)),
-                new OsuMenuItem(@"Change height back", MenuItemType.Destructive, () => this.ResizeHeightTo(Height / 2, 100, Easing.OutQuint)),
-            };
+                get
+                {
+                    List<MenuItem> items = makeMenu().ToList();
+                    items.AddRange(new MenuItem[]
+                    {
+                        new OsuMenuItem(@"Change width", MenuItemType.Highlighted, () => this.ResizeWidthTo(Width * 2, 100, Easing.OutQuint)),
+                        new OsuMenuItem(@"Change height", MenuItemType.Highlighted, () => this.ResizeHeightTo(Height * 2, 100, Easing.OutQuint)),
+                        new OsuMenuItem(@"Change width back", MenuItemType.Destructive, () => this.ResizeWidthTo(Width / 2, 100, Easing.OutQuint)),
+                        new OsuMenuItem(@"Change height back", MenuItemType.Destructive, () => this.ResizeHeightTo(Height / 2, 100, Easing.OutQuint)),
+                    });
+
+                    return items.ToArray();
+                }
+            }
         }
     }
 }

--- a/osu.Game/Graphics/Cursor/OsuContextMenuContainer.cs
+++ b/osu.Game/Graphics/Cursor/OsuContextMenuContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
@@ -9,6 +10,14 @@ namespace osu.Game.Graphics.Cursor
 {
     public class OsuContextMenuContainer : ContextMenuContainer
     {
+        [Cached]
+        private OsuContextMenuSamples samples = new OsuContextMenuSamples();
+
+        public OsuContextMenuContainer()
+        {
+            AddInternal(samples);
+        }
+
         protected override Menu CreateMenu() => new OsuContextMenu(true);
     }
 }

--- a/osu.Game/Graphics/Cursor/OsuContextMenuContainer.cs
+++ b/osu.Game/Graphics/Cursor/OsuContextMenuContainer.cs
@@ -9,6 +9,6 @@ namespace osu.Game.Graphics.Cursor
 {
     public class OsuContextMenuContainer : ContextMenuContainer
     {
-        protected override Menu CreateMenu() => new OsuContextMenu();
+        protected override Menu CreateMenu() => new OsuContextMenu(true);
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
@@ -4,8 +4,6 @@
 using osuTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Effects;
@@ -16,16 +14,15 @@ namespace osu.Game.Graphics.UserInterface
     public class OsuContextMenu : OsuMenu
     {
         private const int fade_duration = 250;
-        private Sample sampleOpen;
-        private Sample sampleClose;
-        private Sample sampleClick;
+
+        [Resolved]
+        private OsuContextMenuSamples samples { get; set; }
 
         // todo: this shouldn't be required after https://github.com/ppy/osu-framework/issues/4519 is fixed.
         private bool wasOpened;
         private readonly bool playClickSample;
-        private readonly Menu parentMenu;
 
-        public OsuContextMenu(bool playClickSample = false, Menu parentMenu = null)
+        public OsuContextMenu(bool playClickSample = false)
             : base(Direction.Vertical)
         {
             MaskingContainer.CornerRadius = 5;
@@ -41,16 +38,12 @@ namespace osu.Game.Graphics.UserInterface
             MaxHeight = 250;
 
             this.playClickSample = playClickSample;
-            this.parentMenu = parentMenu;
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, AudioManager audio)
         {
             BackgroundColour = colours.ContextMenuGray;
-            sampleClick = audio.Samples.Get($"UI/{HoverSampleSet.Default.GetDescription()}-select");
-            sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
-            sampleClose = audio.Samples.Get(@"UI/dropdown-close");
         }
 
         protected override void AnimateOpen()
@@ -58,10 +51,10 @@ namespace osu.Game.Graphics.UserInterface
             this.FadeIn(fade_duration, Easing.OutQuint);
 
             if (playClickSample)
-                sampleClick?.Play();
+                samples.PlayClickSample();
 
             if (!wasOpened)
-                sampleOpen?.Play();
+                samples.PlayOpenSample();
 
             wasOpened = true;
         }
@@ -70,18 +63,12 @@ namespace osu.Game.Graphics.UserInterface
         {
             this.FadeOut(fade_duration, Easing.OutQuint);
 
-            if (parentMenu?.State == MenuState.Closed)
-            {
-                wasOpened = false;
-                return;
-            }
-
             if (wasOpened)
-                sampleClose?.Play();
+                samples.PlayCloseSample();
 
             wasOpened = false;
         }
 
-        protected override Menu CreateSubMenu() => new OsuContextMenu(false, this);
+        protected override Menu CreateSubMenu() => new OsuContextMenu();
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuContextMenuSamples.cs
+++ b/osu.Game/Graphics/UserInterface/OsuContextMenuSamples.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class OsuContextMenuSamples : Component
+    {
+        private Sample sampleClick;
+        private Sample sampleOpen;
+        private Sample sampleClose;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, AudioManager audio)
+        {
+            sampleClick = audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
+            sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
+            sampleClose = audio.Samples.Get(@"UI/dropdown-close");
+        }
+
+        public void PlayClickSample() => Scheduler.AddOnce(playClickSample);
+        private void playClickSample() => sampleClick.Play();
+
+        public void PlayOpenSample() => Scheduler.AddOnce(playOpenSample);
+        private void playOpenSample() => sampleOpen.Play();
+
+        public void PlayCloseSample() => Scheduler.AddOnce(playCloseSample);
+        private void playCloseSample() => sampleClose.Play();
+    }
+}


### PR DESCRIPTION
Adds open/close sounds to context menus (using dropdown sounds... for now?).

There's some issues when nested open submenus are closed via either:
- changing top-level item selection
- opening the context menu elsewhere

Doing these when nested submenus are open will result in the close sample playing for each submenu... simultaneously. Not sure how much of that is my fault vs quirks of `Menu` in o!f though, thus I'm making this PR a bit prematurely to figure it out.

partially addresses #14082