### PR TITLE
Fix backwards containment check in chat channel load callback

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -18,6 +19,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Chat;
 using osu.Game.Overlays.Chat.Selection;
 using osu.Game.Overlays.Chat.Tabs;
 using osu.Game.Users;
@@ -40,6 +42,9 @@ namespace osu.Game.Tests.Visual.Online
         private Channel channel1 => channels[0];
         private Channel channel2 => channels[1];
         private Channel channel3 => channels[2];
+
+        [CanBeNull]
+        private Func<Channel, List<Message>> onGetMessages;
 
         [Resolved]
         private GameHost host { get; set; }
@@ -79,6 +84,8 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("register request handling", () =>
             {
+                onGetMessages = null;
+
                 ((DummyAPIAccess)API).HandleRequest = req =>
                 {
                     switch (req)
@@ -102,6 +109,12 @@ namespace osu.Game.Tests.Visual.Online
                             }
 
                             return true;
+
+                        case GetMessagesRequest getMessages:
+                            var messages = onGetMessages?.Invoke(getMessages.Channel);
+                            if (messages != null)
+                                getMessages.TriggerSuccess(messages);
+                            return true;
                     }
 
                     return false;
@@ -122,14 +135,37 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
-        public void TestSelectingChannelClosesSelector()
+        public void TestChannelSelection()
         {
             AddAssert("Selector is visible", () => chatOverlay.SelectionOverlayState == Visibility.Visible);
+            AddStep("Setup get message response", () => onGetMessages = channel =>
+            {
+                if (channel == channel1)
+                {
+                    return new List<Message>
+                    {
+                        new Message(1)
+                        {
+                            ChannelId = channel1.Id,
+                            Content = "hello from channel 1!",
+                            Sender = new User
+                            {
+                                Id = 2,
+                                Username = "test_user"
+                            }
+                        }
+                    };
+                }
+
+                return null;
+            });
 
             AddStep("Join channel 1", () => channelManager.JoinChannel(channel1));
             AddStep("Switch to channel 1", () => clickDrawable(chatOverlay.TabMap[channel1]));
 
             AddAssert("Current channel is channel 1", () => currentChannel == channel1);
+            AddUntilStep("Loading spinner hidden", () => chatOverlay.ChildrenOfType<LoadingSpinner>().All(spinner => !spinner.IsPresent));
+            AddAssert("Channel message shown", () => chatOverlay.ChildrenOfType<ChatLine>().Count() == 1);
             AddAssert("Channel selector was closed", () => chatOverlay.SelectionOverlayState == Visibility.Hidden);
         }
 

--- a/osu.Game/Online/API/Requests/GetMessagesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetMessagesRequest.cs
@@ -8,13 +8,13 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetMessagesRequest : APIRequest<List<Message>>
     {
-        private readonly Channel channel;
+        public readonly Channel Channel;
 
         public GetMessagesRequest(Channel channel)
         {
-            this.channel = channel;
+            Channel = channel;
         }
 
-        protected override string Target => $@"chat/channels/{channel.Id}/messages";
+        protected override string Target => $@"chat/channels/{Channel.Id}/messages";
     }
 }

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -285,7 +285,7 @@ namespace osu.Game.Overlays
                         return;
 
                     // check once more to ensure the channel hasn't since been removed from the loaded channels list (may have been left by some automated means).
-                    if (loadedChannels.Contains(loaded))
+                    if (!loadedChannels.Contains(loaded))
                         return;
 
                     loading.Hide();


### PR DESCRIPTION
Closes #14964.

I presume that the check is backwards from the preceding comment as the two don't match.

Pretty bad that there was no test coverage for this but there is some now. I exposed `Channel` from the request for that but there's precedent for this (`JoinRoomRequest`).