### PR TITLE
Fix multiplayer client not leaving room

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -190,8 +190,7 @@ namespace osu.Game.Online.Multiplayer
             return joinOrLeaveTaskChain.Add(async () =>
             {
                 await scheduledReset.ConfigureAwait(false);
-                if (Room != null)
-                    await LeaveRoomInternal().ConfigureAwait(false);
+                await LeaveRoomInternal().ConfigureAwait(false);
             });
         }
 


### PR DESCRIPTION
Closes #14287.

The null check on `Room` was intending to handle the kick case as I take it, but in fact was broken entirely and caused leaving rooms to never work. The kick case didn't get broken by this because the server authoritatively kicks anyway, but the client-side leave did.

This revertion means that spectator server as-is will throw exceptions that will get rethrown to the client on kick, because the server is kicking the client on its side, and the client is also attempting to leave on its own side. The latter call throws because according to the server the client is no longer in the room.

The above will be resolved by a server-side change that makes `LeaveRoom` calls not throw if the user is not in the room (seems more sane than a client-side fix, since the client can no longer reliably tell if it's in a room or not).