### PR TITLE
Add missing licence headers

### DIFF
--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game/Overlays/Login/UserAction.cs
+++ b/osu.Game/Overlays/Login/UserAction.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using System.ComponentModel;
 
 namespace osu.Game.Overlays.Login

--- a/osu.Game/Overlays/Login/UserDropdown.cs
+++ b/osu.Game/Overlays/Login/UserDropdown.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;


### PR DESCRIPTION
Noticed this pretty much by accident; they got lost in #14783. The corresponding [CI run](https://github.com/ppy/osu/actions/runs/1244962871) reported them missing, but at a warning level, and because workflow runs can only pass or fail, it was supremely easy to miss.

I tried to quickly fix the workflow to report this as error, but even changing the [warning print](https://github.com/ppy/osu/blob/801bee7c47e280555261016ba82edc8743653fe9/.github/workflows/ci.yml#L83) to errors still doesn't fail either the workflow step or the job itself. Rather than playing around with that bash script it will likely be easier to just adjust CFS to work with github actions properly, which I might get around to doing soon™ if I'm not beaten to it.