### PR TITLE
Add support for saving edited combo colours and displaying them in composer

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 
-            protected override ISkin GetSkin() => throw new NotImplementedException();
+            protected internal override ISkin GetSkin() => throw new NotImplementedException();
 
             public override Stream GetStream(string storagePath) => throw new NotImplementedException();
         }

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Tests.Gameplay
                 this.resources = resources;
             }
 
-            protected override ISkin GetSkin() => new TestSkin("test-sample", resources);
+            protected internal override ISkin GetSkin() => new TestSkin("test-sample", resources);
         }
 
         private class TestDrawableStoryboardSample : DrawableStoryboardSample

--- a/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
@@ -133,11 +133,12 @@ namespace osu.Game.Tests.Skins
         [Test]
         public void TestEmptyComboColoursNoFallback()
         {
-            AddStep("Add custom combo colours to user skin", () => userSource.Configuration.AddComboColours(
+            AddStep("Add custom combo colours to user skin", () => userSource.Configuration.CustomComboColours = new List<Color4>
+            {
                 new Color4(100, 150, 200, 255),
                 new Color4(55, 110, 166, 255),
                 new Color4(75, 125, 175, 255)
-            ));
+            });
 
             AddStep("Disallow default colours fallback in beatmap skin", () => beatmapSource.Configuration.AllowDefaultComboColoursFallback = false);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 this.beatmapSkin = beatmapSkin;
             }
 
-            protected override ISkin GetSkin() => beatmapSkin;
+            protected internal override ISkin GetSkin() => beatmapSkin;
         }
 
         private class TestOsuRuleset : OsuRuleset

--- a/osu.Game.Tests/WaveformTestBeatmap.cs
+++ b/osu.Game.Tests/WaveformTestBeatmap.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests
 
         protected override Waveform GetWaveform() => new Waveform(trackStore.GetStream(firstAudioFile));
 
-        protected override ISkin GetSkin() => null;
+        protected internal override ISkin GetSkin() => null;
 
         public override Stream GetStream(string storagePath) => null;
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -534,7 +534,7 @@ namespace osu.Game.Beatmaps
             protected override IBeatmap GetBeatmap() => beatmap;
             protected override Texture GetBackground() => null;
             protected override Track GetBeatmapTrack() => null;
-            protected override ISkin GetSkin() => null;
+            protected internal override ISkin GetSkin() => null;
             public override Stream GetStream(string storagePath) => null;
         }
     }

--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Beatmaps
                 return storyboard;
             }
 
-            protected override ISkin GetSkin()
+            protected internal override ISkin GetSkin()
             {
                 try
                 {

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Beatmaps
 
         protected override Track GetBeatmapTrack() => GetVirtualTrack();
 
-        protected override ISkin GetSkin() => null;
+        protected internal override ISkin GetSkin() => null;
 
         public override Stream GetStream(string storagePath) => null;
 

--- a/osu.Game/Beatmaps/Formats/IHasComboColours.cs
+++ b/osu.Game/Beatmaps/Formats/IHasComboColours.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osuTK.Graphics;
 
@@ -14,8 +15,16 @@ namespace osu.Game.Beatmaps.Formats
         IReadOnlyList<Color4> ComboColours { get; }
 
         /// <summary>
+        /// The list of custom combo colours.
+        /// If non-empty, <see cref="ComboColours"/> will return these colours;
+        /// if empty, <see cref="ComboColours"/> will fall back to default combo colours.
+        /// </summary>
+        List<Color4> CustomComboColours { get; }
+
+        /// <summary>
         /// Adds combo colours to the list.
         /// </summary>
+        [Obsolete("Use SkinConfiguration.ComboColours directly.")] // can be removed 20220215
         void AddComboColours(params Color4[] colours);
     }
 }

--- a/osu.Game/Beatmaps/Formats/IHasComboColours.cs
+++ b/osu.Game/Beatmaps/Formats/IHasComboColours.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Beatmaps.Formats
         /// <summary>
         /// Adds combo colours to the list.
         /// </summary>
