### PR TITLE
Fix dimmed checked nub artifact

### DIFF
--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Graphics.UserInterface
             };
 
             Current.ValueChanged += filled => fill.FadeTo(filled.NewValue ? 1 : 0, 200, Easing.OutQuint);
+            Current.ValueChanged += filled => this.TransformTo(nameof(BorderThickness), filled.NewValue ? 7 : border_width, 200, Easing.OutQuint);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Graphics.UserInterface
             Current.ValueChanged += filled =>
             {
                 fill.FadeTo(filled.NewValue ? 1 : 0, 200, Easing.OutQuint);
-                this.TransformTo(nameof(BorderThickness), filled.NewValue ? 7 : border_width, 200, Easing.OutQuint);
+                this.TransformTo(nameof(BorderThickness), filled.NewValue ? 8.5f : border_width, 200, Easing.OutQuint);
             };
         }
 

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -46,8 +46,11 @@ namespace osu.Game.Graphics.UserInterface
                 },
             };
 
-            Current.ValueChanged += filled => fill.FadeTo(filled.NewValue ? 1 : 0, 200, Easing.OutQuint);
-            Current.ValueChanged += filled => this.TransformTo(nameof(BorderThickness), filled.NewValue ? 7 : border_width, 200, Easing.OutQuint);
+            Current.ValueChanged += filled =>
+            {
+                fill.FadeTo(filled.NewValue ? 1 : 0, 200, Easing.OutQuint);
+                this.TransformTo(nameof(BorderThickness), filled.NewValue ? 7 : border_width, 200, Easing.OutQuint);
+            };
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
This adds transition that extends nub's border to fill it. Fill fade can be removed, but combined effect looks nicer imo, and the fill is still needed because if removed, the border becomes invisible too for some reason.

**`master`**

https://user-images.githubusercontent.com/38468635/133069020-dc2defda-8494-4d77-abd8-65cc8fa2535d.mp4

**PR**

https://user-images.githubusercontent.com/38468635/133069068-caa02145-0c38-47d1-bd1f-5b2206fcb115.mp4

This fixes #14412.