### PR TITLE
Update settings sidebar colour scheme and general appearance

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private RealmContextFactory realmFactory { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Radius = 2,
-                        Colour = colours.YellowDark.Opacity(0),
+                        Colour = colourProvider.Highlight1.Opacity(0),
                         Type = EdgeEffectType.Shadow,
                         Hollow = true,
                     },
@@ -110,13 +110,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Colour = Color4.Black,
-                            Alpha = 0.6f,
+                            Colour = colourProvider.Background5,
                         },
                         text = new OsuSpriteText
                         {
                             Text = action.GetLocalisableDescription(),
-                            Margin = new MarginPadding(padding),
+                            Margin = new MarginPadding(1.5f * padding),
                         },
                         buttons = new FillFlowContainer<KeyButton>
                         {
@@ -405,7 +404,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             private readonly Box box;
             public readonly OsuSpriteText Text;
 
-            private Color4 hoverColour;
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
 
             private bool isBinding;
 
@@ -448,7 +448,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     box = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.Black
                     },
                     Text = new OsuSpriteText
                     {
@@ -463,9 +462,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load()
             {
-                hoverColour = colours.YellowDark;
+                updateHoverState();
             }
 
             protected override bool OnHover(HoverEvent e)
@@ -484,12 +483,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 if (isBinding)
                 {
-                    box.FadeColour(Color4.White, transition_time, Easing.OutQuint);
+                    box.FadeColour(colourProvider.Light2, transition_time, Easing.OutQuint);
                     Text.FadeColour(Color4.Black, transition_time, Easing.OutQuint);
                 }
                 else
                 {
-                    box.FadeColour(IsHovered ? hoverColour : Color4.Black, transition_time, Easing.OutQuint);
+                    box.FadeColour(IsHovered ? colourProvider.Light4 : colourProvider.Background6, transition_time, Easing.OutQuint);
                     Text.FadeColour(IsHovered ? Color4.Black : Color4.White, transition_time, Easing.OutQuint);
                 }
             }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -27,8 +27,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             this.variant = variant;
 
-            FlowContent.Spacing = new Vector2(0, 1);
-            FlowContent.Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS };
+            FlowContent.Spacing = new Vector2(0, 3);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -165,7 +165,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                             LabelText = TabletSettingsStrings.Rotation,
                             Current = rotation
                         },