-        [Obsolete("Use SkinConfiguration.ComboColours directly.")] // can be removed 20220215
+        [Obsolete("Use CustomComboColours directly.")] // can be removed 20220215
         void AddComboColours(params Color4[] colours);
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Beatmaps.Formats
             {
                 if (!(output is IHasComboColours tHasComboColours)) return;
 
-                tHasComboColours.AddComboColours(colour);
+                tHasComboColours.CustomComboColours.Add(colour);
             }
             else
             {

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -327,7 +327,15 @@ namespace osu.Game.Beatmaps
         public bool SkinLoaded => skin.IsResultAvailable;
         public ISkin Skin => skin.Value;
 
-        protected abstract ISkin GetSkin();
+        /// <summary>
+        /// Creates a new skin instance for this beatmap.
+        /// </summary>
+        /// <remarks>
+        /// This should only be called externally in scenarios where it is explicitly desired to get a new instance of a skin
+        /// (e.g. for editing purposes, to avoid state pollution).
+        /// For standard reading purposes, <see cref="Skin"/> should always be used directly.
+        /// </remarks>
+        protected internal abstract ISkin GetSkin();
 
         private readonly RecyclableLazy<ISkin> skin;
 

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -15,7 +15,6 @@ using osu.Game.Extensions;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
-using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Edit.Compose
 {
@@ -73,7 +72,7 @@ namespace osu.Game.Screens.Edit.Compose
         {
             Debug.Assert(ruleset != null);
 
-            return new RulesetSkinProvidingContainer(ruleset, EditorBeatmap.PlayableBeatmap, beatmap.Value.Skin).WithChild(content);
+            return new EditorSkinProvidingContainer(EditorBeatmap).WithChild(content);
         }
 
         #region Input Handling

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Screens.Edit
             // todo: remove caching of this and consume via editorBeatmap?
             dependencies.Cache(beatDivisor);
 
-            AddInternal(editorBeatmap = new EditorBeatmap(playableBeatmap, loadableBeatmap.Skin));
+            AddInternal(editorBeatmap = new EditorBeatmap(playableBeatmap, loadableBeatmap.GetSkin()));
             dependencies.CacheAs(editorBeatmap);
             changeHandler = new EditorChangeHandler(editorBeatmap);
             dependencies.CacheAs<IEditorChangeHandler>(changeHandler);

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.Edit
         private readonly Bindable<bool> hasTiming = new Bindable<bool>();
 
         [CanBeNull]
-        public readonly ISkin BeatmapSkin;
+        public readonly EditorBeatmapSkin BeatmapSkin;
 
         [Resolved]
         private BindableBeatDivisor beatDivisor { get; set; }
@@ -69,7 +69,8 @@ namespace osu.Game.Screens.Edit
         public EditorBeatmap(IBeatmap playableBeatmap, ISkin beatmapSkin = null)
         {
             PlayableBeatmap = playableBeatmap;
-            BeatmapSkin = beatmapSkin;
+            if (beatmapSkin is Skin skin)
+                BeatmapSkin = new EditorBeatmapSkin(skin);
 
             beatmapProcessor = playableBeatmap.BeatmapInfo.Ruleset?.CreateInstance().CreateBeatmapProcessor(PlayableBeatmap);
 

--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// A beatmap skin which is being edited.
+    /// </summary>
+    public class EditorBeatmapSkin : ISkin
+    {
+        public event Action BeatmapSkinChanged;
+
+        /// <summary>
+        /// The combo colours of this skin.
+        /// If empty, the default combo colours will be used.
+        /// </summary>
+        public BindableList<Colour4> ComboColours;
+
+        private readonly Skin skin;
+
+        public EditorBeatmapSkin(Skin skin)
+        {
+            this.skin = skin;
+
+            ComboColours = new BindableList<Colour4>();
+            if (skin.Configuration.ComboColours != null)
+                ComboColours.AddRange(skin.Configuration.ComboColours.Select(c => (Colour4)c));
+            ComboColours.BindCollectionChanged((_, __) => updateColours());
+        }
+
+        private void invokeSkinChanged() => BeatmapSkinChanged?.Invoke();
+
+        private void updateColours()
+        {
+            skin.Configuration.CustomComboColours = ComboColours.Select(c => (Color4)c).ToList();
+            invokeSkinChanged();
+        }
+
+        #region Delegated ISkin implementation
+
+        public Drawable GetDrawableComponent(ISkinComponent component) => skin.GetDrawableComponent(component);
+        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => skin.GetTexture(componentName, wrapModeS, wrapModeT);
+        public ISample GetSample(ISampleInfo sampleInfo) => skin.GetSample(sampleInfo);
+        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => skin.GetConfig<TLookup, TValue>(lookup);
+
+        #endregion
+    }
+}

--- a/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
+++ b/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Skinning;
+
+#nullable enable
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// A <see cref="SkinProvidingContainer"/> that fires <see cref="ISkinSource.SourceChanged"/> when users have made a change to the beatmap skin
+    /// of the map being edited.
+    /// </summary>
+    public class EditorSkinProvidingContainer : RulesetSkinProvidingContainer
+    {
+        private readonly EditorBeatmapSkin? beatmapSkin;
+
+        public EditorSkinProvidingContainer(EditorBeatmap editorBeatmap)
+            : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap, editorBeatmap.BeatmapSkin)
+        {
+            beatmapSkin = editorBeatmap.BeatmapSkin;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (beatmapSkin != null)
+                beatmapSkin.BeatmapSkinChanged += TriggerSourceChanged;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (beatmapSkin != null)
+                beatmapSkin.BeatmapSkinChanged -= TriggerSourceChanged;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Edit
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 
-            protected override ISkin GetSkin() => throw new NotImplementedException();
+            protected internal override ISkin GetSkin() => throw new NotImplementedException();
 
             public override Stream GetStream(string storagePath) => throw new NotImplementedException();
         }

--- a/osu.Game/Screens/Edit/Setup/ColoursSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ColoursSection.cs
@@ -1,14 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Skinning;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Setup
 {
@@ -31,9 +27,8 @@ namespace osu.Game.Screens.Edit.Setup
                 }
             };
 
-            var colours = Beatmap.BeatmapSkin?.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value;
-            if (colours != null)
-                comboColours.Colours.AddRange(colours.Select(c => (Colour4)c));
+            if (Beatmap.BeatmapSkin != null)
+                comboColours.Colours.BindTo(Beatmap.BeatmapSkin.ComboColours);
         }
     }
 }

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using osu.Framework.IO.Stores;
 using osu.Game.Extensions;
