### PR TITLE
Add new methods to ruleset for quicker mod lookups

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -4,6 +4,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using osu.Game.Online.API;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 
 namespace osu.Game.Benchmarks
@@ -44,6 +45,18 @@ namespace osu.Game.Benchmarks
         public void BenchmarkGetAllModsForReference()
         {
             ruleset.GetAllModsForReference().Consume(new Consumer());
+        }
+
+        [Benchmark]
+        public void BenchmarkGetForAcronym()
+        {
+            ruleset.GetModForAcronym("DT");
+        }
+
+        [Benchmark]
+        public void BenchmarkGetForType()
+        {
+            ruleset.GetMod<ModDoubleTime>();
         }
     }
 }

--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -38,25 +38,25 @@ namespace osu.Game.Benchmarks
         [Benchmark]
         public void BenchmarkGetAllMods()
         {
-            ruleset.GetAllMods().Consume(new Consumer());
+            ruleset.CreateAllMods().Consume(new Consumer());
         }
 
         [Benchmark]
         public void BenchmarkGetAllModsForReference()
         {
-            ruleset.GetAllModsForReference().Consume(new Consumer());
+            ruleset.AllMods.Consume(new Consumer());
         }
 
         [Benchmark]
         public void BenchmarkGetForAcronym()
         {
-            ruleset.GetModForAcronym("DT");
+            ruleset.CreateModFromAcronym("DT");
         }
 
         [Benchmark]
         public void BenchmarkGetForType()
         {
-            ruleset.GetMod<ModDoubleTime>();
+            ruleset.CreateMod<ModDoubleTime>();
         }
     }
 }

--- a/osu.Game.Benchmarks/BenchmarkRuleset.cs
+++ b/osu.Game.Benchmarks/BenchmarkRuleset.cs
@@ -39,5 +39,11 @@ namespace osu.Game.Benchmarks
         {
             ruleset.GetAllMods().Consume(new Consumer());
         }
+
+        [Benchmark]
+        public void BenchmarkGetAllModsForReference()
+        {
+            ruleset.GetAllModsForReference().Consume(new Consumer());
+        }
     }
 }

