### PR TITLE
Improve performance of `OsuGameTestScene` based tests

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -350,13 +350,13 @@ namespace osu.Game.Tests.Visual.Navigation
             // since most overlays use a scroll container that absorbs on mouse down
             NowPlayingOverlay nowPlayingOverlay = null;
 
-            AddStep("enter menu", () => InputManager.Key(Key.Enter));
+            AddUntilStep("Wait for now playing load", () => (nowPlayingOverlay = Game.ChildrenOfType<NowPlayingOverlay>().FirstOrDefault()) != null);
 
-            AddStep("get and press now playing hotkey", () =>
-            {
-                nowPlayingOverlay = Game.ChildrenOfType<NowPlayingOverlay>().Single();
-                InputManager.Key(Key.F6);
-            });
+            AddStep("enter menu", () => InputManager.Key(Key.Enter));
+            AddUntilStep("toolbar displayed", () => Game.Toolbar.State.Value == Visibility.Visible);
+
+            AddStep("open now playing", () => InputManager.Key(Key.F6));
+            AddUntilStep("now playing is visible", () => nowPlayingOverlay.State.Value == Visibility.Visible);
 
             // drag tests
 
@@ -417,7 +417,7 @@ namespace osu.Game.Tests.Visual.Navigation
             pushEscape(); // returns to osu! logo
 
             AddStep("Hold escape", () => InputManager.PressKey(Key.Escape));
-            AddUntilStep("Wait for intro", () => Game.ScreenStack.CurrentScreen is IntroTriangles);
+            AddUntilStep("Wait for intro", () => Game.ScreenStack.CurrentScreen is IntroScreen);
             AddStep("Release escape", () => InputManager.ReleaseKey(Key.Escape));
             AddUntilStep("Wait for game exit", () => Game.ScreenStack.CurrentScreen == null);
             AddStep("test dispose doesn't crash", () => Game.Dispose());

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -127,9 +127,8 @@ namespace osu.Game.Tests.Visual
 
             public new Bindable<IReadOnlyList<Mod>> SelectedMods => base.SelectedMods;
 
+            // if we don't apply these changes, when running under nUnit the version that gets populated is that of nUnit.
             public override Version AssemblyVersion => new Version(0, 0);
-
-            // if we don't do this, when running under nUnit the version that gets populated is that of nUnit.
             public override string Version => "test game";
 
             protected override Loader CreateLoader() => new TestLoader();

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -126,6 +126,8 @@ namespace osu.Game.Tests.Visual
 
             public new Bindable<IReadOnlyList<Mod>> SelectedMods => base.SelectedMods;
 
+            public override Version AssemblyVersion => new Version(0, 0);
+
             // if we don't do this, when running under nUnit the version that gets populated is that of nUnit.
             public override string Version => "test game";
 

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -22,6 +22,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osuTK.Graphics;
+using IntroSequence = osu.Game.Configuration.IntroSequence;
 
 namespace osu.Game.Tests.Visual
 {
@@ -144,6 +145,9 @@ namespace osu.Game.Tests.Visual
             protected override void LoadComplete()
             {
                 base.LoadComplete();
+
+                LocalConfig.SetValue(OsuSetting.IntroSequence, IntroSequence.Circles);
+
                 API.Login("Rhythm Champion", "osu!");
 
                 Dependencies.Get<SessionStatics>().SetValue(Static.MutedAudioNotificationShownOnce, true);


### PR DESCRIPTION
The triangles intro tracks video time, which is not adjusted based on the headless runner's playback rate (ie. it runs in realtime even for headless tests). This is because `HeadlessGameHost` still uses a `Rate` of `1` in its implementation. We may want to reconsider that in the future.

Seems like the simplest solution for now. An alternative would be to have `IntroTriangles` operate in decoupled mode, which I'm attempted separately (at which point I may revert that particular commit of this change). Reasoning being I think the navigation tests should probably be using `Random` intro if anything, to improve test coverage.

Before, the navigation subtree of tests took 3 minutes 40 seconds, after 1 minute 20 seconds. Note that this also affects a few other tests outside the benchmarked namespace, so the improvement should be slightly higher on a full run.

Also disabled the disclaimer as while it doesn't improve headless run performance, it is something we don't really want to see each time we run one of these tests.