### PR TITLE
Add countdown settings to beatmap info

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -58,12 +58,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual("03. Renatus - Soleily 192kbps.mp3", metadata.AudioFile);
                 Assert.AreEqual(0, beatmapInfo.AudioLeadIn);
                 Assert.AreEqual(164471, metadata.PreviewTime);
-                Assert.IsFalse(beatmapInfo.Countdown);
                 Assert.AreEqual(0.7f, beatmapInfo.StackLeniency);
                 Assert.IsTrue(beatmapInfo.RulesetID == 0);
                 Assert.IsFalse(beatmapInfo.LetterboxInBreaks);
                 Assert.IsFalse(beatmapInfo.SpecialStyle);
                 Assert.IsFalse(beatmapInfo.WidescreenStoryboard);
+                Assert.AreEqual(CountdownType.None, beatmapInfo.Countdown);
+                Assert.AreEqual(0, beatmapInfo.CountdownOffset);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -50,12 +50,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var beatmap = decodeAsJson(normal);
             var beatmapInfo = beatmap.BeatmapInfo;
             Assert.AreEqual(0, beatmapInfo.AudioLeadIn);
-            Assert.AreEqual(false, beatmapInfo.Countdown);
             Assert.AreEqual(0.7f, beatmapInfo.StackLeniency);
             Assert.AreEqual(false, beatmapInfo.SpecialStyle);
             Assert.IsTrue(beatmapInfo.RulesetID == 0);
             Assert.AreEqual(false, beatmapInfo.LetterboxInBreaks);
             Assert.AreEqual(false, beatmapInfo.WidescreenStoryboard);
+            Assert.AreEqual(CountdownType.None, beatmapInfo.Countdown);
+            Assert.AreEqual(0, beatmapInfo.CountdownOffset);
         }
 
         [Test]

--- a/osu.Game.Tests/Resources/countdown-settings.osu
+++ b/osu.Game.Tests/Resources/countdown-settings.osu
@@ -1,0 +1,5 @@
+osu file format v14
+
+[General]
+Countdown: 2
+CountdownOffset: 3

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -95,6 +95,10 @@ namespace osu.Game.Beatmaps
         public bool EpilepsyWarning { get; set; }
 
         public CountdownType Countdown { get; set; } = CountdownType.Normal;
+
+        /// <summary>
+        /// The number of beats to move the countdown backwards (compared to its default location).
+        /// </summary>
         public int CountdownOffset { get; set; }
 
         // Editor

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -83,7 +83,6 @@ namespace osu.Game.Beatmaps
 
         // General
         public double AudioLeadIn { get; set; }
-        public bool Countdown { get; set; } = true;
         public float StackLeniency { get; set; } = 0.7f;
         public bool SpecialStyle { get; set; }
 
@@ -94,6 +93,9 @@ namespace osu.Game.Beatmaps
         public bool LetterboxInBreaks { get; set; }
         public bool WidescreenStoryboard { get; set; }
         public bool EpilepsyWarning { get; set; }
+
+        public CountdownType Countdown { get; set; } = CountdownType.Normal;
+        public int CountdownOffset { get; set; }
 
         // Editor
         // This bookmarks stuff is necessary because DB doesn't know how to store int[]

--- a/osu.Game/Beatmaps/CountdownType.cs
+++ b/osu.Game/Beatmaps/CountdownType.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Beatmaps
+{
+    /// <summary>
+    /// The type of countdown shown before the start of gameplay on a given beatmap.
+    /// </summary>
+    public enum CountdownType
+    {
+        None = 0,
+        Normal = 1,
+        HalfSpeed = 2,
+        DoubleSpeed = 3
+    }
+}

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -121,10 +121,6 @@ namespace osu.Game.Beatmaps.Formats
                     metadata.PreviewTime = getOffsetTime(Parsing.ParseInt(pair.Value));
                     break;
 
-                case @"Countdown":
-                    beatmap.BeatmapInfo.Countdown = Parsing.ParseInt(pair.Value) == 1;
-                    break;
-
                 case @"SampleSet":
                     defaultSampleBank = (LegacySampleBank)Enum.Parse(typeof(LegacySampleBank), pair.Value);
                     break;
@@ -175,6 +171,14 @@ namespace osu.Game.Beatmaps.Formats
 
                 case @"EpilepsyWarning":
                     beatmap.BeatmapInfo.EpilepsyWarning = Parsing.ParseInt(pair.Value) == 1;
