### PR TITLE
Improve `PlayerLoader` audio and visual transitions

### DIFF
--- a/osu.Game.Tests/Visual/Audio/TestSceneAudioFilter.cs
+++ b/osu.Game.Tests/Visual/Audio/TestSceneAudioFilter.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -18,15 +19,18 @@ namespace osu.Game.Tests.Visual.Audio
 {
     public class TestSceneAudioFilter : OsuTestScene
     {
-        private OsuSpriteText lowpassText;
-        private AudioFilter lowpassFilter;
+        private OsuSpriteText lowPassText;
+        private AudioFilter lowPassFilter;
 
-        private OsuSpriteText highpassText;
-        private AudioFilter highpassFilter;
+        private OsuSpriteText highPassText;
+        private AudioFilter highPassFilter;
 
         private Track track;
 
         private WaveformTestBeatmap beatmap;
+
+        private OsuSliderBar<int> lowPassSlider;
+        private OsuSliderBar<int> highPassSlider;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
@@ -34,68 +38,93 @@ namespace osu.Game.Tests.Visual.Audio
             beatmap = new WaveformTestBeatmap(audio);
             track = beatmap.LoadTrack();
 
-            OsuSliderBar<int> lowPassCutoff;
-            OsuSliderBar<int> highPassCutoff;
-
             Add(new FillFlowContainer
             {
                 Children = new Drawable[]
                 {
-                    lowpassFilter = new AudioFilter(audio.TrackMixer),
-                    highpassFilter = new AudioFilter(audio.TrackMixer, BQFType.HighPass),
-                    lowpassText = new OsuSpriteText
+                    lowPassFilter = new AudioFilter(audio.TrackMixer),
+                    highPassFilter = new AudioFilter(audio.TrackMixer, BQFType.HighPass),
+                    lowPassText = new OsuSpriteText
                     {
                         Padding = new MarginPadding(20),
-                        Text = $"Low Pass: {lowpassFilter.Cutoff}hz",
+                        Text = $"Low Pass: {lowPassFilter.Cutoff}hz",
                         Font = new FontUsage(size: 40)
                     },
-                    lowPassCutoff = new OsuSliderBar<int>
+                    lowPassSlider = new OsuSliderBar<int>
                     {
                         Width = 500,
                         Height = 50,
                         Padding = new MarginPadding(20),
+                        Current = new BindableInt
+                        {
+                            MinValue = 0,
+                            MaxValue = AudioFilter.MAX_LOWPASS_CUTOFF,
+                        }
                     },
-                    highpassText = new OsuSpriteText
+                    highPassText = new OsuSpriteText
                     {
                         Padding = new MarginPadding(20),
-                        Text = $"High Pass: {highpassFilter.Cutoff}hz",
+                        Text = $"High Pass: {highPassFilter.Cutoff}hz",
                         Font = new FontUsage(size: 40)
                     },
-                    highPassCutoff = new OsuSliderBar<int>
+                    highPassSlider = new OsuSliderBar<int>
                     {
                         Width = 500,
                         Height = 50,
                         Padding = new MarginPadding(20),
+                        Current = new BindableInt
+                        {
+                            MinValue = 0,
+                            MaxValue = AudioFilter.MAX_LOWPASS_CUTOFF,
+                        }
                     }
                 }
             });
 
-            lowPassCutoff.Current.ValueChanged += e =>
+            lowPassSlider.Current.ValueChanged += e =>
             {
-                lowpassText.Text = $"Low Pass: {e.NewValue}hz";
-                lowpassFilter.Cutoff = e.NewValue;
+                lowPassText.Text = $"Low Pass: {e.NewValue}hz";
+                lowPassFilter.Cutoff = e.NewValue;
             };
 
-            highPassCutoff.Current.ValueChanged += e =>
+            highPassSlider.Current.ValueChanged += e =>
             {
-                highpassText.Text = $"High Pass: {e.NewValue}hz";
-                highpassFilter.Cutoff = e.NewValue;
+                highPassText.Text = $"High Pass: {e.NewValue}hz";
+                highPassFilter.Cutoff = e.NewValue;
             };
         }
+
+        #region Overrides of Drawable
+
+        protected override void Update()
+        {
+            base.Update();
+            highPassSlider.Current.Value = highPassFilter.Cutoff;
+            lowPassSlider.Current.Value = lowPassFilter.Cutoff;
+        }
+
+        #endregion
 
         [SetUpSteps]
         public void SetUpSteps()
         {
             AddStep("Play Track", () => track.Start());
+
+            AddStep("Reset filters", () =>
+            {
+                lowPassFilter.Cutoff = AudioFilter.MAX_LOWPASS_CUTOFF;
+                highPassFilter.Cutoff = 0;
+            });
+
             waitTrackPlay();
         }
 
         [Test]
-        public void TestLowPass()
+        public void TestLowPassSweep()
         {
             AddStep("Filter Sweep", () =>
             {
-                lowpassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF).Then()
+                lowPassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF).Then()
                              .CutoffTo(0, 2000, Easing.OutCubic);
             });
 
@@ -103,7 +132,7 @@ namespace osu.Game.Tests.Visual.Audio
 
             AddStep("Filter Sweep (reverse)", () =>
             {
-                lowpassFilter.CutoffTo(0).Then()
+                lowPassFilter.CutoffTo(0).Then()
                              .CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF, 2000, Easing.InCubic);
             });
 
