### PR TITLE
Reduce startup overhead during default key binding handling

### DIFF
--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -11,6 +11,7 @@ using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets;
 using Realms;
 
 namespace osu.Game.Tests.Database
@@ -42,7 +43,7 @@ namespace osu.Game.Tests.Database
 
             KeyBindingContainer testContainer = new TestKeyBindingContainer();
 
-            keyBindingStore.Register(testContainer);
+            keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
 
             Assert.That(queryCount(), Is.EqualTo(3));
 
@@ -66,7 +67,7 @@ namespace osu.Game.Tests.Database
         {
             KeyBindingContainer testContainer = new TestKeyBindingContainer();
 
-            keyBindingStore.Register(testContainer);
+            keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
 
             using (var primaryUsage = realmContextFactory.GetForRead())
             {

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -351,10 +351,7 @@ namespace osu.Game
             base.Content.Add(CreateScalingContainer().WithChildren(mainContent));
 
             KeyBindingStore = new RealmKeyBindingStore(realmFactory);
-            KeyBindingStore.Register(globalBindings);
-
-            foreach (var r in RulesetStore.AvailableRulesets)
-                KeyBindingStore.Register(r);
+            KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);
 
             dependencies.Cache(globalBindings);
 


### PR DESCRIPTION
The main overhead here was from the `.Count` calls, which seem to be very unoptimised. Kind of makes sense since we aren't indexing any of the columns in question, but still a point of concern. May follow up with realm if we run into this kind of thing again, but in this specific case a local optimisation is warranted regardless, as we are iterating this same collection many times and are *unable* to index nullable fields anyways.

Other surrounding changes are to avoid unnecessary multiple transactions for what is a single operation in all cases.

Testing with `Visual.Online` namespace, as this is most noticeable when run many times (as headless tests do):

Before: 50.8s (54.2s with profiling below)

![20210907 152235 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132294873-583839fd-7b86-4ef5-b5ec-82b8c1ae1870.png)

After: 35.9s (40.6s with profiling below)

![20210907 152411 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132294718-6e728555-28e0-4da0-b96d-05598dfdb606.png)
