### PR TITLE
Use different colours for selection and hover in dropdowns

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuDropdown.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuDropdown.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneOsuDropdown : ThemeComparisonTestScene
+    {
+        protected override Drawable CreateContent() =>
+            new OsuEnumDropdown<BeatmapSetOnlineStatus>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 150
+            };
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
+++ b/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public abstract class ThemeComparisonTestScene : OsuGridTestScene
+    {
+        protected ThemeComparisonTestScene()
+            : base(1, 2)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Cell(0, 0).AddRange(new[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.GreySeafoam
+                },
+                CreateContent()
+            });
+        }
+
+        private void createThemedContent(OverlayColourScheme colourScheme)
+        {
+            var colourProvider = new OverlayColourProvider(colourScheme);
+
+            Cell(0, 1).Clear();
+            Cell(0, 1).Add(new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(OverlayColourProvider), colourProvider)
+                },
+                Children = new[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background4
+                    },
+                    CreateContent()
+                }
+            });
+        }
+
+        protected abstract Drawable CreateContent();
+
+        [Test]
+        public void TestAllColourSchemes()
+        {
+            foreach (var scheme in Enum.GetValues(typeof(OverlayColourScheme)).Cast<OverlayColourScheme>())
+                AddStep($"set {scheme} scheme", () => createThemedContent(scheme));
+        }
+    }
+}

--- a/osu.Game/Collections/CollectionFilterDropdown.cs
+++ b/osu.Game/Collections/CollectionFilterDropdown.cs
@@ -181,7 +181,11 @@ namespace osu.Game.Collections
                 MaxHeight = 200;
             }
 
-            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new CollectionDropdownMenuItem(item);
+            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new CollectionDropdownMenuItem(item)
+            {
+                BackgroundColourHover = HoverColour,
+                BackgroundColourSelected = SelectionColour
+            };
         }
 
         protected class CollectionDropdownMenuItem : OsuDropdownMenu.DrawableOsuDropdownMenuItem

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -54,8 +54,8 @@ namespace osu.Game.Graphics.UserInterface
             private void load(OverlayColourProvider? colourProvider, OsuColour colours, AudioManager audio)
             {
                 BackgroundColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
-                HoverColour = colourProvider?.Highlight1 ?? colours.PinkDarker;
-                SelectionColour = colourProvider?.Light4 ?? colours.PinkDarker.Opacity(0.5f);
+                HoverColour = colourProvider?.Light4 ?? colours.PinkDarker;
+                SelectionColour = colourProvider?.Background3 ?? colours.PinkDarker.Opacity(0.5f);
 
                 sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
                 sampleClose = audio.Samples.Get(@"UI/dropdown-close");
@@ -344,7 +344,7 @@ namespace osu.Game.Graphics.UserInterface
             private void load(OverlayColourProvider? colourProvider, OsuColour colours)
             {
                 BackgroundColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
-                BackgroundColourHover = colourProvider?.Highlight1 ?? colours.PinkDarker;
+                BackgroundColourHover = colourProvider?.Light4 ?? colours.PinkDarker;
             }
         }
     }

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -21,36 +21,9 @@ using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class OsuDropdown<T> : Dropdown<T>, IHasAccentColour
+    public class OsuDropdown<T> : Dropdown<T>
     {
         private const float corner_radius = 5;
-
-        private Color4 accentColour;
-
-        public Color4 AccentColour
-        {
-            get => accentColour;
-            set
-            {
-                accentColour = value;
-                updateAccentColour();
-            }
-        }
-
-        [BackgroundDependencyLoader(true)]
-        private void load(OverlayColourProvider? colourProvider, OsuColour colours)
-        {
-            if (accentColour == default)
-                accentColour = colourProvider?.Light4 ?? colours.PinkDarker;
-            updateAccentColour();
-        }
-
-        private void updateAccentColour()
-        {
-            if (Header is IHasAccentColour header) header.AccentColour = accentColour;
-
-            if (Menu is IHasAccentColour menu) menu.AccentColour = accentColour;
-        }
 
         protected override DropdownHeader CreateHeader() => new OsuDropdownHeader();
 
@@ -58,7 +31,7 @@ namespace osu.Game.Graphics.UserInterface
 
         #region OsuDropdownMenu
 
-        protected class OsuDropdownMenu : DropdownMenu, IHasAccentColour
+        protected class OsuDropdownMenu : DropdownMenu
         {
             public override bool HandleNonPositionalInput => State == MenuState.Open;
 
@@ -78,9 +51,11 @@ namespace osu.Game.Graphics.UserInterface
             }
 
             [BackgroundDependencyLoader(true)]
-            private void load(OverlayColourProvider? colourProvider, AudioManager audio)
+            private void load(OverlayColourProvider? colourProvider, OsuColour colours, AudioManager audio)
             {
                 BackgroundColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
+                HoverColour = colourProvider?.Highlight1 ?? colours.PinkDarker;
+                SelectionColour = colourProvider?.Light4 ?? colours.PinkDarker.Opacity(0.5f);
 
                 sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
                 sampleClose = audio.Samples.Get(@"UI/dropdown-close");
@@ -121,56 +96,76 @@ namespace osu.Game.Graphics.UserInterface
                 }
             }
 
