### PR TITLE
Fix intermittent score panel test failure

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneScorePanelList.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneScorePanelList.cs
@@ -221,6 +221,8 @@ namespace osu.Game.Tests.Visual.Ranking
                 list.SelectedScore.Value = middleScore;
             });
 
+            AddUntilStep("wait for all scores to be visible", () => list.ChildrenOfType<ScorePanelTrackingContainer>().All(t => t.IsPresent));
+
             assertScoreState(highestScore, false);
             assertScoreState(middleScore, true);
             assertScoreState(lowestScore, false);


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/3811898645

Can be tested by adding `await Task.Delay(1000)` in `ScoreManager.GetTotalScoreAsync()`.