### PR TITLE
Add countdown settings to setup screen

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDesignSection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDesignSection.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -42,7 +43,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("turn countdown off", () => designSection.EnableCountdown.Current.Value = false);
 
             AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.None);
-            AddUntilStep("other controls hidden", () => !designSection.CountdownSpeed.IsPresent && !designSection.CountdownOffset.IsPresent);
+            AddUntilStep("other controls hidden", () => !designSection.CountdownSettings.IsPresent);
         }
 
         [Test]
@@ -51,12 +52,12 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("turn countdown on", () => designSection.EnableCountdown.Current.Value = true);
 
             AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.Normal);
-            AddUntilStep("other controls shown", () => designSection.CountdownSpeed.IsPresent && designSection.CountdownOffset.IsPresent);
+            AddUntilStep("other controls shown", () => designSection.CountdownSettings.IsPresent);
 
             AddStep("change countdown speed", () => designSection.CountdownSpeed.Current.Value = CountdownType.DoubleSpeed);
 
             AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.DoubleSpeed);
-            AddUntilStep("other controls still shown", () => designSection.CountdownSpeed.IsPresent && designSection.CountdownOffset.IsPresent);
+            AddUntilStep("other controls still shown", () => designSection.CountdownSettings.IsPresent);
         }
 
         [Test]
@@ -90,6 +91,8 @@ namespace osu.Game.Tests.Visual.Editing
         private class TestDesignSection : DesignSection
         {
             public new LabelledSwitchButton EnableCountdown => base.EnableCountdown;
+
+            public new FillFlowContainer CountdownSettings => base.CountdownSettings;
             public new LabelledEnumDropdown<CountdownType> CountdownSpeed => base.CountdownSpeed;
             public new LabelledNumberBox CountdownOffset => base.CountdownOffset;
         }

--- a/osu.Game.Tests/Visual/Editing/TestSceneDesignSection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDesignSection.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Setup;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneDesignSection : OsuManualInputManagerTestScene
+    {
+        private TestDesignSection designSection;
+        private EditorBeatmap editorBeatmap { get; set; }
+
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create blank beatmap", () => editorBeatmap = new EditorBeatmap(new Beatmap()));
+            AddStep("create section", () => Child = new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(EditorBeatmap), editorBeatmap)
+                },
+                Child = designSection = new TestDesignSection()
+            });
+        }
+
+        [Test]
+        public void TestCountdownOff()
+        {
+            AddStep("turn countdown off", () => designSection.EnableCountdown.Current.Value = false);
+
+            AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.None);
+            AddUntilStep("other controls hidden", () => !designSection.CountdownSpeed.IsPresent && !designSection.CountdownOffset.IsPresent);
+        }
+
+        [Test]
+        public void TestCountdownOn()
+        {
+            AddStep("turn countdown on", () => designSection.EnableCountdown.Current.Value = true);
+
+            AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.Normal);
+            AddUntilStep("other controls shown", () => designSection.CountdownSpeed.IsPresent && designSection.CountdownOffset.IsPresent);
+
+            AddStep("change countdown speed", () => designSection.CountdownSpeed.Current.Value = CountdownType.DoubleSpeed);
+
+            AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.DoubleSpeed);
+            AddUntilStep("other controls still shown", () => designSection.CountdownSpeed.IsPresent && designSection.CountdownOffset.IsPresent);
+        }
+
+        [Test]
+        public void TestCountdownOffset()
+        {
+            AddStep("turn countdown on", () => designSection.EnableCountdown.Current.Value = true);
+
+            AddAssert("beatmap has correct type", () => editorBeatmap.BeatmapInfo.Countdown == CountdownType.Normal);
+
+            checkOffsetAfter("1", 1);
+            checkOffsetAfter(string.Empty, 0);
+            checkOffsetAfter("123", 123);
+            checkOffsetAfter("0", 0);
+        }
+
+        private void checkOffsetAfter(string userInput, int expectedFinalValue)
+        {
+            AddStep("click text box", () =>
+            {
+                var textBox = designSection.CountdownOffset.ChildrenOfType<TextBox>().Single();
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("set offset text", () => designSection.CountdownOffset.Current.Value = userInput);
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+
+            AddAssert($"displayed value is {expectedFinalValue}", () => designSection.CountdownOffset.Current.Value == expectedFinalValue.ToString(CultureInfo.InvariantCulture));
+            AddAssert($"beatmap value is {expectedFinalValue}", () => editorBeatmap.BeatmapInfo.CountdownOffset == expectedFinalValue);
+        }
+
+        private class TestDesignSection : DesignSection
+        {
+            public new LabelledSwitchButton EnableCountdown => base.EnableCountdown;
+            public new LabelledEnumDropdown<CountdownType> CountdownSpeed => base.CountdownSpeed;
+            public new LabelledNumberBox CountdownOffset => base.CountdownOffset;
+        }
+    }
+}

