### PR TITLE
Fix mark channel as read error popping up when switching chat channels

### DIFF
--- a/osu.Game/Online/API/Requests/MarkChannelAsReadRequest.cs
+++ b/osu.Game/Online/API/Requests/MarkChannelAsReadRequest.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Online.API.Requests
 
         public MarkChannelAsReadRequest(Channel channel, Message message)
         {
-            this.Channel = channel;
-            this.Message = message;
+            Channel = channel;
+            Message = message;
         }
 
         protected override string Target => $"chat/channels/{Channel.Id}/mark-as-read/{Message.Id}";

--- a/osu.Game/Online/API/Requests/MarkChannelAsReadRequest.cs
+++ b/osu.Game/Online/API/Requests/MarkChannelAsReadRequest.cs
@@ -9,16 +9,16 @@ namespace osu.Game.Online.API.Requests
 {
     public class MarkChannelAsReadRequest : APIRequest
     {
-        private readonly Channel channel;
-        private readonly Message message;
+        public readonly Channel Channel;
+        public readonly Message Message;
 
         public MarkChannelAsReadRequest(Channel channel, Message message)
         {
-            this.channel = channel;
-            this.message = message;
+            this.Channel = channel;
+            this.Message = message;
         }
 
-        protected override string Target => $"chat/channels/{channel.Id}/mark-as-read/{message.Id}";
+        protected override string Target => $"chat/channels/{Channel.Id}/mark-as-read/{Message.Id}";
 
         protected override WebRequest CreateWebRequest()
         {

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -553,7 +553,7 @@ namespace osu.Game.Online.Chat
             if (channel.LastMessageId == channel.LastReadId)
                 return;
 
-            var message = channel.Messages.LastOrDefault();
+            var message = channel.Messages.FindLast(msg => !(msg is LocalMessage));
 
             if (message == null)
                 return;


### PR DESCRIPTION
Fixes #12938

This issue occurred whenever there was a local-only message in the channel to which the user was switching to (so `/help` response or any command error messages).