### PR TITLE
Integrate `EditorLoader` into `EditorTestScene`

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -7,14 +7,11 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Tests.Beatmaps.IO;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
@@ -116,34 +113,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("stack empty", () => Stack.CurrentScreen == null);
         }
 
-        private void switchToDifficulty(Func<BeatmapInfo> difficulty)
-        {
-            AddUntilStep("wait for menubar to load", () => Editor.ChildrenOfType<EditorMenuBar>().Any());
-            AddStep("open file menu", () =>
-            {
-                var menuBar = Editor.ChildrenOfType<EditorMenuBar>().Single();
-                var fileMenu = menuBar.ChildrenOfType<DrawableOsuMenuItem>().First();
-                InputManager.MoveMouseTo(fileMenu);
-                InputManager.Click(MouseButton.Left);
-            });
-
-            AddStep("open difficulty menu", () =>
-            {
-                var difficultySelector =
-                    Editor.ChildrenOfType<DrawableOsuMenuItem>().Single(item => item.Item.Text.Value.ToString().Contains("Change difficulty"));
-                InputManager.MoveMouseTo(difficultySelector);
-            });
-            AddWaitStep("wait for open", 3);
-
-            AddStep("switch to target difficulty", () =>
-            {
-                var difficultyMenuItem =
-                    Editor.ChildrenOfType<DrawableOsuMenuItem>()
-                          .Last(item => item.Item is DifficultyMenuItem difficultyItem && difficultyItem.Beatmap.Equals(difficulty.Invoke()));
-                InputManager.MoveMouseTo(difficultyMenuItem);
-                InputManager.Click(MouseButton.Left);
-            });
-        }
+        private void switchToDifficulty(Func<BeatmapInfo> difficulty) => AddStep("switch to difficulty", () => Editor.SwitchToDifficulty(difficulty.Invoke()));
 
         private void confirmEditingBeatmap(Func<BeatmapInfo> targetDifficulty)
         {

--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -9,26 +9,20 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Menus;
-using osu.Game.Screens.Menu;
 using osu.Game.Tests.Beatmaps.IO;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
-    public class TestSceneDifficultySwitching : ScreenTestScene
+    public class TestSceneDifficultySwitching : EditorTestScene
     {
-        private BeatmapSetInfo importedBeatmapSet;
-        private Editor editor;
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
 
-        // required for screen transitions to work properly
-        // (see comment in EditorLoader.LogoArriving).
-        [Cached]
-        private OsuLogo logo = new OsuLogo
-        {
-            Alpha = 0
-        };
+        protected override bool IsolateSavingFromDatabase => false;
 
         [Resolved]
         private OsuGameBase game { get; set; }
@@ -36,20 +30,18 @@ namespace osu.Game.Tests.Visual.Editing
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 
-        [BackgroundDependencyLoader]
-        private void load() => Add(logo);
+        private BeatmapSetInfo importedBeatmapSet;
 
-        [SetUpSteps]
-        public void SetUp()
+        public override void SetUpSteps()
         {
             AddStep("import test beatmap", () => importedBeatmapSet = ImportBeatmapTest.LoadOszIntoOsu(game, virtualTrack: true).Result);
+            base.SetUpSteps();
+        }
 
-            AddStep("set current beatmap", () => Beatmap.Value = beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First()));
-            AddStep("push loader", () => Stack.Push(new EditorLoader()));
-
-            AddUntilStep("wait for editor push", () => Stack.CurrentScreen is Editor);
-            AddStep("store editor", () => editor = (Editor)Stack.CurrentScreen);
-            AddUntilStep("wait for editor to load", () => editor.IsLoaded);
+        protected override void LoadEditor()
+        {
+            Beatmap.Value = beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First());
+            base.LoadEditor();
         }
 
         [Test]
@@ -72,11 +64,7 @@ namespace osu.Game.Tests.Visual.Editing
             BeatmapInfo targetDifficulty = null;
             PromptForSaveDialog saveDialog = null;
 
