### PR TITLE
Fix `BeatmapSetInfo`'s `Status` value being marked as non-databased

### DIFF
--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -117,7 +117,6 @@ namespace osu.Game.Beatmaps
         [JsonIgnore]
         public DateTimeOffset? LastUpdated => OnlineInfo.LastUpdated;
 
-        [NotMapped]
         [JsonIgnore]
         public BeatmapSetOnlineStatus Status { get; set; } = BeatmapSetOnlineStatus.None;
 


### PR DESCRIPTION
As pointed out [here](https://github.com/ppy/osu/pull/15222#discussion_r735154489). Regressed in #15222.

I've checked all other fields and there don't seem to be any otehrs across both models. Note that some of the new interface fields in `BeatmapInfo` haven't been marked as `NotMapped`, but since we likely won't be generating any new migrations in the near future this should be a non-issue.