### PR TITLE
Remove bindable usage in `PathControlPoint`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -210,9 +210,9 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
                 new Vector2(50, 200),
             }), 0.5);
             AddAssert("1 vertex per 1 nested HO", () => getVertices().Count == hitObject.NestedHitObjects.Count);
-            AddAssert("slider path not yet changed", () => hitObject.Path.ControlPoints[0].Type.Value == PathType.PerfectCurve);
+            AddAssert("slider path not yet changed", () => hitObject.Path.ControlPoints[0].Type == PathType.PerfectCurve);
             addAddVertexSteps(150, 150);
-            AddAssert("slider path change to linear", () => hitObject.Path.ControlPoints[0].Type.Value == PathType.Linear);
+            AddAssert("slider path change to linear", () => hitObject.Path.ControlPoints[0].Type == PathType.Linear);
         }
 
         private void addBlueprintStep(double time, float x, SliderPath sliderPath, double velocity) => AddStep("add selection blueprint", () =>

--- a/osu.Game.Rulesets.Catch.Tests/JuiceStreamPathTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/JuiceStreamPathTest.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                     } while (rng.Next(2) != 0);
 
                     int length = sliderPath.ControlPoints.Count - start + 1;
-                    sliderPath.ControlPoints[start].Type.Value = length <= 2 ? PathType.Linear : length == 3 ? PathType.PerfectCurve : PathType.Bezier;
+                    sliderPath.ControlPoints[start].Type = length <= 2 ? PathType.Linear : length == 3 ? PathType.PerfectCurve : PathType.Bezier;
                 } while (rng.Next(3) != 0);
 
                 if (rng.Next(5) == 0)
@@ -210,13 +210,13 @@ namespace osu.Game.Rulesets.Catch.Tests
 
                 path.ConvertToSliderPath(sliderPath, sliderStartY);
                 Assert.That(sliderPath.Distance, Is.EqualTo(path.Distance).Within(1e-3));
-                Assert.That(sliderPath.ControlPoints[0].Position.Value.X, Is.EqualTo(path.Vertices[0].X));
+                Assert.That(sliderPath.ControlPoints[0].Position.X, Is.EqualTo(path.Vertices[0].X));
                 assertInvariants(path.Vertices, true);
 
                 foreach (var point in sliderPath.ControlPoints)
                 {
-                    Assert.That(point.Type.Value, Is.EqualTo(PathType.Linear).Or.Null);
-                    Assert.That(sliderStartY + point.Position.Value.Y, Is.InRange(0, JuiceStreamPath.OSU_PLAYFIELD_HEIGHT));
+                    Assert.That(point.Type, Is.EqualTo(PathType.Linear).Or.Null);
+                    Assert.That(sliderStartY + point.Position.Y, Is.InRange(0, JuiceStreamPath.OSU_PLAYFIELD_HEIGHT));
                 }
 
                 for (int i = 0; i < 10; i++)

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
                     case JuiceStream juiceStream:
                         // Todo: BUG!! Stable used the last control point as the final position of the path, but it should use the computed path instead.
-                        lastPosition = juiceStream.OriginalX + juiceStream.Path.ControlPoints[^1].Position.Value.X;
+                        lastPosition = juiceStream.OriginalX + juiceStream.Path.ControlPoints[^1].Position.X;
 
                         // Todo: BUG!! Stable attempted to use the end time of the stream, but referenced it too early in execution and used the start time instead.
                         lastStartTime = juiceStream.StartTime;

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             path.ConvertFromSliderPath(sliderPath);
 
             // If the original slider path has non-linear type segments, resample the vertices at nested hit object times to reduce the number of vertices.
-            if (sliderPath.ControlPoints.Any(p => p.Type.Value != null && p.Type.Value != PathType.Linear))
+            if (sliderPath.ControlPoints.Any(p => p.Type != null && p.Type != PathType.Linear))
             {
                 path.ResampleVertices(hitObject.NestedHitObjects
                                                .Skip(1).TakeWhile(h => !(h is Fruit)) // Only droplets in the first span are used.

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                     juiceStream.OriginalX = selectionRange.GetFlippedPosition(juiceStream.OriginalX);
 
                     foreach (var point in juiceStream.Path.ControlPoints)
-                        point.Position.Value *= new Vector2(-1, 1);
+                        point.Position *= new Vector2(-1, 1);
 
                     EditorBeatmap.Update(juiceStream);
                     return true;

--- a/osu.Game.Rulesets.Catch/Mods/CatchModMirror.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModMirror.cs
@@ -68,9 +68,9 @@ namespace osu.Game.Rulesets.Catch.Mods
         /// </summary>
         private static void mirrorJuiceStreamPath(JuiceStream juiceStream)
         {
-            var controlPoints = juiceStream.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
+            var controlPoints = juiceStream.Path.ControlPoints.Select(p => new PathControlPoint(p.Position, p.Type)).ToArray();
             foreach (var point in controlPoints)
-                point.Position.Value = new Vector2(-point.Position.Value.X, point.Position.Value.Y);
+                point.Position = new Vector2(-point.Position.X, point.Position.Y);
 
             juiceStream.Path = new SliderPath(controlPoints, juiceStream.Path.ExpectedDistance.Value);
         }

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
                 if (value != null)
                 {
-                    path.ControlPoints.AddRange(value.ControlPoints.Select(c => new PathControlPoint(c.Position.Value, c.Type.Value)));
+                    path.ControlPoints.AddRange(value.ControlPoints.Select(c => new PathControlPoint(c.Position, c.Type)));
                     path.ExpectedDistance.Value = value.ExpectedDistance.Value;
                 }
             }

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             for (int i = 1; i < vertices.Count; i++)
             {
-                sliderPath.ControlPoints[^1].Type.Value = PathType.Linear;
+                sliderPath.ControlPoints[^1].Type = PathType.Linear;
 
                 float deltaX = vertices[i].X - lastPosition.X;
                 double length = vertices[i].Distance - currentDistance;

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             AddStep($"move mouse to control point {index}", () =>
             {
-                Vector2 position = slider.Path.ControlPoints[index].Position.Value;
+                Vector2 position = slider.Path.ControlPoints[index].Position;
                 InputManager.MoveMouseTo(visualiser.Pieces[0].Parent.ToScreenSpace(position));
             });
         }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddAssert("last connection displayed", () =>
             {
-                var lastConnection = visualiser.Connections.Last(c => c.ControlPoint.Position.Value == new Vector2(300));
+                var lastConnection = visualiser.Connections.Last(c => c.ControlPoint.Position == new Vector2(300));
                 return lastConnection.DrawWidth > 50;
             });
         }
