### PR TITLE
Fix ruleset template player tests failing due to null ruleset ID

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -227,12 +227,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);
         }
 
-        [Test]
-        public void TestNoSubmissionOnCustomRuleset()
+        [TestCase(null)]
+        [TestCase(10)]
+        public void TestNoSubmissionOnCustomRuleset(int? rulesetId)
         {
             prepareTokenResponse(true);
 
-            createPlayerTest(false, createRuleset: () => new OsuRuleset { RulesetInfo = { ID = 10 } });
+            createPlayerTest(false, createRuleset: () => new OsuRuleset { RulesetInfo = { ID = rulesetId } });
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -218,12 +217,11 @@ namespace osu.Game.Screens.Play
 
             Score = CreateScore(playableBeatmap);
 
-            Debug.Assert(ruleset.RulesetInfo.ID != null);
-
             // ensure the score is in a consistent state with the current player.
             Score.ScoreInfo.BeatmapInfo = Beatmap.Value.BeatmapInfo;
             Score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
-            Score.ScoreInfo.RulesetID = ruleset.RulesetInfo.ID.Value;
+            if (ruleset.RulesetInfo.ID != null)
+                Score.ScoreInfo.RulesetID = ruleset.RulesetInfo.ID.Value;
             Score.ScoreInfo.Mods = gameplayMods;
 
             dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score));


### PR DESCRIPTION
I was using rider's "Run All Tests from Solution" today to run final checks on another PR and noticed that ruleset template tests' `TestSceneOsuPlayer` was dying on this assert added in #15130:

https://github.com/ppy/osu/blob/8643c725ccd702c015a47dccd4aacc94ef3b7708/osu.Game/Screens/Play/Player.cs#L221

This is because rulesets won't have an ID unless they're legacy, or they've been retrieved via a `RulesetStore` (i.e. assigned an ID by being saved to database):

https://github.com/ppy/osu/blob/8643c725ccd702c015a47dccd4aacc94ef3b7708/osu.Game/Rulesets/Ruleset.cs#L179-L189

and `TestSceneOsuPlayer` creates a new ruleset raw, not via the store:

https://github.com/ppy/osu/blob/8643c725ccd702c015a47dccd4aacc94ef3b7708/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/TestSceneOsuPlayer.cs#L12

Test coverage from #15130 is insurance that this does not regress what that PR was fixing. But because it was a pretty big issue I've re-tested manually to be extra _extra_ sure.

Also note that `SoloPlayer` will not request a submission token if the ruleset ID is `null`. I've added test coverage for this because there was none.