### PR TITLE
Show mods that are incompatible with the current selection

### DIFF
--- a/osu.Game/Overlays/Mods/IncompatibleIcon.cs
+++ b/osu.Game/Overlays/Mods/IncompatibleIcon.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class IncompatibleIcon : VisibilityContainer, IHasTooltip
+    {
+        private Circle circle;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Size = new Vector2(20);
+
+            State.Value = Visibility.Hidden;
+            Alpha = 0;
+
+            InternalChildren = new Drawable[]
+            {
+                circle = new Circle
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Gray4,
+                },
+                new SpriteIcon
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    Size = new Vector2(0.6f),
+                    Icon = FontAwesome.Solid.Slash,
+                    Colour = Color4.White,
+                    Shadow = true,
+                }
+            };
+        }
+
+        protected override void PopIn()
+        {
+            this.FadeIn(200, Easing.OutQuint);
+            circle.FlashColour(Color4.Red, 500, Easing.OutQuint);
+            this.ScaleTo(1.8f).Then().ScaleTo(1, 500, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            this.FadeOut(200, Easing.OutQuint);
+            this.ScaleTo(0.8f, 200, Easing.In);
+        }
+
+        public LocalisableString TooltipText => "Incompatible with current selected mods";
+    }
+}

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Overlays.Mods
     /// <summary>
     /// Represents a clickable button which can cycle through one of more mods.
     /// </summary>
-    public class ModButton : ModButtonEmpty, IHasTooltip
+    public class ModButton : ModButtonEmpty, IHasCustomTooltip
     {
         private ModIcon foregroundIcon;
         private ModIcon backgroundIcon;
@@ -308,5 +308,9 @@ namespace osu.Game.Overlays.Mods
 
             Mod = mod;
         }
+
+        public ITooltip GetCustomTooltip() => new ModButtonTooltip();
+
+        public object TooltipContent => SelectedMod ?? Mods[0];
     }
 }

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays.Mods
         private ModIcon backgroundIcon;
         private readonly SpriteText text;
         private readonly Container<ModIcon> iconsContainer;
-        private readonly SpriteIcon incompatibleIcon;
+        private readonly CompositeDrawable incompatibleIcon;
 
         /// <summary>
         /// Fired when the selection changes.
@@ -258,7 +258,10 @@ namespace osu.Game.Overlays.Mods
             if (selectedMods.Value.Count > 0 && !selectedMods.Value.Contains(m))
                 isIncompatible = !ModUtils.CheckCompatibleSet(selectedMods.Value.Append(m));
 
-            incompatibleIcon.FadeTo(isIncompatible ? 1 : 0, 200, Easing.OutQuint);
+            if (isIncompatible)
+                incompatibleIcon.Show();
+            else
+                incompatibleIcon.Hide();
         }
 
         private void createIcons()
@@ -315,15 +318,11 @@ namespace osu.Game.Overlays.Mods
                                     Origin = Anchor.Centre,
                                     Anchor = Anchor.Centre,
                                 },
-                                incompatibleIcon = new SpriteIcon
+                                incompatibleIcon = new IncompatibleIcon
                                 {
-                                    Origin = Anchor.BottomRight,
+                                    Origin = Anchor.Centre,
                                     Anchor = Anchor.BottomRight,
-                                    Icon = FontAwesome.Solid.Ban,
-                                    Colour = Color4.Red,
-                                    Size = new Vector2(30),
-                                    Shadow = true,
-                                    Alpha = 0
+                                    Position = new Vector2(-13),
                                 }
                             },
                             RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -311,6 +311,6 @@ namespace osu.Game.Overlays.Mods
 
         public ITooltip GetCustomTooltip() => new ModButtonTooltip();
 
-        public object TooltipContent => SelectedMod ?? Mods[0];
+        public object TooltipContent => SelectedMod ?? Mods.FirstOrDefault();
     }
 }

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -286,7 +286,6 @@ namespace osu.Game.Overlays.Mods
                     },
                 });
             }
-
             else
             {
                 iconsContainer.Add(foregroundIcon = new ModIcon(Mod, false)

--- a/osu.Game/Overlays/Mods/ModButtonTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModButtonTooltip.cs
@@ -13,7 +13,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
 
@@ -80,35 +79,6 @@ namespace osu.Game.Overlays.Mods
 
         protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
         protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
-
-        private Drawable getModItem(Mod mod)
-        {
-            return new FillFlowContainer
-            {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                AutoSizeAxes = Axes.Both,
-                Direction = FillDirection.Horizontal,
-                Children = new Drawable[]
-                {
-                    new ModIcon(mod, false)
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        AutoSizeAxes = Axes.Both,
-                        Scale = new Vector2(0.4f)
-                    },
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Margin = new MarginPadding { Left = 5 },
-                        Font = OsuFont.GetFont(weight: FontWeight.Regular),
-                        Text = mod.Name,
-                    },
-                }
-            };
-        }
 
         private string lastMod;
 

