### PR TITLE
Fix low-pass filter continuing to take effect after fail animation has already ended

### DIFF
--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Screens.Play
 
             this.TransformBindableTo(trackFreq, 0, duration).OnComplete(_ =>
             {
+                RemoveFilters();
                 OnComplete?.Invoke();
             });
 
@@ -137,6 +138,9 @@ namespace osu.Game.Screens.Play
 
         public void RemoveFilters()
         {
+            if (filters.Parent == null)
+                return;
+
             RemoveInternal(filters);
             filters.Dispose();
 


### PR DESCRIPTION
As mentioned in the issue, we eventually will want to isolate gameplay to its own mixer, but this seems amicable as a solution for the time being.

Closes https://github.com/ppy/osu/issues/15228.