### PR TITLE
Refresh appearance and use colour provider theming in sliders and checkboxes

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
@@ -1,11 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -19,28 +23,62 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             AddStep("create component", () =>
             {
-                LabelledSliderBar<double> component;
+                FillFlowContainer flow;
 
-                Child = new Container
+                Child = flow = new FillFlowContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Width = 500,
                     AutoSizeAxes = Axes.Y,
-                    Child = component = new LabelledSliderBar<double>
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
                     {
-                        Current = new BindableDouble(5)
+                        new LabelledSliderBar<double>
                         {
-                            MinValue = 0,
-                            MaxValue = 10,
-                            Precision = 1,
-                        }
-                    }
+                            Current = new BindableDouble(5)
+                            {
+                                MinValue = 0,
+                                MaxValue = 10,
+                                Precision = 1,
+                            },
+                            Label = "a sample component",
+                            Description = hasDescription ? "this text describes the component" : string.Empty,
+                        },
+                    },
                 };
 
-                component.Label = "a sample component";
-                component.Description = hasDescription ? "this text describes the component" : string.Empty;
+                foreach (var colour in Enum.GetValues(typeof(OverlayColourScheme)).OfType<OverlayColourScheme>())
+                {
+                    flow.Add(new OverlayColourContainer(colour)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Child = new LabelledSliderBar<double>
+                        {
+                            Current = new BindableDouble(5)
+                            {
+                                MinValue = 0,
+                                MaxValue = 10,
+                                Precision = 1,
+                            },
+                            Label = "a sample component",
+                            Description = hasDescription ? "this text describes the component" : string.Empty,
+                        }
+                    });
+                }
             });
