### PR TITLE
Make response to failed multiplayer password attempt friendlier

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerLoungeSubScreen.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
@@ -64,7 +65,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        public void TestJoinRoomWithPassword()
+        public void TestJoinRoomWithIncorrectPassword()
+        {
+            DrawableLoungeRoom.PasswordEntryPopover passwordEntryPopover = null;
+
+            AddStep("add room", () => RoomManager.AddRooms(1, withPassword: true));
+            AddStep("select room", () => InputManager.Key(Key.Down));
+            AddStep("attempt join room", () => InputManager.Key(Key.Enter));
+            AddUntilStep("password prompt appeared", () => (passwordEntryPopover = InputManager.ChildrenOfType<DrawableLoungeRoom.PasswordEntryPopover>().FirstOrDefault()) != null);
+            AddStep("enter password in text box", () => passwordEntryPopover.ChildrenOfType<TextBox>().First().Text = "wrong");
+            AddStep("press join room button", () => passwordEntryPopover.ChildrenOfType<OsuButton>().First().TriggerClick());
+
+            AddAssert("room not joined", () => loungeScreen.IsCurrentScreen());
+            AddUntilStep("password prompt still visible", () => passwordEntryPopover.State.Value == Visibility.Visible);
+        }
+
+        [Test]
+        public void TestJoinRoomWithCorrectPassword()
         {
             DrawableLoungeRoom.PasswordEntryPopover passwordEntryPopover = null;
 

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -39,6 +39,33 @@ namespace osu.Game.Extensions
         }
 
         /// <summary>
+        /// Shake the contents of this container.
+        /// </summary>
+        /// <param name="target">The target to shake.</param>
+        /// <param name="shakeDuration">The length of a single shake.</param>
+        /// <param name="shakeMagnitude">Pixels of displacement per shake.</param>
+        /// <param name="maximumLength">The maximum length the shake should last.</param>
+        public static void Shake(this Drawable target, double shakeDuration = 80, float shakeMagnitude = 8, double? maximumLength = null)
+        {
+            // if we don't have enough time, don't bother shaking.
+            if (maximumLength < shakeDuration * 2)
+                return;
+
+            var sequence = target.MoveToX(shakeMagnitude, shakeDuration / 2, Easing.OutSine).Then()
+                                 .MoveToX(-shakeMagnitude, shakeDuration, Easing.InOutSine).Then();
+
+            // if we don't have enough time for the second shake, skip it.
+            if (!maximumLength.HasValue || maximumLength >= shakeDuration * 4)
+            {
+                sequence = sequence
+                           .MoveToX(shakeMagnitude, shakeDuration, Easing.InOutSine).Then()
+                           .MoveToX(-shakeMagnitude, shakeDuration, Easing.InOutSine).Then();
+            }
+
+            sequence.MoveToX(0, shakeDuration / 2, Easing.InSine);
+        }
+
+        /// <summary>
         /// Accepts a delta vector in screen-space coordinates and converts it to one which can be applied to this drawable's position.
         /// </summary>
         /// <param name="drawable">The drawable.</param>

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Extensions
         }
 
         /// <summary>
-        /// Shake the contents of this container.
+        /// Shakes this drawable.
         /// </summary>
         /// <param name="target">The target to shake.</param>
         /// <param name="shakeDuration">The length of a single shake.</param>

--- a/osu.Game/Graphics/Containers/ShakeContainer.cs
+++ b/osu.Game/Graphics/Containers/ShakeContainer.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Extensions;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -17,39 +17,9 @@ namespace osu.Game.Graphics.Containers
         public float ShakeDuration = 80;
 
         /// <summary>
-        /// Total number of shakes. May be shortened if possible.
-        /// </summary>
-        public float TotalShakes = 4;
-
-        /// <summary>
-        /// Pixels of displacement per shake.
-        /// </summary>
-        public float ShakeMagnitude = 8;
-
-        /// <summary>
         /// Shake the contents of this container.
         /// </summary>
         /// <param name="maximumLength">The maximum length the shake should last.</param>
