### PR TITLE
Attempt to fix spinner rewinding tests

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Rulesets.Osu.Tests
 {
     public class TestSceneSpinnerRotation : TestSceneOsuPlayer
     {
+        private const double spinner_start_time = 100;
+        private const double spinner_duration = 6000;
+
         [Resolved]
         private AudioManager audioManager { get; set; }
 
@@ -77,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             double finalTrackerRotation = 0, trackerRotationTolerance = 0;
             double finalSpinnerSymbolRotation = 0, spinnerSymbolRotationTolerance = 0;
 
-            addSeekStep(5000);
+            addSeekStep(spinner_start_time + 5000);
             AddStep("retrieve disc rotation", () =>
             {
                 finalTrackerRotation = drawableSpinner.RotationTracker.Rotation;
@@ -90,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
             AddStep("retrieve cumulative disc rotation", () => finalCumulativeTrackerRotation = drawableSpinner.Result.RateAdjustedRotation);
 
-            addSeekStep(2500);
+            addSeekStep(spinner_start_time + 2500);
             AddAssert("disc rotation rewound",
                 // we want to make sure that the rotation at time 2500 is in the same direction as at time 5000, but about half-way in.
                 // due to the exponential damping applied we're allowing a larger margin of error of about 10%
@@ -102,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 // cumulative rotation is not damped, so we're treating it as the "ground truth" and allowing a comparatively smaller margin of error.
                 () => Precision.AlmostEquals(drawableSpinner.Result.RateAdjustedRotation, finalCumulativeTrackerRotation / 2, 100));
 
-            addSeekStep(5000);
+            addSeekStep(spinner_start_time + 5000);
             AddAssert("is disc rotation almost same",
                 () => Precision.AlmostEquals(drawableSpinner.RotationTracker.Rotation, finalTrackerRotation, trackerRotationTolerance));
             AddAssert("is symbol rotation almost same",
@@ -140,7 +143,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestSpinnerNormalBonusRewinding()
         {
-            addSeekStep(1000);
+            addSeekStep(spinner_start_time + 1000);
 
             AddAssert("player score matching expected bonus score", () =>
             {
@@ -201,24 +204,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("spm almost same", () => Precision.AlmostEquals(expectedSpm, drawableSpinner.SpinsPerMinute.Value, 2.0));
         }
 
-        private Replay applyRateAdjustment(Replay scoreReplay, double rate) => new Replay
-        {
-            Frames = scoreReplay
-                     .Frames
-                     .Cast<OsuReplayFrame>()
-                     .Select(replayFrame =>
-                     {
-                         var adjustedTime = replayFrame.Time * rate;
-                         return new OsuReplayFrame(adjustedTime, replayFrame.Position, replayFrame.Actions.ToArray());
-                     })
-                     .Cast<ReplayFrame>()
-                     .ToList()
-        };
-
         private void addSeekStep(double time)
         {
             AddStep($"seek to {time}", () => Player.GameplayClockContainer.Seek(time));
-
             AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, Player.DrawableRuleset.FrameStableClock.CurrentTime, 100));
         }
 
@@ -241,7 +229,8 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new Spinner
                 {
                     Position = new Vector2(256, 192),
-                    EndTime = 6000,
+                    StartTime = spinner_start_time,
+                    Duration = spinner_duration
                 },
             }
         };


### PR DESCRIPTION
In attempt to fix `TestSpinnerRewindingRotation`: it rewinds to 0, but this can be a variable point in time (up to 100ms away) and not exactly 0.