### PR TITLE
Avoid unnecessary array/LINQ operations when replay frames have no action changes

### DIFF
--- a/osu.Game/Input/Handlers/ReplayInputHandler.cs
+++ b/osu.Game/Input/Handlers/ReplayInputHandler.cs
@@ -42,9 +42,24 @@ namespace osu.Game.Input.Handlers
                 if (!(state is RulesetInputManagerInputState<T> inputState))
                     throw new InvalidOperationException($"{nameof(ReplayState<T>)} should only be applied to a {nameof(RulesetInputManagerInputState<T>)}");
 
-                var lastPressed = inputState.LastReplayState?.PressedActions ?? new List<T>();
-                var released = lastPressed.Except(PressedActions).ToArray();
-                var pressed = PressedActions.Except(lastPressed).ToArray();
+                T[] released = Array.Empty<T>();
+                T[] pressed = Array.Empty<T>();
+
+                var lastPressed = inputState.LastReplayState?.PressedActions;
+
+                if (lastPressed == null || lastPressed.Count == 0)
+                {
+                    pressed = PressedActions.ToArray();
+                }
+                else if (PressedActions.Count == 0)
+                {
+                    released = lastPressed.ToArray();
+                }
+                else if (!lastPressed.SequenceEqual(PressedActions))
+                {
+                    released = lastPressed.Except(PressedActions).ToArray();
+                    pressed = PressedActions.Except(lastPressed).ToArray();
+                }
 
                 inputState.LastReplayState = this;
 


### PR DESCRIPTION
Before (allocations over a gameplay session):

![20210826 131015 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130899271-6d4891e1-29cf-4a89-a087-32e9d264f9c2.png)

![20210826 131232 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130899553-bd1fd52d-5c81-406e-ad86-c79a99591c6c.png)


After:

![20210826 131113 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130899312-1f1e5a9d-03c7-46c8-a781-a97903629b43.png)

![20210826 131256 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130899453-7caeb22f-e6c3-4cf8-bdca-e200c6e2674e.png)
