### PR TITLE
Fix the default background parallax being set incorrectly when no screen is present

### DIFF
--- a/osu.Game/Screens/OsuScreenStack.cs
+++ b/osu.Game/Screens/OsuScreenStack.cs
@@ -51,6 +51,6 @@ namespace osu.Game.Screens
         }
 
         private void setParallax(IScreen next) =>
-            parallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * ((IOsuScreen)next)?.BackgroundParallaxAmount ?? 1.0f;
+            parallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * (((IOsuScreen)next)?.BackgroundParallaxAmount ?? 1.0f);
     }
 }


### PR DESCRIPTION
Was bugging me for a while in some test scenes. Doubt it's even seen anywhere else.

Before:

https://user-images.githubusercontent.com/191335/133758620-2fd48da9-512b-4b92-a94f-86d11c405426.mp4

After:

https://user-images.githubusercontent.com/191335/133758447-219dce48-6853-4195-813c-6dd7b65c717d.mp4