### PR TITLE
Allow intro screens to be created without loading a `MainMenu`

### DIFF
--- a/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
+++ b/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Screens;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osuTK;
@@ -20,6 +19,8 @@ namespace osu.Game.Tests.Visual.Menus
         private OsuLogo logo;
 
         protected OsuScreenStack IntroStack;
+
+        private IntroScreen intro;
 
         protected IntroTestScene()
         {
@@ -39,7 +40,11 @@ namespace osu.Game.Tests.Visual.Menus
                     Position = new Vector2(0.5f),
                 }
             };
+        }
 
+        [Test]
+        public void TestPlayIntro()
+        {
             AddStep("restart sequence", () =>
             {
                 logo.FinishTransforms();
@@ -52,12 +57,12 @@ namespace osu.Game.Tests.Visual.Menus
                     RelativeSizeAxes = Axes.Both,
                 });
 
-                IntroStack.Push(CreateScreen());
+                IntroStack.Push(intro = CreateScreen());
             });
 
-            AddUntilStep("wait for menu", () => IntroStack.CurrentScreen is MainMenu);
+            AddUntilStep("wait for menu", () => intro.DidLoadMenu);
         }
 
-        protected abstract IScreen CreateScreen();
+        protected abstract IntroScreen CreateScreen();
     }
 }

--- a/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
+++ b/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Menus
         }
 
         [Test]
-        public void TestPlayIntro()
+        public virtual void TestPlayIntro()
         {
             AddStep("restart sequence", () =>
             {

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroCircles.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroCircles.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Screens;
 using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual.Menus
@@ -10,6 +9,6 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneIntroCircles : IntroTestScene
     {
-        protected override IScreen CreateScreen() => new IntroCircles();
+        protected override IntroScreen CreateScreen() => new IntroCircles();
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroTriangles.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroTriangles.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Screens;
 using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual.Menus
@@ -10,6 +9,6 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneIntroTriangles : IntroTestScene
     {
-        protected override IScreen CreateScreen() => new IntroTriangles();
+        protected override IntroScreen CreateScreen() => new IntroTriangles();
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroWelcome.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroWelcome.cs
@@ -12,8 +12,10 @@ namespace osu.Game.Tests.Visual.Menus
     {
         protected override IntroScreen CreateScreen() => new IntroWelcome();
 
-        public TestSceneIntroWelcome()
+        public override void TestPlayIntro()
         {
+            base.TestPlayIntro();
+
             AddUntilStep("wait for load", () => MusicController.TrackLoaded);
             AddAssert("correct track", () => Precision.AlmostEquals(MusicController.CurrentTrack.Length, 48000, 1));
             AddAssert("check if menu music loops", () => MusicController.CurrentTrack.Looping);

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroWelcome.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroWelcome.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Screens;
 using osu.Framework.Utils;
 using osu.Game.Screens.Menu;
 
@@ -11,7 +10,7 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneIntroWelcome : IntroTestScene
     {
-        protected override IScreen CreateScreen() => new IntroWelcome();
+        protected override IntroScreen CreateScreen() => new IntroWelcome();
 
         public TestSceneIntroWelcome()
         {

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -49,14 +49,16 @@ namespace osu.Game.Screens
             switch (introSequence)
             {
                 case IntroSequence.Circles:
-                    return new IntroCircles();
+                    return new IntroCircles(createMainMenu);
 
                 case IntroSequence.Welcome:
-                    return new IntroWelcome();
+                    return new IntroWelcome(createMainMenu);
 
                 default:
-                    return new IntroTriangles();
+                    return new IntroTriangles(createMainMenu);
             }
+
+            MainMenu createMainMenu() => new MainMenu();
         }
 
         protected virtual ShaderPrecompiler CreateShaderPrecompiler() => new ShaderPrecompiler();

--- a/osu.Game/Screens/Menu/IntroCircles.cs
+++ b/osu.Game/Screens/Menu/IntroCircles.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -19,6 +21,11 @@ namespace osu.Game.Screens.Menu
         private const double delay_step_two = 600;
 
         private Sample welcome;
+
+        public IntroCircles([CanBeNull] Func<MainMenu> createNextScreen = null)
+            : base(createNextScreen)
+        {
+        }
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -43,6 +44,11 @@ namespace osu.Game.Screens.Menu
 
         private DecoupleableInterpolatingFramedClock decoupledClock;
         private TrianglesIntroSequence intro;
+
+        public IntroTriangles([CanBeNull] Func<MainMenu> createNextScreen = null)
+            : base(createNextScreen)
+        {
+        }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/Menu/IntroWelcome.cs
+++ b/osu.Game/Screens/Menu/IntroWelcome.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using JetBrains.Annotations;
 using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -31,6 +33,11 @@ namespace osu.Game.Screens.Menu
         };
 
         private BackgroundScreenDefault background;
+
+        public IntroWelcome([CanBeNull] Func<MainMenu> createNextScreen = null)
+            : base(createNextScreen)
+        {
+        }
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)


### PR DESCRIPTION
Without this, intro screens would load to the main menu, and leave the visual test browser in a state it can't be exited.