### PR TITLE
Fix changes not being reflected immediately after exiting the editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Menu;
+using osu.Game.Screens.Select;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneEditorSaving : OsuGameTestScene
+    {
+        private Editor editor => Game.ChildrenOfType<Editor>().FirstOrDefault();
+
+        private EditorBeatmap editorBeatmap => (EditorBeatmap)editor.Dependencies.Get(typeof(EditorBeatmap));
+
+        /// <summary>
+        /// Tests the general expected flow of creating a new beatmap, saving it, then loading it back from song select.
+        /// </summary>
+        [Test]
+        public void TestNewBeatmapSaveThenLoad()
+        {
+            AddStep("set default beatmap", () => Game.Beatmap.SetDefault());
+
+            PushAndConfirm(() => new EditorLoader());
+
+            AddUntilStep("wait for editor load", () => editor != null);
+
+            AddStep("Add timing point", () => editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint()));
+
+            AddStep("Enter compose mode", () => InputManager.Key(Key.F1));
+            AddUntilStep("Wait for compose mode load", () => editor.ChildrenOfType<HitObjectComposer>().FirstOrDefault()?.IsLoaded == true);
+
+            AddStep("Change to placement mode", () => InputManager.Key(Key.Number2));
+            AddStep("Move to playfield", () => InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre));
+            AddStep("Place single hitcircle", () => InputManager.Click(MouseButton.Left));
+
+            AddStep("Save and exit", () =>
+            {
+                InputManager.Keys(PlatformAction.Save);
+                InputManager.Key(Key.Escape);
+            });
+
+            AddUntilStep("Wait for main menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
+
+            PushAndConfirm(() => new PlaySongSelect());
+
+            AddUntilStep("Wait for beatmap selected", () => !Game.Beatmap.IsDefault);
+            AddStep("Open options", () => InputManager.Key(Key.F3));
+            AddStep("Enter editor", () => InputManager.Key(Key.Number5));
+
+            AddUntilStep("Wait for editor load", () => editor != null);
+            AddAssert("Beatmap contains single hitcircle", () => editorBeatmap.HitObjects.Count == 1);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Beatmaps
             workingBeatmapCache = CreateWorkingBeatmapCache(audioManager, resources, new FileStore(contextFactory, storage).Store, defaultBeatmap, host);
 
             workingBeatmapCache.BeatmapManager = beatmapModelManager;
+            beatmapModelManager.WorkingBeatmapCache = workingBeatmapCache;
 
             if (performOnlineLookups)
             {
@@ -304,6 +305,9 @@ namespace osu.Game.Beatmaps
         #region Implementation of IWorkingBeatmapCache
 
         public WorkingBeatmap GetWorkingBeatmap(BeatmapInfo importedBeatmap) => workingBeatmapCache.GetWorkingBeatmap(importedBeatmap);
+
+        void IWorkingBeatmapCache.Invalidate(BeatmapSetInfo beatmapSetInfo) => workingBeatmapCache.Invalidate(beatmapSetInfo);
+        void IWorkingBeatmapCache.Invalidate(BeatmapInfo beatmapInfo) => workingBeatmapCache.Invalidate(beatmapInfo);
 
         #endregion
 

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Beatmaps
     /// Handles ef-core storage of beatmaps.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public class BeatmapModelManager : ArchiveModelManager<BeatmapSetInfo, BeatmapSetFileInfo>
+    public class BeatmapModelManager : ArchiveModelManager<BeatmapSetInfo, BeatmapSetFileInfo>, IBeatmapModelManager
     {
         /// <summary>
         /// Fired when a single difficulty has been hidden.
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The game working beatmap cache, used to invalidate entries on changes.
         /// </summary>
-        public WorkingBeatmapCache WorkingBeatmapCache { private get; set; }
+        public IWorkingBeatmapCache WorkingBeatmapCache { private get; set; }
 
         private readonly Bindable<WeakReference<BeatmapInfo>> beatmapRestored = new Bindable<WeakReference<BeatmapInfo>>();
 

--- a/osu.Game/Beatmaps/IBeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/IBeatmapModelManager.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Database;
+
+namespace osu.Game.Beatmaps
+{
+    public interface IBeatmapModelManager : IModelManager<BeatmapSetInfo>
+    {
+        /// <summary>
+        /// Provide an online lookup queue component to handle populating online beatmap metadata.
+        /// </summary>
+        BeatmapOnlineLookupQueue OnlineLookupQueue { set; }
+
+        /// <summary>
+        /// Provide a working beatmap cache, used to invalidate entries on changes.
+        /// </summary>
+        IWorkingBeatmapCache WorkingBeatmapCache { set; }
+    }
+}

--- a/osu.Game/Beatmaps/IWorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmapCache.cs
@@ -11,5 +11,17 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapInfo">The beatmap to lookup.</param>
         /// <returns>A <see cref="WorkingBeatmap"/> instance correlating to the provided <see cref="BeatmapInfo"/>.</returns>
         WorkingBeatmap GetWorkingBeatmap(BeatmapInfo beatmapInfo);
+
+        /// <summary>
+        /// Invalidate a cache entry if it exists.
+        /// </summary>
+        /// <param name="beatmapSetInfo">The beatmap set info to invalidate any cached entries for.</param>
+        void Invalidate(BeatmapSetInfo beatmapSetInfo);
+
+        /// <summary>
+        /// Invalidate a cache entry if it exists.
+        /// </summary>
+        /// <param name="beatmapInfo">The beatmap info to invalidate any cached entries for.</param>
+        void Invalidate(BeatmapInfo beatmapInfo);
     }
 }

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -83,8 +83,17 @@ namespace osu.Game.Tests.Visual
         protected void PushAndConfirm(Func<Screen> newScreen)
         {
             Screen screen = null;
-            AddStep("Push new screen", () => Game.ScreenStack.Push(screen = newScreen()));
-            AddUntilStep("Wait for new screen", () => Game.ScreenStack.CurrentScreen == screen && screen.IsLoaded);
+            IScreen previousScreen = null;
+
+            AddStep("Push new screen", () =>
+            {
+                previousScreen = Game.ScreenStack.CurrentScreen;
+                Game.ScreenStack.Push(screen = newScreen());
+            });
+
+            AddUntilStep("Wait for new screen", () => screen.IsLoaded
+                                                      && Game.ScreenStack.CurrentScreen != previousScreen
+                                                      && previousScreen.GetChildScreen() == screen);
         }
 
         protected void ConfirmAtMainMenu() => AddUntilStep("Wait for main menu", () => Game.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);


### PR DESCRIPTION
The reason was simple enough, but it's pretty bad that we don't have test coverage for this, so I've added that (have tested over many runs that it's pretty robust).

Also of note is the fix to `PushAndConfirm`, which was failing for `EditorLoader` as `EditorLoader` may push a child screen before the assert becomes `true`. Not sure this is worth adding a separate test for as it's already test logic and the new scene kinda "covers" it.

Closes https://github.com/ppy/osu/issues/14972.