### PR TITLE
Add rectangular snap grid to osu! editor composer

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu.Edit;
+using osu.Game.Screens.Edit.Compose.Components;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public class TestSceneOsuEditorGrids : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestGridExclusivity()
+        {
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
+            AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
+            AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
+
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddUntilStep("rectangular grid hidden", () => !this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -57,12 +57,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
             AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
-            gridSizeIs(4);
+            gridSizeIs(32);
 
+            nextGridSizeIs(4);
             nextGridSizeIs(8);
             nextGridSizeIs(16);
             nextGridSizeIs(32);
-            nextGridSizeIs(4);
         }
 
         private void nextGridSizeIs(int size)

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -4,7 +4,9 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Osu.Edit;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Tests.Visual;
 using osuTK;
 using osuTK.Input;
@@ -21,14 +23,33 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
             AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            rectangularGridActive(false);
 
             AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
-            AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
+            rectangularGridActive(true);
 
             AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
+            AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
-            AddUntilStep("rectangular grid hidden", () => !this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
+            rectangularGridActive(false);
+        }
+
+        private void rectangularGridActive(bool active)
+        {
+            AddStep("choose placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move cursor to (1, 1)", () =>
+            {
+                var composer = Editor.ChildrenOfType<OsuRectangularPositionSnapGrid>().Single();
+                InputManager.MoveMouseTo(composer.ToScreenSpace(new Vector2(1, 1)));
+            });
+
+            if (active)
+                AddAssert("placement blueprint at (0, 0)", () => Precision.AlmostEquals(Editor.ChildrenOfType<HitCirclePlacementBlueprint>().Single().HitObject.Position, new Vector2(0, 0)));
+            else
+                AddAssert("placement blueprint at (1, 1)", () => Precision.AlmostEquals(Editor.ChildrenOfType<HitCirclePlacementBlueprint>().Single().HitObject.Position, new Vector2(1, 1)));
+
+            AddStep("choose selection tool", () => InputManager.Key(Key.Number1));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -57,12 +57,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
             AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
-            gridSizeIs(32);
+            gridSizeIs(4);
 
-            nextGridSizeIs(4);
             nextGridSizeIs(8);
             nextGridSizeIs(16);
             nextGridSizeIs(32);
+            nextGridSizeIs(4);
         }
 
         private void nextGridSizeIs(int size)

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Osu.Edit;
-using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Tests.Visual;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Tests.Editor
@@ -24,11 +24,33 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
-            AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
+            AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
 
             AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
-            AddUntilStep("rectangular grid hidden", () => !this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
+            AddUntilStep("rectangular grid hidden", () => !this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
         }
+
+        [Test]
+        public void TestGridSizeToggling()
+        {
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
+            AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Any());
+            gridSizeIs(4);
+
+            nextGridSizeIs(8);
+            nextGridSizeIs(16);
+            nextGridSizeIs(32);
+            nextGridSizeIs(4);
+        }
+
+        private void nextGridSizeIs(int size)
+        {
+            AddStep("toggle to next grid size", () => InputManager.Key(Key.G));
+            gridSizeIs(size);
+        }
+
+        private void gridSizeIs(int size)
+            => AddAssert($"grid size is {size}", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Single().Spacing == new Vector2(size));
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -72,6 +72,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         private void gridSizeIs(int size)
-            => AddAssert($"grid size is {size}", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Single().Spacing == new Vector2(size));
+            => AddAssert($"grid size is {size}", () => this.ChildrenOfType<OsuRectangularPositionSnapGrid>().Single().Spacing == new Vector2(size)
+                                                       && EditorBeatmap.BeatmapInfo.GridSize == size);
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     RelativeSizeAxes = Axes.Both
                 },
-                rectangularPositionSnapGrid = new OsuRectangularPositionSnapGrid(EditorBeatmap.BeatmapInfo.GridSize)
+                rectangularPositionSnapGrid = new OsuRectangularPositionSnapGrid
                 {
                     RelativeSizeAxes = Axes.Both
                 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     RelativeSizeAxes = Axes.Both
                 },
-                rectangularPositionSnapGridContainer = new Container
+                rectangularPositionSnapGrid = new OsuRectangularPositionSnapGrid(EditorBeatmap.BeatmapInfo.GridSize)
                 {
                     RelativeSizeAxes = Axes.Both
                 }
