### PR TITLE
Split importer interface out of `IModelManager`

### DIFF
--- a/osu.Game/Database/IModelImporter.cs
+++ b/osu.Game/Database/IModelImporter.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Game.IO.Archives;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Database
+{
+    /// <summary>
+    /// A class which handles importing of asociated models to the game store.
+    /// </summary>
+    /// <typeparam name="TModel">The model type.</typeparam>
+    public interface IModelImporter<TModel> : IPostNotifications
+        where TModel : class
+    {
+        /// <summary>
+        /// Import one or more <typeparamref name="TModel"/> items from filesystem <paramref name="paths"/>.
+        /// </summary>
+        /// <remarks>
+        /// This will be treated as a low priority import if more than one path is specified; use <see cref="ArchiveModelManager{TModel,TFileModel}.Import(osu.Game.Database.ImportTask[])"/> to always import at standard priority.
+        /// This will post notifications tracking progress.
+        /// </remarks>
+        /// <param name="paths">One or more archive locations on disk.</param>
+        Task Import(params string[] paths);
+
+        Task Import(params ImportTask[] tasks);
+
+        Task<IEnumerable<TModel>> Import(ProgressNotification notification, params ImportTask[] tasks);
+
+        /// <summary>
+        /// Import one <typeparamref name="TModel"/> from the filesystem and delete the file on success.
+        /// Note that this bypasses the UI flow and should only be used for special cases or testing.
+        /// </summary>
+        /// <param name="task">The <see cref="ImportTask"/> containing data about the <typeparamref name="TModel"/> to import.</param>
+        /// <param name="lowPriority">Whether this is a low priority import.</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        /// <returns>The imported model, if successful.</returns>
+        Task<TModel> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Silently import an item from an <see cref="ArchiveReader"/>.
+        /// </summary>
+        /// <param name="archive">The archive to be imported.</param>
+        /// <param name="lowPriority">Whether this is a low priority import.</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        Task<TModel> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Silently import an item from a <typeparamref name="TModel"/>.
+        /// </summary>
+        /// <param name="item">The model to be imported.</param>
+        /// <param name="archive">An optional archive to use for model population.</param>
+        /// <param name="lowPriority">Whether this is a low priority import.</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        Task<TModel> Import(TModel item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// A user displayable name for the model type associated with this manager.
+        /// </summary>
+        string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLower()}";
+    }
+}

--- a/osu.Game/Database/IModelManager.cs
+++ b/osu.Game/Database/IModelManager.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Database
     /// Represents a model manager that publishes events when <typeparamref name="TModel"/>s are added or removed.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IModelManager<TModel> : IModelImporter<TModel>, IPostNotifications
+    public interface IModelManager<TModel> : IModelImporter<TModel>
         where TModel : class
     {
         /// <summary>

--- a/osu.Game/Database/IModelManager.cs
+++ b/osu.Game/Database/IModelManager.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Game.IO;
-using osu.Game.IO.Archives;
-using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Database
 {
@@ -17,7 +14,7 @@ namespace osu.Game.Database
     /// Represents a model manager that publishes events when <typeparamref name="TModel"/>s are added or removed.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IModelManager<TModel> : IPostNotifications
+    public interface IModelManager<TModel> : IModelImporter<TModel>, IPostNotifications
         where TModel : class
     {
         /// <summary>
@@ -84,56 +81,10 @@ namespace osu.Game.Database
         void Undelete(TModel item);
 
         /// <summary>
-        /// Import one or more <typeparamref name="TModel"/> items from filesystem <paramref name="paths"/>.
-        /// </summary>
-        /// <remarks>
-        /// This will be treated as a low priority import if more than one path is specified; use <see cref="ArchiveModelManager{TModel,TFileModel}.Import(osu.Game.Database.ImportTask[])"/> to always import at standard priority.
-        /// This will post notifications tracking progress.
-        /// </remarks>
-        /// <param name="paths">One or more archive locations on disk.</param>
-        Task Import(params string[] paths);
-
-        Task Import(params ImportTask[] tasks);
-
-        Task<IEnumerable<TModel>> Import(ProgressNotification notification, params ImportTask[] tasks);
-
-        /// <summary>
-        /// Import one <typeparamref name="TModel"/> from the filesystem and delete the file on success.
-        /// Note that this bypasses the UI flow and should only be used for special cases or testing.
-        /// </summary>
-        /// <param name="task">The <see cref="ImportTask"/> containing data about the <typeparamref name="TModel"/> to import.</param>
-        /// <param name="lowPriority">Whether this is a low priority import.</param>
-        /// <param name="cancellationToken">An optional cancellation token.</param>
-        /// <returns>The imported model, if successful.</returns>
-        Task<TModel> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Silently import an item from an <see cref="ArchiveReader"/>.
-        /// </summary>
-        /// <param name="archive">The archive to be imported.</param>
-        /// <param name="lowPriority">Whether this is a low priority import.</param>
-        /// <param name="cancellationToken">An optional cancellation token.</param>
-        Task<TModel> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Silently import an item from a <typeparamref name="TModel"/>.
-        /// </summary>
-        /// <param name="item">The model to be imported.</param>
-        /// <param name="archive">An optional archive to use for model population.</param>
-        /// <param name="lowPriority">Whether this is a low priority import.</param>
-        /// <param name="cancellationToken">An optional cancellation token.</param>
-        Task<TModel> Import(TModel item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Checks whether a given <typeparamref name="TModel"/> is already available in the local store.
         /// </summary>
         /// <param name="model">The <typeparamref name="TModel"/> whose existence needs to be checked.</param>
         /// <returns>Whether the <typeparamref name="TModel"/> exists.</returns>
         bool IsAvailableLocally(TModel model);
-
-        /// <summary>
-        /// A user displayable name for the model type associated with this manager.
-        /// </summary>
-        string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLower()}";
     }
 }


### PR DESCRIPTION
The new interface complies with the realm implementation, except that the returned types are not yet marked as `Live<>`.

- [x] Depends on #14900.