### PR TITLE
Parse partially typed status names in song select filter query

### DIFF
--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
-using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select
@@ -64,8 +64,7 @@ namespace osu.Game.Screens.Select
                     return TryUpdateCriteriaRange(ref criteria.BeatDivisor, op, value, tryParseInt);
 
                 case "status":
-                    return TryUpdateCriteriaRange(ref criteria.OnlineStatus, op, value,
-                        (string s, out BeatmapSetOnlineStatus val) => Enum.TryParse(value, true, out val));
+                    return TryUpdateCriteriaRange(ref criteria.OnlineStatus, op, value, tryParseEnum);
 
                 case "creator":
                     return TryUpdateCriteriaText(ref criteria.Creator, op, value);
@@ -119,6 +118,14 @@ namespace osu.Game.Screens.Select
 
         private static bool tryParseInt(string value, out int result) =>
             int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
+
+        private static bool tryParseEnum<TEnum>(string value, out TEnum result) where TEnum : struct
+        {
+            if (Enum.TryParse(value, true, out result)) return true;
+
+            string status = Enum.GetNames(typeof(TEnum)).FirstOrDefault(name => name.StartsWith(value, true, CultureInfo.InvariantCulture));
+            return Enum.TryParse(status, true, out result);
+        }
 
         /// <summary>
         /// Attempts to parse a keyword filter with the specified <paramref name="op"/> and textual <paramref name="value"/>.

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -123,8 +123,8 @@ namespace osu.Game.Screens.Select
         {
             if (Enum.TryParse(value, true, out result)) return true;
 
-            string status = Enum.GetNames(typeof(TEnum)).FirstOrDefault(name => name.StartsWith(value, true, CultureInfo.InvariantCulture));
-            return Enum.TryParse(status, true, out result);
+            value = Enum.GetNames(typeof(TEnum)).FirstOrDefault(name => name.StartsWith(value, true, CultureInfo.InvariantCulture));
+            return Enum.TryParse(value, true, out result);
         }
 
         /// <summary>


### PR DESCRIPTION
Besides `Enum.TryParse`, the parser now also checks if any of the status names starts with the input string. This allows users to type `status=r` instead of `status=ranked`, matching stable behavior.