### PR TITLE
Limit maximum triangles to avoid GL buffer overflow

### DIFF
--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Allocation;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Batches;
+using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Lists;
 
@@ -181,7 +182,10 @@ namespace osu.Game.Graphics.Backgrounds
 
         private void addTriangles(bool randomY)
         {
-            AimCount = (int)(DrawWidth * DrawHeight * 0.002f / (triangleScale * triangleScale) * SpawnRatio);
+            // limited by the maximum size of QuadVertexBuffer for safety.
+            const int max_triangles = QuadVertexBuffer<TexturedVertex2D>.MAX_QUADS;
+
+            AimCount = (int)Math.Min(max_triangles, (DrawWidth * DrawHeight * 0.002f / (triangleScale * triangleScale) * SpawnRatio));
 
             for (int i = 0; i < AimCount - parts.Count; i++)
                 parts.Add(createTriangle(randomY));


### PR DESCRIPTION
I've hope we never hit this, but better than crashing the game.

- [x] Depends on https://github.com/ppy/osu-framework/pull/4775 (for exposed `const`).

![20210915 183410 (dotnet)](https://user-images.githubusercontent.com/191335/133409210-4205ce8d-0407-4968-90a7-ad2786ba7004.gif)