### PR TITLE
Show editor file choosers in a popover rather than inline

### DIFF
--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -31,11 +31,6 @@ namespace osu.Game.Screens.Edit.Setup
 
         public IEnumerable<string> HandledExtensions => handledExtensions;
 
-        /// <summary>
-        /// The target container to display the file chooser in.
-        /// </summary>
-        public Container Target;
-
         private readonly Bindable<FileInfo> currentFile = new Bindable<FileInfo>();
 
         [Resolved]
@@ -72,7 +67,7 @@ namespace osu.Game.Screens.Edit.Setup
             if (file.NewValue == null)
                 return;
 
-            Target.Clear();
+            this.HidePopover();
             Current.Value = file.NewValue.FullName;
         }
 

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -8,22 +8,27 @@ using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Database;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
 {
     /// <summary>
     /// A labelled textbox which reveals an inline file chooser when clicked.
     /// </summary>
-    internal class FileChooserLabelledTextBox : LabelledTextBox, ICanAcceptFiles
+    internal class FileChooserLabelledTextBox : LabelledTextBox, ICanAcceptFiles, IHasPopover
     {
         private readonly string[] handledExtensions;
+
         public IEnumerable<string> HandledExtensions => handledExtensions;
 
         /// <summary>
@@ -51,22 +56,8 @@ namespace osu.Game.Screens.Edit.Setup
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.X,
                 CornerRadius = CORNER_RADIUS,
-                OnFocused = DisplayFileChooser
+                OnFocused = this.ShowPopover
             };
-
-        public void DisplayFileChooser()
-        {
-            OsuFileSelector fileSelector;
-
-            Target.Child = fileSelector = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 400,
-                CurrentFile = { BindTarget = currentFile }
-            };
-
-            sectionsContainer.ScrollTo(fileSelector);
-        }
 
         protected override void LoadComplete()
         {
@@ -109,6 +100,24 @@ namespace osu.Game.Screens.Edit.Setup
                 base.OnFocus(e);
 
                 GetContainingInputManager().TriggerFocusContention(this);
+            }
+        }
+
+        public Popover GetPopover() => new FileChooserPopover(handledExtensions, currentFile);
+
+        private class FileChooserPopover : OsuPopover
+        {
+            public FileChooserPopover(string[] handledExtensions, Bindable<FileInfo> currentFile)
+            {
+                Child = new Container
+                {
+                    Size = new Vector2(600, 400),
+                    Child = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        CurrentFile = { BindTarget = currentFile }
+                    },
+                };
             }
         }
     }

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -39,61 +38,29 @@ namespace osu.Game.Screens.Edit.Setup
         [BackgroundDependencyLoader]
         private void load()
         {
-            Container audioTrackFileChooserContainer = createFileChooserContainer();
-            Container backgroundFileChooserContainer = createFileChooserContainer();
-
             Children = new Drawable[]
             {
-                new FillFlowContainer
+                backgroundTextBox = new FileChooserLabelledTextBox(".jpg", ".jpeg", ".png")
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    Children = new Drawable[]
-                    {
-                        backgroundTextBox = new FileChooserLabelledTextBox(".jpg", ".jpeg", ".png")
-                        {
-                            Label = "Background",
-                            FixedLabelWidth = LABEL_WIDTH,
-                            PlaceholderText = "Click to select a background image",
-                            Current = { Value = working.Value.Metadata.BackgroundFile },
-                            Target = backgroundFileChooserContainer,
-                            TabbableContentContainer = this
-                        },
-                        backgroundFileChooserContainer,
-                    }
+                    Label = "Background",
+                    FixedLabelWidth = LABEL_WIDTH,
+                    PlaceholderText = "Click to select a background image",
+                    Current = { Value = working.Value.Metadata.BackgroundFile },
+                    TabbableContentContainer = this
                 },
-                new FillFlowContainer
+                audioTrackTextBox = new FileChooserLabelledTextBox(".mp3", ".ogg")
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    Children = new Drawable[]
-                    {
-                        audioTrackTextBox = new FileChooserLabelledTextBox(".mp3", ".ogg")
-                        {
-                            Label = "Audio Track",
-                            FixedLabelWidth = LABEL_WIDTH,
-                            PlaceholderText = "Click to select a track",
-                            Current = { Value = working.Value.Metadata.AudioFile },
-                            Target = audioTrackFileChooserContainer,
-                            TabbableContentContainer = this
-                        },
-                        audioTrackFileChooserContainer,
-                    }
-                }
+                    Label = "Audio Track",
+                    FixedLabelWidth = LABEL_WIDTH,
+                    PlaceholderText = "Click to select a track",
+                    Current = { Value = working.Value.Metadata.AudioFile },
+                    TabbableContentContainer = this
+                },
             };
 
             backgroundTextBox.Current.BindValueChanged(backgroundChanged);
             audioTrackTextBox.Current.BindValueChanged(audioTrackChanged);
         }
-
-        private static Container createFileChooserContainer() =>
-            new Container
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-            };
 
         public bool ChangeBackgroundImage(string path)
         {


### PR DESCRIPTION
Supersedes and closes #14370.
Closes #14367.

There's some issues with display, but that goes for all popovers at the moment, and will be resolved by localising the `PopoverContainer`s. This can come as a separate step I think.

https://user-images.githubusercontent.com/191335/130422688-cb1dc498-d3d7-4e43-a3b8-4cf83ff6f92a.mp4

