### PR TITLE
Update appearance of setting default value indicator

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneRestoreDefaultValueButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRestoreDefaultValueButton.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Settings
+{
+    public class TestSceneRestoreDefaultValueButton : OsuTestScene
+    {
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        [Test]
+        public void TestBasic()
+        {
+            RestoreDefaultValueButton<bool> restoreDefaultValueButton = null;
+
+            AddStep("create button", () => Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.GreySeafoam
+                    },
+                    restoreDefaultValueButton = new RestoreDefaultValueButton<bool>
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Current = new BindableBool(),
+                    }
+                }
+            });
+            AddSliderStep("set scale", 1, 4, 1, scale =>
+            {
+                if (restoreDefaultValueButton != null)
+                    restoreDefaultValueButton.Scale = new Vector2(scale);
+            });
+            AddToggleStep("toggle default state", state => restoreDefaultValueButton.Current.Value = state);
+            AddToggleStep("toggle disabled state", state => restoreDefaultValueButton.Current.Disabled = state);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Settings/TestSceneRestoreDefaultValueButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRestoreDefaultValueButton.cs
@@ -18,10 +18,18 @@ namespace osu.Game.Tests.Visual.Settings
         [Resolved]
         private OsuColour colours { get; set; }
 
+        private float scale = 1;
+
+        private readonly Bindable<float> current = new Bindable<float>
+        {
+            Default = default,
+            Value = 1,
+        };
+
         [Test]
         public void TestBasic()
         {
-            RestoreDefaultValueButton<bool> restoreDefaultValueButton = null;
+            RestoreDefaultValueButton<float> restoreDefaultValueButton = null;
 
             AddStep("create button", () => Child = new Container
             {
@@ -33,21 +41,23 @@ namespace osu.Game.Tests.Visual.Settings
                         RelativeSizeAxes = Axes.Both,
                         Colour = colours.GreySeafoam
                     },
-                    restoreDefaultValueButton = new RestoreDefaultValueButton<bool>
+                    restoreDefaultValueButton = new RestoreDefaultValueButton<float>
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Current = new BindableBool(),
+                        Scale = new Vector2(scale),
+                        Current = current,
                     }
                 }
             });
             AddSliderStep("set scale", 1, 4, 1, scale =>
             {
+                this.scale = scale;
                 if (restoreDefaultValueButton != null)
                     restoreDefaultValueButton.Scale = new Vector2(scale);
             });
-            AddToggleStep("toggle default state", state => restoreDefaultValueButton.Current.Value = state);
-            AddToggleStep("toggle disabled state", state => restoreDefaultValueButton.Current.Disabled = state);
+            AddToggleStep("toggle default state", state => current.Value = state ? default : 1);
+            AddToggleStep("toggle disabled state", state => current.Disabled = state);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
@@ -4,8 +4,10 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays;
 
@@ -47,8 +49,8 @@ namespace osu.Game.Tests.Visual.Settings
         public void TestSetAndClearLabelText()
         {
             SettingsTextBox textBox = null;
-            GridContainer settingsItemGrid = null;
             RestoreDefaultValueButton<string> restoreDefaultValueButton = null;
+            OsuTextBox control = null;
 
             AddStep("create settings item", () =>
             {
@@ -64,18 +66,25 @@ namespace osu.Game.Tests.Visual.Settings
             AddUntilStep("wait for loaded", () => textBox.IsLoaded);
             AddStep("retrieve components", () =>
             {
-                settingsItemGrid = textBox.ChildrenOfType<GridContainer>().Single();
                 restoreDefaultValueButton = textBox.ChildrenOfType<RestoreDefaultValueButton<string>>().Single();
+                control = textBox.ChildrenOfType<OsuTextBox>().Single();
             });
 
             AddStep("set non-default value", () => restoreDefaultValueButton.Current.Value = "non-default");
-            AddAssert("default value button next to control", () => settingsItemGrid.Content[1][0] == restoreDefaultValueButton);
+            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, control.DrawHeight, 1));
 
             AddStep("set label", () => textBox.LabelText = "label text");
-            AddAssert("default value button next to label", () => settingsItemGrid.Content[0][0] == restoreDefaultValueButton);
+            AddAssert("default value button centre aligned to label size", () =>
+            {
+                var label = textBox.ChildrenOfType<OsuSpriteText>().Single(spriteText => spriteText.Text == "label text");
+                return Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, label.DrawHeight, 1);
+            });
 
             AddStep("clear label", () => textBox.LabelText = default);
