### PR TITLE
Fix gameplay audio ramping down in frequency a second time at the end of the fail sequence

### DIFF
--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -71,7 +71,6 @@ namespace osu.Game.Screens.Play
             this.TransformBindableTo(trackFreq, 0, duration).OnComplete(_ =>
             {
                 OnComplete?.Invoke();
-                Expire();
             });
 
             failLowPassFilter.CutoffTo(300, duration, Easing.OutCubic);


### PR DESCRIPTION
This was occurring due to the `MasterGameplayClockContainer` handling all pause operations the same, with a frequncy ramp. As the fail animation was immediately cleaning itself up, it would restore the frequency just before the clock is paused, causing a second ramp down.

The easiest solution is just to keep the `FailAnimation` alive after it has run. Can't really think of a better way to do this for now. If it comes up more often we may want to consider giving `MasterGameplayClockContainer` the ability to immediately pause.