--- a/osu.Game/Overlays/Mods/ModButtonTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModButtonTooltip.cs
@@ -80,16 +80,16 @@ namespace osu.Game.Overlays.Mods
         protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
         protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
 
-        private string lastMod;
+        private Mod lastMod;
 
         public bool SetContent(object content)
         {
             if (!(content is Mod mod))
                 return false;
 
-            if (mod.Acronym == lastMod) return true;
+            if (mod.Equals(lastMod)) return true;
 
-            lastMod = mod.Acronym;
+            lastMod = mod;
 
             descriptionText.Text = mod.Description;
 

--- a/osu.Game/Overlays/Mods/ModButtonTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModButtonTooltip.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Overlays.Mods
 
             var allMods = ruleset.Value.CreateInstance().GetAllMods();
 
-            incompatibleMods.Value = allMods.Where(m => incompatibleTypes.Any(t => t.IsInstanceOfType(m))).ToList();
+            incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).ToList();
 
             if (!incompatibleMods.Value.Any())
             {

--- a/osu.Game/Overlays/Mods/ModButtonTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModButtonTooltip.cs
@@ -1,0 +1,145 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play.HUD;
+using osuTK;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class ModButtonTooltip : VisibilityContainer, ITooltip
+    {
+        private readonly OsuSpriteText descriptionText;
+        private readonly Box background;
+        private readonly OsuSpriteText incompatibleText;
+
+        private readonly Bindable<IReadOnlyList<Mod>> incompatibleMods = new Bindable<IReadOnlyList<Mod>>();
+
+        [Resolved]
+        private Bindable<RulesetInfo> ruleset { get; set; }
+
+        public ModButtonTooltip()
+        {
+            AutoSizeAxes = Axes.Both;
+            Masking = true;
+            CornerRadius = 5;
+
+            Children = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding { Left = 10, Right = 10, Top = 5, Bottom = 5 },
+                    Children = new Drawable[]
+                    {
+                        descriptionText = new OsuSpriteText
+                        {
+                            Font = OsuFont.GetFont(weight: FontWeight.Regular),
+                            Margin = new MarginPadding { Bottom = 5 }
+                        },
+                        incompatibleText = new OsuSpriteText
+                        {
+                            Font = OsuFont.GetFont(weight: FontWeight.Regular),
+                            Text = "Incompatible with:"
+                        },
+                        new ModDisplay
+                        {
+                            Current = incompatibleMods,
+                            ExpansionMode = ExpansionMode.AlwaysExpanded,
+                            Scale = new Vector2(0.7f)
+                        }
+                    }
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            background.Colour = colours.Gray3;
+            descriptionText.Colour = colours.BlueLighter;
+            incompatibleText.Colour = colours.BlueLight;
+        }
+
+        protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
+        protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
+
+        private Drawable getModItem(Mod mod)
+        {
+            return new FillFlowContainer
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Children = new Drawable[]
+                {
+                    new ModIcon(mod, false)
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        AutoSizeAxes = Axes.Both,
+                        Scale = new Vector2(0.4f)
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Margin = new MarginPadding { Left = 5 },
+                        Font = OsuFont.GetFont(weight: FontWeight.Regular),
+                        Text = mod.Name,
+                    },
+                }
+            };
+        }
+
+        private string lastMod;
+
+        public bool SetContent(object content)
+        {
+            if (!(content is Mod mod))
+                return false;
+
+            if (mod.Acronym == lastMod) return true;
+
+            lastMod = mod.Acronym;
+
+            descriptionText.Text = mod.Description;
+
+            var incompatibleTypes = mod.IncompatibleMods;
+
+            var allMods = ruleset.Value.CreateInstance().GetAllMods();
+
+            incompatibleMods.Value = allMods.Where(m => incompatibleTypes.Any(t => t.IsInstanceOfType(m))).ToList();
+
+            if (!incompatibleMods.Value.Any())
+            {
+                incompatibleText.Text = "Compatible with all mods";
+                return true;
+            }
+
+            incompatibleText.Text = "Incompatible with:";
+
+            return true;
+        }
+
+        public void Move(Vector2 pos) => Position = pos;
+    }
+}

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Overlays.Mods
 
         protected readonly ModSettingsContainer ModSettingsContainer;
 
+        [Cached]
         public readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         private Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods;


### PR DESCRIPTION
Based on discussion #14304 

A red tint is applied to mods that are incompatible with the current selection. It is purely visual and the buttons are still clickable.
![image](https://user-images.githubusercontent.com/25472513/130340606-c6473794-946b-43d4-8134-7d0f1794191b.png)

The tooltip of mod buttons also lists all the mods that are incompatible. The mods are listed in small icon form to keep the tooltip reasonably sized.
![image](https://user-images.githubusercontent.com/25472513/130340630-d191e7c2-ebc4-4c52-accb-0c06275c86bc.png)

