### PR TITLE
Fix tablet settings incorrectly reporting invalid area

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -2,11 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Handlers.Tablet;
-using osu.Framework.Platform;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings.Sections.Input;
@@ -17,27 +16,57 @@ namespace osu.Game.Tests.Visual.Settings
     [TestFixture]
     public class TestSceneTabletSettings : OsuTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load(GameHost host)
-        {
-            var tabletHandler = new TestTabletHandler();
+        private TestTabletHandler tabletHandler;
+        private TabletSettings settings;
 
-            AddRange(new Drawable[]
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create settings", () =>
             {
-                new TabletSettings(tabletHandler)
+                tabletHandler = new TestTabletHandler();
+
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.None,
-                    Width = SettingsPanel.PANEL_WIDTH,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                }
+                    settings = new TabletSettings(tabletHandler)
+                    {
+                        RelativeSizeAxes = Axes.None,
+                        Width = SettingsPanel.PANEL_WIDTH,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                    }
+                };
             });
 
+            AddStep("set square size", () => tabletHandler.SetTabletSize(new Vector2(100, 100)));
+        }
+
+        [Test]
+        public void TestVariousTabletSizes()
+        {
             AddStep("Test with wide tablet", () => tabletHandler.SetTabletSize(new Vector2(160, 100)));
             AddStep("Test with square tablet", () => tabletHandler.SetTabletSize(new Vector2(300, 300)));
             AddStep("Test with tall tablet", () => tabletHandler.SetTabletSize(new Vector2(100, 300)));
             AddStep("Test with very tall tablet", () => tabletHandler.SetTabletSize(new Vector2(100, 700)));
             AddStep("Test no tablet present", () => tabletHandler.SetTabletSize(Vector2.Zero));
+        }
+
+        [Test]
+        public void TestValidAfterRotation()
+        {
+            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+
+            AddStep("rotate 90", () => tabletHandler.Rotation.Value = 90);
+            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+
+            AddStep("rotate 180", () => tabletHandler.Rotation.Value = 180);
+            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+
+            AddStep("rotate 360", () => tabletHandler.Rotation.Value = 360);
+            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+
+            AddStep("rotate 0", () => tabletHandler.Rotation.Value = 0);
+            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
         }
 
         public class TestTabletHandler : ITabletHandler

--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Tests.Visual.Settings
         }
 
         [Test]
-        public void TestValidAfterRotation()
+        public void TestRotationValidity()
         {
             AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
 
@@ -75,12 +75,34 @@ namespace osu.Game.Tests.Visual.Settings
 
             AddStep("rotate 0", () => tabletHandler.Rotation.Value = 0);
             ensureValid();
+
+            AddStep("rotate 0", () => tabletHandler.Rotation.Value = 45);
+            ensureInvalid();
+
+            AddStep("rotate 0", () => tabletHandler.Rotation.Value = 0);
+            ensureValid();
+        }
+
+        [Test]
+        public void TestOffsetValidity()
+        {
+            ensureValid();
+            AddStep("move right", () => tabletHandler.AreaOffset.Value = Vector2.Zero);
+            ensureInvalid();
+            AddStep("move back", () => tabletHandler.AreaOffset.Value = tabletHandler.AreaSize.Value / 2);
+            ensureValid();
         }
 
         private void ensureValid()
         {
             AddUntilStep("wait for transforms", () => settings.AreaSelection.ChildrenOfType<Container>().All(c => !c.Transforms.Any()));
             AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+        }
+
+        private void ensureInvalid()
+        {
+            AddUntilStep("wait for transforms", () => settings.AreaSelection.ChildrenOfType<Container>().All(c => !c.Transforms.Any()));
+            AddAssert("area invalid", () => !settings.AreaSelection.IsWithinBounds);
         }
 
         public class TestTabletHandler : ITabletHandler

--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -8,6 +9,7 @@ using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Settings.Sections.Input;
 using osuTK;
 
@@ -49,6 +51,27 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("Test with tall tablet", () => tabletHandler.SetTabletSize(new Vector2(100, 300)));
             AddStep("Test with very tall tablet", () => tabletHandler.SetTabletSize(new Vector2(100, 700)));
             AddStep("Test no tablet present", () => tabletHandler.SetTabletSize(Vector2.Zero));
+        }
+
+        [Test]
+        public void TestWideAspectRatioValidity()
+        {
+            AddStep("Test with wide tablet", () => tabletHandler.SetTabletSize(new Vector2(160, 100)));
+
+            AddStep("Reset to full area", () => settings.ChildrenOfType<DangerousSettingsButton>().First().TriggerClick());
+            ensureValid();
+
+            AddStep("rotate 10", () => tabletHandler.Rotation.Value = 10);
+            ensureInvalid();
+
+            AddStep("scale down", () => tabletHandler.AreaSize.Value *= 0.9f);
+            ensureInvalid();
+
+            AddStep("scale down", () => tabletHandler.AreaSize.Value *= 0.9f);
+            ensureInvalid();
+
+            AddStep("scale down", () => tabletHandler.AreaSize.Value *= 0.9f);
+            ensureValid();
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -93,17 +91,9 @@ namespace osu.Game.Tests.Visual.Settings
             ensureValid();
         }
 
