### PR TITLE
Remove delegate overhead in `SkipOverlay`

### DIFF
--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Screens.Play
         private FadeContainer fadeContainer;
         private double displayTime;
 
+        private bool isClickable;
+
         [Resolved]
         private GameplayClock gameplayClock { get; set; }
 
@@ -124,17 +126,18 @@ namespace osu.Game.Screens.Play
         {
             base.Update();
 
-            var progress = fadeOutBeginTime <= displayTime ? 1 : Math.Max(0, 1 - (gameplayClock.CurrentTime - displayTime) / (fadeOutBeginTime - displayTime));
+            double progress = fadeOutBeginTime <= displayTime ? 1 : Math.Max(0, 1 - (gameplayClock.CurrentTime - displayTime) / (fadeOutBeginTime - displayTime));
 
             remainingTimeBox.Width = (float)Interpolation.Lerp(remainingTimeBox.Width, progress, Math.Clamp(Time.Elapsed / 40, 0, 1));
 
-            button.Enabled.Value = progress > 0;
-            buttonContainer.State.Value = progress > 0 ? Visibility.Visible : Visibility.Hidden;
+            isClickable = progress > 0;
+            button.Enabled.Value = isClickable;
+            buttonContainer.State.Value = isClickable ? Visibility.Visible : Visibility.Hidden;
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            if (!e.HasAnyButtonPressed)
+            if (isClickable && !e.HasAnyButtonPressed)
                 fadeContainer.Show();
 
             return base.OnMouseMove(e);

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Play
         public override void Show()
         {
             base.Show();
-            fadeContainer.Show();
+            fadeContainer.TriggerShow();
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
It turns out that due to the way this component was implemented, the internal scheduler could end up with thousands of not-run tasks. Each mouse move event would queue a new `ScheduledDelegate`, and while it *did* cancel the previous one, as long as the scheduler itself is not run this would stack indefinitely (in profiling I saw over 10k `ScheduledDelegates` by the end of a play - not just allocated but with references held by the inner container's `Scheduler`).

I initially just fixed the overhead when the skip overlay should not be showing (due to already having completed its display state) but this still leaves the allocation overhead of the delegates while it is valid, so went the full way and remove the `Schedule`/`Cancel` flow completely.