### PR TITLE
Add "samples match playback rate" setting to setup screen

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.IsFalse(beatmapInfo.LetterboxInBreaks);
                 Assert.IsFalse(beatmapInfo.SpecialStyle);
                 Assert.IsFalse(beatmapInfo.WidescreenStoryboard);
+                Assert.IsFalse(beatmapInfo.SamplesMatchPlaybackRate);
                 Assert.AreEqual(CountdownType.None, beatmapInfo.Countdown);
                 Assert.AreEqual(0, beatmapInfo.CountdownOffset);
             }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -95,6 +95,7 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// Whether or not sound samples should change rate when playing with speed-changing mods.
+        /// TODO: only read/write supported for now, requires implementation in gameplay.
         /// </summary>
         public bool SamplesMatchPlaybackRate { get; set; }
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -93,6 +93,11 @@ namespace osu.Game.Beatmaps
         public bool WidescreenStoryboard { get; set; }
         public bool EpilepsyWarning { get; set; }
 
+        /// <summary>
+        /// Whether or not sound samples should change rate when playing with speed-changing mods.
+        /// </summary>
+        public bool SamplesMatchPlaybackRate { get; set; }
+
         public CountdownType Countdown { get; set; } = CountdownType.Normal;
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Beatmaps
                         Ruleset = ruleset,
                         Metadata = metadata,
                         WidescreenStoryboard = true,
+                        SamplesMatchPlaybackRate = true,
                     }
                 }
             };

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -180,6 +180,10 @@ namespace osu.Game.Beatmaps.Formats
                     beatmap.BeatmapInfo.EpilepsyWarning = Parsing.ParseInt(pair.Value) == 1;
                     break;
 
+                case @"SamplesMatchPlaybackRate":
+                    beatmap.BeatmapInfo.SamplesMatchPlaybackRate = Parsing.ParseInt(pair.Value) == 1;
+                    break;
+
                 case @"Countdown":
                     beatmap.BeatmapInfo.Countdown = (CountdownType)Enum.Parse(typeof(CountdownType), pair.Value);
                     break;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -105,8 +105,8 @@ namespace osu.Game.Beatmaps.Formats
             if (beatmap.BeatmapInfo.RulesetID == 3)
                 writer.WriteLine(FormattableString.Invariant($"SpecialStyle: {(beatmap.BeatmapInfo.SpecialStyle ? '1' : '0')}"));
             writer.WriteLine(FormattableString.Invariant($"WidescreenStoryboard: {(beatmap.BeatmapInfo.WidescreenStoryboard ? '1' : '0')}"));
-            // if (b.SamplesMatchPlaybackRate)
-            //     writer.WriteLine(@"SamplesMatchPlaybackRate: 1");
+            if (beatmap.BeatmapInfo.SamplesMatchPlaybackRate)
+                writer.WriteLine(@"SamplesMatchPlaybackRate: 1");
         }
 
         private void handleEditor(TextWriter writer)

--- a/osu.Game/Migrations/20210912144011_AddSamplesMatchPlaybackRate.Designer.cs
+++ b/osu.Game/Migrations/20210912144011_AddSamplesMatchPlaybackRate.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using osu.Game.Database;
 
 namespace osu.Game.Migrations
 {
     [DbContext(typeof(OsuDbContext))]
-    partial class OsuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210912144011_AddSamplesMatchPlaybackRate")]
+    partial class AddSamplesMatchPlaybackRate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/osu.Game/Migrations/20210912144011_AddSamplesMatchPlaybackRate.cs
+++ b/osu.Game/Migrations/20210912144011_AddSamplesMatchPlaybackRate.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace osu.Game.Migrations
+{
+    public partial class AddSamplesMatchPlaybackRate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SamplesMatchPlaybackRate",
+                table: "BeatmapInfo",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SamplesMatchPlaybackRate",
+                table: "BeatmapInfo");
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Screens.Edit.Setup
         private LabelledSwitchButton widescreenSupport;
         private LabelledSwitchButton epilepsyWarning;
         private LabelledSwitchButton letterboxDuringBreaks;
+        private LabelledSwitchButton samplesMatchPlaybackRate;
 
         public override LocalisableString Title => "Design";
 
@@ -79,6 +80,12 @@ namespace osu.Game.Screens.Edit.Setup
                     Label = "Letterbox during breaks",
                     Description = "Adds horizontal letterboxing to give a cinematic look during breaks.",
                     Current = { Value = Beatmap.BeatmapInfo.LetterboxInBreaks }
+                },
+                samplesMatchPlaybackRate = new LabelledSwitchButton
+                {
+                    Label = "Samples match playback rate",
+                    Description = "When enabled, all samples will speed up or slow down when rate-changing mods are enabled.",
+                    Current = { Value = Beatmap.BeatmapInfo.SamplesMatchPlaybackRate }
                 }
             };
         }
@@ -96,6 +103,7 @@ namespace osu.Game.Screens.Edit.Setup
             widescreenSupport.Current.BindValueChanged(_ => updateBeatmap());
             epilepsyWarning.Current.BindValueChanged(_ => updateBeatmap());
             letterboxDuringBreaks.Current.BindValueChanged(_ => updateBeatmap());
+            samplesMatchPlaybackRate.Current.BindValueChanged(_ => updateBeatmap());
         }
 
         private void updateCountdownSettingsVisibility() => CountdownSettings.FadeTo(EnableCountdown.Current.Value ? 1 : 0);
@@ -115,6 +123,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.BeatmapInfo.WidescreenStoryboard = widescreenSupport.Current.Value;
             Beatmap.BeatmapInfo.EpilepsyWarning = epilepsyWarning.Current.Value;
             Beatmap.BeatmapInfo.LetterboxInBreaks = letterboxDuringBreaks.Current.Value;
+            Beatmap.BeatmapInfo.SamplesMatchPlaybackRate = samplesMatchPlaybackRate.Current.Value;
         }
     }
 }


### PR DESCRIPTION
As per https://github.com/ppy/osu/issues/2434#issuecomment-916535352. Could also close that issue post-merge if it is deemed that the outstanding QoL issues (undo support, UX parity in things like the difficulty setting scrollbars, etc.) are not to be tracked in scope of that issue.

![osu_2021-09-12_17-01-12](https://user-images.githubusercontent.com/20418176/132992926-a377773e-a27b-4ce7-af54-07584c4b28ee.jpg)

As is the case with a few other settings (special style, countdown...) this has no visible effect in lazer yet, but does decode and encode from the legacy format.

I've made this a default for newly-created-in-lazer beatmaps as per an on-stream chat suggestion from @peppy.