@@ -173,7 +173,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private void assertControlPointPathType(int controlPointIndex, PathType? type)
         {
-            AddAssert($"point {controlPointIndex} is {type}", () => slider.Path.ControlPoints[controlPointIndex].Type.Value == type);
+            AddAssert($"point {controlPointIndex} is {type}", () => slider.Path.ControlPoints[controlPointIndex].Type == type);
         }
 
         private void addContextMenuItemStep(string contextMenuText)

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -108,9 +108,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestDragControlPointPathAfterChangingType()
         {
-            AddStep("change type to bezier", () => slider.Path.ControlPoints[2].Type.Value = PathType.Bezier);
+            AddStep("change type to bezier", () => slider.Path.ControlPoints[2].Type = PathType.Bezier);
             AddStep("add point", () => slider.Path.ControlPoints.Add(new PathControlPoint(new Vector2(500, 10))));
-            AddStep("change type to perfect", () => slider.Path.ControlPoints[3].Type.Value = PathType.PerfectCurve);
+            AddStep("change type to perfect", () => slider.Path.ControlPoints[3].Type = PathType.PerfectCurve);
 
             moveMouseToControlPoint(4);
             AddStep("hold", () => InputManager.PressButton(MouseButton.Left));
@@ -137,15 +137,15 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             AddStep($"move mouse to control point {index}", () =>
             {
-                Vector2 position = slider.Position + slider.Path.ControlPoints[index].Position.Value;
+                Vector2 position = slider.Position + slider.Path.ControlPoints[index].Position;
                 InputManager.MoveMouseTo(drawableObject.Parent.ToScreenSpace(position));
             });
         }
 
-        private void assertControlPointType(int index, PathType type) => AddAssert($"control point {index} is {type}", () => slider.Path.ControlPoints[index].Type.Value == type);
+        private void assertControlPointType(int index, PathType type) => AddAssert($"control point {index} is {type}", () => slider.Path.ControlPoints[index].Type == type);
 
         private void assertControlPointPosition(int index, Vector2 position) =>
-            AddAssert($"control point {index} at {position}", () => Precision.AlmostEquals(position, slider.Path.ControlPoints[index].Position.Value, 1));
+            AddAssert($"control point {index} at {position}", () => Precision.AlmostEquals(position, slider.Path.ControlPoints[index].Position, 1));
 
         private class TestSliderBlueprint : SliderSelectionBlueprint
         {

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -385,10 +385,10 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private void assertControlPointCount(int expected) => AddAssert($"has {expected} control points", () => getSlider().Path.ControlPoints.Count == expected);
 
-        private void assertControlPointType(int index, PathType type) => AddAssert($"control point {index} is {type}", () => getSlider().Path.ControlPoints[index].Type.Value == type);
+        private void assertControlPointType(int index, PathType type) => AddAssert($"control point {index} is {type}", () => getSlider().Path.ControlPoints[index].Type == type);
 
         private void assertControlPointPosition(int index, Vector2 position) =>
-            AddAssert($"control point {index} at {position}", () => Precision.AlmostEquals(position, getSlider().Path.ControlPoints[index].Position.Value, 1));
+            AddAssert($"control point {index} at {position}", () => Precision.AlmostEquals(position, getSlider().Path.ControlPoints[index].Position, 1));
 
         private Slider getSlider() => HitObjectContainer.Count > 0 ? ((DrawableSlider)HitObjectContainer[0]).HitObject : null;
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderSelectionBlueprint.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             AddStep($"move mouse to control point {index}", () =>
             {
-                Vector2 position = slider.Position + slider.Path.ControlPoints[index].Position.Value;
+                Vector2 position = slider.Position + slider.Path.ControlPoints[index].Position;
                 InputManager.MoveMouseTo(drawableObject.Parent.ToScreenSpace(position));
             });
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         /// </summary>
         private void updateConnectingPath()
         {
-            Position = slider.StackedPosition + ControlPoint.Position.Value;
+            Position = slider.StackedPosition + ControlPoint.Position;
 
             path.ClearVertices();
 
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 return;
 
             path.AddVertex(Vector2.Zero);
-            path.AddVertex(slider.Path.ControlPoints[nextIndex].Position.Value - ControlPoint.Position.Value);
+            path.AddVertex(slider.Path.ControlPoints[nextIndex].Position - ControlPoint.Position);
 
             path.OriginPosition = path.PositionInBoundingBox(Vector2.Zero);
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         private MenuItem createMenuItemForPathType(PathType? type)
         {
             int totalCount = Pieces.Count(p => p.IsSelected.Value);
-            int countOfState = Pieces.Where(p => p.IsSelected.Value).Count(p => p.ControlPoint.Type.Value == type);
+            int countOfState = Pieces.Where(p => p.IsSelected.Value).Count(p => p.ControlPoint.Type == type);
 
             var item = new TernaryStateRadioMenuItem(type == null ? "Inherit" : type.ToString().Humanize(), MenuItemType.Standard, _ =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -173,12 +173,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     int thirdPointIndex = indexInSegment + 2;
 
                     if (piece.PointsInSegment.Count > thirdPointIndex + 1)
-                        piece.PointsInSegment[thirdPointIndex].Type.Value = piece.PointsInSegment[0].Type.Value;
+                        piece.PointsInSegment[thirdPointIndex].Type = piece.PointsInSegment[0].Type;
 
                     break;
             }
 
-            piece.ControlPoint.Type.Value = type;
+            piece.ControlPoint.Type = type;
         }
 
         [Resolved(CanBeNull = true)]

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                         Debug.Assert(lastPoint != null);
 
                         segmentStart = lastPoint;
-                        segmentStart.Type.Value = PathType.Linear;
+                        segmentStart.Type = PathType.Linear;
 
                         currentSegmentLength = 1;
                     }
@@ -153,15 +153,15 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 case 1:
                 case 2:
-                    segmentStart.Type.Value = PathType.Linear;
+                    segmentStart.Type = PathType.Linear;
                     break;
 
                 case 3:
-                    segmentStart.Type.Value = PathType.PerfectCurve;
+                    segmentStart.Type = PathType.PerfectCurve;
                     break;
 
                 default:
-                    segmentStart.Type.Value = PathType.Bezier;
+                    segmentStart.Type = PathType.Bezier;
                     break;
             }
         }
