### PR TITLE
Add `LocalUserPlayInfo` interface to convey common information about player status

### DIFF
--- a/osu.Desktop/Windows/GameplayWinKeyBlocker.cs
+++ b/osu.Desktop/Windows/GameplayWinKeyBlocker.cs
@@ -5,23 +5,23 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
-using osu.Game;
 using osu.Game.Configuration;
+using osu.Game.Screens.Play;
 
 namespace osu.Desktop.Windows
 {
     public class GameplayWinKeyBlocker : Component
     {
         private Bindable<bool> disableWinKey;
-        private Bindable<bool> localUserPlaying;
+        private IBindable<bool> localUserPlaying;
 
         [Resolved]
         private GameHost host { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame game, OsuConfigManager config)
+        private void load(ILocalUserPlayInfo localUserInfo, OsuConfigManager config)
         {
-            localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
+            localUserPlaying = localUserInfo.IsPlaying.GetBoundCopy();
             localUserPlaying.BindValueChanged(_ => updateBlocking());
 
             disableWinKey = config.GetBindable<bool>(OsuSetting.GameplayDisableWinKey);

--- a/osu.Game/Input/ConfineMouseTracker.cs
+++ b/osu.Game/Input/ConfineMouseTracker.cs
@@ -7,6 +7,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Game.Configuration;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Input
 {
@@ -24,14 +25,14 @@ namespace osu.Game.Input
         private IBindable<bool> localUserPlaying;
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame game, FrameworkConfigManager frameworkConfigManager, OsuConfigManager osuConfigManager)
+        private void load(ILocalUserPlayInfo localUserInfo, FrameworkConfigManager frameworkConfigManager, OsuConfigManager osuConfigManager)
         {
             frameworkConfineMode = frameworkConfigManager.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
             frameworkWindowMode = frameworkConfigManager.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
             frameworkWindowMode.BindValueChanged(_ => updateConfineMode());
 
             osuConfineMode = osuConfigManager.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode);
-            localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
+            localUserPlaying = localUserInfo.IsPlaying.GetBoundCopy();
 
             osuConfineMode.ValueChanged += _ => updateConfineMode();
             localUserPlaying.BindValueChanged(_ => updateConfineMode(), true);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -62,7 +62,7 @@ namespace osu.Game
     /// The full osu! experience. Builds on top of <see cref="OsuGameBase"/> to add menus and binding logic
     /// for initial components that are generally retrieved via DI.
     /// </summary>
-    public class OsuGame : OsuGameBase, IKeyBindingHandler<GlobalAction>
+    public class OsuGame : OsuGameBase, IKeyBindingHandler<GlobalAction>, ILocalUserPlayInfo
     {
         /// <summary>
         /// The amount of global offset to apply when a left/right anchored overlay is displayed (ie. settings or notifications).
@@ -1085,5 +1085,7 @@ namespace osu.Game
             if (newScreen == null)
                 Exit();
         }
+
+        IBindable<bool> ILocalUserPlayInfo.IsPlaying => LocalUserPlaying;
     }
 }

--- a/osu.Game/Performance/HighPerformanceSession.cs
+++ b/osu.Game/Performance/HighPerformanceSession.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Performance
 {
@@ -12,9 +13,9 @@ namespace osu.Game.Performance
         private readonly IBindable<bool> localUserPlaying = new Bindable<bool>();
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame game)
+        private void load(ILocalUserPlayInfo localUserInfo)
         {
-            localUserPlaying.BindTo(game.LocalUserPlaying);
+            localUserPlaying.BindTo(localUserInfo.IsPlaying);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/ILocalUserPlayInfo.cs
+++ b/osu.Game/Screens/Play/ILocalUserPlayInfo.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+
+namespace osu.Game.Screens.Play
+{
+    [Cached]
+    public interface ILocalUserPlayInfo
+    {
+        /// <summary>
+        /// Whether the local user is currently playing.
+        /// </summary>
+        public IBindable<bool> IsPlaying { get; }
+    }
+}

--- a/osu.Game/Screens/Play/ILocalUserPlayInfo.cs
+++ b/osu.Game/Screens/Play/ILocalUserPlayInfo.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Whether the local user is currently playing.
         /// </summary>
-        public IBindable<bool> IsPlaying { get; }
+        IBindable<bool> IsPlaying { get; }
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Play
 {
     [Cached]
     [Cached(typeof(ISamplePlaybackDisabler))]
-    public abstract class Player : ScreenWithBeatmapBackground, ISamplePlaybackDisabler
+    public abstract class Player : ScreenWithBeatmapBackground, ISamplePlaybackDisabler, ILocalUserPlayInfo
     {
         /// <summary>
         /// The delay upon completion of the beatmap before displaying the results screen.
@@ -1052,5 +1052,7 @@ namespace osu.Game.Screens.Play
         #endregion
 
         IBindable<bool> ISamplePlaybackDisabler.SamplePlaybackDisabled => samplePlaybackDisabled;
+
+        IBindable<bool> ILocalUserPlayInfo.IsPlaying => LocalUserPlaying;
     }
 }


### PR DESCRIPTION
Was originally going to make an `IPlayer`, but this seems more suitable as there are cases where it is cached by `OsuGame` as well.
