### PR TITLE
Cache reflection portion of `SettingSource` lookups

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using osu.Game.Online.API;
 using osu.Game.Rulesets.Osu;
 
@@ -36,7 +37,7 @@ namespace osu.Game.Benchmarks
         [Benchmark]
         public void BenchmarkGetAllMods()
         {
-            ruleset.GetAllMods();
+            ruleset.GetAllMods().Consume(new Consumer());
         }
     }
 }

--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Game.Online.API;
+using osu.Game.Rulesets.Osu;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkRuleset : BenchmarkTest
+    {
+        private OsuRuleset ruleset;
+        private APIMod apiModDoubleTime;
+        private APIMod apiModDifficultyAdjust;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            ruleset = new OsuRuleset();
+            apiModDoubleTime = new APIMod { Acronym = "DT" };
+            apiModDifficultyAdjust = new APIMod { Acronym = "DA" };
+        }
+
+        [Benchmark]
+        public void BenchmarkToModDoubleTime()
+        {
+            apiModDoubleTime.ToMod(ruleset);
+        }
+
+        [Benchmark]
+        public void BenchmarkToModDifficultyAdjust()
+        {
+            apiModDifficultyAdjust.ToMod(ruleset);
+        }
+
+        [Benchmark]
+        public void BenchmarkGetAllMods()
+        {
+            ruleset.GetAllMods();
+        }
+    }
+}

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -168,14 +168,14 @@ namespace osu.Game.Configuration
             }
         }
 
-        private static readonly ConcurrentDictionary<Type, IEnumerable<(SettingSourceAttribute, PropertyInfo)>> property_info_cache = new ConcurrentDictionary<Type, IEnumerable<(SettingSourceAttribute, PropertyInfo)>>();
+        private static readonly ConcurrentDictionary<Type, (SettingSourceAttribute, PropertyInfo)[]> property_info_cache = new ConcurrentDictionary<Type, (SettingSourceAttribute, PropertyInfo)[]>();
 
         public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties(this object obj)
         {
             var type = obj.GetType();
 
             if (!property_info_cache.TryGetValue(type, out var properties))
-                property_info_cache[type] = properties = getSettingsSourceProperties(type);
+                property_info_cache[type] = properties = getSettingsSourceProperties(type).ToArray();
 
             return properties;
         }

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -167,18 +167,7 @@ namespace osu.Game.Configuration
             }
         }
 
-        public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties(this object obj)
-        {
-            foreach (var property in obj.GetType().GetProperties(BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance))
-            {
-                var attr = property.GetCustomAttribute<SettingSourceAttribute>(true);
-
-                if (attr == null)
-                    continue;
-
-                yield return (attr, property);
-            }
-        }
+        public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties<T>(this T obj) => SettingSourceCache<T>.SettingSourceProperties;
 
         public static ICollection<(SettingSourceAttribute, PropertyInfo)> GetOrderedSettingsSourceProperties(this object obj)
             => obj.GetSettingsSourceProperties()
@@ -195,6 +184,15 @@ namespace osu.Game.Configuration
                 // Set menu's max height low enough to workaround nested scroll issues (see https://github.com/ppy/osu-framework/issues/4536).
                 protected override DropdownMenu CreateMenu() => base.CreateMenu().With(m => m.MaxHeight = 100);
             }
+        }
+
+        private static class SettingSourceCache<T>
+        {
+            public static (SettingSourceAttribute, PropertyInfo)[] SettingSourceProperties { get; } =
+                typeof(T).GetProperties(BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance)
+                         .Select(property => (property.GetCustomAttribute<SettingSourceAttribute>(), property))
+                         .Where(pair => pair.Item1 != null)
+                         .ToArray();
         }
     }
 }


### PR DESCRIPTION
Fixes the mod-related overhead portion of https://github.com/ppy/osu/issues/14638. There's still a significant performance issue that will be addressed separately. Still not sure if this is 100% correct direction but seems to work well enough.

Before:

![](https://user-images.githubusercontent.com/191335/132330537-7414e9b2-e243-4836-bbde-211366b0a053.png)

After:

(gone)