@@ -21,12 +22,13 @@ namespace osu.Game.Skinning
             : base(skin, new NamespacedResourceStore<byte[]>(resources.Resources, "Skins/Legacy"), resources, string.Empty)
         {
             Configuration.CustomColours["SliderBall"] = new Color4(2, 170, 255, 255);
-            Configuration.AddComboColours(
+            Configuration.CustomComboColours = new List<Color4>
+            {
                 new Color4(255, 192, 0, 255),
                 new Color4(0, 202, 0, 255),
                 new Color4(18, 124, 255, 255),
                 new Color4(242, 24, 57, 255)
-            );
+            };
 
             Configuration.LegacyVersion = 2.7m;
         }

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -27,14 +27,14 @@ namespace osu.Game.Skinning
             new Color4(242, 24, 57, 255),
         };
 
-        private readonly List<Color4> comboColours = new List<Color4>();
+        public List<Color4> CustomComboColours { get; set; } = new List<Color4>();
 
         public IReadOnlyList<Color4> ComboColours
         {
             get
             {
-                if (comboColours.Count > 0)
-                    return comboColours;
+                if (CustomComboColours.Count > 0)
+                    return CustomComboColours;
 
                 if (AllowDefaultComboColoursFallback)
                     return DefaultComboColours;
@@ -43,7 +43,7 @@ namespace osu.Game.Skinning
             }
         }
 
-        public void AddComboColours(params Color4[] colours) => comboColours.AddRange(colours);
+        void IHasComboColours.AddComboColours(params Color4[] colours) => CustomComboColours.AddRange(colours);
 
         public Dictionary<string, Color4> CustomColours { get; } = new Dictionary<string, Color4>();
 

