### PR TITLE
Move labelled dropdown from tournament to main game 

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledDropdown.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledDropdown.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneLabelledDropdown : OsuTestScene
+    {
+        [Test]
+        public void TestLabelledDropdown()
+            => AddStep(@"create dropdown", () => Child = new LabelledDropdown<string>
+            {
+                Label = @"Countdown speed",
+                Items = new[]
+                {
+                    @"Half",
+                    @"Normal",
+                    @"Double"
+                },
+                Description = @"This is a description"
+            });
+
+        [Test]
+        public void TestLabelledEnumDropdown()
+            => AddStep(@"create dropdown", () => Child = new LabelledEnumDropdown<BeatmapSetOnlineStatus>
+            {
+                Label = @"Beatmap status",
+                Description = @"This is a description"
+            });
+    }
+}

--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -1,14 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Drawing;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -130,26 +128,6 @@ namespace osu.Game.Tournament.Screens.Setup
             base.Update();
 
             resolution.Value = $"{ScreenSpaceDrawQuad.Width:N0}x{ScreenSpaceDrawQuad.Height:N0}";
-        }
-
-        public class LabelledDropdown<T> : LabelledComponent<OsuDropdown<T>, T>
-        {
-            public LabelledDropdown()
-                : base(true)
-            {
-            }
-
-            public IEnumerable<T> Items
-            {
-                get => Component.Items;
-                set => Component.Items = value;
-            }
-
-            protected override OsuDropdown<T> CreateComponent() => new OsuDropdown<T>
-            {
-                RelativeSizeAxes = Axes.X,
-                Width = 0.5f,
-            };
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledDropdown.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public class LabelledDropdown<TItem> : LabelledComponent<OsuDropdown<TItem>, TItem>
+    {
+        public LabelledDropdown()
+            : base(true)
+        {
+        }
+
+        public IEnumerable<TItem> Items
+        {
+            get => Component.Items;
+            set => Component.Items = value;
+        }
+
+        protected sealed override OsuDropdown<TItem> CreateComponent() => CreateDropdown().With(d =>
+        {
+            d.RelativeSizeAxes = Axes.X;
+            d.Width = 0.5f;
+        });
+
+        protected virtual OsuDropdown<TItem> CreateDropdown() => new OsuDropdown<TItem>();
+    }
+}

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledEnumDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledEnumDropdown.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public class LabelledEnumDropdown<TEnum> : LabelledDropdown<TEnum>
+        where TEnum : struct, Enum
+    {
+        protected override OsuDropdown<TEnum> CreateDropdown() => new OsuEnumDropdown<TEnum>();
+    }
+}


### PR DESCRIPTION
To be used in the setup screen for countdown settings.

Also adds a `LabelledEnumDropdown<T>` and a test scene while I'm at it.