-        public void Shake(double? maximumLength = null)
-        {
-            const float shake_amount = 8;
-
-            // if we don't have enough time, don't bother shaking.
-            if (maximumLength < ShakeDuration * 2)
-                return;
-
-            var sequence = this.MoveToX(shake_amount, ShakeDuration / 2, Easing.OutSine).Then()
-                               .MoveToX(-shake_amount, ShakeDuration, Easing.InOutSine).Then();
-
-            // if we don't have enough time for the second shake, skip it.
-            if (!maximumLength.HasValue || maximumLength >= ShakeDuration * 4)
-            {
-                sequence = sequence
-                           .MoveToX(shake_amount, ShakeDuration, Easing.InOutSine).Then()
-                           .MoveToX(-shake_amount, ShakeDuration, Easing.InOutSine).Then();
-            }
-
-            sequence.MoveToX(0, ShakeDuration / 2, Easing.InSine);
-        }
+        public void Shake(double? maximumLength = null) => this.Shake(ShakeDuration, maximumLength: maximumLength);
     }
 }

--- a/osu.Game/Graphics/Containers/ShakeContainer.cs
+++ b/osu.Game/Graphics/Containers/ShakeContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -28,11 +27,6 @@ namespace osu.Game.Graphics.Containers
         public float ShakeMagnitude = 8;
 
         /// <summary>
-        /// Fired when <see cref="Shake"/> finishes
-        /// </summary>
-        public event Action OnShakeFinish;
-
-        /// <summary>
         /// Shake the contents of this container.
         /// </summary>
         /// <param name="maximumLength">The maximum length the shake should last.</param>
@@ -56,7 +50,6 @@ namespace osu.Game.Graphics.Containers
             }
 
             sequence.MoveToX(0, ShakeDuration / 2, Easing.InSine);
-            sequence.Finally(_ => OnShakeFinish?.Invoke());
         }
     }
 }

--- a/osu.Game/Graphics/Containers/ShakeContainer.cs
+++ b/osu.Game/Graphics/Containers/ShakeContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -27,6 +28,11 @@ namespace osu.Game.Graphics.Containers
         public float ShakeMagnitude = 8;
 
         /// <summary>
+        /// Fired when <see cref="Shake"/> finishes
+        /// </summary>
+        public event Action OnShakeFinish;
+
+        /// <summary>
         /// Shake the contents of this container.
         /// </summary>
         /// <param name="maximumLength">The maximum length the shake should last.</param>
@@ -50,6 +56,7 @@ namespace osu.Game.Graphics.Containers
             }
 
             sequence.MoveToX(0, ShakeDuration / 2, Easing.InSine);
+            sequence.Finally(_ => OnShakeFinish?.Invoke());
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -87,10 +87,10 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             currentJoinRoomRequest.Failure += exception =>
             {
-                // provide error output if the operation wasn't canceled and the error doesn't stem from an invalid password
-                if (!(exception is OperationCanceledException) && !((APIException)exception).Message.Equals("Invalid room password", StringComparison.Ordinal))
-                    Logger.Log($"Failed to join room: {exception}", level: LogLevel.Important);
-                onError?.Invoke(exception.ToString());
+                if (exception is OperationCanceledException)
+                    return;
+
+                onError?.Invoke(exception.Message);
             };
 
             api.Queue(currentJoinRoomRequest);

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -87,7 +87,8 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             currentJoinRoomRequest.Failure += exception =>
             {
-                if (!(exception is OperationCanceledException))
+                // provide error output if the operation wasn't canceled and the error doesn't stem from an invalid password
+                if (!(exception is OperationCanceledException) && !((APIException)exception).Message.Equals("Invalid room password", StringComparison.Ordinal))
                     Logger.Log($"Failed to join room: {exception}", level: LogLevel.Important);
                 onError?.Invoke(exception.ToString());
             };

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Input.Bindings;
@@ -187,32 +188,50 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
             private OsuPasswordTextBox passwordTextbox;
             private TriangleButton joinButton;
