### PR TITLE
Use colour provider theming in text boxes

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuTextBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuTextBox.cs
@@ -1,80 +1,67 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public class TestSceneOsuTextBox : OsuTestScene
+    public class TestSceneOsuTextBox : ThemeComparisonTestScene
     {
-        private readonly OsuNumberBox numberBox;
+        private IEnumerable<OsuNumberBox> numberBoxes => this.ChildrenOfType<OsuNumberBox>();
 
-        public TestSceneOsuTextBox()
+        protected override Drawable CreateContent() => new FillFlowContainer
         {
-            Child = new Container
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Direction = FillDirection.Vertical,
+            Padding = new MarginPadding(50f),
+            Spacing = new Vector2(0f, 50f),
+            Children = new[]
             {
-                Masking = true,
-                CornerRadius = 10f,
-                AutoSizeAxes = Axes.Both,
-                Padding = new MarginPadding(15f),
-                Children = new Drawable[]
+                new OsuTextBox
                 {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.DarkSlateGray,
-                        Alpha = 0.75f,
-                    },
-                    new FillFlowContainer
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Direction = FillDirection.Vertical,
-                        Padding = new MarginPadding(50f),
-                        Spacing = new Vector2(0f, 50f),
-                        Children = new[]
-                        {
-                            new OsuTextBox
-                            {
-                                Width = 500f,
-                                PlaceholderText = "Normal textbox",
-                            },
-                            new OsuPasswordTextBox
-                            {
-                                Width = 500f,
-                                PlaceholderText = "Password textbox",
-                            },
-                            numberBox = new OsuNumberBox
-                            {
-                                Width = 500f,
-                                PlaceholderText = "Number textbox"
-                            }
-                        }
-                    }
+                    RelativeSizeAxes = Axes.X,
+                    PlaceholderText = "Normal textbox",
+                },
+                new OsuPasswordTextBox
+                {
+                    RelativeSizeAxes = Axes.X,
+                    PlaceholderText = "Password textbox",
+                },
+                new OsuNumberBox
+                {
+                    RelativeSizeAxes = Axes.X,
+                    PlaceholderText = "Number textbox"
                 }
-            };
-        }
+            }
+        };
 
         [Test]
         public void TestNumberBox()
         {
-            clearTextbox(numberBox);
-            AddStep("enter numbers", () => numberBox.Text = "987654321");
-            expectedValue(numberBox, "987654321");
+            AddStep("create themed content", () => CreateThemedContent(OverlayColourScheme.Red));
 
-            clearTextbox(numberBox);
-            AddStep("enter text + single number", () => numberBox.Text = "1 hello 2 world 3");
-            expectedValue(numberBox, "123");
+            clearTextboxes(numberBoxes);
+            AddStep("enter numbers", () => numberBoxes.ForEach(numberBox => numberBox.Text = "987654321"));
+            expectedValue(numberBoxes, "987654321");
 
-            clearTextbox(numberBox);
+            clearTextboxes(numberBoxes);
+            AddStep("enter text + single number", () => numberBoxes.ForEach(numberBox => numberBox.Text = "1 hello 2 world 3"));
+            expectedValue(numberBoxes, "123");
+
+            clearTextboxes(numberBoxes);
         }
 
-        private void clearTextbox(OsuTextBox textBox) => AddStep("clear textbox", () => textBox.Text = null);
-        private void expectedValue(OsuTextBox textBox, string value) => AddAssert("expected textbox value", () => textBox.Text == value);
+        private void clearTextboxes(IEnumerable<OsuTextBox> textBoxes) => AddStep("clear textbox", () => textBoxes.ForEach(textBox => textBox.Text = null));
+        private void expectedValue(IEnumerable<OsuTextBox> textBoxes, string value) => AddAssert("expected textbox value", () => textBoxes.All(textbox => textbox.Text == value));
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
+++ b/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
         }
 