-            AddAssert("default value button next to control", () => settingsItemGrid.Content[1][0] == restoreDefaultValueButton);
+            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, control.DrawHeight, 1));
+
+            AddStep("set warning text", () => textBox.WarningText = "This is some very important warning text! Hopefully it doesn't break the alignment of the default value indicator...");
+            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, control.DrawHeight, 1));
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays;
@@ -29,9 +30,10 @@ namespace osu.Game.Tests.Visual.Settings
                         Value = "test"
                     }
                 };
-
-                restoreDefaultValueButton = textBox.ChildrenOfType<RestoreDefaultValueButton<string>>().Single();
             });
+            AddUntilStep("wait for loaded", () => textBox.IsLoaded);
+            AddStep("retrieve restore default button", () => restoreDefaultValueButton = textBox.ChildrenOfType<RestoreDefaultValueButton<string>>().Single());
+
             AddAssert("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
 
             AddStep("change value from default", () => textBox.Current.Value = "non-default");
@@ -39,6 +41,41 @@ namespace osu.Game.Tests.Visual.Settings
 
             AddStep("restore default", () => textBox.Current.SetDefault());
             AddUntilStep("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
+        }
+
+        [Test]
+        public void TestSetAndClearLabelText()
+        {
+            SettingsTextBox textBox = null;
+            GridContainer settingsItemGrid = null;
+            RestoreDefaultValueButton<string> restoreDefaultValueButton = null;
+
+            AddStep("create settings item", () =>
+            {
+                Child = textBox = new SettingsTextBox
+                {
+                    Current = new Bindable<string>
+                    {
+                        Default = "test",
+                        Value = "test"
+                    }
+                };
+            });
+            AddUntilStep("wait for loaded", () => textBox.IsLoaded);
+            AddStep("retrieve components", () =>
+            {
+                settingsItemGrid = textBox.ChildrenOfType<GridContainer>().Single();
+                restoreDefaultValueButton = textBox.ChildrenOfType<RestoreDefaultValueButton<string>>().Single();
+            });
+
+            AddStep("set non-default value", () => restoreDefaultValueButton.Current.Value = "non-default");
+            AddAssert("default value button next to control", () => settingsItemGrid.Content[1][0] == restoreDefaultValueButton);
+
+            AddStep("set label", () => textBox.LabelText = "label text");
+            AddAssert("default value button next to label", () => settingsItemGrid.Content[0][0] == restoreDefaultValueButton);
+
+            AddStep("clear label", () => textBox.LabelText = default);
+            AddAssert("default value button next to control", () => settingsItemGrid.Content[1][0] == restoreDefaultValueButton);
         }
 
         /// <summary>
@@ -64,9 +101,9 @@ namespace osu.Game.Tests.Visual.Settings
                         Precision = 0.1f,
                     }
                 };
-
-                restoreDefaultValueButton = sliderBar.ChildrenOfType<RestoreDefaultValueButton<float>>().Single();
             });
