### PR TITLE
Preserve current time and clipboard contents when switching between difficulties

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -56,6 +56,22 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestClockPositionPreservedBetweenSwitches()
+        {
+            BeatmapInfo targetDifficulty = null;
+            AddStep("seek editor to 00:05:00", () => EditorClock.Seek(5000));
+
+            AddStep("set target difficulty", () => targetDifficulty = importedBeatmapSet.Beatmaps.Last(beatmap => !beatmap.Equals(Beatmap.Value.BeatmapInfo)));
+            switchToDifficulty(() => targetDifficulty);
+            confirmEditingBeatmap(() => targetDifficulty);
+            AddAssert("editor clock at 00:05:00", () => EditorClock.CurrentTime == 5000);
+
+            AddStep("exit editor", () => Stack.Exit());
+            // ensure editor loader didn't resume.
+            AddAssert("stack empty", () => Stack.CurrentScreen == null);
+        }
+
+        [Test]
         public void TestPreventSwitchDueToUnsavedChanges()
         {
             BeatmapInfo targetDifficulty = null;
@@ -118,7 +134,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void confirmEditingBeatmap(Func<BeatmapInfo> targetDifficulty)
         {
             AddUntilStep("current beatmap is correct", () => Beatmap.Value.BeatmapInfo.Equals(targetDifficulty.Invoke()));
-            AddUntilStep("current screen is editor", () => Stack.CurrentScreen is Editor);
+            AddUntilStep("current screen is editor", () => Stack.CurrentScreen == Editor && Editor?.IsLoaded == true);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -98,8 +98,11 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("exit editor", () => Stack.Exit());
 
-            AddUntilStep("prompt for save dialog shown", () => DialogOverlay.CurrentDialog is PromptForSaveDialog);
-            AddStep("discard changes", () => ((PromptForSaveDialog)DialogOverlay.CurrentDialog).PerformOkAction());
+            if (sameRuleset)
+            {
+                AddUntilStep("prompt for save dialog shown", () => DialogOverlay.CurrentDialog is PromptForSaveDialog);
+                AddStep("discard changes", () => ((PromptForSaveDialog)DialogOverlay.CurrentDialog).PerformOkAction());
+            }
 
             // ensure editor loader didn't resume.
             AddAssert("stack empty", () => Stack.CurrentScreen == null);

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Compose
         public bool OnPressed(PlatformAction action)
         {
             if (action == PlatformAction.Copy)
-                host.GetClipboard().SetText(formatSelectionAsString());
+                host.GetClipboard()?.SetText(formatSelectionAsString());
 
             return false;
         }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -317,6 +317,16 @@ namespace osu.Game.Screens.Edit
         /// </summary>
         public void UpdateClockSource() => clock.ChangeSource(Beatmap.Value.Track);
 
+        /// <summary>
+        /// Restore the editor to a provided state.
+        /// </summary>
+        /// <param name="state">The state to restore.</param>
+        public void RestoreState([NotNull] EditorState state) => Schedule(() =>
+        {
+            clock.Seek(state.Time);
+            clipboard.Value = state.ClipboardContent;
+        });
+
         protected void Save()
         {
             // no longer new after first user-triggered save.
@@ -476,8 +486,6 @@ namespace osu.Game.Screens.Edit
             });
 
             resetTrack(true);
-            if (loader?.State != null)
-                restoreState(loader.State);
         }
 
         public override bool OnExiting(IScreen next)
@@ -745,16 +753,8 @@ namespace osu.Game.Screens.Edit
         protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, new EditorState
         {
             Time = clock.CurrentTimeAccurate,
-            ClipboardContent = editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? clipboard.Value : null
+            ClipboardContent = editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? clipboard.Value : string.Empty
         });
-
-        private void restoreState([NotNull] EditorState state)
-        {
-            if (state.Time != null)
-                clock.Seek(state.Time.Value);
-
-            clipboard.Value = state.ClipboardContent ?? clipboard.Value;
-        }
 
         private void cancelExit() => loader?.CancelPendingDifficultySwitch();
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -744,13 +744,16 @@ namespace osu.Game.Screens.Edit
 
         protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, new EditorState
         {
-            Time = clock.CurrentTimeAccurate
+            Time = clock.CurrentTimeAccurate,
+            ClipboardContent = editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? clipboard.Value : null
         });
 
         private void restoreState([NotNull] EditorState state)
         {
             if (state.Time != null)
                 clock.Seek(state.Time.Value);
+
+            clipboard.Value = state.ClipboardContent ?? clipboard.Value;
         }
 
         private void cancelExit() => loader?.CancelPendingDifficultySwitch();

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -476,6 +476,8 @@ namespace osu.Game.Screens.Edit
             });
 
             resetTrack(true);
+            if (loader?.State != null)
+                restoreState(loader.State);
         }
 
         public override bool OnExiting(IScreen next)
@@ -740,7 +742,16 @@ namespace osu.Game.Screens.Edit
             return new DifficultyMenuItem(beatmapInfo, isCurrentDifficulty, SwitchToDifficulty);
         }
 
