### PR TITLE
Fix "most played beatmap" request breakage after property rename

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIUserMostPlayedBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUserMostPlayedBeatmap.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("count")]
         public int PlayCount { get; set; }
 
-        [JsonProperty]
+        [JsonProperty("beatmap")]
         private BeatmapInfo beatmapInfo { get; set; }
 
         [JsonProperty]


### PR DESCRIPTION
Closes #14963. Regressed in #14932.

I've searched through `osu.Game/Online/API` and this should be the only case of this.

* `GetBeatmapRequest` and `GetScoresRequest` put things from their `BeatmapInfo` into the query string and are therefore safe.
* `APILegacyScoreInfo` was already explicitly specifying the property name.

No tests because this is untestable short of dumping the request to JSON and checking that but that seems counterproductive.