+                    break;
+
+                case @"Countdown":
+                    beatmap.BeatmapInfo.Countdown = (CountdownType)Enum.Parse(typeof(CountdownType), pair.Value);
+                    break;
+
+                case @"CountdownOffset":
+                    beatmap.BeatmapInfo.CountdownOffset = Parsing.ParseInt(pair.Value);
                     break;
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -79,8 +79,7 @@ namespace osu.Game.Beatmaps.Formats
             if (beatmap.Metadata.AudioFile != null) writer.WriteLine(FormattableString.Invariant($"AudioFilename: {Path.GetFileName(beatmap.Metadata.AudioFile)}"));
             writer.WriteLine(FormattableString.Invariant($"AudioLeadIn: {beatmap.BeatmapInfo.AudioLeadIn}"));
             writer.WriteLine(FormattableString.Invariant($"PreviewTime: {beatmap.Metadata.PreviewTime}"));
-            // Todo: Not all countdown types are supported by lazer yet
-            writer.WriteLine(FormattableString.Invariant($"Countdown: {(beatmap.BeatmapInfo.Countdown ? '1' : '0')}"));
+            writer.WriteLine(FormattableString.Invariant($"Countdown: {(int)beatmap.BeatmapInfo.Countdown}"));
             writer.WriteLine(FormattableString.Invariant($"SampleSet: {toLegacySampleBank(beatmap.ControlPointInfo.SamplePointAt(double.MinValue).SampleBank)}"));
             writer.WriteLine(FormattableString.Invariant($"StackLeniency: {beatmap.BeatmapInfo.StackLeniency}"));
             writer.WriteLine(FormattableString.Invariant($"Mode: {beatmap.BeatmapInfo.RulesetID}"));
@@ -95,8 +94,8 @@ namespace osu.Game.Beatmaps.Formats
             //     writer.WriteLine(@"SkinPreference:" + b.SkinPreference);
             if (beatmap.BeatmapInfo.EpilepsyWarning)
                 writer.WriteLine(@"EpilepsyWarning: 1");
-            // if (b.CountdownOffset > 0)
-            //     writer.WriteLine(@"CountdownOffset: " + b.CountdownOffset.ToString());
+            if (beatmap.BeatmapInfo.CountdownOffset > 0)
+                writer.WriteLine(FormattableString.Invariant($@"CountdownOffset: {beatmap.BeatmapInfo.CountdownOffset}"));
             if (beatmap.BeatmapInfo.RulesetID == 3)
                 writer.WriteLine(FormattableString.Invariant($"SpecialStyle: {(beatmap.BeatmapInfo.SpecialStyle ? '1' : '0')}"));
             writer.WriteLine(FormattableString.Invariant($"WidescreenStoryboard: {(beatmap.BeatmapInfo.WidescreenStoryboard ? '1' : '0')}"));

--- a/osu.Game/Migrations/20210824185035_AddCountdownSettings.Designer.cs
+++ b/osu.Game/Migrations/20210824185035_AddCountdownSettings.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using osu.Game.Database;
 
 namespace osu.Game.Migrations
 {
     [DbContext(typeof(OsuDbContext))]
-    partial class OsuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210824185035_AddCountdownSettings")]
+    partial class AddCountdownSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/osu.Game/Migrations/20210824185035_AddCountdownSettings.cs
+++ b/osu.Game/Migrations/20210824185035_AddCountdownSettings.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace osu.Game.Migrations
+{
+    public partial class AddCountdownSettings : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CountdownOffset",
+                table: "BeatmapInfo",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CountdownOffset",
+                table: "BeatmapInfo");
+        }
+    }
+}


### PR DESCRIPTION
By which I mean the countdown type (currently there's only an on-off bool) as well as the offset. For reference, [see wiki](https://osu.ppy.sh/wiki/en/osu%21_File_Formats/Osu_%28file_format%29#general).

PRing this separately due to sheer line count (97% of which is the autogenerated database migration).

With regard to the countdown type, I started off with the existing bool + a separate `CountdownSpeed?` field, but it was kind of awkward in handling in the decoder and encoder, so in this variant the two are just merged into a single `CountdownType` (which is something stable also does).

When it comes to the `bool -> int` change of `Countdown` on the database side, [sqlite doesn't have booleans anyway](https://www.sqlite.org/datatype3.html), so it was an `INTEGER` all along. It should not be a breaking change, and I've tested that it doesn't break, but if it's considered too risky I'll split back into two fields.

All that said **I recommend exercising caution and making database backups just in case if someone is to test this**. The reason I'm saying that is because I accidentally nuked my local db by switching between the first and second iteration of this pull and forgetting to tear down the migration from v1 before running v2. I would PR a change that makes the game copy out `client.db` to a backup file before nuking if migrations fail on launch, but I'm unsure whether that's wasted effort on EF at this point.