### PR TITLE
Remove `BeatmapMetadata` base class from API classes

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets;
 
 namespace osu.Game.Online.API.Requests.Responses
 {
-    public class APIBeatmap : BeatmapMetadata, IBeatmapInfo
+    public class APIBeatmap : IBeatmapInfo
     {
         [JsonProperty(@"id")]
         public int OnlineID { get; set; }
@@ -23,6 +23,9 @@ namespace osu.Game.Online.API.Requests.Responses
 
         [JsonProperty("checksum")]
         public string Checksum { get; set; } = string.Empty;
+
+        [JsonProperty(@"user_id")]
+        public int AuthorID { get; set; }
 
         [JsonProperty(@"beatmapset")]
         public APIBeatmapSet? BeatmapSet { get; set; }
@@ -75,7 +78,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
             return new BeatmapInfo
             {
-                Metadata = set?.Metadata ?? this,
+                Metadata = set?.Metadata ?? new BeatmapMetadata(),
                 Ruleset = rulesets.GetRuleset(RulesetID),
                 StarDifficulty = StarRating,
                 OnlineBeatmapID = OnlineID,
@@ -106,7 +109,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         #region Implementation of IBeatmapInfo
 
-        public IBeatmapMetadataInfo Metadata => this;
+        public IBeatmapMetadataInfo Metadata => new BeatmapMetadata();
 
         public IBeatmapDifficultyInfo Difficulty => new BeatmapDifficulty
         {

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         #region Implementation of IBeatmapInfo
 
-        public IBeatmapMetadataInfo Metadata => new BeatmapMetadata();
+        public IBeatmapMetadataInfo Metadata => (BeatmapSet as IBeatmapSetInfo)?.Metadata ?? new BeatmapMetadata();
 
         public IBeatmapDifficultyInfo Difficulty => new BeatmapDifficulty
         {


### PR DESCRIPTION
Surely it can't be this simple?

I can't find any issues, but worth checking this with due diligence in online views to ensure something isn't missed that doesn't have test coverage.

As per previous PRs, a lot of this is temporary, and mainly removing complexity and providing more options going forward.