### PR TITLE
Hide mods when spectating or beatmap isn't locally available

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -275,6 +275,68 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 var state = i;
                 AddStep($"set state: {state}", () => Client.ChangeUserState(0, state));
             }
+
+            AddStep("set state: downloading", () => Client.ChangeUserBeatmapAvailability(0, BeatmapAvailability.Downloading(0)));
+
+            AddStep("set state: locally available", () => Client.ChangeUserBeatmapAvailability(0, BeatmapAvailability.LocallyAvailable()));
+        }
+
+        [Test]
+        public void TestModOverlap()
+        {
+            AddStep("add dummy mods", () =>
+            {
+                Client.ChangeUserMods(new Mod[]
+                {
+                    new OsuModNoFail(),
+                    new OsuModDoubleTime()
+                });
+            });
+
+            AddStep("add user with mods", () =>
+            {
+                Client.AddUser(new User
+                {
+                    Id = 0,
+                    Username = "Baka",
+                    RulesetsStatistics = new Dictionary<string, UserStatistics>
+                    {
+                        {
+                            Ruleset.Value.ShortName,
+                            new UserStatistics { GlobalRank = RNG.Next(1, 100000), }
+                        }
+                    },
+                    CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                });
+                Client.ChangeUserMods(0, new Mod[]
+                {
+                    new OsuModHardRock(),
+                    new OsuModDoubleTime()
+                });
+            });
+
+            AddStep("set 0 ready", () => Client.ChangeState(MultiplayerUserState.Ready));
+
+            AddStep("set 1 spectate", () => Client.ChangeUserState(0, MultiplayerUserState.Spectating));
+
+            // Have to set back to idle due to status priority.
+            AddStep("set 0 no map, 1 ready", () =>
+            {
+                Client.ChangeState(MultiplayerUserState.Idle);
+                Client.ChangeBeatmapAvailability(BeatmapAvailability.NotDownloaded());
+                Client.ChangeUserState(0, MultiplayerUserState.Ready);
+            });
+
+            AddStep("set 0 downloading", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
+
+            AddStep("set 0 spectate", () => Client.ChangeUserState(0, MultiplayerUserState.Spectating));
+
+            AddStep("make both default", () =>
+            {
+                Client.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
+                Client.ChangeUserState(0, MultiplayerUserState.Idle);
+                Client.ChangeState(MultiplayerUserState.Idle);
+            });
         }
 
         private void createNewParticipantsList()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets;
@@ -189,6 +190,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
             userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);
+
+            if ((User.BeatmapAvailability.State == DownloadState.LocallyAvailable) && (User.State != MultiplayerUserState.Spectating))
+                userModsDisplay.FadeIn(fade_time);
+            else
+                userModsDisplay.FadeOut(fade_time);
 
             if (Client.IsHost && !User.Equals(Client.LocalUser))
                 kickButton.FadeIn(fade_time);


### PR DESCRIPTION
This PR resolves #14712 

**Changes**
- If the beatmap isn't locally available (downloading, no map, importing) or the user is spectating, hide the mod icons in the Player List.

**Testing**
- Tests were added under `ModOverlap()`.

Signed-off-by: 5ln <xnafumie@gmail.com>
*Edited for clarity.*