### PR TITLE
Fix skin editor potentially crashing during close process

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -22,7 +22,6 @@ using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
-using osu.Framework.Development;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -66,10 +66,8 @@ namespace osu.Game.Skinning.Editor
 
         public override void Hide()
         {
-            Debug.Assert(skinEditor != null);
-
             // base call intentionally omitted.
-            skinEditor.Hide();
+            skinEditor?.Hide();
         }
 
         public override void Show()

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -20,6 +22,8 @@ namespace osu.Game.Skinning.Editor
     public class SkinEditorOverlay : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         private readonly ScalingContainer target;
+
+        [CanBeNull]
         private SkinEditor skinEditor;
 
         public const float VISIBLE_TARGET_SCALE = 0.8f;
@@ -62,6 +66,8 @@ namespace osu.Game.Skinning.Editor
 
         public override void Hide()
         {
+            Debug.Assert(skinEditor != null);
+
             // base call intentionally omitted.
             skinEditor.Hide();
         }
@@ -71,8 +77,12 @@ namespace osu.Game.Skinning.Editor
             // base call intentionally omitted.
             if (skinEditor == null)
             {
-                LoadComponentAsync(skinEditor = new SkinEditor(target), AddInternal);
+                skinEditor = new SkinEditor(target);
                 skinEditor.State.BindValueChanged(editorVisibilityChanged);
+
+                Debug.Assert(skinEditor != null);
+
+                LoadComponentAsync(skinEditor, AddInternal);
             }
             else
                 skinEditor.Show();
@@ -98,8 +108,13 @@ namespace osu.Game.Skinning.Editor
             }
         }
 
-        private void updateMasking() =>
+        private void updateMasking()
+        {
+            if (skinEditor == null)
+                return;
+
             target.Masking = skinEditor.State.Value == Visibility.Visible;
+        }
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {


### PR DESCRIPTION
As reported at https://github.com/ppy/osu/discussions/14850#discussioncomment-1399382.

I don't believe this is the only problem (as it doesn't explain the crashes on save). That looks like a database issue.