+            AddUntilStep("wait for loaded", () => sliderBar.IsLoaded);
+            AddStep("retrieve restore default button", () => restoreDefaultValueButton = sliderBar.ChildrenOfType<RestoreDefaultValueButton<float>>().Single());
 
             AddAssert("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
 

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -235,10 +235,17 @@ namespace osu.Game.Graphics
         /// </summary>
         public readonly Color4 Blue3 = Color4Extensions.FromHex(@"3399cc");
 
+        public readonly Color4 Lime0 = Color4Extensions.FromHex(@"ccff99");
+
         /// <summary>
         /// Equivalent to <see cref="OverlayColourProvider.Lime"/>'s <see cref="OverlayColourProvider.Colour1"/>.
         /// </summary>
         public readonly Color4 Lime1 = Color4Extensions.FromHex(@"b2ff66");
+
+        /// <summary>
+        /// Equivalent to <see cref="OverlayColourProvider.Lime"/>'s <see cref="OverlayColourProvider.Colour3"/>.
+        /// </summary>
+        public readonly Color4 Lime3 = Color4Extensions.FromHex(@"7fcc33");
 
         /// <summary>
         /// Equivalent to <see cref="OverlayColourProvider.Orange"/>'s <see cref="OverlayColourProvider.Colour1"/>.

--- a/osu.Game/Overlays/RestoreDefaultValueButton.cs
+++ b/osu.Game/Overlays/RestoreDefaultValueButton.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Overlays
                 Background.FadeColour(colours.Lime3, fade_duration, Easing.OutQuint);
                 Content.TweenEdgeEffectTo(new EdgeEffectParameters
                 {
-                    Colour = colours.Lime3.Opacity(0.4f).Opacity(0.1f),
+                    Colour = colours.Lime3.Opacity(0.1f),
                     Radius = 2,
                     Type = EdgeEffectType.Glow
                 }, fade_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/RestoreDefaultValueButton.cs
+++ b/osu.Game/Overlays/RestoreDefaultValueButton.cs
@@ -3,10 +3,8 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.UserInterface;
@@ -14,6 +12,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osuTK;
 
 namespace osu.Game.Overlays
 {
@@ -45,30 +44,21 @@ namespace osu.Game.Overlays
             }
         }
 
-        private bool hovering;
+        [Resolved]
+        private OsuColour colours { get; set; }
 
-        public RestoreDefaultValueButton()
-        {
-            Height = 1;
-
-            RelativeSizeAxes = Axes.Y;
-            Width = SettingsPanel.CONTENT_MARGINS;
-        }
+        private const float size = 4;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
         {
-            BackgroundColour = colour.Yellow;
-            Content.Width = 0.33f;
-            Content.CornerRadius = 3;
-            Content.EdgeEffect = new EdgeEffectParameters
-            {
-                Colour = BackgroundColour.Opacity(0.1f),
-                Type = EdgeEffectType.Glow,
-                Radius = 2,
-            };
+            BackgroundColour = colour.Lime1;
+            Size = new Vector2(3 * size);
 
-            Padding = new MarginPadding { Vertical = 1.5f };
+            Content.RelativeSizeAxes = Axes.None;
+            Content.Size = new Vector2(size);
+            Content.CornerRadius = size / 2;
+
             Alpha = 0f;
 
             Action += () =>
@@ -81,39 +71,55 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            // avoid unnecessary transforms on first display.
-            Alpha = currentAlpha;
-            Background.Colour = currentColour;
+            updateState();
+            FinishTransforms(true);
         }
 
         public LocalisableString TooltipText => "revert to default";
 
         protected override bool OnHover(HoverEvent e)
         {
-            hovering = true;
             UpdateState();
             return false;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            hovering = false;
             UpdateState();
         }
 
         public void UpdateState() => Scheduler.AddOnce(updateState);
 
-        private float currentAlpha => current.IsDefault ? 0f : hovering && !current.Disabled ? 1f : 0.65f;
-        private ColourInfo currentColour => current.Disabled ? Color4.Gray : BackgroundColour;
+        private const double fade_duration = 200;
 
         private void updateState()
         {
             if (current == null)
                 return;
 
-            this.FadeTo(currentAlpha, 200, Easing.OutQuint);
-            Background.FadeColour(currentColour, 200, Easing.OutQuint);
+            Enabled.Value = !Current.Disabled;
+
+            if (!Current.Disabled)
+            {
+                this.FadeTo(Current.IsDefault ? 0 : 1, fade_duration, Easing.OutQuint);
+                Background.FadeColour(IsHovered ? colours.Lime0 : colours.Lime1, fade_duration, Easing.OutQuint);
+                Content.TweenEdgeEffectTo(new EdgeEffectParameters
+                {
+                    Colour = (IsHovered ? colours.Lime1 : colours.Lime3).Opacity(0.4f),
+                    Radius = IsHovered ? 8 : 4,
+                    Type = EdgeEffectType.Glow
+                }, fade_duration, Easing.OutQuint);
+            }
+            else
+            {
+                Background.FadeColour(colours.Lime3, fade_duration, Easing.OutQuint);
+                Content.TweenEdgeEffectTo(new EdgeEffectParameters
+                {
+                    Colour = colours.Lime3.Opacity(0.4f).Opacity(0.1f),
+                    Radius = 2,
+                    Type = EdgeEffectType.Glow
+                }, fade_duration, Easing.OutQuint);
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -82,64 +82,82 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
-            Padding = new MarginPadding { Horizontal = SettingsPanel.CONTENT_MARGINS };
 
-            InternalChildren = new Drawable[]
+            InternalChild = new GridContainer
             {
-                new RestoreDefaultValueButton<bool>
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                ColumnDimensions = new[]
                 {
-                    Current = isDefault,
-                    Action = RestoreDefaults,
-                    Origin = Anchor.TopRight,
+                    new Dimension(GridSizeMode.Absolute, SettingsPanel.CONTENT_MARGINS),
+                    new Dimension(),
+                    new Dimension(GridSizeMode.Absolute, SettingsPanel.CONTENT_MARGINS),
                 },
-                content = new Container
+                RowDimensions = new[]
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Masking = true,
-                    CornerRadius = padding,
-                    EdgeEffect = new EdgeEffectParameters
+                    new Dimension(GridSizeMode.AutoSize)
+                },
+                Content = new[]
+                {
+                    new Drawable[]
                     {
-                        Radius = 2,
-                        Colour = colourProvider.Highlight1.Opacity(0),
-                        Type = EdgeEffectType.Shadow,
-                        Hollow = true,
-                    },
-                    Children = new Drawable[]
-                    {
-                        new Box
+                        new RestoreDefaultValueButton<bool>
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = colourProvider.Background5,
+                            Current = isDefault,
+                            Action = RestoreDefaults,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre
                         },
-                        text = new OsuSpriteText
+                        content = new Container
                         {
-                            Text = action.GetLocalisableDescription(),
-                            Margin = new MarginPadding(1.5f * padding),
-                        },
-                        buttons = new FillFlowContainer<KeyButton>
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight
-                        },
-                        cancelAndClearButtons = new FillFlowContainer
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Padding = new MarginPadding(padding) { Top = height + padding * 2 },
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight,
-                            Alpha = 0,
-                            Spacing = new Vector2(5),
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Masking = true,
+                            CornerRadius = padding,
+                            EdgeEffect = new EdgeEffectParameters
+                            {
+                                Radius = 2,
+                                Colour = colourProvider.Highlight1.Opacity(0),
+                                Type = EdgeEffectType.Shadow,
+                                Hollow = true,
+                            },
                             Children = new Drawable[]
                             {
-                                new CancelButton { Action = finalise },
-                                new ClearButton { Action = clear },
-                            },
-                        }
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = colourProvider.Background5,
+                                },
+                                text = new OsuSpriteText
+                                {
+                                    Text = action.GetLocalisableDescription(),
+                                    Margin = new MarginPadding(1.5f * padding),
+                                },
+                                buttons = new FillFlowContainer<KeyButton>
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight
+                                },
+                                cancelAndClearButtons = new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding(padding) { Top = height + padding * 2 },
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight,
+                                    Alpha = 0,
+                                    Spacing = new Vector2(5),
+                                    Children = new Drawable[]
+                                    {
+                                        new CancelButton { Action = finalise },
+                                        new ClearButton { Action = clear },
+                                    },
+                                }
+                            }
+                        },
+                        new HoverClickSounds()
                     }
