### PR TITLE
Fix mania notes not updating colour coding correctly

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -66,6 +66,12 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             StartTimeBindable.BindValueChanged(_ => updateSnapColour(), true);
         }
 
+        protected override void OnApply()
+        {
+            base.OnApply();
+            updateSnapColour();
+        }
+
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
         {
             base.OnDirectionChanged(e);


### PR DESCRIPTION
Closes #14647.

Regressed with adding pooling to mania. Aside from the colour coding not switching on/off if the DHO was not alive when it was, I'm pretty sure the snap colour would only ever get applied once and be stuck there.

Most of the diff is the test case and moving the test pieces around so that multiple test cases can be in it. The actual fix is obvious.
