### PR TITLE
Fix out-of-order hits in editor causing exceptions

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -41,6 +41,11 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             protected override GameplayCursorContainer CreateCursor() => null;
 
+            public OsuEditorPlayfield()
+            {
+                HitPolicy = new AnyOrderHitPolicy();
+            }
+
             [BackgroundDependencyLoader]
             private void load(OsuConfigManager config)
             {

--- a/osu.Game.Rulesets.Osu/UI/AnyOrderHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/AnyOrderHitPolicy.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Osu.UI
+{
+    /// <summary>
+    /// An <see cref="IHitPolicy"/> which allows hitobjects to be hit in any order.
+    /// </summary>
+    public class AnyOrderHitPolicy : IHitPolicy
+    {
+        public IHitObjectContainer HitObjectContainer { get; set; }
+
+        public bool IsHittable(DrawableHitObject hitObject, double time) => true;
+
+        public void HandleHit(DrawableHitObject hitObject)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12179

Sometimes, when scrubbing in the timeline while the clock is running, the editor would throw an exception/crash with:
```
Unhandled exception. System.InvalidOperationException: A DrawableSliderHead was hit before it became hittable!
   at osu.Game.Rulesets.Osu.UI.StartTimeOrderedHitPolicy.HandleHit(DrawableHitObject hitObject) in /home/smgi/Repos/osu/osu.Game.Rulesets.Osu/UI/StartTimeOrderedHitPolicy.cs:line 53
   at osu.Game.Rulesets.Osu.UI.OsuPlayfield.onNewResult(DrawableHitObject judgedObject, JudgementResult result) in /home/smgi/Repos/osu/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs:line 145
   at osu.Game.Rulesets.UI.Playfield.<.ctor>b__27_2(DrawableHitObject d, JudgementResult r) in /home/smgi/Repos/osu/osu.Game/Rulesets/UI/Playfield.cs:line 103
   at osu.Game.Rulesets.UI.HitObjectContainer.onNewResult(DrawableHitObject d, JudgementResult r) in /home/smgi/Repos/osu/osu.Game/Rulesets/UI/HitObjectContainer.cs:line 154
   at osu.Game.Rulesets.Objects.Drawables.DrawableHitObject.onNewResult(DrawableHitObject drawableHitObject, JudgementResult result) in /home/smgi/Repos/osu/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs:line 363
   at osu.Game.Rulesets.Objects.Drawables.DrawableHitObject.ApplyResult(Action`1 application) in /home/smgi/Repos/osu/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs:line 676
   at osu.Game.Rulesets.Osu.Objects.Drawables.DrawableHitCircle.CheckForResult(Boolean userTriggered, Double timeOffset) in /home/smgi/Repos/osu/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs:line 141
   at osu.Game.Rulesets.Objects.Drawables.DrawableHitObject.UpdateResult(Boolean userTriggered) in /home/smgi/Repos/osu/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs:line 693
   at osu.Game.Rulesets.Osu.Objects.Drawables.DrawableHitCircle.<load>b__22_4() in /home/smgi/Repos/osu/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs:line 68
   at osu.Game.Rulesets.Osu.Objects.Drawables.DrawableHitCircle.HitReceptor.OnPressed(OsuAction action) in /home/smgi/Repos/osu/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs:line 237
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at osu.Framework.Input.Bindings.KeyBindingContainer`1.PropagatePressed(IEnumerable`1 drawables, T pressed, Single scrollAmount, Boolean isPrecise)
   at osu.Framework.Input.Bindings.KeyBindingContainer`1.TriggerPressed(T pressed)
   at osu.Game.Rulesets.UI.RulesetInputManager`1.HandleInputStateChange(InputStateChangeEvent inputStateChange) in /home/smgi/Repos/osu/osu.Game/Rulesets/UI/RulesetInputManager.cs:line 75
   at osu.Game.Input.Handlers.ReplayInputHandler.ReplayState`1.Apply(InputState state, IInputStateChangeHandler handler) in /home/smgi/Repos/osu/osu.Game/Input/Handlers/ReplayInputHandler.cs:line 51
```
This is because the editor doesn't use frame stability resulting in possible out-of-order hits. The simple solution to this is to disable the hit policy in the editor.

One such exception can be seen in https://github.com/ppy/osu/issues/14210#issuecomment-896143397