### PR TITLE
Fix unbind exception in `DifficultyBindable` due to different bindable type bindings

### DIFF
--- a/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -91,7 +92,7 @@ namespace osu.Game.Rulesets.Mods
         {
             // This is required as SettingsItem relies heavily on this bindable for internal use.
             // The actual update flow is done via the bindable provided in the constructor.
-            private readonly BindableWithCurrent<float?> current = new BindableWithCurrent<float?>();
+            private readonly DifficultyBindableWithCurrent current = new DifficultyBindableWithCurrent();
 
             public Bindable<float?> Current
             {
@@ -113,6 +114,31 @@ namespace osu.Game.Rulesets.Mods
                 AutoSizeAxes = Axes.Y;
                 RelativeSizeAxes = Axes.X;
             }
+        }
+
+        private class DifficultyBindableWithCurrent : DifficultyBindable, IHasCurrentValue<float?>
+        {
+            private Bindable<float?> currentBound;
+
+            public Bindable<float?> Current
+            {
+                get => this;
+                set
+                {
+                    if (value == null)
+                        throw new ArgumentNullException(nameof(value));
+
+                    if (currentBound != null) UnbindFrom(currentBound);
+                    BindTo(currentBound = value);
+                }
+            }
+
+            public DifficultyBindableWithCurrent(float? defaultValue = default)
+                : base(defaultValue)
+            {
+            }
+
+            protected override Bindable<float?> CreateInstance() => new DifficultyBindableWithCurrent();
         }
     }
 }


### PR DESCRIPTION
- Closes #14471 
- See #14478 for previous attempt and https://github.com/ppy/osu/pull/14478#discussion_r695049409 for reason of closing.

Also:
> Note that the reason the UnbindFrom exception in the mentioned issue thread doesn't appear without a debugger is because Drawable intentionally catches exceptions and doesn't perform any actions about them, with the comment "Execution should continue regardless of whether an unbind failed".
>
> https://github.com/ppy/osu-framework/blob/bcf1047e981e40cdfc63233b5a0fdd7f5eeac832/osu.Framework/Graphics/Drawable.cs#L146-L159