+            private ShakeContainer shakeContainer;
 
             [BackgroundDependencyLoader]
             private void load()
             {
-                Child = new FillFlowContainer
+                shakeContainer = new ShakeContainer
                 {
                     Margin = new MarginPadding(10),
-                    Spacing = new Vector2(5),
                     AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Horizontal,
-                    Children = new Drawable[]
+                    Child = new FillFlowContainer
                     {
-                        passwordTextbox = new OsuPasswordTextBox
+                        Margin = new MarginPadding(10),
+                        Spacing = new Vector2(5),
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Children = new Drawable[]
                         {
-                            Width = 200,
-                            PlaceholderText = "password",
-                        },
-                        joinButton = new TriangleButton
-                        {
-                            Width = 80,
-                            Text = "Join Room",
+                            passwordTextbox = new OsuPasswordTextBox
+                            {
+                                Width = 200,
+                                PlaceholderText = "password",
+                            },
+                            joinButton = new TriangleButton
+                            {
+                                Width = 80,
+                                Text = "Join Room",
+                            }
                         }
                     }
                 };
+                Child = shakeContainer;
 
-                joinButton.Action = () => JoinRequested?.Invoke(room, passwordTextbox.Text, null, _ => this.HidePopover());
+                joinButton.Action = () => JoinRequested?.Invoke(room, passwordTextbox.Text, null, joinFailed);
+            }
+
+            private void joinFailed(string error)
+            {
+                passwordTextbox.Text = string.Empty;
+                passwordTextbox.PlaceholderText = "incorrect password";
+                passwordTextbox.Colour = Color4.Red;
+
+                shakeContainer.OnShakeFinish += () => passwordTextbox.Colour = Color4.White;
+
+                shakeContainer.Shake();
             }
 
             protected override void LoadComplete()
@@ -220,7 +239,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 base.LoadComplete();
 
                 Schedule(() => GetContainingInputManager().ChangeFocus(passwordTextbox));
-                passwordTextbox.OnCommit += (_, __) => JoinRequested?.Invoke(room, passwordTextbox.Text, null, _ => this.HidePopover());
+                passwordTextbox.OnCommit += (_, __) => JoinRequested?.Invoke(room, passwordTextbox.Text, null, joinFailed);
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -190,47 +189,44 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
             private OsuPasswordTextBox passwordTextbox;
             private TriangleButton joinButton;
-            private ShakeContainer shakeContainer;
             private OsuSpriteText errorText;
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                Child = shakeContainer = new ShakeContainer
+                Padding = new MarginPadding(10);
+
+                Child = new FillFlowContainer
                 {
                     Margin = new MarginPadding(10),
+                    Spacing = new Vector2(5),
                     AutoSizeAxes = Axes.Both,
-                    Child = new FillFlowContainer
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
                     {
-                        Spacing = new Vector2(5),
-                        AutoSizeAxes = Axes.Both,
-                        Direction = FillDirection.Vertical,
-                        Children = new Drawable[]
+                        new FillFlowContainer
                         {
-                            new FillFlowContainer
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(5),
+                            AutoSizeAxes = Axes.Both,
+                            Children = new Drawable[]
                             {
-                                Direction = FillDirection.Horizontal,
-                                Spacing = new Vector2(5),
-                                AutoSizeAxes = Axes.Both,
-                                Children = new Drawable[]
+                                passwordTextbox = new OsuPasswordTextBox
                                 {
-                                    passwordTextbox = new OsuPasswordTextBox
-                                    {
-                                        Width = 200,
-                                        PlaceholderText = "password",
-                                    },
-                                    joinButton = new TriangleButton
-                                    {
-                                        Width = 80,
-                                        Text = "Join Room",
-                                    }
+                                    Width = 200,
+                                    PlaceholderText = "password",
+                                },
+                                joinButton = new TriangleButton
+                                {
+                                    Width = 80,
+                                    Text = "Join Room",
                                 }
-                            },
-                            errorText = new OsuSpriteText
-                            {
-                                Colour = colours.Red,
-                            },
-                        }
+                            }
+                        },
+                        errorText = new OsuSpriteText
+                        {
+                            Colour = colours.Red,
+                        },
                     }
                 };
 
