### PR TITLE
Fix import notifications not showing correct text

### DIFF
--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Database
             else
             {
                 notification.CompletionText = imported.Count == 1
-                    ? $"Imported {imported.First()}!"
+                    ? $"Imported {imported.First().Value}!"
                     : $"Imported {imported.Count} {HumanisedModelName}s!";
 
                 if (imported.Count > 0 && PostImport != null)


### PR DESCRIPTION
Just fixing this for now. We will probably want to make an interface around `GetDisplayString` or use something common like `IHasDescription` going forward. Not doing this here due to ongoing refactoring around the underlying models.