### PR TITLE
Add ability to make test `APIBeatmapSet`s from test scenes

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -7,14 +7,12 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapListing;
-using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Users;
 using osuTK.Input;
@@ -92,7 +90,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
 
-            AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet, 100).ToArray()));
+            AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 10).ToArray()));
 
             AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
 
@@ -114,7 +112,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("fetch for 0 beatmaps", () => fetchFor());
             AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
 
-            AddStep("fetch for 1 beatmap", () => fetchFor(CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet));
+            AddStep("fetch for 1 beatmap", () => fetchFor(CreateAPIBeatmapSet(Ruleset.Value)));
             AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
 
             AddStep("fetch for 0 beatmaps", () => fetchFor());
@@ -188,7 +186,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestUserWithoutSupporterUsesSupporterOnlyFiltersWithResults()
         {
-            AddStep("fetch for 1 beatmap", () => fetchFor(CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet));
+            AddStep("fetch for 1 beatmap", () => fetchFor(CreateAPIBeatmapSet(Ruleset.Value)));
             AddStep("set dummy as non-supporter", () => ((DummyAPIAccess)API).LocalUser.Value.IsSupporter = false);
 
             // only Rank Achieved filter
@@ -218,7 +216,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestUserWithSupporterUsesSupporterOnlyFiltersWithResults()
         {
-            AddStep("fetch for 1 beatmap", () => fetchFor(CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet));
+            AddStep("fetch for 1 beatmap", () => fetchFor(CreateAPIBeatmapSet(Ruleset.Value)));
             AddStep("set dummy as supporter", () => ((DummyAPIAccess)API).LocalUser.Value.IsSupporter = true);
 
             // only Rank Achieved filter
@@ -247,10 +245,10 @@ namespace osu.Game.Tests.Visual.Online
 
         private static int searchCount;
 
-        private void fetchFor(params BeatmapSetInfo[] beatmaps)
+        private void fetchFor(params APIBeatmapSet[] beatmaps)
         {
             setsForResponse.Clear();
-            setsForResponse.AddRange(beatmaps.Select(b => new TestAPIBeatmapSet(b)));
+            setsForResponse.AddRange(beatmaps);
 
             // trigger arbitrary change for fetching.
             searchControl.Query.Value = $"search {searchCount++}";
@@ -285,18 +283,6 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("no placeholder shown", () =>
                 !overlay.ChildrenOfType<BeatmapListingOverlay.SupporterRequiredDrawable>().Any(d => d.IsPresent)
                 && !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
-        }
-
-        private class TestAPIBeatmapSet : APIBeatmapSet
-        {
-            private readonly BeatmapSetInfo beatmapSet;
-
-            public TestAPIBeatmapSet(BeatmapSetInfo beatmapSet)
-            {
-                this.beatmapSet = beatmapSet;
-            }
-
-            public override BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets) => beatmapSet;
         }
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public string Tags { get; set; } = string.Empty;
 
         [JsonProperty(@"beatmaps")]
-        private IEnumerable<APIBeatmap> beatmaps { get; set; } = Array.Empty<APIBeatmap>();
+        public IEnumerable<APIBeatmap> Beatmaps { get; set; } = Array.Empty<APIBeatmap>();
 
         public virtual BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets)
         {
@@ -132,7 +132,7 @@ namespace osu.Game.Online.API.Requests.Responses
                 OnlineInfo = this
             };
 
-            beatmapSet.Beatmaps = beatmaps.Select(b =>
+            beatmapSet.Beatmaps = Beatmaps.Select(b =>
             {
                 var beatmap = b.ToBeatmapInfo(rulesets);
                 beatmap.BeatmapSet = beatmapSet;
@@ -157,7 +157,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         #region Implementation of IBeatmapSetInfo
 
-        IEnumerable<IBeatmapInfo> IBeatmapSetInfo.Beatmaps => beatmaps;
+        IEnumerable<IBeatmapInfo> IBeatmapSetInfo.Beatmaps => Beatmaps;
 
         IBeatmapMetadataInfo IBeatmapSetInfo.Metadata => metadata;
 

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -20,6 +20,7 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -173,6 +174,56 @@ namespace osu.Game.Tests.Visual
         protected virtual Ruleset CreateRuleset() => null;
 
         protected virtual IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset);
+
+        protected APIBeatmapSet CreateAPIBeatmapSet(RulesetInfo ruleset)
+        {
+            var beatmap = CreateBeatmap(ruleset).BeatmapInfo;
+
+            return new APIBeatmapSet
+            {
+                Covers = beatmap.BeatmapSet.Covers,
+                OnlineID = beatmap.BeatmapSet.OnlineID,
+                Status = beatmap.BeatmapSet.Status,
+                Preview = beatmap.BeatmapSet.Preview,
+                HasFavourited = beatmap.BeatmapSet.HasFavourited,
+                PlayCount = beatmap.BeatmapSet.PlayCount,
+                FavouriteCount = beatmap.BeatmapSet.FavouriteCount,
+                BPM = beatmap.BeatmapSet.BPM,
+                HasExplicitContent = beatmap.BeatmapSet.HasExplicitContent,
+                HasVideo = beatmap.BeatmapSet.HasVideo,
+                HasStoryboard = beatmap.BeatmapSet.HasStoryboard,
+                Submitted = beatmap.BeatmapSet.Submitted,
+                Ranked = beatmap.BeatmapSet.Ranked,
+                LastUpdated = beatmap.BeatmapSet.LastUpdated,
+                TrackId = beatmap.BeatmapSet.TrackId,
+                Title = beatmap.BeatmapSet.Metadata.Title,
+                TitleUnicode = beatmap.BeatmapSet.Metadata.TitleUnicode,
+                Artist = beatmap.BeatmapSet.Metadata.Artist,
+                ArtistUnicode = beatmap.BeatmapSet.Metadata.ArtistUnicode,
+                Author = beatmap.BeatmapSet.Metadata.Author,
+                AuthorID = beatmap.BeatmapSet.Metadata.AuthorID,
+                AuthorString = beatmap.BeatmapSet.Metadata.AuthorString,
+                Availability = beatmap.BeatmapSet.Availability,
+                Genre = beatmap.BeatmapSet.Genre,
+                Language = beatmap.BeatmapSet.Language,
+                Source = beatmap.BeatmapSet.Metadata.Source,
+                Tags = beatmap.BeatmapSet.Metadata.Tags,
+                Beatmaps = new[]
+                {
+                    new APIBeatmap
+                    {
+                        OnlineID = beatmap.OnlineID,
+                        OnlineBeatmapSetID = beatmap.BeatmapSet.OnlineID,
+                        Status = beatmap.Status,
+                        Checksum = beatmap.MD5Hash,
+                        AuthorID = beatmap.Metadata.AuthorID,
+                        RulesetID = beatmap.RulesetID,
+                        StarRating = beatmap.StarDifficulty,
+                        DifficultyName = beatmap.Version,
+                    }
+                }
+            };
+        }
 
         protected WorkingBeatmap CreateWorkingBeatmap(RulesetInfo ruleset) =>
             CreateWorkingBeatmap(CreateBeatmap(ruleset));


### PR DESCRIPTION
Allow tests to create a sample `APIBeatmapSet`. One step towards removing calls to `ToBeatmap` / `ToBeatmapSet`.

I'm not sure where this should be placed - I made the change thinking there was more than one usage of it. Can potentially move it local to the relevant test scene if that's seen as better.