### PR TITLE
Fix diffcalc workflow triggering too often

### DIFF
--- a/.github/workflows/test-diffcalc.yml
+++ b/.github/workflows/test-diffcalc.yml
@@ -23,9 +23,9 @@ jobs:
     continue-on-error: true
 
     if: |
-      ${{ github.event.issue.pull_request }} &&
+      github.event.issue.pull_request &&
       contains(github.event.comment.body, '!pp check') &&
-      ${{ github.event.comment.author_association == 'MEMBER' }}
+      (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The real fix here is removal of the `${{ }}`. The change to user associations doesn't affect us in this repository because we're all listed as members, but would affect e.g. if running on your own repository.