### PR TITLE
Improve multiplayer lounge listing performance

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
@@ -130,6 +130,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Type = { Value = MatchType.HeadToHead },
             }));
 
+            AddUntilStep("wait for panel load", () => drawableRoom.ChildrenOfType<RecentParticipantsList>().Any());
+
             AddAssert("password icon hidden", () => Precision.AlmostEquals(0, drawableRoom.ChildrenOfType<DrawableRoom.PasswordProtectedIcon>().Single().Alpha));
 
             AddStep("set password", () => room.Password.Value = "password");

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
@@ -33,6 +33,12 @@ namespace osu.Game.Tests.Visual.Playlists
         private RoomsContainer roomsContainer => loungeScreen.ChildrenOfType<RoomsContainer>().First();
 
         [Test]
+        public void TestManyRooms()
+        {
+            AddStep("add rooms", () => RoomManager.AddRooms(500));
+        }
+
+        [Test]
         public void TestScrollByDraggingRooms()
         {
             AddStep("reset mouse", () => InputManager.ReleaseButton(MouseButton.Left));

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -65,6 +65,14 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
         {
+            ButtonsContainer = new Container
+            {
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+                RelativeSizeAxes = Axes.Y,
+                AutoSizeAxes = Axes.X
+            };
+
             InternalChildren = new[]
             {
                 // This resolves internal 1px gaps due to applying the (parenting) corner radius and masking across multiple filling background sprites.
@@ -208,13 +216,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                     },
                                     Children = new Drawable[]
                                     {
-                                        ButtonsContainer = new Container
-                                        {
-                                            Anchor = Anchor.CentreRight,
-                                            Origin = Anchor.CentreRight,
-                                            RelativeSizeAxes = Axes.Y,
-                                            AutoSizeAxes = Axes.X
-                                        },
+                                        ButtonsContainer,
                                         recentParticipantsList = new RecentParticipantsList
                                         {
                                             Anchor = Anchor.CentreRight,

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private PasswordProtectedIcon passwordIcon;
         private EndDateInfo endDateInfo;
 
+        private DelayedLoadWrapper wrapper;
+
         public DrawableRoom(Room room)
         {
             Room = room;
@@ -75,155 +77,156 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 {
                     d.RelativeSizeAxes = Axes.Both;
                 }),
-                new Container
-                {
-                    Name = @"Room content",
-                    RelativeSizeAxes = Axes.Both,
-                    // This negative padding resolves 1px gaps between this background and the background above.
-                    Padding = new MarginPadding { Left = 20, Vertical = -0.5f },
-                    Child = new Container
+                wrapper = new DelayedLoadWrapper(() =>
+                    new Container
                     {
+                        Name = @"Room content",
                         RelativeSizeAxes = Axes.Both,
-                        Masking = true,
-                        CornerRadius = CORNER_RADIUS,
-                        Children = new Drawable[]
+                        // This negative padding resolves 1px gaps between this background and the background above.
+                        Padding = new MarginPadding { Left = 20, Vertical = -0.5f },
+                        Child = new Container
                         {
-                            new GridContainer
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            CornerRadius = CORNER_RADIUS,
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                ColumnDimensions = new[]
+                                new GridContainer
                                 {
-                                    new Dimension(GridSizeMode.Relative, 0.2f)
-                                },
-                                Content = new[]
-                                {
-                                    new Drawable[]
+                                    RelativeSizeAxes = Axes.Both,
+                                    ColumnDimensions = new[]
                                     {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = colours.Background5,
-                                        },
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f))
-                                        },
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                Name = @"Left details",
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding
-                                {
-                                    Left = 20,
-                                    Vertical = 5
-                                },
-                                Children = new Drawable[]
-                                {
-                                    new FillFlowContainer
-                                    {
-                                        AutoSizeAxes = Axes.Both,
-                                        Direction = FillDirection.Vertical,
-                                        Children = new Drawable[]
-                                        {
-                                            new FillFlowContainer
-                                            {
-                                                AutoSizeAxes = Axes.Both,
-                                                Direction = FillDirection.Horizontal,
-                                                Spacing = new Vector2(5),
-                                                Children = new Drawable[]
-                                                {
-                                                    new RoomStatusPill
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft
-                                                    },
-                                                    specialCategoryPill = new RoomSpecialCategoryPill
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft
-                                                    },
-                                                    endDateInfo = new EndDateInfo
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
-                                                    },
-                                                }
-                                            },
-                                            new FillFlowContainer
-                                            {
-                                                AutoSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding { Top = 3 },
-                                                Direction = FillDirection.Vertical,
-                                                Children = new Drawable[]
-                                                {
-                                                    new RoomNameText(),
-                                                    new RoomHostText(),
-                                                }
-                                            }
-                                        },
+                                        new Dimension(GridSizeMode.Relative, 0.2f)
                                     },
-                                    new FillFlowContainer
+                                    Content = new[]
                                     {
-                                        Anchor = Anchor.BottomLeft,
-                                        Origin = Anchor.BottomLeft,
-                                        AutoSizeAxes = Axes.Both,
-                                        Direction = FillDirection.Horizontal,
-                                        Spacing = new Vector2(5),
-                                        Children = new Drawable[]
+                                        new Drawable[]
                                         {
-                                            new PlaylistCountPill
+                                            new Box
                                             {
-                                                Anchor = Anchor.CentreLeft,
-                                                Origin = Anchor.CentreLeft,
+                                                RelativeSizeAxes = Axes.Both,
+                                                Colour = colours.Background5,
                                             },
-                                            new StarRatingRangeDisplay
+                                            new Box
                                             {
-                                                Anchor = Anchor.CentreLeft,
-                                                Origin = Anchor.CentreLeft,
-                                                Scale = new Vector2(0.8f)
+                                                RelativeSizeAxes = Axes.Both,
+                                                Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f))
+                                            },
+                                        }
+                                    }
+                                },
+                                new Container
+                                {
+                                    Name = @"Left details",
+                                    RelativeSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding
+                                    {
+                                        Left = 20,
+                                        Vertical = 5
+                                    },
+                                    Children = new Drawable[]
+                                    {
+                                        new FillFlowContainer
+                                        {
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Vertical,
+                                            Children = new Drawable[]
+                                            {
+                                                new FillFlowContainer
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Direction = FillDirection.Horizontal,
+                                                    Spacing = new Vector2(5),
+                                                    Children = new Drawable[]
+                                                    {
+                                                        new RoomStatusPill
+                                                        {
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft
+                                                        },
+                                                        specialCategoryPill = new RoomSpecialCategoryPill
+                                                        {
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft
+                                                        },
+                                                        endDateInfo = new EndDateInfo
+                                                        {
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft,
+                                                        },
+                                                    }
+                                                },
+                                                new FillFlowContainer
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Padding = new MarginPadding { Top = 3 },
+                                                    Direction = FillDirection.Vertical,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        new RoomNameText(),
+                                                        new RoomHostText(),
+                                                    }
+                                                }
+                                            },
+                                        },
+                                        new FillFlowContainer
+                                        {
+                                            Anchor = Anchor.BottomLeft,
+                                            Origin = Anchor.BottomLeft,
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Horizontal,
+                                            Spacing = new Vector2(5),
+                                            Children = new Drawable[]
+                                            {
+                                                new PlaylistCountPill
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                },
+                                                new StarRatingRangeDisplay
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Scale = new Vector2(0.8f)
+                                                }
                                             }
                                         }
                                     }
