### PR TITLE
Fix multiple issues with multi-spectator clock sync handling

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -1,8 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual;
@@ -53,6 +58,48 @@ namespace osu.Game.Tests.Gameplay
             });
 
             AddAssert("current time < time at reset", () => gcc.GameplayClock.CurrentTime < timeAtReset);
+        }
+
+        [Test]
+        public void TestSeekPerformsInGameplayTime(
+            [Values(1.0, 0.5, 2.0, 0.0)] double clockRate,
+            [Values(0.0, 500.0, -500.0)] double userOffset)
+        {
+            OsuConfigManager config = null;
+            WorkingBeatmap working = null;
+            GameplayClockContainer gcc = null;
+
+            AddStep("create container", () =>
+            {
+                config = new OsuConfigManager(LocalStorage);
+
+                working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
+                working.LoadTrack();
+
+                Add(new DependencyProvidingContainer
+                {
+                    CachedDependencies = new (Type, object)[] { (typeof(OsuConfigManager), config) },
+                    Child = gcc = new MasterGameplayClockContainer(working, 0),
+                });
+
+                gcc.Stop();
+                gcc.Reset();
+            });
+
+            if (clockRate != 1.0)
+                AddStep($"set clock rate to {clockRate}", () => working.Track.AddAdjustment(AdjustableProperty.Frequency, new BindableDouble(clockRate)));
+
+            if (userOffset != 0f)
+                AddStep($"set audio offset to {userOffset}", () => config.SetValue(OsuSetting.AudioOffset, userOffset));
+
+            AddStep("seek to 0", () => gcc.Seek(0));
+            AddAssert("gameplay clock time = 0", () => gcc.CurrentTime == 0);
+
+            AddStep("seek to 2500", () => gcc.Seek(2500));
+            AddAssert("gameplay clock time = 2500", () => gcc.CurrentTime == 2500);
+
+            AddStep("seek to -2500", () => gcc.Seek(-2500));
+            AddAssert("gameplay clock time = -2500", () => gcc.GameplayClock.CurrentTime == -2500);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
 using osu.Game.Screens.Play;
@@ -30,6 +31,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private readonly List<MultiplayerRoomUser> playingUsers = new List<MultiplayerRoomUser>();
 
+        private OsuConfigManager localConfig;
+
         private BeatmapSetInfo importedSet;
         private BeatmapInfo importedBeatmap;
         private int importedBeatmapId;
@@ -37,6 +40,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load()
         {
+            Dependencies.Cache(localConfig = new OsuConfigManager(LocalStorage));
+
             importedSet = ImportBeatmapTest.LoadOszIntoOsu(game, virtualTrack: true).Result;
             importedBeatmap = importedSet.Beatmaps.First(b => b.RulesetID == 0);
             importedBeatmapId = importedBeatmap.OnlineBeatmapID ?? -1;
@@ -281,20 +286,44 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("player 2 playing from correct point in time", () => getPlayer(PLAYER_2_ID).ChildrenOfType<DrawableRuleset>().Single().FrameStableClock.CurrentTime > 30000);
         }
 
-        private void loadSpectateScreen(bool waitForPlayerLoad = true)
+        [Test]
+        public void TestSpectatingBeatmapsWithOffsetTiming(
+            [Values(0.0, -2500.0, -10000.0)] double gameplayStartTime,
+            [Values(0.0, 80.0)] double userOffset)
         {
-            AddStep("load screen", () =>
+            AddStep($"set user offset to {userOffset}", () => localConfig.SetValue(OsuSetting.AudioOffset, userOffset));
+
+            start(PLAYER_1_ID);
+
+            loadSpectateScreen(false, gameplayStartTime);
+
+            AddStep("send frame on gameplay start", () => getInstance(PLAYER_1_ID).OnGameplayStarted += () => SpectatorClient.SendFrames(PLAYER_1_ID, 100));
+            AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded && spectatorScreen.AllPlayersLoaded);
+
+            AddWaitStep("wait for progression", 3);
+
+            assertNotCatchingUp(PLAYER_1_ID);
+            assertRunning(PLAYER_1_ID);
+
+            AddStep("reset user offset", () => localConfig.SetValue(OsuSetting.AudioOffset, 0.0));
+        }
+
+        private void loadSpectateScreen(bool waitForPlayerLoad = true, double gameplayStartTime = 0)
+        {
+            AddStep(gameplayStartTime == 0 ? "load screen" : $"load screen (master start = {gameplayStartTime})", () =>
             {
                 Beatmap.Value = beatmapManager.GetWorkingBeatmap(importedBeatmap);
                 Ruleset.Value = importedBeatmap.Ruleset;
 
-                LoadScreen(spectatorScreen = new MultiSpectatorScreen(playingUsers.ToArray()));
+                LoadScreen(spectatorScreen = new TestMultiSpectatorScreen(playingUsers.ToArray(), gameplayStartTime));
             });
 
             AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded && (!waitForPlayerLoad || spectatorScreen.AllPlayersLoaded));
         }
 
