### PR TITLE
Fix delete local score test not waiting for "fetch" to complete

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -162,6 +162,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
+            AddUntilStep("wait for fetch", () => leaderboard.Scores != null);
+
             AddUntilStep("score removed from leaderboard", () => leaderboard.Scores.All(s => s.OnlineScoreID != scoreBeingDeleted.OnlineScoreID));
         }
 


### PR DESCRIPTION
Even though this is a completely local operation in this case, there's still a level of asynchronous operation which was recent introduced with the score ordering:

https://github.com/ppy/osu/blob/853cf6feaa165e833ecb7ca18c6cdffe8ca6e005/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs#L159

This means there is a brief period where the `Scores` property is null, after `Reset()` is called in the re-fetch procedure.