### PR TITLE
Interpolate legacy slider body colours with old "gamma-incorrect" algorithm

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osuTK.Graphics;
@@ -40,7 +39,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 Color4 outerColour = AccentColour.Darken(0.1f);
                 Color4 innerColour = lighten(AccentColour, 0.5f);
 
-                return Interpolation.ValueAt(position / realGradientPortion, outerColour, innerColour, 0, 1);
+                // Stable doesn't use linear space / gamma-correct colour interpolation
+                // for slider bodies, so we can't use Interpolation.ValueAt().
+                // Instead, we use a local method that interpolates between the colours directly in sRGB space.
+                return valueAt(position / realGradientPortion, outerColour, innerColour, 0, 1);
             }
 
             /// <summary>
@@ -54,6 +56,26 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     Math.Min(1, color.G * (1 + 0.5f * amount) + 1 * amount),
                     Math.Min(1, color.B * (1 + 0.5f * amount) + 1 * amount),
                     color.A);
+            }
+
+            private static Color4 valueAt(double time, Color4 startColour, Color4 endColour, double startTime, double endTime)
+            {
+                if (startColour == endColour)
+                    return startColour;
+
+                double current = time - startTime;
+                double duration = endTime - startTime;
+
+                if (duration == 0 || current == 0)
+                    return startColour;
+
+                float t = (float)Math.Max(0, Math.Min(1, current / duration));
+
+                return new Color4(
+                    startColour.R + t * (endColour.R - startColour.R),
+                    startColour.G + t * (endColour.G - startColour.G),
+                    startColour.B + t * (endColour.B - startColour.B),
+                    startColour.A + t * (endColour.A - startColour.A));
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osuTK.Graphics;
@@ -36,13 +37,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
                 position -= realBorderPortion;
 
-                Color4 outerColour = AccentColour.Darken(0.1f);
-                Color4 innerColour = lighten(AccentColour, 0.5f);
+                // Stable interpolates slider body colour directly in sRGB space, and because
+                // Interpolation.ValueAt() uses linear space, we have to counteract applying it
+                // by calling ToSRGB() on the input colours, and ToLinear() on the resulting colour.
 
-                // Stable doesn't use linear space / gamma-correct colour interpolation
-                // for slider bodies, so we can't use Interpolation.ValueAt().
-                // Instead, we use a local method that interpolates between the colours directly in sRGB space.
-                return valueAt(position / realGradientPortion, outerColour, innerColour, 0, 1);
+                Color4 outerColour = AccentColour.Darken(0.1f).ToSRGB();
+                Color4 innerColour = lighten(AccentColour, 0.5f).ToSRGB();
+
+                return Interpolation.ValueAt(position / realGradientPortion, outerColour, innerColour, 0, 1).ToLinear();
             }
 
             /// <summary>
@@ -56,26 +58,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     Math.Min(1, color.G * (1 + 0.5f * amount) + 1 * amount),
                     Math.Min(1, color.B * (1 + 0.5f * amount) + 1 * amount),
                     color.A);
-            }
-
-            private static Color4 valueAt(double time, Color4 startColour, Color4 endColour, double startTime, double endTime)
-            {
-                if (startColour == endColour)
-                    return startColour;
-
-                double current = time - startTime;
-                double duration = endTime - startTime;
-
-                if (duration == 0 || current == 0)
-                    return startColour;
-
-                float t = (float)Math.Max(0, Math.Min(1, current / duration));
-
-                return new Color4(
-                    startColour.R + t * (endColour.R - startColour.R),
-                    startColour.G + t * (endColour.G - startColour.G),
-                    startColour.B + t * (endColour.B - startColour.B),
-                    startColour.A + t * (endColour.A - startColour.A));
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -3,9 +3,9 @@
 
 using System;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
+using osu.Game.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
@@ -37,14 +37,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
                 position -= realBorderPortion;
 
-                // Stable interpolates slider body colour directly in sRGB space, and because
-                // Interpolation.ValueAt() uses linear space, we have to counteract applying it
-                // by calling ToSRGB() on the input colours, and ToLinear() on the resulting colour.
+                Color4 outerColour = AccentColour.Darken(0.1f);
+                Color4 innerColour = lighten(AccentColour, 0.5f);
 
-                Color4 outerColour = AccentColour.Darken(0.1f).ToSRGB();
-                Color4 innerColour = lighten(AccentColour, 0.5f).ToSRGB();
-
-                return Interpolation.ValueAt(position / realGradientPortion, outerColour, innerColour, 0, 1).ToLinear();
+                return LegacyUtils.InterpolateNonLinear(position / realGradientPortion, outerColour, innerColour, 0, 1);
             }
 
             /// <summary>

