### PR TITLE
Fix multiplayer gameplay flow test scene failures due to button not being ready

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -564,11 +564,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddRepeatStep("click spectate button", () =>
+            AddUntilStep("wait for ready button clickable", () => readyButton.ChildrenOfType<OsuButton>().Single().Enabled.Value);
+
+            AddStep("click ready button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerReadyButton>().Single());
+                InputManager.MoveMouseTo(readyButton);
                 InputManager.Click(MouseButton.Left);
-            }, 2);
+            });
+
+            AddUntilStep("wait for start match available", () => readyButton.ChildrenOfType<OsuButton>().Single().Text.ToString().Contains("Start match"));
+
+            AddStep("click start button", () => InputManager.Click(MouseButton.Left));
 
             AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
 
@@ -581,6 +587,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for results", () => Stack.CurrentScreen is ResultsScreen);
         }
+
+        private MultiplayerReadyButton readyButton => this.ChildrenOfType<MultiplayerReadyButton>().Single();
 
         private void createRoom(Func<Room> room)
         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -564,7 +564,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddUntilStep("wait for ready button clickable", () => readyButton.ChildrenOfType<OsuButton>().Single().Enabled.Value);
+            AddUntilStep("wait for ready button to be enabled", () => readyButton.ChildrenOfType<OsuButton>().Single().Enabled.Value);
 
             AddStep("click ready button", () =>
             {
@@ -572,7 +572,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("wait for start match available", () => readyButton.ChildrenOfType<OsuButton>().Single().Text.ToString().Contains("Start match"));
+            AddUntilStep("wait for player to be ready", () => client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("wait for ready button to be enabled", () => readyButton.ChildrenOfType<OsuButton>().Single().Enabled.Value);
 
             AddStep("click start button", () => InputManager.Click(MouseButton.Left));
 


### PR DESCRIPTION
As seen in many test failures (one example: https://github.com/ppy/osu/pull/15043/checks?check_run_id=3890892438).

The first of the new until steps is the important one, which ensures the ongoing operation status has been restored, else the button could still be in a disabled state.

Repro by throwing a cog (`Thread.Sleep`) in [`MultiplayerReadyButton.updateState`](https://github.com/ppy/osu/blob/2b06dacd0e34493461bfdabcedd9984dbf169fd9/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs#L79). Note that this will cause some serious slowdown as it seems to run a lot.