### PR TITLE
Update code inspection settings to hide "merge into pattern" again

### DIFF
--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -105,8 +105,9 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBeProtected_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeCastWithTypeCheck/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeConditionalExpression/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeIntoNegatedPattern/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeIntoPattern/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeSequentialChecks/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeSequentialPatterns/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MethodHasAsyncOverload/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MethodHasAsyncOverloadWithCancellation/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MethodSupportsCancellation/@EntryIndexedValue">WARNING</s:String>


### PR DESCRIPTION
Recently, the "merge into pattern" inspection started showing up back as suggestions, while they were completely disabled before at #11404.

The cause seems to be that the corresponding inspection name was changed from `MergeSequentialPatterns` into `MergeIntoPattern`, and a new `MergeIntoNegatedPattern` inspection showed up along the way.

I've disabled both the new renamed inspection and the new one, as they're all suggesting this specific pattern which we don't want:
- `MergeIntoPattern` (renamed from `MergeSequentialPatterns`):
  ```diff
  -            if (sampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacySample && legacySample.IsLayered)
  +            if (sampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo { IsLayered: true })
  ```
- `MergeIntoNegatedPattern`:
  ```diff
  -            if (ruleset == null || ruleset.ID.HasValue)
  +            if (!(ruleset is { ID: null }))
  ```