### PR TITLE
Rename `APIRequest.Result` to `Response`

### DIFF
--- a/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
+++ b/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Online
 
             AddAssert("response event fired", () => response != null);
 
-            AddAssert("request has response", () => request.Result == response);
+            AddAssert("request has response", () => request.Response == response);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 var req = new GetBeatmapSetRequest(1);
                 api.Queue(req);
 
-                AddUntilStep("wait for api response", () => req.Result != null);
+                AddUntilStep("wait for api response", () => req.Response != null);
 
                 TestUpdateableBeatmapBackgroundSprite background = null;
 
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Child = background = new TestUpdateableBeatmapBackgroundSprite
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Beatmap = { Value = new BeatmapInfo { BeatmapSet = req.Result?.ToBeatmapSet(rulesets) } }
+                        Beatmap = { Value = new BeatmapInfo { BeatmapSet = req.Response?.ToBeatmapSet(rulesets) } }
                     };
                 });
 

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Tournament
                     {
                         var req = new GetBeatmapRequest(new BeatmapInfo { OnlineBeatmapID = b.ID });
                         API.Perform(req);
-                        b.BeatmapInfo = req.Result?.ToBeatmapInfo(RulesetStore);
+                        b.BeatmapInfo = req.Response?.ToBeatmapInfo(RulesetStore);
 
                         addedInfo = true;
                     }
@@ -203,7 +203,7 @@ namespace osu.Game.Tournament
                         {
                             var req = new GetBeatmapRequest(new BeatmapInfo { OnlineBeatmapID = b.ID });
                             req.Perform(API);
-                            b.BeatmapInfo = req.Result?.ToBeatmapInfo(RulesetStore);
+                            b.BeatmapInfo = req.Response?.ToBeatmapInfo(RulesetStore);
 
                             addedInfo = true;
                         }

--- a/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Beatmaps
                 // intentionally blocking to limit web request concurrency
                 api.Perform(req);
 
-                var res = req.Result;
+                var res = req.Response;
 
                 if (res != null)
                 {

--- a/osu.Game/Database/UserLookupCache.cs
+++ b/osu.Game/Database/UserLookupCache.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Database
                     createNewTask();
             }
 
-            List<User> foundUsers = request.Result?.Users;
+            List<User> foundUsers = request.Response?.Users;
 
             if (foundUsers != null)
             {

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Framework.Logging;
@@ -17,7 +18,11 @@ namespace osu.Game.Online.API
     {
         protected override WebRequest CreateWebRequest() => new OsuJsonWebRequest<T>(Uri);
 
-        public T Result { get; private set; }
+        /// <summary>
+        /// The deserialised response object. May be null if the request or deserialisation failed.
+        /// </summary>
+        [CanBeNull]
+        public T Response { get; private set; }
 
         /// <summary>
         /// Invoked on successful completion of an API request.
@@ -27,21 +32,21 @@ namespace osu.Game.Online.API
 
         protected APIRequest()
         {
-            base.Success += () => Success?.Invoke(Result);
+            base.Success += () => Success?.Invoke(Response);
         }
 
         protected override void PostProcess()
         {
             base.PostProcess();
-            Result = ((OsuJsonWebRequest<T>)WebRequest)?.ResponseObject;
+            Response = ((OsuJsonWebRequest<T>)WebRequest)?.ResponseObject;
         }
 
         internal void TriggerSuccess(T result)
         {
-            if (Result != null)
+            if (Response != null)
                 throw new InvalidOperationException("Attempted to trigger success more than once");
 
-            Result = result;
+            Response = result;
 
             TriggerSuccess();
         }

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -143,6 +143,9 @@ namespace osu.Game.Overlays
             switch (request)
             {
                 case GetUserRankingsRequest userRequest:
+                    if (userRequest.Response == null)
+                        return null;
+
                     switch (userRequest.Type)
                     {
                         case UserRankingsType.Performance:
@@ -155,7 +158,12 @@ namespace osu.Game.Overlays
                     return null;
 
                 case GetCountryRankingsRequest countryRequest:
+                {
+                    if (countryRequest.Response == null)
+                        return null;
+
                     return new CountriesTable(1, countryRequest.Response.Countries);
+                }
             }
 
             return null;

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -146,16 +146,16 @@ namespace osu.Game.Overlays
                     switch (userRequest.Type)
                     {
                         case UserRankingsType.Performance:
-                            return new PerformanceTable(1, userRequest.Result.Users);
+                            return new PerformanceTable(1, userRequest.Response.Users);
 
                         case UserRankingsType.Score:
-                            return new ScoresTable(1, userRequest.Result.Users);
+                            return new ScoresTable(1, userRequest.Response.Users);
                     }
 
                     return null;
 
                 case GetCountryRankingsRequest countryRequest:
-                    return new CountriesTable(1, countryRequest.Result.Countries);
+                    return new CountriesTable(1, countryRequest.Response.Countries);
             }
 
             return null;

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             req.Failure += exception =>
             {
-                onError?.Invoke(req.Result?.Error ?? exception.Message);
+                onError?.Invoke(req.Response?.Error ?? exception.Message);
             };
 
             api.Queue(req);


### PR DESCRIPTION
Felt out of line with base class naming, and since this is used around `async` code makes things *look* wrong even when they aren't.