### PR TITLE
Add glow to supporter promo on changelog

### DIFF
--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Overlays.Changelog
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Margin = new MarginPadding { Bottom = 28 },
                     RelativeSizeAxes = Axes.Both,
                     FillMode = FillMode.Fill,
                     Texture = textures.Get(@"Online/supporter-pippi"),
@@ -144,7 +145,7 @@ namespace osu.Game.Overlays.Changelog
                     Origin = Anchor.TopCentre,
                     Width = 75,
                     Height = 75,
-                    Margin = new MarginPadding { Top = 83 },
+                    Margin = new MarginPadding { Top = 70 },
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
                     {

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -149,8 +149,7 @@ namespace osu.Game.Overlays.Changelog
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Shadow,
-                        Colour = Color4.HotPink.Opacity(0.88f),
-                        Offset = new Vector2(0, 0),
+                        Colour = colour.Pink,
                         Radius = 17,
                         Roundness = 39f,
                     },

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Overlays.Changelog
     public class ChangelogSupporterPromo : CompositeDrawable
     {
         private const float image_container_width = 164;
+        private const float heart_size = 75;
 
         private readonly FillFlowContainer textContainer;
         private readonly Container imageContainer;
@@ -143,21 +144,21 @@ namespace osu.Game.Overlays.Changelog
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Width = 75,
-                    Height = 75,
+                    Width = heart_size,
+                    Height = heart_size,
                     Margin = new MarginPadding { Top = 70 },
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Shadow,
                         Colour = colour.Pink,
-                        Radius = 17,
-                        Roundness = 39f,
+                        Radius = 10,
+                        Roundness = heart_size / 2,
                     },
                     Child = new Sprite
                     {
-                        Width = 75,
-                        Height = 75,
+                        Width = heart_size,
+                        Height = heart_size,
                         Texture = textures.Get(@"Online/supporter-heart"),
                     },
                 },

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -144,8 +144,7 @@ namespace osu.Game.Overlays.Changelog
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Width = heart_size,
-                    Height = heart_size,
+                    Size = new Vector2(heart_size),
                     Margin = new MarginPadding { Top = 70 },
                     Masking = true,
                     EdgeEffect = new EdgeEffectParameters
@@ -157,8 +156,7 @@ namespace osu.Game.Overlays.Changelog
                     },
                     Child = new Sprite
                     {
-                        Width = heart_size,
-                        Height = heart_size,
+                        Size = new Vector2(heart_size),
                         Texture = textures.Get(@"Online/supporter-heart"),
                     },
                 },

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -138,14 +138,28 @@ namespace osu.Game.Overlays.Changelog
                     FillMode = FillMode.Fill,
                     Texture = textures.Get(@"Online/supporter-pippi"),
                 },
-                new Sprite
+                new Container
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Width = 75,
                     Height = 75,
-                    Margin = new MarginPadding { Top = 70 },
-                    Texture = textures.Get(@"Online/supporter-heart"),
+                    Margin = new MarginPadding { Top = 83 },
+                    Masking = true,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Colour = Color4.HotPink.Opacity(0.88f),
+                        Offset = new Vector2(0, 0),
+                        Radius = 17,
+                        Roundness = 39f,
+                    },
+                    Child = new Sprite
+                    {
+                        Width = 75,
+                        Height = 75,
+                        Texture = textures.Get(@"Online/supporter-heart"),
+                    },
                 },
             };
         }


### PR DESCRIPTION
Fixes #14303 

before and after:

Website:
![image](https://user-images.githubusercontent.com/35976702/129464437-c9ce7345-cbdc-46d3-8d26-cfbe6b537a96.png)

Lazer before:
![image](https://user-images.githubusercontent.com/35976702/129464441-482e3c8e-3b02-4f75-a677-ce27a9fa2d0d.png)

Lazer after:
![image](https://user-images.githubusercontent.com/35976702/129464450-80a80539-202a-47dd-a420-e6491bdb4b73.png)

I'll note that while the current lazer image is a bit different from the current website one, this is the closest I can get it using EdgeEffect Shadow (instead of CSS's box-shadow, the main difference is that box-shadow has a spread-radius parameter) and the values from the website, but overall they look fairly close.