### PR TITLE
Fix osu! judgements getting scaled twice over different durations

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -37,12 +37,11 @@ namespace osu.Game.Rulesets.Mania.UI
 
             public override void PlayAnimation()
             {
-                base.PlayAnimation();
-
                 switch (Result)
                 {
                     case HitResult.None:
                     case HitResult.Miss:
+                        base.PlayAnimation();
                         break;
 
                     default:
@@ -52,6 +51,8 @@ namespace osu.Game.Rulesets.Mania.UI
                         this.Delay(50)
                             .ScaleTo(0.75f, 250)
                             .FadeOut(200);
+
+                        // osu!mania uses a custom fade length, so the base call is intentionally omitted.
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -74,10 +74,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             public override void PlayAnimation()
             {
-                base.PlayAnimation();
-
                 if (Result != HitResult.Miss)
-                    JudgementText.ScaleTo(new Vector2(0.8f, 1)).Then().ScaleTo(new Vector2(1.2f, 1), 1800, Easing.OutQuint);
+                {
+                    JudgementText
+                        .ScaleTo(new Vector2(0.8f, 1))
+                        .ScaleTo(new Vector2(1.2f, 1), 1800, Easing.OutQuint);
+                }
+
+                base.PlayAnimation();
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -15,6 +16,27 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             this.MoveToY(-100, 500);
             base.ApplyHitAnimations();
+        }
+
+        protected override Drawable CreateDefaultJudgement(HitResult result) => new TaikoJudgementPiece(result);
+
+        private class TaikoJudgementPiece : DefaultJudgementPiece
+        {
+            public TaikoJudgementPiece(HitResult result)
+                : base(result)
+            {
+            }
+
+            public override void PlayAnimation()
+            {
+                if (Result != HitResult.Miss)
+                {
+                    JudgementText.ScaleTo(0.9f);
+                    JudgementText.ScaleTo(1, 500, Easing.OutElastic);
+                }
+
+                base.PlayAnimation();
+            }
         }
     }
 }

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -47,6 +47,13 @@ namespace osu.Game.Rulesets.Judgements
             };
         }
 
+        /// <summary>
+        /// Plays the default animation for this judgement piece.
+        /// </summary>
+        /// <remarks>
+        /// The base implementation only handles fade (for all result types) and misses.
+        /// Individual rulesets are recommended to implement their appropriate hit animations.
+        /// </remarks>
         public virtual void PlayAnimation()
         {
             switch (Result)
@@ -60,12 +67,6 @@ namespace osu.Game.Rulesets.Judgements
 
                     this.RotateTo(0);
                     this.RotateTo(40, 800, Easing.InQuint);
-
-                    break;
-
-                default:
-                    this.ScaleTo(0.9f);
-                    this.ScaleTo(1, 500, Easing.OutElastic);
                     break;
             }
 


### PR DESCRIPTION
Just something I noticed in passing. The underlying implementation did an elastic scale over a differing duration which causes the animation to look quite weird (part of the scale abruptly stops before the rest causing a jarring effect). It looks like the elastic scale was mostly intended for taiko, so I've moved it there for now.

As with the previous changes around this animation, the design is going to change completely so I'm not focusing too much on that (this change makes the animation more "static" if anything).

Before:

https://user-images.githubusercontent.com/191335/131802217-8e6adb9a-93e8-4279-8354-4bb10fe72b5c.mp4


After:

https://user-images.githubusercontent.com/191335/131802037-aacd6bfd-cce7-4f40-922c-c845318a6cbe.mp4