-            private Color4 accentColour;
+            private Color4 hoverColour;
 
-            public Color4 AccentColour
+            public Color4 HoverColour
             {
-                get => accentColour;
+                get => hoverColour;
                 set
                 {
-                    accentColour = value;
-                    foreach (var c in Children.OfType<IHasAccentColour>())
-                        c.AccentColour = value;
+                    hoverColour = value;
+                    foreach (var c in Children.OfType<DrawableOsuDropdownMenuItem>())
+                        c.BackgroundColourHover = value;
+                }
+            }
+
+            private Color4 selectionColour;
+
+            public Color4 SelectionColour
+            {
+                get => selectionColour;
+                set
+                {
+                    selectionColour = value;
+                    foreach (var c in Children.OfType<DrawableOsuDropdownMenuItem>())
+                        c.BackgroundColourSelected = value;
                 }
             }
 
             protected override Menu CreateSubMenu() => new OsuMenu(Direction.Vertical);
 
-            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableOsuDropdownMenuItem(item) { AccentColour = accentColour };
+            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableOsuDropdownMenuItem(item)
+            {
+                BackgroundColourHover = HoverColour,
+                BackgroundColourSelected = SelectionColour
+            };
 
             protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new OsuScrollContainer(direction);
 
             #region DrawableOsuDropdownMenuItem
 
-            public class DrawableOsuDropdownMenuItem : DrawableDropdownMenuItem, IHasAccentColour
+            public class DrawableOsuDropdownMenuItem : DrawableDropdownMenuItem
             {
                 // IsHovered is used
                 public override bool HandlePositionalInput => true;
 
-                private Color4? accentColour;
-
-                public Color4 AccentColour
+                public new Color4 BackgroundColourHover
                 {
-                    get => accentColour ?? nonAccentSelectedColour;
+                    get => base.BackgroundColourHover;
                     set
                     {
-                        accentColour = value;
+                        base.BackgroundColourHover = value;
+                        updateColours();
+                    }
+                }
+
+                public new Color4 BackgroundColourSelected
+                {
+                    get => base.BackgroundColourSelected;
+                    set
+                    {
+                        base.BackgroundColourSelected = value;
                         updateColours();
                     }
                 }
 
                 private void updateColours()
                 {
-                    BackgroundColourHover = accentColour ?? nonAccentHoverColour;
-                    BackgroundColourSelected = accentColour ?? nonAccentSelectedColour;
                     BackgroundColour = BackgroundColourHover.Opacity(0);
 
                     UpdateBackgroundColour();
                     UpdateForegroundColour();
                 }
-
-                private Color4 nonAccentHoverColour;
-                private Color4 nonAccentSelectedColour;
 
                 public DrawableOsuDropdownMenuItem(MenuItem item)
                     : base(item)
@@ -182,12 +177,8 @@ namespace osu.Game.Graphics.UserInterface
                 }
 
                 [BackgroundDependencyLoader]