-        private void start(int[] userIds, int? beatmapId = null)
+        private void start(int userId) => start(new[] { userId });
+
+        private void start(int[] userIds)
         {
             AddStep("start play", () =>
             {
@@ -302,7 +331,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     OnlinePlayDependencies.Client.AddUser(new User { Id = id }, true);
 
-                    SpectatorClient.StartPlay(id, beatmapId ?? importedBeatmapId);
+                    SpectatorClient.StartPlay(id, importedBeatmapId);
                     playingUsers.Add(new MultiplayerRoomUser(id));
                 }
             });
@@ -335,11 +364,37 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private void assertMuted(int userId, bool muted)
             => AddAssert($"{userId} {(muted ? "is" : "is not")} muted", () => getInstance(userId).Mute == muted);
 
+        private void assertRunning(int userId)
+            => AddAssert($"{userId} clock running", () => getInstance(userId).GameplayClock.IsRunning);
+
+        private void assertNotCatchingUp(int userId)
+            => AddAssert($"{userId} in sync", () => !getInstance(userId).GameplayClock.IsCatchingUp);
+
         private void waitForCatchup(int userId)
             => AddUntilStep($"{userId} not catching up", () => !getInstance(userId).GameplayClock.IsCatchingUp);
 
         private Player getPlayer(int userId) => getInstance(userId).ChildrenOfType<Player>().Single();
 
         private PlayerArea getInstance(int userId) => spectatorScreen.ChildrenOfType<PlayerArea>().Single(p => p.UserId == userId);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            localConfig?.Dispose();
+            base.Dispose(isDisposing);
+        }
+
+        private class TestMultiSpectatorScreen : MultiSpectatorScreen
+        {
+            private readonly double? gameplayStartTime;
+
+            public TestMultiSpectatorScreen(MultiplayerRoomUser[] users, double? gameplayStartTime = null)
+                : base(users)
+            {
+                this.gameplayStartTime = gameplayStartTime;
+            }
+
+            protected override MasterGameplayClockContainer CreateMasterGameplayClockContainer(WorkingBeatmap beatmap)
+                => new MasterGameplayClockContainer(beatmap, gameplayStartTime ?? 0, gameplayStartTime.HasValue);
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             if (IsRunning)
             {
-                double elapsedSource = Source.ElapsedFrameTime;
+                double elapsedSource = Math.Max(Source.ElapsedFrameTime, 0);
                 double elapsed = elapsedSource * Rate;
 
                 CurrentTime += elapsed;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -54,18 +54,28 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
             }
 
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                updateContainerState();
+            }
+
             protected override void Update()
