### PR TITLE
Add ruleset-specific sections to setup screen

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaSetupSection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaSetupSection.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Screens.Edit.Setup;
+
+namespace osu.Game.Rulesets.Mania.Edit.Setup
+{
+    public class ManiaSetupSection : RulesetSetupSection
+    {
+        private LabelledSwitchButton specialStyle;
+
+        public ManiaSetupSection()
+            : base(new ManiaRuleset().RulesetInfo)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new Drawable[]
+            {
+                specialStyle = new LabelledSwitchButton
+                {
+                    Label = "Use special (N+1) style",
+                    Current = { Value = Beatmap.BeatmapInfo.SpecialStyle }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            specialStyle.Current.BindValueChanged(_ => updateBeatmap());
+        }
+
+        private void updateBeatmap()
+        {
+            Beatmap.BeatmapInfo.SpecialStyle = specialStyle.Current.Value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaSetupSection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaSetupSection.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
                 specialStyle = new LabelledSwitchButton
                 {
                     Label = "Use special (N+1) style",
+                    Description = "Changes one column to act as a classic \"scratch\" or \"special\" column, which can be moved around by the user's skin (to the left/right/centre). Generally used in 5k (4+1) or 8key (7+1) configurations.",
                     Current = { Value = Beatmap.BeatmapInfo.SpecialStyle }
                 }
             };

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -393,7 +393,7 @@ namespace osu.Game.Rulesets.Mania
             return new ManiaFilterCriteria();
         }
 
-        public override RulesetSetupSection CreateEditorSetupSectionForRuleset() => new ManiaSetupSection();
+        public override RulesetSetupSection CreateEditorSetupSection() => new ManiaSetupSection();
     }
 
     public enum PlayfieldType

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -27,11 +27,13 @@ using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.Difficulty;
 using osu.Game.Rulesets.Mania.Edit;
+using osu.Game.Rulesets.Mania.Edit.Setup;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mania.Skinning.Legacy;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets.Mania
@@ -390,6 +392,8 @@ namespace osu.Game.Rulesets.Mania
         {
             return new ManiaFilterCriteria();
         }
+
+        public override RulesetSetupSection CreateEditorSetupSectionForRuleset() => new ManiaSetupSection();
     }
 
     public enum PlayfieldType

--- a/osu.Game.Rulesets.Osu/Edit/Setup/OsuSetupSection.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Setup/OsuSetupSection.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Screens.Edit.Setup;
+
+namespace osu.Game.Rulesets.Osu.Edit.Setup
+{
+    public class OsuSetupSection : RulesetSetupSection
+    {
+        private LabelledSliderBar<float> stackLeniency;
+
+        public OsuSetupSection()
+            : base(new OsuRuleset().RulesetInfo)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new[]
+            {
+                stackLeniency = new LabelledSliderBar<float>
+                {
+                    Label = "Stack Leniency",
+                    Description = "In play mode, osu! automatically stacks notes which occur at the same location. Increasing this value means it is more likely to snap notes of further time-distance.",
+                    Current = new BindableFloat(Beatmap.BeatmapInfo.StackLeniency)
+                    {
+                        Default = 0.7f,
+                        MinValue = 0,
+                        MaxValue = 1,
+                        Precision = 0.1f
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            stackLeniency.Current.BindValueChanged(_ => updateBeatmap());
+        }
+
+        private void updateBeatmap()
+        {
+            Beatmap.BeatmapInfo.StackLeniency = stackLeniency.Current.Value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -30,9 +30,11 @@ using osu.Game.Skinning;
 using System;
 using System.Linq;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Game.Rulesets.Osu.Edit.Setup;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Legacy;
 using osu.Game.Rulesets.Osu.Statistics;
+using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets.Osu
@@ -305,5 +307,7 @@ namespace osu.Game.Rulesets.Osu
                 }
             };
         }
+
+        public override RulesetSetupSection CreateEditorSetupSectionForRuleset() => new OsuSetupSection();
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -308,6 +308,6 @@ namespace osu.Game.Rulesets.Osu
             };
         }
 
