### PR TITLE
Add ability for gameplay leaderboard scroll when too many users are displayed

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -84,6 +84,23 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("add frenzibyte", () => createRandomScore(new User { Username = "frenzibyte", Id = 14210502 }));
         }
 
+        [Test]
+        public void TestMaxHeight()
+        {
+            int playerNumber = 1;
+            AddRepeatStep("add 3 other players", () => createRandomScore(new User { Username = $"Player {playerNumber++}" }), 3);
+            checkHeight(4);
+
+            AddRepeatStep("add 4 other players", () => createRandomScore(new User { Username = $"Player {playerNumber++}" }), 4);
+            checkHeight(8);
+
+            AddRepeatStep("add 4 other players", () => createRandomScore(new User { Username = $"Player {playerNumber++}" }), 4);
+            checkHeight(8);
+
+            void checkHeight(int panelCount)
+                => AddAssert($"leaderboard height is {panelCount} panels high", () => leaderboard.DrawHeight == (GameplayLeaderboardScore.PANEL_HEIGHT + leaderboard.Spacing) * panelCount);
+        }
+
         private void createRandomScore(User user) => createLeaderboardScore(new BindableDouble(RNG.Next(0, 5_000_000)), user);
 
         private void createLeaderboardScore(BindableDouble score, User user, bool isTracked = false)
