### PR TITLE
Fix screen offsetting not handling scaled game content properly

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneSideOverlays.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneSideOverlays.cs
@@ -1,8 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual.Menus
@@ -21,21 +25,48 @@ namespace osu.Game.Tests.Visual.Menus
         [Test]
         public void TestScreenOffsettingOnSettingsOverlay()
         {
-            AddStep("open settings", () => Game.Settings.Show());
-            AddUntilStep("right screen offset applied", () => Game.ScreenOffsetContainer.X == SettingsPanel.WIDTH * TestOsuGame.SIDE_OVERLAY_OFFSET_RATIO);
+            foreach (var scalingMode in Enum.GetValues(typeof(ScalingMode)).Cast<ScalingMode>())
+            {
+                AddStep($"set scaling mode to {scalingMode}", () =>
+                {
+                    Game.LocalConfig.SetValue(OsuSetting.Scaling, scalingMode);
 
-            AddStep("hide settings", () => Game.Settings.Hide());
-            AddUntilStep("screen offset removed", () => Game.ScreenOffsetContainer.X == 0f);
+                    if (scalingMode != ScalingMode.Off)
+                    {
+                        Game.LocalConfig.SetValue(OsuSetting.ScalingSizeX, 0.5f);
+                        Game.LocalConfig.SetValue(OsuSetting.ScalingSizeY, 0.5f);
+                    }
+                });
+
+                AddStep("open settings", () => Game.Settings.Show());
+                AddUntilStep("right screen offset applied", () => Precision.AlmostEquals(Game.ScreenOffsetContainer.X, SettingsPanel.WIDTH * TestOsuGame.SIDE_OVERLAY_OFFSET_RATIO));
+
+                AddStep("hide settings", () => Game.Settings.Hide());
+                AddUntilStep("screen offset removed", () => Game.ScreenOffsetContainer.X == 0f);
+            }
         }
 
         [Test]
         public void TestScreenOffsettingOnNotificationOverlay()
         {
-            AddStep("open notifications", () => Game.Notifications.Show());
-            AddUntilStep("right screen offset applied", () => Game.ScreenOffsetContainer.X == -NotificationOverlay.WIDTH * TestOsuGame.SIDE_OVERLAY_OFFSET_RATIO);
+            foreach (var scalingMode in Enum.GetValues(typeof(ScalingMode)).Cast<ScalingMode>())
+            {
+                if (scalingMode != ScalingMode.Off)
+                {
+                    AddStep($"set scaling mode to {scalingMode}", () =>
+                    {
+                        Game.LocalConfig.SetValue(OsuSetting.Scaling, scalingMode);
+                        Game.LocalConfig.SetValue(OsuSetting.ScalingSizeX, 0.5f);
+                        Game.LocalConfig.SetValue(OsuSetting.ScalingSizeY, 0.5f);
+                    });
+                }
 
-            AddStep("hide notifications", () => Game.Notifications.Hide());
-            AddUntilStep("screen offset removed", () => Game.ScreenOffsetContainer.X == 0f);
+                AddStep("open notifications", () => Game.Notifications.Show());
+                AddUntilStep("right screen offset applied", () => Precision.AlmostEquals(Game.ScreenOffsetContainer.X, -NotificationOverlay.WIDTH * TestOsuGame.SIDE_OVERLAY_OFFSET_RATIO));
+
+                AddStep("hide notifications", () => Game.Notifications.Hide());
+                AddUntilStep("screen offset removed", () => Game.ScreenOffsetContainer.X == 0f);
+            }
         }
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1019,9 +1019,9 @@ namespace osu.Game
             var horizontalOffset = 0f;
 
             if (Settings.IsLoaded && Settings.IsPresent)
-                horizontalOffset += ToLocalSpace(Settings.ScreenSpaceDrawQuad.TopRight).X * SIDE_OVERLAY_OFFSET_RATIO;
+                horizontalOffset += Content.ToLocalSpace(Settings.ScreenSpaceDrawQuad.TopRight).X * SIDE_OVERLAY_OFFSET_RATIO;
             if (Notifications.IsLoaded && Notifications.IsPresent)
-                horizontalOffset += (ToLocalSpace(Notifications.ScreenSpaceDrawQuad.TopLeft).X - DrawWidth) * SIDE_OVERLAY_OFFSET_RATIO;
+                horizontalOffset += (Content.ToLocalSpace(Notifications.ScreenSpaceDrawQuad.TopLeft).X - Content.DrawWidth) * SIDE_OVERLAY_OFFSET_RATIO;
 
             ScreenOffsetContainer.X = horizontalOffset;
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1018,6 +1018,8 @@ namespace osu.Game
 
             var horizontalOffset = 0f;
 
+            // Calculate the horizontal offset using Content, as it gets nested inside a ScalingMode.Everything container
+            // which should apply to overlays, but not get affected by modes like ScalingMode.ExcludeOverlays which shouldn't.
             if (Settings.IsLoaded && Settings.IsPresent)
                 horizontalOffset += Content.ToLocalSpace(Settings.ScreenSpaceDrawQuad.TopRight).X * SIDE_OVERLAY_OFFSET_RATIO;
             if (Notifications.IsLoaded && Notifications.IsPresent)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1018,8 +1018,9 @@ namespace osu.Game
 
             var horizontalOffset = 0f;
 
-            // Calculate the horizontal offset using Content, as it gets nested inside a ScalingMode.Everything container
-            // which should apply to overlays, but not get affected by modes like ScalingMode.ExcludeOverlays which shouldn't.
+            // Content.ToLocalSpace() is used instead of this.ToLocalSpace() to correctly calculate the offset with scaling modes active.
+            // Content is a child of a scaling container with ScalingMode.Everything set, while the game itself is never scaled.
+            // this avoids a visible jump in the positioning of the screen offset container.
             if (Settings.IsLoaded && Settings.IsPresent)
                 horizontalOffset += Content.ToLocalSpace(Settings.ScreenSpaceDrawQuad.TopRight).X * SIDE_OVERLAY_OFFSET_RATIO;
             if (Notifications.IsLoaded && Notifications.IsPresent)


### PR DESCRIPTION
Closes #14394 

Cause of this was that using `ToLocalSpace` of the internal game instance bypasses scaling entirely, which causes the screen offset calculation logic to become wrong in the case of `ScalingMode.Everything` where the overlay gets scaled down as well.

I've changed to using `Content` instead, which gets affected by `ScalingMode.Everything`, but not with `ScalingMode.ExcludeOverlays`, which is the behaviour we want for calculating screen offsets from overlay's positions in the game.

I've changed the test scene to consider checking in every scaling mode, but I've also changed the until-step asserts to use `Precision.AlmostEquals`, as the calculated screen offsets starts losing precision when the screen is scaled, given that the calculation comes from matrix space conversions:

![CleanShot 2021-08-21 at 04 09 32](https://user-images.githubusercontent.com/22781491/130306171-311ce3d7-ce84-47e7-94a1-51290f7f7dfc.png)
