### PR TITLE
Update beatmap set status pill appearance in line with new designs

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.Tests.Visual.UserInterface;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Beatmaps
+{
+    public class TestSceneBeatmapSetOnlineStatusPill : ThemeComparisonTestScene
+    {
+        protected override Drawable CreateContent() => new FillFlowContainer
+        {
+            AutoSizeAxes = Axes.Both,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Direction = FillDirection.Vertical,
+            Spacing = new Vector2(0, 10),
+            ChildrenEnumerable = Enum.GetValues(typeof(BeatmapSetOnlineStatus)).Cast<BeatmapSetOnlineStatus>().Select(status => new BeatmapSetOnlineStatusPill
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Status = status
+            })
+        };
+    }
+}

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
             Spacing = new Vector2(0, 10),
             ChildrenEnumerable = Enum.GetValues(typeof(BeatmapSetOnlineStatus)).Cast<BeatmapSetOnlineStatus>().Select(status => new BeatmapSetOnlineStatusPill
             {
+                AutoSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Status = status
@@ -41,8 +42,12 @@ namespace osu.Game.Tests.Visual.Beatmaps
         {
             AddStep("create themed content", () => CreateThemedContent(OverlayColourScheme.Red));
 
-            AddStep("set fixed width", () => statusPills.ForEach(pill => pill.FixedWidth = 90));
-            AddStep("unset fixed width", () => statusPills.ForEach(pill => pill.FixedWidth = null));
+            AddStep("set fixed width", () => statusPills.ForEach(pill =>
+            {
+                pill.AutoSizeAxes = Axes.Y;
+                pill.Width = 90;
+            }));
+            AddStep("unset fixed width", () => statusPills.ForEach(pill => pill.AutoSizeAxes = Axes.Both));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapSetOnlineStatusPill.cs
@@ -2,11 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
+using osu.Game.Overlays;
 using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
 
@@ -28,5 +33,16 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 Status = status
             })
         };
+
+        private IEnumerable<BeatmapSetOnlineStatusPill> statusPills => this.ChildrenOfType<BeatmapSetOnlineStatusPill>();
+
+        [Test]
+        public void TestFixedWidth()
+        {
+            AddStep("create themed content", () => CreateThemedContent(OverlayColourScheme.Red));
+
+            AddStep("set fixed width", () => statusPills.ForEach(pill => pill.FixedWidth = 90));
+            AddStep("unset fixed width", () => statusPills.ForEach(pill => pill.FixedWidth = null));
+        }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -47,6 +47,31 @@ namespace osu.Game.Beatmaps.Drawables
             set => statusText.Padding = value;
         }
 
+        private float? fixedWidth;
+
+        /// <summary>
+        /// When set to a non-<see langword="null"/> value, the pill will be forcibly sized to the given width.
+        /// When set to a <see langword="null"/> value, the pill will autosize to its contents.
+        /// </summary>
+        public float? FixedWidth
+        {
+            get => fixedWidth;
+            set
+            {
+                fixedWidth = value;
+
+                if (fixedWidth == null)
+                {
+                    AutoSizeAxes = Axes.Both;
+                }
+                else
+                {
+                    AutoSizeAxes = Axes.Y;
+                    Width = fixedWidth.Value;
+                }
+            }
+        }
+
         private readonly OsuSpriteText statusText;
         private readonly Box background;
 

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -47,31 +47,6 @@ namespace osu.Game.Beatmaps.Drawables
             set => statusText.Padding = value;
         }
 
-        private float? fixedWidth;
-
-        /// <summary>
-        /// When set to a non-<see langword="null"/> value, the pill will be forcibly sized to the given width.
-        /// When set to a <see langword="null"/> value, the pill will autosize to its contents.
-        /// </summary>
-        public float? FixedWidth
-        {
-            get => fixedWidth;
-            set
-            {
-                fixedWidth = value;
-
-                if (fixedWidth == null)
-                {
-                    AutoSizeAxes = Axes.Both;
-                }
-                else
-                {
-                    AutoSizeAxes = Axes.Y;
-                    Width = fixedWidth.Value;
-                }
-            }
-        }
-
         private readonly OsuSpriteText statusText;
         private readonly Box background;
 
