### PR TITLE
Add setting for mouse players in NoScope mod

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osuTK;
+using osu.Game.Beatmaps.Timing;
+
+namespace osu.Game.Rulesets.Osu.Tests.Mods
+{
+    public class TestSceneOsuModNoScope : OsuModTestScene
+    {
+        [Test]
+        public void BreaksAndSpinners() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModNoScope
+            {
+                HiddenComboCount = { Value = 0 },
+                ShowCursorDuringBreaks = { Value = true },
+            },
+            Autoplay = true,
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        Position = new Vector2(300, 192),
+                        StartTime = 0,
+                    },
+                    new HitCircle
+                    {
+                        Position = new Vector2(300, 192),
+                        StartTime = 5000,
+                    },
+                    new Spinner
+                    {
+                        Position = new Vector2(256, 192),
+                        StartTime = 6000,
+                        EndTime = 9000,
+                    },
+                    new HitCircle
+                    {
+                        Position = new Vector2(300, 192),
+                        StartTime = 10000,
+                    },
+                    new HitCircle
+                    {
+                        Position = new Vector2(300, 192),
+                        StartTime = 12000,
+                    },
+                },
+                Breaks = new List<BreakPeriod>
+                {
+                    new BreakPeriod
+                    (
+                        1000,
+                        4000
+                    ),
+                }
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value >= 5
+        });
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -122,6 +122,38 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             });
         }
 
+        [Test]
+        public void CursorVisibleAfterComboBreak()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new OsuModNoScope
+                {
+                    HiddenComboCount = { Value = 1 },
+                },
+                Autoplay = false,
+                Beatmap = new Beatmap
+                {
+                    HitObjects = new List<HitObject>
+                    {
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 0,
+                        },
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 2000,
+                        },
+                    },
+                },
+                PassCondition = () => comboBreak() && cursorVisible(true)
+            });
+
+            AddStep("increase combo", () => Player.ScoreProcessor.Combo.Value += 1);
+        }
+
         private bool checkSomeHit() => Player.ScoreProcessor.JudgedHits >= 1;
 
         private bool cursorVisible(bool visible)
@@ -138,6 +170,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         private bool breakTime()
         {
             return Player.IsBreakTime.Value;
+        }
+
+        private bool comboBreak()
+        {
+            return Player.ScoreProcessor.HighestCombo != Player.ScoreProcessor.Combo;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -2,68 +2,142 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Tests.Mods
 {
     public class TestSceneOsuModNoScope : OsuModTestScene
     {
         [Test]
-        public void BreaksAndSpinners() => CreateModTest(new ModTestData
+        public void CursorVisibleDuringBreak()
         {
-            Mod = new OsuModNoScope
+            CreateModTest(new ModTestData
             {
-                HiddenComboCount = { Value = 0 },
-                AlwaysHidden = { Value = false },
-            },
-            Autoplay = true,
-            Beatmap = new Beatmap
-            {
-                HitObjects = new List<HitObject>
+                Mod = new OsuModNoScope
                 {
-                    new HitCircle
+                    HiddenComboCount = { Value = 0 },
+                },
+                Autoplay = true,
+                Beatmap = new Beatmap
+                {
+                    HitObjects = new List<HitObject>
                     {
-                        Position = new Vector2(300, 192),
-                        StartTime = 0,
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 0,
+                        },
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 6000,
+                        }
                     },
-                    new HitCircle
+                    Breaks = new List<BreakPeriod>
                     {
-                        Position = new Vector2(300, 192),
-                        StartTime = 5000,
-                    },
-                    new Spinner
+                        new BreakPeriod
+                        (
+                            2000,
+                            4000
+                        ),
+                    }
+                },
+                PassCondition = () => breakTime() && cursorVisible(true)
+            });
+        }
+
+        [Test]
+        public void CursorVisibleDuringSpinner()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new OsuModNoScope
+                {
+                    HiddenComboCount = { Value = 0 },
+                },
+                Autoplay = true,
+                Beatmap = new Beatmap
+                {
+                    HitObjects = new List<HitObject>
                     {
-                        Position = new Vector2(256, 192),
-                        StartTime = 6000,
-                        EndTime = 9000,
-                    },
-                    new HitCircle
-                    {
-                        Position = new Vector2(300, 192),
-                        StartTime = 10000,
-                    },
-                    new HitCircle
-                    {
-                        Position = new Vector2(300, 192),
-                        StartTime = 12000,
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 0,
+                        },
+                        new Spinner
+                        {
+                            Position = new Vector2(256, 192),
+                            StartTime = 2000,
+                            EndTime = 4000,
+                        },
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 6000,
+                        }
                     },
                 },