-                },
-                new HoverClickSounds()
+                }
             };
 
             foreach (var b in bindings)

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -82,32 +82,29 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
+            Padding = new MarginPadding { Right = SettingsPanel.CONTENT_MARGINS };
 
-            InternalChild = new GridContainer
+            InternalChildren = new Drawable[]
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                ColumnDimensions = new[]
+                new Container
                 {
-                    new Dimension(GridSizeMode.Absolute, SettingsPanel.CONTENT_MARGINS),
-                    new Dimension(),
-                    new Dimension(GridSizeMode.Absolute, SettingsPanel.CONTENT_MARGINS),
-                },
-                RowDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.AutoSize)
-                },
-                Content = new[]
-                {
-                    new Drawable[]
+                    RelativeSizeAxes = Axes.Y,
+                    Width = SettingsPanel.CONTENT_MARGINS,
+                    Child = new RestoreDefaultValueButton<bool>
                     {
-                        new RestoreDefaultValueButton<bool>
-                        {
-                            Current = isDefault,
-                            Action = RestoreDefaults,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre
-                        },
+                        Current = isDefault,
+                        Action = RestoreDefaults,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS },
+                    Children = new Drawable[]
+                    {
                         content = new Container
                         {
                             RelativeSizeAxes = Axes.X,
@@ -154,10 +151,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                                     },
                                 }
                             }
