### PR TITLE
Add editor shift select

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
 
             // while holding control, we only want to add to selection, not replace an existing selection.
-            if (e.ControlPressed && e.Button == MouseButton.Left && !blueprint.IsSelected)
+            if ((e.ControlPressed || e.ShiftPressed) && e.Button == MouseButton.Left && !blueprint.IsSelected)
             {
                 blueprint.ToggleSelection();
                 return true;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return true;
             }
 
-            // while holding control, we only want to add to selection, not replace an existing selection.
+            // while holding control or shift, we only want to add to selection, not replace an existing selection.
             if ((e.ControlPressed || e.ShiftPressed) && e.Button == MouseButton.Left && !blueprint.IsSelected)
             {
                 blueprint.ToggleSelection();


### PR DESCRIPTION
Fixes #14331 

I'll not that this might not be completely necessary since ctrl clicking does the same thing, but it does add shift click selection support to the editor and fixes the the issue.