--- a/osu.Game.Tests/Mods/ModSettingsEqualityComparison.cs
+++ b/osu.Game.Tests/Mods/ModSettingsEqualityComparison.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Game.Online.API;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Tests.Mods
@@ -11,26 +12,42 @@ namespace osu.Game.Tests.Mods
     public class ModSettingsEqualityComparison
     {
         [Test]
-        public void Test()
+        public void TestAPIMod()
         {
+            var apiMod1 = new APIMod(new OsuModDoubleTime { SpeedChange = { Value = 1.25 } });
+            var apiMod2 = new APIMod(new OsuModDoubleTime { SpeedChange = { Value = 1.26 } });
+            var apiMod3 = new APIMod(new OsuModDoubleTime { SpeedChange = { Value = 1.26 } });
+
+            Assert.That(apiMod1, Is.Not.EqualTo(apiMod2));
+            Assert.That(apiMod2, Is.EqualTo(apiMod2));
+            Assert.That(apiMod2, Is.EqualTo(apiMod3));
+            Assert.That(apiMod3, Is.EqualTo(apiMod2));
+        }
+
+        [Test]
+        public void TestMod()
+        {
+            var ruleset = new OsuRuleset();
+
             var mod1 = new OsuModDoubleTime { SpeedChange = { Value = 1.25 } };
             var mod2 = new OsuModDoubleTime { SpeedChange = { Value = 1.26 } };
             var mod3 = new OsuModDoubleTime { SpeedChange = { Value = 1.26 } };
-            var apiMod1 = new APIMod(mod1);
-            var apiMod2 = new APIMod(mod2);
-            var apiMod3 = new APIMod(mod3);
+
+            var doubleConvertedMod1 = new APIMod(mod1).ToMod(ruleset);
+            var doulbeConvertedMod2 = new APIMod(mod2).ToMod(ruleset);
+            var doulbeConvertedMod3 = new APIMod(mod3).ToMod(ruleset);
 
             Assert.That(mod1, Is.Not.EqualTo(mod2));
-            Assert.That(apiMod1, Is.Not.EqualTo(apiMod2));
+            Assert.That(doubleConvertedMod1, Is.Not.EqualTo(doulbeConvertedMod2));
 
             Assert.That(mod2, Is.EqualTo(mod2));
-            Assert.That(apiMod2, Is.EqualTo(apiMod2));
+            Assert.That(doulbeConvertedMod2, Is.EqualTo(doulbeConvertedMod2));
 
             Assert.That(mod2, Is.EqualTo(mod3));
-            Assert.That(apiMod2, Is.EqualTo(apiMod3));
+            Assert.That(doulbeConvertedMod2, Is.EqualTo(doulbeConvertedMod3));
 
             Assert.That(mod3, Is.EqualTo(mod2));
-            Assert.That(apiMod3, Is.EqualTo(apiMod2));
+            Assert.That(doulbeConvertedMod3, Is.EqualTo(doulbeConvertedMod2));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Configuration;
@@ -71,7 +70,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             var working = CreateWorkingBeatmap(rulesetInfo);
 
             Beatmap.Value = working;
-            SelectedMods.Value = new[] { ruleset.CreateAllMods().First(m => m is ModNoFail) };
+            SelectedMods.Value = new[] { ruleset.CreateMod<ModNoFail>() };
 
             Player = CreatePlayer(ruleset);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             var working = CreateWorkingBeatmap(rulesetInfo);
 
             Beatmap.Value = working;
-            SelectedMods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
+            SelectedMods.Value = new[] { ruleset.CreateAllMods().First(m => m is ModNoFail) };
 
             Player = CreatePlayer(ruleset);
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select EZ mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                SelectedMods.Value = new[] { ruleset.CreateAllMods().OfType<ModEasy>().Single() };
+                SelectedMods.Value = new[] { ruleset.CreateMod<ModEasy>() };
             });
 
             AddAssert("circle size bar is blue", () => barIsBlue(advancedStats.FirstValue));
@@ -106,7 +106,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select HR mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                SelectedMods.Value = new[] { ruleset.CreateAllMods().OfType<ModHardRock>().Single() };
+                SelectedMods.Value = new[] { ruleset.CreateMod<ModHardRock>() };
             });
 
             AddAssert("circle size bar is red", () => barIsRed(advancedStats.FirstValue));
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select unchanged Difficulty Adjust mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                var difficultyAdjustMod = ruleset.CreateAllMods().OfType<ModDifficultyAdjust>().Single();
+                var difficultyAdjustMod = ruleset.CreateMod<ModDifficultyAdjust>();
                 difficultyAdjustMod.ReadFromDifficulty(advancedStats.Beatmap.BaseDifficulty);
                 SelectedMods.Value = new[] { difficultyAdjustMod };
             });
@@ -142,7 +142,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select changed Difficulty Adjust mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                var difficultyAdjustMod = ruleset.CreateAllMods().OfType<OsuModDifficultyAdjust>().Single();
+                var difficultyAdjustMod = ruleset.CreateMod<OsuModDifficultyAdjust>();
                 var originalDifficulty = advancedStats.Beatmap.BaseDifficulty;
 
                 difficultyAdjustMod.ReadFromDifficulty(originalDifficulty);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select EZ mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                SelectedMods.Value = new[] { ruleset.GetAllMods().OfType<ModEasy>().Single() };
+                SelectedMods.Value = new[] { ruleset.CreateAllMods().OfType<ModEasy>().Single() };
             });
 
             AddAssert("circle size bar is blue", () => barIsBlue(advancedStats.FirstValue));
