### PR TITLE
Fix icon orientation for horizontal bar hit error meter

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -128,7 +128,6 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             };
 
             createColourBars(colours);
-            OrientIcons();
         }
 
         protected override void LoadComplete()
@@ -142,11 +141,11 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             arrow.Delay(200).FadeInFromZero(600);
         }
 
-        /// <summary>
-        /// Method to undo any layout rotation to display icons in the correct orientation.
-        /// </summary>
-        public void OrientIcons()
+        protected override void Update()
         {
+            base.Update();
+
+            // undo any layout rotation to display icons in the correct orientation
             iconEarly.Rotation = -Rotation;
             iconLate.Rotation = -Rotation;
         }

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         private const float chevron_size = 8;
 
         private SpriteIcon arrow;
+        private SpriteIcon iconEarly;
+        private SpriteIcon iconLate;
 
         private Container colourBarsEarly;
         private Container colourBarsLate;
@@ -97,25 +99,21 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                                 RelativeSizeAxes = Axes.Both,
                                 Height = 0.5f,
                             },
-                            new SpriteIcon
+                            iconEarly = new SpriteIcon
                             {
                                 Y = -10,
                                 Size = new Vector2(10),
                                 Icon = FontAwesome.Solid.ShippingFast,
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.Centre,
-                                // undo any layout rotation to display the icon the correct orientation
-                                Rotation = -Rotation,
                             },
-                            new SpriteIcon
+                            iconLate = new SpriteIcon
                             {
                                 Y = 10,
                                 Size = new Vector2(10),
                                 Icon = FontAwesome.Solid.Bicycle,
                                 Anchor = Anchor.BottomCentre,
                                 Origin = Anchor.Centre,
-                                // undo any layout rotation to display the icon the correct orientation
-                                Rotation = -Rotation,
                             }
                         }
                     },
@@ -130,6 +128,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             };
 
             createColourBars(colours);
+            OrientIcons();
         }
 
         protected override void LoadComplete()
@@ -141,6 +140,15 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
             arrow.Alpha = 0;
             arrow.Delay(200).FadeInFromZero(600);
+        }
+
+        /// <summary>
+        /// Method to undo any layout rotation to display icons in the correct orientation.
+        /// </summary>
+        public void OrientIcons()
+        {
+            iconEarly.Rotation = -Rotation;
+            iconLate.Rotation = -Rotation;
         }
 
         private void createColourBars(OsuColour colours)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -376,7 +376,6 @@ namespace osu.Game.Skinning
                                     hitError.Anchor = Anchor.BottomCentre;
                                     hitError.Origin = Anchor.CentreLeft;
                                     hitError.Rotation = -90;
-                                    if (hitError is BarHitErrorMeter barHitError) barHitError.OrientIcons();
                                 }
 
                                 if (songProgress != null)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -376,6 +376,7 @@ namespace osu.Game.Skinning
                                     hitError.Anchor = Anchor.BottomCentre;
                                     hitError.Origin = Anchor.CentreLeft;
                                     hitError.Rotation = -90;
+                                    if (hitError is BarHitErrorMeter barHitError) barHitError.OrientIcons();
                                 }
 
                                 if (songProgress != null)


### PR DESCRIPTION
Since the rotation is applied after the meter is already loaded, logic that unspun icons in `load()` couldn't catch that.

**`master`**
![image](https://user-images.githubusercontent.com/38468635/133104094-eca5c0cd-1549-450f-8ba2-7b725a9cb3b3.png)
**PR**
![image](https://user-images.githubusercontent.com/38468635/133104165-60979c29-a50b-4b11-b500-3d2b8cf53d6a.png)
