### PR TITLE
Fix exception in beatmap info overlay

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 maxComboColumn.Text = value.MaxCombo.ToLocalisableString(@"0\x");
 
                 ppColumn.Alpha = value.Beatmap?.Status.GrantsPerformancePoints() == true ? 1 : 0;
-                ppColumn.Text = value.PP.ToLocalisableString(@"N0");
+                ppColumn.Text = value.PP?.ToLocalisableString(@"N0");
 
                 statisticsColumns.ChildrenEnumerable = value.GetStatisticsForDisplay().Select(createStatisticsColumn);
                 modsColumn.Mods = value.Mods;


### PR DESCRIPTION
Closes #14541

This adds the missing null coalescence operator that was causing formatting to fail under the scenario where the returned pp value was null, (ie: when the map is loved)