### PR TITLE
Fix timeline range selection crashing after non-mouse selection

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -223,6 +223,41 @@ namespace osu.Game.Tests.Visual.Editing
             moveMouseToObject(() => addedObjects[2]);
             AddStep("click first", () => InputManager.Click(MouseButton.Left));
             assertSelectionIs(addedObjects.Take(3));
+
+            AddStep("release keys", () =>
+            {
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+            });
+        }
+
+        [Test]
+        public void TestRangeSelectAfterExternalSelection()
+        {
+            var addedObjects = new[]
+            {
+                new HitCircle { StartTime = 100 },
+                new HitCircle { StartTime = 200, Position = new Vector2(100) },
+                new HitCircle { StartTime = 300, Position = new Vector2(200) },
+                new HitCircle { StartTime = 400, Position = new Vector2(300) },
+            };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
+
+            AddStep("select all without mouse", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            assertSelectionIs(addedObjects);
+
+            AddStep("hold down shift", () => InputManager.PressKey(Key.ShiftLeft));
+
+            moveMouseToObject(() => addedObjects[1]);
+            AddStep("click second object", () => InputManager.Click(MouseButton.Left));
+            assertSelectionIs(addedObjects);
+
+            moveMouseToObject(() => addedObjects[3]);
+            AddStep("click fourth object", () => InputManager.Click(MouseButton.Left));
+            assertSelectionIs(addedObjects.Skip(1));
+
+            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
         }
 
         private void assertSelectionIs(IEnumerable<HitObject> hitObjects)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         internal override bool MouseDownSelectionRequested(SelectionBlueprint<HitObject> blueprint, MouseButtonEvent e)
         {
-            if (e.ShiftPressed && e.Button == MouseButton.Left && SelectedItems.Any())
+            if (e.ShiftPressed && e.Button == MouseButton.Left && pivot != null)
             {
                 handleRangeSelection(blueprint, e.ControlPressed);
                 return true;


### PR DESCRIPTION
Closes #14861.

`handleRangeSelection()` relies on the `pivot` not being null. I thought it was safe to assume that the pivot was there if there was a pre-existing selection, but forgot that non-mouse actions (like <kbd>Ctrl</kbd>+<kbd>A</kbd>) can also change the set of selected objects, but _also_ not go through the `MouseDownSelectionRequested()` path that stores the pivot. So the fix is to just use a more direct guard on `pivot` itself.