-                private void load(OsuColour colours)
+                private void load()
                 {
-                    nonAccentHoverColour = colours.PinkDarker;
-                    nonAccentSelectedColour = Color4.Black.Opacity(0.5f);
-                    updateColours();
-
                     AddInternal(new HoverSounds());
                 }
 
@@ -290,7 +281,7 @@ namespace osu.Game.Graphics.UserInterface
 
         #endregion
 
-        public class OsuDropdownHeader : DropdownHeader, IHasAccentColour
+        public class OsuDropdownHeader : DropdownHeader
         {
             protected readonly SpriteText Text;
 
@@ -301,18 +292,6 @@ namespace osu.Game.Graphics.UserInterface
             }
 
             protected readonly SpriteIcon Icon;
-
-            private Color4 accentColour;
-
-            public virtual Color4 AccentColour
-            {
-                get => accentColour;
-                set
-                {
-                    accentColour = value;
-                    BackgroundColourHover = accentColour;
-                }
-            }
 
             public OsuDropdownHeader()
             {
@@ -365,7 +344,7 @@ namespace osu.Game.Graphics.UserInterface
             private void load(OverlayColourProvider? colourProvider, OsuColour colours)
             {
                 BackgroundColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
-                BackgroundColourHover = colourProvider?.Light4 ?? colours.PinkDarker;
+                BackgroundColourHover = colourProvider?.Highlight1 ?? colours.PinkDarker;
             }
         }
     }

--- a/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
@@ -22,20 +22,32 @@ namespace osu.Game.Graphics.UserInterface
             {
                 accentColour = value;
 
-                if (Menu is OsuDropdownMenu dropdownMenu)
-                {
-                    dropdownMenu.HoverColour = value;
-                    dropdownMenu.SelectionColour = value.Opacity(0.5f);
-                }
-
-                if (Header is OsuTabDropdownHeader tabDropdownHeader)
-                    tabDropdownHeader.AccentColour = value;
+                if (IsLoaded)
+                    propagateAccentColour();
             }
+        }
+
+        private void propagateAccentColour()
+        {
+            if (Menu is OsuDropdownMenu dropdownMenu)
+            {
+                dropdownMenu.HoverColour = accentColour;
+                dropdownMenu.SelectionColour = accentColour.Opacity(0.5f);
+            }
+
+            if (Header is OsuTabDropdownHeader tabDropdownHeader)
+                tabDropdownHeader.AccentColour = accentColour;
         }
 
         public OsuTabDropdown()
         {
             RelativeSizeAxes = Axes.X;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            propagateAccentColour();
         }
 
         protected override DropdownMenu CreateMenu() => new OsuTabDropdownMenu();
@@ -80,7 +92,7 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     accentColour = value;
                     BackgroundColourHover = value;
-                    Foreground.Colour = value;
+                    updateColour();
                 }
             }
 
@@ -116,14 +128,19 @@ namespace osu.Game.Graphics.UserInterface
 
             protected override bool OnHover(HoverEvent e)
             {
-                Foreground.Colour = BackgroundColour;
+                updateColour();
                 return base.OnHover(e);
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                Foreground.Colour = BackgroundColourHover;
+                updateColour();
                 base.OnHoverLost(e);
+            }
+
+            private void updateColour()
+            {
+                Foreground.Colour = IsHovered ? BackgroundColour : BackgroundColourHover;
             }
         }
     }