@@ -173,7 +173,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 // The cursor does not overlap a previous control point, so it can be added if not already existing.
                 if (cursor == null)
                 {
-                    HitObject.Path.ControlPoints.Add(cursor = new PathControlPoint { Position = { Value = Vector2.Zero } });
+                    HitObject.Path.ControlPoints.Add(cursor = new PathControlPoint { Position = Vector2.Zero });
 
                     // The path type should be adjusted in the progression of updatePathType() (Linear -> PC -> Bezier).
                     currentSegmentLength++;
@@ -181,7 +181,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 }
 
                 // Update the cursor position.
-                cursor.Position.Value = ToLocalSpace(inputManager.CurrentState.Mouse.Position) - HitObject.Position;
+                cursor.Position = ToLocalSpace(inputManager.CurrentState.Mouse.Position) - HitObject.Position;
             }
             else if (cursor != null)
             {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             Debug.Assert(placementControlPointIndex != null);
 
-            HitObject.Path.ControlPoints[placementControlPointIndex.Value].Position.Value = e.MousePosition - HitObject.Position;
+            HitObject.Path.ControlPoints[placementControlPointIndex.Value].Position = e.MousePosition - HitObject.Position;
         }
 
         protected override void OnDragEnd(DragEndEvent e)
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             for (int i = 0; i < controlPoints.Count - 1; i++)
             {
-                float dist = new Line(controlPoints[i].Position.Value, controlPoints[i + 1].Position.Value).DistanceToPoint(position);
+                float dist = new Line(controlPoints[i].Position, controlPoints[i + 1].Position).DistanceToPoint(position);
 
                 if (dist < minDistance)
                 {
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             }
 
             // Move the control points from the insertion index onwards to make room for the insertion
-            controlPoints.Insert(insertionIndex, new PathControlPoint { Position = { Value = position } });
+            controlPoints.Insert(insertionIndex, new PathControlPoint { Position = position });
 
             return insertionIndex;
         }
@@ -207,8 +207,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 // The first control point in the slider must have a type, so take it from the previous "first" one
                 // Todo: Should be handled within SliderPath itself
-                if (c == controlPoints[0] && controlPoints.Count > 1 && controlPoints[1].Type.Value == null)
-                    controlPoints[1].Type.Value = controlPoints[0].Type.Value;
+                if (c == controlPoints[0] && controlPoints.Count > 1 && controlPoints[1].Type == null)
+                    controlPoints[1].Type = controlPoints[0].Type;
 
                 controlPoints.Remove(c);
             }
@@ -222,9 +222,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             // The path will have a non-zero offset if the head is removed, but sliders don't support this behaviour since the head is positioned at the slider's position
             // So the slider needs to be offset by this amount instead, and all control points offset backwards such that the path is re-positioned at (0, 0)
-            Vector2 first = controlPoints[0].Position.Value;
+            Vector2 first = controlPoints[0].Position;
             foreach (var c in controlPoints)
-                c.Position.Value -= first;
+                c.Position -= first;
             HitObject.Position += first;
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -98,9 +98,9 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     foreach (var point in slider.Path.ControlPoints)
                     {
-                        point.Position.Value = new Vector2(
-                            (direction == Direction.Horizontal ? -1 : 1) * point.Position.Value.X,
-                            (direction == Direction.Vertical ? -1 : 1) * point.Position.Value.Y
+                        point.Position = new Vector2(
+                            (direction == Direction.Horizontal ? -1 : 1) * point.Position.X,
+                            (direction == Direction.Vertical ? -1 : 1) * point.Position.Y
                         );
                     }
                 }
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (h is IHasPath path)
                 {
                     foreach (var point in path.Path.ControlPoints)
-                        point.Position.Value = RotatePointAroundOrigin(point.Position.Value, Vector2.Zero, delta);
+                        point.Position = RotatePointAroundOrigin(point.Position, Vector2.Zero, delta);
                 }
             }
 
@@ -163,9 +163,9 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void scaleSlider(Slider slider, Vector2 scale)
         {
-            referencePathTypes ??= slider.Path.ControlPoints.Select(p => p.Type.Value).ToList();
+            referencePathTypes ??= slider.Path.ControlPoints.Select(p => p.Type).ToList();
 
-            Quad sliderQuad = GetSurroundingQuad(slider.Path.ControlPoints.Select(p => p.Position.Value));
+            Quad sliderQuad = GetSurroundingQuad(slider.Path.ControlPoints.Select(p => p.Position));
 
             // Limit minimum distance between control points after scaling to almost 0. Less than 0 causes the slider to flip, exactly 0 causes a crash through division by 0.
             scale = Vector2.ComponentMax(new Vector2(Precision.FLOAT_EPSILON), sliderQuad.Size + scale) - sliderQuad.Size;
@@ -178,13 +178,13 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             foreach (var point in slider.Path.ControlPoints)
             {
-                oldControlPoints.Enqueue(point.Position.Value);
-                point.Position.Value *= pathRelativeDeltaScale;
+                oldControlPoints.Enqueue(point.Position);
+                point.Position *= pathRelativeDeltaScale;
             }
 
             // Maintain the path types in case they were defaulted to bezier at some point during scaling
             for (int i = 0; i < slider.Path.ControlPoints.Count; ++i)
-                slider.Path.ControlPoints[i].Type.Value = referencePathTypes[i];
+                slider.Path.ControlPoints[i].Type = referencePathTypes[i];
 
             //if sliderhead or sliderend end up outside playfield, revert scaling.
             Quad scaledQuad = getSurroundingQuad(new OsuHitObject[] { slider });
@@ -194,7 +194,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 return;
 
             foreach (var point in slider.Path.ControlPoints)
-                point.Position.Value = oldControlPoints.Dequeue();
+                point.Position = oldControlPoints.Dequeue();
         }
 
         private void scaleHitObjects(OsuHitObject[] hitObjects, Anchor reference, Vector2 scale)

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
                 if (value != null)
                 {
-                    path.ControlPoints.AddRange(value.ControlPoints.Select(c => new PathControlPoint(c.Position.Value, c.Type.Value)));
+                    path.ControlPoints.AddRange(value.ControlPoints.Select(c => new PathControlPoint(c.Position, c.Type)));
                     path.ExpectedDistance.Value = value.ExpectedDistance.Value;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -119,9 +119,9 @@ namespace osu.Game.Rulesets.Osu.Utils
             slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
             slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
 
-            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
+            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position, p.Type)).ToArray();
             foreach (var point in controlPoints)