@@ -243,8 +239,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
                 errorText.Text = error;
                 errorText.FadeOutFromOne(1000, Easing.In);
-
-                shakeContainer.Shake();
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             }
         }
 
-        public Popover GetPopover() => new PasswordEntryPopover(Room) { Lounge = lounge };
+        public Popover GetPopover() => new PasswordEntryPopover(Room);
 
         public MenuItem[] ContextMenuItems => new MenuItem[]
         {
@@ -178,7 +178,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         {
             private readonly Room room;
 
-            public LoungeSubScreen Lounge;
+            [Resolved(canBeNull: true)]
+            private LoungeSubScreen lounge { get; set; }
 
             public PasswordEntryPopover(Room room)
             {
@@ -219,7 +220,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 };
                 Child = shakeContainer;
 
-                joinButton.Action = () => Lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
+                joinButton.Action = () => lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
             }
 
             private void joinFailed(string error)
@@ -234,7 +235,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 base.LoadComplete();
 
                 Schedule(() => GetContainingInputManager().ChangeFocus(passwordTextbox));
-                passwordTextbox.OnCommit += (_, __) => Lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
+                passwordTextbox.OnCommit += (_, __) => lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -225,8 +225,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             private void joinFailed(string error)
             {
                 passwordTextbox.Text = string.Empty;
-                passwordTextbox.PlaceholderText = "incorrect password";
-                passwordTextbox.Colour = Color4.Red;
 
                 shakeContainer.OnShakeFinish += () => passwordTextbox.Colour = Color4.White;
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -14,7 +14,9 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Input.Bindings;
@@ -189,9 +191,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             private OsuPasswordTextBox passwordTextbox;
             private TriangleButton joinButton;
             private ShakeContainer shakeContainer;
+            private OsuSpriteText errorText;
 
             [BackgroundDependencyLoader]
-            private void load()
+            private void load(OsuColour colours)
             {
                 Child = shakeContainer = new ShakeContainer
                 {
@@ -201,19 +204,32 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                     {
                         Spacing = new Vector2(5),
                         AutoSizeAxes = Axes.Both,
-                        Direction = FillDirection.Horizontal,
+                        Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            passwordTextbox = new OsuPasswordTextBox
+                            new FillFlowContainer
                             {
-                                Width = 200,
-                                PlaceholderText = "password",
+                                Direction = FillDirection.Horizontal,
+                                Spacing = new Vector2(5),
+                                AutoSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    passwordTextbox = new OsuPasswordTextBox
+                                    {
+                                        Width = 200,
+                                        PlaceholderText = "password",
+                                    },
+                                    joinButton = new TriangleButton
+                                    {
+                                        Width = 80,
+                                        Text = "Join Room",
+                                    }
+                                }
                             },
-                            joinButton = new TriangleButton
+                            errorText = new OsuSpriteText
                             {
-                                Width = 80,
-                                Text = "Join Room",
-                            }
+                                Colour = colours.Red,
+                            },
                         }
                     }
                 };
@@ -224,6 +240,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             private void joinFailed(string error)
             {
                 passwordTextbox.Text = string.Empty;
+
+                errorText.Text = error;
+                errorText.FadeOutFromOne(1000, Easing.In);
 
                 shakeContainer.Shake();
             }

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -226,8 +226,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             {
                 passwordTextbox.Text = string.Empty;
 
-                shakeContainer.OnShakeFinish += () => passwordTextbox.Colour = Color4.White;
-
                 shakeContainer.Shake();
             }
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -238,7 +239,13 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 passwordTextbox.Text = string.Empty;
 
                 errorText.Text = error;
-                errorText.FadeOutFromOne(1000, Easing.In);
+                errorText
+                    .FadeIn()
+                    .FlashColour(Color4.White, 200)
+                    .Delay(1000)
+                    .FadeOutFromOne(1000, Easing.In);
+
+                Body.Shake();
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -193,13 +193,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             [BackgroundDependencyLoader]
             private void load()
             {
-                shakeContainer = new ShakeContainer
+                Child = shakeContainer = new ShakeContainer
                 {
                     Margin = new MarginPadding(10),
                     AutoSizeAxes = Axes.Both,
                     Child = new FillFlowContainer
                     {
-                        Margin = new MarginPadding(10),
                         Spacing = new Vector2(5),
                         AutoSizeAxes = Axes.Both,
                         Direction = FillDirection.Horizontal,
@@ -218,7 +217,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                         }
                     }
                 };
