### PR TITLE
Remove IJsonSerializable interface

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.Database;
-using osu.Game.IO.Serialization;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 
@@ -18,7 +17,7 @@ namespace osu.Game.Beatmaps
 {
     [ExcludeFromDynamicCompile]
     [Serializable]
-    public class BeatmapInfo : IEquatable<BeatmapInfo>, IJsonSerializable, IHasPrimaryKey
+    public class BeatmapInfo : IEquatable<BeatmapInfo>, IHasPrimaryKey
     {
         public int ID { get; set; }
 

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -4,12 +4,11 @@
 using System.Collections.Generic;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
-using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Beatmaps
 {
-    public interface IBeatmap : IJsonSerializable
+    public interface IBeatmap
     {
         /// <summary>
         /// This beatmap's info.

--- a/osu.Game/IO/Serialization/JsonSerializableExtensions.cs
+++ b/osu.Game/IO/Serialization/JsonSerializableExtensions.cs
@@ -7,21 +7,14 @@ using osu.Framework.IO.Serialization;
 
 namespace osu.Game.IO.Serialization
 {
-    public interface IJsonSerializable
-    {
-    }
-
     public static class JsonSerializableExtensions
     {
-        public static string Serialize(this IJsonSerializable obj) => JsonConvert.SerializeObject(obj, CreateGlobalSettings());
+        public static string Serialize(this object obj) => JsonConvert.SerializeObject(obj, CreateGlobalSettings());
 
         public static T Deserialize<T>(this string objString) => JsonConvert.DeserializeObject<T>(objString, CreateGlobalSettings());
 
         public static void DeserializeInto<T>(this string objString, T target) => JsonConvert.PopulateObject(objString, target, CreateGlobalSettings());
 
-        /// <summary>
-        /// Creates the default <see cref="JsonSerializerSettings"/> that should be used for all <see cref="IJsonSerializable"/>s.
-        /// </summary>
         public static JsonSerializerSettings CreateGlobalSettings() => new JsonSerializerSettings
         {
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
-using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.UI;
 using osu.Game.Utils;
 
@@ -21,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
     /// The base class for gameplay modifiers.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public abstract class Mod : IMod, IEquatable<Mod>, IJsonSerializable, IDeepCloneable<Mod>
+    public abstract class Mod : IMod, IEquatable<Mod>, IDeepCloneable<Mod>
     {
         /// <summary>
         /// The name of this mod.

--- a/osu.Game/Rulesets/Timing/MultiplierControlPoint.cs
+++ b/osu.Game/Rulesets/Timing/MultiplierControlPoint.cs
@@ -3,14 +3,13 @@
 
 using System;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.IO.Serialization;
 
 namespace osu.Game.Rulesets.Timing
 {
     /// <summary>
     /// A control point which adds an aggregated multiplier based on the provided <see cref="TimingPoint"/>'s BeatLength and <see cref="DifficultyPoint"/>'s SpeedMultiplier.
     /// </summary>
-    public class MultiplierControlPoint : IJsonSerializable, IComparable<MultiplierControlPoint>
+    public class MultiplierControlPoint : IComparable<MultiplierControlPoint>
     {
         /// <summary>
         /// The time in milliseconds at which this <see cref="MultiplierControlPoint"/> starts.

--- a/osu.Game/Screens/Edit/ClipboardContent.cs
+++ b/osu.Game/Screens/Edit/ClipboardContent.cs
@@ -4,13 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
-using osu.Game.IO.Serialization;
 using osu.Game.IO.Serialization.Converters;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Edit
 {
-    public class ClipboardContent : IJsonSerializable
+    public class ClipboardContent
     {
         [JsonConverter(typeof(TypedListConverter<HitObject>))]
         public IList<HitObject> HitObjects;

--- a/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
@@ -8,7 +8,6 @@ using Newtonsoft.Json;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Extensions;
-using osu.Game.IO.Serialization;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -18,7 +17,7 @@ namespace osu.Game.Screens.Play.HUD
     /// Serialised information governing custom changes to an <see cref="ISkinnableDrawable"/>.
     /// </summary>
     [Serializable]
-    public class SkinnableInfo : IJsonSerializable
+    public class SkinnableInfo
     {
         public Type Type { get; set; }
 


### PR DESCRIPTION
Was pretty pointless and made it hard to use the custom serialisation terms arbitrarily in tests.

Not 100% on the location of the extensions file. Advise if it should be moved to the main extensions namespace instead.