### PR TITLE
Don't play hover/select sounds for UpdatableAvatar unless it's clickable

### DIFF
--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Profile.Header
                     Origin = Anchor.CentreLeft,
                     Children = new Drawable[]
                     {
-                        avatar = new UpdateableAvatar(openOnClick: false, showGuestOnNull: false)
+                        avatar = new UpdateableAvatar(isInteractive: false, showGuestOnNull: false)
                         {
                             Size = new Vector2(avatar_size),
                             Masking = true,

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays.Toolbar
 
             Add(new OpaqueBackground { Depth = 1 });
 
-            Flow.Add(avatar = new UpdateableAvatar(openOnClick: false)
+            Flow.Add(avatar = new UpdateableAvatar(isInteractive: false)
             {
                 Masking = true,
                 Size = new Vector2(32),

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -69,14 +69,20 @@ namespace osu.Game.Users.Drawables
             if (user == null && !showGuestOnNull)
                 return null;
 
-            var avatar = new ClickableAvatar(user)
+            if (!openOnClick)
+            {
+                return new DrawableAvatar(user)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+
+            return new ClickableAvatar(user)
             {
                 OpenOnClick = openOnClick,
                 ShowUsernameTooltip = showUsernameTooltip,
                 RelativeSizeAxes = Axes.Both,
             };
-
-            return avatar;
         }
     }
 }

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -69,20 +69,22 @@ namespace osu.Game.Users.Drawables
             if (user == null && !showGuestOnNull)
                 return null;
 
-            if (!openOnClick)
+            if (openOnClick)
+            {
+                return new ClickableAvatar(user)
+                {
+                    OpenOnClick = true,
+                    ShowUsernameTooltip = showUsernameTooltip,
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+            else
             {
                 return new DrawableAvatar(user)
                 {
                     RelativeSizeAxes = Axes.Both,
                 };
             }
-
-            return new ClickableAvatar(user)
-            {
-                OpenOnClick = openOnClick,
-                ShowUsernameTooltip = showUsernameTooltip,
-                RelativeSizeAxes = Axes.Both,
-            };
         }
     }
 }

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Users.Drawables
 
         protected override double LoadDelay => 200;
 
-        private readonly bool openOnClick;
+        private readonly bool isInteractive;
         private readonly bool showUsernameTooltip;
         private readonly bool showGuestOnNull;
 
@@ -52,12 +52,12 @@ namespace osu.Game.Users.Drawables
         /// Construct a new UpdateableAvatar.
         /// </summary>
         /// <param name="user">The initial user to display.</param>
-        /// <param name="openOnClick">Whether to open the user's profile when clicked.</param>
-        /// <param name="showUsernameTooltip">Whether to show the username rather than "view profile" on the tooltip.</param>
+        /// <param name="isInteractive">If set to true, hover/click sounds will play and clicking the avatar will open the user's profile.</param>
+        /// <param name="showUsernameTooltip">Whether to show the username rather than "view profile" on the tooltip. (note: this only applies if <paramref name="isInteractive"/> is also true)</param>
         /// <param name="showGuestOnNull">Whether to show a default guest representation on null user (as opposed to nothing).</param>
-        public UpdateableAvatar(User user = null, bool openOnClick = true, bool showUsernameTooltip = false, bool showGuestOnNull = true)
+        public UpdateableAvatar(User user = null, bool isInteractive = true, bool showUsernameTooltip = false, bool showGuestOnNull = true)
         {
-            this.openOnClick = openOnClick;
+            this.isInteractive = isInteractive;
             this.showUsernameTooltip = showUsernameTooltip;
             this.showGuestOnNull = showGuestOnNull;
 
@@ -69,7 +69,7 @@ namespace osu.Game.Users.Drawables
             if (user == null && !showGuestOnNull)
                 return null;
 
-            if (openOnClick)
+            if (isInteractive)
             {
                 return new ClickableAvatar(user)
                 {


### PR DESCRIPTION
This is mainly to fix the case where the avatar displayed in the Toolbar user menu/button plays hover/click sounds even though it's not directly interactable and is part of a menu item.

This thing:
![Screen Shot 2021-09-09 at 3 42 03 pm](https://user-images.githubusercontent.com/272140/132636050-9164403d-40c2-4a1a-b3d1-deb6fb42b99e.png)