### PR TITLE
Use a decoupled clock for triangles intro to avoid startup freezes on broken audio device

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.Menu
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBlack();
 
-        protected void StartTrack()
+        protected virtual void StartTrack()
         {
             // Only start the current track if it is the menu music. A beatmap's track is started when entering the Main Menu.
             if (UsingThemedIntro)

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -115,7 +115,9 @@ namespace osu.Game.Screens.Menu
                 if (setInfo == null)
                     return false;
 
-                return (initialBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0])) != null;
+                initialBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0]);
+
+                return UsingThemedIntro = initialBeatmap != null;
             }
         }
 
@@ -184,7 +186,6 @@ namespace osu.Game.Screens.Menu
             {
                 beatmap.Value = initialBeatmap;
                 Track = initialBeatmap.Track;
-                UsingThemedIntro = !initialBeatmap.Track.IsDummyDevice;
 
                 // ensure the track starts at maximum volume
                 musicController.CurrentTrack.FinishTransforms();

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -41,6 +41,8 @@ namespace osu.Game.Screens.Menu
 
         private Sample welcome;
 
+        private DecoupleableInterpolatingFramedClock decoupledClock;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -56,10 +58,18 @@ namespace osu.Game.Screens.Menu
             {
                 PrepareMenuLoad();
 
+                decoupledClock = new DecoupleableInterpolatingFramedClock
+                {
+                    IsCoupled = false
+                };
+
+                if (UsingThemedIntro)
+                    decoupledClock.ChangeSource(Track);
+
                 LoadComponentAsync(new TrianglesIntroSequence(logo, background)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Clock = new FramedClock(UsingThemedIntro ? Track : null),
+                    Clock = decoupledClock,
                     LoadMenu = LoadMenu
                 }, t =>
                 {
@@ -76,6 +86,12 @@ namespace osu.Game.Screens.Menu
         {
             base.OnResuming(last);
             background.FadeOut(100);
+        }
+
+        protected override void StartTrack()
+        {
+            if (UsingThemedIntro)
+                decoupledClock.Start();
         }
 
         private class TrianglesIntroSequence : CompositeDrawable

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -90,8 +90,7 @@ namespace osu.Game.Screens.Menu
 
         protected override void StartTrack()
         {
-            if (UsingThemedIntro)
-                decoupledClock.Start();
+            decoupledClock.Start();
         }
 
         private class TrianglesIntroSequence : CompositeDrawable


### PR DESCRIPTION
Attempts to fix https://github.com/ppy/osu/issues/7970 (recently came up in https://github.com/ppy/osu/discussions/14633). Needs testing with someone who can reproduce the broken device issue.

Also, this will improve the perceived smoothness of the startup animation. Previously we were sampling directly from the track, which can have limited precision on windows, as an example.