### PR TITLE
Fix nub glow color not having 0 alpha when being set

### DIFF
--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Graphics.UserInterface
                 glowColour = value;
 
                 var effect = EdgeEffect;
-                effect.Colour = value.Opacity(0);
+                effect.Colour = Glowing ? value : value.Opacity(0);
                 EdgeEffect = effect;
             }
         }

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Graphics.UserInterface
                 glowColour = value;
 
                 var effect = EdgeEffect;
-                effect.Colour = value;
+                effect.Colour = value.Opacity(0);
                 EdgeEffect = effect;
             }
         }


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/14345.

Before:
<img width="336" alt="Screen Shot 2021-08-19 at 8 15 18 PM" src="https://user-images.githubusercontent.com/35318437/130174250-02aed85c-3048-4e20-a34c-c4330012f55c.png">

After:
<img width="307" alt="Screen Shot 2021-08-19 at 8 23 31 PM" src="https://user-images.githubusercontent.com/35318437/130174255-0f913466-d12e-430f-9cba-096ab068caa3.png">
