### PR TITLE
Fix GameHosts being run on TPL threads

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1012.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1013.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game.Tests/ImportTest.cs
+++ b/osu.Game.Tests/ImportTest.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests
         protected virtual TestOsuGameBase LoadOsuIntoHost(GameHost host, bool withBeatmap = false)
         {
             var osu = new TestOsuGameBase(withBeatmap);
-            Task.Run(() => host.Run(osu))
+            Task.Factory.StartNew(() => host.Run(osu), TaskCreationOptions.LongRunning)
                 .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
 
             waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");

--- a/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
         public static TournamentGameBase LoadTournament(GameHost host, TournamentGameBase tournament = null)
         {
             tournament ??= new TournamentGameBase();
-            Task.Run(() => host.Run(tournament))
+            Task.Factory.StartNew(() => host.Run(tournament), TaskCreationOptions.LongRunning)
                 .ContinueWith(t => Assert.Fail($"Host threw exception {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
             WaitForOrAssert(() => tournament.IsLoaded, @"osu! failed to start in a reasonable amount of time");
             return tournament;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1012.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1013.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1012.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1013.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1012.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1013.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Not a prereq, but the failure cases are caught by https://github.com/ppy/osu-framework/pull/4820.
Should fix the recent "player disposed" test failures such as in https://github.com/ppy/osu/runs/3865955613 .