### PR TITLE
Beatmap downloader

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
@@ -93,10 +93,10 @@ namespace osu.Game.Tests.Beatmaps
             if (config == null)
                 return;
 
-            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(2007, 1, 1);
-            config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating).Value = 0.0;
-            config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset).Value = 0;
-            config.GetBindable<BeatmapDownloader.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory).Value = BeatmapDownloader.SearchCategory.Both;
+            config.SetValue(OsuSetting.BeatmapDownloadLastTime, new DateTime(2007, 1, 1));
+            config.SetValue(OsuSetting.BeatmapDownloadMinimumStarRating, 0.0);
+            config.SetValue(OsuSetting.BeatmapDownloadRuleset, 0);
+            config.SetValue(OsuSetting.BeatmapDownloadSearchCategory, BeatmapDownloader.SearchCategory.Both);
         }
 
         [TearDown]
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestMatchingCriteriaFailDate()
         {
-            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(2020, 10, 1);
+            config.SetValue(OsuSetting.BeatmapDownloadLastTime, new DateTime(2020, 10, 1));
 
             foreach (var beatmapsetinfo in beatmapSetInfos)
             {
@@ -146,10 +146,10 @@ namespace osu.Game.Tests.Beatmaps
             Assert.True(downloader.DownloadBeatmaps().Result == BeatmapDownloaderStrings.YouNeedToBeLoggedInToDownloadBeatmaps.ToString());
 
             API.Login("dummy", "password");
-            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(DateTime.Now.Ticks + TimeSpan.TicksPerDay * 7);
+            config.SetValue(OsuSetting.BeatmapDownloadLastTime, new DateTime(DateTime.Now.Ticks + TimeSpan.TicksPerDay * 7));
             Assert.True(downloader.DownloadBeatmaps().Result == BeatmapDownloaderStrings.TheLastDownloadedBeatmapTimeIsInTheFuture.ToString());
 
-            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = DateTime.Now.AddSeconds(-30);
+            config.SetValue(OsuSetting.BeatmapDownloadLastTime, DateTime.Now.AddSeconds(-30));
             Assert.True(downloader.DownloadBeatmaps().Result == BeatmapDownloaderStrings.PleaseWaitAMinuteBeforeRequestingNewBeatmaps.ToString());
         }
 

--- a/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    [TestFixture]
+    [HeadlessTest]
+    public class BeatmapDownloaderTest : OsuTestScene
+    {
+        [Resolved]
+        private BeatmapDownloader downloader { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        private LinkedList<BeatmapSetInfo> rulesetList = new LinkedList<BeatmapSetInfo>();
+
+        public BeatmapDownloaderTest()
+        {
+            rulesetList.AddLast(new BeatmapSetInfo()
+            {
+                OnlineBeatmapSetID = 3756,
+                Beatmaps = new List<BeatmapInfo>
+                {
+                    new BeatmapInfo()
+                    {
+                        StarDifficulty = 0.67
+                    },
+                },
+                OnlineInfo = new BeatmapSetOnlineInfo()
+                {
+                    LastUpdated = new DateTime(2008, 11, 4),
+                    Ranked = null,
+                },
+            });
+
+            rulesetList.AddLast(new BeatmapSetInfo()
+            {
+                OnlineBeatmapSetID = 1,
+                Beatmaps = new List<BeatmapInfo>
+                {
+                    new BeatmapInfo()
+                    {
+                        StarDifficulty = 2.40
+                    },
+                },
+                OnlineInfo = new BeatmapSetOnlineInfo()
+                {
+                    LastUpdated = new DateTime(2007, 10, 6),
+                    Ranked = new DateTimeOffset(new DateTime(2007, 10, 6)),
+                },
+            });
+
+            rulesetList.AddLast(new BeatmapSetInfo()
+            {
+                OnlineBeatmapSetID = 1,
+                Beatmaps = new List<BeatmapInfo>
+                {
+                    new BeatmapInfo()
+                    {
+                        StarDifficulty = 4.14
+                    },
+                },
+                OnlineInfo = new BeatmapSetOnlineInfo()
+                {
+                    LastUpdated = new DateTime(2008, 8, 10),
+                    Ranked = new DateTimeOffset(new DateTime(2008, 8, 16)),
+                },
+            });
+        }
+
+        [Test]
+        public void TestMatchingCriteriaSuccess()
+        {
+            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(2007, 10, 1);
+            config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating).Value = 0.0;
+            config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset).Value = 0;
+            config.GetBindable<Overlays.BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory).Value = Overlays.BeatmapListing.SearchCategory.Leaderboard;
+
+            foreach (var beatmapsetinfo in rulesetList)
+            {
+                Assert.True(downloader.MatchesDownloadCriteria(beatmapsetinfo));
+            }
+        }
+
+        [Test]
+        public void TestMatchingCriteriaFail()
+        {
+            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(2020, 10, 1);
+            config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating).Value = 0.0;
+            config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset).Value = 0;
+            config.GetBindable<Overlays.BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory).Value = Overlays.BeatmapListing.SearchCategory.Leaderboard;
+
+            foreach (var beatmapsetinfo in rulesetList)
+            {
+                Assert.False(downloader.MatchesDownloadCriteria(beatmapsetinfo));
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Beatmaps
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private static List<BeatmapSetInfo> rulesetList = new List<BeatmapSetInfo>() {
+        private static List<BeatmapSetInfo> beatmapSetInfos = new List<BeatmapSetInfo>() {
             new BeatmapSetInfo()
             {
                 OnlineBeatmapSetID = 3756,
@@ -96,7 +96,7 @@ namespace osu.Game.Tests.Beatmaps
             config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset).Value = 0;
             config.GetBindable<SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory).Value = SearchCategory.Leaderboard;
 
-            foreach (var beatmapsetinfo in rulesetList)
+            foreach (var beatmapsetinfo in beatmapSetInfos)
             {
                 Assert.True(downloader.MatchesDownloadCriteria(beatmapsetinfo));
             }
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Beatmaps
             config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset).Value = 0;
             config.GetBindable<SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory).Value = SearchCategory.Leaderboard;
 