@@ -94,9 +111,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private class TestGameplayLeaderboard : GameplayLeaderboard
         {
+            public float Spacing => Flow.Spacing.Y;
+
             public bool CheckPositionByUsername(string username, int? expectedPosition)
             {
-                var scoreItem = this.FirstOrDefault(i => i.User?.Username == username);
+                var scoreItem = Flow.FirstOrDefault(i => i.User?.Username == username);
 
                 return scoreItem != null && scoreItem.ScorePosition == expectedPosition;
             }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void createLeaderboardScore(BindableDouble score, User user, bool isTracked = false)
         {
-            var leaderboardScore = leaderboard.AddPlayer(user, isTracked);
+            var leaderboardScore = leaderboard.Add(user, isTracked);
             leaderboardScore.TotalScore.BindTo(score);
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddStep("add local player", () => createLeaderboardScore(playerScore, new User { Username = "You", Id = 3 }, true));
+            AddStep("toggle expanded", () => leaderboard.Expanded.Value = !leaderboard.Expanded.Value);
             AddSliderStep("set player score", 50, 5000000, 1222333, v => playerScore.Value = v);
         }
 

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Play.HUD
         /// Whether the player should be tracked on the leaderboard.
         /// Set to <c>true</c> for the local player or a player whose replay is currently being played.
         /// </param>
-        public ILeaderboardScore AddPlayer([CanBeNull] User user, bool isTracked)
+        public ILeaderboardScore Add([CanBeNull] User user, bool isTracked)
         {
             var drawable = CreateLeaderboardScoreDrawable(user, isTracked);
 

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Screens.Play.HUD
             if (isTracked)
             {
                 if (trackedScore != null)
-                    throw new InvalidOperationException("Cannot track more than one scores.");
+                    throw new InvalidOperationException("Cannot track more than one score.");
 
                 trackedScore = drawable;
             }

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Screens.Play.HUD
                     c.Colour = Color4.Transparent;
                 else
                 {
-                    if (bottomY - fadeBottom > 0 && requiresScroll)
+                    if (requireBottomFade)
                     {
                         c.Colour = ColourInfo.GradientVertical(
                             Color4.White.Opacity(Math.Min(1 - (topY - fadeBottom) / panel_height, 1)),

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -6,29 +6,58 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Containers;
 using osu.Game.Users;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public class GameplayLeaderboard : FillFlowContainer<GameplayLeaderboardScore>
+    public class GameplayLeaderboard : CompositeDrawable
     {
+        private readonly int maxPanels;
         private readonly Cached sorting = new Cached();
 
         public Bindable<bool> Expanded = new Bindable<bool>();
 
-        public GameplayLeaderboard()
+        protected readonly FillFlowContainer<GameplayLeaderboardScore> Flow;
+
+        private bool requiresScroll;
+        private readonly OsuScrollContainer scroll;
+
+        private GameplayLeaderboardScore trackedScore;
+
+        /// <summary>
+        /// Create a new leaderboard.
+        /// </summary>
+        /// <param name="maxPanels">The maximum panels to show at once. Defines the maximum height of this component.</param>
+        public GameplayLeaderboard(int maxPanels = 8)
         {
+            this.maxPanels = maxPanels;
+
             Width = GameplayLeaderboardScore.EXTENDED_WIDTH + GameplayLeaderboardScore.SHEAR_WIDTH;
 
-            Direction = FillDirection.Vertical;
-
-            Spacing = new Vector2(2.5f);
-
-            LayoutDuration = 250;
-            LayoutEasing = Easing.OutQuint;
+            InternalChildren = new Drawable[]
+            {
+                scroll = new ManualScrollScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = Flow = new FillFlowContainer<GameplayLeaderboardScore>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        X = GameplayLeaderboardScore.SHEAR_WIDTH,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(2.5f),
+                        LayoutDuration = 450,
+                        LayoutEasing = Easing.OutQuint,
+                    }
+                }
+            };
         }
 
         protected override void LoadComplete()
@@ -50,22 +79,83 @@ namespace osu.Game.Screens.Play.HUD
         {
             var drawable = CreateLeaderboardScoreDrawable(user, isTracked);
 
+            if (isTracked)
+            {
+                if (trackedScore != null)
+                    throw new InvalidOperationException("Cannot track more than one scores.");
+
+                trackedScore = drawable;
+            }
+
             drawable.Expanded.BindTo(Expanded);
 
-            base.Add(drawable);
+            Flow.Add(drawable);
             drawable.TotalScore.BindValueChanged(_ => sorting.Invalidate(), true);
 
-            Height = Count * (GameplayLeaderboardScore.PANEL_HEIGHT + Spacing.Y);
+            int displayCount = Math.Min(Flow.Count, maxPanels);
+            Height = displayCount * (GameplayLeaderboardScore.PANEL_HEIGHT + Flow.Spacing.Y);
+            requiresScroll = displayCount != Flow.Count;
 
             return drawable;
+        }
+
+        public void Clear()
+        {
+            Flow.Clear();
+            trackedScore = null;
+            scroll.ScrollToStart(false);
         }
 
         protected virtual GameplayLeaderboardScore CreateLeaderboardScoreDrawable(User user, bool isTracked) =>
             new GameplayLeaderboardScore(user, isTracked);
 
-        public sealed override void Add(GameplayLeaderboardScore drawable)
+        protected override void Update()
         {
-            throw new NotSupportedException($"Use {nameof(AddPlayer)} instead.");
+            base.Update();
+
+            if (requiresScroll && trackedScore != null)
+            {
+                float scrollTarget = scroll.GetChildPosInContent(trackedScore) + trackedScore.DrawHeight / 2 - scroll.DrawHeight / 2;
+                scroll.ScrollTo(scrollTarget, false);
+            }
+
+            const float panel_height = GameplayLeaderboardScore.PANEL_HEIGHT;
+
+            float fadeBottom = scroll.Current + scroll.DrawHeight;
+            float fadeTop = scroll.Current + panel_height;
+
+            if (scroll.Current <= 0) fadeTop -= panel_height;
+            if (!scroll.IsScrolledToEnd()) fadeBottom -= panel_height;
+
+            // logic is mostly shared with Leaderboard, copied here for simplicity.
+            foreach (var c in Flow.Children)
+            {
+                float topY = c.ToSpaceOfOtherDrawable(Vector2.Zero, Flow).Y;
+                float bottomY = topY + panel_height;
+
+                bool requireTopFade = requiresScroll && topY <= fadeTop;
+                bool requireBottomFade = requiresScroll && bottomY >= fadeBottom;
+
+                if (!requireTopFade && !requireBottomFade)
+                    c.Colour = Color4.White;
+                else if (topY > fadeBottom + panel_height || bottomY < fadeTop - panel_height)
+                    c.Colour = Color4.Transparent;
+                else
+                {
+                    if (bottomY - fadeBottom > 0 && requiresScroll)
+                    {
+                        c.Colour = ColourInfo.GradientVertical(
+                            Color4.White.Opacity(Math.Min(1 - (topY - fadeBottom) / panel_height, 1)),
+                            Color4.White.Opacity(Math.Min(1 - (bottomY - fadeBottom) / panel_height, 1)));
+                    }
+                    else if (requiresScroll)
+                    {
+                        c.Colour = ColourInfo.GradientVertical(
+                            Color4.White.Opacity(Math.Min(1 - (fadeTop - topY) / panel_height, 1)),
+                            Color4.White.Opacity(Math.Min(1 - (fadeTop - bottomY) / panel_height, 1)));
+                    }
+                }
+            }
         }
 
         private void sort()
@@ -73,15 +163,26 @@ namespace osu.Game.Screens.Play.HUD
             if (sorting.IsValid)
                 return;
 
-            var orderedByScore = this.OrderByDescending(i => i.TotalScore.Value).ToList();
+            var orderedByScore = Flow.OrderByDescending(i => i.TotalScore.Value).ToList();
 
-            for (int i = 0; i < Count; i++)
+            for (int i = 0; i < Flow.Count; i++)
             {
-                SetLayoutPosition(orderedByScore[i], i);
+                Flow.SetLayoutPosition(orderedByScore[i], i);
                 orderedByScore[i].ScorePosition = i + 1;
             }
 
             sorting.Validate();
+        }
+
+        private class ManualScrollScrollContainer : OsuScrollContainer
+        {
+            public ManualScrollScrollContainer()
+            {
+                ScrollbarVisible = false;
+            }
+
+            public override bool HandlePositionalInput => false;
+            public override bool HandleNonPositionalInput => false;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Play.HUD
 
             InternalChildren = new Drawable[]
             {
-                scroll = new ManualScrollScrollContainer
+                scroll = new InputDisabledScrollContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Child = Flow = new FillFlowContainer<GameplayLeaderboardScore>
@@ -174,9 +174,9 @@ namespace osu.Game.Screens.Play.HUD
             sorting.Validate();
         }
 
-        private class ManualScrollScrollContainer : OsuScrollContainer
+        private class InputDisabledScrollContainer : OsuScrollContainer
         {
-            public ManualScrollScrollContainer()
+            public InputDisabledScrollContainer()
             {
                 ScrollbarVisible = false;
             }

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -81,7 +81,10 @@ namespace osu.Game.Screens.Play.HUD
         [CanBeNull]
         public User User { get; }
 
-        private readonly bool trackedPlayer;
+        /// <summary>
+        /// Whether this score is the local user or a replay player (and should be focused / always visible).
+        /// </summary>
+        public readonly bool Tracked;
 
         private Container mainFillContainer;
 
@@ -97,11 +100,11 @@ namespace osu.Game.Screens.Play.HUD
         /// Creates a new <see cref="GameplayLeaderboardScore"/>.
         /// </summary>
         /// <param name="user">The score's player.</param>
-        /// <param name="trackedPlayer">Whether the player is the local user or a replay player.</param>
-        public GameplayLeaderboardScore([CanBeNull] User user, bool trackedPlayer)
+        /// <param name="tracked">Whether the player is the local user or a replay player.</param>
+        public GameplayLeaderboardScore([CanBeNull] User user, bool tracked)
         {
             User = user;
-            this.trackedPlayer = trackedPlayer;
+            Tracked = tracked;
 
             AutoSizeAxes = Axes.X;
             Height = PANEL_HEIGHT;
@@ -338,7 +341,7 @@ namespace osu.Game.Screens.Play.HUD
                 panelColour = BackgroundColour ?? Color4Extensions.FromHex("7fcc33");
                 textColour = TextColour ?? Color4.White;
             }
-            else if (trackedPlayer)
+            else if (Tracked)
             {
                 widthExtension = true;
                 panelColour = BackgroundColour ?? Color4Extensions.FromHex("ffd966");

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Play.HUD
 
                     var trackedUser = UserScores[user.Id];
 
-                    var leaderboardScore = AddPlayer(user, user.Id == api.LocalUser.Value.Id);
+                    var leaderboardScore = Add(user, user.Id == api.LocalUser.Value.Id);
                     leaderboardScore.Accuracy.BindTo(trackedUser.Accuracy);
                     leaderboardScore.TotalScore.BindTo(trackedUser.Score);
                     leaderboardScore.Combo.BindTo(trackedUser.CurrentCombo);


### PR DESCRIPTION
https://user-images.githubusercontent.com/191335/129154878-b1484a70-677a-46df-9bb2-be65af9bda85.mp4

Closes #14206.

Currently set to 8 players at one, which seems to be a reasonable number. In the future, the height of this will likely be adjustable in the skin editor. At that point, the logic will need to change slightly (but shouldn't be a huge deal of work).
