### PR TITLE
Fix editor screen test scenes not updated to show their screens

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -30,7 +31,10 @@ namespace osu.Game.Tests.Visual.Editing
         {
             Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
 
-            Child = new ComposeScreen();
+            Child = new ComposeScreen
+            {
+                State = { Value = Visibility.Visible },
+            };
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneSetupScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneSetupScreen.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Screens.Edit;
@@ -26,7 +27,11 @@ namespace osu.Game.Tests.Visual.Editing
         private void load()
         {
             Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
-            Child = new SetupScreen();
+
+            Child = new SetupScreen
+            {
+                State = { Value = Visibility.Visible },
+            };
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
@@ -30,7 +31,10 @@ namespace osu.Game.Tests.Visual.Editing
             Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
             Beatmap.Disabled = true;
 
-            Child = new TimingScreen();
+            Child = new TimingScreen
+            {
+                State = { Value = Visibility.Visible },
+            };
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Regressed in #14494. 

Screens are intended to start hidden and become visible once loaded (for the "pop in" effect), but test scenes have regressed in return.

Updated all test scenes to set visibility state on screen, just like is the case with any other components that usually starts hidden.