### PR TITLE
Fix config pollution in HUD overlay test scene

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public class TestSceneHUDOverlay : OsuManualInputManagerTestScene
     {
+        private OsuConfigManager localConfig;
+
         private HUDOverlay hudOverlay;
 
         [Cached]
@@ -31,8 +33,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         private Drawable hideTarget => hudOverlay.KeyCounter;
         private FillFlowContainer<KeyCounter> keyCounterFlow => hudOverlay.KeyCounter.ChildrenOfType<FillFlowContainer<KeyCounter>>().First();
 
-        [Resolved]
-        private OsuConfigManager config { get; set; }
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Dependencies.Cache(localConfig = new OsuConfigManager(LocalStorage));
+        }
+
+        [SetUpSteps]
+        public void SetUp() => Schedule(() => localConfig.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always));
 
         [Test]
         public void TestComboCounterIncrementing()
@@ -85,11 +93,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             createNew();
 
-            HUDVisibilityMode originalConfigValue = HUDVisibilityMode.HideDuringGameplay;
-
-            AddStep("get original config value", () => originalConfigValue = config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
-
-            AddStep("set hud to never show", () => config.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
+            AddStep("set hud to never show", () => localConfig.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
 
             AddUntilStep("wait for fade", () => !hideTarget.IsPresent);
 
@@ -98,37 +102,28 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("stop trigering", () => InputManager.ReleaseKey(Key.ControlLeft));
             AddUntilStep("wait for fade", () => !hideTarget.IsPresent);
-
-            AddStep("set original config value", () => config.SetValue(OsuSetting.HUDVisibilityMode, originalConfigValue));
         }
 
         [Test]
         public void TestExternalHideDoesntAffectConfig()
         {
-            HUDVisibilityMode originalConfigValue = HUDVisibilityMode.HideDuringGameplay;
-
             createNew();
 
-            AddStep("get original config value", () => originalConfigValue = config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
-
             AddStep("set showhud false", () => hudOverlay.ShowHud.Value = false);
-            AddAssert("config unchanged", () => originalConfigValue == config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
+            AddAssert("config unchanged", () => localConfig.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode).IsDefault);
 
             AddStep("set showhud true", () => hudOverlay.ShowHud.Value = true);
-            AddAssert("config unchanged", () => originalConfigValue == config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
+            AddAssert("config unchanged", () => localConfig.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode).IsDefault);
         }
 
         [Test]
         public void TestChangeHUDVisibilityOnHiddenKeyCounter()
         {
-            bool keyCounterVisibleValue = false;
-
             createNew();
-            AddStep("save keycounter visible value", () => keyCounterVisibleValue = config.Get<bool>(OsuSetting.KeyOverlay));
 
-            AddStep("set keycounter visible false", () =>
+            AddStep("hide key overlay", () =>
             {
-                config.SetValue(OsuSetting.KeyOverlay, false);
+                localConfig.SetValue(OsuSetting.KeyOverlay, false);
                 hudOverlay.KeyCounter.AlwaysVisible.Value = false;
             });
 
@@ -139,24 +134,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("set showhud true", () => hudOverlay.ShowHud.Value = true);
             AddUntilStep("hidetarget is visible", () => hideTarget.IsPresent);
             AddAssert("key counters still hidden", () => !keyCounterFlow.IsPresent);
-
-            AddStep("return value", () => config.SetValue(OsuSetting.KeyOverlay, keyCounterVisibleValue));
         }
 
         [Test]
         public void TestHiddenHUDDoesntBlockSkinnableComponentsLoad()
         {
-            HUDVisibilityMode originalConfigValue = default;
-
-            AddStep("get original config value", () => originalConfigValue = config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
-
-            AddStep("set hud to never show", () => config.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
+            AddStep("set hud to never show", () => localConfig.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
 
             createNew();
             AddUntilStep("wait for hud load", () => hudOverlay.IsLoaded);
             AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().ComponentsLoaded);
-
-            AddStep("set original config value", () => config.SetValue(OsuSetting.HUDVisibilityMode, originalConfigValue));
         }
 
         private void createNew(Action<HUDOverlay> action = null)
@@ -174,6 +161,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 Child = hudOverlay;
             });
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            localConfig?.Dispose();
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             Dependencies.Cache(localConfig = new OsuConfigManager(LocalStorage));
         }
 
-        [SetUpSteps]
+        [SetUp]
         public void SetUp() => Schedule(() => localConfig.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always));
 
         [Test]


### PR DESCRIPTION
Fixes potential config pollution in the `TestSceneHUDOverlay`, as I noticed from the failure in https://github.com/ppy/osu/runs/3356636562?check_suite_focus=true.

I'm not sure whether this fixes the "skinnable components loaded timed out" failure, but the "showhud is set" one is happening because of the config getting polluted, which I've now replaced with a local `OsuConfigManager` pointing to a uniquely defined storage.

Made me think whether we should have that at an `OsuTestScene`-level given that this exists in `PlayerTestScene`s, in a potentially different form so that the config file itself doesn't get saved or loaded at all.