-            AddStep("remove first hitobject", () =>
-            {
-                var editorBeatmap = editor.ChildrenOfType<EditorBeatmap>().Single();
-                editorBeatmap.RemoveAt(0);
-            });
+            AddStep("remove first hitobject", () => EditorBeatmap.RemoveAt(0));
 
             AddStep("set target difficulty", () => targetDifficulty = importedBeatmapSet.Beatmaps.Last(beatmap => !beatmap.Equals(Beatmap.Value.BeatmapInfo)));
             switchToDifficulty(() => targetDifficulty);
@@ -105,11 +93,7 @@ namespace osu.Game.Tests.Visual.Editing
             BeatmapInfo targetDifficulty = null;
             PromptForSaveDialog saveDialog = null;
 
-            AddStep("remove first hitobject", () =>
-            {
-                var editorBeatmap = editor.ChildrenOfType<EditorBeatmap>().Single();
-                editorBeatmap.RemoveAt(0);
-            });
+            AddStep("remove first hitobject", () => EditorBeatmap.RemoveAt(0));
 
             AddStep("set target difficulty", () => targetDifficulty = importedBeatmapSet.Beatmaps.Last(beatmap => !beatmap.Equals(Beatmap.Value.BeatmapInfo)));
             switchToDifficulty(() => targetDifficulty);
