### PR TITLE
Update appearance of buttons in settings sidebar

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Handlers.Tablet;
@@ -20,6 +21,9 @@ namespace osu.Game.Tests.Visual.Settings
     {
         private TestTabletHandler tabletHandler;
         private TabletSettings settings;
+
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneRoundedButton : OsuTestScene
+    {
+        [Test]
+        public void TestBasic()
+        {
+            RoundedButton button = null;
+
+            AddStep("create button", () => Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Colour4.DarkGray
+                    },
+                    button = new RoundedButton
+                    {
+                        Width = 400,
+                        Text = "Test button",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Action = () => { }
+                    }
+                }
+            });
+
+            AddToggleStep("toggle disabled", disabled => button.Action = disabled ? (Action)null : () => { });
+        }
+    }
+}

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -226,6 +226,11 @@ namespace osu.Game.Graphics
         public readonly Color4 GrayF = Color4Extensions.FromHex(@"fff");
 
         /// <summary>
+        /// Equivalent to <see cref="OverlayColourProvider.Blue"/>'s <see cref="OverlayColourProvider.Colour3"/>.
+        /// </summary>
+        public readonly Color4 Blue3 = Color4Extensions.FromHex(@"3399cc");
+
+        /// <summary>
         /// Equivalent to <see cref="OverlayColourProvider.Lime"/>'s <see cref="OverlayColourProvider.Colour1"/>.
         /// </summary>
         public readonly Color4 Lime1 = Color4Extensions.FromHex(@"b2ff66");

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -226,6 +226,11 @@ namespace osu.Game.Graphics
         public readonly Color4 GrayF = Color4Extensions.FromHex(@"fff");
 
         /// <summary>
+        /// Equivalent to <see cref="OverlayColourProvider.Pink"/>'s <see cref="OverlayColourProvider.Colour3"/>.
+        /// </summary>
+        public readonly Color4 Pink3 = Color4Extensions.FromHex(@"cc3378");
+
+        /// <summary>
         /// Equivalent to <see cref="OverlayColourProvider.Blue"/>'s <see cref="OverlayColourProvider.Colour3"/>.
         /// </summary>
         public readonly Color4 Blue3 = Color4Extensions.FromHex(@"3399cc");

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Effects;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public class RoundedButton : OsuButton
+    {
+        public override float Height
+        {
+            get => base.Height;
+            set
+            {
+                base.Height = value;
+
+                if (IsLoaded)
+                    updateCornerRadius();
+            }
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            BackgroundColour = colours.Blue3;
+
+            Content.EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Shadow,
+                Offset = new Vector2(0, 2),
+                Radius = 4,
+                Colour = Colour4.Black.Opacity(0.15f)
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateCornerRadius();
+        }
+
+        private void updateCornerRadius() => Content.CornerRadius = DrawHeight / 2;
+    }
+}

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -1,15 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Game.Graphics.UserInterface;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public class RoundedButton : OsuButton
+    public class RoundedButton : OsuButton, IFilterable
     {
         public override float Height
         {
@@ -44,5 +46,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
         }
 
         private void updateCornerRadius() => Content.CornerRadius = DrawHeight / 2;
+
+        public virtual IEnumerable<string> FilterTerms => new[] { Text.ToString() };
+
+        public bool MatchingFilter
+        {
+            set => this.FadeTo(value ? 1 : 0);
+        }
+
+        public bool FilteringActive { get; set; }
     }
 }

--- a/osu.Game/Overlays/Settings/DangerousSettingsButton.cs
+++ b/osu.Game/Overlays/Settings/DangerousSettingsButton.cs
@@ -14,10 +14,7 @@ namespace osu.Game.Overlays.Settings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            BackgroundColour = colours.Pink;
-
-            Triangles.ColourDark = colours.PinkDark;
-            Triangles.ColourLight = colours.PinkLight;
+            BackgroundColour = colours.Pink3;
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Database;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets;
 using osu.Game.Localisation;
@@ -59,7 +58,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         }
     }
 
-    public class ResetButton : DangerousTriangleButton
+    public class ResetButton : DangerousSettingsButton
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Overlays/Settings/Sections/Input/RotationPresetButtons.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RotationPresetButtons.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -8,16 +9,24 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {
-    internal class RotationPresetButtons : FillFlowContainer
+    internal class RotationPresetButtons : CompositeDrawable
     {
+        public new MarginPadding Padding
+        {
+            get => base.Padding;
+            set => base.Padding = value;
+        }
+
         private readonly ITabletHandler tabletHandler;
 
         private Bindable<float> rotation;
+        private readonly RotationButton[] rotationPresets = new RotationButton[preset_count];
 
+        private const int preset_count = 4;
         private const int height = 50;
 
         public RotationPresetButtons(ITabletHandler tabletHandler)
@@ -27,18 +36,39 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             RelativeSizeAxes = Axes.X;
             Height = height;
 
-            for (int i = 0; i < 360; i += 90)
+            IEnumerable<Dimension> createColumns(int count)
             {
-                var presetRotation = i;
-
-                Add(new RotationButton(i)
+                for (int i = 0; i < count; ++i)
                 {
-                    RelativeSizeAxes = Axes.X,
-                    Height = height,
-                    Width = 0.25f,
-                    Text = $@"{presetRotation}º",
-                    Action = () => tabletHandler.Rotation.Value = presetRotation,
-                });
+                    if (i > 0)
+                        yield return new Dimension(GridSizeMode.Absolute, 10);
+
+                    yield return new Dimension();
+                }
+            }
+
+            GridContainer grid;
+
+            InternalChild = grid = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = createColumns(preset_count).ToArray()
+            };
+
+            grid.Content = new[] { new Drawable[preset_count * 2 - 1] };
+
+            for (int i = 0; i < preset_count; i++)
+            {
+                var rotationValue = i * 90;
+
+                var rotationPreset = new RotationButton(rotationValue)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Height = 1,
+                    Text = $@"{rotationValue}º",
+                    Action = () => tabletHandler.Rotation.Value = rotationValue,
+                };
+                grid.Content[0][2 * i] = rotationPresets[i] = rotationPreset;
             }
         }
 
