### PR TITLE
Fix playlists lounge sub screen test potentially failing on load

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Tests.Visual.Playlists
             AddStep("reset mouse", () => InputManager.ReleaseButton(MouseButton.Left));
 
             AddStep("add rooms", () => RoomManager.AddRooms(30));
+            AddUntilStep("wait for rooms", () => roomsContainer.Rooms.Count == 30);
 
             AddUntilStep("first room is not masked", () => checkRoomVisible(roomsContainer.Rooms[0]));
 
@@ -53,6 +54,7 @@ namespace osu.Game.Tests.Visual.Playlists
         public void TestScrollSelectedIntoView()
         {
             AddStep("add rooms", () => RoomManager.AddRooms(30));
+            AddUntilStep("wait for rooms", () => roomsContainer.Rooms.Count == 30);
 
             AddUntilStep("first room is not masked", () => checkRoomVisible(roomsContainer.Rooms[0]));
 


### PR DESCRIPTION
Noticed while I was going through the failures in #14378, adding an until step waiting for rooms to become visible fixes it. (reason why it failed is because `FlowingChildren` ignores rooms which have `Alpha = 0`, and rooms have an initial transform of 0->1 on load complete)