### PR TITLE
Fix text overflowing on dropdown headers

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -274,21 +274,40 @@ namespace osu.Game.Graphics.UserInterface
                 CornerRadius = corner_radius;
                 Height = 40;
 
-                Foreground.Children = new Drawable[]
+                Foreground.Child = new GridContainer
                 {
-                    Text = new OsuSpriteText
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    RowDimensions = new[]
                     {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
+                        new Dimension(GridSizeMode.AutoSize),
                     },
-                    Icon = new SpriteIcon
+                    ColumnDimensions = new[]
                     {
-                        Icon = FontAwesome.Solid.ChevronDown,
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Margin = new MarginPadding { Right = 5 },
-                        Size = new Vector2(12),
+                        new Dimension(),
+                        new Dimension(GridSizeMode.AutoSize),
                     },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            Text = new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.X,
+                                Truncate = true,
+                            },
+                            Icon = new SpriteIcon
+                            {
+                                Icon = FontAwesome.Solid.ChevronDown,
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Margin = new MarginPadding { Horizontal = 5 },
+                                Size = new Vector2(12),
+                            },
+                        }
+                    }
                 };
 
                 AddInternal(new HoverClickSounds());


### PR DESCRIPTION
Before:
<img width="352" alt="Screen Shot 2021-09-24 at 10 00 56 PM" src="https://user-images.githubusercontent.com/35318437/134758951-43f9d8c7-ccad-40ec-91a5-92907fd5837a.png">


After:
<img width="371" alt="Screen Shot 2021-09-24 at 10 00 08 PM" src="https://user-images.githubusercontent.com/35318437/134758938-9188029e-764e-43a2-9a82-ad215d269352.png">