### PR TITLE
Fix osu!mania hold notes eating input whenever on screen

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -275,9 +275,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 return false;
 
             beginHoldAt(Time.Current - Head.HitObject.StartTime);
-            Head.UpdateResult();
 
-            return true;
+            return Head.UpdateResult();
         }
 
         private void beginHoldAt(double timeOffset)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             Origin = Anchor.TopCentre;
         }
 
-        public void UpdateResult() => base.UpdateResult(true);
+        public bool UpdateResult() => base.UpdateResult(true);
 
         protected override void UpdateInitialTransforms()
         {


### PR DESCRIPTION
This looks like an oversight, which in turn caused columns to never play samples when the column's key was pressed and the next object in the column is a hold note. I've tested this as much as I can in gameplay and it looks to work as expected, but I'd recommend it's independently tested in review as it does have the potential to effect scoring in an unexpected way.
