### PR TITLE
Fix tournament client silently failing on error during parsing

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/LadderInfoSerialisationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/LadderInfoSerialisationTest.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Game.Tournament.Models;
+
+namespace osu.Game.Tournament.Tests.NonVisual
+{
+    [TestFixture]
+    public class LadderInfoSerialisationTest
+    {
+        [Test]
+        public void TestDeserialise()
+        {
+            var ladder = createSampleLadder();
+            string serialised = JsonConvert.SerializeObject(ladder);
+
+            JsonConvert.DeserializeObject<LadderInfo>(serialised, new JsonPointConverter());
+        }
+
+        [Test]
+        public void TestSerialise()
+        {
+            var ladder = createSampleLadder();
+            JsonConvert.SerializeObject(ladder);
+        }
+
+        private static LadderInfo createSampleLadder()
+        {
+            var match = TournamentTestScene.CreateSampleMatch();
+
+            return new LadderInfo
+            {
+                PlayersPerTeam = { Value = 4 },
+                Teams =
+                {
+                    match.Team1.Value,
+                    match.Team2.Value,
+                },
+                Rounds =
+                {
+                    new TournamentRound
+                    {
+                        Beatmaps =
+                        {
+                            new RoundBeatmap { BeatmapInfo = TournamentTestScene.CreateSampleBeatmapInfo() },
+                            new RoundBeatmap { BeatmapInfo = TournamentTestScene.CreateSampleBeatmapInfo() },
+                        }
+                    }
+                },
+
+                Matches =
+                {
+                    match,
+                },
+                Progressions =
+                {
+                    new TournamentProgression(1, 2),
+                    new TournamentProgression(1, 3, true),
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -8,6 +8,7 @@ using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Tests.Visual;
 using osu.Game.Tournament.IO;
@@ -152,7 +153,16 @@ namespace osu.Game.Tournament.Tests
         };
 
         public static BeatmapInfo CreateSampleBeatmapInfo() =>
-            new BeatmapInfo { Metadata = new BeatmapMetadata { Title = "Test Title", Artist = "Test Artist", ID = RNG.Next(0, 1000000) } };
+            new BeatmapInfo
+            {
+                Metadata = new BeatmapMetadata
+                {
+                    Title = "Test Title",
+                    Artist = "Test Artist",
+                    ID = RNG.Next(0, 1000000)
+                },
+                OnlineInfo = new BeatmapOnlineInfo(),
+            };
 
         protected override ITestSceneTestRunner CreateRunner() => new TournamentTestSceneTestRunner();
 

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -8,7 +8,6 @@ using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Tests.Visual;
 using osu.Game.Tournament.IO;

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
@@ -60,72 +61,89 @@ namespace osu.Game.Tournament
 
             loadingSpinner.Show();
 
-            BracketLoadTask.ContinueWith(_ => LoadComponentsAsync(new[]
+            BracketLoadTask.ContinueWith(t =>
             {
-                new Container
+                if (t.IsFaulted)
                 {
-                    CornerRadius = 10,
-                    Depth = float.MinValue,
-                    Position = new Vector2(5),
-                    Masking = true,
-                    AutoSizeAxes = Axes.Both,
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                    Children = new Drawable[]
+                    Schedule(() =>
                     {
-                        new Box
-                        {
-                            Colour = OsuColour.Gray(0.2f),
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new TourneyButton
-                        {
-                            Text = "Save Changes",
-                            Width = 140,
-                            Height = 50,
-                            Padding = new MarginPadding
-                            {
-                                Top = 10,
-                                Left = 10,
-                            },
-                            Margin = new MarginPadding
-                            {
-                                Right = 10,
-                                Bottom = 10,
-                            },
-                            Action = SaveChanges,
-                        },
-                    }
-                },
-                heightWarning = new WarningBox("Please make the window wider")
-                {
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
-                    Margin = new MarginPadding(20),
-                },
-                new OsuContextMenuContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = new TournamentSceneManager()
+                        loadingSpinner.Hide();
+                        loadingSpinner.Expire();
+
+                        Logger.Error(t.Exception, "Couldn't load bracket with error");
+                        Add(new WarningBox("Your bracket.json file could not be parsed. Please check runtime.log for more details."));
+                    });
+
+                    return;
                 }
-            }, drawables =>
-            {
-                loadingSpinner.Hide();
-                loadingSpinner.Expire();
 
-                AddRange(drawables);
-
-                windowSize.BindValueChanged(size => ScheduleAfterChildren(() =>
+                LoadComponentsAsync(new[]
                 {
-                    var minWidth = (int)(size.NewValue.Height / 768f * TournamentSceneManager.REQUIRED_WIDTH) - 1;
-                    heightWarning.Alpha = size.NewValue.Width < minWidth ? 1 : 0;
-                }), true);
-
-                windowMode.BindValueChanged(mode => ScheduleAfterChildren(() =>
+                    new Container
+                    {
+                        CornerRadius = 10,
+                        Depth = float.MinValue,
+                        Position = new Vector2(5),
+                        Masking = true,
+                        AutoSizeAxes = Axes.Both,
+                        Anchor = Anchor.BottomRight,
+                        Origin = Anchor.BottomRight,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Colour = OsuColour.Gray(0.2f),
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            new TourneyButton
+                            {
+                                Text = "Save Changes",
+                                Width = 140,
+                                Height = 50,
+                                Padding = new MarginPadding
+                                {
+                                    Top = 10,
+                                    Left = 10,
+                                },
+                                Margin = new MarginPadding
+                                {
+                                    Right = 10,
+                                    Bottom = 10,
+                                },
+                                Action = SaveChanges,
+                            },
+                        }
+                    },
+                    heightWarning = new WarningBox("Please make the window wider")
+                    {
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                        Margin = new MarginPadding(20),
+                    },
+                    new OsuContextMenuContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new TournamentSceneManager()
+                    }
+                }, drawables =>
                 {
-                    windowMode.Value = WindowMode.Windowed;
-                }), true);
-            }));
+                    loadingSpinner.Hide();
+                    loadingSpinner.Expire();
+
+                    AddRange(drawables);
+
+                    windowSize.BindValueChanged(size => ScheduleAfterChildren(() =>
+                    {
+                        var minWidth = (int)(size.NewValue.Height / 768f * TournamentSceneManager.REQUIRED_WIDTH) - 1;
+                        heightWarning.Alpha = size.NewValue.Width < minWidth ? 1 : 0;
+                    }), true);
+
+                    windowMode.BindValueChanged(mode => ScheduleAfterChildren(() =>
+                    {
+                        windowMode.Value = WindowMode.Windowed;
+                    }), true);
+                });
+            });
         }
     }
 }

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Tournament
             {
                 Type = type;
                 BackgroundColour = OsuColour.Gray(0.2f);
-                Action = () => RequestSelection(type);
+                Action = () => RequestSelection?.Invoke(type);
 
                 RelativeSizeAxes = Axes.X;
             }


### PR DESCRIPTION
Now an error message will be displayed. Also added test coverage of serialisation of a sample ladder to avoid future regressions. May need to replace this with a json file at some point, as it's not 100% serialisation coverage as it stands (some areas of the model are not used).