### PR TITLE
Hide left border of beatmap wedge

### DIFF
--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Screens.Select
 {
     public class BeatmapInfoWedge : VisibilityContainer
     {
+        public const float BORDER_THICKNESS = 2.5f;
         private const float shear_width = 36.75f;
 
         private static readonly Vector2 wedged_container_shear = new Vector2(shear_width / SongSelect.WEDGE_HEIGHT, 0);
@@ -59,7 +60,7 @@ namespace osu.Game.Screens.Select
             Shear = wedged_container_shear;
             Masking = true;
             BorderColour = new Color4(221, 255, 255, 255);
-            BorderThickness = 2.5f;
+            BorderThickness = BORDER_THICKNESS;
             Alpha = 0;
             EdgeEffect = new EdgeEffectParameters
             {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -203,6 +203,7 @@ namespace osu.Game.Screens.Select
                                                 Margin = new MarginPadding
                                                 {
                                                     Right = left_area_padding,
+                                                    Left = -BeatmapInfoWedge.BORDER_THICKNESS, // Hide the left border
                                                 },
                                             },
                                             new Container


### PR DESCRIPTION
We have a little bit of the sheared border showing at the top of the beatmap wedge, which has been annoying me for a while now. I think we want to hide the left border in any case?

Before:
![before](https://user-images.githubusercontent.com/1329837/129364552-84f45658-1eed-4341-902f-ad2e2d07ff7a.png)

After:
![after](https://user-images.githubusercontent.com/1329837/129364565-39c04efb-326b-400d-947e-81cb7fe58c4f.png)