-                Breaks = new List<BreakPeriod>
+                PassCondition = () => spinnerTime() && cursorVisible(true)
+            });
+        }
+
+        [Test]
+        public void CursorHiddenAfterHit()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new OsuModNoScope
                 {
-                    new BreakPeriod
-                    (
-                        1000,
-                        4000
-                    ),
-                }
-            },
-            PassCondition = () => Player.ScoreProcessor.Combo.Value >= 5
-        });
+                    HiddenComboCount = { Value = 1 },
+                },
+                Autoplay = true,
+                Beatmap = new Beatmap
+                {
+                    HitObjects = new List<HitObject>
+                    {
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 0,
+                        },
+                        new HitCircle
+                        {
+                            Position = new Vector2(300, 192),
+                            StartTime = 2000,
+                        },
+                    },
+                },
+                PassCondition = () => checkSomeHit() && cursorVisible(false)
+            });
+        }
+
+        private bool checkSomeHit() => Player.ScoreProcessor.JudgedHits >= 1;
+
+        private bool cursorVisible(bool visible)
+        {
+            float alpha = visible ? 1 : 0;
+            return Precision.AlmostEquals(Player.DrawableRuleset.Cursor.Alpha, alpha, 0.1);
+        }
+
+        private bool spinnerTime()
+        {
+            return Player.ChildrenOfType<DrawableSpinner>().SingleOrDefault()?.Progress > 0;
+        }
+
+        private bool breakTime()
+        {
+            return Player.IsBreakTime.Value;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModNoScope
             {
                 HiddenComboCount = { Value = 0 },
-                ShowCursorDuringBreaks = { Value = true },
+                AlwaysHidden = { Value = false },
             },
             Autoplay = true,
             Beatmap = new Beatmap

--- a/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
@@ -63,8 +63,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             MaxValue = 50,
         };
 
-        [SettingSource("Show on rest", "Show cursor during breaks and spinners.")]
-        public BindableBool ShowCursorDuringBreaks { get; } = new BindableBool();
+        [SettingSource("Always hidden", "Don't show cursor during breaks and spinners.")]
+        public BindableBool AlwaysHidden { get; } = new BindableBool();
 
         public ScoreRank AdjustRank(ScoreRank rank, double accuracy) => rank;
 
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var time = playfield.Clock.CurrentTime;
 
-            if (ShowCursorDuringBreaks.Value)
+            if (!AlwaysHidden.Value)
             {
                 if (breaksPeriods.IsInAny(time) || spinnerPeriods.IsInAny(time))
                 {
@@ -128,6 +128,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
     public class HiddenComboSlider : OsuSliderBar<int>
     {
-        public override LocalisableString TooltipText => Current.Value == 0 ? "always hidden" : base.TooltipText;
+        public override LocalisableString TooltipText => Current.Value == 0 ? "start hidden" : base.TooltipText;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private float targetAlpha;
 
-        private bool rest;
+        private bool restPeriod;
 
-        private bool restSpinner;
+        private bool spinnerPeriod;
 
         private PeriodTracker breaksPeriods;
 
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 if (breaksPeriods.IsInAny(time) || spinnerPeriods.IsInAny(time))
                 {
                     targetAlpha = 1;
-                    rest = true;
+                    restPeriod = true;
                 }
                 else if (HiddenComboCount.Value == 0)
                 {
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 if (spinnerPeriods.IsInAny(time))
                 {
-                    restSpinner = true;
+                    spinnerPeriod = true;
                 }
             }
 
@@ -114,11 +114,11 @@ namespace osu.Game.Rulesets.Osu.Mods
                     lastComboBeforeRest = 0;
                 }
 
-                if (rest)
+                if (restPeriod)
                 {
                     // handle combo increase after spinner
-                    lastComboBeforeRest = restSpinner ? combo.NewValue : combo.NewValue - 1;
-                    restSpinner = false;
+                    lastComboBeforeRest = spinnerPeriod ? combo.NewValue : combo.NewValue - 1;
+                    restPeriod = spinnerPeriod = false;
                 }
 
                 targetAlpha = 1 - (float)(combo.NewValue - lastComboBeforeRest) / HiddenComboCount.Value;


### PR DESCRIPTION
Since it's really challenging to adjust aim after spinners and breaks (at least using mouse) I've added a setting to show cursor during these parts.

Closes https://github.com/ppy/osu/discussions/15140