### PR TITLE
Fix cursor particles not spawned during kiai

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneCursorParticles.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneCursorParticles.cs
@@ -98,6 +98,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 {
                     var controlPointInfo = new ControlPointInfo();
                     controlPointInfo.Add(0, new EffectControlPoint { KiaiMode = true });
+                    controlPointInfo.Add(5000, new EffectControlPoint { KiaiMode = false });
 
                     return new Beatmap
                     {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorParticles.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorParticles.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             DrawableHitObject kiaiHitObject = null;
 
             // Check whether currently in a kiai section first. This is only done as an optimisation to avoid enumerating AliveObjects when not necessary.
-            if (gameplayBeatmap.ControlPointInfo.EffectPointAt(gameplayBeatmap.Time.Current).KiaiMode)
+            if (gameplayBeatmap.ControlPointInfo.EffectPointAt(Time.Current).KiaiMode)
                 kiaiHitObject = playfield.HitObjectContainer.AliveObjects.FirstOrDefault(isTracking);
 
             kiaiSpewer.Active.Value = kiaiHitObject != null;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorParticles.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorParticles.cs
@@ -39,9 +39,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         [Resolved(canBeNull: true)]
         private GameplayBeatmap gameplayBeatmap { get; set; }
 
-        [Resolved(canBeNull: true)]
-        private GameplayClock gameplayClock { get; set; }
-
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, OsuColour colours)
         {


### PR DESCRIPTION
It was referring to the `GameplayBeatmap`'s current time, which comes from the `Player` rather than the `DrawableRuleset`/`GamplayClock`.