### PR TITLE
Avoid `Enum.GetValues` allocation overhead in each score population pass

### DIFF
--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Utils;
 
 namespace osu.Game.Rulesets.Scoring
@@ -170,6 +172,11 @@ namespace osu.Game.Rulesets.Scoring
         /// Whether a <see cref="HitResult"/> is scorable.
         /// </summary>
         public static bool IsScorable(this HitResult result) => result >= HitResult.Miss && result < HitResult.IgnoreMiss;
+
+        /// <summary>
+        /// An array of all scorable <see cref="HitResult"/>s.
+        /// </summary>
+        public static readonly HitResult[] SCORABLE_TYPES = ((HitResult[])Enum.GetValues(typeof(HitResult))).Where(r => r.IsScorable()).ToArray();
 
         /// <summary>
         /// Whether a <see cref="HitResult"/> is valid within a given <see cref="HitResult"/> range.

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -339,7 +339,7 @@ namespace osu.Game.Rulesets.Scoring
             score.Accuracy = Accuracy.Value;
             score.Rank = Rank.Value;
 
-            foreach (var result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r.IsScorable()))
+            foreach (var result in HitResultExtensions.SCORABLE_TYPES)
                 score.Statistics[result] = GetStatistic(result);
 
             score.HitEvents = hitEvents;


### PR DESCRIPTION
A simple one

Before:

![20210826 134216 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130901842-344c80aa-ae61-491a-8824-0f17e6f750b4.png)


After:

![20210826 134229 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/130901859-e2fe40d2-1c7e-433c-98d3-23df1bb1359c.png)

