### PR TITLE
Rewrite blueprint sorting logic to be more robust

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneBlueprintOrdering.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBlueprintOrdering.cs
@@ -21,7 +21,7 @@ using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
-    public class TestSceneBlueprintSelection : EditorTestScene
+    public class TestSceneBlueprintOrdering : EditorTestScene
     {
         protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneBlueprintOrdering.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBlueprintOrdering.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Compose.Components;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Tests.Beatmaps;
 using osuTK;
 using osuTK.Input;
@@ -94,6 +95,32 @@ namespace osu.Game.Tests.Visual.Editing
                 var hasCombo = Editor.ChildrenOfType<HitCircleSelectionBlueprint>().Single(b => b.IsSelected).Item as IHasComboInformation;
                 return hasCombo?.IndexInCurrentCombo == 0;
             });
+        }
+
+        [Test]
+        public void TestPlacementOfConcurrentObjectWithDuration()
+        {
+            AddStep("seek to timing point", () => EditorClock.Seek(2170));
+            AddStep("add hit circle", () => EditorBeatmap.Add(createHitCircle(2170, Vector2.Zero)));
+
+            AddStep("choose spinner placement tool", () =>
+            {
+                InputManager.Key(Key.Number4);
+                var hitObjectContainer = Editor.ChildrenOfType<HitObjectContainer>().Single();
+                InputManager.MoveMouseTo(hitObjectContainer.ScreenSpaceDrawQuad.Centre);
+            });
+
+            AddStep("begin placing spinner", () =>
+            {
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("end placing spinner", () =>
+            {
+                EditorClock.Seek(2500);
+                InputManager.Click(MouseButton.Right);
+            });
+
+            AddAssert("two timeline blueprints present", () => Editor.ChildrenOfType<TimelineHitObjectBlueprint>().Count() == 2);
         }
 
         private HitCircle createHitCircle(double startTime, Vector2 position) => new HitCircle

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -45,13 +46,23 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // Put earlier blueprints towards the end of the list, so they handle input first
             int i = yObj.Item.StartTime.CompareTo(xObj.Item.StartTime);
-
             if (i != 0) return i;
 
             // Fall back to end time if the start time is equal.
             i = yObj.Item.GetEndTime().CompareTo(xObj.Item.GetEndTime());
+            if (i != 0) return i;
 
-            return i == 0 ? CompareReverseChildID(y, x) : i;
+            // As a final fallback, use combo information if available.
+            if (xObj.Item is IHasComboInformation xHasCombo && yObj.Item is IHasComboInformation yHasCombo)
+            {
+                i = yHasCombo.ComboIndex.CompareTo(xHasCombo.ComboIndex);
+                if (i != 0) return i;
+
+                i = yHasCombo.IndexInCurrentCombo.CompareTo(xHasCombo.IndexInCurrentCombo);
+                if (i != 0) return i;
+            }
+
+            return CompareReverseChildID(y, x);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -41,25 +41,25 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override int Compare(Drawable x, Drawable y)
         {
-            var xObj = (SelectionBlueprint<HitObject>)x;
-            var yObj = (SelectionBlueprint<HitObject>)y;
+            var xObj = ((SelectionBlueprint<HitObject>)x).Item;
+            var yObj = ((SelectionBlueprint<HitObject>)y).Item;
 
             // Put earlier blueprints towards the end of the list, so they handle input first
-            int i = yObj.Item.StartTime.CompareTo(xObj.Item.StartTime);
-            if (i != 0) return i;
+            int result = yObj.StartTime.CompareTo(xObj.StartTime);
+            if (result != 0) return result;
 
             // Fall back to end time if the start time is equal.
-            i = yObj.Item.GetEndTime().CompareTo(xObj.Item.GetEndTime());
-            if (i != 0) return i;
+            result = yObj.GetEndTime().CompareTo(xObj.GetEndTime());
+            if (result != 0) return result;
 
             // As a final fallback, use combo information if available.
-            if (xObj.Item is IHasComboInformation xHasCombo && yObj.Item is IHasComboInformation yHasCombo)
+            if (xObj is IHasComboInformation xHasCombo && yObj is IHasComboInformation yHasCombo)
             {
-                i = yHasCombo.ComboIndex.CompareTo(xHasCombo.ComboIndex);
-                if (i != 0) return i;
+                result = yHasCombo.ComboIndex.CompareTo(xHasCombo.ComboIndex);
+                if (result != 0) return result;
 
-                i = yHasCombo.IndexInCurrentCombo.CompareTo(xHasCombo.IndexInCurrentCombo);
-                if (i != 0) return i;
+                result = yHasCombo.IndexInCurrentCombo.CompareTo(xHasCombo.IndexInCurrentCombo);
+                if (result != 0) return result;
             }
 
             return CompareReverseChildID(y, x);


### PR DESCRIPTION
- Closes #12046.
- Closes #13473.

PRing this for discussion, mostly. I wouldn't generally clump up fixes for two bugs in one PR, if it weren't for the fact that the proposed fix for both touches the same class, namely `HitObjectOrderedSelectionContainer`.

The general issue with it as it is implemented in `master` is that it tries to internally ensure that the sort order is always consistent by tracking `StartTimeBindable` of all its objects and re-sorting on change, but that is generally not going to be sufficient in many edge cases (two of which cause the issues above: the first is caused by concurrent hitobjects with combo information that you may want to ensure are sorted by increasing combo index/index in combo, and the second is caused by possibly-concurrent hitobjects with varying end time). The options at that point are to either re-sort on every mutation, or to track every single property that could affect the sorting order in the same way.

I have [previously said that I don't consider the first option as an acceptable fix](https://github.com/ppy/osu/issues/13473#issuecomment-860105365), but I changed my mind, as making `EndTime` or `IHasComboInformation` bindable is not trivial, will generally come with a lot of overhead (in the form of _a lot_ more code, and adding more bindables to hitobjects), and the sort generally _shouldn't_ be very expensive - the number of active blueprints at any given time is limited by pooling/lifetime constraints, and the sort operation will only run on actual mutations.

Test cases included cover both issues. `TestSceneBlueprintSelection` was moved over to `TestSceneBlueprintOrdering`, with the existing one test preserved/moved over as well.