+            {
+                updateContainerState();
+                base.Update();
+            }
+
+            protected override GameplayClock CreateGameplayClock(IFrameBasedClock source) => new GameplayClock(source);
+
+            private void updateContainerState()
             {
                 // The player clock's running state is controlled externally, but the local pausing state needs to be updated to stop gameplay.
                 if (SourceClock.IsRunning)
                     Start();
                 else
                     Stop();
-
-                base.Update();
             }
-
-            protected override GameplayClock CreateGameplayClock(IFrameBasedClock source) => new GameplayClock(source);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Spectator;
 using osu.Game.Screens.Play;
@@ -66,7 +67,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             Container leaderboardContainer;
             Container scoreDisplayContainer;
 
-            masterClockContainer = new MasterGameplayClockContainer(Beatmap.Value, 0);
+            masterClockContainer = CreateMasterGameplayClockContainer(Beatmap.Value);
 
             InternalChildren = new[]
             {
@@ -224,5 +225,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             multiplayerClient.ChangeState(MultiplayerUserState.Idle);
             return base.OnBackButton();
         }
+
+        protected virtual MasterGameplayClockContainer CreateMasterGameplayClockContainer(WorkingBeatmap beatmap) => new MasterGameplayClockContainer(beatmap, 0);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
     public class PlayerArea : CompositeDrawable
     {
         /// <summary>
+        /// Raised after <see cref="Player.StartGameplay"/> is called on <see cref="Player"/>.
+        /// </summary>
+        public event Action OnGameplayStarted;
+
+        /// <summary>
         /// Whether a <see cref="Player"/> is loaded in the area.
         /// </summary>
         public bool PlayerLoaded => (stack?.CurrentScreen as Player)?.IsLoaded == true;
@@ -90,7 +95,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 Child = stack = new OsuScreenStack()
             };
 
