### PR TITLE
Implement /msg command

### DIFF
--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -269,6 +269,10 @@ namespace osu.Game.Online.Chat
                     request.Success += user =>
                     {
                         OpenPrivateChannel(user);
+
+                        if (args.Length < 2)
+                            return; // Only open the channel if no message was provided
+
                         var message = new Message
                         {
                             Content = args[1],

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -263,7 +263,7 @@ namespace osu.Game.Online.Chat
                         break;
                     }
 
-                    var args = content.Split(" ");
+                    var args = content.Split(' ', 2);
 
                     var request = new GetUserRequest(args[0]);
                     request.Success += user =>
@@ -271,12 +271,12 @@ namespace osu.Game.Online.Chat
                         OpenPrivateChannel(user);
                         var message = new Message
                         {
-                            Content = string.Join(" ", args[1..]),
+                            Content = args[1],
                             Sender = user,
                             IsAction = false,
                             ChannelId = CurrentChannel.Value.Id,
                             Timestamp = DateTimeOffset.Now,
-                            DisplayContent = string.Join(" ", args[1..])
+                            DisplayContent = args[1],
                         };
                         var messageRequest = new PostMessageRequest(message);
                         messageRequest.Failure += e => Logger.Error(e, $"Message to user {user} failed to send.", LoggingTarget.Network);

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -256,10 +256,6 @@ namespace osu.Game.Online.Chat
                     JoinChannel(channel);
                     break;
 
-                case "help":
-                    target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel], /np, /msg [user] [message]"));
-                    break;
-
                 case "msg":
                     if (string.IsNullOrWhiteSpace(content))
                     {
@@ -288,6 +284,10 @@ namespace osu.Game.Online.Chat
                     };
                     request.Failure += _ => target.AddNewMessages(new ErrorMessage($"User {args[0]} not found."));
                     api.Queue(request);
+                    break;
+
+                case "help":
+                    target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel], /np, /msg [user] [message]"));
                     break;
 
                 default:

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Online.Chat
                     break;
 
                 case "help":
-                    target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel], /np"));
+                    target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel], /np, /msg [user] [message]"));
                     break;
 
                 case "msg":


### PR DESCRIPTION
The `/msg [user] [message]` command opens a new channel with the specified user and immediately sends the given message to them.

Implements the usage of this command described by [the wiki](https://osu.ppy.sh/wiki/en/Chat_Console#/help). This command isn't implemented on stable to my knowledge, however.