-                point.Position.Value = new Vector2(-point.Position.Value.X, point.Position.Value.Y);
+                point.Position = new Vector2(-point.Position.X, point.Position.Y);
 
             slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
         }
@@ -140,9 +140,9 @@ namespace osu.Game.Rulesets.Osu.Utils
             slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
             slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
 
-            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position.Value, p.Type.Value)).ToArray();
+            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position, p.Type)).ToArray();
             foreach (var point in controlPoints)
-                point.Position.Value = new Vector2(point.Position.Value.X, -point.Position.Value.Y);
+                point.Position = new Vector2(point.Position.X, -point.Position.Y);
 
             slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
         }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -666,111 +666,111 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 // Multi-segment
                 var first = ((IHasPath)decoded.HitObjects[0]).Path;
 
-                Assert.That(first.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(first.ControlPoints[0].Type.Value, Is.EqualTo(PathType.PerfectCurve));
-                Assert.That(first.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(161, -244)));
-                Assert.That(first.ControlPoints[1].Type.Value, Is.EqualTo(null));
+                Assert.That(first.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(first.ControlPoints[0].Type, Is.EqualTo(PathType.PerfectCurve));
+                Assert.That(first.ControlPoints[1].Position, Is.EqualTo(new Vector2(161, -244)));
+                Assert.That(first.ControlPoints[1].Type, Is.EqualTo(null));
 
-                Assert.That(first.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(376, -3)));
-                Assert.That(first.ControlPoints[2].Type.Value, Is.EqualTo(PathType.Bezier));
-                Assert.That(first.ControlPoints[3].Position.Value, Is.EqualTo(new Vector2(68, 15)));
-                Assert.That(first.ControlPoints[3].Type.Value, Is.EqualTo(null));
-                Assert.That(first.ControlPoints[4].Position.Value, Is.EqualTo(new Vector2(259, -132)));
-                Assert.That(first.ControlPoints[4].Type.Value, Is.EqualTo(null));
-                Assert.That(first.ControlPoints[5].Position.Value, Is.EqualTo(new Vector2(92, -107)));
-                Assert.That(first.ControlPoints[5].Type.Value, Is.EqualTo(null));
+                Assert.That(first.ControlPoints[2].Position, Is.EqualTo(new Vector2(376, -3)));
+                Assert.That(first.ControlPoints[2].Type, Is.EqualTo(PathType.Bezier));
+                Assert.That(first.ControlPoints[3].Position, Is.EqualTo(new Vector2(68, 15)));
+                Assert.That(first.ControlPoints[3].Type, Is.EqualTo(null));
+                Assert.That(first.ControlPoints[4].Position, Is.EqualTo(new Vector2(259, -132)));
+                Assert.That(first.ControlPoints[4].Type, Is.EqualTo(null));
+                Assert.That(first.ControlPoints[5].Position, Is.EqualTo(new Vector2(92, -107)));
+                Assert.That(first.ControlPoints[5].Type, Is.EqualTo(null));
 
                 // Single-segment
                 var second = ((IHasPath)decoded.HitObjects[1]).Path;
 
