### PR TITLE
Fix few cases where `MultiplayerRoomUser.User` is assumed to not be null

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
@@ -48,7 +49,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 1);
 
-            AddStep("add non-resolvable user", () => Client.AddNullUser(-3));
+            AddStep("add non-resolvable user", () => Client.AddNullUser());
+            AddAssert("null user added", () => Client.Room.AsNonNull().Users.Count(u => u.User == null) == 1);
 
             AddUntilStep("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 2);
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -53,6 +53,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("null user added", () => Client.Room.AsNonNull().Users.Count(u => u.User == null) == 1);
 
             AddUntilStep("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 2);
+
+            AddStep("kick null user", () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.User.User == null)
+                                                .ChildrenOfType<ParticipantPanel.KickButton>().Single().TriggerClick());
+
+            AddAssert("null user kicked", () => Client.Room.AsNonNull().Users.Count == 1);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -168,12 +167,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Origin = Anchor.Centre,
                             Alpha = 0,
                             Margin = new MarginPadding(4),
-                            Action = () =>
-                            {
-                                Debug.Assert(user != null);
-
-                                Client.KickUser(user.Id);
-                            }
+                            Action = () => Client.KickUser(User.UserID),
                         },
                     },
                 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             Colour = Color4Extensions.FromHex("#F7E65D"),
                             Alpha = 0
                         },
-                        new TeamDisplay(user),
+                        new TeamDisplay(User),
                         new Container
                         {
                             RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -11,7 +11,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
-using osu.Game.Users;
 using osuTK;
 using osuTK.Graphics;
 
@@ -19,16 +18,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 {
     internal class TeamDisplay : MultiplayerRoomComposite
     {
-        private readonly User user;
+        private readonly MultiplayerRoomUser user;
+
         private Drawable box;
 
         [Resolved]
         private OsuColour colours { get; set; }
 
-        [Resolved]
-        private MultiplayerClient client { get; set; }
-
-        public TeamDisplay(User user)
+        public TeamDisplay(MultiplayerRoomUser user)
         {
             this.user = user;
 
@@ -61,7 +58,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 }
             };
 
-            if (user.Id == client.LocalUser?.UserID)
+            if (Client.LocalUser?.Equals(user) == true)
             {
                 InternalChild = new OsuClickableContainer
                 {
@@ -79,9 +76,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
         private void changeTeam()
         {
-            client.SendMatchRequest(new ChangeTeamRequest
+            Client.SendMatchRequest(new ChangeTeamRequest
             {
-                TeamID = ((client.LocalUser?.MatchState as TeamVersusUserState)?.TeamID + 1) % 2 ?? 0,
+                TeamID = ((Client.LocalUser?.MatchState as TeamVersusUserState)?.TeamID + 1) % 2 ?? 0,
             });
         }
 
@@ -93,7 +90,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             // we don't have a way of knowing when an individual user's state has updated, so just handle on RoomUpdated for now.
 
-            var userRoomState = Room?.Users.FirstOrDefault(u => u.UserID == user.Id)?.MatchState;
+            var userRoomState = Room?.Users.FirstOrDefault(u => u.Equals(user))?.MatchState;
 
             const double duration = 400;
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return roomUser;
         }
 
-        public void AddNullUser(int userId) => ((IMultiplayerClient)this).UserJoined(new MultiplayerRoomUser(userId));
+        public void AddNullUser() => ((IMultiplayerClient)this).UserJoined(new MultiplayerRoomUser(TestUserLookupCache.NULL_USER_ID));
 
         public void RemoveUser(User user)
         {

--- a/osu.Game/Tests/Visual/TestUserLookupCache.cs
+++ b/osu.Game/Tests/Visual/TestUserLookupCache.cs
@@ -10,10 +10,22 @@ namespace osu.Game.Tests.Visual
 {
     public class TestUserLookupCache : UserLookupCache
     {
-        protected override Task<User> ComputeValueAsync(int lookup, CancellationToken token = default) => Task.FromResult(new User
+        /// <summary>
+        /// A special user ID which <see cref="ComputeValueAsync"/> would return a <see langword="null"/> <see cref="User"/> for.
+        /// As a simulation to what a regular <see cref="UserLookupCache"/> would return in the case of failing to fetch the user.
+        /// </summary>
+        public const int NULL_USER_ID = -1;
+
+        protected override Task<User> ComputeValueAsync(int lookup, CancellationToken token = default)
         {
-            Id = lookup,
-            Username = $"User {lookup}"
-        });
+            if (lookup == NULL_USER_ID)
+                return Task.FromResult((User)null);
+
+            return Task.FromResult(new User
+            {
+                Id = lookup,
+                Username = $"User {lookup}"
+            });
+        }
     }
 }


### PR DESCRIPTION
Closes #14302 

- https://github.com/ppy/osu/commit/e65c8b4e47278eee96794d797172ade92eee9550 – Changes `TeamDisplay` to take `MultiplayerRoomUser`, rather than the underlying `User` itself which may be null.
- https://github.com/ppy/osu/commit/8c38762240a5d5c9fbebba80f5e42a812437a763 – Fixes `KickButton` action asserting that the underlying `User` can't be null and using its `Id`, rather than the more reliable `MultiplayerRoomUser.UserID`.

Ironically, test coverage for null users already existed and should've caught the `TeamDisplay` case at least, but with the recent changes to the online-play test scene structure, the test scene obtained a `TestUserLookupCache` that would return actual non-null `User`s regardless of the given ID, regressing `AddNullUser` from actually adding a null user.

I've resolved that regression in an explicit manner by adding a `NULL_USER_ID` special case, which `AddNullUser` would use to achieve its purpose. And I have ensured that never happens again by asserting the added user does have a null `User`.