-                                }
-                            },
-                            new FillFlowContainer
-                            {
-                                Name = "Right content",
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                AutoSizeAxes = Axes.X,
-                                RelativeSizeAxes = Axes.Y,
-                                Spacing = new Vector2(5),
-                                Padding = new MarginPadding
-                                {
-                                    Right = 10,
-                                    Vertical = 20,
                                 },
-                                Children = new Drawable[]
+                                new FillFlowContainer
                                 {
-                                    ButtonsContainer = new Container
+                                    Name = "Right content",
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    AutoSizeAxes = Axes.X,
+                                    RelativeSizeAxes = Axes.Y,
+                                    Spacing = new Vector2(5),
+                                    Padding = new MarginPadding
                                     {
-                                        Anchor = Anchor.CentreRight,
-                                        Origin = Anchor.CentreRight,
-                                        RelativeSizeAxes = Axes.Y,
-                                        AutoSizeAxes = Axes.X
+                                        Right = 10,
+                                        Vertical = 20,
                                     },
-                                    recentParticipantsList = new RecentParticipantsList
+                                    Children = new Drawable[]
                                     {
-                                        Anchor = Anchor.CentreRight,
-                                        Origin = Anchor.CentreRight,
-                                        NumberOfCircles = NumberOfAvatars
+                                        ButtonsContainer = new Container
+                                        {
+                                            Anchor = Anchor.CentreRight,
+                                            Origin = Anchor.CentreRight,
+                                            RelativeSizeAxes = Axes.Y,
+                                            AutoSizeAxes = Axes.X
+                                        },
+                                        recentParticipantsList = new RecentParticipantsList
+                                        {
+                                            Anchor = Anchor.CentreRight,
+                                            Origin = Anchor.CentreRight,
+                                            NumberOfCircles = NumberOfAvatars
+                                        }
                                     }
-                                }
+                                },
+                                passwordIcon = new PasswordProtectedIcon { Alpha = 0 }
                             },
-                            passwordIcon = new PasswordProtectedIcon { Alpha = 0 }
                         },
-                    },
-                },
+                    }, 0)
             };
         }
 
