### PR TITLE
Fix crash when entering multiplayer gameplay

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Tests.Resources
 {
     public static class TestResources
     {
+        public const double QUICK_BEATMAP_LENGTH = 10000;
+
         public static DllResourceStore GetStore() => new DllResourceStore(typeof(TestResources).Assembly);
 
         public static Stream OpenResource(string name) => GetStore().GetStream($"Resources/{name}");

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneGameplayChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneGameplayChatDisplay.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             base.SetUpSteps();
 
-            AddStep("load chat display", () => Child = chatDisplay = new GameplayChatDisplay
+            AddStep("load chat display", () => Child = chatDisplay = new GameplayChatDisplay(SelectedRoom.Value)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("initialise gameplay", () =>
             {
-                Stack.Push(player = new MultiplayerPlayer(Client.CurrentMatchPlayingItem.Value, Client.Room?.Users.ToArray()));
+                Stack.Push(player = new MultiplayerPlayer(Client.APIRoom, Client.CurrentMatchPlayingItem.Value, Client.Room?.Users.ToArray()));
             });
         }
 

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
@@ -10,21 +10,21 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 {
     public class MatchChatDisplay : StandAloneChatDisplay
     {
-        [Resolved(typeof(Room), nameof(Room.RoomID))]
-        private Bindable<long?> roomId { get; set; }
-
-        [Resolved(typeof(Room), nameof(Room.ChannelId))]
-        private Bindable<int> channelId { get; set; }
+        private readonly IBindable<long?> roomId = new Bindable<long?>();
+        private readonly IBindable<int> channelId = new Bindable<int>();
 
         [Resolved(CanBeNull = true)]
         private ChannelManager channelManager { get; set; }
 
         private readonly bool leaveChannelOnDispose;
 
-        public MatchChatDisplay(bool leaveChannelOnDispose = true)
+        public MatchChatDisplay(Room room, bool leaveChannelOnDispose = true)
             : base(true)
         {
             this.leaveChannelOnDispose = leaveChannelOnDispose;
+
+            roomId.BindTo(room.RoomID);
+            channelId.BindTo(room.ChannelId);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
@@ -10,36 +10,36 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 {
     public class MatchChatDisplay : StandAloneChatDisplay
     {
-        private readonly IBindable<long?> roomId = new Bindable<long?>();
         private readonly IBindable<int> channelId = new Bindable<int>();
 
         [Resolved(CanBeNull = true)]
         private ChannelManager channelManager { get; set; }
 
+        private readonly Room room;
         private readonly bool leaveChannelOnDispose;
 
         public MatchChatDisplay(Room room, bool leaveChannelOnDispose = true)
             : base(true)
         {
+            this.room = room;
             this.leaveChannelOnDispose = leaveChannelOnDispose;
-
-            roomId.BindTo(room.RoomID);
-            channelId.BindTo(room.ChannelId);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
+            // Required for the time being since this component is created prior to the room being joined.
+            channelId.BindTo(room.ChannelId);
             channelId.BindValueChanged(_ => updateChannel(), true);
         }
 
         private void updateChannel()
         {
-            if (roomId.Value == null || channelId.Value == 0)
+            if (room.RoomID.Value == null || channelId.Value == 0)
                 return;
 
-            Channel.Value = channelManager?.JoinChannel(new Channel { Id = channelId.Value, Type = ChannelType.Multiplayer, Name = $"#lazermp_{roomId.Value}" });
+            Channel.Value = channelManager?.JoinChannel(new Channel { Id = channelId.Value, Type = ChannelType.Multiplayer, Name = $"#lazermp_{room.RoomID.Value}" });
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.Play;
 
@@ -29,8 +30,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         public override bool PropagateNonPositionalInputSubTree => true;
 
-        public GameplayChatDisplay()
-            : base(leaveChannelOnDispose: false)
+        public GameplayChatDisplay(Room room)
+            : base(room, leaveChannelOnDispose: false)
         {
             RelativeSizeAxes = Axes.X;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                 },
                                             },
                                             new Drawable[] { new OverlinedHeader("Chat") { Margin = new MarginPadding { Vertical = 5 }, }, },
-                                            new Drawable[] { new MatchChatDisplay { RelativeSizeAxes = Axes.Both } }
+                                            new Drawable[] { new MatchChatDisplay(Room) { RelativeSizeAxes = Axes.Both } }
                                         },
                                         RowDimensions = new[]
                                         {
@@ -395,7 +395,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     return new MultiSpectatorScreen(users.Take(PlayerGrid.MAX_PLAYERS).ToArray());
 
                 default:
-                    return new PlayerLoader(() => new MultiplayerPlayer(SelectedItem.Value, users));
+                    return new PlayerLoader(() => new MultiplayerPlayer(Room, SelectedItem.Value, users));
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -187,10 +187,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override ResultsScreen CreateResults(ScoreInfo score)
         {
-            Debug.Assert(RoomId.Value != null);
+            Debug.Assert(Room.RoomID.Value != null);
+
             return leaderboard.TeamScores.Count == 2
-                ? new MultiplayerTeamResultsScreen(score, RoomId.Value.Value, PlaylistItem, leaderboard.TeamScores)
-                : new MultiplayerResultsScreen(score, RoomId.Value.Value, PlaylistItem);
+                ? new MultiplayerTeamResultsScreen(score, Room.RoomID.Value.Value, PlaylistItem, leaderboard.TeamScores)
+                : new MultiplayerResultsScreen(score, Room.RoomID.Value.Value, PlaylistItem);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -45,10 +45,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// <summary>
         /// Construct a multiplayer player.
         /// </summary>
+        /// <param name="room">The room.</param>
         /// <param name="playlistItem">The playlist item to be played.</param>
         /// <param name="users">The users which are participating in this game.</param>
-        public MultiplayerPlayer(PlaylistItem playlistItem, MultiplayerRoomUser[] users)
-            : base(playlistItem, new PlayerConfiguration
+        public MultiplayerPlayer(Room room, PlaylistItem playlistItem, MultiplayerRoomUser[] users)
+            : base(room, playlistItem, new PlayerConfiguration
             {
                 AllowPause = false,
                 AllowRestart = false,
@@ -92,7 +93,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 }
             });
 
-            LoadComponentAsync(new GameplayChatDisplay
+            LoadComponentAsync(new GameplayChatDisplay(Room)
             {
                 Expanded = { BindTarget = HUDOverlay.ShowHud },
             }, chat => leaderboardFlow.Insert(2, chat));

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
     {
         public Action Exited;
 
-        public PlaylistsPlayer(PlaylistItem playlistItem, PlayerConfiguration configuration = null)
-            : base(playlistItem, configuration)
+        public PlaylistsPlayer(Room room, PlaylistItem playlistItem, PlayerConfiguration configuration = null)
+            : base(room, playlistItem, configuration)
         {
         }
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -51,8 +51,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override ResultsScreen CreateResults(ScoreInfo score)
         {
-            Debug.Assert(RoomId.Value != null);
-            return new PlaylistsResultsScreen(score, RoomId.Value.Value, PlaylistItem, true);
+            Debug.Assert(Room.RoomID.Value != null);
+            return new PlaylistsResultsScreen(score, Room.RoomID.Value.Value, PlaylistItem, true);
         }
 
         protected override async Task PrepareScoreForResultsAsync(Score score)

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                             },
                             new Drawable[] { leaderboard = new MatchLeaderboard { RelativeSizeAxes = Axes.Both }, },
                             new Drawable[] { new OverlinedHeader("Chat"), },
-                            new Drawable[] { new MatchChatDisplay { RelativeSizeAxes = Axes.Both } }
+                            new Drawable[] { new MatchChatDisplay(Room) { RelativeSizeAxes = Axes.Both } }
                         },
                         RowDimensions = new[]
                         {
@@ -199,7 +199,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             Logger.Log($"Polling adjusted (selection: {selectionPollingComponent.TimeBetweenPolls.Value})");
         }
 
-        protected override Screen CreateGameplayScreen() => new PlayerLoader(() => new PlaylistsPlayer(SelectedItem.Value)
+        protected override Screen CreateGameplayScreen() => new PlayerLoader(() => new PlaylistsPlayer(Room, SelectedItem.Value)
         {
             Exited = () => leaderboard.RefreshScores()
         });

--- a/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
+using System.Diagnostics;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
@@ -13,8 +13,6 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public abstract class RoomSubmittingPlayer : SubmittingPlayer
     {
-        protected readonly IBindable<long?> RoomId = new Bindable<long?>();
-
         protected readonly PlaylistItem PlaylistItem;
         protected readonly Room Room;
 
@@ -23,18 +21,20 @@ namespace osu.Game.Screens.Play
         {
             Room = room;
             PlaylistItem = playlistItem;
-
-            RoomId.BindTo(room.RoomID);
         }
 
         protected override APIRequest<APIScoreToken> CreateTokenRequest()
         {
-            if (!(RoomId.Value is long roomId))
+            if (!(Room.RoomID.Value is long roomId))
                 return null;
 
             return new CreateRoomScoreRequest(roomId, PlaylistItem.ID, Game.VersionHash);
         }
 
-        protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token) => new SubmitRoomScoreRequest(token, RoomId.Value ?? 0, PlaylistItem.ID, score.ScoreInfo);
+        protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token)
+        {
+            Debug.Assert(Room.RoomID.Value != null);
+            return new SubmitRoomScoreRequest(token, Room.RoomID.Value.Value, PlaylistItem.ID, score.ScoreInfo);
+        }
     }
 }

--- a/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -14,15 +13,18 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public abstract class RoomSubmittingPlayer : SubmittingPlayer
     {
-        [Resolved(typeof(Room), nameof(Room.RoomID))]
-        protected Bindable<long?> RoomId { get; private set; }
+        protected readonly IBindable<long?> RoomId = new Bindable<long?>();
 
         protected readonly PlaylistItem PlaylistItem;
+        protected readonly Room Room;
 
-        protected RoomSubmittingPlayer(PlaylistItem playlistItem, PlayerConfiguration configuration = null)
+        protected RoomSubmittingPlayer(Room room, PlaylistItem playlistItem, PlayerConfiguration configuration = null)
             : base(configuration)
         {
+            Room = room;
             PlaylistItem = playlistItem;
+
+            RoomId.BindTo(room.RoomID);
         }
 
         protected override APIRequest<APIScoreToken> CreateTokenRequest()


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/14473

Contrary to `DrawableRoom`/`RoomSubScreen`, I've gone with not caching the `Room` in `RoomSubmittingPlayer` because it's only used in one sub-component for the time being.