### PR TITLE
Fix BPM display not updating if rate-changing mods were enabled after selecting beatmap

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using NUnit.Framework;
@@ -11,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -19,6 +21,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Select;
 using osuTK;
@@ -139,6 +142,29 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestTruncation()
         {
             selectBeatmap(createLongMetadata());
+        }
+
+        [Test]
+        public void TestBPMUpdates()
+        {
+            const float bpm = 120;
+            IBeatmap beatmap = createTestBeatmap(new OsuRuleset().RulesetInfo);
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 60 * 1000 / bpm });
+
+            OsuModDoubleTime doubleTime = null;
+
+            selectBeatmap(beatmap);
+            checkDisplayedBPM(bpm);
+
+            AddStep("select DT", () => SelectedMods.Value = new[] { doubleTime = new OsuModDoubleTime() });
+            checkDisplayedBPM(bpm * 1.5f);
+
+            AddStep("change DT rate", () => doubleTime.SpeedChange.Value = 2);
+            checkDisplayedBPM(bpm * 2);
+
+            void checkDisplayedBPM(float target) =>
+                AddUntilStep($"displayed bpm is {target}", () => this.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Any(
+                    label => label.Statistic.Name == "BPM" && label.Statistic.Content == target.ToString(CultureInfo.InvariantCulture)));
         }
 
         private void selectBeatmap([CanBeNull] IBeatmap b)

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -71,6 +71,7 @@ namespace osu.Game.Screens.Select
         private void load()
         {
             ruleset.BindValueChanged(_ => updateDisplay());
+            mods.BindValueChanged(_ => updateDisplay());
         }
 
         private const double animation_duration = 800;

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -449,8 +449,11 @@ namespace osu.Game.Screens.Select
             {
                 public LocalisableString TooltipText { get; }
 
+                internal BeatmapStatistic Statistic { get; }
+
                 public InfoLabel(BeatmapStatistic statistic)
                 {
+                    Statistic = statistic;
                     TooltipText = statistic.Name;
                     AutoSizeAxes = Axes.Both;
 


### PR DESCRIPTION
Closes #14446.

The BPM display already updated correctly prior to b419ea7, but in a very roundabout way. Changes to the value of the star difficulty bindable - including indirect changes via the set of active mods changing - would trigger the wedge display to regenerate and load asynchronously, and that included the BPM display.

b419ea7 accidentally broke this by moving down the bindable retrieval to a lower level, at which point `WedgeInfoText` would only receive the set of mods selected at the time at which a given beatmap was selected, and not receive any further updates, breaking the BPM display updating in real time (as `WedgeInfoText` could not be aware that rate-changing mods were even in effect).

To resolve, explicitly reload the wedge's contents on mod changes.