-            foreach (var beatmapsetinfo in rulesetList)
+            foreach (var beatmapsetinfo in beatmapSetInfos)
             {
                 Assert.False(downloader.MatchesDownloadCriteria(beatmapsetinfo));
             }
@@ -155,7 +155,7 @@ namespace osu.Game.Tests.Beatmaps
 
             protected override void sendAPIReqeust(int iteration, RulesetInfo ruleset, SearchCategory searchCategory, Cursor cursor = null)
             {
-                handleAPIReqeust(SearchResult.ResultsReturned(rulesetList), null, iteration, ruleset, searchCategory);
+                handleAPIReqeust(SearchResult.ResultsReturned(beatmapSetInfos), null, iteration, ruleset, searchCategory);
             }
         }
     }

--- a/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
@@ -104,6 +105,28 @@ namespace osu.Game.Tests.Beatmaps
             {
                 Assert.False(downloader.MatchesDownloadCriteria(beatmapsetinfo));
             }
+        }
+
+        [Test]
+        public void TestDownloadFunctionSuccess()
+        {
+            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(DateTime.Now.Ticks - TimeSpan.TicksPerDay * 7);
+            config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating).Value = 7.0;
+            config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset).Value = 0;
+            config.GetBindable<Overlays.BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory).Value = Overlays.BeatmapListing.SearchCategory.Leaderboard;
+
+            //Will fail because no API Access, waiting for response from a knowlegeable Person to fix this
+            Assert.True(downloader.DownloadBeatmaps().Result);
+        }
+
+        [Test]
+        public void TestDownloadFunctionFail()
+        {
+            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(DateTime.Now.Ticks + TimeSpan.TicksPerDay * 7);
+            Assert.False(downloader.DownloadBeatmaps().Result);
+
+            config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = DateTime.Now.AddSeconds(-30);
+            Assert.False(downloader.DownloadBeatmaps().Result);
         }
     }
 }

--- a/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
@@ -147,12 +147,14 @@ namespace osu.Game.Tests.Beatmaps
             {
             }
 
+            //skip download part for speed
             protected override void downloadBeatmap(BeatmapSetInfo beatmapSetInfo)
             {
                 beatmapManager.Download(beatmapSetInfo);
                 beatmapManager.GetExistingDownload(beatmapSetInfo).TriggerSuccess();
             }
 
