### PR TITLE
Disable FtB pass for particle spewer

### DIFF
--- a/osu.Game/Graphics/ParticleExplosion.cs
+++ b/osu.Game/Graphics/ParticleExplosion.cs
@@ -115,6 +115,8 @@ namespace osu.Game.Graphics
                         null, TextureCoords);
                 }
             }
+
+            protected override bool CanDrawOpaqueInterior => false;
         }
 
         private readonly struct ParticlePart

--- a/osu.Game/Graphics/ParticleSpewer.cs
+++ b/osu.Game/Graphics/ParticleSpewer.cs
@@ -164,6 +164,8 @@ namespace osu.Game.Graphics
 
                 return Vector2Extensions.Transform(new Vector2(x, y), DrawInfo.Matrix);
             }
+
+            protected override bool CanDrawOpaqueInterior => false;
         }
 
         #endregion


### PR DESCRIPTION
Not super important, just safety for if this is used with an opaque sprite, because the FtB pass hasn't been considered for this `DrawNode` implementation at all.