### PR TITLE
Add various logging output in an atttempt to figure multiplayer test failure

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for dependencies screen", () => Stack.CurrentScreen is DependenciesScreen);
-            AddUntilStep("wait for dependencies to start load", () => dependenciesScreen.LoadState > LoadState.Ready);
+            AddUntilStep("wait for dependencies to start load", () => dependenciesScreen.LoadState > LoadState.NotLoaded);
             AddUntilStep("wait for dependencies to load", () => dependenciesScreen.IsLoaded);
 
             AddStep("load multiplayer", () => LoadScreen(multiplayerScreen));

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -68,6 +69,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 LoadScreen(dependenciesScreen = new DependenciesScreen(client));
             });
 
+            AddUntilStep("wait for dependencies screen", () => Stack.CurrentScreen is DependenciesScreen);
+            AddUntilStep("wait for dependencies to start load", () => dependenciesScreen.LoadState > LoadState.Ready);
             AddUntilStep("wait for dependencies to load", () => dependenciesScreen.IsLoaded);
 
             AddStep("load multiplayer", () => LoadScreen(multiplayerScreen));

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
-using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Screens;

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -4,6 +4,8 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Screens;
@@ -32,6 +34,9 @@ namespace osu.Game.Tests.Visual
                 content = new Container { RelativeSizeAxes = Axes.Both },
                 DialogOverlay = new DialogOverlay()
             });
+
+            Stack.ScreenPushed += (lastScreen, newScreen) => Logger.Log($"{nameof(ScreenTestScene)} screen changed → {newScreen}");
+            Stack.ScreenExited += (lastScreen, newScreen) => Logger.Log($"{nameof(ScreenTestScene)} screen changed ← {newScreen}");
         }
 
         protected void LoadScreen(OsuScreen screen) => Stack.Push(screen);


### PR DESCRIPTION
I can't figure out why this is happening, but looking to most probably be something very low level in the screen loading code. A starting point is understanding where things get stuck, so let's add logging and wait for the issue to arise again.

Open to any suggestions of further logging to add.

https://github.com/ppy/osu/pull/14907/checks?check_run_id=3794347620