### PR TITLE
Fix intermittent multiplayer tests

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -359,22 +359,25 @@ namespace osu.Game.Online.Multiplayer
             if (Room == null)
                 return;
 
-            await PopulateUser(user).ConfigureAwait(false);
-
-            Scheduler.Add(() =>
+            await Task.Run(async () =>
             {
-                if (Room == null)
-                    return;
+                await PopulateUser(user).ConfigureAwait(false);
 
-                // for sanity, ensure that there can be no duplicate users in the room user list.
-                if (Room.Users.Any(existing => existing.UserID == user.UserID))
-                    return;
+                Scheduler.Add(() =>
+                {
+                    if (Room == null)
+                        return;
 
-                Room.Users.Add(user);
+                    // for sanity, ensure that there can be no duplicate users in the room user list.
+                    if (Room.Users.Any(existing => existing.UserID == user.UserID))
+                        return;
 
-                UserJoined?.Invoke(user);
-                RoomUpdated?.Invoke();
-            }, false);
+                    Room.Users.Add(user);
+
+                    UserJoined?.Invoke(user);
+                    RoomUpdated?.Invoke();
+                });
+            }).ConfigureAwait(false);
         }
 
         Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user) =>

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -359,25 +359,22 @@ namespace osu.Game.Online.Multiplayer
             if (Room == null)
                 return;
 
-            await Task.Run(async () =>
+            await PopulateUser(user).ConfigureAwait(false);
+
+            Scheduler.Add(() =>
             {
-                await PopulateUser(user).ConfigureAwait(false);
+                if (Room == null)
+                    return;
 
-                Scheduler.Add(() =>
-                {
-                    if (Room == null)
-                        return;
+                // for sanity, ensure that there can be no duplicate users in the room user list.
+                if (Room.Users.Any(existing => existing.UserID == user.UserID))
+                    return;
 
-                    // for sanity, ensure that there can be no duplicate users in the room user list.
-                    if (Room.Users.Any(existing => existing.UserID == user.UserID))
-                        return;
+                Room.Users.Add(user);
 
-                    Room.Users.Add(user);
-
-                    UserJoined?.Invoke(user);
-                    RoomUpdated?.Invoke();
-                });
-            }).ConfigureAwait(false);
+                UserJoined?.Invoke(user);
+                RoomUpdated?.Invoke();
+            });
         }
 
         Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user) =>

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             ((IMultiplayerClient)this).UserJoined(user).Wait();
 
-            // We want the user to be immediately available for testing, so force a scheduler update.
+            // We want the user to be immediately available for testing, so force a scheduler update to run the update-bound continuation.
             Scheduler.Update();
         }
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -53,7 +53,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public MultiplayerRoomUser AddUser(User user, bool markAsPlaying = false)
         {
             var roomUser = new MultiplayerRoomUser(user.Id) { User = user };
-            ((IMultiplayerClient)this).UserJoined(roomUser);
+
+            addUser(roomUser);
 
             if (markAsPlaying)
                 PlayingUserIds.Add(user.Id);
@@ -61,7 +62,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return roomUser;
         }
 
-        public void AddNullUser() => ((IMultiplayerClient)this).UserJoined(new MultiplayerRoomUser(TestUserLookupCache.NULL_USER_ID));
+        public void AddNullUser() => addUser(new MultiplayerRoomUser(TestUserLookupCache.NULL_USER_ID));
+
+        private void addUser(MultiplayerRoomUser user)
+        {
+            ((IMultiplayerClient)this).UserJoined(user).Wait();
+
+            // We want the user to be immediately available for testing, so force a scheduler update.
+            Scheduler.Update();
+        }
 
         public void RemoveUser(User user)
         {


### PR DESCRIPTION
For example: https://github.com/ppy/osu/runs/3894596852

It's pretty self-explanatory: typical testing patterns are something like:
```
AddStep("add user", () =>
{
    Client.AddUser(user);
    Client.ChangeUserState(user, ...);
});
```
And the `UserJoined()` implementation has an `await`, so the user doesn't always join instantly.

There's two fixes here:
1. Waiting on the task to finish via `.Wait()`.
2. Running the scheduler once more afterwards. All methods in `MultiplayerClient` use `Scheduler.Add(..., forceScheduled: false)`, so in the example above the call to `ChangeUserState` would perform the scheduled delegate immediately. I don't really want to change this right now since it was supposedly done to fix other tests in https://github.com/ppy/osu/commit/04d54c40dbdc65f08975f1ca065ddd4ca1b67d9f.

Can be tested by adding an `await Task.Delay(1000)` in `MultiplayerClient.UserJoined()` (15 tests fail, which pass after this PR).