### PR TITLE
Unify team score display logic with other components

### DIFF
--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -171,6 +172,8 @@ namespace osu.Game.Screens.Play.HUD
                 => displayedSpriteText.Font = winning
                     ? OsuFont.Torus.With(weight: FontWeight.Bold, size: font_size, fixedWidth: true)
                     : OsuFont.Torus.With(weight: FontWeight.Regular, size: font_size * 0.8f, fixedWidth: true);
+
+            protected override LocalisableString FormatCount(double count) => count.ToLocalisableString(@"N0");
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Screens.Play.HUD
                     continue;
 
                 if (TeamScores.TryGetValue(u.Team.Value, out var team))
-                    team.Value += (int)u.Score.Value;
+                    team.Value += (int)Math.Round(u.Score.Value);
             }
         }
 


### PR DESCRIPTION
Two small but quite visible changes to the team score display:

* `MultiplayerGameplayLeaderboard` was truncating user scores to integers while summing them up, while [`ScoreManager` usually rounds](https://github.com/ppy/osu/blob/0642a337df02653c6273f13b3b2c5acdad5d2915/osu.Game/Scoring/ScoreManager.cs#L231). This could lead to off-by-ones compared to e.g. score panels, or everything else for that matter (and that's an off-by-one for each score, so the more players in a team, the potentially worse it gets). Was especially obvious in 1v1 testing.
* I've also added commas to the team totals because it looked off at the results screen compared to the score panels. There's already precedent for doing this web-side - [match UI already shows score totals and differences with commas](https://osu.ppy.sh/community/matches/82923349) so I figure this should be relatively uncontroversial.