+        }
+
+        private class OverlayColourContainer : Container
+        {
+            [Cached]
+            private OverlayColourProvider colourProvider;
+
+            public OverlayColourContainer(OverlayColourScheme scheme)
+            {
+                colourProvider = new OverlayColourProvider(scheme);
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsCheckbox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsCheckbox.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneSettingsCheckbox : OsuTestScene
+    {
+        [TestCase]
+        public void TestCheckbox()
+        {
+            AddStep("create component", () =>
+            {
+                FillFlowContainer flow;
+
+                Child = flow = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 500,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(5),
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new SettingsCheckbox
+                        {
+                            LabelText = "a sample component",
+                        },
+                    },
+                };
+
+                foreach (var colour1 in Enum.GetValues(typeof(OverlayColourScheme)).OfType<OverlayColourScheme>())
+                {
+                    flow.Add(new OverlayColourContainer(colour1)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Child = new SettingsCheckbox
+                        {
+                            LabelText = "a sample component",
+                        }
+                    });
+                }
+            });
+        }
+
+        private class OverlayColourContainer : Container
+        {
+            [Cached]
+            private OverlayColourProvider colourProvider;
+
+            public OverlayColourContainer(OverlayColourScheme scheme)
+            {
+                colourProvider = new OverlayColourProvider(scheme);
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float border_width = 3;
 
-        private const double animate_in_duration = 150;
+        private const double animate_in_duration = 200;
         private const double animate_out_duration = 500;
 
         public Nub()
@@ -62,14 +62,14 @@ namespace osu.Game.Graphics.UserInterface
         {
             AccentColour = colourProvider?.Highlight1 ?? colours.Pink;
             GlowingAccentColour = colourProvider?.Highlight1.Lighten(0.2f) ?? colours.PinkLighter;
-            GlowColour = colourProvider?.Dark3 ?? colours.PinkDarker;
+            GlowColour = colourProvider?.Light4 ?? colours.PinkDarker;
 
             EdgeEffect = new EdgeEffectParameters
             {
                 Colour = GlowColour.Opacity(0),
                 Type = EdgeEffectType.Glow,
                 Radius = 10,
-                Roundness = 8,
+                Roundness = 10,
             };
         }
 
@@ -85,7 +85,7 @@ namespace osu.Game.Graphics.UserInterface
                 if (value)
                 {
                     this.FadeColour(GlowingAccentColour, animate_in_duration, Easing.OutQuint);
-                    FadeEdgeEffectTo(1, animate_in_duration, Easing.OutQuint);
+                    FadeEdgeEffectTo(0.6f, animate_in_duration, Easing.OutQuint);
                 }
                 else
                 {

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
@@ -12,13 +13,16 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterface
 {
     public class Nub : CircularContainer, IHasCurrentValue<bool>, IHasAccentColour
     {
-        public const float COLLAPSED_SIZE = 20;
-        public const float EXPANDED_SIZE = 40;
+        public const float HEIGHT = 15;
+
+        public const float COLLAPSED_SIZE = 30;
+        public const float EXPANDED_SIZE = 50;
 
         private const float border_width = 3;
 
@@ -29,7 +33,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             Box fill;
 
-            Size = new Vector2(COLLAPSED_SIZE, 12);
+            Size = new Vector2(COLLAPSED_SIZE, HEIGHT);
 
             BorderColour = Color4.White;
             BorderThickness = border_width;
@@ -53,12 +57,12 @@ namespace osu.Game.Graphics.UserInterface
             };
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        [BackgroundDependencyLoader(true)]
+        private void load([CanBeNull] OverlayColourProvider colourProvider, OsuColour colours)
         {
-            AccentColour = colours.Pink;
-            GlowingAccentColour = colours.PinkLighter;
-            GlowColour = colours.PinkDarker;
+            AccentColour = colourProvider?.Highlight1 ?? colours.Pink;
+            GlowingAccentColour = colourProvider?.Highlight1.Lighten(0.2f) ?? colours.PinkLighter;
+            GlowColour = colourProvider?.Dark3 ?? colours.PinkDarker;
 
             EdgeEffect = new EdgeEffectParameters
             {
@@ -96,9 +100,9 @@ namespace osu.Game.Graphics.UserInterface
             set
             {
                 if (value)
-                    this.ResizeTo(new Vector2(EXPANDED_SIZE, 12), animate_in_duration, Easing.OutQuint);
+                    this.ResizeTo(new Vector2(EXPANDED_SIZE, HEIGHT), animate_in_duration, Easing.OutQuint);
                 else
-                    this.ResizeTo(new Vector2(COLLAPSED_SIZE, 12), animate_out_duration, Easing.OutQuint);
+                    this.ResizeTo(new Vector2(COLLAPSED_SIZE, HEIGHT), animate_out_duration, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -17,11 +17,10 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class Nub : CircularContainer, IHasCurrentValue<bool>, IHasAccentColour
+    public class Nub : CompositeDrawable, IHasCurrentValue<bool>, IHasAccentColour
     {
         public const float HEIGHT = 15;
 
-        public const float COLLAPSED_SIZE = 30;
         public const float EXPANDED_SIZE = 50;
 
         private const float border_width = 3;
@@ -29,31 +28,33 @@ namespace osu.Game.Graphics.UserInterface
         private const double animate_in_duration = 200;
         private const double animate_out_duration = 500;
 
+        private readonly Box fill;
+        private readonly Container main;
+
         public Nub()
         {
-            Box fill;
+            Size = new Vector2(EXPANDED_SIZE, HEIGHT);
 
-            Size = new Vector2(COLLAPSED_SIZE, HEIGHT);
-
-            BorderColour = Color4.White;
-            BorderThickness = border_width;
-
-            Masking = true;
-
-            Children = new[]
+            InternalChildren = new[]
             {
-                fill = new Box
+                main = new CircularContainer
                 {
+                    BorderColour = Color4.White,
+                    BorderThickness = border_width,
+                    Masking = true,
                     RelativeSizeAxes = Axes.Both,
-                    Alpha = 0,
-                    AlwaysPresent = true,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Children = new Drawable[]
+                    {
+                        fill = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0,
+                            AlwaysPresent = true,
+                        },
+                    }
                 },
-            };
-
-            Current.ValueChanged += filled =>
-            {
-                fill.FadeTo(filled.NewValue ? 1 : 0, 200, Easing.OutQuint);
-                this.TransformTo(nameof(BorderThickness), filled.NewValue ? 8.5f : border_width, 200, Easing.OutQuint);
             };
         }
 
@@ -64,13 +65,20 @@ namespace osu.Game.Graphics.UserInterface
             GlowingAccentColour = colourProvider?.Highlight1.Lighten(0.2f) ?? colours.PinkLighter;
             GlowColour = colourProvider?.Light4 ?? colours.PinkDarker;
 
-            EdgeEffect = new EdgeEffectParameters
+            main.EdgeEffect = new EdgeEffectParameters
             {
                 Colour = GlowColour.Opacity(0),
                 Type = EdgeEffectType.Glow,
                 Radius = 10,
                 Roundness = 10,
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Current.BindValueChanged(onCurrentValueChanged, true);
         }
 
         private bool glowing;
@@ -84,25 +92,14 @@ namespace osu.Game.Graphics.UserInterface
 
                 if (value)
                 {
-                    this.FadeColour(GlowingAccentColour, animate_in_duration, Easing.OutQuint);
-                    FadeEdgeEffectTo(0.6f, animate_in_duration, Easing.OutQuint);
+                    main.FadeColour(GlowingAccentColour, animate_in_duration, Easing.OutQuint);
+                    main.FadeEdgeEffectTo(0.6f, animate_in_duration, Easing.OutQuint);
                 }
                 else
                 {
-                    FadeEdgeEffectTo(0, animate_out_duration);
-                    this.FadeColour(AccentColour, animate_out_duration);
+                    main.FadeEdgeEffectTo(0, animate_out_duration);
+                    main.FadeColour(AccentColour, animate_out_duration);
                 }
-            }
-        }
-
-        public bool Expanded
-        {
-            set
-            {
-                if (value)
-                    this.ResizeTo(new Vector2(EXPANDED_SIZE, HEIGHT), animate_in_duration, Easing.OutQuint);
-                else
-                    this.ResizeTo(new Vector2(COLLAPSED_SIZE, HEIGHT), animate_out_duration, Easing.OutQuint);
             }
         }
 
@@ -130,7 +127,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 accentColour = value;
                 if (!Glowing)
-                    Colour = value;
+                    main.Colour = value;
             }
         }
 
@@ -143,7 +140,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 glowingAccentColour = value;
                 if (Glowing)
-                    Colour = value;
+                    main.Colour = value;
             }
         }
 
@@ -158,8 +155,20 @@ namespace osu.Game.Graphics.UserInterface
 
                 var effect = EdgeEffect;
                 effect.Colour = Glowing ? value : value.Opacity(0);
-                EdgeEffect = effect;
+                main.EdgeEffect = effect;
             }
+        }
+
+        private void onCurrentValueChanged(ValueChangedEvent<bool> filled)
+        {
+            fill.FadeTo(filled.NewValue ? 1 : 0, 200, Easing.OutQuint);
+
+            if (filled.NewValue)
+                main.ResizeWidthTo(1, animate_in_duration, Easing.OutElasticHalf);
+            else
+                main.ResizeWidthTo(0.9f, animate_out_duration, Easing.OutElastic);
+
+            main.TransformTo(nameof(BorderThickness), filled.NewValue ? 8.5f : border_width, 200, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -63,14 +63,14 @@ namespace osu.Game.Graphics.UserInterface
         {
             AccentColour = colourProvider?.Highlight1 ?? colours.Pink;
             GlowingAccentColour = colourProvider?.Highlight1.Lighten(0.2f) ?? colours.PinkLighter;
-            GlowColour = colourProvider?.Light4 ?? colours.PinkDarker;
+            GlowColour = colourProvider?.Highlight1 ?? colours.PinkLighter;
 
             main.EdgeEffect = new EdgeEffectParameters
             {
                 Colour = GlowColour.Opacity(0),
                 Type = EdgeEffectType.Glow,
-                Radius = 10,
-                Roundness = 10,
+                Radius = 8,
+                Roundness = 5,
             };
         }
 
@@ -93,12 +93,12 @@ namespace osu.Game.Graphics.UserInterface
                 if (value)
                 {
                     main.FadeColour(GlowingAccentColour, animate_in_duration, Easing.OutQuint);
-                    main.FadeEdgeEffectTo(0.6f, animate_in_duration, Easing.OutQuint);
+                    main.FadeEdgeEffectTo(0.2f, animate_in_duration, Easing.OutQuint);
                 }
                 else
                 {
-                    main.FadeEdgeEffectTo(0, animate_out_duration);
-                    main.FadeColour(AccentColour, animate_out_duration);
+                    main.FadeEdgeEffectTo(0, animate_out_duration, Easing.OutQuint);
+                    main.FadeColour(AccentColour, animate_out_duration, Easing.OutQuint);
                 }
             }
         }