-                Assert.That(second.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(second.ControlPoints[0].Type.Value, Is.EqualTo(PathType.PerfectCurve));
-                Assert.That(second.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(161, -244)));
-                Assert.That(second.ControlPoints[1].Type.Value, Is.EqualTo(null));
-                Assert.That(second.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(376, -3)));
-                Assert.That(second.ControlPoints[2].Type.Value, Is.EqualTo(null));
+                Assert.That(second.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(second.ControlPoints[0].Type, Is.EqualTo(PathType.PerfectCurve));
+                Assert.That(second.ControlPoints[1].Position, Is.EqualTo(new Vector2(161, -244)));
+                Assert.That(second.ControlPoints[1].Type, Is.EqualTo(null));
+                Assert.That(second.ControlPoints[2].Position, Is.EqualTo(new Vector2(376, -3)));
+                Assert.That(second.ControlPoints[2].Type, Is.EqualTo(null));
 
                 // Implicit multi-segment
                 var third = ((IHasPath)decoded.HitObjects[2]).Path;
 
-                Assert.That(third.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(third.ControlPoints[0].Type.Value, Is.EqualTo(PathType.Bezier));
-                Assert.That(third.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(0, 192)));
-                Assert.That(third.ControlPoints[1].Type.Value, Is.EqualTo(null));
-                Assert.That(third.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(224, 192)));
-                Assert.That(third.ControlPoints[2].Type.Value, Is.EqualTo(null));
+                Assert.That(third.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(third.ControlPoints[0].Type, Is.EqualTo(PathType.Bezier));
+                Assert.That(third.ControlPoints[1].Position, Is.EqualTo(new Vector2(0, 192)));
+                Assert.That(third.ControlPoints[1].Type, Is.EqualTo(null));
+                Assert.That(third.ControlPoints[2].Position, Is.EqualTo(new Vector2(224, 192)));
+                Assert.That(third.ControlPoints[2].Type, Is.EqualTo(null));
 
-                Assert.That(third.ControlPoints[3].Position.Value, Is.EqualTo(new Vector2(224, 0)));
-                Assert.That(third.ControlPoints[3].Type.Value, Is.EqualTo(PathType.Bezier));
-                Assert.That(third.ControlPoints[4].Position.Value, Is.EqualTo(new Vector2(224, -192)));
-                Assert.That(third.ControlPoints[4].Type.Value, Is.EqualTo(null));
-                Assert.That(third.ControlPoints[5].Position.Value, Is.EqualTo(new Vector2(480, -192)));
-                Assert.That(third.ControlPoints[5].Type.Value, Is.EqualTo(null));
-                Assert.That(third.ControlPoints[6].Position.Value, Is.EqualTo(new Vector2(480, 0)));
-                Assert.That(third.ControlPoints[6].Type.Value, Is.EqualTo(null));
+                Assert.That(third.ControlPoints[3].Position, Is.EqualTo(new Vector2(224, 0)));
+                Assert.That(third.ControlPoints[3].Type, Is.EqualTo(PathType.Bezier));
+                Assert.That(third.ControlPoints[4].Position, Is.EqualTo(new Vector2(224, -192)));
+                Assert.That(third.ControlPoints[4].Type, Is.EqualTo(null));
+                Assert.That(third.ControlPoints[5].Position, Is.EqualTo(new Vector2(480, -192)));
+                Assert.That(third.ControlPoints[5].Type, Is.EqualTo(null));
+                Assert.That(third.ControlPoints[6].Position, Is.EqualTo(new Vector2(480, 0)));
+                Assert.That(third.ControlPoints[6].Type, Is.EqualTo(null));
 
                 // Last control point duplicated
                 var fourth = ((IHasPath)decoded.HitObjects[3]).Path;
 
-                Assert.That(fourth.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(fourth.ControlPoints[0].Type.Value, Is.EqualTo(PathType.Bezier));
-                Assert.That(fourth.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(1, 1)));
-                Assert.That(fourth.ControlPoints[1].Type.Value, Is.EqualTo(null));
-                Assert.That(fourth.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(2, 2)));
-                Assert.That(fourth.ControlPoints[2].Type.Value, Is.EqualTo(null));
-                Assert.That(fourth.ControlPoints[3].Position.Value, Is.EqualTo(new Vector2(3, 3)));
-                Assert.That(fourth.ControlPoints[3].Type.Value, Is.EqualTo(null));
-                Assert.That(fourth.ControlPoints[4].Position.Value, Is.EqualTo(new Vector2(3, 3)));
-                Assert.That(fourth.ControlPoints[4].Type.Value, Is.EqualTo(null));
+                Assert.That(fourth.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(fourth.ControlPoints[0].Type, Is.EqualTo(PathType.Bezier));
+                Assert.That(fourth.ControlPoints[1].Position, Is.EqualTo(new Vector2(1, 1)));
+                Assert.That(fourth.ControlPoints[1].Type, Is.EqualTo(null));
+                Assert.That(fourth.ControlPoints[2].Position, Is.EqualTo(new Vector2(2, 2)));
+                Assert.That(fourth.ControlPoints[2].Type, Is.EqualTo(null));
+                Assert.That(fourth.ControlPoints[3].Position, Is.EqualTo(new Vector2(3, 3)));
+                Assert.That(fourth.ControlPoints[3].Type, Is.EqualTo(null));
+                Assert.That(fourth.ControlPoints[4].Position, Is.EqualTo(new Vector2(3, 3)));
+                Assert.That(fourth.ControlPoints[4].Type, Is.EqualTo(null));
 
                 // Last control point in segment duplicated
                 var fifth = ((IHasPath)decoded.HitObjects[4]).Path;
 
-                Assert.That(fifth.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(fifth.ControlPoints[0].Type.Value, Is.EqualTo(PathType.Bezier));
-                Assert.That(fifth.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(1, 1)));
-                Assert.That(fifth.ControlPoints[1].Type.Value, Is.EqualTo(null));
-                Assert.That(fifth.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(2, 2)));
-                Assert.That(fifth.ControlPoints[2].Type.Value, Is.EqualTo(null));
-                Assert.That(fifth.ControlPoints[3].Position.Value, Is.EqualTo(new Vector2(3, 3)));
-                Assert.That(fifth.ControlPoints[3].Type.Value, Is.EqualTo(null));
-                Assert.That(fifth.ControlPoints[4].Position.Value, Is.EqualTo(new Vector2(3, 3)));
-                Assert.That(fifth.ControlPoints[4].Type.Value, Is.EqualTo(null));
+                Assert.That(fifth.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(fifth.ControlPoints[0].Type, Is.EqualTo(PathType.Bezier));
+                Assert.That(fifth.ControlPoints[1].Position, Is.EqualTo(new Vector2(1, 1)));
+                Assert.That(fifth.ControlPoints[1].Type, Is.EqualTo(null));
+                Assert.That(fifth.ControlPoints[2].Position, Is.EqualTo(new Vector2(2, 2)));
+                Assert.That(fifth.ControlPoints[2].Type, Is.EqualTo(null));
+                Assert.That(fifth.ControlPoints[3].Position, Is.EqualTo(new Vector2(3, 3)));
+                Assert.That(fifth.ControlPoints[3].Type, Is.EqualTo(null));
+                Assert.That(fifth.ControlPoints[4].Position, Is.EqualTo(new Vector2(3, 3)));
+                Assert.That(fifth.ControlPoints[4].Type, Is.EqualTo(null));
 
-                Assert.That(fifth.ControlPoints[5].Position.Value, Is.EqualTo(new Vector2(4, 4)));
-                Assert.That(fifth.ControlPoints[5].Type.Value, Is.EqualTo(PathType.Bezier));
-                Assert.That(fifth.ControlPoints[6].Position.Value, Is.EqualTo(new Vector2(5, 5)));
-                Assert.That(fifth.ControlPoints[6].Type.Value, Is.EqualTo(null));
+                Assert.That(fifth.ControlPoints[5].Position, Is.EqualTo(new Vector2(4, 4)));
+                Assert.That(fifth.ControlPoints[5].Type, Is.EqualTo(PathType.Bezier));
+                Assert.That(fifth.ControlPoints[6].Position, Is.EqualTo(new Vector2(5, 5)));
+                Assert.That(fifth.ControlPoints[6].Type, Is.EqualTo(null));
 
                 // Implicit perfect-curve multi-segment(Should convert to bezier to match stable)
                 var sixth = ((IHasPath)decoded.HitObjects[5]).Path;
 
-                Assert.That(sixth.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(sixth.ControlPoints[0].Type.Value == PathType.Bezier);
-                Assert.That(sixth.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(75, 145)));
-                Assert.That(sixth.ControlPoints[1].Type.Value == null);
-                Assert.That(sixth.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(170, 75)));
+                Assert.That(sixth.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(sixth.ControlPoints[0].Type == PathType.Bezier);
+                Assert.That(sixth.ControlPoints[1].Position, Is.EqualTo(new Vector2(75, 145)));
+                Assert.That(sixth.ControlPoints[1].Type == null);
+                Assert.That(sixth.ControlPoints[2].Position, Is.EqualTo(new Vector2(170, 75)));
 
-                Assert.That(sixth.ControlPoints[2].Type.Value == PathType.Bezier);
-                Assert.That(sixth.ControlPoints[3].Position.Value, Is.EqualTo(new Vector2(300, 145)));
-                Assert.That(sixth.ControlPoints[3].Type.Value == null);
-                Assert.That(sixth.ControlPoints[4].Position.Value, Is.EqualTo(new Vector2(410, 20)));
-                Assert.That(sixth.ControlPoints[4].Type.Value == null);
+                Assert.That(sixth.ControlPoints[2].Type == PathType.Bezier);
+                Assert.That(sixth.ControlPoints[3].Position, Is.EqualTo(new Vector2(300, 145)));
+                Assert.That(sixth.ControlPoints[3].Type == null);
+                Assert.That(sixth.ControlPoints[4].Position, Is.EqualTo(new Vector2(410, 20)));
+                Assert.That(sixth.ControlPoints[4].Type == null);
 
                 // Explicit perfect-curve multi-segment(Should not convert to bezier)
                 var seventh = ((IHasPath)decoded.HitObjects[6]).Path;
 
-                Assert.That(seventh.ControlPoints[0].Position.Value, Is.EqualTo(Vector2.Zero));
-                Assert.That(seventh.ControlPoints[0].Type.Value == PathType.PerfectCurve);
-                Assert.That(seventh.ControlPoints[1].Position.Value, Is.EqualTo(new Vector2(75, 145)));
-                Assert.That(seventh.ControlPoints[1].Type.Value == null);
-                Assert.That(seventh.ControlPoints[2].Position.Value, Is.EqualTo(new Vector2(170, 75)));
+                Assert.That(seventh.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+                Assert.That(seventh.ControlPoints[0].Type == PathType.PerfectCurve);
+                Assert.That(seventh.ControlPoints[1].Position, Is.EqualTo(new Vector2(75, 145)));
+                Assert.That(seventh.ControlPoints[1].Type == null);
+                Assert.That(seventh.ControlPoints[2].Position, Is.EqualTo(new Vector2(170, 75)));
 
-                Assert.That(seventh.ControlPoints[2].Type.Value == PathType.PerfectCurve);
-                Assert.That(seventh.ControlPoints[3].Position.Value, Is.EqualTo(new Vector2(300, 145)));
-                Assert.That(seventh.ControlPoints[3].Type.Value == null);
-                Assert.That(seventh.ControlPoints[4].Position.Value, Is.EqualTo(new Vector2(410, 20)));
-                Assert.That(seventh.ControlPoints[4].Type.Value == null);
+                Assert.That(seventh.ControlPoints[2].Type == PathType.PerfectCurve);
+                Assert.That(seventh.ControlPoints[3].Position, Is.EqualTo(new Vector2(300, 145)));
+                Assert.That(seventh.ControlPoints[3].Type == null);
+                Assert.That(seventh.ControlPoints[4].Position, Is.EqualTo(new Vector2(410, 20)));
+                Assert.That(seventh.ControlPoints[4].Type == null);
             }
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
@@ -74,14 +74,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestAddControlPoint()
         {
             AddStep("create path", () => path.ControlPoints.AddRange(createSegment(PathType.Linear, Vector2.Zero, new Vector2(0, 100))));
-            AddStep("add point", () => path.ControlPoints.Add(new PathControlPoint { Position = { Value = new Vector2(100) } }));
+            AddStep("add point", () => path.ControlPoints.Add(new PathControlPoint { Position = new Vector2(100) }));
         }
 
         [Test]
         public void TestInsertControlPoint()
         {
             AddStep("create path", () => path.ControlPoints.AddRange(createSegment(PathType.Linear, Vector2.Zero, new Vector2(100))));
-            AddStep("insert point", () => path.ControlPoints.Insert(1, new PathControlPoint { Position = { Value = new Vector2(0, 100) } }));
+            AddStep("insert point", () => path.ControlPoints.Insert(1, new PathControlPoint { Position = new Vector2(0, 100) }));
         }
 
         [Test]
@@ -95,14 +95,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestChangePathType()
         {
             AddStep("create path", () => path.ControlPoints.AddRange(createSegment(PathType.Linear, Vector2.Zero, new Vector2(0, 100), new Vector2(100))));
-            AddStep("change type to bezier", () => path.ControlPoints[0].Type.Value = PathType.Bezier);
+            AddStep("change type to bezier", () => path.ControlPoints[0].Type = PathType.Bezier);
         }
 
         [Test]
         public void TestAddSegmentByChangingType()
         {
             AddStep("create path", () => path.ControlPoints.AddRange(createSegment(PathType.Linear, Vector2.Zero, new Vector2(0, 100), new Vector2(100), new Vector2(100, 0))));
-            AddStep("change second point type to bezier", () => path.ControlPoints[1].Type.Value = PathType.Bezier);
+            AddStep("change second point type to bezier", () => path.ControlPoints[1].Type = PathType.Bezier);
         }
 
         [Test]
@@ -111,10 +111,10 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("create path", () =>
             {
                 path.ControlPoints.AddRange(createSegment(PathType.Linear, Vector2.Zero, new Vector2(0, 100), new Vector2(100), new Vector2(100, 0)));
-                path.ControlPoints[1].Type.Value = PathType.Bezier;
+                path.ControlPoints[1].Type = PathType.Bezier;
             });
 
-            AddStep("change second point type to null", () => path.ControlPoints[1].Type.Value = null);
+            AddStep("change second point type to null", () => path.ControlPoints[1].Type = null);
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("create path", () =>
             {
                 path.ControlPoints.AddRange(createSegment(PathType.Linear, Vector2.Zero, new Vector2(0, 100), new Vector2(100), new Vector2(100, 0)));
-                path.ControlPoints[1].Type.Value = PathType.Bezier;
+                path.ControlPoints[1].Type = PathType.Bezier;
             });
 
             AddStep("remove second point", () => path.ControlPoints.RemoveAt(1));
@@ -185,8 +185,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private List<PathControlPoint> createSegment(PathType type, params Vector2[] controlPoints)
         {
-            var points = controlPoints.Select(p => new PathControlPoint { Position = { Value = p } }).ToList();
-            points[0].Type.Value = type;
+            var points = controlPoints.Select(p => new PathControlPoint { Position = p }).ToList();
+            points[0].Type = type;
             return points;
         }
     }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -323,22 +323,22 @@ namespace osu.Game.Beatmaps.Formats
             {
                 PathControlPoint point = pathData.Path.ControlPoints[i];
 
-                if (point.Type.Value != null)
+                if (point.Type != null)
                 {
                     // We've reached a new (explicit) segment!
 
                     // Explicit segments have a new format in which the type is injected into the middle of the control point string.
                     // To preserve compatibility with osu-stable as much as possible, explicit segments with the same type are converted to use implicit segments by duplicating the control point.
                     // One exception are consecutive perfect curves, which aren't supported in osu!stable and can lead to decoding issues if encoded as implicit segments
-                    bool needsExplicitSegment = point.Type.Value != lastType || point.Type.Value == PathType.PerfectCurve;
+                    bool needsExplicitSegment = point.Type != lastType || point.Type == PathType.PerfectCurve;
 
                     // Another exception to this is when the last two control points of the last segment were duplicated. This is not a scenario supported by osu!stable.
                     // Lazer does not add implicit segments for the last two control points of _any_ explicit segment, so an explicit segment is forced in order to maintain consistency with the decoder.
                     if (i > 1)
                     {
                         // We need to use the absolute control point position to determine equality, otherwise floating point issues may arise.
-                        Vector2 p1 = position + pathData.Path.ControlPoints[i - 1].Position.Value;
-                        Vector2 p2 = position + pathData.Path.ControlPoints[i - 2].Position.Value;
+                        Vector2 p1 = position + pathData.Path.ControlPoints[i - 1].Position;
+                        Vector2 p2 = position + pathData.Path.ControlPoints[i - 2].Position;
 
                         if ((int)p1.X == (int)p2.X && (int)p1.Y == (int)p2.Y)
                             needsExplicitSegment = true;
@@ -346,7 +346,7 @@ namespace osu.Game.Beatmaps.Formats
 
                     if (needsExplicitSegment)
                     {
-                        switch (point.Type.Value)
+                        switch (point.Type)
                         {
                             case PathType.Bezier:
                                 writer.Write("B|");
@@ -365,18 +365,18 @@ namespace osu.Game.Beatmaps.Formats
                                 break;
                         }
 
-                        lastType = point.Type.Value;
+                        lastType = point.Type;
                     }
                     else
                     {
                         // New segment with the same type - duplicate the control point
-                        writer.Write(FormattableString.Invariant($"{position.X + point.Position.Value.X}:{position.Y + point.Position.Value.Y}|"));
+                        writer.Write(FormattableString.Invariant($"{position.X + point.Position.X}:{position.Y + point.Position.Y}|"));
                     }
                 }
 
                 if (i != 0)
                 {
-                    writer.Write(FormattableString.Invariant($"{position.X + point.Position.Value.X}:{position.Y + point.Position.Value.Y}"));
+                    writer.Write(FormattableString.Invariant($"{position.X + point.Position.X}:{position.Y + point.Position.Y}"));
                     writer.Write(i != pathData.Path.ControlPoints.Count - 1 ? "|" : ",");
                 }
             }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -323,7 +323,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             }
 
             // The first control point must have a definite type.
