### PR TITLE
Fix startup import test waiting on potentially incorrect notification type

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneStartupImport.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneStartupImport.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Game.Database;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.Navigation
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestImportCreatedNotification()
         {
-            AddUntilStep("Import notification was presented", () => Game.Notifications.ChildrenOfType<ImportProgressNotification>().Count() == 1);
+            AddUntilStep("Import notification was presented", () => Game.Notifications.ChildrenOfType<ProgressCompletionNotification>().Count() == 1);
         }
     }
 }


### PR DESCRIPTION
If the import finishes before arriving at a point the notification can be displayed, the progress notification is potentially replaced with the "completed" one.

As seen in https://github.com/ppy/osu/pull/15107/checks?check_run_id=3896472100