### PR TITLE
Split `ArchiveModelManager` into two pieces

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -32,12 +32,15 @@ namespace osu.Game.Beatmaps
     public class BeatmapManager : IModelDownloader<BeatmapSetInfo>, IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, ICanAcceptFiles, IWorkingBeatmapCache
     {
         private readonly BeatmapModelManager beatmapModelManager;
+        private readonly BeatmapModelDownloader beatmapModelDownloader;
+
         private readonly WorkingBeatmapCache workingBeatmapCache;
 
         public BeatmapManager(Storage storage, IDatabaseContextFactory contextFactory, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host = null,
                               WorkingBeatmap defaultBeatmap = null, bool performOnlineLookups = false)
         {
             beatmapModelManager = CreateBeatmapModelManager(storage, contextFactory, rulesets, api, host);
+            beatmapModelDownloader = CreateBeatmapModelDownloader(beatmapModelManager, api, host);
             workingBeatmapCache = CreateWorkingBeatmapCache(audioManager, resources, new FileStore(contextFactory, storage).Store, defaultBeatmap, host);
 
             workingBeatmapCache.BeatmapManager = beatmapModelManager;
@@ -49,11 +52,16 @@ namespace osu.Game.Beatmaps
             }
         }
 
+        protected virtual BeatmapModelDownloader CreateBeatmapModelDownloader(BeatmapModelManager modelManager, IAPIProvider api, GameHost host)
+        {
+            return new BeatmapModelDownloader(modelManager, api, host);
+        }
+
         protected virtual WorkingBeatmapCache CreateWorkingBeatmapCache(AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> storage, WorkingBeatmap defaultBeatmap, GameHost host) =>
             new WorkingBeatmapCache(audioManager, resources, storage, defaultBeatmap, host);
 
         protected virtual BeatmapModelManager CreateBeatmapModelManager(Storage storage, IDatabaseContextFactory contextFactory, RulesetStore rulesets, IAPIProvider api, GameHost host) =>
-            new BeatmapModelManager(storage, contextFactory, rulesets, api, host);
+            new BeatmapModelManager(storage, contextFactory, rulesets, host);
 
         /// <summary>
         /// Create a new <see cref="WorkingBeatmap"/>.
@@ -156,7 +164,14 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Fired when a notification should be presented to the user.
         /// </summary>
-        public Action<Notification> PostNotification { set => beatmapModelManager.PostNotification = value; }
+        public Action<Notification> PostNotification
+        {
+            set
+            {
+                beatmapModelManager.PostNotification = value;
+                beatmapModelDownloader.PostNotification = value;
+            }
+        }
 
         /// <summary>
         /// Fired when the user requests to view the resulting import.
@@ -178,6 +193,11 @@ namespace osu.Game.Beatmaps
         #endregion
 
         #region Implementation of IModelManager<BeatmapSetInfo>
+
+        public bool IsAvailableLocally(BeatmapSetInfo model)
+        {
+            return beatmapModelManager.IsAvailableLocally(model);
+        }
 
         public IBindable<WeakReference<BeatmapSetInfo>> ItemUpdated => beatmapModelManager.ItemUpdated;
 
@@ -227,23 +247,18 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IModelDownloader<BeatmapSetInfo>
 
-        public IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> DownloadBegan => beatmapModelManager.DownloadBegan;
+        public IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> DownloadBegan => beatmapModelDownloader.DownloadBegan;
 
-        public IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> DownloadFailed => beatmapModelManager.DownloadFailed;
-
-        public bool IsAvailableLocally(BeatmapSetInfo model)
-        {
-            return beatmapModelManager.IsAvailableLocally(model);
-        }
+        public IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> DownloadFailed => beatmapModelDownloader.DownloadFailed;
 
         public bool Download(BeatmapSetInfo model, bool minimiseDownloadSize = false)
         {
-            return beatmapModelManager.Download(model, minimiseDownloadSize);
+            return beatmapModelDownloader.Download(model, minimiseDownloadSize);
         }
 
         public ArchiveDownloadRequest<BeatmapSetInfo> GetExistingDownload(BeatmapSetInfo model)
         {
-            return beatmapModelManager.GetExistingDownload(model);
+            return beatmapModelDownloader.GetExistingDownload(model);
         }
 
         #endregion

