### PR TITLE
Fix wiki main page blurb overflowing at higher ui scale

### DIFF
--- a/osu.Game/Overlays/Wiki/WikiMainPage.cs
+++ b/osu.Game/Overlays/Wiki/WikiMainPage.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Containers;
 using HtmlAgilityPack;
 using osu.Framework.Allocation;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Wiki
 {
@@ -56,12 +56,12 @@ namespace osu.Game.Overlays.Wiki
                 {
                     Vertical = 30,
                 },
-                Child = new OsuSpriteText
+                Child = new OsuTextFlowContainer(t => t.Font = OsuFont.GetFont(Typeface.Inter, size: 12, weight: FontWeight.Light))
                 {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Text = blurbNode.InnerText,
-                    Font = OsuFont.GetFont(Typeface.Inter, size: 12, weight: FontWeight.Light),
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
+                    TextAnchor = Anchor.TopCentre,
                 }
             };
         }


### PR DESCRIPTION
Before:
![osu_2021-09-16_17-49-45](https://user-images.githubusercontent.com/35318437/133706663-6df99327-f473-40d1-b2af-c28e55623fa5.png)

After:
![osu_2021-09-16_17-50-38](https://user-images.githubusercontent.com/35318437/133706677-22cb4233-dc12-41b1-94a9-7962f9963b2e.png)
