### PR TITLE
Attempt to set heath drain and gain to same as in stable

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -13,10 +13,10 @@ namespace osu.Game.Rulesets.Mania.Judgements
             switch (result)
             {
                 case HitResult.SmallTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.25;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.LargeTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.45;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.7;
 
                 case HitResult.SmallTickMiss:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.015;
@@ -31,16 +31,16 @@ namespace osu.Game.Rulesets.Mania.Judgements
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.025;
 
                 case HitResult.Ok:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.45;
-
-                case HitResult.Good:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.55;
 
+                case HitResult.Good:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.7;
+
                 case HitResult.Great:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.9;
 
                 case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.775;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.95;
 
                 default:
                     return base.HealthIncreaseFor(result);

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -13,34 +13,34 @@ namespace osu.Game.Rulesets.Mania.Judgements
             switch (result)
             {
                 case HitResult.SmallTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.25;
 
                 case HitResult.LargeTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.9;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.45;
 
                 case HitResult.SmallTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.02;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.015;
 
                 case HitResult.LargeTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.1;
-
-                case HitResult.Miss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.8;
-
-                case HitResult.Meh:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
 
+                case HitResult.Miss:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.4;
+
+                case HitResult.Meh:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.025;
+
                 case HitResult.Ok:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.7;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.45;
 
                 case HitResult.Good:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 1.1;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.55;
 
                 case HitResult.Great:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 1.5;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
 
                 case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 1.55;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.775;
 
                 default:
                     return base.HealthIncreaseFor(result);

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -12,26 +12,35 @@ namespace osu.Game.Rulesets.Mania.Judgements
         {
             switch (result)
             {
+                case HitResult.SmallTickHit:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+
                 case HitResult.LargeTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.9;
+
+                case HitResult.SmallTickMiss:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.02;
 
                 case HitResult.LargeTickMiss:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.1;
 
+                case HitResult.Miss:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.8;
+
                 case HitResult.Meh:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
 
                 case HitResult.Ok:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.3;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.7;
 
                 case HitResult.Good:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 1.1;
 
                 case HitResult.Great:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.8;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 1.5;
 
                 case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 1.55;
 
                 default:
                     return base.HealthIncreaseFor(result);

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Rulesets.Judgements
 
         /// <summary>
         /// The default health increase for a maximum judgement, as a proportion of total health.
-        /// By default, each maximum judgement restores 5% of total health.
+        /// By default, each maximum judgement restores 3.5% of total health.
         /// </summary>
-        protected const double DEFAULT_MAX_HEALTH_INCREASE = 0.05;
+        protected const double DEFAULT_MAX_HEALTH_INCREASE = 0.035;
 
         /// <summary>
         /// The maximum <see cref="HitResult"/> that can be achieved.
@@ -91,16 +91,16 @@ namespace osu.Game.Rulesets.Judgements
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.SmallTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 2;
 
                 case HitResult.LargeTickHit:
                     return DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.LargeTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 3;
 
                 case HitResult.Miss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 4;
 
                 case HitResult.Meh:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The minimum health target at an HP drain rate of 10.
         /// </summary>
-        private const double max_health_target = 0.005;
+        private const double max_health_target = 0.35;
 
 
         private IBeatmap beatmap;

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         private const double max_health_target = 0.30;
 
+        /// <summary>
+        /// Multiplier for the health drain amount
+        /// </summary>
+        private const double overall_health_drain = 0.5;
+
         private IBeatmap beatmap;
 
         private double gameplayEndTime;
@@ -166,7 +171,7 @@ namespace osu.Game.Rulesets.Scoring
                     // Apply health adjustments
                     currentHealth -= (healthIncreases[i].time - lastTime) * result;
                     lowestHealth = Math.Min(lowestHealth, currentHealth);
-                    currentHealth = Math.Min(1, currentHealth + healthIncreases[i].health * 0.5f);
+                    currentHealth = Math.Min(1, currentHealth + healthIncreases[i].health);
 
                     // Common scenario for when the drain rate is definitely too harsh
                     if (lowestHealth < 0)
@@ -182,7 +187,7 @@ namespace osu.Game.Rulesets.Scoring
                 result += 1.0 / adjustment * Math.Sign(lowestHealth - targetMinimumHealth);
             }
 
-            return result;
+            return result * overall_health_drain;
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Scoring
                     // Apply health adjustments
                     currentHealth -= (healthIncreases[i].time - lastTime) * result;
                     lowestHealth = Math.Min(lowestHealth, currentHealth);
-                    currentHealth = Math.Min(1, currentHealth + healthIncreases[i].health);
+                    currentHealth = Math.Min(1, currentHealth + healthIncreases[i].health * 0.5f);
 
                     // Common scenario for when the drain rate is definitely too harsh
                     if (lowestHealth < 0)

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -27,22 +27,18 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The minimum health target at an HP drain rate of 0.
         /// </summary>
-        private const double min_health_target = 0.95;
+        private const double min_health_target = 0.985;
 
         /// <summary>
         /// The minimum health target at an HP drain rate of 5.
         /// </summary>
-        private const double mid_health_target = 0.70;
+        private const double mid_health_target = 0.9699;
 
         /// <summary>
         /// The minimum health target at an HP drain rate of 10.
         /// </summary>
-        private const double max_health_target = 0.30;
+        private const double max_health_target = 0.005;
 
-        /// <summary>
-        /// Multiplier for the health drain amount
-        /// </summary>
-        private const double overall_health_drain = 0.5;
 
         private IBeatmap beatmap;
 
@@ -187,7 +183,7 @@ namespace osu.Game.Rulesets.Scoring
                 result += 1.0 / adjustment * Math.Sign(lowestHealth - targetMinimumHealth);
             }
 
-            return result * overall_health_drain;
+            return result;
         }
     }
 }


### PR DESCRIPTION
The biggest modification is that misses are now far more brutal than before - the same as in stable. I'm pretty sure I also solved the issue @kiwec was pointing out here: https://github.com/ppy/osu/issues/7975, where you couldn't really get HP back if you lost it.

Mainly this change is just fiddling with some constants, but it does the job :)

Edit:
I made a short video that shows the change well:
https://youtu.be/ZGYNaTuqiZM