### PR TITLE
Add null check for Android ruleset loading

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -30,7 +30,13 @@ namespace osu.Game.Rulesets
             // On android in release configuration assemblies are loaded from the apk directly into memory.
             // We cannot read assemblies from cwd, so should check loaded assemblies instead.
             loadFromAppDomain();
-            loadFromDisk();
+
+            // This null check prevents Android from attempting to load the rulesets from disk.
+            // RuntimeInfo.StartupDirectory returns null on Android, and returns a path on other platforms.
+            if (RuntimeInfo.StartupDirectory != null)
+            {
+                loadFromDisk();
+            }
 
             // the event handler contains code for resolving dependency on the game assembly for rulesets located outside the base game directory.
             // It needs to be attached to the assembly lookup event before the actual call to loadUserRulesets() else rulesets located out of the base game directory will fail

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -31,12 +31,11 @@ namespace osu.Game.Rulesets
             // We cannot read assemblies from cwd, so should check loaded assemblies instead.
             loadFromAppDomain();
 
-            // This null check prevents Android from attempting to load the rulesets from disk.
-            // RuntimeInfo.StartupDirectory returns null on Android, and returns a path on other platforms.
+            // This null check prevents Android from attempting to load the rulesets from disk,
+            // as the underlying path "AppContext.BaseDirectory", despite being non-nullable, it returns null on android.
+            // See https://github.com/xamarin/xamarin-android/issues/3489.
             if (RuntimeInfo.StartupDirectory != null)
-            {
                 loadFromDisk();
-            }
 
             // the event handler contains code for resolving dependency on the game assembly for rulesets located outside the base game directory.
             // It needs to be attached to the assembly lookup event before the actual call to loadUserRulesets() else rulesets located out of the base game directory will fail


### PR DESCRIPTION
Replacement of https://github.com/ppy/osu-framework/pull/4700, closes #6507

This PR adds a check to ensure that the path that `loadFromDisk()` uses is not null. If the path is null, which happens on Android, then the function is not run. This prevents the "Could not load rulesets from directory" error on Android.