### PR TITLE
Fix intermittent playlist results screen test failures

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -163,7 +163,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddUntilStep("wait for fetch", () => leaderboard.Scores != null);
-
             AddUntilStep("score removed from leaderboard", () => leaderboard.Scores.All(s => s.OnlineScoreID != scoreBeingDeleted.OnlineScoreID));
         }
 
@@ -171,6 +170,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestDeleteViaDatabase()
         {
             AddStep("delete top score", () => scoreManager.Delete(importedScores[0]));
+            AddUntilStep("wait for fetch", () => leaderboard.Scores != null);
             AddUntilStep("score removed from leaderboard", () => leaderboard.Scores.All(s => s.OnlineScoreID != importedScores[0].OnlineScoreID));
         }
     }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -74,10 +74,9 @@ namespace osu.Game.Scoring
 
             var totalScores = await Task.WhenAll(scores.Select(s => GetTotalScoreAsync(s, cancellationToken: cancellationToken))).ConfigureAwait(false);
 
-            return scores.Select((s, i) => (index: i, score: s))
-                         .OrderByDescending(key => totalScores[key.index])
-                         .ThenBy(key => key.score.OnlineScoreID)
-                         .Select(key => key.score)
+            return scores.Select((score, index) => (score: score, totalScore: totalScores[index]))
+                         .OrderByDescending(g => g.totalScore)
+                         .Select(g => g.score)
                          .ToArray();
         }
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Scoring
 
             return scores.Select((score, index) => (score: score, totalScore: totalScores[index]))
                          .OrderByDescending(g => g.totalScore)
+                         .ThenBy(g => g.score.OnlineScoreID)
                          .Select(g => g.score)
                          .ToArray();
         }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Scoring
 
             var totalScores = await Task.WhenAll(scores.Select(s => GetTotalScoreAsync(s, cancellationToken: cancellationToken))).ConfigureAwait(false);
 
-            return scores.Select((score, index) => (score: score, totalScore: totalScores[index]))
+            return scores.Select((score, index) => (score, totalScore: totalScores[index]))
                          .OrderByDescending(g => g.totalScore)
                          .ThenBy(g => g.score.OnlineScoreID)
                          .Select(g => g.score)


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/pull/14997/checks?check_run_id=3834534946, but I'm pretty sure this has been failing intermittently for a while now.

Can be tested by adding `await Task.Delay(1000)` in `GetTotalScoreAsync()`.

Tested across all tests (with the delay):
![image](https://user-images.githubusercontent.com/1329837/136508745-461f3f1d-5a9a-40a2-9cea-fc12c562f565.png)