### PR TITLE
Fix another spinner test failure

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                     {
                         new Spinner
                         {
-                            Duration = 2000,
-                            Position = OsuPlayfield.BASE_SIZE / 2
+                            Duration = 6000,
+                            Position = OsuPlayfield.BASE_SIZE / 2,
                         }
                     }
                 },


### PR DESCRIPTION
Not sure how to better fix this. It seems like 477 RPM is only reached a little bit before the spinner ends, so I'm just increasing the spinner duration to lengthen the time it sticks to 477.