-        public override RulesetSetupSection CreateEditorSetupSectionForRuleset() => new OsuSetupSection();
+        public override RulesetSetupSection CreateEditorSetupSection() => new OsuSetupSection();
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneSetupScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneSetupScreen.cs
@@ -4,8 +4,13 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
 
@@ -23,15 +28,31 @@ namespace osu.Game.Tests.Visual.Editing
             editorBeatmap = new EditorBeatmap(new OsuBeatmap());
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+        [Test]
+        public void TestOsu() => runForRuleset(new OsuRuleset().RulesetInfo);
 
-            Child = new SetupScreen
+        [Test]
+        public void TestTaiko() => runForRuleset(new TaikoRuleset().RulesetInfo);
+
+        [Test]
+        public void TestCatch() => runForRuleset(new CatchRuleset().RulesetInfo);
+
+        [Test]
+        public void TestMania() => runForRuleset(new ManiaRuleset().RulesetInfo);
+
+        private void runForRuleset(RulesetInfo rulesetInfo)
+        {
+            AddStep("create screen", () =>
             {
-                State = { Value = Visibility.Visible },
-            };
+                editorBeatmap.BeatmapInfo.Ruleset = rulesetInfo;
+
+                Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+
+                Child = new SetupScreen
+                {
+                    State = { Value = Visibility.Visible },
+                };
+            });
         }
     }
 }

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -28,6 +28,7 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Testing;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Filter;
+using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets
@@ -315,5 +316,11 @@ namespace osu.Game.Rulesets
         /// </summary>
         [CanBeNull]
         public virtual IRulesetFilterCriteria CreateRulesetFilterCriteria() => null;
+
+        /// <summary>
+        /// Can be overridden to add a ruleset-specific section to the editor beatmap setup screen.
+        /// </summary>
+        [CanBeNull]
+        public virtual RulesetSetupSection CreateEditorSetupSectionForRuleset() => null;
     }
 }

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -321,6 +321,6 @@ namespace osu.Game.Rulesets
         /// Can be overridden to add a ruleset-specific section to the editor beatmap setup screen.
         /// </summary>
         [CanBeNull]
-        public virtual RulesetSetupSection CreateEditorSetupSectionForRuleset() => null;
+        public virtual RulesetSetupSection CreateEditorSetupSection() => null;
     }
 }

