### PR TITLE
Fix incorrect legacy skin slider body alpha

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 // Roughly matches osu!stable's slider border portions.
                 => base.CalculatedBorderPortion * 0.77f;
 
-            public new Color4 AccentColour => new Color4(base.AccentColour.R, base.AccentColour.G, base.AccentColour.B, base.AccentColour.A * 0.70f);
+            public new Color4 AccentColour => new Color4(base.AccentColour.R, base.AccentColour.G, base.AccentColour.B, 0.7f);
 
             protected override Color4 ColourAt(float position)
             {


### PR DESCRIPTION
Something which I noticed with my skin because at one point I tried to adjust the alpha value. This value is locked to `(byte)180` in stable, which is approximately 0.7.