### PR TITLE
Add support for range selection to editor timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="e">The mouse event responsible for selection.</param>
         /// <returns>Whether a selection was performed.</returns>
-        internal bool MouseDownSelectionRequested(SelectionBlueprint<T> blueprint, MouseButtonEvent e)
+        internal virtual bool MouseDownSelectionRequested(SelectionBlueprint<T> blueprint, MouseButtonEvent e)
         {
             if (e.ShiftPressed && e.Button == MouseButton.Right)
             {


### PR DESCRIPTION
- Closes #14331.
- [x] Depends on #14852.

https://user-images.githubusercontent.com/20418176/134819444-73bc15a9-66ff-4fc4-85e8-c47dca7f12cf.mp4

The UX was modeled closely after my observations on how range selections work in rider, firefox and a few other places on my linux box. The above video doesn't show that behaviour super well, so I encourage reading tests and/or checking this out locally, but in general:

- Click an object (which we'll name the *pivot*), then press <kbd>Shift</kbd> and then click another object to select all objects between the pivot and the last clicked object. Other objects that were selected previously to the range selection may be deselected by this.
- In order to use range selection, but to also preserve other previously selected objects, hold <kbd>Ctrl</kbd> in addition to <kbd>Shift</kbd>. This makes it so that the selection is always cumulative, and allows for selecting many discontinuous ranges (as can be seen on the above video).

The implementation is a little complex but the end result feels really close to how I'm used to computers handling range selections in general. I haven't found any major discrepancy (there are quirks / unintuitive cases - e.g. when deselections via <kbd>Ctrl</kbd> are involved - but they mostly match how other applications handle range selection anyway).