### PR TITLE
Add alternate Torus font

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.918.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2021.929.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuFont.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuFont.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneOsuFont : OsuTestScene
+    {
+        private OsuSpriteText spriteText;
+
+        private readonly BindableBool useAlternates = new BindableBool();
+        private readonly Bindable<FontWeight> weight = new Bindable<FontWeight>(FontWeight.Regular);
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = spriteText = new OsuSpriteText
+            {
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                RelativeSizeAxes = Axes.X,
+                AllowMultiline = true,
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            useAlternates.BindValueChanged(_ => updateFont());
+            weight.BindValueChanged(_ => updateFont(), true);
+        }
+
+        private void updateFont()
+        {
+            FontUsage usage = useAlternates.Value ? OsuFont.TorusAlternate : OsuFont.Torus;
+            spriteText.Font = usage.With(size: 40, weight: weight.Value);
+        }
+
+        [Test]
+        public void TestTorusAlternates()
+        {
+            AddStep("set all ASCII letters", () => spriteText.Text = @"ABCDEFGHIJKLMNOPQRSTUVWXYZ
+abcdefghijklmnopqrstuvwxyz");
+            AddStep("set all alternates", () => spriteText.Text = @"A Á Ă Â Ä À Ā Ą Å Ã
+Æ B D Ð Ď Đ E É Ě Ê
+Ë Ė È Ē Ę F G Ğ Ģ Ġ
+H I Í Î Ï İ Ì Ī Į K
+Ķ O Œ P Þ Q R Ŕ Ř Ŗ
+T Ŧ Ť Ţ Ț V W Ẃ Ŵ Ẅ
+Ẁ X Y Ý Ŷ Ÿ Ỳ a á ă
+â ä à ā ą å ã æ b d
+ď đ e é ě ê ë ė è ē
+ę f g ğ ģ ġ k ķ m n
+ń ň ņ ŋ ñ o œ p þ q
+t ŧ ť ţ ț u ú û ü ù
+ű ū ų ů w ẃ ŵ ẅ ẁ x
+y ý ŷ ÿ ỳ");
+
+            AddToggleStep("toggle alternates", alternates => useAlternates.Value = alternates);
+
+            addSetWeightStep(FontWeight.Light);
+            addSetWeightStep(FontWeight.Regular);
+            addSetWeightStep(FontWeight.SemiBold);
+            addSetWeightStep(FontWeight.Bold);
+
+            void addSetWeightStep(FontWeight newWeight) => AddStep($"set weight {newWeight}", () => weight.Value = newWeight);
+        }
+    }
+}

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Graphics
 
         public static FontUsage Torus => GetFont(Typeface.Torus, weight: FontWeight.Regular);
 
+        public static FontUsage TorusAlternate => GetFont(Typeface.TorusAlternate, weight: FontWeight.Regular);
+
         public static FontUsage Inter => GetFont(Typeface.Inter, weight: FontWeight.Regular);
 
         /// <summary>
@@ -56,6 +58,9 @@ namespace osu.Game.Graphics
 
                 case Typeface.Torus:
                     return "Torus";
+
+                case Typeface.TorusAlternate:
+                    return "Torus-Alternate";
 
                 case Typeface.Inter:
                     return "Inter";
@@ -113,6 +118,7 @@ namespace osu.Game.Graphics
     {
         Venera,
         Torus,
+        TorusAlternate,
         Inter,
     }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -347,6 +347,11 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Torus/Torus-SemiBold");
             AddFont(Resources, @"Fonts/Torus/Torus-Bold");
 
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Regular");
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Light");
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-SemiBold");
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Bold");
+
             AddFont(Resources, @"Fonts/Inter/Inter-Regular");
             AddFont(Resources, @"Fonts/Inter/Inter-RegularItalic");
             AddFont(Resources, @"Fonts/Inter/Inter-Light");

--- a/osu.Game/Screens/OnlinePlay/Header.cs
+++ b/osu.Game/Screens/OnlinePlay/Header.cs
@@ -72,21 +72,21 @@ namespace osu.Game.Screens.OnlinePlay
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
-                                Font = OsuFont.GetFont(size: 24),
+                                Font = OsuFont.TorusAlternate.With(size: 24),
                                 Text = mainTitle
                             },
                             dot = new OsuSpriteText
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
-                                Font = OsuFont.GetFont(size: 24),
+                                Font = OsuFont.TorusAlternate.With(size: 24),
                                 Text = "·"
                             },
                             pageTitle = new OsuSpriteText
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
-                                Font = OsuFont.GetFont(size: 24),
+                                Font = OsuFont.TorusAlternate.With(size: 24),
                                 Text = "Lounge"
                             }
                         }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.929.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.918.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.929.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.918.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/155

This pull adds integration of alternate Torus assets from the above pull, adds a test scene to preview differences between the variants:

https://user-images.githubusercontent.com/20418176/135773943-c773876a-5cca-4e4a-97c6-7c77e08b67b5.mp4

and finally adds an usage [matching designs](https://www.figma.com/file/XJCRjfvTlVIwZBWoAz5kB2/Client%2FPlaylist-Multiplayer?node-id=0%3A1) in the online lounge screen headers:

![osu_2021-10-04_00-42-22](https://user-images.githubusercontent.com/20418176/135773920-8152b958-7b84-4b8f-a9a9-f7d36b0ace7f.jpg)