--- a/osu.Game/Beatmaps/BeatmapModelDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapModelDownloader.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Platform;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+
+namespace osu.Game.Beatmaps
+{
+    public class BeatmapModelDownloader : ModelDownloader<BeatmapSetInfo>
+    {
+        protected override ArchiveDownloadRequest<BeatmapSetInfo> CreateDownloadRequest(BeatmapSetInfo set, bool minimiseDownloadSize) =>
+            new DownloadBeatmapSetRequest(set, minimiseDownloadSize);
+
+        public BeatmapModelDownloader(BeatmapModelManager beatmapModelManager, IAPIProvider api, GameHost host = null)
+            : base(beatmapModelManager, api, host)
+        {
+        }
+    }
+}

--- a/osu.Game/Collections/CollectionManager.cs
+++ b/osu.Game/Collections/CollectionManager.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.IO.Legacy;
 using osu.Game.Overlays.Notifications;
@@ -27,7 +28,7 @@ namespace osu.Game.Collections
     /// This is currently reading and writing from the osu-stable file format. This is a temporary arrangement until we refactor the
     /// database backing the game. Going forward writing should be done in a similar way to other model stores.
     /// </remarks>
-    public class CollectionManager : Component
+    public class CollectionManager : Component, IPostNotifications
     {
         /// <summary>
         /// Database version in stable-compatible YYYYMMDD format.
@@ -106,9 +107,6 @@ namespace osu.Game.Collections
             backgroundSave();
         });
 
-        /// <summary>
-        /// Set an endpoint for notifications to be posted to.
-        /// </summary>
         public Action<Notification> PostNotification { protected get; set; }
 
         /// <summary>

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -57,9 +57,6 @@ namespace osu.Game.Database
         /// </summary>
         private static readonly ThreadedTaskScheduler import_scheduler_low_priority = new ThreadedTaskScheduler(import_queue_request_concurrency, nameof(ArchiveModelManager<TModel, TFileModel>));
 
-        /// <summary>
-        /// Set an endpoint for notifications to be posted to.
-        /// </summary>
         public Action<Notification> PostNotification { protected get; set; }
 
         /// <summary>

--- a/osu.Game/Database/IModelDownloader.cs
+++ b/osu.Game/Database/IModelDownloader.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Database
     /// Represents a <see cref="IModelManager{TModel}"/> that can download new models from an external source.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IModelDownloader<TModel> : IModelManager<TModel>
+    public interface IModelDownloader<TModel> : IPostNotifications
         where TModel : class
     {
         /// <summary>
@@ -25,13 +25,6 @@ namespace osu.Game.Database
         /// This is NOT run on the update thread and should be scheduled.
         /// </summary>
         IBindable<WeakReference<ArchiveDownloadRequest<TModel>>> DownloadFailed { get; }
-
-        /// <summary>
-        /// Checks whether a given <typeparamref name="TModel"/> is already available in the local store.
-        /// </summary>
-        /// <param name="model">The <typeparamref name="TModel"/> whose existence needs to be checked.</param>
-        /// <returns>Whether the <typeparamref name="TModel"/> exists.</returns>
-        bool IsAvailableLocally(TModel model);
 
         /// <summary>
         /// Begin a download for the requested <typeparamref name="TModel"/>.

--- a/osu.Game/Database/IModelManager.cs
+++ b/osu.Game/Database/IModelManager.cs
@@ -123,5 +123,17 @@ namespace osu.Game.Database
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         Task<TModel> Import(TModel item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Checks whether a given <typeparamref name="TModel"/> is already available in the local store.
+        /// </summary>
+        /// <param name="model">The <typeparamref name="TModel"/> whose existence needs to be checked.</param>
+        /// <returns>Whether the <typeparamref name="TModel"/> exists.</returns>
+        bool IsAvailableLocally(TModel model);
+
+        /// <summary>
+        /// A user displayable name for the model type associated with this manager.
+        /// </summary>
+        string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLower()}";
     }
 }

--- a/osu.Game/Database/IModelManager.cs
+++ b/osu.Game/Database/IModelManager.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Database
     /// Represents a model manager that publishes events when <typeparamref name="TModel"/>s are added or removed.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IModelManager<TModel>