@@ -112,11 +141,11 @@ namespace osu.Game.Tests.Visual.Audio
         }
 
         [Test]
-        public void TestHighPass()
+        public void TestHighPassSweep()
         {
             AddStep("Filter Sweep", () =>
             {
-                highpassFilter.CutoffTo(0).Then()
+                highPassFilter.CutoffTo(0).Then()
                               .CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF, 2000, Easing.InCubic);
             });
 
@@ -124,7 +153,7 @@ namespace osu.Game.Tests.Visual.Audio
 
             AddStep("Filter Sweep (reverse)", () =>
             {
-                highpassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF).Then()
+                highPassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF).Then()
                               .CutoffTo(0, 2000, Easing.OutCubic);
             });
 

--- a/osu.Game.Tests/Visual/Audio/TestSceneAudioFilter.cs
+++ b/osu.Game.Tests/Visual/Audio/TestSceneAudioFilter.cs
@@ -34,6 +34,9 @@ namespace osu.Game.Tests.Visual.Audio
             beatmap = new WaveformTestBeatmap(audio);
             track = beatmap.LoadTrack();
 
+            OsuSliderBar<int> lowPassCutoff;
+            OsuSliderBar<int> highPassCutoff;
+
             Add(new FillFlowContainer
             {
                 Children = new Drawable[]
@@ -43,33 +46,41 @@ namespace osu.Game.Tests.Visual.Audio
                     lowpassText = new OsuSpriteText
                     {
                         Padding = new MarginPadding(20),
-                        Text = $"Low Pass: {lowpassFilter.Cutoff.Value}hz",
+                        Text = $"Low Pass: {lowpassFilter.Cutoff}hz",
                         Font = new FontUsage(size: 40)
                     },
-                    new OsuSliderBar<int>
+                    lowPassCutoff = new OsuSliderBar<int>
                     {
                         Width = 500,
                         Height = 50,
                         Padding = new MarginPadding(20),
-                        Current = { BindTarget = lowpassFilter.Cutoff }
                     },
                     highpassText = new OsuSpriteText
                     {
                         Padding = new MarginPadding(20),
-                        Text = $"High Pass: {highpassFilter.Cutoff.Value}hz",
+                        Text = $"High Pass: {highpassFilter.Cutoff}hz",
                         Font = new FontUsage(size: 40)
                     },
-                    new OsuSliderBar<int>
+                    highPassCutoff = new OsuSliderBar<int>
                     {
                         Width = 500,
                         Height = 50,
                         Padding = new MarginPadding(20),
-                        Current = { BindTarget = highpassFilter.Cutoff }
                     }
                 }
             });
-            lowpassFilter.Cutoff.ValueChanged += e => lowpassText.Text = $"Low Pass: {e.NewValue}hz";
-            highpassFilter.Cutoff.ValueChanged += e => highpassText.Text = $"High Pass: {e.NewValue}hz";
+
+            lowPassCutoff.Current.ValueChanged += e =>
+            {
+                lowpassText.Text = $"Low Pass: {e.NewValue}hz";
+                lowpassFilter.Cutoff = e.NewValue;
+            };
+
+            highPassCutoff.Current.ValueChanged += e =>
+            {
+                highpassText.Text = $"High Pass: {e.NewValue}hz";
+                highpassFilter.Cutoff = e.NewValue;
+            };
         }
 
         [SetUpSteps]

--- a/osu.Game/Audio/Effects/ITransformableFilter.cs
+++ b/osu.Game/Audio/Effects/ITransformableFilter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Transforms;
 
@@ -12,7 +11,7 @@ namespace osu.Game.Audio.Effects
         /// <summary>
         /// The filter cutoff.
         /// </summary>
-        BindableNumber<int> Cutoff { get; }
+        int Cutoff { get; set; }
     }
 
     public static class FilterableAudioComponentExtensions
@@ -40,7 +39,7 @@ namespace osu.Game.Audio.Effects
         public static TransformSequence<T> CutoffTo<T, TEasing>(this T component, int newCutoff, double duration, TEasing easing)
             where T : class, ITransformableFilter, IDrawable
             where TEasing : IEasingFunction
-            => component.TransformBindableTo(component.Cutoff, newCutoff, duration, easing);
+            => component.TransformTo(nameof(component.Cutoff), newCutoff, duration, easing);
 
         /// <summary>
         /// Smoothly adjusts filter cutoff over time.
@@ -49,6 +48,6 @@ namespace osu.Game.Audio.Effects
         public static TransformSequence<T> CutoffTo<T, TEasing>(this TransformSequence<T> sequence, int newCutoff, double duration, TEasing easing)
             where T : class, ITransformableFilter, IDrawable
             where TEasing : IEasingFunction
-            => sequence.Append(o => o.TransformBindableTo(o.Cutoff, newCutoff, duration, easing));
+            => sequence.Append(o => o.TransformTo(nameof(o.Cutoff), newCutoff, duration, easing));
     }
 }


### PR DESCRIPTION
This adjusts the low pass in line with proposal at #15060. This includes changing the duration and easing of the effects to better match visuals, but also adding a return to original frequency range on entering gameplay. It felt weird having it not match visually until now.

Also fixes the cutoff restoration not working on `PlayerLoader.Exit` due to underlying bindables getting unbound from the `ValueChanged` event.

Closes #15060.