### PR TITLE
Add high-pass filter to gameplay fail sequence

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1015.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1014.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Game.Rulesets.UI;
 using System;
 using System.Collections.Generic;
+using ManagedBass.Fx;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
@@ -35,6 +36,7 @@ namespace osu.Game.Screens.Play
         private Track track;
 
         private AudioFilter failLowPassFilter;
+        private AudioFilter failHighPassFilter;
 
         private const float duration = 2500;
 
@@ -52,6 +54,7 @@ namespace osu.Game.Screens.Play
             failSample = audio.Samples.Get(@"Gameplay/failsound");
 
             AddInternal(failLowPassFilter = new AudioFilter(audio.TrackMixer));
+            AddInternal(failHighPassFilter = new AudioFilter(audio.TrackMixer, BQFType.HighPass));
         }
 
         private bool started;
@@ -66,14 +69,14 @@ namespace osu.Game.Screens.Play
 
             started = true;
 
-            failSample.Play();
-
             this.TransformBindableTo(trackFreq, 0, duration).OnComplete(_ =>
             {
                 OnComplete?.Invoke();
             });
 
+            failHighPassFilter.CutoffTo(300);
             failLowPassFilter.CutoffTo(300, duration, Easing.OutCubic);
+            failSample.Play();
 
             track.AddAdjustment(AdjustableProperty.Frequency, trackFreq);
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.1014.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1015.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1014.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1004.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1015.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Clears out the low-end to make room for the bass frequencies of the new fail sample (ppy/osu-resources#157).