### PR TITLE
Adjust checkbox / sliderbar animation speeds to match sound effects better

### DIFF
--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -21,6 +21,9 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float border_width = 3;
 
+        private const double animate_in_duration = 150;
+        private const double animate_out_duration = 500;
+
         public Nub()
         {
             Box fill;
@@ -77,20 +80,26 @@ namespace osu.Game.Graphics.UserInterface
 
                 if (value)
                 {
-                    this.FadeColour(GlowingAccentColour, 500, Easing.OutQuint);
-                    FadeEdgeEffectTo(1, 500, Easing.OutQuint);
+                    this.FadeColour(GlowingAccentColour, animate_in_duration, Easing.OutQuint);
+                    FadeEdgeEffectTo(1, animate_in_duration, Easing.OutQuint);
                 }
                 else
                 {
-                    FadeEdgeEffectTo(0, 500);
-                    this.FadeColour(AccentColour, 500);
+                    FadeEdgeEffectTo(0, animate_out_duration);
+                    this.FadeColour(AccentColour, animate_out_duration);
                 }
             }
         }
 
         public bool Expanded
         {
-            set => this.ResizeTo(new Vector2(value ? EXPANDED_SIZE : COLLAPSED_SIZE, 12), 500, Easing.OutQuint);
+            set
+            {
+                if (value)
+                    this.ResizeTo(new Vector2(EXPANDED_SIZE, 12), animate_in_duration, Easing.OutQuint);
+                else
+                    this.ResizeTo(new Vector2(COLLAPSED_SIZE, 12), animate_out_duration, Easing.OutQuint);
+            }
         }
 
         private readonly Bindable<bool> current = new Bindable<bool>();


### PR DESCRIPTION
I have a huge list of changes like this I will eventually get to, but this one is by far the worst and bugs me every time I use the settings panel.