-        private void ensureValid()
-        {
-            AddUntilStep("wait for transforms", () => settings.AreaSelection.ChildrenOfType<Container>().All(c => !c.Transforms.Any()));
-            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
-        }
+        private void ensureValid() => AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
 
-        private void ensureInvalid()
-        {
-            AddUntilStep("wait for transforms", () => settings.AreaSelection.ChildrenOfType<Container>().All(c => !c.Transforms.Any()));
-            AddAssert("area invalid", () => !settings.AreaSelection.IsWithinBounds);
-        }
+        private void ensureInvalid() => AddAssert("area invalid", () => !settings.AreaSelection.IsWithinBounds);
 
         public class TestTabletHandler : ITabletHandler
         {

--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -57,15 +59,27 @@ namespace osu.Game.Tests.Visual.Settings
             AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
 
             AddStep("rotate 90", () => tabletHandler.Rotation.Value = 90);
-            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+            ensureValid();
 
             AddStep("rotate 180", () => tabletHandler.Rotation.Value = 180);
-            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+
+            ensureValid();
+
+            AddStep("rotate 270", () => tabletHandler.Rotation.Value = 270);
+
+            ensureValid();
 
             AddStep("rotate 360", () => tabletHandler.Rotation.Value = 360);
-            AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
+
+            ensureValid();
 
             AddStep("rotate 0", () => tabletHandler.Rotation.Value = 0);
+            ensureValid();
+        }
+
+        private void ensureValid()
+        {
+            AddUntilStep("wait for transforms", () => settings.AreaSelection.ChildrenOfType<Container>().All(c => !c.Transforms.Any()));
             AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);
         }
 

--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("rotate 0", () => tabletHandler.Rotation.Value = 0);
             ensureValid();
 
-            AddStep("rotate 0", () => tabletHandler.Rotation.Value = 45);
+            AddStep("rotate 45", () => tabletHandler.Rotation.Value = 45);
             ensureInvalid();
 
             AddStep("rotate 0", () => tabletHandler.Rotation.Value = 0);

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -131,9 +131,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             rotation.BindTo(handler.Rotation);
             rotation.BindValueChanged(val =>
             {
-                tabletContainer.RotateTo(-val.NewValue, 800, Easing.OutQuint);
-                usableAreaContainer.RotateTo(val.NewValue, 100, Easing.OutQuint)
-                                   .OnComplete(_ => checkBounds()); // required as we are using SSDQ.
+                usableAreaContainer.RotateTo(val.NewValue, 100, Easing.OutQuint);
+                tabletContainer.RotateTo(-val.NewValue, 800, Easing.OutQuint)
+                               .OnComplete(_ => checkBounds()); // required as we are using SSDQ.
             }, true);
 
             tablet.BindTo(handler.Tablet);

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class TabletAreaSelection : CompositeDrawable
     {
+        public bool IsWithinBounds { get; private set; }
+
         private readonly ITabletHandler handler;
 
         private Container tabletContainer;
@@ -171,10 +173,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             var usableSsdq = usableAreaContainer.ScreenSpaceDrawQuad;
 
-            bool isWithinBounds = tabletContainer.ScreenSpaceDrawQuad.Contains(usableSsdq.TopLeft + new Vector2(1)) &&
-                                  tabletContainer.ScreenSpaceDrawQuad.Contains(usableSsdq.BottomRight - new Vector2(1));
+            IsWithinBounds = tabletContainer.ScreenSpaceDrawQuad.Contains(usableSsdq.TopLeft + new Vector2(1)) &&
+                             tabletContainer.ScreenSpaceDrawQuad.Contains(usableSsdq.BottomRight - new Vector2(1));
 
-            usableFill.FadeColour(isWithinBounds ? colour.Blue : colour.RedLight, 100);
+            usableFill.FadeColour(IsWithinBounds ? colour.Blue : colour.RedLight, 100);
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class TabletSettings : SettingsSubsection
     {
+        public TabletAreaSelection AreaSelection { get; private set; }
+
         private readonly ITabletHandler tabletHandler;
 
         private readonly Bindable<bool> enabled = new BindableBool(true);
@@ -121,7 +123,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        new TabletAreaSelection(tabletHandler)
+                        AreaSelection = new TabletAreaSelection(tabletHandler)
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = 300,


### PR DESCRIPTION
Was ready to spend some time figuring out the particular reasoning for floating point issues, but this fix seems the simplest (and I haven't been able to break it since).

Closes https://github.com/ppy/osu/issues/14570