### PR TITLE
Add build-only CI jobs for mobile platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,48 @@ jobs:
           name: osu-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
           path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
 
+  build-only-android:
+    name: Build only (Android)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Build
+        run: msbuild osu.Android.slnf /restore /p:Configuration=Debug
+
+  build-only-ios:
+    # While this workflow technically *can* run, it fails as iOS builds are blocked by multiple issues.
+    # See https://github.com/ppy/osu-framework/issues/4677 for the details.
+    # The job can be unblocked once those issues are resolved and game deployments can happen again.
+    if: false
+    name: Build only (iOS)
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
+
+      # Contrary to seemingly any other msbuild, msbuild running on macOS/Mono
+      # cannot accept .sln(f) files as arguments.
+      # Build just the main game for now.
+      - name: Build
+        run: msbuild osu.iOS/osu.iOS.csproj /restore /p:Configuration=Debug
+
   inspect-code:
     name: Code Quality
     runs-on: ubuntu-latest

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -105,7 +106,7 @@ namespace osu.Game.Tests.Visual.Online
                             }
                             else
                             {
-                                getUser.TriggerFailure(new Exception());
+                                getUser.TriggerFailure(new WebException());
                             }
 
                             return true;


### PR DESCRIPTION
Kind of the same thing as https://github.com/ppy/osu-framework/pull/4836, but with caveats. The naive attempt to add [failed miserably for both](https://github.com/bdach/osu/actions/runs/1378111729), for different reasons:

* iOS refuses to build [for known reasons](https://github.com/ppy/osu-framework/issues/4677) (managedbass, to be specific), so I've disabled the job. Unsure if it's much use like that, I'll just remove instead on request.
* Android in turn reported a weird inspection about "insufficiently specific exception type" in a test that normal compilations don't seemingly raise. I went ahead and fixed it in 0073282 because might as well.

[Here](https://github.com/bdach/osu/actions/runs/1378143816) is a link to a workflow run with the above changes applied.