### PR TITLE
Fix match footer test scene not working in test browser

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 
@@ -15,11 +16,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             SelectedRoom.Value = new Room();
 
-            Child = new MultiplayerMatchFooter
+            Child = new Container
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Height = 50
+                RelativeSizeAxes = Axes.X,
+                Height = 50,
+                Child = new MultiplayerMatchFooter()
             };
         });
     }


### PR DESCRIPTION
It's now internally `RelativeSizeAxes = Axes.Both` so height can't be specified.