### PR TITLE
Fix storyboard outro during fail test not being lenient enough

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -90,8 +90,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest(() =>
             {
                 AddStep("fail on first judgement", () => currentFailConditions = (_, __) => true);
-                AddStep("set storyboard duration to 1.3s", () => currentStoryboardDuration = 1300);
+
+                // Fail occurs at 164ms with the provided beatmap.
+                // Fail animation runs for 2.5s realtime but the gameplay time change is *variable* due to the frequency transform being applied, so we need a bit of lenience.
+                AddStep("set storyboard duration to 0.6s", () => currentStoryboardDuration = 600);
             });
+
             AddUntilStep("wait for fail", () => Player.HasFailed);
             AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
             AddUntilStep("wait for fail overlay", () => Player.FailOverlay.State.Value == Visibility.Visible);

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Play
 {
     /// <summary>
     /// Manage the animation to be applied when a player fails.
-    /// Single file; automatically disposed after use.
+    /// Single use and automatically disposed after use.
     /// </summary>
     public class FailAnimation : CompositeDrawable
     {


### PR DESCRIPTION
Tried to explain with inline comment, but the issue is that the frequency adjust is applied from the update thread onto the audio track. Depending on how the update thread runs (ie. it might not run as frequently as we expect) the duration of the fail process can change.

Hopefully this extra lenience is enough to cover the test failures. If not, the test will need to be restructured further.