### PR TITLE
Fix volume meter not being highlighted when hovering before show

### DIFF
--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -355,6 +355,12 @@ namespace osu.Game.Overlays.Volume
             return base.OnMouseMove(e);
         }
 
+        protected override bool OnHover(HoverEvent e)
+        {
+            State = SelectionState.Selected;
+            return false;
+        }
+
         protected override void OnHoverLost(HoverLostEvent e)
         {
         }


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/commit/7d405f04fbff8d449864958e2ddb4b3c65511ce1.

Before:
![Screen Recording 2021-09-08 at 11 45 40 AM](https://user-images.githubusercontent.com/35318437/132567719-1cb92e24-c2ae-4330-ab37-7eee0dcc1fac.gif)

After:
![Screen Recording 2021-09-08 at 11 48 59 AM](https://user-images.githubusercontent.com/35318437/132567714-138d05f4-5344-4f78-a90b-a649ab4e773a.gif)