### PR TITLE
Change default skin's judgement result transform to reduce allocation overhead

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 base.PlayAnimation();
 
                 if (Result != HitResult.Miss)
-                    JudgementText.TransformSpacingTo(Vector2.Zero).Then().TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);
+                    JudgementText.ScaleTo(new Vector2(0.8f, 1)).Then().ScaleTo(new Vector2(1.2f, 1), 1800, Easing.OutQuint);
             }
         }
     }


### PR DESCRIPTION
I wasn't too sure how this would look in comparison to the spacing transform, but I think I actually prefer it visually (else I would have gone with another solution). We're probably going to be doing a complete redesign of these either way, so it's neither here nor there IMO.

The underlying issue is one we are going to need to revisit framework side (potentially by deciding it is not a focus for optimisation) involving `SpriteText` invalidating its `TextBuilder` on a spacing property change.

Before:

![20210826 132142 (dotnet)](https://user-images.githubusercontent.com/191335/130900125-0023d108-7af1-4e4c-8498-7d963339f462.gif)

After:

![20210826 132102 (dotnet)](https://user-images.githubusercontent.com/191335/130900086-54ed8bf8-217f-45d6-9297-e02f44bf1b29.gif)


Before:

![20210826 133540 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130901288-eae10fc9-d1c5-443e-811c-42e8b673f5b2.png)


After:

![20210826 133609 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130901315-e0a46ad6-023b-4b20-a148-5fc6fcc98141.png)
