### PR TITLE
Fix multiplayer spectating test failures

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -312,6 +312,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
+            AddUntilStep("wait for spectating user state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+
             AddStep("start match externally", () => client.StartMatch());
 
             AddAssert("play not started", () => multiplayerScreen.IsCurrentScreen());
@@ -347,6 +349,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerSpectateButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
+
+            AddUntilStep("wait for spectating user state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
 
             AddStep("start match externally", () => client.StartMatch());
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -129,6 +129,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
+            AddUntilStep("wait for spectating user state", () => Client.LocalUser?.State == MultiplayerUserState.Spectating);
+
             AddUntilStep("wait for ready button to be enabled", () => this.ChildrenOfType<MultiplayerReadyButton>().Single().ChildrenOfType<ReadyButton>().Single().Enabled.Value);
 
             AddStep("click ready button", () =>


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/pull/14239/checks?check_run_id=3316200185

Can be tested with:
```diff
diff --git a/osu.Game/Online/Multiplayer/MultiplayerClient.cs b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
index 4607211cdf..ffccb2b935 100644
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -418,10 +418,12 @@ Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
             return Task.CompletedTask;
         }
 
-        Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
+        async Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
         {
             if (Room == null)
-                return Task.CompletedTask;
+                return;
+
+            await Task.Delay(1000).ConfigureAwait(false);
 
             Scheduler.Add(() =>
             {
@@ -435,7 +437,7 @@ Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
                 RoomUpdated?.Invoke();
             }, false);
 
-            return Task.CompletedTask;
+            return;
         }
 
         Task IMultiplayerClient.MatchUserStateChanged(int userId, MatchUserState state)
```

With that being said, there's a case to be made for the ongoing operation tracker re-enabling our buttons while we haven't yet received an updated state from the server. This is a much larger/deeper issue which is harder to fix.