--- a/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
@@ -11,8 +11,28 @@ using osu.Framework.Input.Events;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class OsuTabDropdown<T> : OsuDropdown<T>
+    public class OsuTabDropdown<T> : OsuDropdown<T>, IHasAccentColour
     {
+        private Color4 accentColour;
+
+        public Color4 AccentColour
+        {
+            get => accentColour;
+            set
+            {
+                accentColour = value;
+
+                if (Menu is OsuDropdownMenu dropdownMenu)
+                {
+                    dropdownMenu.HoverColour = value;
+                    dropdownMenu.SelectionColour = value.Opacity(0.5f);
+                }
+
+                if (Header is OsuTabDropdownHeader tabDropdownHeader)
+                    tabDropdownHeader.AccentColour = value;
+            }
+        }
+
         public OsuTabDropdown()
         {
             RelativeSizeAxes = Axes.X;
@@ -37,7 +57,7 @@ namespace osu.Game.Graphics.UserInterface
                 MaxHeight = 400;
             }
 
-            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableOsuTabDropdownMenuItem(item) { AccentColour = AccentColour };
+            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableOsuTabDropdownMenuItem(item);
 
             private class DrawableOsuTabDropdownMenuItem : DrawableOsuDropdownMenuItem
             {
@@ -49,14 +69,17 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        protected class OsuTabDropdownHeader : OsuDropdownHeader
+        protected class OsuTabDropdownHeader : OsuDropdownHeader, IHasAccentColour
         {
-            public override Color4 AccentColour
+            private Color4 accentColour;
+
+            public Color4 AccentColour
             {
-                get => base.AccentColour;
+                get => accentColour;
                 set
                 {
-                    base.AccentColour = value;
+                    accentColour = value;
+                    BackgroundColourHover = value;
                     Foreground.Colour = value;
                 }
             }

--- a/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
@@ -27,18 +27,6 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        private void propagateAccentColour()
-        {
-            if (Menu is OsuDropdownMenu dropdownMenu)
-            {
-                dropdownMenu.HoverColour = accentColour;
-                dropdownMenu.SelectionColour = accentColour.Opacity(0.5f);
-            }
-
-            if (Header is OsuTabDropdownHeader tabDropdownHeader)
-                tabDropdownHeader.AccentColour = accentColour;
-        }
-
         public OsuTabDropdown()
         {
             RelativeSizeAxes = Axes.X;
@@ -57,6 +45,18 @@ namespace osu.Game.Graphics.UserInterface
             Anchor = Anchor.TopRight,
             Origin = Anchor.TopRight
         };
+
+        private void propagateAccentColour()
+        {
+            if (Menu is OsuDropdownMenu dropdownMenu)
+            {
+                dropdownMenu.HoverColour = accentColour;
+                dropdownMenu.SelectionColour = accentColour.Opacity(0.5f);
+            }
+
+            if (Header is OsuTabDropdownHeader tabDropdownHeader)
+                tabDropdownHeader.AccentColour = accentColour;
+        }
 
         private class OsuTabDropdownMenu : OsuDropdownMenu
         {

--- a/osu.Game/Overlays/Login/UserDropdown.cs
+++ b/osu.Game/Overlays/Login/UserDropdown.cs
@@ -29,12 +29,6 @@ namespace osu.Game.Overlays.Login
             }
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            AccentColour = colours.Gray5;
-        }
-
         protected class UserDropdownMenu : OsuDropdownMenu
         {
             public UserDropdownMenu()
@@ -56,6 +50,7 @@ namespace osu.Game.Overlays.Login
             private void load(OsuColour colours)
             {
                 BackgroundColour = colours.Gray3;
+                HoverColour = SelectionColour = colours.Gray5;
             }
 
             protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableUserDropdownMenuItem(item);
@@ -118,6 +113,7 @@ namespace osu.Game.Overlays.Login
             private void load(OsuColour colours)
             {
                 BackgroundColour = colours.Gray3;
+                BackgroundColourHover = colours.Gray5;
             }
         }
     }

--- a/osu.Game/Overlays/Login/UserDropdown.cs
+++ b/osu.Game/Overlays/Login/UserDropdown.cs
@@ -50,7 +50,8 @@ namespace osu.Game.Overlays.Login
             private void load(OsuColour colours)
             {
                 BackgroundColour = colours.Gray3;
-                HoverColour = SelectionColour = colours.Gray5;
+                SelectionColour = colours.Gray4;
+                HoverColour = colours.Gray5;
             }
 
             protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableUserDropdownMenuItem(item);

--- a/osu.Game/Overlays/Music/CollectionDropdown.cs
+++ b/osu.Game/Overlays/Music/CollectionDropdown.cs
@@ -19,12 +19,6 @@ namespace osu.Game.Overlays.Music
     {
         protected override bool ShowManageCollectionsItem => false;
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            AccentColour = colours.Gray6;
-        }
-
         protected override CollectionDropdownHeader CreateCollectionHeader() => new CollectionsHeader();
 
         protected override CollectionDropdownMenu CreateCollectionMenu() => new CollectionsMenu();
@@ -41,6 +35,7 @@ namespace osu.Game.Overlays.Music
             private void load(OsuColour colours)
             {
                 BackgroundColour = colours.Gray4;
+                HoverColour = SelectionColour = colours.Gray6;
             }
         }
 
