### PR TITLE
Fix weird textbox behaviour when entering a random mod seed overflowing int backing

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsNumberBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsNumberBox.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Overlays.Settings
                 {
                     numberBox = new OutlinedNumberBox
                     {
+                        LengthLimit = 9, // limited to less than a value that could overflow int32 backing.
                         Margin = new MarginPadding { Top = 5 },
                         RelativeSizeAxes = Axes.X,
                         CommitOnFocusLost = true


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/191335/136500925-11a301d7-95c5-4160-989b-bc59287a0e98.mp4

After:

https://user-images.githubusercontent.com/191335/136500871-6622bb84-8047-48ae-8264-1ee85bb9fb04.mp4

I did attempt to do this using a value rejection method (and setting the textbox back to the previous value in such cases) but it both doesn't show the red error flash, and doesn't really work - the textbox caret will relocate to a random position. That kind of think is going to need to wait for a refactor of that class.

Closes https://github.com/ppy/osu/issues/13920.