### PR TITLE
Fix timing point limits being too strict

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         {
             Precision = 0.01,
             Default = 1,
-            MinValue = 0.1,
+            MinValue = 0.01,
             MaxValue = 10
         };
 

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         public readonly BindableDouble BeatLengthBindable = new BindableDouble(DEFAULT_BEAT_LENGTH)
         {
             Default = DEFAULT_BEAT_LENGTH,
-            MinValue = 6,
+            MinValue = 0.6,
             MaxValue = 60000
         };
 


### PR DESCRIPTION
This becomes very noticable in mania, where those end-of-range values are often used in gimmicky SV maps.

As an example, using [this map](https://osu.ppy.sh/beatmapsets/1182702#mania/2769068) (difficulty `brrrrrrrrrrrrrr vip`):
Lazer before this change:

https://user-images.githubusercontent.com/35152647/136656846-74a3e403-9c41-401a-9311-c317451b5660.mp4

Lazer with this change:

https://user-images.githubusercontent.com/35152647/136656857-1ae6ba1d-e9b9-40da-b51e-d2c8371cc599.mp4

And as reference stable:

https://user-images.githubusercontent.com/35152647/136656866-2676dbfd-e51f-429f-9e4f-545f05fa1dc8.mp4


