### PR TITLE
Fix gameplay HUD load being delayed if initially hidden

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -12,6 +12,7 @@ using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
+using osu.Game.Skinning;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -140,6 +141,22 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("key counters still hidden", () => !keyCounterFlow.IsPresent);
 
             AddStep("return value", () => config.SetValue(OsuSetting.KeyOverlay, keyCounterVisibleValue));
+        }
+
+        [Test]
+        public void TestHiddenHUDDoesntBlockSkinnableComponentsLoad()
+        {
+            HUDVisibilityMode originalConfigValue = default;
+
+            AddStep("get original config value", () => originalConfigValue = config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
+
+            AddStep("set hud to never show", () => config.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
+
+            createNew();
+            AddUntilStep("wait for hud load", () => hudOverlay.IsLoaded);
+            AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().ComponentsLoaded);
+
+            AddStep("set original config value", () => config.SetValue(OsuSetting.HUDVisibilityMode, originalConfigValue));
         }
 
         private void createNew(Action<HUDOverlay> action = null)

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -57,8 +57,6 @@ namespace osu.Game.Screens.Play
 
         private Bindable<HUDVisibilityMode> configVisibilityMode;
 
-        private readonly Container visibilityContainer;
-
         private readonly BindableBool replayLoaded = new BindableBool();
 
         private static bool hasShownNotificationOnce;
@@ -72,7 +70,7 @@ namespace osu.Game.Screens.Play
 
         private readonly SkinnableTargetContainer mainComponents;
 
-        private IEnumerable<Drawable> hideTargets => new Drawable[] { visibilityContainer, KeyCounter, topRightElements };
+        private IEnumerable<Drawable> hideTargets => new Drawable[] { mainComponents, KeyCounter, topRightElements };
 
         public HUDOverlay(DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
         {
@@ -84,13 +82,9 @@ namespace osu.Game.Screens.Play
             Children = new Drawable[]
             {
                 CreateFailingLayer(),
-                visibilityContainer = new Container
+                mainComponents = new SkinnableTargetContainer(SkinnableTarget.MainHUDComponents)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = mainComponents = new SkinnableTargetContainer(SkinnableTarget.MainHUDComponents)
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                    },
                 },
                 topRightElements = new FillFlowContainer
                 {


### PR DESCRIPTION
Was happening due to the hide of skinnable components (in the case of `showHud = false`) happening one level higher from `SkinnableTargetsContainer`, causing the `SkinnableTargetsContainer`'s scheduler to not be updated and not be able to process the scheduled load complete from `LoadComponentAsync`, therefore not being able to add the components to the hierarchy and result in the test failure mentioned in https://github.com/ppy/osu/pull/14263#discussion_r688968859.