### PR TITLE
Fix key counter overlay not rewinding count fully

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
@@ -103,6 +103,30 @@ namespace osu.Game.Tests.Visual.Gameplay
             checkFrameCount(0);
         }
 
+        [Test]
+        public void TestSeekToSameTimePreservesRate()
+        {
+            AddStep("set manual clock rate", () => manualClock.Rate = 1);
+            seekManualTo(5000);
+            createStabilityContainer();
+            checkRate(1);
+
+            seekManualTo(10000);
+            checkRate(1);
+
+            seekManualTo(10000);
+            checkRate(1);
+
+            seekManualTo(5000);
+            checkRate(-1);
+
+            seekManualTo(5000);
+            checkRate(-1);
+
+            seekManualTo(10000);
+            checkRate(1);
+        }
+
         private const int max_frames_catchup = 50;
 
         private void createStabilityContainer(double gameplayStartTime = double.MinValue) => AddStep("create container", () =>
@@ -115,6 +139,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void checkFrameCount(int frames) =>
             AddAssert($"elapsed frames is {frames}", () => consumer.ElapsedFrames == frames);
+
+        private void checkRate(double rate) =>
+            AddAssert($"clock rate is {rate}", () => consumer.Clock.Rate == rate);
 
         public class ClockConsumingChild : CompositeDrawable
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestSeekToSameTimePreservesRate()
+        public void TestRatePreservedWhenTimeNotProgressing()
         {
             AddStep("set manual clock rate", () => manualClock.Rate = 1);
             seekManualTo(5000);
@@ -114,13 +114,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             seekManualTo(10000);
             checkRate(1);
 
-            seekManualTo(10000);
+            AddWaitStep("wait some", 3);
             checkRate(1);
 
             seekManualTo(5000);
             checkRate(-1);
 
-            seekManualTo(5000);
+            AddWaitStep("wait some", 3);
             checkRate(-1);
 
             seekManualTo(10000);

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -55,7 +55,10 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The current direction of playback to be exposed to frame stable children.
         /// </summary>
-        private int direction;
+        /// <remarks>
+        /// Initially it is presumed that playback will proceed in the forward direction.
+        /// </remarks>
+        private int direction = 1;
 
         [BackgroundDependencyLoader(true)]
         private void load(GameplayClock clock, ISamplePlaybackDisabler sampleDisabler)
@@ -139,7 +142,9 @@ namespace osu.Game.Rulesets.UI
                     state = PlaybackState.NotValid;
             }
 
-            if (state == PlaybackState.Valid)
+            // if the proposed time is the same as the current time, assume that the clock will continue progressing in the same direction as previously.
+            // this avoids spurious flips in direction from -1 to 1 during rewinds.
+            if (state == PlaybackState.Valid && proposedTime != manualClock.CurrentTime)
                 direction = proposedTime >= manualClock.CurrentTime ? 1 : -1;
 
             double timeBehind = Math.Abs(proposedTime - parentGameplayClock.CurrentTime);


### PR DESCRIPTION
For the paper trail on why frame stability logic was causing failures in the key counter, see [this issue comment](https://github.com/ppy/osu/issues/15027#issuecomment-939511558). This PR also includes an illustrative test case - at b1ad316, the second `rate == -1` check fails, as the frame stable clock returns a rate of 1 despite the source clock not moving in either direction.

This change is enough to close #15027. I am willing to follow up with the other fix mentioned in the comment linked above (removing replay frames with same start time) but that is a change that is a bit more involved due to how `ReplayRecorder` is structured and requires more care - so I figured I'd rather get this part out already as it fixes the problem and I'm reasonably certain that it's the correct change to apply.

Note that I also add an explicit initialisation of `direction` to 1. This fell out after writing the test case and discovering that without that initialisation, `direction` remained 0 until the first seek, which seemed like undesirable behaviour.