-            vertices[0].Type.Value = type;
+            vertices[0].Type = type;
 
             // A path can have multiple implicit segments of the same type if there are two sequential control points with the same position.
             // To handle such cases, this code may return multiple path segments with the final control point in each segment having a non-null type.
@@ -337,7 +337,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             while (++endIndex < vertices.Length - endPointLength)
             {
                 // Keep incrementing while an implicit segment doesn't need to be started
-                if (vertices[endIndex].Position.Value != vertices[endIndex - 1].Position.Value)
+                if (vertices[endIndex].Position != vertices[endIndex - 1].Position)
                     continue;
 
                 // The last control point of each segment is not allowed to start a new implicit segment.
@@ -345,7 +345,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                     continue;
 
                 // Force a type on the last point, and return the current control point set as a segment.
-                vertices[endIndex - 1].Type.Value = type;
+                vertices[endIndex - 1].Type = type;
                 yield return vertices.AsMemory().Slice(startIndex, endIndex - startIndex);
 
                 // Skip the current control point - as it's the same as the one that's just been returned.
@@ -360,11 +360,11 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 string[] vertexSplit = value.Split(':');
 
                 Vector2 pos = new Vector2((int)Parsing.ParseDouble(vertexSplit[0], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseDouble(vertexSplit[1], Parsing.MAX_COORDINATE_VALUE)) - startPos;
-                point = new PathControlPoint { Position = { Value = pos } };
+                point = new PathControlPoint { Position = pos };
             }
 
-            static bool isLinear(PathControlPoint[] p) => Precision.AlmostEquals(0, (p[1].Position.Value.Y - p[0].Position.Value.Y) * (p[2].Position.Value.X - p[0].Position.Value.X)
-                                                                                    - (p[1].Position.Value.X - p[0].Position.Value.X) * (p[2].Position.Value.Y - p[0].Position.Value.Y));
+            static bool isLinear(PathControlPoint[] p) => Precision.AlmostEquals(0, (p[1].Position.Y - p[0].Position.Y) * (p[2].Position.X - p[0].Position.X)
+                                                                                    - (p[1].Position.X - p[0].Position.X) * (p[2].Position.Y - p[0].Position.Y));
         }
 
         private PathControlPoint[] mergePointsLists(List<Memory<PathControlPoint>> controlPointList)

