### PR TITLE
Add simple download progress display to download buttons on playlist items

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -14,7 +14,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Rooms;
-using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapListing.Panels;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -15,6 +15,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapListing.Panels;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
@@ -215,7 +216,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             assertDownloadButtonVisible(false);
 
             void assertDownloadButtonVisible(bool visible) => AddUntilStep($"download button {(visible ? "shown" : "hidden")}",
-                () => playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().Alpha == (visible ? 1 : 0));
+                () => playlist.ChildrenOfType<BeatmapPanelDownloadButton>().Single().Alpha == (visible ? 1 : 0));
         }
 
         [Test]
@@ -229,7 +230,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             createPlaylist(byOnlineId, byChecksum);
 
-            AddAssert("download buttons shown", () => playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().All(d => d.IsPresent));
+            AddAssert("download buttons shown", () => playlist.ChildrenOfType<BeatmapPanelDownloadButton>().All(d => d.IsPresent));
         }
 
         [Test]

--- a/osu.Game/Graphics/UserInterface/GrayButton.cs
+++ b/osu.Game/Graphics/UserInterface/GrayButton.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load()
         {
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 Background = new Box
                 {
@@ -42,7 +42,7 @@ namespace osu.Game.Graphics.UserInterface
                     Size = new Vector2(13),
                     Icon = icon,
                 },
-            };
+            });
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
@@ -37,6 +37,13 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                     RelativeSizeAxes = Axes.Both,
                 },
             };
+
+            button.Add(new DownloadProgressBar(beatmapSet)
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                Depth = -1,
+            });
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
The colours here look a bit weird but I don't want to put too much thought into it. Just wanted to fix this UX as it's pretty annoying not knowing how your download is going in a multiplayer game (ie. spectator mode, where it doesn't show the progress in the player list for yourself).


https://user-images.githubusercontent.com/191335/128817456-be8c7368-9a8d-4819-b0b8-f071288267b9.mp4

