### PR TITLE
Fix cross-thread list manipulation in `SkinProvidingContainer`

### DIFF
--- a/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Skins
 
             public new void TriggerSourceChanged() => base.TriggerSourceChanged();
 
-            protected override void OnSourceChanged()
+            protected override void RefreshSources()
             {
                 SetSources(sources);
             }

--- a/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
@@ -67,8 +66,7 @@ namespace osu.Game.Tests.Skins
 
             protected override void OnSourceChanged()
             {
-                ResetSources();
-                sources.ForEach(AddSource);
+                SetSources(sources);
             }
         }
 

--- a/osu.Game/Skinning/ISkinSource.cs
+++ b/osu.Game/Skinning/ISkinSource.cs
@@ -12,6 +12,9 @@ namespace osu.Game.Skinning
     /// </summary>
     public interface ISkinSource : ISkin
     {
+        /// <summary>
+        /// Fired whenever a source change occurs, signalling that consumers should re-query as required.
+        /// </summary>
         event Action SourceChanged;
 
         /// <summary>

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Skinning
             return base.CreateChildDependencies(parent);
         }
 
-        protected override void OnSourceChanged()
+        protected override void RefreshSources()
         {
             // Populate a local list first so we can adjust the returned order as we go.
             var sources = new List<ISkin>();

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -60,8 +60,6 @@ namespace osu.Game.Skinning
 
         protected override void OnSourceChanged()
         {
-            ResetSources();
-
             // Populate a local list first so we can adjust the returned order as we go.
             var sources = new List<ISkin>();
 
@@ -91,8 +89,7 @@ namespace osu.Game.Skinning
             else
                 sources.Add(rulesetResourcesSkin);
 
-            foreach (var skin in sources)
-                AddSource(skin);
+            SetSources(sources);
         }
 
         protected ISkin GetLegacyRulesetTransformedSkin(ISkin legacySkin)

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -173,6 +173,9 @@ namespace osu.Game.Skinning
         /// <summary>
         /// Replace the sources used for lookups in this container.
         /// </summary>
+        /// <remarks>
+        /// This does not implicitly fire a <see cref="SourceChanged"/> event. Consider calling <see cref="TriggerSourceChanged"/> if required.
+        /// </remarks>
         /// <param name="sources">The new sources.</param>
         protected void SetSources(IEnumerable<ISkin> sources)
         {
@@ -195,15 +198,15 @@ namespace osu.Game.Skinning
         }
 
         /// <summary>
-        /// Invoked when any source has changed (either <see cref="ParentSource"/> or sources replaced via <see cref="SetSources"/>).
+        /// Invoked after any consumed source change, before the external <see cref="SourceChanged"/> event is fired.
         /// This is also invoked once initially during <see cref="CreateChildDependencies"/> to ensure sources are ready for children consumption.
         /// </summary>
-        protected virtual void OnSourceChanged() { }
+        protected virtual void RefreshSources() { }
 
         protected void TriggerSourceChanged()
         {
             // Expose to implementations, giving them a chance to react before notifying external consumers.
-            OnSourceChanged();
+            RefreshSources();
 
             SourceChanged?.Invoke();
         }

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -41,6 +41,8 @@ namespace osu.Game.Skinning
 
         protected virtual bool AllowColourLookup => true;
 
+        private readonly object sourceSetLock = new object();
+
         /// <summary>
         /// A dictionary mapping each <see cref="ISkin"/> source to a wrapper which handles lookup allowances.
         /// </summary>
@@ -174,18 +176,21 @@ namespace osu.Game.Skinning
         /// <param name="sources">The new sources.</param>
         protected void SetSources(IEnumerable<ISkin> sources)
         {
-            foreach (var skin in skinSources)
+            lock (sourceSetLock)
             {
-                if (skin.skin is ISkinSource source)
-                    source.SourceChanged -= TriggerSourceChanged;
-            }
+                foreach (var skin in skinSources)
+                {
+                    if (skin.skin is ISkinSource source)
+                        source.SourceChanged -= TriggerSourceChanged;
+                }
 
-            skinSources = sources.Select(skin => (skin, new DisableableSkinSource(skin, this))).ToArray();
+                skinSources = sources.Select(skin => (skin, new DisableableSkinSource(skin, this))).ToArray();
 
-            foreach (var skin in skinSources)
-            {
-                if (skin.skin is ISkinSource source)
-                    source.SourceChanged += TriggerSourceChanged;
+                foreach (var skin in skinSources)
+                {
+                    if (skin.skin is ISkinSource source)
+                        source.SourceChanged += TriggerSourceChanged;
+                }
             }
         }
 


### PR DESCRIPTION
As seen in [CI failure](https://github.com/ppy/osu/pull/15038/checks?check_run_id=3861179477).

Switched to using array for simplicity. The usage here is read heavy and seldom write, so it seems logical.

Removed `RemoveSource` as it was not used outside the reset operation, which has now been simplified.