### PR TITLE
Fix gameplay HUD load not always completing if initially hidden

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -142,7 +142,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("set hud to never show", () => localConfig.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
 
             createNew();
+
             AddUntilStep("wait for hud load", () => hudOverlay.IsLoaded);
+            AddUntilStep("wait for components to be hidden", () => !hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().IsPresent);
+
+            AddStep("reload components", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().Reload());
             AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().ComponentsLoaded);
         }
 

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Skinning
 
         private readonly BindableList<ISkinnableDrawable> components = new BindableList<ISkinnableDrawable>();
 
-        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks; // ensure that components are loaded even if the target container is hidden (ie. due to user toggle).
 
         public bool ComponentsLoaded { get; private set; }
 

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Skinning
 
         private readonly BindableList<ISkinnableDrawable> components = new BindableList<ISkinnableDrawable>();
 
+        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
         public bool ComponentsLoaded { get; private set; }
 
         public SkinnableTargetContainer(SkinnableTarget target)


### PR DESCRIPTION
This test was added in https://github.com/ppy/osu/pull/14337 to show that the failure case had been fixed. The PR set the expectation that HUD components should complete their load even if the HUD is set to not visible. However the test only passed because `ShowHud` animates the fadeout of components over 300ms such that there is a period where load can complete during the fadeout.
The failure case had not actually been fixed and we've been having intermittent test failures such as https://github.com/ppy/osu/pull/14474/checks?check_run_id=3407903613 since.

I'm not sure if there's a better way to do this than `Reload()` - ideally I'd like to inject some long-running-load component and control everything precisely, but this structure doesn't seem to lend itself to that. Accepting suggestions.