@@ -153,7 +153,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 glowColour = value;
 
-                var effect = EdgeEffect;
+                var effect = main.EdgeEffect;
                 effect.Colour = Glowing ? value : value.Opacity(0);
                 main.EdgeEffect = effect;
             }

--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -9,16 +9,11 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
 {
     public class OsuCheckbox : Checkbox
     {
-        public Color4 CheckedColor { get; set; } = Color4.Cyan;
-        public Color4 UncheckedColor { get; set; } = Color4.White;
-        public int FadeDuration { get; set; }
-
         /// <summary>
         /// Whether to play sounds when the state changes as a result of user interaction.
         /// </summary>
@@ -104,14 +99,12 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnHover(HoverEvent e)
         {
             Nub.Glowing = true;
-            Nub.Expanded = true;
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
             Nub.Glowing = false;
-            Nub.Expanded = false;
             base.OnHoverLost(e);
         }
 

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Globalization;
+using JetBrains.Annotations;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -16,6 +18,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -52,34 +55,63 @@ namespace osu.Game.Graphics.UserInterface
             {
                 accentColour = value;
                 leftBox.Colour = value;
+            }
+        }
+
+        private Colour4 backgroundColour;
+
+        public Color4 BackgroundColour
+        {
+            get => backgroundColour;
+            set
+            {
+                backgroundColour = value;
                 rightBox.Colour = value;
             }
         }
 
         public OsuSliderBar()
         {
-            Height = 12;
-            RangePadding = 20;
+            Height = Nub.HEIGHT;
+            RangePadding = Nub.EXPANDED_SIZE / 2;
             Children = new Drawable[]
             {
-                leftBox = new Box
+                new Container
                 {
-                    Height = 2,
-                    EdgeSmoothness = new Vector2(0, 0.5f),
-                    Position = new Vector2(2, 0),
-                    RelativeSizeAxes = Axes.None,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                },
-                rightBox = new Box
-                {
-                    Height = 2,
-                    EdgeSmoothness = new Vector2(0, 0.5f),
-                    Position = new Vector2(-2, 0),
-                    RelativeSizeAxes = Axes.None,
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.CentreRight,
-                    Alpha = 0.5f,
+                    Padding = new MarginPadding { Horizontal = 2 },
+                    Child = new CircularContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Masking = true,
+                        CornerRadius = 5f,
+                        Children = new Drawable[]
+                        {
+                            leftBox = new Box
+                            {
+                                Height = 5,
+                                EdgeSmoothness = new Vector2(0, 0.5f),
+                                RelativeSizeAxes = Axes.None,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                            },
+                            rightBox = new Box
+                            {
+                                Height = 5,
+                                EdgeSmoothness = new Vector2(0, 0.5f),
+                                RelativeSizeAxes = Axes.None,
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Alpha = 0.5f,
+                            },
+                        },
+                    },
                 },
                 nubContainer = new Container
                 {
@@ -89,6 +121,7 @@ namespace osu.Game.Graphics.UserInterface
                         Origin = Anchor.TopCentre,
                         RelativePositionAxes = Axes.X,
                         Expanded = true,
+                        Current = { Value = true }
                     },
                 },
                 new HoverClickSounds()
@@ -97,11 +130,12 @@ namespace osu.Game.Graphics.UserInterface
             Current.DisabledChanged += disabled => { Alpha = disabled ? 0.3f : 1; };
         }
 
