### PR TITLE
Expand `TestSceneSectionsContainer` to test for the scrolled to section being visible

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSectionsContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSectionsContainer.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Graphics.Containers;
 using osuTK.Graphics;
 
@@ -61,10 +62,12 @@ namespace osu.Game.Tests.Visual.UserInterface
             ));
             AddStep("scroll up", () => triggerUserScroll(1));
             AddStep("scroll down", () => triggerUserScroll(-1));
+            AddStep("scroll up a bit", () => triggerUserScroll(0.1f));
+            AddStep("scroll down a bit", () => triggerUserScroll(-0.1f));
         }
 
         [Test]
-        public void TestCorrectSectionSelected()
+        public void TestCorrectSelectionAndVisibleTop()
         {
             const int sections_count = 11;
             float[] alternating = { 0.07f, 0.33f, 0.16f, 0.33f };
@@ -79,6 +82,12 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 AddStep($"scroll to section {scrollIndex + 1}", () => container.ScrollTo(container.Children[scrollIndex]));
                 AddUntilStep("correct section selected", () => container.SelectedSection.Value == container.Children[scrollIndex]);
+                AddUntilStep("section top is visible", () =>
+                {
+                    float scrollPosition = container.ChildrenOfType<UserTrackingScrollContainer>().First().Current;
+                    float sectionTop = container.Children[scrollIndex].BoundingBox.Top;
+                    return scrollPosition < sectionTop;
+                });
             }
 
             for (int i = 1; i < sections_count; i++)


### PR DESCRIPTION
While peppy was writing #14384 having this might have prevented a regression getting in. Seems like a good thing to have if sections container is ever changed again.

Should be self explanatory. Sections usually have headers and when some `.ScrollTo()` action is applied to `SectionsContainer` it's expected that the header will be visible. This PR tests that the scrolled to section's bounding-box's top part is below current scroll value.

edit: This indeed fails on 03e6ca5ba930830960bb5541f7b7be6fb2dc0f9a