### PR TITLE
Don't flash screen red on fail if the user has disabled red tinting

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
@@ -20,14 +20,15 @@ namespace osu.Game.Tests.Visual.Gameplay
     /// </summary>
     public abstract class TestSceneAllRulesetPlayers : RateAdjustedBeatmapTestScene
     {
-        protected Player Player;
+        protected Player Player { get; private set; }
+
+        protected OsuConfigManager Config { get; private set; }
 
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
         {
-            OsuConfigManager manager;
-            Dependencies.Cache(manager = new OsuConfigManager(LocalStorage));
-            manager.GetBindable<double>(OsuSetting.DimLevel).Value = 1.0;
+            Dependencies.Cache(Config = new OsuConfigManager(LocalStorage));
+            Config.GetBindable<double>(OsuSetting.DimLevel).Value = 1.0;
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play;
@@ -15,6 +17,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             SelectedMods.Value = Array.Empty<Mod>();
             return new FailPlayer();
+        }
+
+        [Test]
+        public void TestOsuWithoutRedTint()
+        {
+            AddStep("Disable red tint", () => Config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, false));
+            TestOsu();
+            AddStep("Enable red tint", () => Config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, true));
         }
 
         protected override void AddCheckSteps()

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Audio.Effects;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
@@ -35,7 +36,7 @@ namespace osu.Game.Screens.Play
 
         private Container filters;
 
-        private Box failFlash;
+        private Box redFlashLayer;
 
         private Track track;
 
@@ -45,6 +46,9 @@ namespace osu.Game.Screens.Play
         private const float duration = 2500;
 
         private Sample failSample;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
 
         protected override Container<Drawable> Content { get; } = new Container
         {
@@ -77,7 +81,7 @@ namespace osu.Game.Screens.Play
                     },
                 },
                 Content,
-                failFlash = new Box
+                redFlashLayer = new Box
                 {
                     Colour = Color4.Red,
                     RelativeSizeAxes = Axes.Both,
@@ -114,7 +118,8 @@ namespace osu.Game.Screens.Play
             applyToPlayfield(drawableRuleset.Playfield);
             drawableRuleset.Playfield.HitObjectContainer.FadeOut(duration / 2);
 
-            failFlash.FadeOutFromOne(1000);
+            if (config.Get<bool>(OsuSetting.FadePlayfieldWhenHealthLow))
+                redFlashLayer.FadeOutFromOne(1000);
 
             Content.Masking = true;
 


### PR DESCRIPTION
Don't want to add more settings for now. This makes sense I think. Looks very underwhelming but oh well, pro players etc.

Closes https://github.com/ppy/osu/discussions/15171.