+    public interface IModelManager<TModel> : IPostNotifications
         where TModel : class
     {
         /// <summary>

--- a/osu.Game/Database/IPostNotifications.cs
+++ b/osu.Game/Database/IPostNotifications.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Database
+{
+    public interface IPostNotifications
+    {
+        /// <summary>
+        /// And action which will be fired when a notification should be presented to the user.
+        /// </summary>
+        public Action<Notification> PostNotification { set; }
+    }
+}

--- a/osu.Game/Database/IPresentImports.cs
+++ b/osu.Game/Database/IPresentImports.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.Database
+{
+    public interface IPresentImports<TModel>
+        where TModel : class
+    {
+        /// <summary>
+        /// Fired when the user requests to view the resulting import.
+        /// </summary>
+        public Action<IEnumerable<TModel>> PresentImport { set; }
+    }
+}

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -1,29 +1,24 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Humanizer;
-using osu.Framework.Logging;
-using osu.Framework.Platform;
-using osu.Game.Online.API;
-using osu.Game.Overlays.Notifications;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Humanizer;
 using osu.Framework.Bindables;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Online.API;
+using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Database
 {
-    /// <summary>
-    /// An <see cref="ArchiveModelManager{TModel, TFileModel}"/> that has the ability to download models using an <see cref="IAPIProvider"/> and
-    /// import them into the store.
-    /// </summary>
-    /// <typeparam name="TModel">The model type.</typeparam>
-    /// <typeparam name="TFileModel">The associated file join type.</typeparam>
-    public abstract class DownloadableArchiveModelManager<TModel, TFileModel> : ArchiveModelManager<TModel, TFileModel>, IModelDownloader<TModel>
-        where TModel : class, IHasFiles<TFileModel>, IHasPrimaryKey, ISoftDelete, IEquatable<TModel>
-        where TFileModel : class, INamedFileInfo, new()
+    public abstract class ModelDownloader<TModel> : IModelDownloader<TModel>
+        where TModel : class, IHasPrimaryKey, ISoftDelete, IEquatable<TModel>
     {
+        public Action<Notification> PostNotification { protected get; set; }
+
         public IBindable<WeakReference<ArchiveDownloadRequest<TModel>>> DownloadBegan => downloadBegan;
 
         private readonly Bindable<WeakReference<ArchiveDownloadRequest<TModel>>> downloadBegan = new Bindable<WeakReference<ArchiveDownloadRequest<TModel>>>();
@@ -32,18 +27,15 @@ namespace osu.Game.Database
 
         private readonly Bindable<WeakReference<ArchiveDownloadRequest<TModel>>> downloadFailed = new Bindable<WeakReference<ArchiveDownloadRequest<TModel>>>();
 
+        private readonly IModelManager<TModel> modelManager;
         private readonly IAPIProvider api;
 
         private readonly List<ArchiveDownloadRequest<TModel>> currentDownloads = new List<ArchiveDownloadRequest<TModel>>();
 
-        private readonly MutableDatabaseBackedStoreWithFileIncludes<TModel, TFileModel> modelStore;
-
-        protected DownloadableArchiveModelManager(Storage storage, IDatabaseContextFactory contextFactory, IAPIProvider api, MutableDatabaseBackedStoreWithFileIncludes<TModel, TFileModel> modelStore,
-                                                  IIpcHost importHost = null)
-            : base(storage, contextFactory, modelStore, importHost)
+        protected ModelDownloader(IModelManager<TModel> modelManager, IAPIProvider api, IIpcHost importHost = null)
         {
+            this.modelManager = modelManager;
             this.api = api;
-            this.modelStore = modelStore;
         }
 
         /// <summary>
@@ -76,7 +68,7 @@ namespace osu.Game.Database
                 Task.Factory.StartNew(async () =>
                 {
                     // This gets scheduled back to the update thread, but we want the import to run in the background.
-                    var imported = await Import(notification, new ImportTask(filename)).ConfigureAwait(false);
+                    var imported = await modelManager.Import(notification, new ImportTask(filename)).ConfigureAwait(false);
 
                     // for now a failed import will be marked as a failed download for simplicity.
                     if (!imported.Any())
@@ -111,20 +103,9 @@ namespace osu.Game.Database
                 notification.State = ProgressNotificationState.Cancelled;
 
                 if (!(error is OperationCanceledException))
-                    Logger.Error(error, $"{HumanisedModelName.Titleize()} download failed!");
+                    Logger.Error(error, $"{modelManager.HumanisedModelName.Titleize()} download failed!");
             }
         }
-
-        public bool IsAvailableLocally(TModel model) => CheckLocalAvailability(model, modelStore.ConsumableItems.Where(m => !m.DeletePending));
-
-        /// <summary>
-        /// Performs implementation specific comparisons to determine whether a given model is present in the local store.
-        /// </summary>
-        /// <param name="model">The <typeparamref name="TModel"/> whose existence needs to be checked.</param>
-        /// <param name="items">The usable items present in the store.</param>
-        /// <returns>Whether the <typeparamref name="TModel"/> exists.</returns>
-        protected virtual bool CheckLocalAvailability(TModel model, IQueryable<TModel> items)
-            => model.ID > 0 && items.Any(i => i.ID == model.ID && i.Files.Any());
 
         public ArchiveDownloadRequest<TModel> GetExistingDownload(TModel model) => currentDownloads.Find(r => r.Model.Equals(model));
 

--- a/osu.Game/Online/DownloadTrackingComposite.cs
+++ b/osu.Game/Online/DownloadTrackingComposite.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Online
     /// </summary>
     public abstract class DownloadTrackingComposite<TModel, TModelManager> : CompositeDrawable
         where TModel : class, IEquatable<TModel>
-        where TModelManager : class, IModelDownloader<TModel>
+        where TModelManager : class, IModelDownloader<TModel>, IModelManager<TModel>
     {
         protected readonly Bindable<TModel> Model = new Bindable<TModel>();
 
@@ -35,7 +35,7 @@ namespace osu.Game.Online
             Model.Value = model;
         }
 
-        private IBindable<WeakReference<TModel>> managedUpdated;
+        private IBindable<WeakReference<TModel>> managerUpdated;
         private IBindable<WeakReference<TModel>> managerRemoved;
         private IBindable<WeakReference<ArchiveDownloadRequest<TModel>>> managerDownloadBegan;
         private IBindable<WeakReference<ArchiveDownloadRequest<TModel>>> managerDownloadFailed;
@@ -60,8 +60,8 @@ namespace osu.Game.Online
             managerDownloadBegan.BindValueChanged(downloadBegan);
             managerDownloadFailed = Manager.DownloadFailed.GetBoundCopy();
             managerDownloadFailed.BindValueChanged(downloadFailed);
-            managedUpdated = Manager.ItemUpdated.GetBoundCopy();
-            managedUpdated.BindValueChanged(itemUpdated);
+            managerUpdated = Manager.ItemUpdated.GetBoundCopy();
+            managerUpdated.BindValueChanged(itemUpdated);
             managerRemoved = Manager.ItemRemoved.GetBoundCopy();
             managerRemoved.BindValueChanged(itemRemoved);
         }
@@ -77,7 +77,7 @@ namespace osu.Game.Online
 
         /// <summary>
         /// Whether the given model is available in the database.
-        /// By default, this calls <see cref="IModelDownloader{TModel}.IsAvailableLocally"/>,
+        /// By default, this calls <see cref="IModelManager{TModel}.IsAvailableLocally"/>,
         /// but can be overriden to add additional checks for verifying the model in database.
         /// </summary>
         protected virtual bool IsModelAvailableLocally() => Manager?.IsAvailableLocally(Model.Value) == true;

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -9,102 +9,48 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore;
 using osu.Framework.Bindables;
-using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.IO;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring.Legacy;
 
 namespace osu.Game.Scoring
 {
-    public class ScoreManager : DownloadableArchiveModelManager<ScoreInfo, ScoreFileInfo>
+    public class ScoreManager : IModelManager<ScoreInfo>, IModelFileManager<ScoreInfo, ScoreFileInfo>, IModelDownloader<ScoreInfo>, ICanAcceptFiles, IPresentImports<ScoreInfo>
     {
-        public override IEnumerable<string> HandledExtensions => new[] { ".osr" };
-
-        protected override string[] HashableFileTypes => new[] { ".osr" };
-
-        protected override string ImportFromStablePath => Path.Combine("Data", "r");
-
-        private readonly RulesetStore rulesets;
-        private readonly Func<BeatmapManager> beatmaps;
         private readonly Scheduler scheduler;
-
-        [CanBeNull]
         private readonly Func<BeatmapDifficultyCache> difficulties;
-
-        [CanBeNull]
         private readonly OsuConfigManager configManager;
+        private readonly ScoreModelManager scoreModelManager;
+        private readonly ScoreModelDownloader scoreModelDownloader;
 
         public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, IAPIProvider api, IDatabaseContextFactory contextFactory, Scheduler scheduler,
                             IIpcHost importHost = null, Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
-            : base(storage, contextFactory, api, new ScoreStore(contextFactory, storage), importHost)
         {
-            this.rulesets = rulesets;
-            this.beatmaps = beatmaps;
             this.scheduler = scheduler;
             this.difficulties = difficulties;
             this.configManager = configManager;
+
+            scoreModelManager = new ScoreModelManager(rulesets, beatmaps, storage, contextFactory, importHost);
+            scoreModelDownloader = new ScoreModelDownloader(scoreModelManager, api, importHost);
         }
 
-        protected override ScoreInfo CreateModel(ArchiveReader archive)
-        {
-            if (archive == null)
-                return null;
+        public Score GetScore(ScoreInfo score) => scoreModelManager.GetScore(score);
 
-            using (var stream = archive.GetStream(archive.Filenames.First(f => f.EndsWith(".osr", StringComparison.OrdinalIgnoreCase))))
-            {
-                try
-                {
-                    return new DatabasedLegacyScoreDecoder(rulesets, beatmaps()).Parse(stream).ScoreInfo;
-                }
-                catch (LegacyScoreDecoder.BeatmapNotFoundException e)
-                {
-                    Logger.Log(e.Message, LoggingTarget.Information, LogLevel.Error);
-                    return null;
-                }
-            }
-        }
+        public List<ScoreInfo> GetAllUsableScores() => scoreModelManager.GetAllUsableScores();
 
-        protected override Task Populate(ScoreInfo model, ArchiveReader archive, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
+        public IEnumerable<ScoreInfo> QueryScores(Expression<Func<ScoreInfo, bool>> query) => scoreModelManager.QueryScores(query);
 
-        public override void ExportModelTo(ScoreInfo model, Stream outputStream)
-        {
-            var file = model.Files.SingleOrDefault();
-            if (file == null)
-                return;
-
-            using (var inputStream = Files.Storage.GetStream(file.FileInfo.StoragePath))
-                inputStream.CopyTo(outputStream);
-        }
-
-        protected override IEnumerable<string> GetStableImportPaths(Storage storage)
-            => storage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
-                      .Select(path => storage.GetFullPath(path));
-
-        public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
-
-        public List<ScoreInfo> GetAllUsableScores() => ModelStore.ConsumableItems.Where(s => !s.DeletePending).ToList();
-
-        public IEnumerable<ScoreInfo> QueryScores(Expression<Func<ScoreInfo, bool>> query) => ModelStore.ConsumableItems.AsNoTracking().Where(query);
-
-        public ScoreInfo Query(Expression<Func<ScoreInfo, bool>> query) => ModelStore.ConsumableItems.AsNoTracking().FirstOrDefault(query);
-
-        protected override ArchiveDownloadRequest<ScoreInfo> CreateDownloadRequest(ScoreInfo score, bool minimiseDownload) => new DownloadReplayRequest(score);
-
-        protected override bool CheckLocalAvailability(ScoreInfo model, IQueryable<ScoreInfo> items)
-            => base.CheckLocalAvailability(model, items)
-               || (model.OnlineScoreID != null && items.Any(i => i.OnlineScoreID == model.OnlineScoreID));
+        public ScoreInfo Query(Expression<Func<ScoreInfo, bool>> query) => scoreModelManager.Query(query);
 
         /// <summary>
         /// Orders an array of <see cref="ScoreInfo"/>s by total score.
@@ -281,5 +227,149 @@ namespace osu.Game.Scoring
                 this.totalScore.BindValueChanged(v => Value = v.NewValue.ToString("N0"), true);
             }
         }
+
+        #region Implementation of IPostNotifications
+
+        public Action<Notification> PostNotification
+        {
+            set
+            {
+                scoreModelManager.PostNotification = value;
+                scoreModelDownloader.PostNotification = value;
+            }
+        }
+
+        #endregion
+
+        #region Implementation of IModelManager<ScoreInfo>
+
+        public IBindable<WeakReference<ScoreInfo>> ItemUpdated => scoreModelManager.ItemUpdated;
+
+        public IBindable<WeakReference<ScoreInfo>> ItemRemoved => scoreModelManager.ItemRemoved;
+
+        public Task ImportFromStableAsync(StableStorage stableStorage)
+        {
+            return scoreModelManager.ImportFromStableAsync(stableStorage);
+        }
+
+        public void Export(ScoreInfo item)
+        {
+            scoreModelManager.Export(item);
+        }
+
+        public void ExportModelTo(ScoreInfo model, Stream outputStream)
+        {
+            scoreModelManager.ExportModelTo(model, outputStream);
+        }
+
+        public void Update(ScoreInfo item)
+        {
+            scoreModelManager.Update(item);
+        }
+
+        public bool Delete(ScoreInfo item)
+        {
+            return scoreModelManager.Delete(item);
+        }
+
+        public void Delete(List<ScoreInfo> items, bool silent = false)
+        {
+            scoreModelManager.Delete(items, silent);
+        }
+
+        public void Undelete(List<ScoreInfo> items, bool silent = false)
+        {
+            scoreModelManager.Undelete(items, silent);
+        }
+
+        public void Undelete(ScoreInfo item)
+        {
+            scoreModelManager.Undelete(item);
+        }
+
+        public Task Import(params string[] paths)
+        {
+            return scoreModelManager.Import(paths);
+        }
+
+        public Task Import(params ImportTask[] tasks)
+        {
+            return scoreModelManager.Import(tasks);
+        }
+
+        public IEnumerable<string> HandledExtensions => scoreModelManager.HandledExtensions;
+
+        public Task<IEnumerable<ScoreInfo>> Import(ProgressNotification notification, params ImportTask[] tasks)
+        {
+            return scoreModelManager.Import(notification, tasks);
+        }
+
+        public Task<ScoreInfo> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
+        {
+            return scoreModelManager.Import(task, lowPriority, cancellationToken);
+        }
+
+        public Task<ScoreInfo> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
+        {
+            return scoreModelManager.Import(archive, lowPriority, cancellationToken);
+        }
+
+        public Task<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
+        {
+            return scoreModelManager.Import(item, archive, lowPriority, cancellationToken);
+        }
+
+        public bool IsAvailableLocally(ScoreInfo model)
+        {
+            return scoreModelManager.IsAvailableLocally(model);
+        }
+
+        #endregion
+
+        #region Implementation of IModelFileManager<in ScoreInfo,in ScoreFileInfo>
+
+        public void ReplaceFile(ScoreInfo model, ScoreFileInfo file, Stream contents, string filename = null)
+        {
+            scoreModelManager.ReplaceFile(model, file, contents, filename);
+        }
+
+        public void DeleteFile(ScoreInfo model, ScoreFileInfo file)
+        {
+            scoreModelManager.DeleteFile(model, file);
+        }
+
+        public void AddFile(ScoreInfo model, Stream contents, string filename)
+        {
+            scoreModelManager.AddFile(model, contents, filename);
+        }
+
+        #endregion
+
+        #region Implementation of IModelDownloader<ScoreInfo>
+
+        public IBindable<WeakReference<ArchiveDownloadRequest<ScoreInfo>>> DownloadBegan => scoreModelDownloader.DownloadBegan;
+
+        public IBindable<WeakReference<ArchiveDownloadRequest<ScoreInfo>>> DownloadFailed => scoreModelDownloader.DownloadFailed;
+
+        public bool Download(ScoreInfo model, bool minimiseDownloadSize)
+        {
+            return scoreModelDownloader.Download(model, minimiseDownloadSize);
+        }
+
+        public ArchiveDownloadRequest<ScoreInfo> GetExistingDownload(ScoreInfo model)
+        {
+            return scoreModelDownloader.GetExistingDownload(model);
+        }
+
+        #endregion
+
+        #region Implementation of IPresentImports<ScoreInfo>
+
+        public Action<IEnumerable<ScoreInfo>> PresentImport
+        {
+            set => scoreModelManager.PresentImport = value;
+        }
+
+        #endregion
     }
 }

--- a/osu.Game/Scoring/ScoreModelDownloader.cs
+++ b/osu.Game/Scoring/ScoreModelDownloader.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Platform;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+
+namespace osu.Game.Scoring
+{
+    public class ScoreModelDownloader : ModelDownloader<ScoreInfo>
+    {
+        public ScoreModelDownloader(ScoreModelManager scoreManager, IAPIProvider api, IIpcHost importHost = null)
+            : base(scoreManager, api, importHost)
+        {
+        }
+
+        protected override ArchiveDownloadRequest<ScoreInfo> CreateDownloadRequest(ScoreInfo score, bool minimiseDownload) => new DownloadReplayRequest(score);
+    }
+}

--- a/osu.Game/Scoring/ScoreModelManager.cs
+++ b/osu.Game/Scoring/ScoreModelManager.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.IO.Archives;
+using osu.Game.Rulesets;
+using osu.Game.Scoring.Legacy;
+
+namespace osu.Game.Scoring
+{
+    public class ScoreModelManager : ArchiveModelManager<ScoreInfo, ScoreFileInfo>
+    {
+        public override IEnumerable<string> HandledExtensions => new[] { ".osr" };
+
+        protected override string[] HashableFileTypes => new[] { ".osr" };
+
+        protected override string ImportFromStablePath => Path.Combine("Data", "r");
+
+        private readonly RulesetStore rulesets;
+        private readonly Func<BeatmapManager> beatmaps;
+
+        public ScoreModelManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, IDatabaseContextFactory contextFactory, IIpcHost importHost = null)
+            : base(storage, contextFactory, new ScoreStore(contextFactory, storage), importHost)
+        {
+            this.rulesets = rulesets;
+            this.beatmaps = beatmaps;
+        }
+
+        protected override ScoreInfo CreateModel(ArchiveReader archive)
+        {
+            if (archive == null)
+                return null;
+
+            using (var stream = archive.GetStream(archive.Filenames.First(f => f.EndsWith(".osr", StringComparison.OrdinalIgnoreCase))))
+            {
+                try
+                {
+                    return new DatabasedLegacyScoreDecoder(rulesets, beatmaps()).Parse(stream).ScoreInfo;
+                }
+                catch (LegacyScoreDecoder.BeatmapNotFoundException e)
+                {
+                    Logger.Log(e.Message, LoggingTarget.Information, LogLevel.Error);
+                    return null;
+                }
+            }
+        }
+
+        public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
+
+        public List<ScoreInfo> GetAllUsableScores() => ModelStore.ConsumableItems.Where(s => !s.DeletePending).ToList();
+
+        public IEnumerable<ScoreInfo> QueryScores(Expression<Func<ScoreInfo, bool>> query) => ModelStore.ConsumableItems.AsNoTracking().Where(query);
+
+        public ScoreInfo Query(Expression<Func<ScoreInfo, bool>> query) => ModelStore.ConsumableItems.AsNoTracking().FirstOrDefault(query);
+
+        protected override Task Populate(ScoreInfo model, ArchiveReader archive, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        protected override bool CheckLocalAvailability(ScoreInfo model, IQueryable<ScoreInfo> items)
+            => base.CheckLocalAvailability(model, items)
+               || (model.OnlineScoreID != null && items.Any(i => i.OnlineScoreID == model.OnlineScoreID));
+
+        public override void ExportModelTo(ScoreInfo model, Stream outputStream)
+        {
+            var file = model.Files.SingleOrDefault();
+            if (file == null)
+                return;
+
+            using (var inputStream = Files.Storage.GetStream(file.FileInfo.StoragePath))
+                inputStream.CopyTo(outputStream);
+        }
+
+        protected override IEnumerable<string> GetStableImportPaths(Storage storage)
+            => storage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
+                      .Select(path => storage.GetFullPath(path));
+    }
+}

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Ranking
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuGame game, ScoreManager scores)
+        private void load(OsuGame game, ScoreModelDownloader scores)
         {
             InternalChild = shakeContainer = new ShakeContainer
             {

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Tests.Visual
             internal class TestBeatmapModelManager : BeatmapModelManager
             {
                 public TestBeatmapModelManager(Storage storage, IDatabaseContextFactory databaseContextFactory, RulesetStore rulesetStore, IAPIProvider apiProvider, GameHost gameHost)
-                    : base(storage, databaseContextFactory, rulesetStore, apiProvider, gameHost)
+                    : base(storage, databaseContextFactory, rulesetStore, gameHost)
                 {
                 }
 


### PR DESCRIPTION
Seprates out download support into a separate class, rather than using subclassing.

In the process I also needed to decompose `ScoreManger`, so that's bundled in here (had to be done eventually anyway).

- [x] Depends on https://github.com/ppy/osu/pull/14899