### PR TITLE
Fix incorrect keyboard navigation order in score panel list 

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneScorePanelList.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneScorePanelList.cs
@@ -203,6 +203,71 @@ namespace osu.Game.Tests.Visual.Ranking
             assertExpandedPanelCentred();
         }
 
+        [Test]
+        public void TestKeyboardNavigation()
+        {
+            var lowestScore = new TestScoreInfo(new OsuRuleset().RulesetInfo) { MaxCombo = 100 };
+            var middleScore = new TestScoreInfo(new OsuRuleset().RulesetInfo) { MaxCombo = 200 };
+            var highestScore = new TestScoreInfo(new OsuRuleset().RulesetInfo) { MaxCombo = 300 };
+
+            createListStep(() => new ScorePanelList());
+
+            AddStep("add scores and select middle", () =>
+            {
+                // order of addition purposefully scrambled.
+                list.AddScore(middleScore);
+                list.AddScore(lowestScore);
+                list.AddScore(highestScore);
+                list.SelectedScore.Value = middleScore;
+            });
+
+            assertScoreState(highestScore, false);
+            assertScoreState(middleScore, true);
+            assertScoreState(lowestScore, false);
+
+            AddStep("press left", () => InputManager.Key(Key.Left));
+
+            assertScoreState(highestScore, true);
+            assertScoreState(middleScore, false);
+            assertScoreState(lowestScore, false);
+            assertExpandedPanelCentred();
+
+            AddStep("press left at start of list", () => InputManager.Key(Key.Left));
+
+            assertScoreState(highestScore, true);
+            assertScoreState(middleScore, false);
+            assertScoreState(lowestScore, false);
+            assertExpandedPanelCentred();
+
+            AddStep("press right", () => InputManager.Key(Key.Right));
+
+            assertScoreState(highestScore, false);
+            assertScoreState(middleScore, true);
+            assertScoreState(lowestScore, false);
+            assertExpandedPanelCentred();
+
+            AddStep("press right again", () => InputManager.Key(Key.Right));
+
+            assertScoreState(highestScore, false);
+            assertScoreState(middleScore, false);
+            assertScoreState(lowestScore, true);
+            assertExpandedPanelCentred();
+
+            AddStep("press right at end of list", () => InputManager.Key(Key.Right));
+
+            assertScoreState(highestScore, false);
+            assertScoreState(middleScore, false);
+            assertScoreState(lowestScore, true);
+            assertExpandedPanelCentred();
+
+            AddStep("press left", () => InputManager.Key(Key.Left));
+
+            assertScoreState(highestScore, false);
+            assertScoreState(middleScore, true);
+            assertScoreState(lowestScore, false);
+            assertExpandedPanelCentred();
+        }
+
         private void createListStep(Func<ScorePanelList> creationFunc)
         {
             AddStep("create list", () => Child = list = creationFunc().With(d =>

--- a/osu.Game/Screens/Ranking/ScorePanelList.cs
+++ b/osu.Game/Screens/Ranking/ScorePanelList.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -306,18 +307,18 @@ namespace osu.Game.Screens.Ranking
             if (expandedPanel == null)
                 return base.OnKeyDown(e);
 
-            var expandedPanelIndex = flow.GetPanelIndex(expandedPanel.Score);
-
             switch (e.Key)
             {
                 case Key.Left:
-                    if (expandedPanelIndex > 0)
-                        SelectedScore.Value = flow.Children[expandedPanelIndex - 1].Panel.Score;
+                    var previousScore = flow.GetPreviousScore(expandedPanel.Score);
+                    if (previousScore != null)
+                        SelectedScore.Value = previousScore;
                     return true;
 
                 case Key.Right:
-                    if (expandedPanelIndex < flow.Count - 1)
-                        SelectedScore.Value = flow.Children[expandedPanelIndex + 1].Panel.Score;
+                    var nextScore = flow.GetNextScore(expandedPanel.Score);
+                    if (nextScore != null)
+                        SelectedScore.Value = nextScore;
                     return true;
             }
 
@@ -335,6 +336,12 @@ namespace osu.Game.Screens.Ranking
             public override IEnumerable<Drawable> FlowingChildren => applySorting(AliveInternalChildren);
 
             public int GetPanelIndex(ScoreInfo score) => applySorting(Children).TakeWhile(s => s.Panel.Score != score).Count();
+
+            [CanBeNull]
+            public ScoreInfo GetPreviousScore(ScoreInfo score) => applySorting(Children).TakeWhile(s => s.Panel.Score != score).LastOrDefault()?.Panel.Score;
+
+            [CanBeNull]
+            public ScoreInfo GetNextScore(ScoreInfo score) => applySorting(Children).SkipWhile(s => s.Panel.Score != score).ElementAtOrDefault(1)?.Panel.Score;
 
             private IEnumerable<ScorePanelTrackingContainer> applySorting(IEnumerable<Drawable> drawables) => drawables.OfType<ScorePanelTrackingContainer>()
                                                                                                                        .OrderByDescending(GetLayoutPosition)


### PR DESCRIPTION
Closes #14665.

Solution is a little LINQ-y, but so was the previous code, and the new code should be *pretty much* comparably LINQ-y, so may be fine...?