### PR TITLE
Show login failure messages on login form

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneLoginPanel.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneLoginPanel.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Overlays.Login;
 
 namespace osu.Game.Tests.Visual.Menus
@@ -30,9 +31,22 @@ namespace osu.Game.Tests.Visual.Menus
         }
 
         [Test]
-        public void TestBasicLogin()
+        public void TestLoginSuccess()
         {
             AddStep("logout", () => API.Logout());
+
+            AddStep("enter password", () => loginPanel.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
+            AddStep("submit", () => loginPanel.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
+        }
+
+        [Test]
+        public void TestLoginFailure()
+        {
+            AddStep("logout", () =>
+            {
+                API.Logout();
+                ((DummyAPIAccess)API).FailNextLogin();
+            });
 
             AddStep("enter password", () => loginPanel.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
             AddStep("submit", () => loginPanel.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());

--- a/osu.Game/Graphics/ErrorTextFlowContainer.cs
+++ b/osu.Game/Graphics/ErrorTextFlowContainer.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 using osuTK.Graphics;
 
-namespace osu.Game.Overlays.AccountCreation
+namespace osu.Game.Graphics
 {
     public class ErrorTextFlowContainer : OsuTextFlowContainer
     {

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Game.Users;
@@ -54,6 +55,11 @@ namespace osu.Game.Online.API
         /// The root URL of of the website, excluding the trailing slash.
         /// </summary>
         string WebsiteRootUrl { get; }
+
+        /// <summary>
+        /// The last login error that occurred, if any.
+        /// </summary>
+        Exception? LastLoginError { get; }
 
         /// <summary>
         /// The current connection state of the API.

--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using System.Net.Http;
+using Newtonsoft.Json;
 using osu.Framework.Bindables;
 
 namespace osu.Game.Online.API
@@ -32,10 +34,10 @@ namespace osu.Game.Online.API
             this.endpoint = endpoint;
         }
 
-        internal bool AuthenticateWithLogin(string username, string password)
+        internal void AuthenticateWithLogin(string username, string password)
         {
-            if (string.IsNullOrEmpty(username)) return false;
-            if (string.IsNullOrEmpty(password)) return false;
+            if (string.IsNullOrEmpty(username)) throw new ArgumentException("Missing username.");
+            if (string.IsNullOrEmpty(password)) throw new ArgumentException("Missing password.");
 
             using (var req = new AccessTokenRequestPassword(username, password)
             {
@@ -49,13 +51,27 @@ namespace osu.Game.Online.API
                 {
                     req.Perform();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    return false;
+                    Token.Value = null;
+
+                    var throwableException = ex;
+
+                    try
+                    {
+                        // attempt to decode a displayable error string.
+                        var error = JsonConvert.DeserializeObject<OAuthError>(req.GetResponseString() ?? string.Empty);
+                        if (error != null)
+                            throwableException = new APIException(error.Message, ex);
+                    }
+                    catch
+                    {
+                    }
+
+                    throw throwableException;
                 }
 
                 Token.Value = req.ResponseObject;
-                return true;
             }
         }
 
@@ -181,6 +197,15 @@ namespace osu.Game.Online.API
 
                 base.PrePerform();
             }
+        }
+
+        private class OAuthError
+        {
+            [JsonProperty("error")]
+            public string ErrorType { get; set; }
+
+            [JsonProperty("hint")]
+            public string Message { get; set; }
         }
     }
 }

--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Online.API
                         // attempt to decode a displayable error string.
                         var error = JsonConvert.DeserializeObject<OAuthError>(req.GetResponseString() ?? string.Empty);
                         if (error != null)
-                            throwableException = new APIException(error.Message, ex);
+                            throwableException = new APIException(error.UserDisplayableError, ex);
                     }
                     catch
                     {
@@ -201,10 +201,15 @@ namespace osu.Game.Online.API
 
         private class OAuthError
         {
+            public string UserDisplayableError => !string.IsNullOrEmpty(Hint) ? Hint : ErrorIdentifier;
+
             [JsonProperty("error")]
-            public string ErrorType { get; set; }
+            public string ErrorIdentifier { get; set; }
 
             [JsonProperty("hint")]
+            public string Hint { get; set; }
+
+            [JsonProperty("message")]
             public string Message { get; set; }
         }
     }

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
@@ -42,6 +43,9 @@ namespace osu.Game.Overlays.Login
             Spacing = new Vector2(0, 5);
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
+
+            ErrorTextFlowContainer errorText;
+
             Children = new Drawable[]
             {
                 username = new OsuTextBox
@@ -56,6 +60,11 @@ namespace osu.Game.Overlays.Login
                     PlaceholderText = "password",
                     RelativeSizeAxes = Axes.X,
                     TabbableContentContainer = this,
+                },
+                errorText = new ErrorTextFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                 },
                 new SettingsCheckbox
                 {
@@ -97,6 +106,9 @@ namespace osu.Game.Overlays.Login
             };
 
             password.OnCommit += (sender, newText) => performLogin();
+
+            if (api?.LastLoginError?.Message is string error)
+                errorText.AddErrors(new[] { error });
         }
 
         public override bool AcceptsFocus => true;


### PR DESCRIPTION
I've gone about this in a simple way, hopefully doesn't feel too bad. The whole `Login` call should likely be changed to an async call, or something with a callback, but not interested in rewriting the `APIAccess.run()` loop right now (where the login procedure happens).

This depends on `osu-web` deploy, which is currently running on production (and dev has been updated already).

Closes https://github.com/ppy/osu/issues/4086.

https://user-images.githubusercontent.com/191335/135805410-13d2582b-4df6-4b10-a4c9-bf9c2d55b20a.mp4