-            stack.Push(new MultiSpectatorPlayerLoader(Score, () => new MultiSpectatorPlayer(Score, GameplayClock)));
+            stack.Push(new MultiSpectatorPlayerLoader(Score, () =>
+            {
+                var player = new MultiSpectatorPlayer(Score, GameplayClock);
+                player.OnGameplayStarted += OnGameplayStarted;
+                return player;
+            }));
+
             loadingLayer.Hide();
         }
 

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.Play
         {
             // remove the offset component here because most of the time we want the seek to be aligned to gameplay, not the audio track.
             // we may want to consider reversing the application of offsets in the future as it may feel more correct.
-            base.Seek(time - totalOffset);
+            base.Seek(time - totalOffset * GameplayClock.Rate);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public const double RESULTS_DISPLAY_DELAY = 1000.0;
 
+        /// <summary>
+        /// Raised after <see cref="StartGameplay"/> is called.
+        /// </summary>
+        public event Action OnGameplayStarted;
+
         public override bool AllowBackButton => false; // handled by HoldForMenuButton
 
         protected override UserActivity InitialActivity => new UserActivity.SoloGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
@@ -934,7 +939,9 @@ namespace osu.Game.Screens.Play
             updateGameplayState();
 
             GameplayClockContainer.FadeInFromZero(750, Easing.OutQuint);
+
             StartGameplay();
+            OnGameplayStarted?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #14162 

This resolves multiple issues I have found so far with the multi-spectator, all occurring when a user clock offset is applied and/or a beatmap has `AudioLeadIn` value set.

The following changes cannot be separated each into its own PR as one could potentially cause a bug to arise due to being hidden originally, but grouping them all together seems to make everything remain working correctly.

#### https://github.com/ppy/osu/commit/b1e3327f979dd779bdc3be36e2177317a5f6ed8c

This was causing master clock with an offset applied to accumulatively have its current time decreased everytime `Start()` is called (due to there being a `Seek(CurrentTime)` call), resulting in the master clock moving away from the spectator clock and potentially result in a catch-22 scenario.

I've added failing test cases ensuring that seeking to an arbitrary time would be equal to what `GameplayClock.CurrentTime` will have, and not get broken by the applied user offsets https://github.com/ppy/osu/commit/066863586a39a88ed894b12101ede5b31f1882b9.

#### https://github.com/ppy/osu/commit/3c271e4db7aa443485b9d47f88538dbdc6b62f3d

Since `GameplayClockContainer`s initially have their running state (`IsPaused`) set to true, the spectator clock container would incorrectly have `IsPaused = true` until it is corrected back on the first `Update()` call.

There's a chance after `MultiSpectatorPlayer.StartGameplay()` is called (which resets the clock container and therefore incorrectly start the spectator clock) and before the first `Update()` call on the spectator clock container, in which the first frame can arrive and cause `SpectatorPlayer` to perform a seek to the frame time as the initial point.

Performing a seek while the spectator clock is running causes it to think it should advance forward, and therefore move away from the master clock depending on the `ElapsedFrameTime` from the last performed seek on the master clock.

The last performed seek on the master clock before the load of spectator players would be at `MultiSpectatorScreen.LoadComplete()`, in which a `Reset` is performed, causing the master clock to seek to 0 in the base `Reset` implementation, and then seek to the value of [`startOffset`](https://github.com/ppy/osu/blob/979495ddb2fab589c76372b8fd74354efe94f2c1/osu.Game/Screens/Play/MasterGameplayClockContainer.cs#L154) ([which is the reason why only certain beatmaps trigger this bug, ones with `AudioLeadIn` or storyboard layers to be specific](https://github.com/ppy/osu/blob/979495ddb2fab589c76372b8fd74354efe94f2c1/osu.Game/Screens/Play/MasterGameplayClockContainer.cs#L77-L94)).

The following logs confirm what I've stated above, from testing with production server (with gameplay start time set to `-50000` for testing convenience):
```
2021-08-11 07:31:34 [verbose]: CatchUpSyncManager: Not ready, stopping clocks.
2021-08-11 07:31:34 [verbose]: MultiSpectatorPlayer: Reached StartGameplay
2021-08-11 07:31:34 [verbose]: SpectatorGameplayClockContainer: resetting.
2021-08-11 07:31:34 [verbose]: SpectatorGameplayClockContainer: seeking to 0ms (0 -> 0)
2021-08-11 07:31:34 [verbose]: SpectatorGameplayClockContainer: starting at position 0ms
2021-08-11 07:31:34 [verbose]: SpectatorGameplayClockContainer: seeking to 0ms (0 -> 0)
2021-08-11 07:31:34 [verbose]: MultiSpectatorPlayer: OnNewFrames called
2021-08-11 07:31:34 [verbose]: SpectatorGameplayClockContainer: seeking to 4890.9615211973205ms (0 -> 4890.9615211973205)
2021-08-11 07:31:34 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Increasing current time by -50084.942106ms x1
2021-08-11 07:31:34 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Increasing current time by -50084.942106ms x1
2021-08-11 07:31:34 [verbose]: CatchUpSyncManager: Not ready, stopping clocks.
```
(notice `OnNewFrames` called before the `CatchUpSyncManager` stops the clock back)

#### https://github.com/ppy/osu/commit/de18f30afb1aee1ec344aebd62f53add714776ec

In all cases, a catch-up spectator player clock should never rewind back, but either stay still or follow the value of `Source.ElapsedFrameTime` when it's advancing.

Making the catch-up spectator player clock not rewind on negative elapsed frame time avoids it from moving away from master clock, which would've otherwise resulted in the master clock stopping and `ElapsedFrameTime` decreasing to `-Offset` due to the `Rate` changing to 0, which affected the `CurrentTime` due to `HardwareCorrectionOffsetClock`'s logic...

It's a bit too confusing to go through all of this, and I'm not yet entirely sure about this being the final solution, might need further discussion on the matter.

---

@smoogipoo requesting your review in case I failed to notice something with the changes I've applied, they all seem to make sense to me as far as my testing and logging went.