### PR TITLE
Improve visibility of repeat ticks / drag areas on timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -166,14 +166,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
 
             if (IsSelected)
-            {
                 border.Show();
-                colour = colour.Lighten(0.3f);
-            }
             else
-            {
                 border.Hide();
-            }
 
             if (Item is IHasDuration duration && duration.Duration > 0)
                 circle.Colour = ColourInfo.GradientHorizontal(colour, colour.Lighten(0.4f));
@@ -212,14 +207,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             for (int i = 0; i < repeats.RepeatCount; i++)
             {
-                repeatsContainer.Add(new Circle
+                repeatsContainer.Add(new Tick
                 {
-                    Size = new Vector2(circle_size / 3),
-                    Alpha = 0.2f,
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.Centre,
-                    RelativePositionAxes = Axes.X,
-                    X = (float)(i + 1) / (repeats.RepeatCount + 1),
+                    X = (float)(i + 1) / (repeats.RepeatCount + 1)
                 });
             }
         }
@@ -232,6 +222,17 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         public override Quad SelectionQuad => circle.ScreenSpaceDrawQuad;
 
         public override Vector2 ScreenSpaceSelectionPoint => ScreenSpaceDrawQuad.TopLeft;
+
+        private class Tick : Circle
+        {
+            public Tick()
+            {
+                Size = new Vector2(circle_size / 4);
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.Centre;
+                RelativePositionAxes = Axes.X;
+            }
+        }
 
         public class DragArea : Circle
         {
@@ -304,20 +305,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             private void updateState()
             {
-                if (hasMouseDown)
-                {
-                    this.ScaleTo(0.7f, 200, Easing.OutQuint);
-                }
-                else if (IsHovered)
-                {
-                    this.ScaleTo(0.8f, 200, Easing.OutQuint);
-                }
-                else
-                {
-                    this.ScaleTo(0.6f, 200, Easing.OutQuint);
-                }
+                float scale = 0.5f;
 
-                this.FadeTo(IsHovered || hasMouseDown ? 0.8f : 0.2f, 200, Easing.OutQuint);
+                if (hasMouseDown)
+                    scale = 0.6f;
+                else if (IsHovered)
+                    scale = 0.7f;
+
+                this.ScaleTo(scale, 200, Easing.OutQuint);
+                this.FadeTo(IsHovered || hasMouseDown ? 1f : 0.9f, 200, Easing.OutQuint);
             }
 
             [Resolved]


### PR DESCRIPTION
Bright colours in only one of RGB components aren't handled great by the light/dark toggle logic. Rather than try and fix that, I've opted to just increase the opacity to make sure the points are always visible. I think it looks okay.

Before:

![20210817 182041 (dotnet)](https://user-images.githubusercontent.com/191335/129699585-7f57e6a7-437b-4e78-902c-8034ecd34de4.png)

After:

![20210817 181904 (dotnet)](https://user-images.githubusercontent.com/191335/129699326-f6ddbf38-8f61-4331-ad6d-84a9f891deb6.png)