@@ -83,7 +58,6 @@ namespace osu.Game.Beatmaps.Drawables
 
         public BeatmapSetOnlineStatusPill()
         {
-            AutoSizeAxes = Axes.Both;
             Masking = true;
 
             Children = new Drawable[]

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
+using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -8,15 +11,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
     public class BeatmapSetOnlineStatusPill : CircularContainer
     {
-        private readonly OsuSpriteText statusText;
-        private readonly Box background;
-
         private BeatmapSetOnlineStatus status;
 
         public BeatmapSetOnlineStatus Status
@@ -29,8 +30,8 @@ namespace osu.Game.Beatmaps.Drawables
 
                 status = value;
 
-                Alpha = value == BeatmapSetOnlineStatus.None ? 0 : 1;
-                statusText.Text = value.GetLocalisableDescription().ToUpper();
+                if (IsLoaded)
+                    updateState();
             }
         }
 
@@ -46,11 +47,14 @@ namespace osu.Game.Beatmaps.Drawables
             set => statusText.Padding = value;
         }
 
-        public Color4 BackgroundColour
-        {
-            get => background.Colour;
-            set => background.Colour = value;
-        }
+        private readonly OsuSpriteText statusText;
+        private readonly Box background;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved(CanBeNull = true)]
+        private OverlayColourProvider? colourProvider { get; set; }
 
         public BeatmapSetOnlineStatusPill()
         {
@@ -63,7 +67,6 @@ namespace osu.Game.Beatmaps.Drawables
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.Black,
-                    Alpha = 0.5f,
                 },
                 statusText = new OsuSpriteText
                 {
@@ -74,6 +77,27 @@ namespace osu.Game.Beatmaps.Drawables
             };
 
             Status = BeatmapSetOnlineStatus.None;
+            TextPadding = new MarginPadding { Horizontal = 5, Bottom = 1 };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateState();
+        }
+
+        private void updateState()
+        {
+            Alpha = Status == BeatmapSetOnlineStatus.None ? 0 : 1;
+
+            statusText.Text = Status.GetLocalisableDescription().ToUpper();
+
+            if (colourProvider != null)
+                statusText.Colour = status == BeatmapSetOnlineStatus.Graveyard ? colourProvider.Background1 : colourProvider.Background3;
+            else
+                statusText.Colour = status == BeatmapSetOnlineStatus.Graveyard ? colours.GreySeafoamLight : Color4.Black;
+
+            background.Colour = OsuColour.ForBeatmapSetOnlineStatus(Status) ?? colourProvider?.Light1 ?? colours.GreySeafoamLighter;
         }
     }
 }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -119,6 +119,42 @@ namespace osu.Game.Graphics
         }
 
         /// <summary>
