### PR TITLE
Fix dragging on an editor file selection text box causing repeated popover display

### DIFF
--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -89,6 +89,13 @@ namespace osu.Game.Screens.Edit.Setup
         {
             public Action OnFocused;
 
+            protected override bool OnDragStart(DragStartEvent e)
+            {
+                // This text box is intended to be "read only" without actually specifying that.
+                // As such we don't want to allow the user to select its content with a drag.
+                return false;
+            }
+
             protected override void OnFocus(FocusEvent e)
             {
                 OnFocused?.Invoke();


### PR DESCRIPTION
Local fix and no tests as this is a pretty weird usage of `TextBox`.  We'll probably want to change it to not use a textbox eventually.

Closes #14969.