### PR TITLE
Use comma separator for tournament score displays

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
@@ -132,6 +132,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             private OsuSpriteText displayedSpriteText;
 
             public MatchScoreCounter()
+                : base(useCommaSeparator: true)
             {
                 Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
             }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
@@ -127,12 +127,11 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             score2Text.X = Math.Max(5 + score2Text.DrawWidth / 2, score2Bar.DrawWidth);
         }
 
-        private class MatchScoreCounter : ScoreCounter
+        private class MatchScoreCounter : CommaSeparatedScoreCounter
         {
             private OsuSpriteText displayedSpriteText;
 
             public MatchScoreCounter()
-                : base(useCommaSeparator: true)
             {
                 Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
             }

--- a/osu.Game/Graphics/UserInterface/CommaSeparatedScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/CommaSeparatedScoreCounter.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public abstract class CommaSeparatedScoreCounter : RollingCounter<double>
+    {
+        protected override double RollingDuration => 1000;
+        protected override Easing RollingEasing => Easing.Out;
+
+        protected override double GetProportionalDuration(double currentValue, double newValue) =>
+            currentValue > newValue ? currentValue - newValue : newValue - currentValue;
+
+        protected override LocalisableString FormatCount(double count) => ((long)count).ToLocalisableString(@"N0");
+
+        protected override OsuSpriteText CreateSpriteText()
+            => base.CreateSpriteText().With(s => s.Font = s.Font.With(fixedWidth: true));
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/ScoreCounter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -17,23 +16,14 @@ namespace osu.Game.Graphics.UserInterface
 
         public Bindable<int> RequiredDisplayDigits { get; } = new Bindable<int>();
 
-        private string formatString = string.Empty;
+        private string formatString;
 
         /// <summary>
         /// Displays score.
         /// </summary>
         /// <param name="leading">How many leading zeroes the counter will have.</param>
-        /// <param name="useCommaSeparator">Whether comma separators should be displayed.</param>
-        protected ScoreCounter(int leading = 0, bool useCommaSeparator = false)
+        protected ScoreCounter(int leading = 0)
         {
-            if (useCommaSeparator)
-            {
-                if (leading > 0)
-                    throw new ArgumentException("Should not mix leading zeroes and comma separators as it doesn't make sense");
-
-                formatString = @"N0";
-            }
-
             RequiredDisplayDigits.Value = leading;
             RequiredDisplayDigits.BindValueChanged(displayDigitsChanged, true);
         }
@@ -44,10 +34,8 @@ namespace osu.Game.Graphics.UserInterface
             UpdateDisplay();
         }
 
-        protected override double GetProportionalDuration(double currentValue, double newValue)
-        {
-            return currentValue > newValue ? currentValue - newValue : newValue - currentValue;
-        }
+        protected override double GetProportionalDuration(double currentValue, double newValue) =>
+            currentValue > newValue ? currentValue - newValue : newValue - currentValue;
 
         protected override LocalisableString FormatCount(double count) => ((long)count).ToLocalisableString(formatString);
 

--- a/osu.Game/Graphics/UserInterface/ScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/ScoreCounter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -29,6 +30,9 @@ namespace osu.Game.Graphics.UserInterface
         {
             UseCommaSeparator = useCommaSeparator;
 
+            if (useCommaSeparator && leading > 0)
+                throw new ArgumentException("Should not mix leading zeroes and comma separators as it doesn't make sense");
+
             RequiredDisplayDigits.Value = leading;
             RequiredDisplayDigits.BindValueChanged(_ => UpdateDisplay());
         }
@@ -41,14 +45,15 @@ namespace osu.Game.Graphics.UserInterface
         protected override LocalisableString FormatCount(double count)
         {
             string format = new string('0', RequiredDisplayDigits.Value);
+            var output = ((long)count).ToString(format);
 
             if (UseCommaSeparator)
             {
-                for (int i = format.Length - 3; i > 0; i -= 3)
-                    format = format.Insert(i, @",");
+                for (int i = output.Length - 3; i > 0; i -= 3)
+                    output = output.Insert(i, @",");
             }
 
-            return ((long)count).ToString(format);
+            return output;
         }
 
         protected override OsuSpriteText CreateSpriteText()

--- a/osu.Game/Screens/Play/HUD/DefaultScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultScoreCounter.cs
@@ -11,7 +11,6 @@ namespace osu.Game.Screens.Play.HUD
     public class DefaultScoreCounter : GameplayScoreCounter, ISkinnableDrawable
     {
         public DefaultScoreCounter()
-            : base(6)
         {
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;

--- a/osu.Game/Screens/Play/HUD/GameplayScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayScoreCounter.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Screens.Play.HUD
     {
         private Bindable<ScoringMode> scoreDisplayMode;
 
-        protected GameplayScoreCounter(int leading = 0, bool useCommaSeparator = false)
-            : base(leading, useCommaSeparator)
+        protected GameplayScoreCounter()
+            : base(6)
         {
         }
 

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -146,12 +146,11 @@ namespace osu.Game.Screens.Play.HUD
             Score2Text.X = Math.Max(5 + Score2Text.DrawWidth / 2, score2Bar.DrawWidth);
         }
 
-        protected class MatchScoreCounter : ScoreCounter
+        protected class MatchScoreCounter : CommaSeparatedScoreCounter
         {
             private OsuSpriteText displayedSpriteText;
 
             public MatchScoreCounter()
-                : base(useCommaSeparator: true)
             {
                 Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
             }

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -4,11 +4,9 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -153,6 +151,7 @@ namespace osu.Game.Screens.Play.HUD
             private OsuSpriteText displayedSpriteText;
 
             public MatchScoreCounter()
+                : base(useCommaSeparator: true)
             {
                 Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
             }
@@ -173,8 +172,6 @@ namespace osu.Game.Screens.Play.HUD
                 => displayedSpriteText.Font = winning
                     ? OsuFont.Torus.With(weight: FontWeight.Bold, size: font_size, fixedWidth: true)
                     : OsuFont.Torus.With(weight: FontWeight.Regular, size: font_size * 0.8f, fixedWidth: true);
-
-            protected override LocalisableString FormatCount(double count) => count.ToLocalisableString(@"N0");
         }
     }
 }

--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Skinning
         public bool UsesFixedAnchor { get; set; }
 
         public LegacyScoreCounter()
-            : base(6)
         {
             Anchor = Anchor.TopRight;
             Origin = Anchor.TopRight;


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/discussions/15019.

Also fixes the fact this never really worked with leading zeroes (and wasn't tested because it really doesn't work with both applied at once - I've exceptioned against this for now).