### PR TITLE
Move `AllowTrackAdjustments` specification to `RoomSubScreen`

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
     {
         public override string Title => "Lounge";
 
-        public override bool? AllowTrackAdjustments => false;
-
         protected override BackgroundScreen CreateBackground() => new LoungeBackgroundScreen
         {
             SelectedRoom = { BindTarget = SelectedRoom }

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Screens.OnlinePlay.Match
         [Cached(typeof(IBindable<PlaylistItem>))]
         protected readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
 
+        public override bool? AllowTrackAdjustments => true;
+
         protected override BackgroundScreen CreateBackground() => new RoomBackgroundScreen(Room.Playlist.FirstOrDefault())
         {
             SelectedItem = { BindTarget = SelectedItem }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySubScreen.cs
@@ -11,8 +11,6 @@ namespace osu.Game.Screens.OnlinePlay
     {
         public override bool DisallowExternalBeatmapRulesetChanges => false;
 
-        public override bool? AllowTrackAdjustments => true;
-
         public virtual string ShortTitle => Title;
 
         [Resolved(CanBeNull = true)]


### PR DESCRIPTION
Feels like a better place to put this, rather than having two levels of subclasses set `true` then `false`. Basically we want all screens to inherit except the room screen, which is the point after which the rate changes should be applied.

Alternative to https://github.com/ppy/osu/pull/14772.