### PR TITLE
Metadata wrong exportation when containing invalid path character

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
+                    //var temp = "C:\\Users\\youss\\ASP.NET projects\\423194 Reol - SYSTEMATIC LOVE [no video].osz";
                     string extractedFolder = $"{temp}_extracted";
                     Directory.CreateDirectory(extractedFolder);
 
@@ -153,15 +154,18 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     try
                     {
-                        var firstImport = await LoadOszIntoOsu(osu);
+                        var firstImport = await LoadOszIntoOsu(osu, temp); //, extractedFolder);
+
+                        foreach (var beatmapInfo in firstImport.Beatmaps)
+                        {
+                            foreach (char c in Path.GetInvalidFileNameChars())
+                                beatmapInfo.Path = beatmapInfo.Path.Replace(c, '_');
+                        }
 
                         var manager = osu.Dependencies.Get<BeatmapManager>();
                         manager.Export(firstImport);
 
-                        var exportFile = $"{firstImport.Metadata}.osz";
-                        foreach (char c in Path.GetInvalidFileNameChars())
-                            exportFile = exportFile.Replace(c, '_');
-                        exportFullPath += "\\" + exportFile;
+                        exportFullPath += $"\\{firstImport.Metadata}.osz";
 
                         var secondImport = await LoadOszIntoOsu(osu, exportFullPath);
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -266,22 +266,14 @@ namespace osu.Game.Beatmaps
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
 
-                    // removing incompatible characters before exporting
-                    string mArtist = metadata.Artist;
-                    string mTitle = metadata.Title;
-                    string mAuthor = metadata.Author.ToString();
-                    string mVersion = beatmapInfo.Version;
-                    List<char> incompatibleChars = new List<char>{'/','\\','<','>','|','?','*','\"',':'};
-                    for(int i = 0; i < incompatibleChars.Count; i++)
-                    {
-                        mArtist = mArtist.Replace(incompatibleChars[i].ToString(),"");
-                        mTitle = mTitle.Replace(incompatibleChars[i].ToString(),"");
-                        mAuthor = mAuthor.Replace(incompatibleChars[i].ToString(),"");
-                        mVersion = mVersion.Replace(incompatibleChars[i].ToString(),"");
-                    }
-
+                    
                     // metadata may have changed; update the path with the standard format.
-                    beatmapInfo.Path = $"{mArtist} - {mTitle} ({mAuthor}) [{mVersion}].osu";
+                    beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";
+
+                    // removing incompatible characters before exporting
+                    foreach(char c in Path.GetInvalidFileNameChars())
+                        beatmapInfo.Path = beatmapInfo.Path.Replace(c.ToString(),"");
+
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 
                     // update existing or populate new file's filename.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -266,8 +266,22 @@ namespace osu.Game.Beatmaps
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
 
+                    // removing incompatible characters before exporting
+                    string mArtist = metadata.Artist;
+                    string mTitle = metadata.Title;
+                    string mAuthor = metadata.Author.ToString();
+                    string mVersion = beatmapInfo.Version;
+                    List<char> incompatibleChars = new List<char>{'/','\\','<','>','|','?','*','\"',':'};
+                    for(int i = 0; i < incompatibleChars.Count; i++)
+                    {
+                        mArtist = mArtist.Replace(incompatibleChars[i].ToString(),"");
+                        mTitle = mTitle.Replace(incompatibleChars[i].ToString(),"");
+                        mAuthor = mAuthor.Replace(incompatibleChars[i].ToString(),"");
+                        mVersion = mVersion.Replace(incompatibleChars[i].ToString(),"");
+                    }
+
                     // metadata may have changed; update the path with the standard format.
-                    beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";
+                    beatmapInfo.Path = $"{mArtist} - {mTitle} ({mAuthor}) [{mVersion}].osu";
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 
                     // update existing or populate new file's filename.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -265,13 +265,13 @@ namespace osu.Game.Beatmaps
 
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
-                    
+
                     // metadata may have changed; update the path with the standard format.
                     beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";
 
-                    // removing incompatible characters before exporting
-                    foreach(char c in Path.GetInvalidFileNameChars())
-                        beatmapInfo.Path = beatmapInfo.Path.Replace(c.ToString(),"");
+                    // remove incompatible characters from path
+                    foreach (char c in Path.GetInvalidFileNameChars())
+                        beatmapInfo.Path = beatmapInfo.Path.Replace(c.ToString(), "");
 
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -270,8 +270,7 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";
 
                     // remove incompatible characters from path
-                    foreach (char c in Path.GetInvalidFileNameChars())
-                        beatmapInfo.Path = beatmapInfo.Path.Replace(c.ToString(), "");
+                    beatmapInfo.Path = getValidFilename(beatmapInfo.Path);
 
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -265,7 +265,6 @@ namespace osu.Game.Beatmaps
 
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
-
                     
                     // metadata may have changed; update the path with the standard format.
                     beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";
 
                     // remove incompatible characters from path
-                    beatmapInfo.Path = getValidFilename(beatmapInfo.Path);
+                    beatmapInfo.Path = GetValidFilename(beatmapInfo.Path);
 
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -468,7 +468,7 @@ namespace osu.Game.Database
             if (retrievedItem == null)
                 throw new ArgumentException(@"Specified model could not be found", nameof(item));
 
-            using (var outputStream = exportStorage.GetStream($"{getValidFilename(item.ToString())}{HandledExtensions.First()}", FileAccess.Write, FileMode.Create))
+            using (var outputStream = exportStorage.GetStream($"{GetValidFilename(item.ToString())}{HandledExtensions.First()}", FileAccess.Write, FileMode.Create))
                 ExportModelTo(retrievedItem, outputStream);
 
             exportStorage.OpenInNativeExplorer();
@@ -893,7 +893,7 @@ namespace osu.Game.Database
 
         #endregion
 
-        protected static string getValidFilename(string filename)
+        protected static string GetValidFilename(string filename)
         {
             foreach (char c in Path.GetInvalidFileNameChars())
                 filename = filename.Replace(c, '_');

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -893,7 +893,7 @@ namespace osu.Game.Database
 
         #endregion
 
-        private string getValidFilename(string filename)
+        protected static string getValidFilename(string filename)
         {
             foreach (char c in Path.GetInvalidFileNameChars())
                 filename = filename.Replace(c, '_');


### PR DESCRIPTION
"Maps with slashes in metadata are exported incorrectly"
Replaced all incompatible characters in maps' metadata with empty string right before exporting, testing with importing the maps to and from osu!lazer and stable (kept going back and forth with the import/export)

Closes #14758