### PR TITLE
Close the file chooser in the editor when clicking it a second time

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneFileChooserLabelledTextBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneFileChooserLabelledTextBox.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Screens.Edit.Setup;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneFileChooserLabelledTextBox : OsuManualInputManagerTestScene
+    {
+        private FileChooserLabelledTextBox fileChooser;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Container fileChooserContainer = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+            };
+
+            Child = new FillFlowContainer
+            {
+                Width = 600,
+                AutoSizeAxes = Axes.Y,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    fileChooser = new FileChooserLabelledTextBox(".jpg", ".jpeg", ".png")
+                    {
+                        Label = "File Chooser",
+                        FixedLabelWidth = 160,
+                        PlaceholderText = "Click to select a file",
+                        Target = fileChooserContainer,
+                        TabbableContentContainer = this
+                    },
+                    fileChooserContainer
+                }
+            };
+        });
+
+        [Test]
+        public void TestFileChooserToggles()
+        {
+            FileChooserLabelledTextBox.FileChooserOsuTextBox textBox = null;
+            AddStep("retrieve text box", () => textBox = this.ChildrenOfType<FileChooserLabelledTextBox.FileChooserOsuTextBox>().First());
+
+            AddStep("hover over text box", () => InputManager.MoveMouseTo(textBox));
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("file chooser is expanded", () => fileChooser.IsExpanded);
+
+            AddStep("hover over text box", () => InputManager.MoveMouseTo(textBox));
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("file chooser is no longer expanded", () => !fileChooser.IsExpanded);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Screens.Edit.Setup
         /// </summary>
         public Container Target;
 
+        private OsuFileSelector fileSelector;
+
         private readonly Bindable<FileInfo> currentFile = new Bindable<FileInfo>();
 
         [Resolved]
@@ -56,16 +58,22 @@ namespace osu.Game.Screens.Edit.Setup
 
         public void DisplayFileChooser()
         {
-            OsuFileSelector fileSelector;
-
-            Target.Child = fileSelector = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
+            if (fileSelector == null)
             {
-                RelativeSizeAxes = Axes.X,
-                Height = 400,
-                CurrentFile = { BindTarget = currentFile }
-            };
+                Target.Child = fileSelector = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 400,
+                    CurrentFile = { BindTarget = currentFile }
+                };
 
-            sectionsContainer.ScrollTo(fileSelector);
+                sectionsContainer.ScrollTo(fileSelector);
+            }
+            else
+            {
+                fileSelector = null;
+                Target.Clear();
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -55,10 +55,10 @@ namespace osu.Game.Screens.Edit.Setup
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.X,
                 CornerRadius = CORNER_RADIUS,
-                OnFocused = DisplayFileChooser
+                OnFocused = ToggleFileChooser
             };
 
-        public void DisplayFileChooser()
+        public void ToggleFileChooser()
         {
             if (!IsExpanded)
             {

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -73,8 +73,7 @@ namespace osu.Game.Screens.Edit.Setup
             }
             else
             {
-                fileSelector = null;
-                Target.Clear();
+                hideFileSelector();
             }
         }
 
@@ -91,8 +90,14 @@ namespace osu.Game.Screens.Edit.Setup
             if (file.NewValue == null)
                 return;
 
-            Target.Clear();
+            hideFileSelector();
             Current.Value = file.NewValue.FullName;
+        }
+
+        private void hideFileSelector()
+        {
+            fileSelector = null;
+            Target.Clear();
         }
 
         Task ICanAcceptFiles.Import(params string[] paths)

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -33,12 +33,14 @@ namespace osu.Game.Screens.Edit.Setup
 
         private OsuFileSelector fileSelector;
 
+        public bool IsExpanded => fileSelector != null;
+
         private readonly Bindable<FileInfo> currentFile = new Bindable<FileInfo>();
 
         [Resolved]
         private OsuGameBase game { get; set; }
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private SectionsContainer<SetupSection> sectionsContainer { get; set; }
 
         public FileChooserLabelledTextBox(params string[] handledExtensions)
@@ -67,7 +69,7 @@ namespace osu.Game.Screens.Edit.Setup
                     CurrentFile = { BindTarget = currentFile }
                 };
 
-                sectionsContainer.ScrollTo(fileSelector);
+                sectionsContainer?.ScrollTo(fileSelector);
             }
             else
             {

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Edit.Setup
 
         public void DisplayFileChooser()
         {
-            if (fileSelector == null)
+            if (!IsExpanded)
             {
                 Target.Child = fileSelector = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
                 {


### PR DESCRIPTION
Closes #14367.
This will close the file chooser when the text box is clicked a second time.