### PR TITLE
Simplify user graph tooltips implementation

### DIFF
--- a/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
@@ -8,7 +8,6 @@ using Humanizer;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Resources.Localisation.Web;
@@ -61,40 +60,16 @@ namespace osu.Game.Overlays.Profile.Header.Components
             placeholder.FadeIn(FADE_DURATION, Easing.Out);
         }
 
-        protected override object GetTooltipContent(int index, int rank)
+        protected override UserGraphTooltipContent GetTooltipContent(int index, int rank)
         {
             var days = ranked_days - index + 1;
 
-            return new TooltipDisplayContent
+            return new UserGraphTooltipContent
             {
-                Rank = rank.ToLocalisableString("\\##,##0"),
+                Name = UsersStrings.ShowRankGlobalSimple,
+                Count = rank.ToLocalisableString("\\##,##0"),
                 Time = days == 0 ? "now" : $"{"day".ToQuantity(days)} ago"
             };
-        }
-
-        protected override UserGraphTooltip GetTooltip() => new RankGraphTooltip();
-
-        private class RankGraphTooltip : UserGraphTooltip
-        {
-            public RankGraphTooltip()
-                : base(UsersStrings.ShowRankGlobalSimple)
-            {
-            }
-
-            public override void SetContent(object content)
-            {
-                if (!(content is TooltipDisplayContent info))
-                    return;
-
-                Counter.Text = info.Rank;
-                BottomText.Text = info.Time;
-            }
-        }
-
-        private class TooltipDisplayContent
-        {
-            public LocalisableString Rank;
-            public string Time;
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
@@ -64,12 +64,10 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             var days = ranked_days - index + 1;
 
-            return new UserGraphTooltipContent
-            {
-                Name = UsersStrings.ShowRankGlobalSimple,
-                Count = rank.ToLocalisableString("\\##,##0"),
-                Time = days == 0 ? "now" : $"{"day".ToQuantity(days)} ago"
-            };
+            return new UserGraphTooltipContent(
+                UsersStrings.ShowRankGlobalSimple,
+                rank.ToLocalisableString("\\##,##0"),
+                days == 0 ? "now" : $"{"day".ToQuantity(days)} ago");
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -28,11 +28,12 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override float GetDataPointHeight(long playCount) => playCount;
 
-        protected override UserGraphTooltipContent GetTooltipContent(DateTime date, long playCount) => new UserGraphTooltipContent
+        protected override UserGraphTooltipContent GetTooltipContent(DateTime date, long playCount)
         {
-            Name = tooltipCounterName,
-            Count = playCount.ToLocalisableString("N0"),
-            Time = date.ToLocalisableString("MMMM yyyy")
-        };
+            return new UserGraphTooltipContent(
+                tooltipCounterName,
+                playCount.ToLocalisableString("N0"),
+                date.ToLocalisableString("MMMM yyyy"));
+        }
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -28,43 +28,11 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override float GetDataPointHeight(long playCount) => playCount;
 
-        protected override UserGraphTooltip GetTooltip() => new HistoryGraphTooltip(tooltipCounterName);
-
-        protected override object GetTooltipContent(DateTime date, long playCount)
+        protected override UserGraphTooltipContent GetTooltipContent(DateTime date, long playCount) => new UserGraphTooltipContent
         {
-            return new TooltipDisplayContent
-            {
-                Name = tooltipCounterName,
-                Count = playCount.ToLocalisableString("N0"),
-                Date = date.ToLocalisableString("MMMM yyyy")
-            };
-        }
-
-        protected class HistoryGraphTooltip : UserGraphTooltip
-        {
-            private readonly LocalisableString tooltipCounterName;
-
-            public HistoryGraphTooltip(LocalisableString tooltipCounterName)
-                : base(tooltipCounterName)
-            {
-                this.tooltipCounterName = tooltipCounterName;
-            }
-
-            public override void SetContent(object content)
-            {
-                if (!(content is TooltipDisplayContent info) || info.Name != tooltipCounterName)
-                    return;
-
-                Counter.Text = info.Count;
-                BottomText.Text = info.Date;
-            }
-        }
-
-        private class TooltipDisplayContent
-        {
-            public LocalisableString Name;
-            public LocalisableString Count;
-            public LocalisableString Date;
-        }
+            Name = tooltipCounterName,
+            Count = playCount.ToLocalisableString("N0"),
+            Time = date.ToLocalisableString("MMMM yyyy")
+        };
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -28,12 +28,10 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override float GetDataPointHeight(long playCount) => playCount;
 
-        protected override UserGraphTooltipContent GetTooltipContent(DateTime date, long playCount)
-        {
-            return new UserGraphTooltipContent(
+        protected override UserGraphTooltipContent GetTooltipContent(DateTime date, long playCount) =>
+            new UserGraphTooltipContent(
                 tooltipCounterName,
                 playCount.ToLocalisableString("N0"),
                 date.ToLocalisableString("MMMM yyyy"));
-        }
     }
 }

--- a/osu.Game/Overlays/Profile/UserGraph.cs
+++ b/osu.Game/Overlays/Profile/UserGraph.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Overlays.Profile
             get
             {
                 if (data == null || hoveredIndex == -1)
-                    return default;
+                    return null;
 
                 var (key, value) = data[hoveredIndex];
                 return GetTooltipContent(key, value);
@@ -295,7 +295,7 @@ namespace osu.Game.Overlays.Profile
         }
     }
 
-    public readonly struct UserGraphTooltipContent
+    public class UserGraphTooltipContent
     {
         // todo: could use init-only properties on C# 9 which read better than a constructor.
         public LocalisableString Name { get; }

--- a/osu.Game/Overlays/Profile/UserGraph.cs
+++ b/osu.Game/Overlays/Profile/UserGraph.cs
@@ -295,11 +295,18 @@ namespace osu.Game.Overlays.Profile
         }
     }
 
-    public class UserGraphTooltipContent
+    public readonly struct UserGraphTooltipContent
     {
-        // todo: change to init-only on C# 9
-        public LocalisableString Name { get; set; }
-        public LocalisableString Count { get; set; }
-        public LocalisableString Time { get; set; }
+        // todo: could use init-only properties on C# 9 which read better than a constructor.
+        public LocalisableString Name { get; }
+        public LocalisableString Count { get; }
+        public LocalisableString Time { get; }
+
+        public UserGraphTooltipContent(LocalisableString name, LocalisableString count, LocalisableString time)
+        {
+            Name = name;
+            Count = count;
+            Time = time;
+        }
     }
 }


### PR DESCRIPTION
Allows all user graph implementations to have one tooltip shared for them, by including the name as part of the tooltip content instead. Also simplifies a fair bit of logic there.

This is something I've noticed while I was looking at updating tooltips to use generics (which were added in ppy/osu-framework#4736), didn't really understand the complexity and the unnecessary limitation of reusing such tooltips so I decided to rewrite it as such.