### PR TITLE
Fix settings section not being selected when the search term changes

### DIFF
--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -202,8 +202,6 @@ namespace osu.Game.Graphics.Containers
             });
         }
 
-        private int lastKnownChildrenCount;
-
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
@@ -222,12 +220,10 @@ namespace osu.Game.Graphics.Containers
             }
 
             float currentScroll = scrollContainer.Current;
-            var presentChildren = Children.Where(c => c.IsPresent);
 
-            if (currentScroll != lastKnownScroll || presentChildren.Count() != lastKnownChildrenCount)
+            if (currentScroll != lastKnownScroll)
             {
                 lastKnownScroll = currentScroll;
-                lastKnownChildrenCount = presentChildren.Count();
 
                 // reset last clicked section because user started scrolling themselves
                 if (scrollContainer.UserScrolling)
@@ -252,6 +248,8 @@ namespace osu.Game.Graphics.Containers
                 float selectionLenienceAboveSection = Math.Min(smallestSectionHeight / 2.0f, scrollContainer.DisplayableContent * 0.05f);
 
                 float scrollCentre = fixedHeaderSize + scrollContainer.DisplayableContent * scroll_y_centre + selectionLenienceAboveSection;
+
+                var presentChildren = Children.Where(c => c.IsPresent);
 
                 if (lastClickedSection != null)
                     SelectedSection.Value = lastClickedSection;

--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -202,6 +202,8 @@ namespace osu.Game.Graphics.Containers
             });
         }
 
+        private int lastKnownChildrenCount = 0;
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
@@ -220,10 +222,12 @@ namespace osu.Game.Graphics.Containers
             }
 
             float currentScroll = scrollContainer.Current;
+            var presentChildren = Children.Where(c => c.IsPresent);
 
-            if (currentScroll != lastKnownScroll)
+            if (currentScroll != lastKnownScroll || presentChildren.Count() != lastKnownChildrenCount)
             {
                 lastKnownScroll = currentScroll;
+                lastKnownChildrenCount = presentChildren.Count();
 
                 // reset last clicked section because user started scrolling themselves
                 if (scrollContainer.UserScrolling)
@@ -248,8 +252,6 @@ namespace osu.Game.Graphics.Containers
                 float selectionLenienceAboveSection = Math.Min(smallestSectionHeight / 2.0f, scrollContainer.DisplayableContent * 0.05f);
 
                 float scrollCentre = fixedHeaderSize + scrollContainer.DisplayableContent * scroll_y_centre + selectionLenienceAboveSection;
-
-                var presentChildren = Children.Where(c => c.IsPresent);
 
                 if (lastClickedSection != null)
                     SelectedSection.Value = lastClickedSection;

--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Graphics.Containers
             });
         }
 
-        private int lastKnownChildrenCount = 0;
+        private int lastKnownChildrenCount;
 
         protected override void UpdateAfterChildren()
         {

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Overlays
 
                 loading.Hide();
 
-                searchTextBox.Current.BindValueChanged(term => SectionsContainer.SearchContainer.SearchTerm = term.NewValue, true);
+                searchTextBox.Current.BindValueChanged(term => SectionsContainer.SearchTerm = term.NewValue, true);
                 searchTextBox.TakeFocus();
 
                 loadSidebarButtons();


### PR DESCRIPTION
Currently in `SectionsContainer` the selected section only updates on scroll. This PR makes it so the selected section also updates when the number of present children change (for instance when the search term changes)

Master:
https://user-images.githubusercontent.com/10225220/130475573-64e08ce0-1884-4fcd-87ca-415afcd4e5f5.mp4

This change:
https://user-images.githubusercontent.com/10225220/130475578-2178291e-228b-46a7-9df1-0c09aca66f29.mp4

