### PR TITLE
Override `CreateInstance()` in osu! bindable subclasses

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.813.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.813.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.818.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Mods
             {
                 // Intercept and extract the internal number bindable from DifficultyBindable.
                 // This will provide bounds and precision specifications for the slider bar.
-                difficultyBindable = ((DifficultyBindable)value).GetBoundCopy();
+                difficultyBindable = (DifficultyBindable)value.GetBoundCopy();
                 sliderDisplayCurrent.BindTo(difficultyBindable.CurrentNumber);
 
                 base.Current = difficultyBindable;

--- a/osu.Game/Rulesets/Mods/DifficultyBindable.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyBindable.cs
@@ -128,6 +128,6 @@ namespace osu.Game.Rulesets.Mods
             ExtendedLimits.UnbindFrom(otherDifficultyBindable.ExtendedLimits);
         }
 
-        public new DifficultyBindable GetBoundCopy() => new DifficultyBindable { BindTarget = this };
+        protected override Bindable<float?> CreateInstance() => new DifficultyBindable();
     }
 }

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -41,6 +41,8 @@ namespace osu.Game.Screens.Edit
         protected override int DefaultMaxValue => VALID_DIVISORS.Last();
         protected override int DefaultPrecision => 1;
 
+        protected override Bindable<int> CreateInstance() => new BindableBeatDivisor();
+
         /// <summary>
         /// Retrieves the appropriate colour for a beat divisor.
         /// </summary>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.3.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.813.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.818.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.813.0" />
     <PackageReference Include="Sentry" Version="3.8.3" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.813.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.818.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.813.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.813.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.818.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
In-line with the changes in ppy/osu-framework#4689

- [x] Depends on framework bump

Three bindables are left which don't have this overriden due to them already not having a value-only constructor and not supporting `GetBoundCopy()` properly:
 - `BeatmapDifficultyCache.BindableStarDifficulty`.
 - `TotalScoreBindable`
 - `TotalScoreStringBindable`

I could add support for them by passing the required data to them, as they seem to be able to have that shared, but I'm hesitant to support something which never had a reasonable usage, so I left that for now.