### PR TITLE
Avoid unnecessary unbind operations when constructing `FollowPointLifetimeEntry`

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Objects;
@@ -20,8 +21,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         {
             Start = start;
             LifetimeStart = Start.StartTime;
-
-            bindEvents();
         }
 
         private OsuHitObject? end;
@@ -41,31 +40,39 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             }
         }
 
+        private bool wasBound = false;
+
         private void bindEvents()
         {
             UnbindEvents();
+
+            if (End == null)
+                return;
 
             // Note: Positions are bound for instantaneous feedback from positional changes from the editor, before ApplyDefaults() is called on hitobjects.
             Start.DefaultsApplied += onDefaultsApplied;
             Start.PositionBindable.ValueChanged += onPositionChanged;
 
-            if (End != null)
-            {
-                End.DefaultsApplied += onDefaultsApplied;
-                End.PositionBindable.ValueChanged += onPositionChanged;
-            }
+            End.DefaultsApplied += onDefaultsApplied;
+            End.PositionBindable.ValueChanged += onPositionChanged;
+
+            wasBound = true;
         }
 
         public void UnbindEvents()
         {
+            if (!wasBound)
+                return;
+
+            Debug.Assert(End != null);
+
             Start.DefaultsApplied -= onDefaultsApplied;
             Start.PositionBindable.ValueChanged -= onPositionChanged;
 
-            if (End != null)
-            {
-                End.DefaultsApplied -= onDefaultsApplied;
-                End.PositionBindable.ValueChanged -= onPositionChanged;
-            }
+            End.DefaultsApplied -= onDefaultsApplied;
+            End.PositionBindable.ValueChanged -= onPositionChanged;
+
+            wasBound = false;
         }
 
         private void onDefaultsApplied(HitObject obj) => refreshLifetimes();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             }
         }
 
-        private bool wasBound = false;
+        private bool wasBound;
 
         private void bindEvents()
         {


### PR DESCRIPTION
Until now, an unbind operations were happening even when there was no end point set yet. This would cause needless allocation of delegates.

Before (allocations over gameplay session, including beatmap load):

![20210826 130146 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130898673-7d642007-522a-4244-899c-de9b560f3d28.png)

After:

![20210826 130208 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130898633-e239fd2f-34c2-41da-ab0e-cf8c77a36c0b.png)
