### PR TITLE
Fix pixels poking out of the top edge of editor setup screen

### DIFF
--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Edit.Setup
         {
             AddRange(new Drawable[]
             {
-                sections = new SectionsContainer<SetupSection>
+                sections = new SetupScreenSectionsContainer
                 {
                     FixedHeader = header,
                     RelativeSizeAxes = Axes.Both,
@@ -39,6 +39,20 @@ namespace osu.Game.Screens.Edit.Setup
                     }
                 },
             });
+        }
+
+        private class SetupScreenSectionsContainer : SectionsContainer<SetupSection>
+        {
+            protected override UserTrackingScrollContainer CreateScrollContainer()
+            {
+                var scrollContainer = base.CreateScrollContainer();
+
+                // Workaround for masking issues (see https://github.com/ppy/osu-framework/issues/1675#issuecomment-910023157)
+                // Note that this actually causes the full scroll range to be reduced by 2px at the bottom, but it's not really noticeable.
+                scrollContainer.Margin = new MarginPadding { Top = 2 };
+
+                return scrollContainer;
+            }
         }
     }
 }


### PR DESCRIPTION
I usually wouldn't bother with these issues as they will eventually be fixed, but this one catches me out every time (more visible than other cases I guess?).

This was the best (read: simplest) way I could find to fix the issue

Before

https://user-images.githubusercontent.com/191335/131633680-3fb4d9e9-7753-45f7-80ed-c9f69accfcb9.mp4

After

https://user-images.githubusercontent.com/191335/131633408-d6e7f12d-6454-4eee-b4a9-e832dbc8c9cd.mp4

