### PR TITLE
Fix `MatchSettingsOverlay` not properly resetting focus on hide

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchSettingsOverlay.cs
@@ -41,11 +41,13 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
         protected override void PopIn()
         {
+            base.PopIn();
             Settings.MoveToY(0, TRANSITION_DURATION, Easing.OutQuint);
         }
 
         protected override void PopOut()
         {
+            base.PopOut();
             Settings.MoveToY(-1, TRANSITION_DURATION, Easing.InSine);
         }
 


### PR DESCRIPTION
Closes #14356 

Since `MatchSettingsOverlay` overriden `PopIn` and `PopOut` without calling the base methods, focus wasn't being reset correctly when the overlay gets hidden, due to the focus reset logic residing in the base class `FocusedOverlayContainer`'s `PopOut` method and not being called.

And, interestingly, focused drawables get added to the input queue regardless of whether they have `Propagate*InputSubTree = false`, that's why `MatchSettingsOverlay` was receiving `OnPressed` even when it's hidden.