### PR TITLE
Fix triangles intro attempting to restart track after it is disposed

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -15,6 +15,7 @@ using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Menu;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.Play;
@@ -386,6 +387,19 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("move cursor to background", () => InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.BottomRight));
             AddStep("click left mouse button", () => InputManager.Click(MouseButton.Left));
             AddAssert("now playing is hidden", () => nowPlayingOverlay.State.Value == Visibility.Hidden);
+        }
+
+        [Test]
+        public void TestExitGameFromSongSelect()
+        {
+            PushAndConfirm(() => new TestPlaySongSelect());
+            exitViaEscapeAndConfirm();
+
+            pushEscape(); // returns to osu! logo
+
+            AddStep("Hold escape", () => InputManager.PressKey(Key.Escape));
+            AddUntilStep("Wait for intro", () => Game.ScreenStack.CurrentScreen is IntroTriangles);
+            AddUntilStep("Wait for game exit", () => Game.ScreenStack.CurrentScreen == null);
         }
 
         private void pushEscape() =>

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Screens.Menu
         private Sample welcome;
 
         private DecoupleableInterpolatingFramedClock decoupledClock;
+        private TrianglesIntroSequence intro;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -66,7 +67,7 @@ namespace osu.Game.Screens.Menu
                 if (UsingThemedIntro)
                     decoupledClock.ChangeSource(Track);
 
-                LoadComponentAsync(new TrianglesIntroSequence(logo, background)
+                LoadComponentAsync(intro = new TrianglesIntroSequence(logo, background)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Clock = decoupledClock,
@@ -80,6 +81,14 @@ namespace osu.Game.Screens.Menu
                     StartTrack();
                 });
             }
+        }
+
+        public override void OnSuspending(IScreen next)
+        {
+            base.OnSuspending(next);
+
+            // important as there is a clock attached to a track which will likely be disposed before returning to this screen.
+            intro.Expire();
         }
 
         public override void OnResuming(IScreen last)


### PR DESCRIPTION
Fixed issue pointed out at https://github.com/ppy/osu/pull/14683#issuecomment-916625963.

Note that `TestSceneScreenNavigation` is a bit broken right now. You can run the test alone to ensure it's working as expected. I'll fix `OsuGameTestScene` in a separate PR.