### PR TITLE
Allow intro screen to retrieve beatmap even if rulesets is not loaded

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -365,6 +365,10 @@ namespace osu.Game.Beatmaps
                     queryable = beatmaps.BeatmapSetsOverview;
                     break;
 
+                case IncludedDetails.AllButRuleset:
+                    queryable = beatmaps.BeatmapSetsWithoutRuleset;
+                    break;
+
                 case IncludedDetails.AllButFiles:
                     queryable = beatmaps.BeatmapSetsWithoutFiles;
                     break;
@@ -384,8 +388,33 @@ namespace osu.Game.Beatmaps
         /// Perform a lookup query on available <see cref="BeatmapSetInfo"/>s.
         /// </summary>
         /// <param name="query">The query.</param>
+        /// <param name="includes">The level of detail to include in the returned objects.</param>
         /// <returns>Results from the provided query.</returns>
-        public IEnumerable<BeatmapSetInfo> QueryBeatmapSets(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.ConsumableItems.AsNoTracking().Where(query);
+        public IEnumerable<BeatmapSetInfo> QueryBeatmapSets(Expression<Func<BeatmapSetInfo, bool>> query, IncludedDetails includes = IncludedDetails.All)
+        {
+            IQueryable<BeatmapSetInfo> queryable;
+
+            switch (includes)
+            {
+                case IncludedDetails.Minimal:
+                    queryable = beatmaps.BeatmapSetsOverview;
+                    break;
+
+                case IncludedDetails.AllButRuleset:
+                    queryable = beatmaps.BeatmapSetsWithoutRuleset;
+                    break;
+
+                case IncludedDetails.AllButFiles:
+                    queryable = beatmaps.BeatmapSetsWithoutFiles;
+                    break;
+
+                default:
+                    queryable = beatmaps.ConsumableItems;
+                    break;
+            }
+
+            return queryable.AsNoTracking().Where(query);
+        }
 
         /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapInfo"/>s.
@@ -553,6 +582,11 @@ namespace osu.Game.Beatmaps
         /// Include all difficulties, rulesets, difficulty metadata but no files.
         /// </summary>
         AllButFiles,
+
+        /// <summary>
+        /// Include everything except ruleset. Used for cases where we aren't sure the ruleset is present but still want to consume the beatmap.
+        /// </summary>
+        AllButRuleset,
 
         /// <summary>
         /// Include everything.

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -92,6 +92,13 @@ namespace osu.Game.Beatmaps
                                                                                .Include(s => s.Beatmaps)
                                                                                .AsNoTracking();
 
+        public IQueryable<BeatmapSetInfo> BeatmapSetsWithoutRuleset => ContextFactory.Get().BeatmapSetInfo
+                                                                                     .Include(s => s.Metadata)
+                                                                                     .Include(s => s.Files).ThenInclude(f => f.FileInfo)
+                                                                                     .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
+                                                                                     .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
+                                                                                     .AsNoTracking();
+
         public IQueryable<BeatmapSetInfo> BeatmapSetsWithoutFiles => ContextFactory.Get().BeatmapSetInfo
                                                                                    .Include(s => s.Metadata)
                                                                                    .Include(s => s.Beatmaps).ThenInclude(s => s.Ruleset)

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -109,7 +110,7 @@ namespace osu.Game.Screens.Menu
 
             bool loadThemedIntro()
             {
-                setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == BeatmapHash);
+                setInfo = beatmaps.QueryBeatmapSets(b => b.Hash == BeatmapHash, IncludedDetails.AllButRuleset).FirstOrDefault();
 
                 if (setInfo == null)
                     return false;


### PR DESCRIPTION
This would potentially affect ruleset developers who have never run the game. In the normal case, the rulesets would still be loaded from disk and avoid the issue.