### PR TITLE
Fix epilepsy warning not being faded out on an early exit during gameplay load

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for current", () => loader.IsCurrentScreen());
 
-            AddAssert($"epilepsy warning {(warning ? "present" : "absent")}", () => this.ChildrenOfType<EpilepsyWarning>().Any() == warning);
+            AddAssert($"epilepsy warning {(warning ? "present" : "absent")}", () => (getWarning() != null) == warning);
 
             if (warning)
             {
@@ -335,11 +335,16 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for current", () => loader.IsCurrentScreen());
 
-            AddUntilStep("wait for epilepsy warning", () => loader.ChildrenOfType<EpilepsyWarning>().Single().Alpha > 0);
+            AddUntilStep("wait for epilepsy warning", () => getWarning().Alpha > 0);
+            AddUntilStep("warning is shown", () => getWarning().State.Value == Visibility.Visible);
+
             AddStep("exit early", () => loader.Exit());
 
+            AddUntilStep("warning is hidden", () => getWarning().State.Value == Visibility.Hidden);
             AddUntilStep("sound volume restored", () => Beatmap.Value.Track.AggregateVolume.Value == 1);
         }
+
+        private EpilepsyWarning getWarning() => loader.ChildrenOfType<EpilepsyWarning>().SingleOrDefault();
 
         private class TestPlayerLoader : PlayerLoader
         {

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -246,6 +246,9 @@ namespace osu.Game.Screens.Play
             cancelLoad();
             contentOut();
 
+            // If the load sequence was interrupted, the epilepsy warning may already be displayed (or in the process of being displayed).
+            epilepsyWarning?.Hide();
+
             // Ensure the screen doesn't expire until all the outwards fade operations have completed.
             this.Delay(content_out_duration).FadeOut();
 


### PR DESCRIPTION
Closes #15161.