### PR TITLE
Implement Relax difficulty calculation in osu!

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
             double flashlightRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
 
+            if (mods.Any(h => h is OsuModRelax))
+                speedRating = 0.0;
+
             double baseAimPerformance = Math.Pow(5 * Math.Max(1, aimRating / 0.0675) - 4, 3) / 100000;
             double baseSpeedPerformance = Math.Pow(5 * Math.Max(1, speedRating / 0.0675) - 4, 3) / 100000;
             double baseFlashlightPerformance = 0.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -40,11 +40,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             countMeh = Score.Statistics.GetValueOrDefault(HitResult.Meh);
             countMiss = Score.Statistics.GetValueOrDefault(HitResult.Miss);
 
-            if (mods.Any(h => h is OsuModRelax))
-            {
-                countMiss += countOk + countMeh;
-            }
-
             // Custom multipliers for NoFail and SpunOut.
             double multiplier = 1.12; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
@@ -53,6 +48,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(m => m is OsuModSpunOut))
                 multiplier *= 1.0 - Math.Pow((double)Attributes.SpinnerCount / totalHits, 0.85);
+
+            if (mods.Any(h => h is OsuModRelax))
+            {
+                countMiss += countOk + countMeh;
+                multiplier *= 0.6;
+            }
 
             double aimValue = computeAimValue();
             double speedValue = computeSpeedValue();
@@ -95,11 +96,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             aimValue *= lengthBonus;
 
-            if (mods.Any(h => h is OsuModRelax))
-            {
-                aimValue *= 0.6;
-            }
-
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
                 aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), countMiss);
@@ -135,11 +131,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private double computeSpeedValue()
         {
             double speedValue = Math.Pow(5.0 * Math.Max(1.0, Attributes.SpeedStrain / 0.0675) - 4.0, 3.0) / 100000.0;
-
-            if (mods.Any(h => h is OsuModRelax))
-            {
-                speedValue *= 0.6;
-            }
 
             // Longer maps are worth more.
             double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
@@ -221,11 +212,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // Add an additional bonus for HDFL.
             if (mods.Any(h => h is OsuModHidden))
                 flashlightValue *= 1.3;
-
-            if (mods.Any(h => h is OsuModRelax))
-            {
-                flashlightValue *= 0.6;
-            }
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -40,6 +40,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             countMeh = Score.Statistics.GetValueOrDefault(HitResult.Meh);
             countMiss = Score.Statistics.GetValueOrDefault(HitResult.Miss);
 
+            if (mods.Any(h => h is OsuModRelax))
+            {
+                countMiss += countOk + countMeh;
+            }
+
             // Custom multipliers for NoFail and SpunOut.
             double multiplier = 1.12; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
@@ -92,8 +97,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(h => h is OsuModRelax))
             {
-                aimValue *= 0.75;
-                countMiss += countOk + countMeh;
+                aimValue *= 0.6;
             }
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
@@ -134,8 +138,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(h => h is OsuModRelax))
             {
-                speedValue *= 0.75;
-                countMiss += countOk + countMeh;
+                speedValue *= 0.6;
             }
 
             // Longer maps are worth more.
@@ -218,6 +221,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // Add an additional bonus for HDFL.
             if (mods.Any(h => h is OsuModHidden))
                 flashlightValue *= 1.3;
+
+            if (mods.Any(h => h is OsuModRelax))
+            {
+                flashlightValue *= 0.6;
+            }
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -90,6 +90,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             aimValue *= lengthBonus;
 
+            if (mods.Any(h => h is OsuModRelax))
+            {
+                aimValue *= 0.75;
+                countMiss += countOk + countMeh;
+            }
+
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
                 aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), countMiss);
@@ -126,6 +132,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             double speedValue = Math.Pow(5.0 * Math.Max(1.0, Attributes.SpeedStrain / 0.0675) - 4.0, 3.0) / 100000.0;
 
+            if (mods.Any(h => h is OsuModRelax))
+            {
+                speedValue *= 0.75;
+                countMiss += countOk + countMeh;
+            }
+
             // Longer maps are worth more.
             double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
                                  (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
@@ -160,6 +172,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private double computeAccuracyValue()
         {
+            if (mods.Any(h => h is OsuModRelax))
+                return 0.0;
+
             // This percentage only considers HitCircles of any value - in this part of the calculation we focus on hitting the timing hit window.
             double betterAccuracyPercentage;
             int amountHitObjectsWithAccuracy = Attributes.HitCircleCount;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -7,8 +7,6 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Framework.Utils;
-using System.Linq;
-using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -81,9 +81,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 }
             }
 
-            if (Mods.Any(m => m is OsuModRelax))
-                speedBonus = 0.0;
-
             return (1 + (speedBonus - 1) * 0.75)
                    * angleBonus
                    * (0.95 + speedBonus * Math.Pow(distance / single_spacing_threshold, 3.5))

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -7,6 +7,8 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Framework.Utils;
+using System.Linq;
+using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
@@ -78,6 +80,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                         angleBonus += (1 - angleBonus) * Math.Min((90 - distance) / 10, 1) * Math.Sin((pi_over_2 - osuCurrent.Angle.Value) / pi_over_4);
                 }
             }
+
+            if (Mods.Any(m => m is OsuModRelax))
+                speedBonus = 0.0;
 
             return (1 + (speedBonus - 1) * 0.75)
                    * angleBonus


### PR DESCRIPTION
Since it was confirmed that automation mods like Relax and Autopilot will be submitting to leaderboards in lazer, I thought I'd go ahead and start accounting for it in osu! difficulty calculation. I'm not sure whether Relax scores will be processed and assigned a pp value in the first place, especially with profile top plays in mind, but I have balanced the values so that relax and non-relax scores could theoretically co-exist. This was done with feedback.

This is done by the following:

- Return 0 for accuracy pp. Not requiring to tap means not needing to tap accurately.
- Set `speedBonus` to 0 in the Speed skill. This means Speed should only return distance-related values (flow aim). This also means Relax will change the SR of a map.
- Add 100s and 50s to the miss count. You have to really mess up aiming to get a 100 or a 50, so we harshen the penalty so that score performance calculator sees those as misses.
- Apply a flat 0.6x nerf to Aim and Speed. Aiming with relax is easier, since you can essentially "fling" your cursor without worrying about tapping or being on time and you can still hit circles.

Example values (these RX scores are real scores set): https://hastebin.com/raw/izuwacuren

And just saying for lurkers: not intended for stable by any means, of course.