### PR TITLE
Add basic design settings to editor setup screen

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Beatmaps
                         BaseDifficulty = new BeatmapDifficulty(),
                         Ruleset = ruleset,
                         Metadata = metadata,
+                        WidescreenStoryboard = true,
                     }
                 }
             };

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -93,8 +93,8 @@ namespace osu.Game.Beatmaps.Formats
             //     writer.WriteLine(@"OverlayPosition: " + b.OverlayPosition);
             // if (!string.IsNullOrEmpty(b.SkinPreference))
             //     writer.WriteLine(@"SkinPreference:" + b.SkinPreference);
-            // if (b.EpilepsyWarning)
-            //     writer.WriteLine(@"EpilepsyWarning: 1");
+            if (beatmap.BeatmapInfo.EpilepsyWarning)
+                writer.WriteLine(@"EpilepsyWarning: 1");
             // if (b.CountdownOffset > 0)
             //     writer.WriteLine(@"CountdownOffset: " + b.CountdownOffset.ToString());
             if (beatmap.BeatmapInfo.RulesetID == 3)

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Screens.Edit.Setup
                 widescreenSupport = new LabelledSwitchButton
                 {
                     Label = "Widescreen support",
+                    Description = "Allows storyboards to use the full screen space, rather than be confined to a 4:3 area.",
                     Current = { Value = Beatmap.BeatmapInfo.WidescreenStoryboard }
                 },
                 epilepsyWarning = new LabelledSwitchButton
@@ -34,6 +35,7 @@ namespace osu.Game.Screens.Edit.Setup
                 letterboxDuringBreaks = new LabelledSwitchButton
                 {
                     Label = "Letterbox during breaks",
+                    Description = "Adds horizontal letterboxing to give a cinematic look during breaks.",
                     Current = { Value = Beatmap.BeatmapInfo.LetterboxInBreaks }
                 }
             };

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Setup
                 epilepsyWarning = new LabelledSwitchButton
                 {
                     Label = "Epilepsy warning",
-                    Description = "Setting this is recommended if the storyboard contains scenes with rapidly flashing colours.",
+                    Description = "Recommended if the storyboard contains scenes with rapidly flashing colours.",
                     Current = { Value = Beatmap.BeatmapInfo.EpilepsyWarning }
                 },
                 letterboxDuringBreaks = new LabelledSwitchButton

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Setup
                 epilepsyWarning = new LabelledSwitchButton
                 {
                     Label = "Epilepsy warning",
-                    Description = "Recommended if the storyboard contains scenes with rapidly flashing colours.",
+                    Description = "Recommended if the storyboard or video contain scenes with rapidly flashing colours.",
                     Current = { Value = Beatmap.BeatmapInfo.EpilepsyWarning }
                 },
                 letterboxDuringBreaks = new LabelledSwitchButton

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    internal class DesignSection : SetupSection
+    {
+        private LabelledSwitchButton widescreenSupport;
+        private LabelledSwitchButton epilepsyWarning;
+        private LabelledSwitchButton letterboxDuringBreaks;
+
+        public override LocalisableString Title => "Design";
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new[]
+            {
+                widescreenSupport = new LabelledSwitchButton
+                {
+                    Label = "Widescreen support",
+                    Current = { Value = Beatmap.BeatmapInfo.WidescreenStoryboard }
+                },
+                epilepsyWarning = new LabelledSwitchButton
+                {
+                    Label = "Epilepsy warning",
+                    Description = "Setting this is recommended if the storyboard contains scenes with rapidly flashing colours.",
+                    Current = { Value = Beatmap.BeatmapInfo.EpilepsyWarning }
+                },
+                letterboxDuringBreaks = new LabelledSwitchButton
+                {
+                    Label = "Letterbox during breaks",
+                    Current = { Value = Beatmap.BeatmapInfo.LetterboxInBreaks }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            widescreenSupport.Current.BindValueChanged(_ => updateBeatmap());
+            epilepsyWarning.Current.BindValueChanged(_ => updateBeatmap());
+            letterboxDuringBreaks.Current.BindValueChanged(_ => updateBeatmap());
+        }
+
+        private void updateBeatmap()
+        {
+            Beatmap.BeatmapInfo.WidescreenStoryboard = widescreenSupport.Current.Value;
+            Beatmap.BeatmapInfo.EpilepsyWarning = epilepsyWarning.Current.Value;
+            Beatmap.BeatmapInfo.LetterboxInBreaks = letterboxDuringBreaks.Current.Value;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -34,7 +34,8 @@ namespace osu.Game.Screens.Edit.Setup
                         new ResourcesSection(),
                         new MetadataSection(),
                         new DifficultySection(),
-                        new ColoursSection()
+                        new ColoursSection(),
+                        new DesignSection(),
                     }
                 },
             });


### PR DESCRIPTION
Only the ones that don't require any satellite changes and can be added directly, namely: widescreen storyboard, epilepsy warning and letterboxing during breaks.

![osu_2021-08-22_17-51-36](https://user-images.githubusercontent.com/20418176/130361594-a89bed46-b37f-48c5-96e1-7a6bbc08a075.jpg)

Combo fire isn't added back as it is obsolete.

Countdown settings will be coming in separate upcoming pulls (even though there is no support whatsoever in player yet). The same goes for the rest of setup screen settings that are there on stable (barring audio tab, because I don't know what to do with that one).