--- a/osu.Game/Rulesets/Objects/PathControlPoint.cs
+++ b/osu.Game/Rulesets/Objects/PathControlPoint.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Newtonsoft.Json;
-using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK;
 
@@ -11,31 +10,55 @@ namespace osu.Game.Rulesets.Objects
 {
     public class PathControlPoint : IEquatable<PathControlPoint>
     {
+        private Vector2 position;
+
         /// <summary>
         /// The position of this <see cref="PathControlPoint"/>.
         /// </summary>
         [JsonProperty]
-        public readonly Bindable<Vector2> Position = new Bindable<Vector2>();
+        public Vector2 Position
+        {
+            get => position;
+            set
+            {
+                if (value == position)
+                    return;
+
+                position = value;
+                Changed?.Invoke();
+            }
+        }
+
+        private PathType? type;
 
         /// <summary>
         /// The type of path segment starting at this <see cref="PathControlPoint"/>.
         /// If null, this <see cref="PathControlPoint"/> will be a part of the previous path segment.
         /// </summary>
         [JsonProperty]
-        public readonly Bindable<PathType?> Type = new Bindable<PathType?>();
+        public PathType? Type
+        {
+            get => type;
+            set
+            {
+                if (value == type)
+                    return;
+
+                type = value;
+                Changed?.Invoke();
+            }
+        }
 
         /// <summary>
         /// Invoked when any property of this <see cref="PathControlPoint"/> is changed.
         /// </summary>
-        internal event Action Changed;
+        public event Action Changed;
 
         /// <summary>
         /// Creates a new <see cref="PathControlPoint"/>.
         /// </summary>
         public PathControlPoint()
         {
-            Position.ValueChanged += _ => Changed?.Invoke();
-            Type.ValueChanged += _ => Changed?.Invoke();
         }
 
         /// <summary>
@@ -46,10 +69,10 @@ namespace osu.Game.Rulesets.Objects
         public PathControlPoint(Vector2 position, PathType? type = null)
             : this()
         {
-            Position.Value = position;
-            Type.Value = type;
+            Position = position;
+            Type = type;
         }
 
-        public bool Equals(PathControlPoint other) => Position.Value == other?.Position.Value && Type.Value == other.Type.Value;
+        public bool Equals(PathControlPoint other) => Position == other?.Position && Type == other.Type;
     }
 }

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Rulesets.Objects
 
             foreach (PathControlPoint point in ControlPoints)
             {
-                if (point.Type.Value != null)
+                if (point.Type != null)
                 {
                     if (!found)
                         pointsInCurrentSegment.Clear();
@@ -215,18 +215,18 @@ namespace osu.Game.Rulesets.Objects
 
             Vector2[] vertices = new Vector2[ControlPoints.Count];
             for (int i = 0; i < ControlPoints.Count; i++)
-                vertices[i] = ControlPoints[i].Position.Value;
+                vertices[i] = ControlPoints[i].Position;
 
             int start = 0;
 
             for (int i = 0; i < ControlPoints.Count; i++)
             {
-                if (ControlPoints[i].Type.Value == null && i < ControlPoints.Count - 1)
+                if (ControlPoints[i].Type == null && i < ControlPoints.Count - 1)
                     continue;
 
                 // The current vertex ends the segment
                 var segmentVertices = vertices.AsSpan().Slice(start, i - start + 1);
-                var segmentType = ControlPoints[start].Type.Value ?? PathType.Linear;
+                var segmentType = ControlPoints[start].Type ?? PathType.Linear;
 
                 foreach (Vector2 t in calculateSubPath(segmentVertices, segmentType))
                 {

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Objects
         public static void Reverse(this SliderPath sliderPath, out Vector2 positionalOffset)
         {
             var points = sliderPath.ControlPoints.ToArray();
-            positionalOffset = points.Last().Position.Value;
+            positionalOffset = points.Last().Position;
 
             sliderPath.ControlPoints.Clear();
 
@@ -28,17 +28,13 @@ namespace osu.Game.Rulesets.Objects
             for (var i = 0; i < points.Length; i++)
             {
                 var p = points[i];
-                p.Position.Value -= positionalOffset;
+                p.Position -= positionalOffset;
 
                 // propagate types forwards to last null type
                 if (i == points.Length - 1)
-                    p.Type.Value = lastType;
-                else if (p.Type.Value != null)
-                {
-                    var newType = p.Type.Value;
-                    p.Type.Value = lastType;
-                    lastType = newType;
-                }
+                    p.Type = lastType;
+                else if (p.Type != null)
+                    (p.Type, lastType) = (lastType, p.Type);
 
                 sliderPath.ControlPoints.Insert(0, p);
             }


### PR DESCRIPTION
This is a breaking change for rulesets that read directly from control points, but I think it is beneficial due to the large amount of usage of this class.

I originally intended just to remove the allocations of the two delegates handling the `Changed` flow internally, but as nothing was really using the bindables for anything more than a general "point has changed" case, this felt like a better direction (potentially a code quality improvement too?).

Before:

![20210826 124357 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130897128-79c88cf5-f596-4641-b149-df723d9c9fcb.png)

After:

![20210826 124426 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130897152-6b2aa7ac-7cb7-4a64-8513-4cc3934f476b.png)

Special attention to the "retained bytes" part.

Actual gameplay effect is around 3,000 less bindables (on a map that doesn't abuse `PathControlPoint`s, in this case [big black](https://osu.ppy.sh/beatmapsets/41823#osu/131891)), but potentially a lot higher depending on how sliders are defined in the beatmap file.