-        [BackgroundDependencyLoader]
-        private void load(AudioManager audio, OsuColour colours)
+        [BackgroundDependencyLoader(true)]
+        private void load(AudioManager audio, [CanBeNull] OverlayColourProvider colourProvider, OsuColour colours)
         {
             sample = audio.Samples.Get(@"UI/notch-tick");
-            AccentColour = colours.Pink;
+            AccentColour = colourProvider?.Highlight1 ?? colours.Pink;
+            BackgroundColour = colourProvider?.Background5 ?? colours.Pink.Opacity(0.5f);
         }
 
         protected override void Update()
@@ -127,18 +161,6 @@ namespace osu.Game.Graphics.UserInterface
         {
             Nub.Glowing = false;
             base.OnHoverLost(e);
-        }
-
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            Nub.Current.Value = true;
-            return base.OnMouseDown(e);
-        }
-
-        protected override void OnMouseUp(MouseUpEvent e)
-        {
-            Nub.Current.Value = false;
-            base.OnMouseUp(e);
         }
 
         protected override void OnUserChange(T value)

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -153,14 +153,25 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnHover(HoverEvent e)
         {
-            Nub.Glowing = true;
+            updateGlow();
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            Nub.Glowing = false;
+            updateGlow();
             base.OnHoverLost(e);
+        }
+
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+            updateGlow();
+            base.OnDragEnd(e);
+        }
+
+        private void updateGlow()
+        {
+            Nub.Glowing = IsHovered || IsDragged;
         }
 
         protected override void OnUserChange(T value)

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -120,7 +120,6 @@ namespace osu.Game.Graphics.UserInterface
                     {
                         Origin = Anchor.TopCentre,
                         RelativePositionAxes = Axes.X,
-                        Expanded = true,
                         Current = { Value = true }
                     },
                 },

