### PR TITLE
Fix osu!mania editor crashing on compose screen load

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Compose;
+using osu.Game.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Mania.Tests.Editor
+{
+    public class TestSceneManiaComposeScreen : EditorClockTestScene
+    {
+        [Resolved]
+        private SkinManager skins { get; set; }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("setup compose screen", () =>
+            {
+                var editorBeatmap = new EditorBeatmap(new ManiaBeatmap(new StageDefinition { Columns = 4 }))
+                {
+                    BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
+                };
+
+                Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+
+                Child = new DependencyProvidingContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    CachedDependencies = new (Type, object)[]
+                    {
+                        (typeof(EditorBeatmap), editorBeatmap),
+                        (typeof(IBeatSnapProvider), editorBeatmap),
+                    },
+                    Child = new ComposeScreen { State = { Value = Visibility.Visible } },
+                };
+            });
+
+            AddUntilStep("wait for composer", () => this.ChildrenOfType<HitObjectComposer>().SingleOrDefault()?.IsLoaded == true);
+        }
+
+        [Test]
+        public void TestDefaultSkin()
+        {
+            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = SkinInfo.Default);
+        }
+
+        [Test]
+        public void TestLegacySkin()
+        {
+            AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.Info);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
+++ b/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit
         private readonly EditorBeatmapSkin? beatmapSkin;
 
         public EditorSkinProvidingContainer(EditorBeatmap editorBeatmap)
-            : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap, editorBeatmap.BeatmapSkin)
+            : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin)
         {
             beatmapSkin = editorBeatmap.BeatmapSkin;
         }

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using JetBrains.Annotations;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
@@ -27,6 +28,9 @@ namespace osu.Game.Tests.Visual
         protected TestEditor Editor { get; private set; }
 
         protected EditorClock EditorClock { get; private set; }
+
+        [Resolved]
+        private SkinManager skins { get; set; }
 
         /// <summary>
         /// Whether any saves performed by the editor should be isolate (and not persist) to the underlying <see cref="BeatmapManager"/>.
@@ -55,6 +59,12 @@ namespace osu.Game.Tests.Visual
             AddUntilStep("wait for editor to load", () => EditorComponentsReady);
             AddStep("get beatmap", () => EditorBeatmap = Editor.ChildrenOfType<EditorBeatmap>().Single());
             AddStep("get clock", () => EditorClock = Editor.ChildrenOfType<EditorClock>().Single());
+        }
+
+        [Test]
+        public void TestLegacySkin()
+        {
+            AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.Info);
         }
 
         protected virtual void LoadEditor()

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using JetBrains.Annotations;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
@@ -28,9 +27,6 @@ namespace osu.Game.Tests.Visual
         protected TestEditor Editor { get; private set; }
 
         protected EditorClock EditorClock { get; private set; }
-
-        [Resolved]
-        private SkinManager skins { get; set; }
 
         /// <summary>
         /// Whether any saves performed by the editor should be isolate (and not persist) to the underlying <see cref="BeatmapManager"/>.
@@ -59,12 +55,6 @@ namespace osu.Game.Tests.Visual
             AddUntilStep("wait for editor to load", () => EditorComponentsReady);
             AddStep("get beatmap", () => EditorBeatmap = Editor.ChildrenOfType<EditorBeatmap>().Single());
             AddStep("get clock", () => EditorClock = Editor.ChildrenOfType<EditorClock>().Single());
-        }
-
-        [Test]
-        public void TestLegacySkin()
-        {
-            AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.Info);
         }
 
         protected virtual void LoadEditor()


### PR DESCRIPTION
Closes #14491 

Fixes the issue by providing the `PlayableBeatmap` rather than the editor beatmap, just like how it used to be prior to the editor skin changes.

I've took a bit and went forwards and backwards on how to test this, but I've ended up writing an isolated test case that switches the current skin to default legacy, which should be enough to cover this case on mania and all other rulesets, without too many changes.