### PR TITLE
Fix online room being deselected when joined

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -172,8 +172,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
             sampleJoin?.Play();
             lounge?.Join(Room, null);
-
-            return base.OnClick(e);
+            return true;
         }
 
         public class PasswordEntryPopover : OsuPopover


### PR DESCRIPTION
Without this the click falls through to `RoomsContainer` which deselects the room:
https://github.com/ppy/osu/blob/3f37d4395f9a45b640b540feac39f051d6a211d9/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs#L140-L145