-                        new RotationPresetButtons(tabletHandler),
+                        new RotationPresetButtons(tabletHandler)
+                        {
+                            Padding = new MarginPadding
+                            {
+                                Horizontal = SettingsPanel.CONTENT_MARGINS
+                            }
+                        },
                         new SettingsSlider<float>
                         {
                             TransferValueOnCommit = true,

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings.Sections.Maintenance;
-using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
@@ -21,7 +20,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public MaintenanceSection()
         {
-            FlowContent.Spacing = new Vector2(0, 5);
             Children = new Drawable[]
             {
                 new GeneralSettings()

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -16,7 +16,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Skinning;
 using osu.Game.Skinning.Editor;
-using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
@@ -63,8 +62,6 @@ namespace osu.Game.Overlays.Settings.Sections
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(OsuConfigManager config, [CanBeNull] SkinEditorOverlay skinEditor)
         {
-            FlowContent.Spacing = new Vector2(0, 5);
-
             Children = new Drawable[]
             {
                 skinDropdown = new SkinSettingsDropdown(),

--- a/osu.Game/Overlays/Settings/SettingsHeader.cs
+++ b/osu.Game/Overlays/Settings/SettingsHeader.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays.Settings
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Settings
                         new OsuSpriteText
                         {
                             Text = heading,
-                            Font = OsuFont.GetFont(size: 40),
+                            Font = OsuFont.TorusAlternate.With(size: 40),
                             Margin = new MarginPadding
                             {
                                 Left = SettingsPanel.CONTENT_MARGINS,
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Settings
                         },
                         new OsuSpriteText
                         {
-                            Colour = colours.Pink,
+                            Colour = colourProvider.Content2,
                             Text = subheading,
                             Font = OsuFont.GetFont(size: 18),
                             Margin = new MarginPadding

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osuTK;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -29,6 +30,8 @@ namespace osu.Game.Overlays.Settings
 
         public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
         public virtual IEnumerable<string> FilterTerms => new[] { Header.ToString() };
+
+        public const int ITEM_SPACING = 14;
 
         private const int header_size = 24;
         private const int border_size = 4;
@@ -52,8 +55,9 @@ namespace osu.Game.Overlays.Settings
             {
                 Margin = new MarginPadding
                 {
-                    Top = header_size
+                    Top = 36
                 },
+                Spacing = new Vector2(0, ITEM_SPACING),
                 Direction = FillDirection.Vertical,
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -30,8 +30,7 @@ namespace osu.Game.Overlays.Settings
         public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
         public virtual IEnumerable<string> FilterTerms => new[] { Header.ToString() };
 
-        private const int header_size = 26;
-        private const int margin = 20;
+        private const int header_size = 24;
         private const int border_size = 4;
 
         public bool MatchingFilter
@@ -77,8 +76,8 @@ namespace osu.Game.Overlays.Settings
                 {
                     Padding = new MarginPadding
                     {
-                        Top = margin + border_size,
-                        Bottom = margin + 10,
+                        Top = 28,
+                        Bottom = 40,
                     },
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
@@ -86,13 +85,11 @@ namespace osu.Game.Overlays.Settings
                     {
                         header = new OsuSpriteText
                         {
-                            Font = OsuFont.GetFont(size: header_size),
+                            Font = OsuFont.TorusAlternate.With(size: header_size),
                             Text = Header,
-                            Colour = colours.Yellow,
                             Margin = new MarginPadding
                             {
-                                Left = SettingsPanel.CONTENT_MARGINS,
-                                Right = SettingsPanel.CONTENT_MARGINS
+                                Horizontal = SettingsPanel.CONTENT_MARGINS
                             }
                         },
                         FlowContent

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -12,7 +12,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -33,7 +32,7 @@ namespace osu.Game.Overlays.Settings
 
         private const int header_size = 26;
         private const int margin = 20;
-        private const int border_size = 2;
+        private const int border_size = 4;
 
         public bool MatchingFilter
         {
@@ -63,14 +62,14 @@ namespace osu.Game.Overlays.Settings
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
             AddRangeInternal(new Drawable[]
             {
                 new Box
                 {
                     Name = "separator",
-                    Colour = new Color4(0, 0, 0, 255),
+                    Colour = colourProvider.Background6,
                     RelativeSizeAxes = Axes.X,
                     Height = border_size,
                 },

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -46,12 +46,16 @@ namespace osu.Game.Overlays.Settings
 
             FlowContent = new FillFlowContainer
             {
+                Margin = new MarginPadding { Top = SettingsSection.ITEM_SPACING },
                 Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 8),
+                Spacing = new Vector2(0, SettingsSection.ITEM_SPACING),
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
             };
         }
+
+        private const int header_height = 43;
+        private const int header_font_size = 20;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -60,9 +64,9 @@ namespace osu.Game.Overlays.Settings
             {
                 new OsuSpriteText
                 {
-                    Text = Header.ToString().ToUpper(), // TODO: Add localisation support after https://github.com/ppy/osu-framework/pull/4603 is merged.
-                    Margin = new MarginPadding { Vertical = 30, Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS },
-                    Font = OsuFont.GetFont(weight: FontWeight.Bold),
+                    Text = Header,
+                    Margin = new MarginPadding { Vertical = (header_height - header_font_size) * 0.5f, Horizontal = SettingsPanel.CONTENT_MARGINS },
+                    Font = OsuFont.GetFont(size: header_font_size),
                 },
                 FlowContent
             });

--- a/osu.Game/Overlays/Settings/Sidebar.cs
+++ b/osu.Game/Overlays/Settings/Sidebar.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -17,8 +18,9 @@ namespace osu.Game.Overlays.Settings
 {
     public class Sidebar : Container<SidebarButton>, IStateful<ExpandedState>
     {
+        private readonly Box background;
         private readonly FillFlowContainer<SidebarButton> content;
-        public const float DEFAULT_WIDTH = Toolbar.Toolbar.HEIGHT * 1.4f;
+        public const float DEFAULT_WIDTH = 70;
         public const int EXPANDED_WIDTH = 200;
 
         public event Action<ExpandedState> StateChanged;
@@ -30,7 +32,7 @@ namespace osu.Game.Overlays.Settings
             RelativeSizeAxes = Axes.Y;
             InternalChildren = new Drawable[]
             {
-                new Box
+                background = new Box
                 {
                     Colour = OsuColour.Gray(0.02f),
                     RelativeSizeAxes = Axes.Both,
@@ -50,6 +52,12 @@ namespace osu.Game.Overlays.Settings
                     }
                 },
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            background.Colour = colourProvider.Background5;
         }
 
         private ScheduledDelegate expandEvent;
@@ -80,8 +88,6 @@ namespace osu.Game.Overlays.Settings
         {
             public SidebarScrollContainer()
             {
-                Content.Anchor = Anchor.CentreLeft;
-                Content.Origin = Anchor.CentreLeft;
                 RelativeSizeAxes = Axes.Both;
                 ScrollbarVisible = false;
             }

--- a/osu.Game/Overlays/Settings/Sidebar.cs
+++ b/osu.Game/Overlays/Settings/Sidebar.cs
@@ -16,16 +16,16 @@ using osuTK;
 
 namespace osu.Game.Overlays.Settings
 {
-    public class Sidebar : Container<SidebarButton>, IStateful<ExpandedState>
+    public class Sidebar : Container<SidebarIconButton>, IStateful<ExpandedState>
     {
         private readonly Box background;
-        private readonly FillFlowContainer<SidebarButton> content;
+        private readonly FillFlowContainer<SidebarIconButton> content;
         public const float DEFAULT_WIDTH = 70;
         public const int EXPANDED_WIDTH = 200;
 
         public event Action<ExpandedState> StateChanged;
 
-        protected override Container<SidebarButton> Content => content;
+        protected override Container<SidebarIconButton> Content => content;
 
         public Sidebar()
         {
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays.Settings
                 {
                     Children = new[]
                     {
-                        content = new FillFlowContainer<SidebarButton>
+                        content = new FillFlowContainer<SidebarIconButton>
                         {
                             Origin = Anchor.CentreLeft,
                             Anchor = Anchor.CentreLeft,

--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 
@@ -10,12 +9,10 @@ namespace osu.Game.Overlays.Settings
 {
     public abstract class SidebarButton : OsuButton
     {
-        private const double fade_duration = 50;
+        protected const double FADE_DURATION = 500;
 
         [Resolved]
         protected OverlayColourProvider ColourProvider { get; private set; }
-
-        protected abstract Drawable HoverTarget { get; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -38,9 +35,6 @@ namespace osu.Game.Overlays.Settings
 
         protected override void OnHoverLost(HoverLostEvent e) => UpdateState();
 
-        protected virtual void UpdateState()
-        {
-            HoverTarget.FadeColour(IsHovered ? ColourProvider.Light1 : ColourProvider.Light3, fade_duration, Easing.OutQuint);
-        }
+        protected abstract void UpdateState();
     }
 }

--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -1,144 +1,46 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Settings
 {
-    public class SidebarButton : OsuButton
+    public abstract class SidebarButton : OsuButton
     {
         private const double fade_duration = 50;
 
-        private readonly ConstrainedIconContainer iconContainer;
-        private readonly SpriteText headerText;
-        private readonly CircularContainer selectionIndicator;
-        private readonly Container text;
-
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
+        protected OverlayColourProvider ColourProvider { get; private set; }
 
-        // always consider as part of flow, even when not visible (for the sake of the initial animation).
-        public override bool IsPresent => true;
-
-        private SettingsSection section;
-
-        public SettingsSection Section
-        {
-            get => section;
-            set
-            {
-                section = value;
-                headerText.Text = value.Header;
-                iconContainer.Icon = value.CreateIcon();
-            }
-        }
-
-        private bool selected;
-
-        public bool Selected
-        {
-            get => selected;
-            set
-            {
-                selected = value;
-
-                if (IsLoaded)
-                    updateState();
-            }
-        }
-
-        public SidebarButton()
-        {
-            RelativeSizeAxes = Axes.X;
-            Height = 46;
-
-            AddRange(new Drawable[]
-            {
-                text = new Container
-                {
-                    Width = Sidebar.DEFAULT_WIDTH,
-                    RelativeSizeAxes = Axes.Y,
-                    Colour = OsuColour.Gray(0.6f),
-                    Children = new Drawable[]
-                    {
-                        headerText = new OsuSpriteText
-                        {
-                            Position = new Vector2(Sidebar.DEFAULT_WIDTH + 10, 0),
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                        },
-                        iconContainer = new ConstrainedIconContainer
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Size = new Vector2(20),
-                        },
-                    }
-                },
-                selectionIndicator = new CircularContainer
-                {
-                    Alpha = 0,
-                    Width = 3,
-                    Height = 18,
-                    Masking = true,
-                    CornerRadius = 1.5f,
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    Margin = new MarginPadding
-                    {
-                        Left = 9,
-                    },
-                    Child = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Colour4.White
-                    }
-                },
-            });
-        }
+        protected abstract Drawable HoverTarget { get; }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            BackgroundColour = colourProvider.Background5;
-            selectionIndicator.Colour = colourProvider.Highlight1;
+            BackgroundColour = ColourProvider.Background5;
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            updateState();
+            UpdateState();
+            FinishTransforms(true);
         }
 
         protected override bool OnHover(HoverEvent e)
         {
-            updateState();
+            UpdateState();
             return false;
         }
 
-        protected override void OnHoverLost(HoverLostEvent e) => updateState();
+        protected override void OnHoverLost(HoverLostEvent e) => UpdateState();
 
-        private void updateState()
+        protected virtual void UpdateState()
         {
-            if (Selected)
-            {
-                text.FadeColour(colourProvider.Content1, fade_duration, Easing.OutQuint);
-                selectionIndicator.FadeIn(fade_duration, Easing.OutQuint);
-                return;
-            }
-
-            text.FadeColour(IsHovered ? colourProvider.Light1 : colourProvider.Light3, fade_duration, Easing.OutQuint);
-            selectionIndicator.FadeOut(fade_duration, Easing.OutQuint);
+            HoverTarget.FadeColour(IsHovered ? ColourProvider.Light1 : ColourProvider.Light3, fade_duration, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osuTK;
-using osuTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -17,10 +17,15 @@ namespace osu.Game.Overlays.Settings
 {
     public class SidebarButton : OsuButton
     {
+        private const double fade_duration = 50;
+
         private readonly ConstrainedIconContainer iconContainer;
         private readonly SpriteText headerText;
-        private readonly Box selectionIndicator;
+        private readonly CircularContainer selectionIndicator;
         private readonly Container text;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; }
 
         // always consider as part of flow, even when not visible (for the sake of the initial animation).
         public override bool IsPresent => true;
@@ -47,25 +52,15 @@ namespace osu.Game.Overlays.Settings
             {
                 selected = value;
 
-                if (selected)
-                {
-                    selectionIndicator.FadeIn(50);
-                    text.FadeColour(Color4.White, 50);
-                }
-                else
-                {
-                    selectionIndicator.FadeOut(50);
-                    text.FadeColour(OsuColour.Gray(0.6f), 50);
-                }
+                if (IsLoaded)
+                    updateState();
             }
         }
 
         public SidebarButton()
         {
-            Height = Sidebar.DEFAULT_WIDTH;
             RelativeSizeAxes = Axes.X;
-
-            BackgroundColour = Color4.Black;
+            Height = 46;
 
             AddRange(new Drawable[]
             {
@@ -90,21 +85,60 @@ namespace osu.Game.Overlays.Settings
                         },
                     }
                 },
-                selectionIndicator = new Box
+                selectionIndicator = new CircularContainer
                 {
                     Alpha = 0,
-                    RelativeSizeAxes = Axes.Y,
-                    Width = 5,
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.CentreRight,
+                    Width = 3,
+                    Height = 18,
+                    Masking = true,
+                    CornerRadius = 1.5f,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding
+                    {
+                        Left = 9,
+                    },
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Colour4.White
+                    }
                 },
             });
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load()
         {
-            selectionIndicator.Colour = colours.Yellow;
+            BackgroundColour = colourProvider.Background5;
+            selectionIndicator.Colour = colourProvider.Highlight1;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateState();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return false;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e) => updateState();
+
+        private void updateState()
+        {
+            if (Selected)
+            {
+                text.FadeColour(colourProvider.Content1, fade_duration, Easing.OutQuint);
+                selectionIndicator.FadeIn(fade_duration, Easing.OutQuint);
+                return;
+            }
+
+            text.FadeColour(IsHovered ? colourProvider.Light1 : colourProvider.Light3, fade_duration, Easing.OutQuint);
+            selectionIndicator.FadeOut(fade_duration, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/SidebarIconButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarIconButton.cs
@@ -15,7 +15,10 @@ namespace osu.Game.Overlays.Settings
 {
     public class SidebarIconButton : SidebarButton
     {
-        private const double fade_duration = 50;
+        private const double fade_duration = 500;
+
+        private const float selection_indicator_height_active = 18;
+        private const float selection_indicator_height_inactive = 4;
 
         private readonly ConstrainedIconContainer iconContainer;
         private readonly SpriteText headerText;
@@ -85,8 +88,8 @@ namespace osu.Game.Overlays.Settings
                 selectionIndicator = new CircularContainer
                 {
                     Alpha = 0,
-                    Width = 3,
-                    Height = 18,
+                    Width = 4,
+                    Height = selection_indicator_height_inactive,
                     Masking = true,
                     CornerRadius = 1.5f,
                     Anchor = Anchor.CentreLeft,
@@ -116,10 +119,12 @@ namespace osu.Game.Overlays.Settings
             {
                 text.FadeColour(ColourProvider.Content1, fade_duration, Easing.OutQuint);
                 selectionIndicator.FadeIn(fade_duration, Easing.OutQuint);
+                selectionIndicator.ResizeHeightTo(selection_indicator_height_active, fade_duration, Easing.OutElasticHalf);
                 return;
             }
 
             selectionIndicator.FadeOut(fade_duration, Easing.OutQuint);
+            selectionIndicator.ResizeHeightTo(selection_indicator_height_inactive, fade_duration, Easing.OutQuint);
             base.UpdateState();
         }
     }

--- a/osu.Game/Overlays/Settings/SidebarIconButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarIconButton.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Overlays.Settings
+{
+    public class SidebarIconButton : SidebarButton
+    {
+        private const double fade_duration = 50;
+
+        private readonly ConstrainedIconContainer iconContainer;
+        private readonly SpriteText headerText;
+        private readonly CircularContainer selectionIndicator;
+        private readonly Container text;
+
+        protected override Drawable HoverTarget => text;
+
+        // always consider as part of flow, even when not visible (for the sake of the initial animation).
+        public override bool IsPresent => true;
+
+        private SettingsSection section;
+
+        public SettingsSection Section
+        {
+            get => section;
+            set
+            {
+                section = value;
+                headerText.Text = value.Header;
+                iconContainer.Icon = value.CreateIcon();
+            }
+        }
+
+        private bool selected;
+
+        public bool Selected
+        {
+            get => selected;
+            set
+            {
+                selected = value;
+
+                if (IsLoaded)
+                    UpdateState();
+            }
+        }
+
+        public SidebarIconButton()
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = 46;
+
+            AddRange(new Drawable[]
+            {
+                text = new Container
+                {
+                    Width = Sidebar.DEFAULT_WIDTH,
+                    RelativeSizeAxes = Axes.Y,
+                    Colour = OsuColour.Gray(0.6f),
+                    Children = new Drawable[]
+                    {
+                        headerText = new OsuSpriteText
+                        {
+                            Position = new Vector2(Sidebar.DEFAULT_WIDTH + 10, 0),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                        },
+                        iconContainer = new ConstrainedIconContainer
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(20),
+                        },
+                    }
+                },
+                selectionIndicator = new CircularContainer
+                {
+                    Alpha = 0,
+                    Width = 3,
+                    Height = 18,
+                    Masking = true,
+                    CornerRadius = 1.5f,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding
+                    {
+                        Left = 9,
+                    },
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Colour4.White
+                    }
+                },
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            selectionIndicator.Colour = ColourProvider.Highlight1;
+        }
+
+        protected override void UpdateState()
+        {
+            if (Selected)
+            {
+                text.FadeColour(ColourProvider.Content1, fade_duration, Easing.OutQuint);
+                selectionIndicator.FadeIn(fade_duration, Easing.OutQuint);
+                return;
+            }
+
+            selectionIndicator.FadeOut(fade_duration, Easing.OutQuint);
+            base.UpdateState();
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/SidebarIconButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarIconButton.cs
@@ -15,17 +15,13 @@ namespace osu.Game.Overlays.Settings
 {
     public class SidebarIconButton : SidebarButton
     {
-        private const double fade_duration = 500;
-
         private const float selection_indicator_height_active = 18;
         private const float selection_indicator_height_inactive = 4;
 
         private readonly ConstrainedIconContainer iconContainer;
         private readonly SpriteText headerText;
         private readonly CircularContainer selectionIndicator;
-        private readonly Container text;
-
-        protected override Drawable HoverTarget => text;
+        private readonly Container textIconContent;
 
         // always consider as part of flow, even when not visible (for the sake of the initial animation).
         public override bool IsPresent => true;
@@ -64,7 +60,7 @@ namespace osu.Game.Overlays.Settings
 
             AddRange(new Drawable[]
             {
-                text = new Container
+                textIconContent = new Container
                 {
                     Width = Sidebar.DEFAULT_WIDTH,
                     RelativeSizeAxes = Axes.Y,
@@ -117,15 +113,18 @@ namespace osu.Game.Overlays.Settings
         {
             if (Selected)
             {
-                text.FadeColour(ColourProvider.Content1, fade_duration, Easing.OutQuint);
-                selectionIndicator.FadeIn(fade_duration, Easing.OutQuint);
-                selectionIndicator.ResizeHeightTo(selection_indicator_height_active, fade_duration, Easing.OutElasticHalf);
-                return;
-            }
+                textIconContent.FadeColour(ColourProvider.Content1, FADE_DURATION, Easing.OutQuint);
 
-            selectionIndicator.FadeOut(fade_duration, Easing.OutQuint);
-            selectionIndicator.ResizeHeightTo(selection_indicator_height_inactive, fade_duration, Easing.OutQuint);
-            base.UpdateState();
+                selectionIndicator.FadeIn(FADE_DURATION, Easing.OutQuint);
+                selectionIndicator.ResizeHeightTo(selection_indicator_height_active, FADE_DURATION, Easing.OutElasticHalf);
+            }
+            else
+            {
+                textIconContent.FadeColour(IsHovered ? ColourProvider.Light1 : ColourProvider.Light3, FADE_DURATION, Easing.OutQuint);
+
+                selectionIndicator.FadeOut(FADE_DURATION, Easing.OutQuint);
+                selectionIndicator.ResizeHeightTo(selection_indicator_height_inactive, FADE_DURATION, Easing.OutQuint);
+            }
         }
     }
 }

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Overlays
     [Cached]
     public abstract class SettingsPanel : OsuFocusedOverlayContainer
     {
-        public const float CONTENT_MARGINS = 15;
+        public const float CONTENT_MARGINS = 20;
 
         public const float TRANSITION_LENGTH = 600;
 
@@ -106,17 +106,23 @@ namespace osu.Game.Overlays
                 RelativeSizeAxes = Axes.Both,
                 ExpandableHeader = CreateHeader(),
                 SelectedSection = { BindTarget = CurrentSection },
-                FixedHeader = searchTextBox = new SeekLimitedSearchTextBox
+                FixedHeader = new Container
                 {
                     RelativeSizeAxes = Axes.X,
-                    Origin = Anchor.TopCentre,
-                    Anchor = Anchor.TopCentre,
-                    Width = 0.95f,
-                    Margin = new MarginPadding
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding
                     {
-                        Top = 20,
-                        Bottom = 20
+                        Vertical = 20,
+                        Horizontal = CONTENT_MARGINS
                     },
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Child = searchTextBox = new SeekLimitedSearchTextBox
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Origin = Anchor.TopCentre,
+                        Anchor = Anchor.TopCentre,
+                    }
                 },
                 Footer = CreateFooter().With(f => f.Alpha = 0)
             });

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays
         protected override Container<Drawable> Content => ContentContainer;
 
         protected Sidebar Sidebar;
-        private SidebarButton selectedSidebarButton;
+        private SidebarIconButton selectedSidebarButton;
 
         public SettingsSectionsContainer SectionsContainer { get; private set; }
 
@@ -252,11 +252,11 @@ namespace osu.Game.Overlays
             });
         }
 
-        private IEnumerable<SidebarButton> createSidebarButtons()
+        private IEnumerable<SidebarIconButton> createSidebarButtons()
         {
             foreach (var section in SectionsContainer)
             {
-                yield return new SidebarButton
+                yield return new SidebarIconButton
                 {
                     Section = section,
                     Action = () =>

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osuTK;
-using osuTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -15,7 +14,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
@@ -64,6 +62,9 @@ namespace osu.Game.Overlays
 
         public IBindable<SettingsSection> CurrentSection = new Bindable<SettingsSection>();
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
         protected SettingsPanel(bool showSidebar)
         {
             this.showSidebar = showSidebar;
@@ -89,7 +90,7 @@ namespace osu.Game.Overlays
                         Origin = Anchor.TopRight,
                         Scale = new Vector2(2, 1), // over-extend to the left for transitions
                         RelativeSizeAxes = Axes.Both,
-                        Colour = OsuColour.Gray(0.05f),
+                        Colour = colourProvider.Background4,
                         Alpha = 1,
                     },
                     loading = new LoadingLayer
@@ -292,11 +293,12 @@ namespace osu.Game.Overlays
                     Direction = FillDirection.Vertical,
                 };
 
-            public SettingsSectionsContainer()
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
             {
                 HeaderBackground = new Box
                 {
-                    Colour = Color4.Black,
+                    Colour = colourProvider.Background4,
                     RelativeSizeAxes = Axes.Both
                 };
             }

--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osuTK;
 
@@ -33,22 +32,20 @@ namespace osu.Game.Overlays
 
         protected override bool DimMainContent => false; // dimming is handled by main overlay
 
-        private class BackButton : OsuButton
+        private class BackButton : SidebarButton
         {
-            [Resolved]
-            private OverlayColourProvider colourProvider { get; set; }
+            private Container content;
+
+            protected override Drawable HoverTarget => content;
 
             [BackgroundDependencyLoader]
             private void load()
             {
                 Size = new Vector2(Sidebar.DEFAULT_WIDTH);
 
-                BackgroundColour = colourProvider.Background5;
-                Hover.Colour = Colour4.Transparent;
-
                 AddRange(new Drawable[]
                 {
-                    new Container
+                    content = new Container
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -36,8 +36,6 @@ namespace osu.Game.Overlays
         {
             private Container content;
 
-            protected override Drawable HoverTarget => content;
-
             [BackgroundDependencyLoader]
             private void load()
             {
@@ -70,6 +68,11 @@ namespace osu.Game.Overlays
                         }
                     }
                 });
+            }
+
+            protected override void UpdateState()
+            {
+                content.FadeColour(IsHovered ? ColourProvider.Light1 : ColourProvider.Light3, FADE_DURATION, Easing.OutQuint);
             }
         }
     }

--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -10,7 +10,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Overlays
 {
@@ -36,12 +35,16 @@ namespace osu.Game.Overlays
 
         private class BackButton : OsuButton
         {
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
+
             [BackgroundDependencyLoader]
             private void load()
             {
                 Size = new Vector2(Sidebar.DEFAULT_WIDTH);
 
-                BackgroundColour = Color4.Black;
+                BackgroundColour = colourProvider.Background5;
+                Hover.Colour = Colour4.Transparent;
 
                 AddRange(new Drawable[]
                 {


### PR DESCRIPTION
Based on the following designs: https://www.figma.com/file/IjrU0u7MFdgmxDofqTlsZb/UI%2FClient-Settings?node-id=0%3A1

https://user-images.githubusercontent.com/20418176/136675412-13087618-f2b7-49f8-9e24-1d748626cb63.mp4

The general goal was to get to 80% of the end goal at first rather than get it all perfect on the first go. Mandatory pre-emptive notes follow:

* From what I understand, the "moss green" colour scheme used on the design is a placeholder and the real design can use any hue, which is decided by *[unknown conditions/decision processes I am not aware of and which have not been divulged despite a comment on the design file that asks this exact question]*. I used purple because the [web settings page](https://osu.ppy.sh/home/account/edit) does so too, and because it doesn't look awful with the existing controls. Changing this will be a question of a few lines of code at most even if a new hue is to be added for this, so I think there is value in getting this out regardless of that.
* Speaking of existing controls, I am aware that they are not updated here. This is intentional both to reduce scope and to ensure that the existing controls look good everywhere they are used after adding `OverlayColourProvider` support to them. Shared controls will be changed individually in follow-up PRs. (Doesn't help that hover behaviours are missing from the design, either.)
* Some spacings may look to be specified differently than on the figma on first glance. All occurrences of this should be around text and the weird measurements involved (i.e. sometimes the design specifies dimensions from top-of-container to [cap-height](https://en.wikipedia.org/wiki/Cap_height)-of-text, which is not feasible for `SpriteText`, and so I use some other method - but the measurements are still taken from the figma, one way or another).
* Some parts of the sidebar were not on the designs, so I winged them myself. In particular I am referring to: the sidebar header part and the keybinding subpanel. Any changes there were made to either try to match the rest of the design better or just make these particular parts look not-awful until a better design is in place.
* Tablet settings have old spacings remaining, because applying the new spacings would make it so that the half of the controls that modify the tablet area no longer fit on the screen under the tablet area preview, making the UX a bit useless (need to scroll back and forth to preview the area).

Perhaps it's a bit dubious to be getting this out despite all of the above, but I made most of this last weekend in a few hours and so maybe things can get a rolling start now that some of the work has actually been done. I'll close if it turns out otherwise, but I think the outstanding issues can be either fixed here with low effort or iterated on in the future.