-        protected void SwitchToDifficulty(BeatmapInfo beatmapInfo) => loader?.ScheduleDifficultySwitch(beatmapInfo);
+        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, new EditorState
+        {
+            Time = clock.CurrentTimeAccurate
+        });
+
+        private void restoreState([NotNull] EditorState state)
+        {
+            if (state.Time != null)
+                clock.Seek(state.Time.Value);
+        }
 
         private void cancelExit() => loader?.CancelPendingDifficultySwitch();
 

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -91,7 +91,13 @@ namespace osu.Game.Screens.Edit
 
         private void pushEditor()
         {
-            this.Push(CreateEditor());
+            var editor = CreateEditor();
+
+            this.Push(editor);
+
+            if (state != null)
+                editor.RestoreState(state);
+
             ValidForResume = false;
         }
 

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -20,6 +20,13 @@ namespace osu.Game.Screens.Edit
     /// </summary>
     public class EditorLoader : ScreenWithBeatmapBackground
     {
+        /// <summary>
+        /// The stored state from the last editor opened.
+        /// This will be read by the next editor instance to be opened to restore any relevant previous state.
+        /// </summary>
+        [CanBeNull]
+        public EditorState State;
+
         public override float BackgroundParallaxAmount => 0.1f;
 
         public override bool AllowBackButton => false;
@@ -61,7 +68,7 @@ namespace osu.Game.Screens.Edit
             }
         }
 
-        public void ScheduleDifficultySwitch(BeatmapInfo beatmapInfo)
+        public void ScheduleDifficultySwitch(BeatmapInfo nextBeatmap, EditorState editorState)
         {
             scheduledDifficultySwitch?.Cancel();
             ValidForResume = true;
@@ -70,7 +77,8 @@ namespace osu.Game.Screens.Edit
 
             scheduledDifficultySwitch = Schedule(() =>
             {
-                Beatmap.Value = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+                Beatmap.Value = beatmapManager.GetWorkingBeatmap(nextBeatmap);
+                State = editorState;
 
                 // This screen is a weird exception to the rule that nothing after song select changes the global beatmap.
                 // Because of this, we need to update the background stack's beatmap to match.

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Edit
         /// This will be read by the next editor instance to be opened to restore any relevant previous state.
         /// </summary>
         [CanBeNull]
-        public EditorState State;
+        private EditorState state;
 
         public override float BackgroundParallaxAmount => 0.1f;
 
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.Edit
             scheduledDifficultySwitch = Schedule(() =>
             {
                 Beatmap.Value = beatmapManager.GetWorkingBeatmap(nextBeatmap);
-                State = editorState;
+                state = editorState;
 
                 // This screen is a weird exception to the rule that nothing after song select changes the global beatmap.
                 // Because of this, we need to update the background stack's beatmap to match.

--- a/osu.Game/Screens/Edit/EditorState.cs
+++ b/osu.Game/Screens/Edit/EditorState.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// Structure used to transport data between <see cref="Editor"/> instances on difficulty change.
+    /// It's intended to be received by <see cref="EditorLoader"/> from one editor instance and passed down to the next one.
+    /// </summary>
+    public class EditorState
+    {
+        /// <summary>
+        /// The current clock time when a difficulty switch was requested.
+        /// </summary>
+        public double? Time { get; set; }
+    }
+}

--- a/osu.Game/Screens/Edit/EditorState.cs
+++ b/osu.Game/Screens/Edit/EditorState.cs
@@ -15,5 +15,10 @@ namespace osu.Game.Screens.Edit
         /// The current clock time when a difficulty switch was requested.
         /// </summary>
         public double? Time { get; set; }
+
+        /// <summary>
+        /// The current editor clipboard content at the time when a difficulty switch was requested.
+        /// </summary>
+        public string? ClipboardContent { get; set; }
     }
 }

--- a/osu.Game/Screens/Edit/EditorState.cs
+++ b/osu.Game/Screens/Edit/EditorState.cs
@@ -6,19 +6,18 @@
 namespace osu.Game.Screens.Edit
 {
     /// <summary>
-    /// Structure used to transport data between <see cref="Editor"/> instances on difficulty change.
-    /// It's intended to be received by <see cref="EditorLoader"/> from one editor instance and passed down to the next one.
+    /// Structure used to convey the general state of an <see cref="Editor"/> instance.
     /// </summary>
     public class EditorState
     {
         /// <summary>
-        /// The current clock time when a difficulty switch was requested.
+        /// The current audio time.
         /// </summary>
-        public double? Time { get; set; }
+        public double Time { get; set; }
 
         /// <summary>
-        /// The current editor clipboard content at the time when a difficulty switch was requested.
+        /// The editor clipboard content.
         /// </summary>
-        public string? ClipboardContent { get; set; }
+        public string ClipboardContent { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
As suggested in https://github.com/ppy/osu/pull/14640#issuecomment-914078373.

https://user-images.githubusercontent.com/20418176/133144192-a07a99d3-70cc-480b-9b4b-4f1b4a677820.mp4

Obviously these two pieces of state listed in the title aren't the only ones that should ever get transferred, they were just the easiest/most obvious to move over. The main point is adding the mechanism that facilitates this (which is achieved by passing `EditorState`). Clipboard does not work cross-ruleset for simplicity/prevention of crashes.

79d0f48 also includes a nullcheck to an existing unprotected `GetClipboard()` usage (which is the only game-side usage), as a follow-up to my framework change at https://github.com/ppy/osu-framework/pull/4769. Removing it won't actually fail/crash the test now that I'm using `EditorTestScene` and its `Copy()`/`Paste()` methods directly, but I figured I might as well keep that change here to get it out of the way before the framework bump.