-                        },
-                        new HoverClickSounds()
+                        }
                     }
-                }
+                },
+                new HoverClickSounds()
             };
 
             foreach (var b in bindings)

--- a/osu.Game/Overlays/Settings/SettingsDropdown.cs
+++ b/osu.Game/Overlays/Settings/SettingsDropdown.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
-using osuTK;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -27,11 +26,6 @@ namespace osu.Game.Overlays.Settings
         }
 
         public override IEnumerable<string> FilterTerms => base.FilterTerms.Concat(Control.Items.Select(i => i.ToString()));
-
-        public SettingsDropdown()
-        {
-            FlowContent.Spacing = new Vector2(0, 10);
-        }
 
         protected sealed override Drawable CreateControl() => CreateDropdown();
 

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -115,13 +115,18 @@ namespace osu.Game.Overlays.Settings
                 {
                     Width = SettingsPanel.CONTENT_MARGINS,
                 },
-                FlowContent = new FillFlowContainer
+                new Container
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS },
-                    Spacing = new Vector2(0, 10),
-                    Child = Control = CreateControl(),
+                    Child = FlowContent = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(0, 10),
+                        Child = Control = CreateControl(),
+                    }
                 }
             };
 

--- a/osu.Game/Overlays/Settings/SettingsNumberBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsNumberBox.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.Settings
         protected override Drawable CreateControl() => new NumberControl
         {
             RelativeSizeAxes = Axes.X,
-            Margin = new MarginPadding { Top = 5 }
         };
 
         private sealed class NumberControl : CompositeDrawable, IHasCurrentValue<int?>

--- a/osu.Game/Overlays/Settings/SettingsSlider.cs
+++ b/osu.Game/Overlays/Settings/SettingsSlider.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Overlays.Settings
     {
         protected override Drawable CreateControl() => new TSlider
         {
-            Margin = new MarginPadding { Vertical = 10 },
             RelativeSizeAxes = Axes.X
         };
 

--- a/osu.Game/Overlays/Settings/SettingsTextBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsTextBox.cs
@@ -11,7 +11,6 @@ namespace osu.Game.Overlays.Settings
     {
         protected override Drawable CreateControl() => new OutlinedTextBox
         {
-            Margin = new MarginPadding { Top = 5 },
             RelativeSizeAxes = Axes.X,
             CommitOnFocusLost = true
         };

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSliderBar.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSliderBar.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         protected override Drawable CreateControl() => new Sliderbar
         {
-            Margin = new MarginPadding { Top = 5, Bottom = 5 },
             RelativeSizeAxes = Axes.X
         };
 


### PR DESCRIPTION
Loosely based on the following designs: https://www.figma.com/file/IjrU0u7MFdgmxDofqTlsZb/UI%2FClient-Settings?node-id=0%3A1

https://user-images.githubusercontent.com/20418176/137644785-fdc5df69-49ea-46b3-aef7-8eb0e70beddd.mp4

The idle/default behaviour was provided in the design, but there was no hover/disabled behaviour, so I improvised. The clickable area is quite a bit larger than what it looks to be to alleviate pixel hunting, although I'm not super sure if it's large enough still.

The dot will appear next to the setting control if the setting has no label, and next to the label if there is one. This was the most finicky part of this implementation by far. It looks to work pretty well, though.

Colours taken from https://www.figma.com/file/VIkXMYNPMtQem2RJg9k2iQ/Asset%2FColours?node-id=0%3A1.