### PR TITLE
Cache buffered background to fix multiplayer lounge performance

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
@@ -10,12 +10,12 @@ namespace osu.Game.Screens.OnlinePlay.Components
 {
     public class OnlinePlayBackgroundSprite : OnlinePlayComposite
     {
-        private readonly BeatmapSetCoverType beatmapSetCoverType;
+        protected readonly BeatmapSetCoverType BeatmapSetCoverType;
         private UpdateableBeatmapBackgroundSprite sprite;
 
         public OnlinePlayBackgroundSprite(BeatmapSetCoverType beatmapSetCoverType = BeatmapSetCoverType.Cover)
         {
-            this.beatmapSetCoverType = beatmapSetCoverType;
+            BeatmapSetCoverType = beatmapSetCoverType;
         }
 
         [BackgroundDependencyLoader]
@@ -33,6 +33,6 @@ namespace osu.Game.Screens.OnlinePlay.Components
             sprite.Beatmap.Value = Playlist.FirstOrDefault()?.Beatmap.Value;
         }
 
-        protected virtual UpdateableBeatmapBackgroundSprite CreateBackgroundSprite() => new UpdateableBeatmapBackgroundSprite(beatmapSetCoverType) { RelativeSizeAxes = Axes.Both };
+        protected virtual UpdateableBeatmapBackgroundSprite CreateBackgroundSprite() => new UpdateableBeatmapBackgroundSprite(BeatmapSetCoverType) { RelativeSizeAxes = Axes.Both };
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -158,21 +158,14 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
             Children = new Drawable[]
             {
                 // This resolves internal 1px gaps due to applying the (parenting) corner radius and masking across multiple filling background sprites.
-                new BufferedContainer
+                new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = colours.Background5,
-                        },
-                        new OnlinePlayBackgroundSprite
-                        {
-                            RelativeSizeAxes = Axes.Both
-                        },
-                    }
+                    Colour = colours.Background5,
+                },
+                new OnlinePlayBackgroundSprite
+                {
+                    RelativeSizeAxes = Axes.Both
                 },
                 new Container
                 {
@@ -187,37 +180,29 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                         CornerRadius = corner_radius,
                         Children = new Drawable[]
                         {
-                            // This resolves internal 1px gaps due to applying the (parenting) corner radius and masking across multiple filling background sprites.
-                            new BufferedContainer
+                            new GridContainer
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Children = new Drawable[]
+                                ColumnDimensions = new[]
                                 {
-                                    new GridContainer
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        ColumnDimensions = new[]
-                                        {
-                                            new Dimension(GridSizeMode.Relative, 0.2f)
-                                        },
-                                        Content = new[]
-                                        {
-                                            new Drawable[]
-                                            {
-                                                new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = colours.Background5,
-                                                },
-                                                new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f))
-                                                },
-                                            }
-                                        }
-                                    },
+                                    new Dimension(GridSizeMode.Relative, 0.2f)
                                 },
+                                Content = new[]
+                                {
+                                    new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = colours.Background5,
+                                        },
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f))
+                                        },
+                                    }
+                                }
                             },
                             new Container
                             {

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -329,6 +329,7 @@ namespace osu.Game.Screens.OnlinePlay
 
                     RelativeSizeAxes = Axes.Both;
                     BlurSigma = new Vector2(10);
+                    FrameBufferScale = new Vector2(0.5f);
                     CacheDrawnFrameBuffer = true;
                 }
 


### PR DESCRIPTION
Consider this a request for comment. It's the cleanest solution I can come up with without dropping either the blur, or use of `ModelBackedDrawable`.

Intended to resolve https://github.com/ppy/osu/issues/14276.