@@ -231,23 +234,26 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         {
             base.LoadComplete();
 
-            roomCategory.BindTo(Room.Category);
-            roomCategory.BindValueChanged(c =>
+            wrapper.DelayedLoadComplete += _ =>
             {
-                if (c.NewValue == RoomCategory.Spotlight)
-                    specialCategoryPill.Show();
-                else
-                    specialCategoryPill.Hide();
-            }, true);
+                roomCategory.BindTo(Room.Category);
+                roomCategory.BindValueChanged(c =>
+                {
+                    if (c.NewValue == RoomCategory.Spotlight)
+                        specialCategoryPill.Show();
+                    else
+                        specialCategoryPill.Hide();
+                }, true);
 
-            roomType.BindTo(Room.Type);
-            roomType.BindValueChanged(t =>
-            {
-                endDateInfo.Alpha = t.NewValue == MatchType.Playlists ? 1 : 0;
-            }, true);
+                roomType.BindTo(Room.Type);
+                roomType.BindValueChanged(t =>
+                {
+                    endDateInfo.Alpha = t.NewValue == MatchType.Playlists ? 1 : 0;
+                }, true);
 
-            hasPassword.BindTo(Room.HasPassword);
-            hasPassword.BindValueChanged(v => passwordIcon.Alpha = v.NewValue ? 1 : 0, true);
+                hasPassword.BindTo(Room.HasPassword);
+                hasPassword.BindValueChanged(v => passwordIcon.Alpha = v.NewValue ? 1 : 0, true);
+            };
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -227,6 +227,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                             },
                         },
                     }, 0)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                }
             };
         }
 
@@ -236,6 +239,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
             wrapper.DelayedLoadComplete += _ =>
             {
+                wrapper.FadeInFromZero(200);
+
                 roomCategory.BindTo(Room.Category);
                 roomCategory.BindValueChanged(c =>
                 {

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -64,9 +64,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         protected override void LoadComplete()
         {
-            rooms.CollectionChanged += roomsChanged;
             roomManager.RoomsUpdated += updateSorting;
 
+            rooms.CollectionChanged += roomsChanged;
             rooms.BindTo(roomManager.Rooms);
 
             Filter?.BindValueChanged(criteria => applyFilterCriteria(criteria.NewValue), true);
@@ -108,10 +108,14 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private void addRooms(IEnumerable<Room> rooms)
         {
-            foreach (var room in rooms)
-                roomFlow.Add(new DrawableLoungeRoom(room) { SelectedRoom = { BindTarget = SelectedRoom } });
+            LoadComponentsAsync(rooms.Select(room =>
+                new DrawableLoungeRoom(room) { SelectedRoom = { BindTarget = SelectedRoom } }), rooms =>
+            {
+                // check against rooms collection to ensure the room wasn't removed since this async load started.
+                roomFlow.AddRange(rooms.Where(r => this.rooms.Contains(r.Room)));
 
-            applyFilterCriteria(Filter?.Value);
+                applyFilterCriteria(Filter?.Value);
+            });
         }
 
         private void removeRooms(IEnumerable<Room> rooms)

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -64,9 +64,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         protected override void LoadComplete()
         {
+            rooms.CollectionChanged += roomsChanged;
             roomManager.RoomsUpdated += updateSorting;
 
-            rooms.CollectionChanged += roomsChanged;
             rooms.BindTo(roomManager.Rooms);
 
             Filter?.BindValueChanged(criteria => applyFilterCriteria(criteria.NewValue), true);
@@ -108,14 +108,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private void addRooms(IEnumerable<Room> rooms)
         {
-            LoadComponentsAsync(rooms.Select(room =>
-                new DrawableLoungeRoom(room) { SelectedRoom = { BindTarget = SelectedRoom } }), rooms =>
-            {
-                // check against rooms collection to ensure the room wasn't removed since this async load started.
-                roomFlow.AddRange(rooms.Where(r => this.rooms.Contains(r.Room)));
+            foreach (var room in rooms)
+                roomFlow.Add(new DrawableLoungeRoom(room) { SelectedRoom = { BindTarget = SelectedRoom } });
 
-                applyFilterCriteria(Filter?.Value);
-            });
+            applyFilterCriteria(Filter?.Value);
         }
 
         private void removeRooms(IEnumerable<Room> rooms)

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -83,12 +83,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         {
             base.LoadComplete();
 
-            if (matchingFilter)
-                this.FadeInFromZero(transition_duration);
-            else
-                Alpha = 0;
+            Alpha = matchingFilter ? 1 : 0;
+            selectionBox.Alpha = SelectedRoom.Value == Room ? 1 : 0;
 
-            SelectedRoom.BindValueChanged(updateSelectedRoom, true);
+            SelectedRoom.BindValueChanged(updateSelectedRoom);
         }
 
         private void updateSelectedRoom(ValueChangedEvent<Room> selected)


### PR DESCRIPTION
I initially attempted to load the rooms asynchronously but it turns out this didn't help much - the main overhead is in the layout of contained (24!) `FillFlowContainer`s, amongst other things.

Easiest solution here was to just use a `DelayedLoadWrapper`. With this, asynchronous load of the panels actually added to performance degradation so I've left the initial construction as a synchronous call still (have left the commit/revert in case you want to experiment or confirm).

There's a slight stutter with 500 rooms, but it's far better than it was before. Note that the performance will still be pretty shocking until https://github.com/ppy/osu/pull/14674 is addressed.

Closes https://github.com/ppy/osu/issues/14638