### PR TITLE
Ensure `FailAnimation` is disposed synchronously to avoid test failures

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1011.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1012.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1011.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Audio/Effects/AudioFilter.cs
+++ b/osu.Game/Audio/Effects/AudioFilter.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using ManagedBass.Fx;
 using osu.Framework.Audio.Mixing;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Logging;
 
 namespace osu.Game.Audio.Effects
 {

--- a/osu.Game/Audio/Effects/AudioFilter.cs
+++ b/osu.Game/Audio/Effects/AudioFilter.cs
@@ -132,16 +132,8 @@ namespace osu.Game.Audio.Effects
         {
             base.Dispose(isDisposing);
 
-            try
-            {
-                if (mixer.Effects.Contains(filter))
-                    detachFilter();
-            }
-            catch (Exception e)
-            {
-                Logger.Log($"Exception in audio filter disposal: {e}");
-                throw;
-            }
+            if (mixer.Effects.Contains(filter))
+                detachFilter();
         }
     }
 }

--- a/osu.Game/Audio/Effects/AudioFilter.cs
+++ b/osu.Game/Audio/Effects/AudioFilter.cs
@@ -1,11 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using ManagedBass.Fx;
 using osu.Framework.Audio.Mixing;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 
 namespace osu.Game.Audio.Effects
 {
@@ -130,8 +132,15 @@ namespace osu.Game.Audio.Effects
         {
             base.Dispose(isDisposing);
 
-            if (mixer.Effects.Contains(filter))
-                detachFilter();
+            try
+            {
+                if (mixer.Effects.Contains(filter))
+                    detachFilter();
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Exception in audio filter disposal: {e}");
+            }
         }
     }
 }

--- a/osu.Game/Audio/Effects/AudioFilter.cs
+++ b/osu.Game/Audio/Effects/AudioFilter.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Audio.Effects
             catch (Exception e)
             {
                 Logger.Log($"Exception in audio filter disposal: {e}");
+                throw;
             }
         }
     }

--- a/osu.Game/Overlays/OSD/TrackedSettingToast.cs
+++ b/osu.Game/Overlays/OSD/TrackedSettingToast.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.OSD
         private Sample sampleChange;
 
         public TrackedSettingToast(SettingDescription description)
-            : base(description.Name, description.Value, description.Shortcut)
+            : base(description.Name.ToString(), description.Value.ToString(), description.Shortcut.ToString())
         {
             FillFlowContainer<OptionLight> optionLights;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -947,7 +947,7 @@ namespace osu.Game.Screens.Play
 
         public override void OnSuspending(IScreen next)
         {
-            screenSuspension?.Expire();
+            screenSuspension?.RemoveAndDisposeImmediately();
 
             fadeOut();
             base.OnSuspending(next);
@@ -955,7 +955,8 @@ namespace osu.Game.Screens.Play
 
         public override bool OnExiting(IScreen next)
         {
-            screenSuspension?.Expire();
+            screenSuspension?.RemoveAndDisposeImmediately();
+            failAnimation?.RemoveAndDisposeImmediately();
 
             // if arriving here and the results screen preparation task hasn't run, it's safe to say the user has not completed the beatmap.
             if (prepareScoreForDisplayTask == null)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1011.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1011.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1012.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1011.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1012.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1011.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1012.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1011.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1011.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/4818
- Closes https://github.com/ppy/osu/issues/15028 (in theory, all three issues). I can't immediately repro any locally, but will need to run some CI runs to see if they repro again.

Not really a final solution, but as in similar past cases, it better marks the wonky behaviour (with the use of the new extension method) so when we do have a better way to handle it, we can switch to that.

There may be other places in the game that should be using this same extension method. On a quick check I couldn't find any outside of `Player` though.