--- a/osu.Game/Beatmaps/CountdownType.cs
+++ b/osu.Game/Beatmaps/CountdownType.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.ComponentModel;
+
 namespace osu.Game.Beatmaps
 {
     /// <summary>
@@ -9,8 +11,14 @@ namespace osu.Game.Beatmaps
     public enum CountdownType
     {
         None = 0,
+
+        [Description("Normal")]
         Normal = 1,
+
+        [Description("Half speed")]
         HalfSpeed = 2,
+
+        [Description("Double speed")]
         DoubleSpeed = 3
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledNumberBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledNumberBox.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public class LabelledNumberBox : LabelledTextBox
+    {
+        protected override OsuTextBox CreateTextBox() => new OsuNumberBox();
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Screens.Edit.Setup
 {
     internal class DesignSection : SetupSection
     {
-        private const float fade_duration = 250;
-
         protected LabelledSwitchButton EnableCountdown;
         protected LabelledEnumDropdown<CountdownType> CountdownSpeed;
         protected LabelledNumberBox CountdownOffset;
@@ -90,7 +88,6 @@ namespace osu.Game.Screens.Edit.Setup
             base.LoadComplete();
 
             EnableCountdown.Current.BindValueChanged(_ => updateCountdownSettingsVisibility(), true);
-            countdownSettings.FinishTransforms(true);
 
             EnableCountdown.Current.BindValueChanged(_ => updateBeatmap());
             CountdownSpeed.Current.BindValueChanged(_ => updateBeatmap());
@@ -101,16 +98,7 @@ namespace osu.Game.Screens.Edit.Setup
             letterboxDuringBreaks.Current.BindValueChanged(_ => updateBeatmap());
         }
 
-        private void updateCountdownSettingsVisibility()
-        {
-            bool countdownEnabled = EnableCountdown.Current.Value;
-
-            foreach (var child in countdownSettings)
-            {
-                child.ScaleTo(new Vector2(1, countdownEnabled ? 1 : 0), fade_duration, Easing.OutQuint)
-                     .FadeTo(countdownEnabled ? 1 : 0, fade_duration, Easing.OutQuint);
-            }
-        }
+        private void updateCountdownSettingsVisibility() => countdownSettings.FadeTo(EnableCountdown.Current.Value ? 1 : 0);
 
         private void onOffsetCommitted()
         {

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -1,14 +1,28 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Globalization;
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
 {
     internal class DesignSection : SetupSection
     {
+        private const float fade_duration = 250;
+
+        private LabelledSwitchButton enableCountdown;
+        private FillFlowContainer countdownSettings;
+        private LabelledEnumDropdown<CountdownType> countdownSpeed;
+        private LabelledNumberBox countdownOffset;
+
         private LabelledSwitchButton widescreenSupport;
         private LabelledSwitchButton epilepsyWarning;
         private LabelledSwitchButton letterboxDuringBreaks;
@@ -20,6 +34,35 @@ namespace osu.Game.Screens.Edit.Setup
         {
             Children = new[]
             {
+                enableCountdown = new LabelledSwitchButton
+                {
+                    Label = "Enable countdown",
+                    Current = { Value = Beatmap.BeatmapInfo.Countdown != CountdownType.None },
+                    Description = "If enabled, an \"Are you ready? 3, 2, 1, GO!\" countdown will be inserted at the beginning of the beatmap, assuming there is enough time to do so."
+                },
+                countdownSettings = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(10),
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        countdownSpeed = new LabelledEnumDropdown<CountdownType>
+                        {
+                            Label = "Countdown speed",
+                            Current = { Value = Beatmap.BeatmapInfo.Countdown != CountdownType.None ? Beatmap.BeatmapInfo.Countdown : CountdownType.Normal },
+                            Items = Enum.GetValues(typeof(CountdownType)).Cast<CountdownType>().Where(type => type != CountdownType.None)
+                        },
+                        countdownOffset = new LabelledNumberBox
+                        {
+                            Label = "Countdown offset",
+                            Current = { Value = Beatmap.BeatmapInfo.CountdownOffset.ToString() },
+                            Description = "If the countdown sounds off-time, use this to make it appear one or more beats early.",
+                        }
+                    }
+                },
+                Empty(),
                 widescreenSupport = new LabelledSwitchButton
                 {
                     Label = "Widescreen support",
@@ -45,13 +88,34 @@ namespace osu.Game.Screens.Edit.Setup
         {
             base.LoadComplete();
 
+            enableCountdown.Current.BindValueChanged(_ => updateCountdownSettingsVisibility(), true);
+            countdownSettings.FinishTransforms(true);
+
+            enableCountdown.Current.BindValueChanged(_ => updateBeatmap());
+            countdownSpeed.Current.BindValueChanged(_ => updateBeatmap());
+            countdownOffset.OnCommit += (_, __) => updateBeatmap();
+
             widescreenSupport.Current.BindValueChanged(_ => updateBeatmap());
             epilepsyWarning.Current.BindValueChanged(_ => updateBeatmap());
             letterboxDuringBreaks.Current.BindValueChanged(_ => updateBeatmap());
         }
 
+        private void updateCountdownSettingsVisibility()
+        {
+            bool countdownEnabled = enableCountdown.Current.Value;
+
+            foreach (var child in countdownSettings)
+            {
+                child.ScaleTo(new Vector2(1, countdownEnabled ? 1 : 0), fade_duration, Easing.OutQuint)
+                     .FadeTo(countdownEnabled ? 1 : 0, fade_duration, Easing.OutQuint);
+            }
+        }
+
         private void updateBeatmap()
         {
+            Beatmap.BeatmapInfo.Countdown = enableCountdown.Current.Value ? countdownSpeed.Current.Value : CountdownType.None;
+            Beatmap.BeatmapInfo.CountdownOffset = int.TryParse(countdownOffset.Current.Value, NumberStyles.None, CultureInfo.InvariantCulture, out int offset) ? offset : 0;
+
             Beatmap.BeatmapInfo.WidescreenStoryboard = widescreenSupport.Current.Value;
             Beatmap.BeatmapInfo.EpilepsyWarning = epilepsyWarning.Current.Value;
             Beatmap.BeatmapInfo.LetterboxInBreaks = letterboxDuringBreaks.Current.Value;

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -18,14 +18,15 @@ namespace osu.Game.Screens.Edit.Setup
     {
         private const float fade_duration = 250;
 
-        private LabelledSwitchButton enableCountdown;
-        private FillFlowContainer countdownSettings;
-        private LabelledEnumDropdown<CountdownType> countdownSpeed;
-        private LabelledNumberBox countdownOffset;
+        protected LabelledSwitchButton EnableCountdown;
+        protected LabelledEnumDropdown<CountdownType> CountdownSpeed;
+        protected LabelledNumberBox CountdownOffset;
 
         private LabelledSwitchButton widescreenSupport;
         private LabelledSwitchButton epilepsyWarning;
         private LabelledSwitchButton letterboxDuringBreaks;
+
+        private FillFlowContainer countdownSettings;
 
         public override LocalisableString Title => "Design";
 
@@ -34,7 +35,7 @@ namespace osu.Game.Screens.Edit.Setup
         {
             Children = new[]
             {
-                enableCountdown = new LabelledSwitchButton
+                EnableCountdown = new LabelledSwitchButton
                 {
                     Label = "Enable countdown",
                     Current = { Value = Beatmap.BeatmapInfo.Countdown != CountdownType.None },
@@ -48,13 +49,13 @@ namespace osu.Game.Screens.Edit.Setup
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        countdownSpeed = new LabelledEnumDropdown<CountdownType>
+                        CountdownSpeed = new LabelledEnumDropdown<CountdownType>
                         {
                             Label = "Countdown speed",
                             Current = { Value = Beatmap.BeatmapInfo.Countdown != CountdownType.None ? Beatmap.BeatmapInfo.Countdown : CountdownType.Normal },
                             Items = Enum.GetValues(typeof(CountdownType)).Cast<CountdownType>().Where(type => type != CountdownType.None)
                         },
-                        countdownOffset = new LabelledNumberBox
+                        CountdownOffset = new LabelledNumberBox
                         {
                             Label = "Countdown offset",
                             Current = { Value = Beatmap.BeatmapInfo.CountdownOffset.ToString() },
@@ -88,12 +89,12 @@ namespace osu.Game.Screens.Edit.Setup
         {
             base.LoadComplete();
 
-            enableCountdown.Current.BindValueChanged(_ => updateCountdownSettingsVisibility(), true);
+            EnableCountdown.Current.BindValueChanged(_ => updateCountdownSettingsVisibility(), true);
             countdownSettings.FinishTransforms(true);
 
-            enableCountdown.Current.BindValueChanged(_ => updateBeatmap());
-            countdownSpeed.Current.BindValueChanged(_ => updateBeatmap());
-            countdownOffset.OnCommit += (_, __) => updateBeatmap();
+            EnableCountdown.Current.BindValueChanged(_ => updateBeatmap());
+            CountdownSpeed.Current.BindValueChanged(_ => updateBeatmap());
+            CountdownOffset.OnCommit += (_, __) => onOffsetCommitted();
 
             widescreenSupport.Current.BindValueChanged(_ => updateBeatmap());
             epilepsyWarning.Current.BindValueChanged(_ => updateBeatmap());
@@ -102,7 +103,7 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void updateCountdownSettingsVisibility()
         {
-            bool countdownEnabled = enableCountdown.Current.Value;
+            bool countdownEnabled = EnableCountdown.Current.Value;
 
             foreach (var child in countdownSettings)
             {
@@ -111,10 +112,17 @@ namespace osu.Game.Screens.Edit.Setup
             }
         }
 
+        private void onOffsetCommitted()
+        {
+            updateBeatmap();
+            // update displayed text to ensure parsed value matches display (i.e. if empty string was provided).
+            CountdownOffset.Current.Value = Beatmap.BeatmapInfo.CountdownOffset.ToString(CultureInfo.InvariantCulture);
+        }
+
         private void updateBeatmap()
         {
-            Beatmap.BeatmapInfo.Countdown = enableCountdown.Current.Value ? countdownSpeed.Current.Value : CountdownType.None;
-            Beatmap.BeatmapInfo.CountdownOffset = int.TryParse(countdownOffset.Current.Value, NumberStyles.None, CultureInfo.InvariantCulture, out int offset) ? offset : 0;
+            Beatmap.BeatmapInfo.Countdown = EnableCountdown.Current.Value ? CountdownSpeed.Current.Value : CountdownType.None;
+            Beatmap.BeatmapInfo.CountdownOffset = int.TryParse(CountdownOffset.Current.Value, NumberStyles.None, CultureInfo.InvariantCulture, out int offset) ? offset : 0;
 
             Beatmap.BeatmapInfo.WidescreenStoryboard = widescreenSupport.Current.Value;
             Beatmap.BeatmapInfo.EpilepsyWarning = epilepsyWarning.Current.Value;

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -17,14 +17,14 @@ namespace osu.Game.Screens.Edit.Setup
     internal class DesignSection : SetupSection
     {
         protected LabelledSwitchButton EnableCountdown;
+
+        protected FillFlowContainer CountdownSettings;
         protected LabelledEnumDropdown<CountdownType> CountdownSpeed;
         protected LabelledNumberBox CountdownOffset;
 
         private LabelledSwitchButton widescreenSupport;
         private LabelledSwitchButton epilepsyWarning;
         private LabelledSwitchButton letterboxDuringBreaks;
-
-        private FillFlowContainer countdownSettings;
 
         public override LocalisableString Title => "Design";
 
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.Edit.Setup
                     Current = { Value = Beatmap.BeatmapInfo.Countdown != CountdownType.None },
                     Description = "If enabled, an \"Are you ready? 3, 2, 1, GO!\" countdown will be inserted at the beginning of the beatmap, assuming there is enough time to do so."
                 },
-                countdownSettings = new FillFlowContainer
+                CountdownSettings = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
@@ -98,7 +98,7 @@ namespace osu.Game.Screens.Edit.Setup
             letterboxDuringBreaks.Current.BindValueChanged(_ => updateBeatmap());
         }
 
-        private void updateCountdownSettingsVisibility() => countdownSettings.FadeTo(EnableCountdown.Current.Value ? 1 : 0);
+        private void updateCountdownSettingsVisibility() => CountdownSettings.FadeTo(EnableCountdown.Current.Value ? 1 : 0);
 
         private void onOffsetCommitted()
         {


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/14580

![osu_2021-08-30_22-37-40](https://user-images.githubusercontent.com/20418176/131402177-da77332a-871a-48c5-b223-3d0c0c575a48.jpg)

Because the countdown is not yet implemented and there's a bit of conditional show/hide and parsing logic I added tests this time. Probably could have not bothered but oh well they're there now.

There's also an addition of a labelled textbox in this diff, but it's a 12-line class, and that's including using statements and the license header, so I really didn't want to bother splitting that out as well. I'll do it on request, I guess.