### PR TITLE
Avoid unnecessary mod settings copy attempt (when no settings exist to copy)

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using osu.Game.Online.API;
 using osu.Game.Rulesets.Osu;
 
@@ -36,7 +37,7 @@ namespace osu.Game.Benchmarks
         [Benchmark]
         public void BenchmarkGetAllMods()
         {
-            ruleset.GetAllMods();
+            ruleset.GetAllMods().Consume(new Consumer());
         }
     }
 }

--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Game.Online.API;
+using osu.Game.Rulesets.Osu;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkRuleset : BenchmarkTest
+    {
+        private OsuRuleset ruleset;
+        private APIMod apiModDoubleTime;
+        private APIMod apiModDifficultyAdjust;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            ruleset = new OsuRuleset();
+            apiModDoubleTime = new APIMod { Acronym = "DT" };
+            apiModDifficultyAdjust = new APIMod { Acronym = "DA" };
+        }
+
+        [Benchmark]
+        public void BenchmarkToModDoubleTime()
+        {
+            apiModDoubleTime.ToMod(ruleset);
+        }
+
+        [Benchmark]
+        public void BenchmarkToModDifficultyAdjust()
+        {
+            apiModDifficultyAdjust.ToMod(ruleset);
+        }
+
+        [Benchmark]
+        public void BenchmarkGetAllMods()
+        {
+            ruleset.GetAllMods();
+        }
+    }
+}

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -168,14 +168,14 @@ namespace osu.Game.Configuration
             }
         }
 
-        private static readonly ConcurrentDictionary<Type, IEnumerable<(SettingSourceAttribute, PropertyInfo)>> property_info_cache = new ConcurrentDictionary<Type, IEnumerable<(SettingSourceAttribute, PropertyInfo)>>();
+        private static readonly ConcurrentDictionary<Type, (SettingSourceAttribute, PropertyInfo)[]> property_info_cache = new ConcurrentDictionary<Type, (SettingSourceAttribute, PropertyInfo)[]>();
 
         public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties(this object obj)
         {
             var type = obj.GetType();
 
             if (!property_info_cache.TryGetValue(type, out var properties))
-                property_info_cache[type] = properties = getSettingsSourceProperties(type);
+                property_info_cache[type] = properties = getSettingsSourceProperties(type).ToArray();
 
             return properties;
         }

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -167,18 +167,7 @@ namespace osu.Game.Configuration
             }
         }
 
-        public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties(this object obj)
-        {
-            foreach (var property in obj.GetType().GetProperties(BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance))
-            {
-                var attr = property.GetCustomAttribute<SettingSourceAttribute>(true);
-
-                if (attr == null)
-                    continue;
-
-                yield return (attr, property);
-            }
-        }
+        public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties<T>(this T obj) => SettingSourceCache<T>.SettingSourceProperties;
 
         public static ICollection<(SettingSourceAttribute, PropertyInfo)> GetOrderedSettingsSourceProperties(this object obj)
             => obj.GetSettingsSourceProperties()
@@ -195,6 +184,15 @@ namespace osu.Game.Configuration
                 // Set menu's max height low enough to workaround nested scroll issues (see https://github.com/ppy/osu-framework/issues/4536).
                 protected override DropdownMenu CreateMenu() => base.CreateMenu().With(m => m.MaxHeight = 100);
             }
+        }
+
+        private static class SettingSourceCache<T>
+        {
+            public static (SettingSourceAttribute, PropertyInfo)[] SettingSourceProperties { get; } =
+                typeof(T).GetProperties(BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance)
+                         .Select(property => (property.GetCustomAttribute<SettingSourceAttribute>(), property))
+                         .Where(pair => pair.Item1 != null)
+                         .ToArray();
         }
     }
 }

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -53,12 +53,15 @@ namespace osu.Game.Online.API
             if (resultMod == null)
                 throw new InvalidOperationException($"There is no mod in the ruleset ({ruleset.ShortName}) matching the acronym {Acronym}.");
 
-            foreach (var (_, property) in resultMod.GetSettingsSourceProperties())
+            if (Settings.Count > 0)
             {
-                if (!Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
-                    continue;
+                foreach (var (_, property) in resultMod.GetSettingsSourceProperties())
+                {
+                    if (!Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
+                        continue;
 
-                resultMod.CopyAdjustedSetting((IBindable)property.GetValue(resultMod), settingValue);
+                    resultMod.CopyAdjustedSetting((IBindable)property.GetValue(resultMod), settingValue);
+                }
             }
 
             return resultMod;


### PR DESCRIPTION
- [x] Depends on #14674

as of #14674:

|                         Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------- |----------:|----------:|----------:|-------:|----------:|
|       BenchmarkToModDoubleTime |  6.176 us | 0.0307 us | 0.0272 us | 0.3510 |      4 KB |
| BenchmarkToModDifficultyAdjust | 21.568 us | 0.1429 us | 0.1267 us | 0.7935 |      9 KB |
|            BenchmarkGetAllMods | 15.669 us | 0.1784 us | 0.1669 us | 1.3428 |     15 KB |

this pr:

|                         Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------- |----------:|----------:|----------:|-------:|----------:|
|       BenchmarkToModDoubleTime |  3.680 us | 0.0276 us | 0.0258 us | 0.3433 |      4 KB |
| BenchmarkToModDifficultyAdjust | 10.370 us | 0.0928 us | 0.0823 us | 0.7629 |      9 KB |
|            BenchmarkGetAllMods | 15.955 us | 0.1187 us | 0.1110 us | 1.3428 |     15 KB |