@@ -49,15 +79,18 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             rotation = tabletHandler.Rotation.GetBoundCopy();
             rotation.BindValueChanged(val =>
             {
-                foreach (var b in Children.OfType<RotationButton>())
+                foreach (var b in rotationPresets)
                     b.IsSelected = b.Preset == val.NewValue;
             }, true);
         }
 
-        public class RotationButton : TriangleButton
+        public class RotationButton : RoundedButton
         {
             [Resolved]
             private OsuColour colours { get; set; }
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
 
             public readonly int Preset;
 
@@ -91,18 +124,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             private void updateColour()
             {
-                if (isSelected)
-                {
-                    BackgroundColour = colours.BlueDark;
-                    Triangles.ColourDark = colours.BlueDarker;
-                    Triangles.ColourLight = colours.Blue;
-                }
-                else
-                {
-                    BackgroundColour = colours.Gray4;
-                    Triangles.ColourDark = colours.Gray5;
-                    Triangles.ColourLight = colours.Gray6;
-                }
+                BackgroundColour = isSelected ? colours.Blue3 : colourProvider.Background3;
             }
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
@@ -10,7 +10,6 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Database;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
@@ -21,15 +20,15 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         protected override LocalisableString Header => "General";
 
-        private TriangleButton importBeatmapsButton;
-        private TriangleButton importScoresButton;
-        private TriangleButton importSkinsButton;
-        private TriangleButton importCollectionsButton;
-        private TriangleButton deleteBeatmapsButton;
-        private TriangleButton deleteScoresButton;
-        private TriangleButton deleteSkinsButton;
-        private TriangleButton restoreButton;
-        private TriangleButton undeleteButton;
+        private SettingsButton importBeatmapsButton;
+        private SettingsButton importScoresButton;
+        private SettingsButton importSkinsButton;
+        private SettingsButton importCollectionsButton;
+        private SettingsButton deleteBeatmapsButton;
+        private SettingsButton deleteScoresButton;
+        private SettingsButton deleteSkinsButton;
+        private SettingsButton restoreButton;
+        private SettingsButton undeleteButton;
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(BeatmapManager beatmaps, ScoreManager scores, SkinManager skins, [CanBeNull] CollectionManager collectionManager, [CanBeNull] StableImportManager stableImportManager, DialogOverlay dialogOverlay)

--- a/osu.Game/Overlays/Settings/SettingsButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsButton.cs
@@ -6,11 +6,11 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Overlays.Settings
 {
-    public class SettingsButton : TriangleButton, IHasTooltip
+    public class SettingsButton : RoundedButton, IHasTooltip
     {
         public SettingsButton()
         {


### PR DESCRIPTION
Could also call this the "removal of triangles from settings sidebar" pull.

Based on the following designs: https://www.figma.com/file/IjrU0u7MFdgmxDofqTlsZb/UI%2FClient-Settings?node-id=0%3A1

https://user-images.githubusercontent.com/20418176/136857083-83dd6799-7984-4598-8127-df6727b556e4.mp4

Pre-emptive notes:

* Hover behaviours were not specified on figma, so I just used `OsuButton` defaults. Looks inoffensive enough to me.
* The "destructive button" colour was also not explicitly specified. But given that normal ones used `Blue3`, I used `Pink3` for the destructive ones. The colour specs can be found [here](https://www.figma.com/file/VIkXMYNPMtQem2RJg9k2iQ/Asset%2FColours?node-id=0%3A1), in the *"Basic" Colour Theme* section.
* I didn't quite know what to do with the tablet settings preset buttons (because they are not on the designs) - leaving `TriangleButton`s looked wrong there, and so did leaving the gray colour, so I improvised. I think it looks okay but may need correcting or revisiting later.
* The shadow spec for the button is not exactly the same as figma values, but figma values - namely, `rgba(0, 0, 0, 0.25)` - resulted in a shadow that looked way too strong (unsure why - different shadow algo than CSS? gamma correction again?), so I toned it down a notch.

On a semi-related note, I also have drafts of changes for checkboxes, sliders and dropdowns - but I need to work on them more. Initially I was just adding `OverlayColourProvider`s to the base controls everywhere and hoping the themed colours would look good everywhere, but there are places where this is not the case (editor setup screen, room creation subscreen in multiplayer). So I'm thinking that I'll take a similar approach to what I've done here, which is make the themed controls separate classes and use those locally in settings, and then everywhere else after everywhere else is fully migrated to newest designs.
