### PR TITLE
Fix 'Reset all bindings in section' button appearing when it shouldn't during searches

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings.Sections.Input;
 using osuTK.Input;
@@ -228,6 +229,22 @@ namespace osu.Game.Tests.Visual.Settings
             });
 
             AddAssert("first binding selected", () => multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().IsBinding);
+        }
+
+        [Test]
+        public void TestFilteringHidesResetSectionButtons()
+        {
+            SearchTextBox searchTextBox = null;
+
+            AddStep("add any search term", () =>
+            {
+                searchTextBox = panel.ChildrenOfType<SearchTextBox>().Single();
+                searchTextBox.Current.Value = "chat";
+            });
+            AddUntilStep("all reset section bindings buttons hidden", () => panel.ChildrenOfType<ResetButton>().All(button => button.Alpha == 0));
+
+            AddStep("clear search term", () => searchTextBox.Current.Value = string.Empty);
+            AddUntilStep("all reset section bindings buttons shown", () => panel.ChildrenOfType<ResetButton>().All(button => button.Alpha == 1));
         }
 
         private void checkBinding(string name, string keyName)

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -75,5 +75,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             Content.CornerRadius = 5;
         }
+
+        public override IEnumerable<string> FilterTerms => Enumerable.Empty<string>();
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             Content.CornerRadius = 5;
         }
 
+        // Empty FilterTerms so that the ResetButton is visible only when the whole subsection is visible.
         public override IEnumerable<string> FilterTerms => Enumerable.Empty<string>();
     }
 }


### PR DESCRIPTION
  The button will now appear if and only if all the bindings in its section are visible (not filtered out by the search).
  
  Discussed in https://github.com/ppy/osu/discussions/14877. (Should I have converted that discussion to issue?)