### PR TITLE
Fix `AudioFilter` test not stopping track on forced exit

### DIFF
--- a/osu.Game.Tests/Visual/Audio/TestSceneAudioFilter.cs
+++ b/osu.Game.Tests/Visual/Audio/TestSceneAudioFilter.cs
@@ -163,5 +163,11 @@ namespace osu.Game.Tests.Visual.Audio
         }
 
         private void waitTrackPlay() => AddWaitStep("Let track play", 10);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            track?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
The track could remain playing forever if you don't run the stop step.