### PR TITLE
Improve highlighted chat username shadow effect

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -110,15 +110,15 @@ namespace osu.Game.Overlays.Chat
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Roundness = 1,
-                        Offset = new Vector2(0, 3),
-                        Radius = 3,
+                        Radius = 1,
                         Colour = Color4.Black.Opacity(0.3f),
+                        Offset = new Vector2(0, 1),
                         Type = EdgeEffectType.Shadow,
                     },
                     Child = new Container
                     {
                         AutoSizeAxes = Axes.Both,
-                        Y = 3,
+                        Y = 0,
                         Masking = true,
                         CornerRadius = 4,
                         Children = new Drawable[]


### PR DESCRIPTION
The offset effect changes depending on the render size (edge effects seem to be in screen coordinates) so having the `Offset` in the edgeeffect could result in worse misalignment than above, causing the shadow to even appear above instead of below the filled box.

Before:

![20210821 143555 (dotnet)](https://user-images.githubusercontent.com/191335/130311733-9c4ec722-b186-486e-9e2c-9a6b695b8058.png)

After:

![20210821 143507 (dotnet)](https://user-images.githubusercontent.com/191335/130311714-72e0301c-ade9-436f-aa97-86397fad5605.png)