@@ -134,10 +118,10 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void switchToDifficulty(Func<BeatmapInfo> difficulty)
         {
-            AddUntilStep("wait for menubar to load", () => editor.ChildrenOfType<EditorMenuBar>().Any());
+            AddUntilStep("wait for menubar to load", () => Editor.ChildrenOfType<EditorMenuBar>().Any());
             AddStep("open file menu", () =>
             {
-                var menuBar = editor.ChildrenOfType<EditorMenuBar>().Single();
+                var menuBar = Editor.ChildrenOfType<EditorMenuBar>().Single();
                 var fileMenu = menuBar.ChildrenOfType<DrawableOsuMenuItem>().First();
                 InputManager.MoveMouseTo(fileMenu);
                 InputManager.Click(MouseButton.Left);
@@ -146,7 +130,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("open difficulty menu", () =>
             {
                 var difficultySelector =
-                    editor.ChildrenOfType<DrawableOsuMenuItem>().Single(item => item.Item.Text.Value.ToString().Contains("Change difficulty"));
+                    Editor.ChildrenOfType<DrawableOsuMenuItem>().Single(item => item.Item.Text.Value.ToString().Contains("Change difficulty"));
                 InputManager.MoveMouseTo(difficultySelector);
             });
             AddWaitStep("wait for open", 3);
@@ -154,7 +138,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("switch to target difficulty", () =>
             {
                 var difficultyMenuItem =
-                    editor.ChildrenOfType<DrawableOsuMenuItem>()
+                    Editor.ChildrenOfType<DrawableOsuMenuItem>()
                           .Last(item => item.Item is DifficultyMenuItem difficultyItem && difficultyItem.Beatmap.Equals(difficulty.Invoke()));
                 InputManager.MoveMouseTo(difficultyMenuItem);
                 InputManager.Click(MouseButton.Left);

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -11,6 +11,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Tests.Resources;
 using SharpCompress.Archives;
@@ -55,6 +56,9 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestExitWithoutSave()
         {
+            EditorBeatmap editorBeatmap = null;
+
+            AddStep("store editor beatmap", () => editorBeatmap = EditorBeatmap);
             AddStep("exit without save", () =>
             {
                 Editor.Exit();
@@ -62,7 +66,7 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddUntilStep("wait for exit", () => !Editor.IsCurrentScreen());
-            AddAssert("new beatmap not persisted", () => beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID)?.DeletePending == true);
+            AddAssert("new beatmap not persisted", () => beatmapManager.QueryBeatmapSet(s => s.ID == editorBeatmap.BeatmapInfo.BeatmapSet.ID)?.DeletePending == true);
         }
 
         [Test]

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -737,10 +737,10 @@ namespace osu.Game.Screens.Edit
         private DifficultyMenuItem createDifficultyMenuItem(BeatmapInfo beatmapInfo)
         {
             bool isCurrentDifficulty = playableBeatmap.BeatmapInfo.Equals(beatmapInfo);
-            return new DifficultyMenuItem(beatmapInfo, isCurrentDifficulty, switchToDifficulty);
+            return new DifficultyMenuItem(beatmapInfo, isCurrentDifficulty, SwitchToDifficulty);
         }
 
-        private void switchToDifficulty(BeatmapInfo beatmapInfo) => loader?.ScheduleDifficultySwitch(beatmapInfo);
+        protected void SwitchToDifficulty(BeatmapInfo beatmapInfo) => loader?.ScheduleDifficultySwitch(beatmapInfo);
 
         private void cancelExit() => loader?.CancelPendingDifficultySwitch();
 

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -34,6 +34,20 @@ namespace osu.Game.Screens.Edit
         [CanBeNull]
         private ScheduledDelegate scheduledDifficultySwitch;
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddRangeInternal(new Drawable[]
+            {
+                new LoadingSpinner(true)
+                {
+                    State = { Value = Visibility.Visible },
+                }
+            });
+        }
+
+        protected virtual Editor CreateEditor() => new Editor(this);
+
         protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
             base.LogoArriving(logo, resuming);
@@ -45,18 +59,6 @@ namespace osu.Game.Screens.Edit
                 // before enqueueing this screen's LogoArriving onto the logo animation sequence.
                 pushEditor();
             }
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            AddRangeInternal(new Drawable[]
-            {
-                new LoadingSpinner(true)
-                {
-                    State = { Value = Visibility.Visible },
-                }
-            });
         }
 
         public void ScheduleDifficultySwitch(BeatmapInfo beatmapInfo)
@@ -81,7 +83,7 @@ namespace osu.Game.Screens.Edit
 
         private void pushEditor()
         {
-            this.Push(new Editor(this));
+            this.Push(CreateEditor());
             ValidForResume = false;
         }
 

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -103,6 +103,8 @@ namespace osu.Game.Tests.Visual
 
             public new void Paste() => base.Paste();
 
+            public new void SwitchToDifficulty(BeatmapInfo beatmapInfo) => base.SwitchToDifficulty(beatmapInfo);
+
             public new bool HasUnsavedChanges => base.HasUnsavedChanges;
 
             public TestEditor(EditorLoader loader = null)

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -23,13 +23,12 @@ namespace osu.Game.Tests.Visual
 {
     public abstract class EditorTestScene : ScreenTestScene
     {
-        protected EditorBeatmap EditorBeatmap;
-
         private TestEditorLoader editorLoader;
 
         protected TestEditor Editor => editorLoader.Editor;
 
-        protected EditorClock EditorClock { get; private set; }
+        protected EditorBeatmap EditorBeatmap => Editor.ChildrenOfType<EditorBeatmap>().Single();
+        protected EditorClock EditorClock => Editor.ChildrenOfType<EditorClock>().Single();
 
         /// <summary>
         /// Whether any saves performed by the editor should be isolate (and not persist) to the underlying <see cref="BeatmapManager"/>.
@@ -66,8 +65,6 @@ namespace osu.Game.Tests.Visual
 
             AddStep("load editor", LoadEditor);
             AddUntilStep("wait for editor to load", () => EditorComponentsReady);
-            AddStep("get beatmap", () => EditorBeatmap = Editor.ChildrenOfType<EditorBeatmap>().Single());
-            AddStep("get clock", () => EditorClock = Editor.ChildrenOfType<EditorClock>().Single());
         }
 
         protected virtual void LoadEditor()


### PR DESCRIPTION
In the recent PR adding support for switching between difficulties in the editor, I wrote a test scene that was sort of re-inventing parts of `EditorTestScene`. As I went forward with more changes in that direction (like transferring editor state such as current clock time or clipboard contents, and creating new difficulties, both of which I have locally queued), I found that I was re-engineering more and more of `EditorTestScene`. Therefore this PR's intention is to unify the two and have all `EditorTestScene`s go through `EditorLoader`.

Aside from a reduction in code size of the test scene in question, any possible future editor test scene can now cheaply use the difficulty switching capabilities. The associated cost is that now the properties exposed by `EditorTestScene` (`Editor`, `EditorClock` and `EditorBeatmap` can change during the test's runtime and are not guaranteed to be constant (the last commit here fixes one case that depended on it).

I'm PRing this first without starting the dependency chain as I'm not entirely certain of this direction, but I don't think it's too bad. But obviously opinions welcome.
