### PR TITLE
Avoid unnecessarily loading fonts in headless testing

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -205,31 +205,7 @@ namespace osu.Game
             dependencies.CacheAs(this);
             dependencies.CacheAs(LocalConfig);
 
-            AddFont(Resources, @"Fonts/osuFont");
-
-            AddFont(Resources, @"Fonts/Torus/Torus-Regular");
-            AddFont(Resources, @"Fonts/Torus/Torus-Light");
-            AddFont(Resources, @"Fonts/Torus/Torus-SemiBold");
-            AddFont(Resources, @"Fonts/Torus/Torus-Bold");
-
-            AddFont(Resources, @"Fonts/Inter/Inter-Regular");
-            AddFont(Resources, @"Fonts/Inter/Inter-RegularItalic");
-            AddFont(Resources, @"Fonts/Inter/Inter-Light");
-            AddFont(Resources, @"Fonts/Inter/Inter-LightItalic");
-            AddFont(Resources, @"Fonts/Inter/Inter-SemiBold");
-            AddFont(Resources, @"Fonts/Inter/Inter-SemiBoldItalic");
-            AddFont(Resources, @"Fonts/Inter/Inter-Bold");
-            AddFont(Resources, @"Fonts/Inter/Inter-BoldItalic");
-
-            AddFont(Resources, @"Fonts/Noto/Noto-Basic");
-            AddFont(Resources, @"Fonts/Noto/Noto-Hangul");
-            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Basic");
-            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Compatibility");
-            AddFont(Resources, @"Fonts/Noto/Noto-Thai");
-
-            AddFont(Resources, @"Fonts/Venera/Venera-Light");
-            AddFont(Resources, @"Fonts/Venera/Venera-Bold");
-            AddFont(Resources, @"Fonts/Venera/Venera-Black");
+            InitialiseFonts();
 
             Audio.Samples.PlaybackConcurrency = SAMPLE_CONCURRENCY;
 
@@ -366,6 +342,35 @@ namespace osu.Game
             dependencies.CacheAs(MusicController);
 
             Ruleset.BindValueChanged(onRulesetChanged);
+        }
+
+        protected virtual void InitialiseFonts()
+        {
+            AddFont(Resources, @"Fonts/osuFont");
+
+            AddFont(Resources, @"Fonts/Torus/Torus-Regular");
+            AddFont(Resources, @"Fonts/Torus/Torus-Light");
+            AddFont(Resources, @"Fonts/Torus/Torus-SemiBold");
+            AddFont(Resources, @"Fonts/Torus/Torus-Bold");
+
+            AddFont(Resources, @"Fonts/Inter/Inter-Regular");
+            AddFont(Resources, @"Fonts/Inter/Inter-RegularItalic");
+            AddFont(Resources, @"Fonts/Inter/Inter-Light");
+            AddFont(Resources, @"Fonts/Inter/Inter-LightItalic");
+            AddFont(Resources, @"Fonts/Inter/Inter-SemiBold");
+            AddFont(Resources, @"Fonts/Inter/Inter-SemiBoldItalic");
+            AddFont(Resources, @"Fonts/Inter/Inter-Bold");
+            AddFont(Resources, @"Fonts/Inter/Inter-BoldItalic");
+
+            AddFont(Resources, @"Fonts/Noto/Noto-Basic");
+            AddFont(Resources, @"Fonts/Noto/Noto-Hangul");
+            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Basic");
+            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Compatibility");
+            AddFont(Resources, @"Fonts/Noto/Noto-Thai");
+
+            AddFont(Resources, @"Fonts/Venera/Venera-Light");
+            AddFont(Resources, @"Fonts/Venera/Venera-Bold");
+            AddFont(Resources, @"Fonts/Venera/Venera-Black");
         }
 
         private IDisposable blocking;

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -367,6 +367,11 @@ namespace osu.Game.Tests.Visual
                 Add(runner = new TestSceneTestRunner.TestRunner());
             }
 
+            protected override void InitialiseFonts()
+            {
+                // skip fonts load as it's not required for testing purposes.
+            }
+
             public void RunTestBlocking(TestScene test) => runner.RunTestBlocking(test);
         }
     }


### PR DESCRIPTION
Just a quick drive-by change. Not really of much use on systems with many spare cores (and no thermal restrictions), but may help users that are running tests on low core machines (and potentially CI). Investigated this area due to my rider getting freezes when running tests on an ongoing basis - not sure this helps but @frenzibyte has also reported thermal throttling while running tests, and this will alleviate some degree of that no doubt.

Profiling by running the `VisualTests.Online` namespace (chosen due to number of test classes, as the overhead here increases with number of classes run):

Before:

![20210907 143942 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132290573-6776627e-f862-4fe8-90d9-ef8693aa17fc.png)

After:

![20210907 144312 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132290452-7b4230d5-c7b4-48c7-8e12-3c1699a999cc.png)

At some point we made need the correct fonts loaded for testing purposes, but nothing looks to fail without them for the time being. I don't think the reduction in testing scope (ie. the font loads are no longer tested) is of great importance. Also, it will already be tested in the navigation / `OsuGame` tests that don't bypass this load procedure in their nested testing.