### PR TITLE
Fix incorrect length mapping in `APIBeatmap`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -51,8 +51,10 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"accuracy")]
         private float overallDifficulty { get; set; }
 
+        public double Length => lengthInSeconds * 1000;
+
         [JsonProperty(@"total_length")]
-        public double Length { get; set; }
+        private double lengthInSeconds { get; set; }
 
         [JsonProperty(@"count_circles")]
         private int circleCount { get; set; }


### PR DESCRIPTION
I don't think this is currently used, but it looks wrong. API returns seconds, but `IBeatmapInfo` exposes milliseconds.