### PR TITLE
Ensure a `DrawableChannel` is not attempted to be added after disposal

### DIFF
--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -430,7 +430,7 @@ namespace osu.Game.Overlays
             base.PopOut();
         }
 
-        private void joinedChannelsChanged(object sender, NotifyCollectionChangedEventArgs args) => Schedule(() =>
+        private void joinedChannelsChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
             switch (args.Action)
             {
@@ -458,7 +458,7 @@ namespace osu.Game.Overlays
 
                     break;
             }
-        });
+        }
 
         private void availableChannelsChanged(object sender, NotifyCollectionChangedEventArgs args)
         {

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -284,7 +284,7 @@ namespace osu.Game.Overlays
                     if (currentChannel.Value != e.NewValue)
                         return;
 
-                    // check once more to ensure the channel hasn't since been removed from the loaded channels like (may have been left by some automated means).
+                    // check once more to ensure the channel hasn't since been removed from the loaded channels list (may have been left by some automated means).
                     if (loadedChannels.Contains(loaded))
                         return;
 

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -284,6 +284,10 @@ namespace osu.Game.Overlays
                     if (currentChannel.Value != e.NewValue)
                         return;
 
+                    // check once more to ensure the channel hasn't since been removed from the loaded channels like (may have been left by some automated means).
+                    if (loadedChannels.Contains(loaded))
+                        return;
+
                     loading.Hide();
 
                     currentChannelContainer.Clear(false);
@@ -426,7 +430,7 @@ namespace osu.Game.Overlays
             base.PopOut();
         }
 
-        private void joinedChannelsChanged(object sender, NotifyCollectionChangedEventArgs args)
+        private void joinedChannelsChanged(object sender, NotifyCollectionChangedEventArgs args) => Schedule(() =>
         {
             switch (args.Action)
             {
@@ -444,10 +448,9 @@ namespace osu.Game.Overlays
 
                         if (loaded != null)
                         {
-                            loadedChannels.Remove(loaded);
-
                             // Because the container is only cleared in the async load callback of a new channel, it is forcefully cleared
                             // to ensure that the previous channel doesn't get updated after it's disposed
+                            loadedChannels.Remove(loaded);
                             currentChannelContainer.Remove(loaded);
                             loaded.Dispose();
                         }
@@ -455,7 +458,7 @@ namespace osu.Game.Overlays
 
                     break;
             }
-        }
+        });
 
         private void availableChannelsChanged(object sender, NotifyCollectionChangedEventArgs args)
         {


### PR DESCRIPTION
Fixes common test failures (seen [here](https://github.com/ppy/osu/pull/14920/checks?check_run_id=3767740561) as one example).

The `Schedule()` is there for safety, because `ChannelManager` is operating on its collections from multiple threads. At some point we will likely want to look at making `ChannelManager.JoinChannel` always run on the update thread, but this is non-trivial due to async usages that expect to receive the `Channel` immediately. Not really wanting to look at fixing that right now (and may actually never occur) - just focused on fixing the CI issue.