### PR TITLE
Fix a couple of remaining temp file edge cases in tests

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -424,14 +424,14 @@ namespace osu.Game.Tests.Beatmaps.IO
                     checkBeatmapCount(osu, 12);
                     checkSingleReferencedFileCount(osu, 18);
 
-                    var breakTemp = TestResources.GetTestBeatmapForImport();
+                    var brokenTempFilename = TestResources.GetTestBeatmapForImport();
 
                     MemoryStream brokenOsu = new MemoryStream();
-                    MemoryStream brokenOsz = new MemoryStream(await File.ReadAllBytesAsync(breakTemp));
+                    MemoryStream brokenOsz = new MemoryStream(await File.ReadAllBytesAsync(brokenTempFilename));
 
-                    File.Delete(breakTemp);
+                    File.Delete(brokenTempFilename);
 
-                    using (var outStream = File.Open(breakTemp, FileMode.CreateNew))
+                    using (var outStream = File.Open(brokenTempFilename, FileMode.CreateNew))
                     using (var zip = ZipArchive.Open(brokenOsz))
                     {
                         zip.AddEntry("broken.osu", brokenOsu, false);
@@ -441,7 +441,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     // this will trigger purging of the existing beatmap (online set id match) but should rollback due to broken osu.
                     try
                     {
-                        await manager.Import(new ImportTask(breakTemp));
+                        await manager.Import(new ImportTask(brokenTempFilename));
                     }
                     catch
                     {
@@ -456,6 +456,8 @@ namespace osu.Game.Tests.Beatmaps.IO
                     checkSingleReferencedFileCount(osu, 18);
 
                     Assert.AreEqual(1, loggedExceptionCount);
+
+                    File.Delete(brokenTempFilename);
                 }
                 finally
                 {

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -1,15 +1,19 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
 using NUnit.Framework;
 using osu.Framework.IO.Stores;
+using osu.Framework.Testing;
 
 namespace osu.Game.Tests.Resources
 {
     public static class TestResources
     {
         public const double QUICK_BEATMAP_LENGTH = 10000;
+
+        private static readonly TemporaryNativeStorage temp_storage = new TemporaryNativeStorage("TestResources");
 
         public static DllResourceStore GetStore() => new DllResourceStore(typeof(TestResources).Assembly);
 
@@ -25,7 +29,7 @@ namespace osu.Game.Tests.Resources
         /// <returns>A path to a copy of a beatmap archive (osz). Should be deleted after use.</returns>
         public static string GetQuickTestBeatmapForImport()
         {
-            var tempPath = Path.GetTempFileName() + ".osz";
+            var tempPath = getTempFilename();
             using (var stream = OpenResource("Archives/241526 Soleily - Renatus_virtual_quick.osz"))
             using (var newFile = File.Create(tempPath))
                 stream.CopyTo(newFile);
@@ -41,7 +45,7 @@ namespace osu.Game.Tests.Resources
         /// <returns>A path to a copy of a beatmap archive (osz). Should be deleted after use.</returns>
         public static string GetTestBeatmapForImport(bool virtualTrack = false)
         {
-            var tempPath = Path.GetTempFileName() + ".osz";
+            var tempPath = getTempFilename();
 
             using (var stream = GetTestBeatmapStream(virtualTrack))
             using (var newFile = File.Create(tempPath))
@@ -50,5 +54,7 @@ namespace osu.Game.Tests.Resources
             Assert.IsTrue(File.Exists(tempPath));
             return tempPath;
         }
+
+        private static string getTempFilename() => temp_storage.GetFullPath(Guid.NewGuid() + ".osz");
     }
 }


### PR DESCRIPTION
Should contain all test file generation in the `of-headless-tests` folder, and (in most cases) ensure it's empty at the end of a full test run. Quite useful if you want to reduce disk IO and improve test performance by mounting a ramdisk at the single folder location (on macOS at least it's a bit of a pain to mount a ramdisk on the whole of the temp folder, as it's guid'd and split over multiple locations).