### PR TITLE
Fix `TestDifficultyIconSelectingForDifferentRuleset` potentially failing due to async load

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -714,10 +714,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
 
             FilterableDifficultyIcon difficultyIcon = null;
-            AddStep("Find an icon for different ruleset", () =>
+            AddUntilStep("Find an icon for different ruleset", () =>
             {
                 difficultyIcon = set.ChildrenOfType<FilterableDifficultyIcon>()
-                                    .First(icon => icon.Item.BeatmapInfo.Ruleset.ID == 3);
+                                    .FirstOrDefault(icon => icon.Item.BeatmapInfo.Ruleset.ID == 3);
+                return difficultyIcon != null;
             });
 
             AddAssert("Check ruleset is osu!", () => Ruleset.Value.ID == 0);


### PR DESCRIPTION
As seen:

https://github.com/ppy/osu/runs/3777490864
https://github.com/ppy/osu/pull/14917/checks?check_run_id=3799992067

`DrawableCarouselBeatmapSet` loads its difficulty `SetPanelContent` at a second level of async load (via `DelayedLoadWrapper`) so these failures make sense:

https://github.com/ppy/osu/blob/973c31132be80ccfc14cac0621fc871db987f406/osu.Game/Screens/Select/Carousel/SetPanelContent.cs#L70-L75

Can repro by increasing the load delay to `1000`.