+        /// Retrieves a colour for the given <see cref="BeatmapSetOnlineStatus"/>.
+        /// A <see langword="null"/> value indicates that a "background" shade from the local <see cref="OverlayColourProvider"/>
+        /// (or another fallback colour) should be used.
+        /// </summary>
+        /// <remarks>
+        /// Sourced from web: https://github.com/ppy/osu-web/blob/007eebb1916ed5cb6a7866d82d8011b1060a945e/resources/assets/less/layout.less#L36-L50
+        /// </remarks>
+        public static Color4? ForBeatmapSetOnlineStatus(BeatmapSetOnlineStatus status)
+        {
+            switch (status)
+            {
+                case BeatmapSetOnlineStatus.Ranked:
+                case BeatmapSetOnlineStatus.Approved:
+                    return Color4Extensions.FromHex(@"b3ff66");
+
+                case BeatmapSetOnlineStatus.Loved:
+                    return Color4Extensions.FromHex(@"ff66ab");
+
+                case BeatmapSetOnlineStatus.Qualified:
+                    return Color4Extensions.FromHex(@"66ccff");
+
+                case BeatmapSetOnlineStatus.Pending:
+                    return Color4Extensions.FromHex(@"ffd966");
+
+                case BeatmapSetOnlineStatus.WIP:
+                    return Color4Extensions.FromHex(@"ff9966");
+
+                case BeatmapSetOnlineStatus.Graveyard:
+                    return Color4.Black;
+
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
         /// Returns a foreground text colour that is supposed to contrast well with
         /// the supplied <paramref name="backgroundColour"/>.
         /// </summary>

--- a/osu.Game/Overlays/BeatmapListing/Panels/GridBeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/GridBeatmapPanel.cs
@@ -243,6 +243,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 
             statusContainer.Add(new BeatmapSetOnlineStatusPill
             {
+                AutoSizeAxes = Axes.Both,
                 TextSize = 12,
                 TextPadding = new MarginPadding { Horizontal = 10, Vertical = 5 },
                 Status = SetInfo.OnlineInfo?.Status ?? BeatmapSetOnlineStatus.None,

--- a/osu.Game/Overlays/BeatmapListing/Panels/ListBeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/ListBeatmapPanel.cs
@@ -257,6 +257,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 
             statusContainer.Add(new BeatmapSetOnlineStatusPill
             {
+                AutoSizeAxes = Axes.Both,
                 TextSize = 12,
                 TextPadding = new MarginPadding { Horizontal = 10, Vertical = 4 },
                 Status = SetInfo.OnlineInfo?.Status ?? BeatmapSetOnlineStatus.None,

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -198,6 +198,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         {
                             onlineStatusPill = new BeatmapSetOnlineStatusPill
                             {
+                                AutoSizeAxes = Axes.Both,
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
                                 TextSize = 14,

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -220,7 +220,6 @@ namespace osu.Game.Overlays.BeatmapSet
         private void load(OverlayColourProvider colourProvider)
         {
             coverGradient.Colour = ColourInfo.GradientVertical(colourProvider.Background6.Opacity(0.3f), colourProvider.Background6.Opacity(0.8f));
-            onlineStatusPill.BackgroundColour = colourProvider.Background6;
 
             State.BindValueChanged(_ => updateDownloadButtons());
 

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -257,6 +257,7 @@ namespace osu.Game.Screens.Select
                             },
                             StatusPill = new BeatmapSetOnlineStatusPill
                             {
+                                AutoSizeAxes = Axes.Both,
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
                                 Shear = -wedged_container_shear,

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Screens.Select.Carousel
                         {
                             new BeatmapSetOnlineStatusPill
                             {
+                                AutoSizeAxes = Axes.Both,
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
                                 Margin = new MarginPadding { Right = 5 },


### PR DESCRIPTION
This is the first pull of a chain whose goal is adding the new beatmap card design to the game (#14216).

The sources for the design are: the web-side implementation and [this figma design file](https://www.figma.com/file/TQj2lJJHSN32Gooco3gU7OGt/Asset---Icons?node-id=516%3A0). Because the figma design is outdated/different, web-side implementation takes precedence.

Here's a preview of how the updated pills look in the game (taken using the test scene added in this pull):

![2021-10-24-204140_1341x324_scrot](https://user-images.githubusercontent.com/20418176/138610199-fd3a680c-62bf-492e-8266-903d169780b6.png)

Note that because this is an existing component, this will also immediately have an effect in a few other places:

| old beatmap panel | beatmap listing overlay | song select wedge | song select carousel item |
| :-: | :-: | :-: | :-: |
| ![image](https://user-images.githubusercontent.com/20418176/138610251-998da511-7070-453e-b4ec-657ffcbb1384.png) | ![image](https://user-images.githubusercontent.com/20418176/138610276-2c5181ca-135c-4678-b2ad-90e8955c80a8.png) | ![image](https://user-images.githubusercontent.com/20418176/138610292-62a4e456-3688-475c-9b6b-13842e580dee.png) | ![image](https://user-images.githubusercontent.com/20418176/138610297-b9d22d9a-9e49-498c-91d6-bb0ffdb8e6f7.png) |

I don't think this looks *too* bad, except maybe the old panel - which is what I intend to replace anyway - so I just left it be and applied the new colours globally instead of adding a "v2" component that would majorly be the same thing anyway. (Note that the [new beatmap set overlay design](https://www.figma.com/file/HDSXf4LPPV7hnD5wrWYG4jix/Web%2FBeatmap-Info?node-id=477%3A637) also uses these colours too, so that was another reason why this seemed like the correct thing to do.)




