### PR TITLE
Improve `DifficultyAdjustSettingsControl` current bindable transferal logic

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Overlays.Settings
         {
             public ControlDoesNotImplementCurrentException()
                 : base(@$"Control created via {nameof(CreateControl)} must implement {nameof(IHasCurrentValue<T>)}, "
-                       + @$"or override {nameof(Current)} on this item for custom implementation.")
+                       + @$"or, if custom implementation is intended, override {nameof(Current)} on this item instead.")
             {
             }
         }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -158,8 +158,7 @@ namespace osu.Game.Overlays.Settings
         private class ControlDoesNotImplementCurrentException : InvalidOperationException
         {
             public ControlDoesNotImplementCurrentException()
-                : base(@$"Control created via {nameof(CreateControl)} must implement {nameof(IHasCurrentValue<T>)}, "
-                       + @$"or, if custom implementation is intended, override {nameof(Current)} on this item instead.")
+                : base(@$"Control created via {nameof(CreateControl)} must implement {nameof(IHasCurrentValue<T>)}")
             {
             }
         }

--- a/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Settings;
@@ -38,8 +37,6 @@ namespace osu.Game.Rulesets.Mods
         /// When there is no override (ie. <see cref="Current"/> is null), this value will match the beatmap provided default via <see cref="updateCurrentFromSlider"/>.
         /// </remarks>
         private BindableNumber<float> sliderDisplayCurrent => current.DisplayBindable;
-
-        protected override Drawable CreateControl() => new SliderControl(sliderDisplayCurrent);
 
         protected override void LoadComplete()
         {
@@ -80,6 +77,12 @@ namespace osu.Game.Rulesets.Mods
             isInternalChange = false;
         }
 
+        protected override Drawable CreateControl() => new SettingsSlider<float>
+        {
+            ShowsDefaultIndicator = false,
+            Current = sliderDisplayCurrent,
+        };
+
         private class DifficultyBindableWithCurrent : DifficultyBindable, IHasCurrentValue<float?>
         {
             private Bindable<float?> currentBound;
@@ -103,24 +106,6 @@ namespace osu.Game.Rulesets.Mods
             }
 
             protected override Bindable<float?> CreateInstance() => new DifficultyBindableWithCurrent();
-        }
-
-        private class SliderControl : CompositeDrawable
-        {
-            public SliderControl(BindableNumber<float> currentNumber)
-            {
-                InternalChildren = new Drawable[]
-                {
-                    new SettingsSlider<float>
-                    {
-                        ShowsDefaultIndicator = false,
-                        Current = currentNumber,
-                    }
-                };
-
-                AutoSizeAxes = Axes.Y;
-                RelativeSizeAxes = Axes.X;
-            }
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/DifficultyBindable.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyBindable.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         /// An internal numeric bindable to hold and propagate min/max/precision.
         /// The value of this bindable should not be set.
         /// </summary>
-        internal readonly BindableFloat CurrentNumber = new BindableFloat
+        internal readonly BindableFloat DisplayBindable = new BindableFloat
         {
             MinValue = 0,
             MaxValue = 10,
@@ -31,12 +31,12 @@ namespace osu.Game.Rulesets.Mods
 
         public float Precision
         {
-            set => CurrentNumber.Precision = value;
+            set => DisplayBindable.Precision = value;
         }
 
         public float MinValue
         {
-            set => CurrentNumber.MinValue = value;
+            set => DisplayBindable.MinValue = value;
         }
 
         private float maxValue;
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Mods
             {
                 // Ensure that in the case serialisation runs in the wrong order (and limit extensions aren't applied yet) the deserialised value is still propagated.
                 if (value != null)
-                    CurrentNumber.MaxValue = MathF.Max(CurrentNumber.MaxValue, value.Value);
+                    DisplayBindable.MaxValue = MathF.Max(DisplayBindable.MaxValue, value.Value);
 
                 base.Value = value;
             }
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Mods
 
         private void updateMaxValue()
         {
-            CurrentNumber.MaxValue = ExtendedLimits.Value && extendedMaxValue != null ? extendedMaxValue.Value : maxValue;
+            DisplayBindable.MaxValue = ExtendedLimits.Value && extendedMaxValue != null ? extendedMaxValue.Value : maxValue;
         }
 
         public override void BindTo(Bindable<float?> them)
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Mods
             ExtendedLimits.BindTarget = otherDifficultyBindable.ExtendedLimits;
 
             // the actual values need to be copied after the max value constraints.
-            CurrentNumber.BindTarget = otherDifficultyBindable.CurrentNumber;
+            DisplayBindable.BindTarget = otherDifficultyBindable.DisplayBindable;
             base.BindTo(them);
         }
 
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Mods
 
             base.UnbindFrom(them);
 
-            CurrentNumber.UnbindFrom(otherDifficultyBindable.CurrentNumber);
+            DisplayBindable.UnbindFrom(otherDifficultyBindable.DisplayBindable);
             ExtendedLimits.UnbindFrom(otherDifficultyBindable.ExtendedLimits);
         }
 


### PR DESCRIPTION
Closes #14471 

The fix for the exception in the linked issue was to define a `DifficultyBindableWithCurrent` that inherits from `DifficultyBindable` but has similar logic to `BindableWithCurrent`, instead of using `BindableWithCurrent` directly and binding it to `DifficultyBindable`s which caused that exception.

I've also refactored `DifficultyAdjustSettingsControl` a touch to not be required to implement a weird `float? Current` bindable in the underlying slider control, and simplified a bit of things in result thanks to the implemented `DifficultyBindable.BindTo` logic that allows it.

Note that the reason the `UnbindFrom` exception in the mentioned issue thread doesn't appear without a debugger is because `Drawable` intentionally catches exceptions and doesn't perform any actions about them, with the comment "Execution should continue regardless of whether an unbind failed".

https://github.com/ppy/osu-framework/blob/bcf1047e981e40cdfc63233b5a0fdd7f5eeac832/osu.Framework/Graphics/Drawable.cs#L146-L159

---

I've tested all the possible scenarios I can think of (solo and multiplayer) just to make sure there are no regressions, and everything looks to be alright.