--- a/osu.Game/Overlays/Settings/SettingsSlider.cs
+++ b/osu.Game/Overlays/Settings/SettingsSlider.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Settings
     {
         protected override Drawable CreateControl() => new TSlider
         {
-            Margin = new MarginPadding { Top = 5, Bottom = 5 },
+            Margin = new MarginPadding { Vertical = 10 },
             RelativeSizeAxes = Axes.X
         };
 

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerCheckbox.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerCheckbox.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             Nub.AccentColour = colours.Yellow;
             Nub.GlowingAccentColour = colours.YellowLighter;
-            Nub.GlowColour = colours.YellowDarker;
+            Nub.GlowColour = colours.YellowDark;
         }
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSliderBar.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSliderBar.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 AccentColour = colours.Yellow;
                 Nub.AccentColour = colours.Yellow;
                 Nub.GlowingAccentColour = colours.YellowLighter;
-                Nub.GlowColour = colours.YellowDarker;
+                Nub.GlowColour = colours.YellowDark;
             }
         }
     }


### PR DESCRIPTION
Based (somewhat loosely at this point) on the following designs: https://www.figma.com/file/IjrU0u7MFdgmxDofqTlsZb/UI%2FClient-Settings?node-id=0%3A1

PRing mostly for comment and mostly because I had it prepared before, but I'm well aware that some decisions here could be questionable. Just wanted to get it out, I guess.

https://user-images.githubusercontent.com/20418176/137405437-e2af767c-994a-466c-9410-cc6751434c28.mp4

In short:

* `OverlayColourProvider` usages everywhere.
* Per design above, the "nub" used in checkboxes has been made taller and wider.
* Slider bar background "line" now has rounded caps, and in themed views the right part of it is uses a background colour rather than semi-transparent accent.
* Slider bar nub is no longer ever hollow.

That last part in particular unfortunately makes usages where the slider is semi-transparent somewhat worse (can't find the original issue about this but I'm sure there was one - there's a part near where the nub overlaps with the bar that ends up looking jank). Open to discussion what to do about it. (reverting that change? replacing usages of slider alpha with using multiplicative `Colour` to emulate same effect?)

Hover behaviour for nubs and sliders wasn't defined, so I just tried to keep it similar to existing as with previous changes.