-        private void createThemedContent(OverlayColourScheme colourScheme)
+        protected void CreateThemedContent(OverlayColourScheme colourScheme)
         {
             var colourProvider = new OverlayColourProvider(colourScheme);
 
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestAllColourSchemes()
         {
             foreach (var scheme in Enum.GetValues(typeof(OverlayColourScheme)).Cast<OverlayColourScheme>())
-                AddStep($"set {scheme} scheme", () => createThemedContent(scheme));
+                AddStep($"set {scheme} scheme", () => CreateThemedContent(scheme));
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using osuTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Input.Events;
@@ -8,6 +10,7 @@ using osu.Framework.Platform;
 using osu.Game.Input.Bindings;
 using osuTK.Input;
 using osu.Framework.Input.Bindings;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -42,13 +45,13 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost? host { get; set; }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [BackgroundDependencyLoader(true)]
+        private void load(OverlayColourProvider? colourProvider)
         {
-            BackgroundUnfocused = new Color4(10, 10, 10, 255);
-            BackgroundFocused = new Color4(10, 10, 10, 255);
+            BackgroundUnfocused = colourProvider?.Background5 ?? new Color4(10, 10, 10, 255);
+            BackgroundFocused = colourProvider?.Background5 ?? new Color4(10, 10, 10, 255);
         }
 
         // We may not be focused yet, but we need to handle keyboard input to be able to request focus

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Graphics.UserInterface
         private Sample? textCommittedSample;
         private Sample? caretMovedSample;
 
+        private OsuCaret? caret;
+
         public OsuTextBox()
         {
             Height = 40;
@@ -62,8 +64,12 @@ namespace osu.Game.Graphics.UserInterface
         private void load(OverlayColourProvider? colourProvider, OsuColour colour, AudioManager audio)
         {
             BackgroundUnfocused = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
-            BackgroundFocused = colourProvider?.Background3 ?? OsuColour.Gray(0.3f).Opacity(0.8f);
+            BackgroundFocused = colourProvider?.Background4 ?? OsuColour.Gray(0.3f).Opacity(0.8f);
             BackgroundCommit = BorderColour = colourProvider?.Highlight1 ?? colour.Yellow;
+            selectionColour = colourProvider?.Background1 ?? new Color4(249, 90, 255, 255);
+
+            if (caret != null)
+                caret.SelectionColour = selectionColour;
 
             Placeholder.Colour = colourProvider?.Foreground1 ?? new Color4(180, 180, 180, 255);
 
@@ -76,7 +82,9 @@ namespace osu.Game.Graphics.UserInterface
             caretMovedSample = audio.Samples.Get(@"Keyboard/key-movement");
         }
 
-        protected override Color4 SelectionColour => new Color4(249, 90, 255, 255);
+        private Color4 selectionColour;
+
+        protected override Color4 SelectionColour => selectionColour;
 
         protected override void OnUserTextAdded(string added)
         {
@@ -128,7 +136,7 @@ namespace osu.Game.Graphics.UserInterface
             Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: CalculatedTextSize) },
         };
 
-        protected override Caret CreateCaret() => new OsuCaret
+        protected override Caret CreateCaret() => caret = new OsuCaret
         {
             CaretWidth = CaretWidth,
             SelectionColour = SelectionColour,

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -17,18 +19,13 @@ using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
     public class OsuTextBox : BasicTextBox
     {
-        private readonly Sample[] textAddedSamples = new Sample[4];
-        private Sample capsTextAddedSample;
-        private Sample textRemovedSample;
-        private Sample textCommittedSample;
-        private Sample caretMovedSample;
-
         /// <summary>
         /// Whether to allow playing a different samples based on the type of character.
         /// If set to false, the same sample will be used for all characters.
@@ -42,9 +39,14 @@ namespace osu.Game.Graphics.UserInterface
         protected override SpriteText CreatePlaceholder() => new OsuSpriteText
         {
             Font = OsuFont.GetFont(italics: true),
-            Colour = new Color4(180, 180, 180, 255),
             Margin = new MarginPadding { Left = 2 },
         };
+
+        private readonly Sample?[] textAddedSamples = new Sample[4];
+        private Sample? capsTextAddedSample;
+        private Sample? textRemovedSample;
+        private Sample? textCommittedSample;
+        private Sample? caretMovedSample;
 
         public OsuTextBox()
         {
@@ -56,12 +58,14 @@ namespace osu.Game.Graphics.UserInterface
             Current.DisabledChanged += disabled => { Alpha = disabled ? 0.3f : 1; };
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colour, AudioManager audio)
+        [BackgroundDependencyLoader(true)]
+        private void load(OverlayColourProvider? colourProvider, OsuColour colour, AudioManager audio)
         {
-            BackgroundUnfocused = Color4.Black.Opacity(0.5f);
-            BackgroundFocused = OsuColour.Gray(0.3f).Opacity(0.8f);
-            BackgroundCommit = BorderColour = colour.Yellow;
+            BackgroundUnfocused = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
+            BackgroundFocused = colourProvider?.Background3 ?? OsuColour.Gray(0.3f).Opacity(0.8f);
+            BackgroundCommit = BorderColour = colourProvider?.Highlight1 ?? colour.Yellow;
+
+            Placeholder.Colour = colourProvider?.Foreground1 ?? new Color4(180, 180, 180, 255);
 
             for (int i = 0; i < textAddedSamples.Length; i++)
                 textAddedSamples[i] = audio.Samples.Get($@"Keyboard/key-press-{1 + i}");

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -17,7 +17,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
@@ -126,7 +125,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = Header.HEIGHT,
-                            Child = searchTextBox = new LoungeSearchTextBox
+                            Child = searchTextBox = new SearchTextBox
                             {
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,
@@ -362,15 +361,5 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         protected abstract RoomSubScreen CreateRoomSubScreen(Room room);
 
         protected abstract ListingPollingComponent CreatePollingComponent();
-
-        private class LoungeSearchTextBox : SearchTextBox
-        {
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                BackgroundUnfocused = OsuColour.Gray(0.06f);
-                BackgroundFocused = OsuColour.Gray(0.12f);
-            }
-        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
@@ -12,7 +12,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Online.Rooms;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Match.Components
 {
@@ -89,31 +88,6 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
-        }
-
-        protected class SettingsTextBox : OsuTextBox
-        {
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                BackgroundUnfocused = Color4.Black;
-                BackgroundFocused = Color4.Black;
-            }
-        }
-
-        protected class SettingsNumberTextBox : SettingsTextBox
-        {
-            protected override bool CanAddCharacter(char character) => char.IsNumber(character);
-        }
-
-        protected class SettingsPasswordTextBox : OsuPasswordTextBox
-        {
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                BackgroundUnfocused = Color4.Black;
-                BackgroundFocused = Color4.Black;
-            }
         }
 
         protected class SectionContainer : FillFlowContainer<Section>

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                             {
                                                                 new Section("Room name")
                                                                 {
-                                                                    Child = NameField = new SettingsTextBox
+                                                                    Child = NameField = new OsuTextBox
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
@@ -202,7 +202,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                                 new Section("Max participants")
                                                                 {
                                                                     Alpha = disabled_alpha,
-                                                                    Child = MaxParticipantsField = new SettingsNumberTextBox
+                                                                    Child = MaxParticipantsField = new OsuNumberBox
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
@@ -211,7 +211,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                                 },
                                                                 new Section("Password (optional)")
                                                                 {
-                                                                    Child = PasswordTextBox = new SettingsPasswordTextBox
+                                                                    Child = PasswordTextBox = new OsuPasswordTextBox
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                     {
                                                         new Section("Room name")
                                                         {
-                                                            Child = NameField = new SettingsTextBox
+                                                            Child = NameField = new OsuTextBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
                                                                 TabbableContentContainer = this,
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                         },
                                                         new Section("Allowed attempts (across all playlist items)")
                                                         {
-                                                            Child = MaxAttemptsField = new SettingsNumberTextBox
+                                                            Child = MaxAttemptsField = new OsuNumberBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
                                                                 TabbableContentContainer = this,
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                         new Section("Max participants")
                                                         {
                                                             Alpha = disabled_alpha,
-                                                            Child = MaxParticipantsField = new SettingsNumberTextBox
+                                                            Child = MaxParticipantsField = new OsuNumberBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
                                                                 TabbableContentContainer = this,
@@ -178,7 +178,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                         new Section("Password (optional)")
                                                         {
                                                             Alpha = disabled_alpha,
-                                                            Child = new SettingsPasswordTextBox
+                                                            Child = new OsuPasswordTextBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
                                                                 TabbableContentContainer = this,


### PR DESCRIPTION
This is the last update I have for now when it comes to settings panel related changes. There's no real design here, I was mostly winging this one and using whichever colours seemed to make most sense.

https://user-images.githubusercontent.com/20418176/138170724-75ea890f-023b-419f-bf3b-70167ccf6903.mp4

Test scene also included:

![2021-10-20-225354_2560x1014_scrot](https://user-images.githubusercontent.com/20418176/138170746-5911dfda-df24-40f5-949b-640c8419a722.png)

Note that selection colour is still not themed and that is because the framework side support is not quite there. `BasicTextBox`'s `SelectionColour` is [only queried on caret creation](https://github.com/ppy/osu-framework/blob/c02c0858804013c503484cd89b55f81b95bdf7da/osu.Framework/Graphics/UserInterface/BasicTextBox.cs#L133-L137), which [runs in ctor of the text box](https://github.com/ppy/osu-framework/blob/c02c0858804013c503484cd89b55f81b95bdf7da/osu.Framework/Graphics/UserInterface/TextBox.cs#L124). So I cannot use colour providers there without framework changes (and breaking changes at that). If you think that's fine to break then I'll proceed with the appropriate change to fix that and use it game-side, even as part of this pull.