+            //skip api request for speed
             protected override void sendAPIReqeust(int iteration, RulesetInfo ruleset, SearchCategory searchCategory, Cursor cursor = null)
             {
                 handleAPIReqeust(SearchResult.ResultsReturned(beatmapSetInfos), null, iteration, ruleset, searchCategory);

--- a/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDownloaderTest.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Beatmaps
         private static List<BeatmapSetInfo> beatmapSetInfos = new List<BeatmapSetInfo>() {
             new BeatmapSetInfo()
             {
-                ID = 1,
+                ID = 0,
                 OnlineBeatmapSetID = 3756,
                 Beatmaps = new List<BeatmapInfo>
                 {
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Beatmaps
             },
             new BeatmapSetInfo()
             {
-                ID = 1,
+                ID = 0,
                 OnlineBeatmapSetID = 1,
                 Beatmaps = new List<BeatmapInfo>
                 {
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Beatmaps
             },
             new BeatmapSetInfo()
             {
-                ID = 1,
+                ID = 0,
                 OnlineBeatmapSetID = 2459,
                 Beatmaps = new List<BeatmapInfo>
                 {

--- a/osu.Game.Tests/Visual/TestSceneOsuGame.cs
+++ b/osu.Game.Tests/Visual/TestSceneOsuGame.cs
@@ -83,6 +83,7 @@ namespace osu.Game.Tests.Visual
             typeof(Bindable<WorkingBeatmap>),
             typeof(GlobalActionContainer),
             typeof(PreviewTrackManager),
+            typeof(BeatmapDownloader),
         };
 
         private OsuGame game;

--- a/osu.Game/Beatmaps/BeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapDownloader.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps
             category = config.GetBindable<SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory);
             ruelsetId = config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset);
 
-            if (config.GetBindable<bool>(OsuSetting.BeatmapDownloadStartUp).Value)
+            if (config.Get<bool>(OsuSetting.BeatmapDownloadStartUp))
             {
                 Task.Run(DownloadBeatmaps);
             }
@@ -216,7 +216,6 @@ namespace osu.Game.Beatmaps
     [Serializable]
     internal class DownloaderException : Exception
     {
-
         public DownloaderException(string message) : base(message)
         {
         }

--- a/osu.Game/Beatmaps/BeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapDownloader.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Rulesets;
+using static osu.Game.Overlays.BeatmapListing.BeatmapListingFilterControl;
+
+namespace osu.Game.Beatmaps
+{
+    public class BeatmapDownloader
+    {
+        private BeatmapManager beatmapManager { get; set; }
+        private IAPIProvider api { get; set; }
+        private RulesetStore rulesets { get; set; }
+        private Bindable<DateTime> lastBeatmapDownloadTime { get; set; }
+        private Bindable<double> minimumStarRating { get; set; }
+        private Bindable<bool> noVideoSetting { get; set; }
+        private Bindable<Overlays.BeatmapListing.SearchCategory> category { get; set; }
+        private Bindable<int> ruelsetId { get; set; }
+
+        private const int max_requests = 10;
+
+        /// <summary> 
+        /// Downloads Maps that have a higher MaxStarDifficulty than specified in OsuSetting.BeatmapDownloadMinimumStarRating
+        /// It stops downloading when it hits a Map that is ranked earlier then OsuSetting.BeatmapDownloadLastTime
+        /// </summary>
+        public BeatmapDownloader(OsuConfigManager config, BeatmapManager beatmapManager, IAPIProvider api, RulesetStore rulesets)
+        {
+            this.beatmapManager = beatmapManager;
+            this.api = api;
+            this.rulesets = rulesets;
+
+            noVideoSetting = config.GetBindable<bool>(OsuSetting.PreferNoVideo);
+            lastBeatmapDownloadTime = config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime);
+            minimumStarRating = config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating);
+            category = config.GetBindable<Overlays.BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory);
+            ruelsetId = config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset);
+        }
+
+        /// <summary>
+        /// Sends the SearchBeatmapSetsRequest to the API and process the Result
+        /// </summary>
+        /// <returns>If it was successful or not</returns>
+        public Task<bool> DownloadBeatmapsAsync()
+        {
+            return Task.Run(() =>
+            {
+                //needed if we need to do multiple api reqeusts
+                bool upToDate = false;
+                int nReqeusts = 0;
+                SearchBeatmapSetsRequest getSetsRequest;
+                SearchBeatmapSetsResponse lastResponse = null;
+
+                RulesetInfo ruleset = rulesets.GetRuleset(ruelsetId.Value);
+                Overlays.BeatmapListing.SearchCategory searchCategory = category.Value;
+
+                if (ruleset == null || lastBeatmapDownloadTime.Value >= DateTime.Now)
+                {
+                    return false;
+                }
+
+                while (!upToDate)
+                {
+                    bool currRunFinished = false;
+
+                    getSetsRequest = new SearchBeatmapSetsRequest(@"", ruleset, lastResponse?.Cursor, null, searchCategory);
+
+                    getSetsRequest.Success += response =>
+                                {
+                                    var sets = response.BeatmapSets.Select(responseJson => responseJson.ToBeatmapSet(rulesets)).ToList();
+
+                                    lastResponse = response;
+                                    getSetsRequest = null;
+
+                                    if (sets.Count == 0 || nReqeusts >= max_requests)
+                                    {
+                                        upToDate = true;
+                                        return;
+                                    }
+
+                                    if (handleSearchResults(SearchResult.ResultsReturned(sets)))
+                                    {
+                                        upToDate = true;
+                                    }
+
+                                    currRunFinished = true;
+                                };
+
+                    api.Queue(getSetsRequest);
+                    nReqeusts++;
+
+                    while (!currRunFinished) { Task.Delay(100); }
+                }
+
+                lastBeatmapDownloadTime.Value = DateTime.Now;
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Filters and downloads any Maps with the matching Criteria
+        /// </summary>
+        /// <param name="result">Results from a SearchBeatmapSetsRequest</param>
+        /// <returns>Whether it found a Map that was ranked/released earlier than lastBeatmapDownloadTime</returns>
+        private bool handleSearchResults(SearchResult result)
+        {
+            bool hitLastOne = false;
+
+            foreach (var beatmapSetInfo in result.Results)
+            {
+                switch (beatmapSetInfo.OnlineInfo.Status)
+                {
+                    case BeatmapSetOnlineStatus.None:
+                        break;
+                    case BeatmapSetOnlineStatus.Graveyard:
+                    case BeatmapSetOnlineStatus.WIP:
+                    case BeatmapSetOnlineStatus.Pending:
+                        if (beatmapSetInfo.DateAdded.DateTime > lastBeatmapDownloadTime.Value)
+                        {
+                            if (beatmapSetInfo.MaxStarDifficulty >= minimumStarRating.Value)
+                            {
+                                beatmapManager.Download(beatmapSetInfo, noVideoSetting.Value);
+                            }
+                        }
+                        else
+                        {
+                            hitLastOne = true;
+                        }
+                        break;
+                    case BeatmapSetOnlineStatus.Ranked:
+                    case BeatmapSetOnlineStatus.Approved:
+                    case BeatmapSetOnlineStatus.Qualified:
+                    case BeatmapSetOnlineStatus.Loved:
+                        if (beatmapSetInfo.OnlineInfo.Ranked?.DateTime > lastBeatmapDownloadTime.Value)
+                        {
+                            if (beatmapSetInfo.MaxStarDifficulty >= minimumStarRating.Value)
+                            {
+                                beatmapManager.Download(beatmapSetInfo, noVideoSetting.Value);
+                            }
+                        }
+                        else
+                        {
+                            hitLastOne = true;
+                        }
+                        break;
+                }
+            }
+
+            return hitLastOne;
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapDownloader.cs
@@ -4,10 +4,14 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using static osu.Game.Overlays.BeatmapListing.BeatmapListingFilterControl;
 
@@ -24,11 +28,11 @@ namespace osu.Game.Beatmaps
         private Bindable<Overlays.BeatmapListing.SearchCategory> category { get; set; }
         private Bindable<int> ruelsetId { get; set; }
 
-        private const int max_requests = 10;
+        private const int max_requests = 100;
 
         /// <summary> 
-        /// Downloads Maps that have a higher MaxStarDifficulty than specified in OsuSetting.BeatmapDownloadMinimumStarRating
-        /// It stops downloading when it hits a Map that is ranked earlier then OsuSetting.BeatmapDownloadLastTime
+        /// Downloads <see cref="BeatmapSetInfo"/> that have a higher <see cref="BeatmapSetInfo.MaxStarDifficulty"/>  than specified in <see cref="OsuSetting.BeatmapDownloadMinimumStarRating"/>.
+        /// It stops requesting more <see cref="BeatmapSetInfo"/> when it gets a BeatmapSet that is uploaded/ranked earlier then <see cref="OsuSetting.BeatmapDownloadLastTime"/>.
         /// </summary>
         public BeatmapDownloader(OsuConfigManager config, BeatmapManager beatmapManager, IAPIProvider api, RulesetStore rulesets)
         {
@@ -44,14 +48,14 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Sends the SearchBeatmapSetsRequest to the API and process the Result
+        /// Sends the <see cref="SearchBeatmapSetsRequest"/> to the API and processes the Result.
         /// </summary>
-        /// <returns>If it was successful or not</returns>
+        /// <returns>If it was successful or not.</returns>
         public Task<bool> DownloadBeatmapsAsync()
         {
             return Task.Run(() =>
             {
-                //needed if we need to do multiple api reqeusts
+                //needed if multiple api reqeusts are required
                 bool upToDate = false;
                 int nReqeusts = 0;
                 SearchBeatmapSetsRequest getSetsRequest;
@@ -69,7 +73,7 @@ namespace osu.Game.Beatmaps
                 {
                     bool currRunFinished = false;
 
-                    getSetsRequest = new SearchBeatmapSetsRequest(@"", ruleset, lastResponse?.Cursor, null, searchCategory);
+                    getSetsRequest = new SearchBeatmapSetsRequest($"star>={minimumStarRating.Value}", ruleset, lastResponse?.Cursor, null, searchCategory);
 
                     getSetsRequest.Success += response =>
                                 {
@@ -78,13 +82,13 @@ namespace osu.Game.Beatmaps
                                     lastResponse = response;
                                     getSetsRequest = null;
 
-                                    if (sets.Count == 0 || nReqeusts >= max_requests)
+                                    if (sets.Count == 0)
                                     {
                                         upToDate = true;
                                         return;
                                     }
 
-                                    if (handleSearchResults(SearchResult.ResultsReturned(sets)))
+                                    if (handleSearchResults(SearchResult.ResultsReturned(sets)) || nReqeusts >= max_requests)
                                     {
                                         upToDate = true;
                                     }
@@ -105,55 +109,43 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Filters and downloads any Maps with the matching Criteria
+        /// Filters and downloads any <see cref="BeatmapSetInfo"/> with the matching Criteria.
         /// </summary>
-        /// <param name="result">Results from a SearchBeatmapSetsRequest</param>
-        /// <returns>Whether it found a Map that was ranked/released earlier than lastBeatmapDownloadTime</returns>
+        /// <param name="result"><see cref="SearchResult"/> from a <see cref="SearchBeatmapSetsRequest"/>.</param>
+        /// <returns>Whether it found a <see cref="BeatmapSetInfo"/> that was uploaded/ranked before the <see cref="OsuSetting.BeatmapDownloadLastTime"/> Date.</returns>
         private bool handleSearchResults(SearchResult result)
         {
-            bool hitLastOne = false;
-
             foreach (var beatmapSetInfo in result.Results)
             {
-                switch (beatmapSetInfo.OnlineInfo.Status)
+                if (MatchesDownloadCriteria(beatmapSetInfo))
                 {
-                    case BeatmapSetOnlineStatus.None:
-                        break;
-                    case BeatmapSetOnlineStatus.Graveyard:
-                    case BeatmapSetOnlineStatus.WIP:
-                    case BeatmapSetOnlineStatus.Pending:
-                        if (beatmapSetInfo.DateAdded.DateTime > lastBeatmapDownloadTime.Value)
-                        {
-                            if (beatmapSetInfo.MaxStarDifficulty >= minimumStarRating.Value)
-                            {
-                                beatmapManager.Download(beatmapSetInfo, noVideoSetting.Value);
-                            }
-                        }
-                        else
-                        {
-                            hitLastOne = true;
-                        }
-                        break;
-                    case BeatmapSetOnlineStatus.Ranked:
-                    case BeatmapSetOnlineStatus.Approved:
-                    case BeatmapSetOnlineStatus.Qualified:
-                    case BeatmapSetOnlineStatus.Loved:
-                        if (beatmapSetInfo.OnlineInfo.Ranked?.DateTime > lastBeatmapDownloadTime.Value)
-                        {
-                            if (beatmapSetInfo.MaxStarDifficulty >= minimumStarRating.Value)
-                            {
-                                beatmapManager.Download(beatmapSetInfo, noVideoSetting.Value);
-                            }
-                        }
-                        else
-                        {
-                            hitLastOne = true;
-                        }
-                        break;
+                    beatmapManager.Download(beatmapSetInfo, noVideoSetting.Value);
                 }
             }
 
-            return hitLastOne;
+            return result.Results.Where(b => !isAfterLastBeatmapDownloadTime(b)).Any();
+        }
+
+        /// <summary>
+        /// Checks whether the <see cref="BeatmapSetInfo"/> matches the Download Criteria.
+        /// </summary>
+        /// <param name="beatmapSetInfo">The <see cref="BeatmapSetInfo"/> to check.</param>
+        /// <returns>Whether the <see cref="BeatmapSetInfo"/> matches the Criteria.</returns>
+        public bool MatchesDownloadCriteria(BeatmapSetInfo beatmapSetInfo)
+        {
+            //May be expanded at some point
+            return isAfterLastBeatmapDownloadTime(beatmapSetInfo);
+        }
+
+        /// <summary>
+        /// Checks whether the <see cref="BeatmapSetInfo"/> was uploaded/ranked before or after the <see cref="OsuSetting.BeatmapDownloadLastTime"/> Variable.
+        /// Uses <see cref="BeatmapSetOnlineInfo.Ranked"/> Date when available otherwise the <see cref="BeatmapSetOnlineInfo.LastUpdated"/> Date.
+        /// </summary>
+        /// <param name="beatmapSetInfo">The <see cref="BeatmapSetInfo"/> to check.</param>
+        /// <returns>Whether the <see cref="BeatmapSetInfo"/> Date is before or after <see cref="OsuSetting.BeatmapDownloadLastTime"/>.</returns>
+        private bool isAfterLastBeatmapDownloadTime(BeatmapSetInfo beatmapSetInfo)
+        {
+            return (beatmapSetInfo.OnlineInfo.Ranked == null && beatmapSetInfo.OnlineInfo.LastUpdated?.DateTime > lastBeatmapDownloadTime.Value) || beatmapSetInfo.OnlineInfo.Ranked?.DateTime > lastBeatmapDownloadTime.Value;
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapDownloader.cs
@@ -101,6 +101,12 @@ namespace osu.Game.Beatmaps
 
                         while (!finished) { Task.Delay(100); }
 
+                        notifications?.Post(new SimpleNotification
+                        {
+                            Text = $"Finished downloading new Beatmaps",
+                            Icon = FontAwesome.Solid.Cross,
+                        });
+
                         return true;
                     }
                     catch (DownloaderException ex)

--- a/osu.Game/Beatmaps/BeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapDownloader.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;

--- a/osu.Game/Beatmaps/BeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapDownloader.cs
@@ -80,9 +80,10 @@ namespace osu.Game.Beatmaps
                             throw new DownloaderException(BeatmapDownloaderStrings.YouNeedToBeLoggedInToDownloadBeatmaps.ToString());
                         }
 
+                        //Should never be hit since GetRuleset returns FirstOrDefault
                         if (ruleset == null)
                         {
-                            throw new DownloaderException(BeatmapDownloaderStrings.NoRulesetFoundWithThisID.ToString());
+                            throw new DownloaderException("No Ruleset available");
                         }
 
                         if (lastBeatmapDownloadTime.Value >= DateTime.Now)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.BeatmapDownloadMinimumStarRating, 0.0, 0, 10, 0.1);
             SetDefault(OsuSetting.BeatmapDownloadLastTime, DateTime.Now);
-            SetDefault(OsuSetting.BeatmapDownloadSearchCategory, Overlays.BeatmapListing.SearchCategory.Leaderboard);
+            SetDefault(OsuSetting.BeatmapDownloadSearchCategory, Beatmaps.BeatmapDownloader.SearchCategory.Both);
             SetDefault(OsuSetting.BeatmapDownloadRuleset, 0, 0, int.MaxValue);
             SetDefault(OsuSetting.BeatmapDownloadStartUp, false);
         }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -11,6 +11,7 @@ using osu.Framework.Testing;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
@@ -146,6 +147,11 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f);
             SetDefault(OsuSetting.EditorHitAnimations, false);
+
+            SetDefault(OsuSetting.BeatmapDownloadMinimumStarRating, 0.0, 0, 10, 0.1);
+            SetDefault(OsuSetting.BeatmapDownloadLastTime, DateTime.Now);
+            SetDefault(OsuSetting.BeatmapDownloadSearchCategory, Overlays.BeatmapListing.SearchCategory.Leaderboard);
+            SetDefault(OsuSetting.BeatmapDownloadRuleset, 0, 0, int.MaxValue);
         }
 
         public OsuConfigManager(Storage storage)
@@ -274,5 +280,9 @@ namespace osu.Game.Configuration
         DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
         ShowOnlineExplicitContent,
+        BeatmapDownloadMinimumStarRating,
+        BeatmapDownloadLastTime,
+        BeatmapDownloadSearchCategory,
+        BeatmapDownloadRuleset,
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -152,6 +152,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.BeatmapDownloadLastTime, DateTime.Now);
             SetDefault(OsuSetting.BeatmapDownloadSearchCategory, Overlays.BeatmapListing.SearchCategory.Leaderboard);
             SetDefault(OsuSetting.BeatmapDownloadRuleset, 0, 0, int.MaxValue);
+            SetDefault(OsuSetting.BeatmapDownloadStartUp, false);
         }
 
         public OsuConfigManager(Storage storage)
@@ -284,5 +285,6 @@ namespace osu.Game.Configuration
         BeatmapDownloadLastTime,
         BeatmapDownloadSearchCategory,
         BeatmapDownloadRuleset,
+        BeatmapDownloadStartUp,
     }
 }

--- a/osu.Game/Localisation/BeatmapDownloaderStrings.cs
+++ b/osu.Game/Localisation/BeatmapDownloaderStrings.cs
@@ -15,11 +15,6 @@ namespace osu.Game.Localisation
         public static LocalisableString YouNeedToBeLoggedInToDownloadBeatmaps => new TranslatableString(getKey(@"you_need_to_be_logged_in_to_download_beatmaps"), @"You need to be logged in to download Beatmaps");
 
         /// <summary>
-        /// "No Ruleset found with this ID"
-        /// </summary>
-        public static LocalisableString NoRulesetFoundWithThisID => new TranslatableString(getKey(@"no_ruleset_found_with_this_i_d"), @"No Ruleset found with this ID");
-
-        /// <summary>
         /// "The Last Downloaded Beatmap Time is in the Future"
         /// </summary>
         public static LocalisableString TheLastDownloadedBeatmapTimeIsInTheFuture => new TranslatableString(getKey(@"the_last_downloaded_beatmap_time_is_in_the_future"), @"The Last Downloaded Beatmap Time is in the Future");

--- a/osu.Game/Localisation/BeatmapDownloaderStrings.cs
+++ b/osu.Game/Localisation/BeatmapDownloaderStrings.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class BeatmapDownloaderStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.BeatmapDownloader";
+
+        /// <summary>
+        /// "You need to be logged in to download Beatmaps"
+        /// </summary>
+        public static LocalisableString YouNeedToBeLoggedInToDownloadBeatmaps => new TranslatableString(getKey(@"you_need_to_be_logged_in_to_download_beatmaps"), @"You need to be logged in to download Beatmaps");
+
+        /// <summary>
+        /// "No Ruleset found with this ID"
+        /// </summary>
+        public static LocalisableString NoRulesetFoundWithThisID => new TranslatableString(getKey(@"no_ruleset_found_with_this_i_d"), @"No Ruleset found with this ID");
+
+        /// <summary>
+        /// "The Last Downloaded Beatmap Time is in the Future"
+        /// </summary>
+        public static LocalisableString TheLastDownloadedBeatmapTimeIsInTheFuture => new TranslatableString(getKey(@"the_last_downloaded_beatmap_time_is_in_the_future"), @"The Last Downloaded Beatmap Time is in the Future");
+
+        /// <summary>
+        /// "Please wait a Minute before requesting new Beatmaps"
+        /// </summary>
+        public static LocalisableString PleaseWaitAMinuteBeforeRequestingNewBeatmaps => new TranslatableString(getKey(@"please_wait_a_minute_before_requesting_new_beatmaps"), @"Please wait a Minute before requesting new Beatmaps");
+
+        /// <summary>
+        /// "Finished downloading new Beatmaps"
+        /// </summary>
+        public static LocalisableString FinishedDownloadingNewBeatmaps => new TranslatableString(getKey(@"finished_downloading_new_beatmaps"), @"Finished downloading new Beatmaps");
+
+        /// <summary>
+        /// "An Error has occured while downloading the Beatmaps: {0}"
+        /// </summary>
+        public static LocalisableString AnErrorHasOccuredWhileDownloadingTheBeatmaps(string arg0) => new TranslatableString(getKey(@"an_error_has_occured_while_downloading_the_beatmaps"), @"An Error has occured while downloading the Beatmaps: {0}", arg0);
+
+        /// <summary>
+        /// "An internal Error has occured while downloading the Beatmaps: {0}"
+        /// </summary>
+        public static LocalisableString AnInternalErrorHasOccuredWhileDownloadingTheBeatmaps(string arg0) => new TranslatableString(getKey(@"an_internal_error_has_occured_while_downloading_the_beatmaps"), @"An internal Error has occured while downloading the Beatmaps: {0}", arg0);
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -103,6 +103,8 @@ namespace osu.Game
 
         protected MusicController MusicController { get; private set; }
 
+        protected BeatmapDownloader BeatmapDownloader { get; private set; }
+
         protected IAPIProvider API { get; set; }
 
         protected Storage Storage { get; set; }
@@ -364,6 +366,8 @@ namespace osu.Game
 
             AddInternal(MusicController = new MusicController());
             dependencies.CacheAs(MusicController);
+
+            dependencies.CacheAs(BeatmapDownloader = new BeatmapDownloader(LocalConfig, BeatmapManager, API, RulesetStore));
 
             Ruleset.BindValueChanged(onRulesetChanged);
         }

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -6,11 +6,8 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Online.API;
 using osu.Game.Overlays.Notifications;
-using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
 {
@@ -25,10 +22,8 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
         private NotificationOverlay notifications { get; set; }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, BeatmapManager beatmapManager, IAPIProvider api, RulesetStore rulesets)
+        private void load(OsuConfigManager config, Beatmaps.BeatmapDownloader beatmapDownloader)
         {
-            Beatmaps.BeatmapDownloader beatmapDownloader = new Beatmaps.BeatmapDownloader(config, beatmapManager, api, rulesets);
-
             Add(downloadBeatmapsButton = new SettingsButton
             {
                 Text = "Download Beatmaps now",

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
-using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
 {
@@ -17,9 +15,6 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
         protected override LocalisableString Header => "Downloader Buttons";
 
         private SettingsButton downloadBeatmapsButton;
-
-        [Resolved(CanBeNull = true)]
-        private NotificationOverlay notifications { get; set; }
 
         [BackgroundDependencyLoader(true)]
         private void load(OsuConfigManager config, Beatmaps.BeatmapDownloader beatmapDownloader)

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
 {
     public class BeatmapDownloaderButtons : SettingsSubsection
     {
-
         [Resolved(CanBeNull = true)]
         private NotificationOverlay notifications { get; set; }
 

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -4,13 +4,19 @@
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
 {
     public class BeatmapDownloaderButtons : SettingsSubsection
     {
+
+        [Resolved(CanBeNull = true)]
+        private NotificationOverlay notifications { get; set; }
 
         protected override LocalisableString Header => "Downloader Buttons";
 
@@ -27,6 +33,22 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                     downloadBeatmapsButton.Enabled.Value = false;
                     Task.Run(beatmapDownloader.DownloadBeatmaps).ContinueWith(t => Schedule(() =>
                     {
+                        if (t.Result.Length == 0)
+                        {
+                            notifications?.Post(new SimpleNotification
+                            {
+                                Text = BeatmapDownloaderStrings.FinishedDownloadingNewBeatmaps.ToString(),
+                                Icon = FontAwesome.Solid.Check,
+                            });
+                        }
+                        else
+                        {
+                            notifications?.Post(new SimpleNotification
+                            {
+                                Text = BeatmapDownloaderStrings.AnErrorHasOccuredWhileDownloadingTheBeatmaps(t.Result).ToString(),
+                                Icon = FontAwesome.Solid.Cross,
+                            });
+                        }
                         downloadBeatmapsButton.Enabled.Value = true;
                     }));
                 }

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                 Text = "Set Time to now",
                 Action = () =>
                 {
-                    config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = DateTime.Now;
+                    config.SetValue(OsuSetting.BeatmapDownloadLastTime,DateTime.Now);
                 }
             });
 
@@ -76,7 +76,7 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                 Text = "Set Time to 1 week ago",
                 Action = () =>
                 {
-                    config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(DateTime.Now.Ticks - TimeSpan.TicksPerDay * 7);
+                    config.SetValue(OsuSetting.BeatmapDownloadLastTime,new DateTime(DateTime.Now.Ticks - TimeSpan.TicksPerDay * 7));
                 }
             });
         }

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                     downloadBeatmapsButton.Enabled.Value = false;
                     Task.Run(beatmapDownloader.DownloadBeatmapsAsync).ContinueWith(t => Schedule(() =>
                     {
-                        if (t.Result)
+                        if (t.Result.Length == 0)
                         {
                             notifications?.Post(new SimpleNotification
                             {
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                         {
                             notifications?.Post(new SimpleNotification
                             {
-                                Text = "An Error has occured while downloading the Beatmaps",
+                                Text = $"An Error has occured while downloading the Beatmaps: {t.Result}",
                                 Icon = FontAwesome.Solid.Cross,
                             });
                         }

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Online.API;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
+{
+    public class BeatmapDownloaderButtons : SettingsSubsection
+    {
+
+        protected override LocalisableString Header => "Downloader Buttons";
+
+        private SettingsButton downloadBeatmapsButton;
+
+        [Resolved(CanBeNull = true)]
+        private NotificationOverlay notifications { get; set; }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuConfigManager config, BeatmapManager beatmapManager, IAPIProvider api, RulesetStore rulesets)
+        {
+            Beatmaps.BeatmapDownloader beatmapDownloader = new Beatmaps.BeatmapDownloader(config, beatmapManager, api, rulesets);
+
+            Add(downloadBeatmapsButton = new SettingsButton
+            {
+                Text = "Download Beatmaps now",
+                Action = () =>
+                {
+                    downloadBeatmapsButton.Enabled.Value = false;
+                    Task.Run(beatmapDownloader.DownloadBeatmapsAsync).ContinueWith(t => Schedule(() =>
+                    {
+                        if (t.Result)
+                        {
+                            notifications?.Post(new SimpleNotification
+                            {
+                                Text = "Finished downloading the newest filtered Beatmaps",
+                                Icon = FontAwesome.Solid.Check,
+                            });
+                        }
+                        else
+                        {
+                            notifications?.Post(new SimpleNotification
+                            {
+                                Text = "An Error has occured while downloading the Beatmaps",
+                                Icon = FontAwesome.Solid.Cross,
+                            });
+                        }
+
+                        downloadBeatmapsButton.Enabled.Value = true;
+                    }));
+                }
+            });
+
+            Add(new SettingsButton
+            {
+                Text = "Set Time to now",
+                Action = () =>
+                {
+                    config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = DateTime.Now;
+                }
+            });
+
+            Add(new SettingsButton
+            {
+                Text = "Set Time to 1 week ago",
+                Action = () =>
+                {
+                    config.GetBindable<DateTime>(OsuSetting.BeatmapDownloadLastTime).Value = new DateTime(DateTime.Now.Ticks - TimeSpan.TicksPerDay * 7);
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderButtons.cs
@@ -30,27 +30,19 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                 Action = () =>
                 {
                     downloadBeatmapsButton.Enabled.Value = false;
-                    Task.Run(beatmapDownloader.DownloadBeatmapsAsync).ContinueWith(t => Schedule(() =>
+                    Task.Run(beatmapDownloader.DownloadBeatmaps).ContinueWith(t => Schedule(() =>
                     {
-                        if (t.Result.Length == 0)
-                        {
-                            notifications?.Post(new SimpleNotification
-                            {
-                                Text = "Finished downloading the newest filtered Beatmaps",
-                                Icon = FontAwesome.Solid.Check,
-                            });
-                        }
-                        else
-                        {
-                            notifications?.Post(new SimpleNotification
-                            {
-                                Text = $"An Error has occured while downloading the Beatmaps: {t.Result}",
-                                Icon = FontAwesome.Solid.Cross,
-                            });
-                        }
-
                         downloadBeatmapsButton.Enabled.Value = true;
                     }));
+                }
+            });
+
+            Add(new SettingsButton
+            {
+                Text = "Stop the Downloader",
+                Action = () =>
+                {
+                    beatmapDownloader.ForceStop();
                 }
             });
 

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
@@ -30,10 +30,10 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
                 KeyboardStep = 0.1f,
             });
 
-            Add(new SettingsEnumDropdown<BeatmapListing.SearchCategory>
+            Add(new SettingsEnumDropdown<Beatmaps.BeatmapDownloader.SearchCategory>
             {
                 LabelText = "Category",
-                Current = config.GetBindable<BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory),
+                Current = config.GetBindable<Beatmaps.BeatmapDownloader.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory),
             });
 
             Add(rulesetInfoDropdown = new SettingsDropdown<RulesetInfo>

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
@@ -12,7 +12,6 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
 {
     public class BeatmapDownloaderSettings : SettingsSubsection
     {
-
         protected override LocalisableString Header => "Downloader Settings";
 
         private SettingsDropdown<RulesetInfo> rulesetInfoDropdown;

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
@@ -46,6 +46,12 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
             {
                 ruleset.Value = rulesetInfoDropdown.Current.Value.ID ?? 0;
             };
+
+            Add(new SettingsCheckbox
+            {
+                LabelText = "Download at launch",
+                Current = config.GetBindable<bool>(OsuSetting.BeatmapDownloadStartUp),
+            });
         }
     }
 

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
@@ -22,22 +22,26 @@ namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
         private void load(OsuConfigManager config, RulesetStore rulesets)
         {
             ruleset = config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset);
+
             Add(new SettingsSlider<double, StarsSlider>
             {
-                LabelText = "Minimum Star Rating",
+                LabelText = "Download Sets that have atleast",
                 Current = config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating),
                 KeyboardStep = 0.1f,
             });
+
             Add(new SettingsEnumDropdown<BeatmapListing.SearchCategory>
             {
                 LabelText = "Category",
                 Current = config.GetBindable<BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory),
             });
+
             Add(rulesetInfoDropdown = new SettingsDropdown<RulesetInfo>
             {
                 LabelText = "Ruleset",
                 Items = rulesets.AvailableRulesets,
             });
+
             rulesetInfoDropdown.SettingChanged += () =>
             {
                 ruleset.Value = rulesetInfoDropdown.Current.Value.ID ?? 0;

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloader/BeatmapDownloaderSettings.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Overlays.Settings.Sections.BeatmapDownloader
+{
+    public class BeatmapDownloaderSettings : SettingsSubsection
+    {
+
+        protected override LocalisableString Header => "Downloader Settings";
+
+        private SettingsDropdown<RulesetInfo> rulesetInfoDropdown;
+        private Bindable<int> ruleset { get; set; }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuConfigManager config, RulesetStore rulesets)
+        {
+            ruleset = config.GetBindable<int>(OsuSetting.BeatmapDownloadRuleset);
+            Add(new SettingsSlider<double, StarsSlider>
+            {
+                LabelText = "Minimum Star Rating",
+                Current = config.GetBindable<double>(OsuSetting.BeatmapDownloadMinimumStarRating),
+                KeyboardStep = 0.1f,
+            });
+            Add(new SettingsEnumDropdown<BeatmapListing.SearchCategory>
+            {
+                LabelText = "Category",
+                Current = config.GetBindable<BeatmapListing.SearchCategory>(OsuSetting.BeatmapDownloadSearchCategory),
+            });
+            Add(rulesetInfoDropdown = new SettingsDropdown<RulesetInfo>
+            {
+                LabelText = "Ruleset",
+                Items = rulesets.AvailableRulesets,
+            });
+            rulesetInfoDropdown.SettingChanged += () =>
+            {
+                ruleset.Value = rulesetInfoDropdown.Current.Value.ID ?? 0;
+            };
+        }
+    }
+
+    internal class StarsSlider : OsuSliderBar<double>
+    {
+        public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/BeatmapDownloaderSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/BeatmapDownloaderSection.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Overlays.Settings.Sections.BeatmapDownloader;
+
+namespace osu.Game.Overlays.Settings.Sections
+{
+    public class BeatmapDownloaderSection : SettingsSection
+    {
+        public override string Header => "Beatmap Downloader";
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            Icon = FontAwesome.Solid.ArrowDown
+        };
+
+        public BeatmapDownloaderSection()
+        {
+            Children = new Drawable[]
+            {
+                new BeatmapDownloaderSettings(),
+                new BeatmapDownloaderButtons(),
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Overlays
             new UserInterfaceSection(),
             new GameplaySection(),
             new SkinSection(),
+            new BeatmapDownloaderSection(),
             new OnlineSection(),
             new MaintenanceSection(),
             new DebugSection(),


### PR DESCRIPTION
This implements [Discussion](https://github.com/ppy/osu/discussions/13074) as reasonable as possible.

This Beatmap Downloader can automatically download Beatmaps filtered by
- SR
- Ranked/Loved/Both
- Ruleset

It downloads Beatmaps until it hits the Date it last downloaded Beatmaps, so you will always have the newest Beatmaps downloaded. Default Date is DateTime.Now.

The Autodownload at the launch of the Game is configurable. Default is off.

Will remove the "Set Time to now" and "Set Time to 1 week ago"  Buttons before merging, they are still there for manual testing if needed.