@@ -106,7 +106,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select HR mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                SelectedMods.Value = new[] { ruleset.GetAllMods().OfType<ModHardRock>().Single() };
+                SelectedMods.Value = new[] { ruleset.CreateAllMods().OfType<ModHardRock>().Single() };
             });
 
             AddAssert("circle size bar is red", () => barIsRed(advancedStats.FirstValue));
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select unchanged Difficulty Adjust mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                var difficultyAdjustMod = ruleset.GetAllMods().OfType<ModDifficultyAdjust>().Single();
+                var difficultyAdjustMod = ruleset.CreateAllMods().OfType<ModDifficultyAdjust>().Single();
                 difficultyAdjustMod.ReadFromDifficulty(advancedStats.Beatmap.BaseDifficulty);
                 SelectedMods.Value = new[] { difficultyAdjustMod };
             });
@@ -142,7 +142,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select changed Difficulty Adjust mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                var difficultyAdjustMod = ruleset.GetAllMods().OfType<OsuModDifficultyAdjust>().Single();
+                var difficultyAdjustMod = ruleset.CreateAllMods().OfType<OsuModDifficultyAdjust>().Single();
                 var originalDifficulty = advancedStats.Beatmap.BaseDifficulty;
 
                 difficultyAdjustMod.ReadFromDifficulty(originalDifficulty);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep("setup display", () =>
             {
-                var randomMods = Ruleset.Value.CreateInstance().GetAllMods().OrderBy(_ => RNG.Next()).Take(5).ToList();
+                var randomMods = Ruleset.Value.CreateInstance().CreateAllMods().OrderBy(_ => RNG.Next()).Take(5).ToList();
 
                 OsuLogo logo = new OsuLogo { Scale = new Vector2(0.15f) };
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModFlowDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModFlowDisplay.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Width = 200,
                 Current =
                 {
-                    Value = new OsuRuleset().GetAllMods().ToArray(),
+                    Value = new OsuRuleset().CreateAllMods().ToArray(),
                 }
             };
         });

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -158,8 +158,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             var mania = new ManiaRuleset();
 
             testModsWithSameBaseType(
-                mania.GetAllMods().Single(m => m.GetType() == typeof(ManiaModFadeIn)),
-                mania.GetAllMods().Single(m => m.GetType() == typeof(ManiaModHidden)));
+                mania.CreateAllMods().Single(m => m.GetType() == typeof(ManiaModFadeIn)),
+                mania.CreateAllMods().Single(m => m.GetType() == typeof(ManiaModHidden)));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -158,8 +158,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             var mania = new ManiaRuleset();
 
             testModsWithSameBaseType(
-                mania.CreateAllMods().Single(m => m.GetType() == typeof(ManiaModFadeIn)),
-                mania.CreateAllMods().Single(m => m.GetType() == typeof(ManiaModHidden)));
+                mania.CreateMod<ManiaModFadeIn>(),
+                mania.CreateMod<ManiaModHidden>());
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tournament.Tests.Components
         private void success(APIBeatmap apiBeatmap)
         {
             beatmap = apiBeatmap.ToBeatmap(rulesets);
-            var mods = rulesets.GetRuleset(Ladder.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods();
+            var mods = rulesets.GetRuleset(Ladder.Ruleset.Value.ID ?? 0).CreateInstance().CreateAllMods();
 
             foreach (var mod in mods)
             {

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tournament.Tests.Components
         private void success(APIBeatmap apiBeatmap)
         {
             beatmap = apiBeatmap.ToBeatmap(rulesets);
-            var mods = rulesets.GetRuleset(Ladder.Ruleset.Value.ID ?? 0).CreateInstance().CreateAllMods();
+            var mods = rulesets.GetRuleset(Ladder.Ruleset.Value.ID ?? 0).CreateInstance().AllMods;
 
             foreach (var mod in mods)
             {

--- a/osu.Game.Tournament/Components/TournamentModIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentModIcon.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tournament.Components
             }
 
             var ruleset = rulesets.GetRuleset(ladderInfo.Ruleset.Value?.ID ?? 0);
-            var modIcon = ruleset?.CreateInstance().GetModForAcronym(modAcronym);
+            var modIcon = ruleset?.CreateInstance().CreateModFromAcronym(modAcronym);
 
             if (modIcon == null)
                 return;

--- a/osu.Game.Tournament/Components/TournamentModIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentModIcon.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Tournament/Components/TournamentModIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentModIcon.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tournament.Components
             }
 
             var ruleset = rulesets.GetRuleset(ladderInfo.Ruleset.Value?.ID ?? 0);
-            var modIcon = ruleset?.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == modAcronym);
+            var modIcon = ruleset?.CreateInstance().GetModForAcronym(modAcronym);
 
             if (modIcon == null)
                 return;

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Online.API
 
         public Mod ToMod(Ruleset ruleset)
         {
-            Mod resultMod = ruleset.GetAllMods().FirstOrDefault(m => m.Acronym == Acronym);
+            Mod resultMod = ruleset.GetModForAcronym(Acronym);
 
             if (resultMod == null)
                 throw new InvalidOperationException($"There is no mod in the ruleset ({ruleset.ShortName}) matching the acronym {Acronym}.");

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Online.API
 
         public Mod ToMod(Ruleset ruleset)
         {
-            Mod resultMod = ruleset.GetModForAcronym(Acronym);
+            Mod resultMod = ruleset.CreateModFromAcronym(Acronym);
 
             if (resultMod == null)
                 throw new InvalidOperationException($"There is no mod in the ruleset ({ruleset.ShortName}) matching the acronym {Acronym}.");

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -16,7 +16,7 @@ using osu.Game.Utils;
 namespace osu.Game.Online.API
 {
     [MessagePackObject]
-    public class APIMod
+    public class APIMod : IEquatable<APIMod>
     {
         [JsonProperty("acronym")]
         [Key(0)]
@@ -72,8 +72,7 @@ namespace osu.Game.Online.API
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Acronym == other.Acronym &&
-                   Settings.SequenceEqual(other.Settings, ModSettingsEqualityComparer.Default);
+            return Acronym == other.Acronym && Settings.SequenceEqual(other.Settings, ModSettingsEqualityComparer.Default);
         }
 
         public override string ToString()

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -16,7 +16,7 @@ using osu.Game.Utils;
 namespace osu.Game.Online.API
 {
     [MessagePackObject]
-    public class APIMod : IMod, IEquatable<APIMod>
+    public class APIMod
     {
         [JsonProperty("acronym")]
         [Key(0)]
@@ -66,8 +66,6 @@ namespace osu.Game.Online.API
 
             return resultMod;
         }
-
-        public bool Equals(IMod other) => other is APIMod them && Equals(them);
 
         public bool Equals(APIMod other)
         {

--- a/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
@@ -23,10 +23,10 @@ namespace osu.Game.Online.API.Requests.Responses
 
             var rulesetInstance = ruleset.CreateInstance();
 
-            var mods = Mods != null ? Mods.Select(acronym => rulesetInstance.GetModForAcronym(acronym)).Where(m => m != null).ToArray() : Array.Empty<Mod>();
+            var mods = Mods != null ? Mods.Select(acronym => rulesetInstance.CreateModFromAcronym(acronym)).Where(m => m != null).ToArray() : Array.Empty<Mod>();
 
             // all API scores provided by this class are considered to be legacy.
-            mods = mods.Append(rulesetInstance.GetMod<ModClassic>()).ToArray();
+            mods = mods.Append(rulesetInstance.CreateMod<ModClassic>()).ToArray();
 
             var scoreInfo = new ScoreInfo
             {

--- a/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Online.API.Requests.Responses
             var mods = Mods != null ? Mods.Select(acronym => rulesetInstance.GetModForAcronym(acronym)).Where(m => m != null).ToArray() : Array.Empty<Mod>();
 
             // all API scores provided by this class are considered to be legacy.
-            mods = mods.Append(rulesetInstance.GetAllMods().OfType<ModClassic>().Single()).ToArray();
+            mods = mods.Append(rulesetInstance.GetMod<ModClassic>()).ToArray();
 
             var scoreInfo = new ScoreInfo
             {

--- a/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
             var rulesetInstance = ruleset.CreateInstance();
 
-            var mods = Mods != null ? rulesetInstance.GetAllMods().Where(mod => Mods.Contains(mod.Acronym)).ToArray() : Array.Empty<Mod>();
+            var mods = Mods != null ? Mods.Select(acronym => rulesetInstance.GetModForAcronym(acronym)).Where(m => m != null).ToArray() : Array.Empty<Mod>();
 
             // all API scores provided by this class are considered to be legacy.
             mods = mods.Append(rulesetInstance.GetAllMods().OfType<ModClassic>().Single()).ToArray();

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -166,7 +166,7 @@ namespace osu.Game
 
         public OsuGameBase()
         {
-            UseDevelopmentServer = DebugUtils.IsDebugBuild;
+            UseDevelopmentServer = false;
             Name = @"osu!";
         }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -166,7 +166,7 @@ namespace osu.Game
 
         public OsuGameBase()
         {
-            UseDevelopmentServer = false;
+            UseDevelopmentServer = DebugUtils.IsDebugBuild;
             Name = @"osu!";
         }
 

--- a/osu.Game/Overlays/BeatmapSet/LeaderboardModSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/LeaderboardModSelector.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 return;
 
             modsContainer.Add(new ModButton(new ModNoMod()));
-            modsContainer.AddRange(ruleset.NewValue.CreateInstance().GetAllModsForReference().Where(m => m.UserPlayable).Select(m => new ModButton(m)));
+            modsContainer.AddRange(ruleset.NewValue.CreateInstance().AllMods.Where(m => m.UserPlayable).Select(m => new ModButton(m.CreateInstance())));
 
             modsContainer.ForEach(button =>
             {

--- a/osu.Game/Overlays/BeatmapSet/LeaderboardModSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/LeaderboardModSelector.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 return;
 
             modsContainer.Add(new ModButton(new ModNoMod()));
-            modsContainer.AddRange(ruleset.NewValue.CreateInstance().GetAllMods().Where(m => m.UserPlayable).Select(m => new ModButton(m)));
+            modsContainer.AddRange(ruleset.NewValue.CreateInstance().GetAllModsForReference().Where(m => m.UserPlayable).Select(m => new ModButton(m)));
 
             modsContainer.ForEach(button =>
             {

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModButton.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModButton.cs
@@ -107,9 +107,9 @@ namespace osu.Game.Overlays.Mods
 
                 var incompatibleTypes = mod.IncompatibleMods;
 
-                var allMods = ruleset.Value.CreateInstance().GetAllModsForReference();
+                var allMods = ruleset.Value.CreateInstance().AllMods;
 
-                incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).ToList();
+                incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).Select(m => m.CreateInstance()).ToList();
                 incompatibleText.Text = incompatibleMods.Value.Any() ? "Incompatible with:" : "Compatible with all mods";
             }
         }

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModButton.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModButton.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Overlays.Mods
 
                 var incompatibleTypes = mod.IncompatibleMods;
 
-                var allMods = ruleset.Value.CreateInstance().GetAllMods();
+                var allMods = ruleset.Value.CreateInstance().GetAllModsForReference();
 
                 incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).ToList();
                 incompatibleText.Text = incompatibleMods.Value.Any() ? "Incompatible with:" : "Compatible with all mods";

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -27,6 +27,6 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Create a fresh <see cref="Mod"/> instance based on this mod.
         /// </summary>
-        Mod CreateInstance() => ((Mod)this).DeepClone();
+        Mod CreateInstance() => (Mod)Activator.CreateInstance(GetType());
     }
 }

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using Newtonsoft.Json;
+using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -11,7 +11,22 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// The shortened name of this mod.
         /// </summary>
-        [JsonProperty("acronym")]
         string Acronym { get; }
+
+        /// <summary>
+        /// The icon of this mod.
+        /// </summary>
+        IconUsage? Icon { get; }
+
+        /// <summary>
+        /// Whether this mod is playable by an end user.
+        /// Should be <c>false</c> for cases where the user is not interacting with the game (so it can be excluded from multiplayer selection, for example).
+        /// </summary>
+        bool UserPlayable { get; }
+
+        /// <summary>
+        /// Create a fresh <see cref="Mod"/> instance based on this mod.
+        /// </summary>
+        Mod CreateInstance() => ((Mod)this).DeepClone();
     }
 }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -33,9 +33,6 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         public abstract string Acronym { get; }
 
-        /// <summary>
-        /// The icon of this mod.
-        /// </summary>
         [JsonIgnore]
         public virtual IconUsage? Icon => null;
 
@@ -106,10 +103,6 @@ namespace osu.Game.Rulesets.Mods
         [JsonIgnore]
         public virtual bool HasImplementation => this is IApplicableMod;
 
-        /// <summary>
-        /// Whether this mod is playable by an end user.
-        /// Should be <c>false</c> for cases where the user is not interacting with the game (so it can be excluded from mutliplayer selection, for example).
-        /// </summary>
         [JsonIgnore]
         public virtual bool UserPlayable => true;
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -24,7 +24,6 @@ using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Users;
 using JetBrains.Annotations;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Testing;
@@ -82,6 +81,20 @@ namespace osu.Game.Rulesets
 
             if (type != null)
                 return (Mod)Activator.CreateInstance(type);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a fresh instance of the mod matching the specified type.
+        /// </summary>
+        public T GetMod<T>()
+            where T : Mod
+        {
+            var type = GetAllModsForReference().FirstOrDefault(m => m is T)?.GetType();
+
+            if (type != null)
+                return (T)Activator.CreateInstance(type);
 
             return null;
         }
@@ -166,7 +179,7 @@ namespace osu.Game.Rulesets
         }
 
         [CanBeNull]
-        public ModAutoplay GetAutoplayMod() => GetAllMods().OfType<ModAutoplay>().FirstOrDefault();
+        public ModAutoplay GetAutoplayMod() => GetMod<ModAutoplay>();
 
         public virtual ISkin CreateLegacySkinProvider([NotNull] ISkin skin, IBeatmap beatmap) => null;
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -80,12 +80,7 @@ namespace osu.Game.Rulesets
         /// <param name="acronym">The acronym to query for .</param>
         public Mod CreateModFromAcronym(string acronym)
         {
-            var type = AllMods.FirstOrDefault(m => m.Acronym == acronym)?.GetType();
-
-            if (type != null)
-                return (Mod)Activator.CreateInstance(type);
-
-            return null;
+            return AllMods.FirstOrDefault(m => m.Acronym == acronym)?.CreateInstance();
         }
 
         /// <summary>
@@ -94,12 +89,7 @@ namespace osu.Game.Rulesets
         public T CreateMod<T>()
             where T : Mod
         {
-            var type = AllMods.FirstOrDefault(m => m is T)?.GetType();
-
-            if (type != null)
-                return (T)Activator.CreateInstance(type);
-
-            return null;
+            return AllMods.FirstOrDefault(m => m is T)?.CreateInstance() as T;
         }
 
         public abstract IEnumerable<Mod> GetModsFor(ModType type);

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Scoring.Legacy
 
                 // lazer replays get a really high version number.
                 if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
-                    scoreInfo.Mods = scoreInfo.Mods.Append(currentRuleset.GetMod<ModClassic>()).ToArray();
+                    scoreInfo.Mods = scoreInfo.Mods.Append(currentRuleset.CreateMod<ModClassic>()).ToArray();
 
                 currentBeatmap = workingBeatmap.GetPlayableBeatmap(currentRuleset.RulesetInfo, scoreInfo.Mods);
                 scoreInfo.Beatmap = currentBeatmap.BeatmapInfo;

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Scoring.Legacy
 
                 // lazer replays get a really high version number.
                 if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
-                    scoreInfo.Mods = scoreInfo.Mods.Append(currentRuleset.GetAllMods().OfType<ModClassic>().Single()).ToArray();
+                    scoreInfo.Mods = scoreInfo.Mods.Append(currentRuleset.GetMod<ModClassic>()).ToArray();
 
                 currentBeatmap = workingBeatmap.GetPlayableBeatmap(currentRuleset.RulesetInfo, scoreInfo.Mods);
                 scoreInfo.Beatmap = currentBeatmap.BeatmapInfo;

--- a/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.Beatmaps
         protected void TestToLegacy(LegacyMods expectedLegacyMods, Type[] providedModTypes)
         {
             var ruleset = CreateRuleset();
-            var modInstances = ruleset.GetAllMods()
+            var modInstances = ruleset.CreateAllMods()
                                       .Where(mod => providedModTypes.Contains(mod.GetType()))
                                       .ToArray();
             var actualLegacyMods = ruleset.ConvertToLegacyMods(modInstances);

--- a/osu.Game/Tests/TestScoreInfo.cs
+++ b/osu.Game/Tests/TestScoreInfo.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tests
             RulesetID = ruleset.ID ?? 0;
 
             Mods = excessMods
-                ? ruleset.CreateInstance().GetAllMods().ToArray()
+                ? ruleset.CreateInstance().CreateAllMods().ToArray()
                 : new Mod[] { new TestModHardRock(), new TestModDoubleTime() };
 
             TotalScore = 2845370;

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual
 
             if (!AllowFail)
             {
-                var noFailMod = ruleset.GetMod<ModNoFail>();
+                var noFailMod = ruleset.CreateMod<ModNoFail>();
                 if (noFailMod != null)
                     SelectedMods.Value = new[] { noFailMod };
             }

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual
 
             if (!AllowFail)
             {
-                var noFailMod = ruleset.GetAllMods().FirstOrDefault(m => m is ModNoFail);
+                var noFailMod = ruleset.GetMod<ModNoFail>();
                 if (noFailMod != null)
                     SelectedMods.Value = new[] { noFailMod };
             }


### PR DESCRIPTION
- [x] Depends on #14695 

Maybe not the prettiest solution but I think it's beneficial to have *something* in place. Open to discussion on an alternative.

As of #14695:

|                         Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------- |----------:|----------:|----------:|-------:|----------:|
|       BenchmarkToModDoubleTime |  3.654 us | 0.0201 us | 0.0188 us | 0.3433 |      4 KB |
| BenchmarkToModDifficultyAdjust | 10.432 us | 0.0914 us | 0.0763 us | 0.7629 |      9 KB |
|            BenchmarkGetAllMods | 16.014 us | 0.0917 us | 0.0766 us | 1.3428 |     15 KB |
|         BenchmarkGetForAcronym |  3.649 us | 0.0271 us | 0.0254 us | 0.3357 |      4 KB |
|            BenchmarkGetForType |  3.583 us | 0.0201 us | 0.0168 us | 0.3357 |      4 KB |

(last two calls are done using `GetAllMods()` as per previous usages)

This PR:

|                          Method |        Mean |     Error |    StdDev |  Gen 0 | Allocated |
|-------------------------------- |------------:|----------:|----------:|-------:|----------:|
|        BenchmarkToModDoubleTime |    388.3 ns |   3.33 ns |   3.12 ns | 0.0296 |     344 B |
|  BenchmarkToModDifficultyAdjust |  5,021.0 ns |  56.14 ns |  49.77 ns | 0.3204 |   3,736 B |
|             BenchmarkGetAllMods | 15,611.5 ns | 177.84 ns | 157.65 ns | 1.3428 |  15,752 B |
| BenchmarkGetAllModsForReference |    283.5 ns |   2.31 ns |   1.93 ns | 0.0110 |     128 B |
|          BenchmarkGetForAcronym |    377.5 ns |   2.57 ns |   2.41 ns | 0.0296 |     344 B |
|             BenchmarkGetForType |    366.5 ns |   2.96 ns |   2.47 ns | 0.0219 |     256 B |