--- a/osu.Game/Screens/Edit/Setup/RulesetSetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/RulesetSetupSection.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Screens.Edit.Setup
 {
     public abstract class RulesetSetupSection : SetupSection
     {
-        public sealed override LocalisableString Title => $"{rulesetInfo.Name}-specific";
+        public sealed override LocalisableString Title => $"Ruleset ({rulesetInfo.Name})";
 
         private readonly RulesetInfo rulesetInfo;
 

--- a/osu.Game/Screens/Edit/Setup/RulesetSetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/RulesetSetupSection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    public abstract class RulesetSetupSection : SetupSection
+    {
+        public sealed override LocalisableString Title => $"{rulesetInfo.Name}-specific";
+
+        private readonly RulesetInfo rulesetInfo;
+
+        protected RulesetSetupSection(RulesetInfo rulesetInfo)
+        {
+            this.rulesetInfo = rulesetInfo;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Edit.Setup
                 new DesignSection(),
             };
 
-            var rulesetSpecificSection = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateEditorSetupSectionForRuleset();
+            var rulesetSpecificSection = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateEditorSetupSection();
             if (rulesetSpecificSection != null)
                 sectionsEnumerable.Add(rulesetSpecificSection);
 

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Screens.Edit.Setup
     public class SetupScreen : EditorRoundedScreen
     {
         [Cached]
-        private SectionsContainer<SetupSection> sections = new SectionsContainer<SetupSection>();
+        private SectionsContainer<SetupSection> sections { get; } = new SetupScreenSectionsContainer();
 
         [Cached]
         private SetupScreenHeader header = new SetupScreenHeader();
@@ -37,15 +37,12 @@ namespace osu.Game.Screens.Edit.Setup
             if (rulesetSpecificSection != null)
                 sectionsEnumerable.Add(rulesetSpecificSection);
 
-            AddRange(new Drawable[]
+            Add(sections.With(s =>
             {
-                sections = new SetupScreenSectionsContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    ChildrenEnumerable = sectionsEnumerable,
-                    FixedHeader = header
-                },
-            });
+                s.RelativeSizeAxes = Axes.Both;
+                s.ChildrenEnumerable = sectionsEnumerable;
+                s.FixedHeader = header;
+            }));
         }
 
         private class SetupScreenSectionsContainer : SectionsContainer<SetupSection>

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
@@ -21,22 +22,28 @@ namespace osu.Game.Screens.Edit.Setup
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(EditorBeatmap beatmap)
         {
+            var sectionsEnumerable = new List<SetupSection>
+            {
+                new ResourcesSection(),
+                new MetadataSection(),
+                new DifficultySection(),
+                new ColoursSection(),
+                new DesignSection(),
+            };
+
+            var rulesetSpecificSection = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateEditorSetupSectionForRuleset();
+            if (rulesetSpecificSection != null)
+                sectionsEnumerable.Add(rulesetSpecificSection);
+
             AddRange(new Drawable[]
             {
                 sections = new SetupScreenSectionsContainer
                 {
-                    FixedHeader = header,
                     RelativeSizeAxes = Axes.Both,
-                    Children = new SetupSection[]
-                    {
-                        new ResourcesSection(),
-                        new MetadataSection(),
-                        new DifficultySection(),
-                        new ColoursSection(),
-                        new DesignSection(),
-                    }
+                    ChildrenEnumerable = sectionsEnumerable,
+                    FixedHeader = header
                 },
             });
         }

--- a/osu.Game/Screens/Edit/Setup/SetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupSection.cs
@@ -12,9 +12,9 @@ using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
 {
-    internal abstract class SetupSection : Container
+    public abstract class SetupSection : Container
     {
-        private readonly FillFlowContainer flow;
+        private FillFlowContainer flow;
 
         /// <summary>
         /// Used to align some of the child <see cref="LabelledDrawable{T}"/>s together to achieve a grid-like look.
@@ -31,7 +31,8 @@ namespace osu.Game.Screens.Edit.Setup
 
         public abstract LocalisableString Title { get; }
 
-        protected SetupSection()
+        [BackgroundDependencyLoader]
+        private void load()
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;


### PR DESCRIPTION
Before you read on: I know there is an issue with the tab header not scrolling down properly the first time if you try to scroll to the new sections. It is not easy to fix and it is a pre-existing deep issue with `SectionsContainer` (that even happens e.g. on the user profile overlay). I will elaborate on this in a separate issue shortly. I'm asking to look away for now, but if that is deemed unacceptable, I'll divert efforts to tackle that first.

---

With that disclaimer out of the way: This PR adds ruleset-specific sections to osu! and mania editor setup screens, containing: stack leniency and special style, respectively.

| osu! | osu!mania |
| :-: | :-: |
| ![osu_2021-09-04_20-07-50](https://user-images.githubusercontent.com/20418176/132104469-d4dc6050-e35c-4aab-bee0-f1c972c3b333.jpg) | ![osu_2021-09-04_20-08-05](https://user-images.githubusercontent.com/20418176/132104482-a335e175-c732-43bf-b1b4-48eafbee6f43.jpg) |

Additionally, an instance of assigning twice to a `[Cached]` property is fixed (it was insanely luckly that the child that resolved that property only read it after it was assigned to the second time - in general it is *not* safe to assign to `[Cached]` members from BDL; normally only assigning once in BDL will throw).