### PR TITLE
Increase verbosity of github actions runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet build -c Debug -warnaserror osu.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx;verbosity=detailed"
         shell: pwsh
 
       # Attempt to upload results even if test fails.


### PR DESCRIPTION
We are catching and logging unobserved exceptions, but these can't be seen in github actions output currently. This is a test to see if increasing verbosity helps with visibility.