@@ -89,8 +89,6 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             gridSnapToggle.ValueChanged += _ =>
             {
-                updateRectangularPositionSnapGrid();
-
                 if (gridSnapToggle.Value == TernaryState.True)
                     distanceSnapToggle.Value = TernaryState.False;
             };
@@ -110,6 +108,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private readonly Cached distanceSnapGridCache = new Cached();
         private double? lastDistanceSnapGridTime;
+
+        private RectangularPositionSnapGrid rectangularPositionSnapGrid;
 
         protected override void Update()
         {
@@ -297,22 +297,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                 return null;
 
             return new OsuDistanceSnapGrid((OsuHitObject)sourceObject, (OsuHitObject)targetObject);
-        }
-
-        private Container rectangularPositionSnapGridContainer;
-        private RectangularPositionSnapGrid rectangularPositionSnapGrid;
-
-        private void updateRectangularPositionSnapGrid()
-        {
-            rectangularPositionSnapGridContainer.Clear();
-
-            if (gridSnapToggle.Value == TernaryState.True)
-            {
-                rectangularPositionSnapGridContainer.Add(rectangularPositionSnapGrid = new OsuRectangularPositionSnapGrid(EditorBeatmap.BeatmapInfo.GridSize)
-                {
-                    RelativeSizeAxes = Axes.Both
-                });
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -42,12 +42,12 @@ namespace osu.Game.Rulesets.Osu.Edit
         };
 
         private readonly Bindable<TernaryState> distanceSnapToggle = new Bindable<TernaryState>();
-        private readonly Bindable<TernaryState> gridSnapToggle = new Bindable<TernaryState>();
+        private readonly Bindable<TernaryState> rectangularGridSnapToggle = new Bindable<TernaryState>();
 
         protected override IEnumerable<TernaryButton> CreateTernaryButtons() => base.CreateTernaryButtons().Concat(new[]
         {
             new TernaryButton(distanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Ruler }),
-            new TernaryButton(gridSnapToggle, "Grid Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Th })
+            new TernaryButton(rectangularGridSnapToggle, "Grid Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Th })
         });
 
         private BindableList<HitObject> selectedHitObjects;
@@ -84,12 +84,12 @@ namespace osu.Game.Rulesets.Osu.Edit
                 updateDistanceSnapGrid();
 
                 if (distanceSnapToggle.Value == TernaryState.True)
-                    gridSnapToggle.Value = TernaryState.False;
+                    rectangularGridSnapToggle.Value = TernaryState.False;
             };
 
-            gridSnapToggle.ValueChanged += _ =>
+            rectangularGridSnapToggle.ValueChanged += _ =>
             {
-                if (gridSnapToggle.Value == TernaryState.True)
+                if (rectangularGridSnapToggle.Value == TernaryState.True)
                     distanceSnapToggle.Value = TernaryState.False;
             };
 
@@ -142,13 +142,13 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (positionSnap.ScreenSpacePosition != screenSpacePosition)
                 return positionSnap;
 
-            if (distanceSnapGrid != null)
+            if (distanceSnapToggle.Value == TernaryState.True && distanceSnapGrid != null)
             {
                 (Vector2 pos, double time) = distanceSnapGrid.GetSnappedPosition(distanceSnapGrid.ToLocalSpace(screenSpacePosition));
                 return new SnapResult(distanceSnapGrid.ToScreenSpace(pos), time, PlayfieldAtScreenSpacePosition(screenSpacePosition));
             }
 
-            if (rectangularPositionSnapGrid != null)
+            if (rectangularGridSnapToggle.Value == TernaryState.True)
             {
                 Vector2 pos = rectangularPositionSnapGrid.GetSnappedPosition(rectangularPositionSnapGrid.ToLocalSpace(screenSpacePosition));
                 return new SnapResult(rectangularPositionSnapGrid.ToScreenSpace(pos), null, PlayfieldAtScreenSpacePosition(screenSpacePosition));

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -17,7 +17,6 @@ using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
@@ -309,7 +308,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             if (gridSnapToggle.Value == TernaryState.True)
             {
-                rectangularPositionSnapGridContainer.Add(rectangularPositionSnapGrid = new RectangularPositionSnapGrid(OsuPlayfield.BASE_SIZE / 2, new Vector2(16))
+                rectangularPositionSnapGridContainer.Add(rectangularPositionSnapGrid = new OsuRectangularPositionSnapGrid(EditorBeatmap.BeatmapInfo.GridSize)
                 {
                     RelativeSizeAxes = Axes.Both
                 });

--- a/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public class OsuRectangularPositionSnapGrid : RectangularPositionSnapGrid
+    {
+        private static readonly int[] grid_sizes = { 4, 8, 16, 32 };
+
+        private int currentGridSizeIndex;
+
+        public OsuRectangularPositionSnapGrid(int gridSize)
+            : base(OsuPlayfield.BASE_SIZE / 2)
+        {
+            var gridSizeIndex = Array.IndexOf(grid_sizes, gridSize);
+            if (gridSizeIndex > 0)
+                currentGridSizeIndex = gridSizeIndex;
+            updateSpacing();
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Key == Key.G)
+            {
+                nextGridSize();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void nextGridSize()
+        {
+            currentGridSizeIndex = (currentGridSizeIndex + 1) % grid_sizes.Length;
+            updateSpacing();
+        }
+
+        private void updateSpacing()
+        {
+            Spacing = new Vector2(grid_sizes[currentGridSizeIndex]);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         private void load()
         {
             var gridSizeIndex = Array.IndexOf(grid_sizes, editorBeatmap.BeatmapInfo.GridSize);
-            if (gridSizeIndex > 0)
+            if (gridSizeIndex >= 0)
                 currentGridSizeIndex = gridSizeIndex;
             updateSpacing();
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
@@ -2,15 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
-    public class OsuRectangularPositionSnapGrid : RectangularPositionSnapGrid
+    public class OsuRectangularPositionSnapGrid : RectangularPositionSnapGrid, IKeyBindingHandler<GlobalAction>
     {
         private static readonly int[] grid_sizes = { 4, 8, 16, 32 };
 
@@ -25,17 +26,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             updateSpacing();
         }
 
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (e.Key == Key.G)
-            {
-                nextGridSize();
-                return true;
-            }
-
-            return false;
-        }
-
         private void nextGridSize()
         {
             currentGridSizeIndex = (currentGridSizeIndex + 1) % grid_sizes.Length;
@@ -45,6 +35,22 @@ namespace osu.Game.Rulesets.Osu.Edit
         private void updateSpacing()
         {
             Spacing = new Vector2(grid_sizes[currentGridSizeIndex]);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.EditorCycleGridDisplayMode:
+                    nextGridSize();
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -17,10 +19,18 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private int currentGridSizeIndex = grid_sizes.Length - 1;
 
-        public OsuRectangularPositionSnapGrid(int gridSize)
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
+        public OsuRectangularPositionSnapGrid()
             : base(OsuPlayfield.BASE_SIZE / 2)
         {
-            var gridSizeIndex = Array.IndexOf(grid_sizes, gridSize);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var gridSizeIndex = Array.IndexOf(grid_sizes, editorBeatmap.BeatmapInfo.GridSize);
             if (gridSizeIndex > 0)
                 currentGridSizeIndex = gridSizeIndex;
             updateSpacing();
@@ -34,7 +44,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void updateSpacing()
         {
-            Spacing = new Vector2(grid_sizes[currentGridSizeIndex]);
+            int gridSize = grid_sizes[currentGridSizeIndex];
+
+            editorBeatmap.BeatmapInfo.GridSize = gridSize;
+            Spacing = new Vector2(gridSize);
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuRectangularPositionSnapGrid.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Edit
     {
         private static readonly int[] grid_sizes = { 4, 8, 16, 32 };
 
-        private int currentGridSizeIndex;
+        private int currentGridSizeIndex = grid_sizes.Length - 1;
 
         public OsuRectangularPositionSnapGrid(int gridSize)
             : base(OsuPlayfield.BASE_SIZE / 2)

--- a/osu.Game.Tests/Visual/Editing/TestSceneRectangularPositionSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneRectangularPositionSnapGrid.cs
@@ -49,9 +49,10 @@ namespace osu.Game.Tests.Visual.Editing
         {
             RectangularPositionSnapGrid grid = null;
 
-            AddStep("create grid", () => Child = grid = new RectangularPositionSnapGrid(position, spacing)
+            AddStep("create grid", () => Child = grid = new RectangularPositionSnapGrid(position)
             {
-                RelativeSizeAxes = Axes.Both
+                RelativeSizeAxes = Axes.Both,
+                Spacing = spacing
             });
 
             AddStep("add snapping cursor", () => Add(new SnappingCursorContainer

--- a/osu.Game.Tests/Visual/Editing/TestSceneRectangularPositionSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneRectangularPositionSnapGrid.cs
@@ -1,0 +1,103 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneRectangularPositionSnapGrid : OsuManualInputManagerTestScene
+    {
+        private Container content;
+        protected override Container<Drawable> Content => content;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            base.Content.AddRange(new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Colour4.Gray
+                },
+                content = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                }
+            });
+        }
+
+        private static readonly object[][] test_cases =
+        {
+            new object[] { new Vector2(0, 0), new Vector2(10, 10) },
+            new object[] { new Vector2(240, 180), new Vector2(10, 15) },
+            new object[] { new Vector2(160, 120), new Vector2(30, 20) },
+            new object[] { new Vector2(480, 360), new Vector2(100, 100) },
+        };
+
+        [TestCaseSource(nameof(test_cases))]
+        public void TestRectangularGrid(Vector2 position, Vector2 spacing)
+        {
+            RectangularPositionSnapGrid grid = null;
+
+            AddStep("create grid", () => Child = grid = new RectangularPositionSnapGrid(position, spacing)
+            {
+                RelativeSizeAxes = Axes.Both
+            });
+
+            AddStep("add snapping cursor", () => Add(new SnappingCursorContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                GetSnapPosition = pos => grid.GetSnappedPosition(grid.ToLocalSpace(pos))
+            }));
+        }
+
+        private class SnappingCursorContainer : CompositeDrawable
+        {
+            public Func<Vector2, Vector2> GetSnapPosition;
+
+            private readonly Drawable cursor;
+
+            public SnappingCursorContainer()
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                InternalChild = cursor = new Circle
+                {
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(50),
+                    Colour = Color4.Red
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                updatePosition(GetContainingInputManager().CurrentState.Mouse.Position);
+            }
+
+            protected override bool OnMouseMove(MouseMoveEvent e)
+            {
+                base.OnMouseMove(e);
+
+                updatePosition(e.ScreenSpaceMousePosition);
+                return true;
+            }
+
+            private void updatePosition(Vector2 screenSpacePosition)
+            {
+                cursor.Position = GetSnapPosition.Invoke(screenSpacePosition);
+            }
+        }
+    }
+}

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, GlobalAction.EditorVerifyMode),
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
+            new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -284,6 +285,9 @@ namespace osu.Game.Input.Bindings
         SeekReplayBackward,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleChatFocus))]
-        ToggleChatFocus
+        ToggleChatFocus,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridDisplayMode))]
+        EditorCycleGridDisplayMode
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -165,6 +165,11 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorTimingMode => new TranslatableString(getKey(@"editor_timing_mode"), @"Timing mode");
 
         /// <summary>
+        /// "Cycle grid display mode"
+        /// </summary>
+        public static LocalisableString EditorCycleGridDisplayMode => new TranslatableString(getKey(@"editor_cycle_grid_display_mode"), @"Cycle grid display mode");
+
+        /// <summary>
         /// "Hold for HUD"
         /// </summary>
         public static LocalisableString HoldForHUD => new TranslatableString(getKey(@"hold_for_hud"), @"Hold for HUD");

--- a/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
@@ -17,17 +17,29 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         public Vector2 StartPosition { get; }
 
+        private Vector2 spacing = Vector2.One;
+
         /// <summary>
         /// The spacing between grid lines of this <see cref="RectangularPositionSnapGrid"/>.
         /// </summary>
-        public Vector2 Spacing { get; }
+        public Vector2 Spacing
+        {
+            get => spacing;
+            set
+            {
+                if (spacing.X <= 0 || spacing.Y <= 0)
+                    throw new ArgumentException("Grid spacing must be positive.");
+
+                spacing = value;
+                gridCache.Invalidate();
+            }
+        }
 
         private readonly LayoutValue gridCache = new LayoutValue(Invalidation.RequiredParentSizeToFit);
 
-        public RectangularPositionSnapGrid(Vector2 startPosition, Vector2 spacing)
+        public RectangularPositionSnapGrid(Vector2 startPosition)
         {
             StartPosition = startPosition;
-            Spacing = spacing;
 
             AddLayout(gridCache);
         }

--- a/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Layout;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public class RectangularPositionSnapGrid : CompositeDrawable
+    {
+        /// <summary>
+        /// The position of the origin of this <see cref="RectangularPositionSnapGrid"/> in local coordinates.
+        /// </summary>
+        public Vector2 StartPosition { get; }
+
+        /// <summary>
+        /// The spacing between grid lines of this <see cref="RectangularPositionSnapGrid"/>.
+        /// </summary>
+        public Vector2 Spacing { get; }
+
+        private readonly LayoutValue gridCache = new LayoutValue(Invalidation.RequiredParentSizeToFit);
+
+        public RectangularPositionSnapGrid(Vector2 startPosition, Vector2 spacing)
+        {
+            StartPosition = startPosition;
+            Spacing = spacing;
+
+            AddLayout(gridCache);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!gridCache.IsValid)
+            {
+                ClearInternal();
+                createContent();
+                gridCache.Validate();
+            }
+        }
+
+        private void createContent()
+        {
+            var drawSize = DrawSize;
+
+            generateGridLines(Direction.Horizontal, StartPosition.Y, 0, -Spacing.Y);
+            generateGridLines(Direction.Horizontal, StartPosition.Y, drawSize.Y, Spacing.Y);
+
+            generateGridLines(Direction.Vertical, StartPosition.X, 0, -Spacing.X);
+            generateGridLines(Direction.Vertical, StartPosition.X, drawSize.X, Spacing.X);
+        }
+
+        private void generateGridLines(Direction direction, float startPosition, float endPosition, float step)
+        {
+            int index = 0;
+            float currentPosition = startPosition;
+
+            while ((endPosition - currentPosition) * Math.Sign(step) > 0)
+            {
+                var gridLine = new Box
+                {
+                    Colour = Colour4.White,
+                    Alpha = index == 0 ? 0.3f : 0.1f,
+                    EdgeSmoothness = new Vector2(0.2f)
+                };
+
+                if (direction == Direction.Horizontal)
+                {
+                    gridLine.RelativeSizeAxes = Axes.X;
+                    gridLine.Height = 1;
+                    gridLine.Y = currentPosition;
+                }
+                else
+                {
+                    gridLine.RelativeSizeAxes = Axes.Y;
+                    gridLine.Width = 1;
+                    gridLine.X = currentPosition;
+                }
+
+                AddInternal(gridLine);
+
+                index += 1;
+                currentPosition = startPosition + index * step;
+            }
+        }
+
+        public Vector2 GetSnappedPosition(Vector2 original)
+        {
+            Vector2 relativeToStart = original - StartPosition;
+            Vector2 offset = Vector2.Divide(relativeToStart, Spacing);
+            Vector2 roundedOffset = new Vector2(MathF.Round(offset.X), MathF.Round(offset.Y));
+
+            return StartPosition + Vector2.Multiply(roundedOffset, Spacing);
+        }
+    }
+}


### PR DESCRIPTION
https://user-images.githubusercontent.com/20418176/133939345-60fa5f74-4459-4825-9391-014600efd89e.mp4

Appearance matching stable, also implements toggling grid size matching stable using the <kbd>G</kbd> key. The grid size is read from the beatmap file if stored. Contrary to stable however, the rectangular grid and the distance snap grid are mutually exclusive (for now? I just didn't see much point in having them both on at the same time)

Up to the grid toggling this was reasonably straightforward, but I wasn't sure where to put that part. The grid sizes available sort of rely on the semi-legacy 512x384 sizing of the playfield, so I made that stuff osu!-specific for now. May need to revisit that when work on the design tab starts.

The main grid component was written in a way that should be agnostic towards that (supports arbitrary start positions and spacings, not necessarily square ones even). Therefore, this also paves a potential way forward to allowing the grid to be rooted at the selected object, or custom grid spacings, if any of that is deemed as wanted.

The component's implementation is relatively ~~stupid~~ straightforward but doesn't seem to tank performance *too* much.

There was a fair few bits that I stole from the distance snap implementation but I didn't want to commonise that too much until the general direction is clear.