### PR TITLE
Fix editor crashing when quickly switching between screens

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorScreenModes.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorScreenModes.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Components.Menus;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneEditorScreenModes : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestSwitchScreensInstantaneously()
+        {
+            AddStep("switch between all screens at once", () =>
+            {
+                foreach (var screen in Enum.GetValues(typeof(EditorScreenMode)).Cast<EditorScreenMode>())
+                    Editor.ChildrenOfType<EditorMenuBar>().Single().Mode.Value = screen;
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -605,19 +605,14 @@ namespace osu.Game.Screens.Edit
         {
             var lastScreen = currentScreen;
 
-            lastScreen?
-                .ScaleTo(0.98f, 200, Easing.OutQuint)
-                .FadeOut(200, Easing.OutQuint);
+            lastScreen?.Hide();
 
             try
             {
                 if ((currentScreen = screenContainer.SingleOrDefault(s => s.Type == e.NewValue)) != null)
                 {
                     screenContainer.ChangeChildDepth(currentScreen, lastScreen?.Depth + 1 ?? 0);
-
-                    currentScreen
-                        .ScaleTo(1, 200, Easing.OutQuint)
-                        .FadeIn(200, Easing.OutQuint);
+                    currentScreen.Show();
                     return;
                 }
 
@@ -650,7 +645,10 @@ namespace osu.Game.Screens.Edit
                 LoadComponentAsync(currentScreen, newScreen =>
                 {
                     if (newScreen == currentScreen)
+                    {
                         screenContainer.Add(newScreen);
+                        newScreen.Show();
+                    }
                 });
             }
             finally

--- a/osu.Game/Screens/Edit/EditorScreen.cs
+++ b/osu.Game/Screens/Edit/EditorScreen.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Screens.Edit
     /// <summary>
     /// TODO: eventually make this inherit Screen and add a local screen stack inside the Editor.
     /// </summary>
-    public abstract class EditorScreen : Container
+    public abstract class EditorScreen : VisibilityContainer
     {
         [Resolved]
         protected EditorBeatmap EditorBeatmap { get; private set; }
@@ -31,13 +31,16 @@ namespace osu.Game.Screens.Edit
             InternalChild = content = new Container { RelativeSizeAxes = Axes.Both };
         }
 
-        protected override void LoadComplete()
+        protected override void PopIn()
         {
-            base.LoadComplete();
+            this.ScaleTo(1f, 200, Easing.OutQuint)
+                .FadeIn(200, Easing.OutQuint);
+        }
 
-            this.FadeTo(0)
-                .Then()
-                .FadeTo(1f, 250, Easing.OutQuint);
+        protected override void PopOut()
+        {
+            this.ScaleTo(0.98f, 200, Easing.OutQuint)
+                .FadeOut(200, Easing.OutQuint);
         }
     }
 }


### PR DESCRIPTION
Noticed while I was writing a test for fixing #14491.

```
TearDown : osu.Framework.Graphics.Drawable+InvalidThreadForMutationException : Cannot mutate the Transforms of a Loading Drawable while not on the load thread. Consider using Schedule to schedule the mutation operation.
--TearDown
   at osu.Framework.Graphics.Drawable.EnsureMutationAllowed(String member)
   at osu.Framework.Graphics.Drawable.EnsureTransformMutationAllowed()
   at osu.Framework.Graphics.Transforms.Transformable.AddTransform(Transform transform, Nullable`1 customTransformID)
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis](TThis t, Transform transform)
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping)
   at osu.Framework.Graphics.TransformableExtensions.ScaleTo[T,TEasing](T drawable, Vector2 newScale, Double duration, TEasing& easing)
   at osu.Framework.Graphics.TransformableExtensions.ScaleTo[T,TEasing](T drawable, Single newScale, Double duration, TEasing& easing)
   at osu.Framework.Graphics.TransformableExtensions.ScaleTo[T](T drawable, Single newScale, Double duration, Easing easing)
   at osu.Game.Screens.Edit.Editor.onModeChanged(ValueChangedEvent`1 e) in /Users/salman/Desktop/osu/osu.Game/Screens/Edit/Editor.cs:line 608
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source)
   at osu.Framework.Bindables.Bindable`1.set_Value(T value)
   at osu.Game.Tests.Visual.Editing.TestSceneEditorScreenModes.<TestSwitchScreensInstantaneously>b__1_0() in /Users/salman/Desktop/osu/osu.Game.Tests/Visual/Editing/TestSceneEditorScreenModes.cs:line 25
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/salman/Desktop/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 370
   at osu.Framework.Testing.TestScene.RunTests()
```

Reproducible in game by opening an editor and switching between screens very quickly, via the hotkeys. 

Resolved by changing `EditorScreen` to implement `VisibilityContainer` instead so that the hide and show transforms can be applied safely without doing so while the screen isn't fully loaded yet.

There's only a pretty unnoticable difference in the initial show animation now, which is that a scale transform is also applied, while previously on a fade happen. Doesn't seem bad enough to work around it.