-                Child = shakeContainer;
 
                 joinButton.Action = () => lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
             }

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -123,7 +122,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             }
         }
 
-        public Popover GetPopover() => new PasswordEntryPopover(Room) { JoinRequested = lounge.Join };
+        public Popover GetPopover() => new PasswordEntryPopover(Room) { Lounge = lounge };
 
         public MenuItem[] ContextMenuItems => new MenuItem[]
         {
@@ -179,7 +178,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         {
             private readonly Room room;
 
-            public Action<Room, string, Action<Room>, Action<string>> JoinRequested;
+            public LoungeSubScreen Lounge;
 
             public PasswordEntryPopover(Room room)
             {
@@ -220,7 +219,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 };
                 Child = shakeContainer;
 
-                joinButton.Action = () => JoinRequested?.Invoke(room, passwordTextbox.Text, null, joinFailed);
+                joinButton.Action = () => Lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
             }
 
             private void joinFailed(string error)
@@ -239,7 +238,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 base.LoadComplete();
 
                 Schedule(() => GetContainingInputManager().ChangeFocus(passwordTextbox));
-                passwordTextbox.OnCommit += (_, __) => JoinRequested?.Invoke(room, passwordTextbox.Text, null, joinFailed);
+                passwordTextbox.OnCommit += (_, __) => Lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         {
             private readonly Room room;
 
-            public Action<Room, string> JoinRequested;
+            public Action<Room, string, Action<Room>, Action<string>> JoinRequested;
 
             public PasswordEntryPopover(Room room)
             {
@@ -186,6 +186,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             }
 
             private OsuPasswordTextBox passwordTextbox;
+            private TriangleButton joinButton;
 
             [BackgroundDependencyLoader]
             private void load()
@@ -201,15 +202,17 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                         passwordTextbox = new OsuPasswordTextBox
                         {
                             Width = 200,
+                            PlaceholderText = "password",
                         },
-                        new TriangleButton
+                        joinButton = new TriangleButton
                         {
                             Width = 80,
                             Text = "Join Room",
-                            Action = () => JoinRequested?.Invoke(room, passwordTextbox.Text)
                         }
                     }
                 };
+
+                joinButton.Action = () => JoinRequested?.Invoke(room, passwordTextbox.Text, null, _ => this.HidePopover());
             }
 
             protected override void LoadComplete()
@@ -217,7 +220,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 base.LoadComplete();
 
                 Schedule(() => GetContainingInputManager().ChangeFocus(passwordTextbox));
-                passwordTextbox.OnCommit += (_, __) => JoinRequested?.Invoke(room, passwordTextbox.Text);
+                passwordTextbox.OnCommit += (_, __) => JoinRequested?.Invoke(room, passwordTextbox.Text, null, _ => this.HidePopover());
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -195,8 +195,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                Padding = new MarginPadding(10);
-
                 Child = new FillFlowContainer
                 {
                     Margin = new MarginPadding(10),

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -290,7 +290,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             popoverContainer.HidePopover();
         }
 
-        public void Join(Room room, string password) => Schedule(() =>
+        public void Join(Room room, string password, Action<Room> onSuccess = null, Action<string> onFailure = null) => Schedule(() =>
         {
             if (joiningRoomOperation != null)
                 return;
@@ -302,10 +302,12 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 Open(room);
                 joiningRoomOperation?.Dispose();
                 joiningRoomOperation = null;
-            }, _ =>
+                onSuccess?.Invoke(room);
+            }, error =>
             {
                 joiningRoomOperation?.Dispose();
                 joiningRoomOperation = null;
+                onFailure?.Invoke(error);
             });
         });
 


### PR DESCRIPTION
Instead of throwing an error, just close the popover and let the user continue with what they were doing
* Resolves #14421 