--- a/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Tests.Beatmaps
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 
-            protected override ISkin GetSkin() => throw new NotImplementedException();
+            protected internal override ISkin GetSkin() => throw new NotImplementedException();
 
             public override Stream GetStream(string storagePath) => throw new NotImplementedException();
 

--- a/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
+++ b/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Tests.Beatmaps
                 this.resources = resources;
             }
 
-            protected override ISkin GetSkin() => new LegacyBeatmapSkin(skinBeatmapInfo, resourceStore, resources);
+            protected internal override ISkin GetSkin() => new LegacyBeatmapSkin(skinBeatmapInfo, resourceStore, resources);
         }
     }
 }

--- a/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Beatmaps
                 HasColours = hasColours;
             }
 
-            protected override ISkin GetSkin() => new TestBeatmapSkin(BeatmapInfo, HasColours);
+            protected internal override ISkin GetSkin() => new TestBeatmapSkin(BeatmapInfo, HasColours);
         }
 
         protected class TestBeatmapSkin : LegacyBeatmapSkin

--- a/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Tests.Beatmaps
             {
                 if (hasColours)
                 {
-                    Configuration.AddComboColours(Colours);
+                    Configuration.CustomComboColours = Colours.ToList();
                     Configuration.CustomColours.Add("HyperDash", HYPER_DASH_COLOUR);
                     Configuration.CustomColours.Add("HyperDashAfterImage", HYPER_DASH_AFTER_IMAGE_COLOUR);
                     Configuration.CustomColours.Add("HyperDashFruit", HYPER_DASH_FRUIT_COLOUR);
@@ -145,7 +145,7 @@ namespace osu.Game.Tests.Beatmaps
             {
                 if (hasCustomColours)
                 {
-                    Configuration.AddComboColours(Colours);
+                    Configuration.CustomComboColours = Colours.ToList();
                     Configuration.CustomColours.Add("HyperDash", HYPER_DASH_COLOUR);
                     Configuration.CustomColours.Add("HyperDashAfterImage", HYPER_DASH_AFTER_IMAGE_COLOUR);
                     Configuration.CustomColours.Add("HyperDashFruit", HYPER_DASH_FRUIT_COLOUR);

--- a/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Beatmaps
 
         protected override Storyboard GetStoryboard() => storyboard ?? base.GetStoryboard();
 
-        protected override ISkin GetSkin() => null;
+        protected internal override ISkin GetSkin() => null;
 
         public override Stream GetStream(string storagePath) => null;
 


### PR DESCRIPTION
PRing mostly for comment as changing skin things is a bit of uncharted territory for the editor.

https://user-images.githubusercontent.com/20418176/129489991-11e1f10e-2beb-4b71-8d4e-39649d4425e1.mp4

No undo/redo support yet. This pull's goal is to make the changed combo colours actually show up on timeline/in composer and save to the beatmap file.

I felt pretty alright with the general existence of `EditorBeatmapSkin` and `EditorSkinProvidingContainer`, the major sticking points would however be:

- Exposing the mutable `CustomComboColours` on `IHasComboColours`. I tried not to do this and broke tests in the process, because `ComboColours` is doing fallback logic and it's not easy to change that without lots of API breakage. And `IHasCustomColours` is already outwardly mutable which mania even relies on, so it felt alright to do this.
- More importantly, the issue of accidentally mutating the cached `WorkingBeatmap` returned (this time I accidentally mutated its skin, initially). I considered a few options to get past this:
  - Deep cloning: awkward, because `Skin` has `SkinInfo` and a deep chain of DB entities following that
  - Using the now-unused [`Recycle()`](https://github.com/ppy/osu/blob/f49c9673ccf415b46d8e14f46fb2c35ab2f86e02/osu.Game/Beatmaps/WorkingBeatmap.cs#L352-L358) on `WorkingBeatmap.Skin` to nuke it upon exiting editor - felt slightly ugly
  - Exposing `WorkingBeatmap.GetSkin()` so that editor can get a local copy for mutating to its own heart's content - I opted for this, and it would have been alright if not for the ten-something satellite changes because that's what happens when you change access modifiers on a virtual method. It also "automagically" solves the case of a new beatmap for now, as it internally creates a new `LegacyBeatmapSkin`. This same spiel will happen again with storyboard, etc.