### PR TITLE
Change `OnlineID` to non-nullable to allow for indexing in Realm

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IHasOnlineID
 
-        public int? OnlineID => OnlineBeatmapID;
+        public int OnlineID => OnlineBeatmapID ?? -1;
 
         #endregion
 

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IHasOnlineID
 
-        public int? OnlineID => OnlineBeatmapSetID;
+        public int OnlineID => OnlineBeatmapSetID ?? -1;
 
         #endregion
 

--- a/osu.Game/Database/IHasOnlineID.cs
+++ b/osu.Game/Database/IHasOnlineID.cs
@@ -8,8 +8,8 @@ namespace osu.Game.Database
     public interface IHasOnlineID
     {
         /// <summary>
-        /// The server-side ID representing this instance, if one exists.
+        /// The server-side ID representing this instance, if one exists. -1 denotes a missing ID.
         /// </summary>
-        int? OnlineID { get; }
+        int OnlineID { get; }
     }
 }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Development;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
+using osu.Game.Models;
 using Realms;
 
 #nullable enable
@@ -26,7 +28,12 @@ namespace osu.Game.Database
         /// </summary>
         public readonly string Filename;
 
-        private const int schema_version = 6;
+        /// <summary>
+        /// Version history:
+        /// 6  First tracked version (~20211018)
+        /// 7  Changed OnlineID fields to non-nullable to add indexing support (20211018)
+        /// </summary>
+        private const int schema_version = 7;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking context creation during blocking periods.
@@ -120,6 +127,31 @@ namespace osu.Game.Database
 
         private void onMigration(Migration migration, ulong lastSchemaVersion)
         {
+            if (lastSchemaVersion < 7)
+            {
+                convertOnlineIDs<RealmBeatmap>();
+                convertOnlineIDs<RealmBeatmapSet>();
+                convertOnlineIDs<RealmRuleset>();
+
+                void convertOnlineIDs<T>() where T : RealmObject
+                {
+                    var className = typeof(T).Name.Replace(@"Realm", string.Empty);
+
+                    var oldItems = migration.OldRealm.DynamicApi.All(className);
+                    var newItems = migration.NewRealm.DynamicApi.All(className);
+
+                    int itemCount = newItems.Count();
+
+                    for (int i = 0; i < itemCount; i++)
+                    {
+                        var oldItem = oldItems.ElementAt(i);
+                        var newItem = newItems.ElementAt(i);
+
+                        long? nullableOnlineID = oldItem.OnlineID;
+                        newItem.OnlineID = (int)(nullableOnlineID ?? -1);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Database
                         var oldItem = oldItems.ElementAt(i);
                         var newItem = newItems.ElementAt(i);
 
-                        long? nullableOnlineID = oldItem.OnlineID;
+                        long? nullableOnlineID = oldItem?.OnlineID;
                         newItem.OnlineID = (int)(nullableOnlineID ?? -1);
                     }
                 }

--- a/osu.Game/Models/RealmBeatmap.cs
+++ b/osu.Game/Models/RealmBeatmap.cs
@@ -44,7 +44,8 @@ namespace osu.Game.Models
         [MapTo(nameof(Status))]
         public int StatusInt { get; set; }
 
-        public int? OnlineID { get; set; }
+        [Indexed]
+        public int OnlineID { get; set; } = -1;
 
         public double Length { get; set; }
 

--- a/osu.Game/Models/RealmBeatmapSet.cs
+++ b/osu.Game/Models/RealmBeatmapSet.cs
@@ -20,7 +20,8 @@ namespace osu.Game.Models
         [PrimaryKey]
         public Guid ID { get; set; } = Guid.NewGuid();
 
-        public int? OnlineID { get; set; }
+        [Indexed]
+        public int OnlineID { get; set; } = -1;
 
         public DateTimeOffset DateAdded { get; set; }
 
@@ -62,7 +63,7 @@ namespace osu.Game.Models
             if (IsManaged && other.IsManaged)
                 return ID == other.ID;
 
-            if (OnlineID.HasValue && other.OnlineID.HasValue)
+            if (OnlineID >= 0 && other.OnlineID >= 0)
                 return OnlineID == other.OnlineID;
 
             if (!string.IsNullOrEmpty(Hash) && !string.IsNullOrEmpty(other.Hash))

--- a/osu.Game/Models/RealmRuleset.cs
+++ b/osu.Game/Models/RealmRuleset.cs
@@ -18,7 +18,8 @@ namespace osu.Game.Models
         [PrimaryKey]
         public string ShortName { get; set; } = string.Empty;
 
-        public int? OnlineID { get; set; }
+        [Indexed]
+        public int OnlineID { get; set; } = -1;
 
         public string Name { get; set; } = string.Empty;
 
@@ -29,7 +30,7 @@ namespace osu.Game.Models
             ShortName = shortName;
             Name = name;
             InstantiationInfo = instantiationInfo;
-            OnlineID = onlineID;
+            OnlineID = onlineID ?? -1;
         }
 
         [UsedImplicitly]
@@ -39,7 +40,7 @@ namespace osu.Game.Models
 
         public RealmRuleset(int? onlineID, string name, string shortName, bool available)
         {
-            OnlineID = onlineID;
+            OnlineID = onlineID ?? -1;
             Name = name;
             ShortName = shortName;
             Available = available;

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets
 
         #region Implementation of IHasOnlineID
 
-        public int? OnlineID => ID;
+        public int OnlineID => ID ?? -1;
 
         #endregion
     }


### PR DESCRIPTION
The actual data migration is not required as we haven't had any clients actually loading data (just a version bump would be enough to appease realm), but I've added it just to give an example of how it should be done. I've also tested it with sample data.

Of note:
- We can't get the mapped type name because the [extension method is internal](https://github.com/realm/realm-dotnet/blob/master/Realm/Realm/Extensions/ReflectionExtensions.cs#L46), so I'm just doing a `string.Replace`.
- All integer values are stored internally as `long`/`Int64`, which is why the seemingly weird cast is required.