--- a/osu.Game/Skinning/LegacyHealthDisplay.cs
+++ b/osu.Game/Skinning/LegacyHealthDisplay.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -83,10 +84,10 @@ namespace osu.Game.Skinning
         private static Color4 getFillColour(double hp)
         {
             if (hp < 0.2)
-                return Interpolation.ValueAt(0.2 - hp, Color4.Black, Color4.Red, 0, 0.2);
+                return LegacyUtils.InterpolateNonLinear(0.2 - hp, Color4.Black, Color4.Red, 0, 0.2);
 
             if (hp < epic_cutoff)
-                return Interpolation.ValueAt(0.5 - hp, Color4.White, Color4.Black, 0, 0.5);
+                return LegacyUtils.InterpolateNonLinear(0.5 - hp, Color4.White, Color4.Black, 0, 0.5);
 
             return Color4.White;
         }

--- a/osu.Game/Utils/LegacyUtils.cs
+++ b/osu.Game/Utils/LegacyUtils.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osuTK.Graphics;
+
+namespace osu.Game.Utils
+{
+    public static class LegacyUtils
+    {
+        public static Color4 InterpolateNonLinear(double time, Color4 startColour, Color4 endColour, double startTime, double endTime, Easing easing = Easing.None)
+            => InterpolateNonLinear(time, startColour, endColour, startTime, endTime, new DefaultEasingFunction(easing));
+
+        public static Colour4 InterpolateNonLinear(double time, Colour4 startColour, Colour4 endColour, double startTime, double endTime, Easing easing = Easing.None)
+            => InterpolateNonLinear(time, startColour, endColour, startTime, endTime, new DefaultEasingFunction(easing));
+
+        /// <summary>
+        /// Interpolates between two sRGB <see cref="Color4"/>s directly in sRGB space.
+        /// </summary>
+        public static Color4 InterpolateNonLinear<TEasing>(double time, Color4 startColour, Color4 endColour, double startTime, double endTime, TEasing easing) where TEasing : IEasingFunction
+        {
+            if (startColour == endColour)
+                return startColour;
+
+            double current = time - startTime;
+            double duration = endTime - startTime;
+
+            if (duration == 0 || current == 0)
+                return startColour;
+
+            float t = Math.Max(0, Math.Min(1, (float)easing.ApplyEasing(current / duration)));
+
+            return new Color4(
+                startColour.R + t * (endColour.R - startColour.R),
+                startColour.G + t * (endColour.G - startColour.G),
+                startColour.B + t * (endColour.B - startColour.B),
+                startColour.A + t * (endColour.A - startColour.A));
+        }
+
+        /// <summary>
+        /// Interpolates between two sRGB <see cref="Colour4"/>s directly in sRGB space.
+        /// </summary>
+        public static Colour4 InterpolateNonLinear<TEasing>(double time, Colour4 startColour, Colour4 endColour, double startTime, double endTime, in TEasing easing) where TEasing : IEasingFunction
+        {
+            if (startColour == endColour)
+                return startColour;
+
+            double current = time - startTime;
+            double duration = endTime - startTime;
+
+            if (duration == 0 || current == 0)
+                return startColour;
+
+            float t = Math.Max(0, Math.Min(1, (float)easing.ApplyEasing(current / duration)));
+
+            return new Colour4(
+                startColour.R + t * (endColour.R - startColour.R),
+                startColour.G + t * (endColour.G - startColour.G),
+                startColour.B + t * (endColour.B - startColour.B),
+                startColour.A + t * (endColour.A - startColour.A));
+        }
+    }
+}

--- a/osu.Game/Utils/LegacyUtils.cs
+++ b/osu.Game/Utils/LegacyUtils.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Utils
         /// <summary>
         /// Interpolates between two sRGB <see cref="Colour4"/>s directly in sRGB space.
         /// </summary>
-        public static Colour4 InterpolateNonLinear<TEasing>(double time, Colour4 startColour, Colour4 endColour, double startTime, double endTime, in TEasing easing) where TEasing : IEasingFunction
+        public static Colour4 InterpolateNonLinear<TEasing>(double time, Colour4 startColour, Colour4 endColour, double startTime, double endTime, TEasing easing) where TEasing : IEasingFunction
         {
             if (startColour == endColour)
                 return startColour;


### PR DESCRIPTION
Resolves #14165

Stable doesn't use linear space / gamma-correct colour interpolation for slider bodies, and because of a recent framework change that implements such interpolation (see: https://github.com/ppy/osu-framework/pull/4657/), legacy slider bodies now look incorrect.

This PR adds the `ValueAt()` method before the linear space change to a new `LegacyUtils` class as `InterpolateNonLinear()`. This method is then used to bring the legacy slider bodies back in line with stable / how they were before.