@@ -50,6 +45,7 @@ namespace osu.Game.Overlays.Music
             private void load(OsuColour colours)
             {
                 BackgroundColour = colours.Gray4;
+                BackgroundColourHover = colours.Gray6;
             }
 
             public CollectionsHeader()

--- a/osu.Game/Overlays/Music/CollectionDropdown.cs
+++ b/osu.Game/Overlays/Music/CollectionDropdown.cs
@@ -35,7 +35,8 @@ namespace osu.Game.Overlays.Music
             private void load(OsuColour colours)
             {
                 BackgroundColour = colours.Gray4;
-                HoverColour = SelectionColour = colours.Gray6;
+                SelectionColour = colours.Gray5;
+                HoverColour = colours.Gray6;
             }
         }
 

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -175,18 +175,18 @@ namespace osu.Game.Overlays.Rankings
 
         private class SpotlightsDropdown : OsuDropdown<APISpotlight>
         {
-            private DropdownMenu menu;
+            private OsuDropdownMenu menu;
 
-            protected override DropdownMenu CreateMenu() => menu = base.CreateMenu().With(m => m.MaxHeight = 400);
+            protected override DropdownMenu CreateMenu() => menu = (OsuDropdownMenu)base.CreateMenu().With(m => m.MaxHeight = 400);
 
             protected override DropdownHeader CreateHeader() => new SpotlightsDropdownHeader();
 
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {
-                // osu-web adds a 0.6 opacity container on top of the 0.5 base one when hovering, 0.8 on a single container here matches the resulting colour
-                AccentColour = colourProvider.Background6.Opacity(0.8f);
                 menu.BackgroundColour = colourProvider.Background5;
+                menu.HoverColour = colourProvider.Background4;
+                menu.SelectionColour = colourProvider.Background3;
                 Padding = new MarginPadding { Vertical = 20 };
             }
 
@@ -205,7 +205,8 @@ namespace osu.Game.Overlays.Rankings
                 private void load(OverlayColourProvider colourProvider)
                 {
                     BackgroundColour = colourProvider.Background6.Opacity(0.5f);
-                    BackgroundColourHover = colourProvider.Background5;
+                    // osu-web adds a 0.6 opacity container on top of the 0.5 base one when hovering, 0.8 on a single container here matches the resulting colour
+                    BackgroundColourHover = colourProvider.Background6.Opacity(0.8f);
                 }
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/ppy/osu/pull/15070#issuecomment-942941710.

https://user-images.githubusercontent.com/20418176/137989987-481577be-5e6c-4313-9c34-8253e1e38e86.mp4

Colour choices were improvisational, so feel free to tweak. In particular I initially used `Highlight1` from the colour themes for hover, but that colour has atrocious contrast with white on like half the colour shades, so I went back to more muted colours. I imagine that dropdowns will need more attention from @arflyte anyhow.

This also includes a test scene that allows previewing all overlay colour schemes, as well as the reference "unthemed" look:

![2021-10-19-230406_2560x1014_scrot](https://user-images.githubusercontent.com/20418176/137990284-fd3e300a-acfa-4284-906f-ffef8637fee3.png)

It's written in a reusable manner as I plan on reusing it (for text box, which is next).

Note that there is one place that still has the `IHasAccentColour` thing and that is `OsuTabDropdown`. The reason for that is that the current expectation with regard to those is that the tab control (which also has an accent colour) should use that accent colour in the overflow dropdown too. I did put a slight spin on it by making the selection colour half-transparent, though.

I also recoloured a few existing dropdowns that had local styling. For rankings I followed web's design, for everything else I used what seemed like common sense.