### PR TITLE
Add distance snapping to osu!catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneCatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneCatchDistanceSnapGrid.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Edit;
+using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    public class TestSceneCatchDistanceSnapGrid : OsuManualInputManagerTestScene
+    {
+        private readonly ManualClock manualClock = new ManualClock();
+
+        [Cached(typeof(Playfield))]
+        private readonly CatchPlayfield playfield;
+
+        private ScrollingHitObjectContainer hitObjectContainer => playfield.HitObjectContainer;
+
+        private readonly CatchDistanceSnapGrid distanceGrid;
+
+        private readonly FruitOutline fruitOutline;
+
+        private readonly Fruit fruit = new Fruit();
+
+        public TestSceneCatchDistanceSnapGrid()
+        {
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Y,
+                Width = 500,
+
+                Children = new Drawable[]
+                {
+                    new ScrollingTestContainer(ScrollingDirection.Down)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = playfield = new CatchPlayfield(new BeatmapDifficulty())
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Clock = new FramedClock(manualClock)
+                        }
+                    },
+                    distanceGrid = new CatchDistanceSnapGrid(new double[] { 0, -1, 1 }),
+                    fruitOutline = new FruitOutline()
+                },
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            distanceGrid.StartTime = 100;
+            distanceGrid.StartX = 250;
+
+            Vector2 screenSpacePosition = InputManager.CurrentState.Mouse.Position;
+
+            var result = distanceGrid.GetSnappedPosition(screenSpacePosition);
+
+            if (result != null)
+            {
+                fruit.OriginalX = hitObjectContainer.ToLocalSpace(result.ScreenSpacePosition).X;
+
+                if (result.Time != null)
+                    fruit.StartTime = result.Time.Value;
+            }
+
+            fruitOutline.Position = CatchHitObjectUtils.GetStartPosition(hitObjectContainer, fruit);
+            fruitOutline.UpdateFrom(fruit);
+        }
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            manualClock.CurrentTime -= e.ScrollDelta.Y * 50;
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         private readonly List<Path> verticalPaths = new List<Path>();
 
-        private readonly List<List<Vector2>> verticalLineVertices = new List<List<Vector2>>();
+        private readonly List<Vector2[]> verticalLineVertices = new List<Vector2[]>();
 
         [Resolved]
         private Playfield playfield { get; set; }
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                     Alpha = 0.5f,
                 });
 
-                verticalLineVertices.Add(new List<Vector2> { Vector2.Zero, Vector2.Zero });
+                verticalLineVertices.Add(new[] { Vector2.Zero, Vector2.Zero });
             }
 
             AddRangeInternal(verticalPaths);
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                 float x = (float)((endTime - StartTime) * velocity);
                 float y = hitObjectContainer.PositionAtTime(endTime, StartTime);
 
-                List<Vector2> lineVertices = verticalLineVertices[i];
+                Vector2[] lineVertices = verticalLineVertices[i];
                 lineVertices[0] = new Vector2(StartX, startY);
                 lineVertices[1] = lineVertices[0] + new Vector2(x, y);
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
@@ -17,6 +17,10 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Edit
 {
+    /// <summary>
+    /// The guide lines used in the osu!catch editor to compose patterns that can be caught with constant speed.
+    /// Currently, only forward placement (an object is snapped based on the previous object, not the opposite) is supported.
+    /// </summary>
     public class CatchDistanceSnapGrid : CompositeDrawable
     {
         public double StartTime { get; set; }

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -63,9 +64,11 @@ namespace osu.Game.Rulesets.Catch.Edit
             for (int i = 0; i < velocities.Length; i++)
             {
                 double velocity = velocities[i];
+                var verticalPath = verticalPaths[i];
 
                 // The line ends at the top of the screen.
-                double endTime = hitObjectContainer.TimeAtPosition(-hitObjectContainer.DrawHeight, hitObjectContainer.Time.Current);
+                double topScreenTime = hitObjectContainer.TimeAtPosition(-hitObjectContainer.DrawHeight, hitObjectContainer.Time.Current);
+                double endTime = Math.Max(StartTime, topScreenTime);
 
                 float x = (float)((endTime - StartTime) * velocity);
                 float y = hitObjectContainer.PositionAtTime(endTime, StartTime);
@@ -74,7 +77,6 @@ namespace osu.Game.Rulesets.Catch.Edit
                 lineVertices[0] = new Vector2(StartX, startY);
                 lineVertices[1] = lineVertices[0] + new Vector2(x, y);
 
-                var verticalPath = verticalPaths[i];
                 verticalPath.Vertices = verticalLineVertices[i];
                 verticalPath.OriginPosition = verticalPath.PositionInBoundingBox(Vector2.Zero);
             }

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
@@ -1,0 +1,107 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Lines;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class CatchDistanceSnapGrid : CompositeDrawable
+    {
+        public double StartTime { get; set; }
+
+        public float StartX { get; set; }
+
+        private readonly double[] velocities;
+
+        private readonly List<Path> verticalPaths = new List<Path>();
+
+        private readonly List<List<Vector2>> verticalLineVertices = new List<List<Vector2>>();
+
+        [Resolved]
+        private Playfield playfield { get; set; }
+
+        private ScrollingHitObjectContainer hitObjectContainer => (ScrollingHitObjectContainer)playfield.HitObjectContainer;
+
+        public CatchDistanceSnapGrid(double[] velocities)
+        {
+            RelativeSizeAxes = Axes.Both;
+            Anchor = Anchor.BottomLeft;
+
+            this.velocities = velocities;
+
+            for (int i = 0; i < velocities.Length; i++)
+            {
+                verticalPaths.Add(new SmoothPath
+                {
+                    PathRadius = 2,
+                    Alpha = 0.5f,
+                });
+
+                verticalLineVertices.Add(new List<Vector2> { Vector2.Zero, Vector2.Zero });
+            }
+
+            AddRangeInternal(verticalPaths);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            float startY = hitObjectContainer.PositionAtTime(StartTime);
+
+            for (int i = 0; i < velocities.Length; i++)
+            {
+                double velocity = velocities[i];
+
+                // The line ends at the top of the screen.
+                double endTime = hitObjectContainer.TimeAtPosition(-hitObjectContainer.DrawHeight, hitObjectContainer.Time.Current);
+
+                float x = (float)((endTime - StartTime) * velocity);
+                float y = hitObjectContainer.PositionAtTime(endTime, StartTime);
+
+                List<Vector2> lineVertices = verticalLineVertices[i];
+                lineVertices[0] = new Vector2(StartX, startY);
+                lineVertices[1] = lineVertices[0] + new Vector2(x, y);
+
+                var verticalPath = verticalPaths[i];
+                verticalPath.Vertices = verticalLineVertices[i];
+                verticalPath.OriginPosition = verticalPath.PositionInBoundingBox(Vector2.Zero);
+            }
+        }
+
+        [CanBeNull]
+        public SnapResult GetSnappedPosition(Vector2 screenSpacePosition)
+        {
+            double time = hitObjectContainer.TimeAtScreenSpacePosition(screenSpacePosition);
+
+            return enumerateSnappingCandidates(time)
+                   .OrderBy(pos => Vector2.DistanceSquared(screenSpacePosition, pos.ScreenSpacePosition))
+                   .FirstOrDefault();
+        }
+
+        private IEnumerable<SnapResult> enumerateSnappingCandidates(double time)
+        {
+            float y = hitObjectContainer.PositionAtTime(time);
+
+            foreach (double velocity in velocities)
+            {
+                float x = (float)(StartX + (time - StartTime) * velocity);
+                Vector2 screenSpacePosition = hitObjectContainer.ToScreenSpace(new Vector2(x, y + hitObjectContainer.DrawHeight));
+                yield return new SnapResult(screenSpacePosition, time);
+            }
+        }
+
+        protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
@@ -87,6 +87,16 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
             double time = hitObjectContainer.TimeAtScreenSpacePosition(screenSpacePosition);
 
+            // If the cursor is below the distance snap grid, snap to the origin.
+            // Not returning `null` to retain the continuous snapping behavior when the cursor is slightly below the origin.
+            // This behavior is not currently visible in the editor because editor chooses the snap start time based on the mouse position.
+            if (time <= StartTime)
+            {
+                float y = hitObjectContainer.PositionAtTime(StartTime);
+                Vector2 originPosition = hitObjectContainer.ToScreenSpace(new Vector2(StartX, y));
+                return new SnapResult(originPosition, StartTime);
+            }
+
             return enumerateSnappingCandidates(time)
                    .OrderBy(pos => Vector2.DistanceSquared(screenSpacePosition, pos.ScreenSpacePosition))
                    .FirstOrDefault();

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -2,14 +2,23 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -17,6 +26,14 @@ namespace osu.Game.Rulesets.Catch.Edit
 {
     public class CatchHitObjectComposer : HitObjectComposer<CatchHitObject>
     {
+        private const float distance_snap_radius = 50;
+
+        private CatchDistanceSnapGrid distanceSnapGrid;
+
+        private readonly Bindable<TernaryState> distanceSnapToggle = new Bindable<TernaryState>();
+
+        private InputManager inputManager;
+
         public CatchHitObjectComposer(CatchRuleset ruleset)
             : base(ruleset)
         {
@@ -30,6 +47,27 @@ namespace osu.Game.Rulesets.Catch.Edit
                 RelativeSizeAxes = Axes.Both,
                 PlayfieldBorderStyle = { Value = PlayfieldBorderStyle.Corners }
             });
+
+            LayerBelowRuleset.Add(distanceSnapGrid = new CatchDistanceSnapGrid(new[]
+            {
+                0.0,
+                Catcher.BASE_SPEED, -Catcher.BASE_SPEED,
+                Catcher.BASE_SPEED / 2, -Catcher.BASE_SPEED / 2,
+            }));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            updateDistanceSnapGrid();
         }
 
         protected override DrawableRuleset<CatchHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null) =>
@@ -42,14 +80,90 @@ namespace osu.Game.Rulesets.Catch.Edit
             new BananaShowerCompositionTool()
         };
 
+        protected override IEnumerable<TernaryButton> CreateTernaryButtons() => base.CreateTernaryButtons().Concat(new[]
+        {
+            new TernaryButton(distanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Ruler })
+        });
+
         public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {
             var result = base.SnapScreenSpacePositionToValidTime(screenSpacePosition);
-            // TODO: implement position snap
             result.ScreenSpacePosition.X = screenSpacePosition.X;
+
+            if (distanceSnapGrid.IsPresent && distanceSnapGrid.GetSnappedPosition(result.ScreenSpacePosition) is SnapResult snapResult &&
+                Vector2.Distance(snapResult.ScreenSpacePosition, result.ScreenSpacePosition) < distance_snap_radius)
+            {
+                result = snapResult;
+            }
+
             return result;
         }
 
         protected override ComposeBlueprintContainer CreateBlueprintContainer() => new CatchBlueprintContainer(this);
+
+        [CanBeNull]
+        private PalpableCatchHitObject getPreviousHitObject(double time)
+        {
+            var hitObject = EditorBeatmap.HitObjects.OfType<CatchHitObject>().LastOrDefault(h => h.GetEndTime() < time && !(h is BananaShower));
+
+            switch (hitObject)
+            {
+                case Fruit fruit:
+                    return fruit;
+
+                case JuiceStream juiceStream:
+                    return juiceStream.NestedHitObjects.OfType<PalpableCatchHitObject>().LastOrDefault(h => !(h is TinyDroplet));
+
+                default:
+                    return null;
+            }
+        }
+
+        [CanBeNull]
+        private PalpableCatchHitObject getDistanceSnapGridSourceHitObject()
+        {
+            switch (BlueprintContainer.CurrentTool)
+            {
+                case SelectTool _:
+                    if (EditorBeatmap.SelectedHitObjects.Count == 0)
+                        return null;
+
+                    double minTime = EditorBeatmap.SelectedHitObjects.Min(hitObject => hitObject.StartTime);
+                    return getPreviousHitObject(minTime);
+
+                case FruitCompositionTool _:
+                case JuiceStreamCompositionTool _:
+                    if (!CursorInPlacementArea)
+                        return null;
+
+                    if (EditorBeatmap.PlacementObject.Value is JuiceStream)
+                    {
+                        // Juice stream path is not subject to snapping.
+                        return null;
+                    }
+
+                    double timeAtCursor = ((CatchPlayfield)Playfield).TimeAtScreenSpacePosition(inputManager.CurrentState.Mouse.Position);
+                    return getPreviousHitObject(timeAtCursor);
+
+                default:
+                    return null;
+            }
+        }
+
+        private void updateDistanceSnapGrid()
+        {
+            var sourceHitObject = getDistanceSnapGridSourceHitObject();
+
+            if (distanceSnapToggle.Value != TernaryState.True || sourceHitObject == null)
+            {
+                distanceSnapGrid.Hide();
+            }
+            else
+            {
+                distanceSnapGrid.Show();
+                distanceSnapGrid.StartTime = sourceHitObject.GetEndTime();
+                distanceSnapGrid.StartX = sourceHitObject.EffectiveX;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Catch.Edit
         protected override ComposeBlueprintContainer CreateBlueprintContainer() => new CatchBlueprintContainer(this);
 
         [CanBeNull]
-        private PalpableCatchHitObject getPreviousHitObject(double time)
+        private PalpableCatchHitObject getLastSnappableHitObject(double time)
         {
             var hitObject = EditorBeatmap.HitObjects.OfType<CatchHitObject>().LastOrDefault(h => h.GetEndTime() < time && !(h is BananaShower));
 
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                         return null;
 
                     double minTime = EditorBeatmap.SelectedHitObjects.Min(hitObject => hitObject.StartTime);
-                    return getPreviousHitObject(minTime);
+                    return getLastSnappableHitObject(minTime);
 
                 case FruitCompositionTool _:
                 case JuiceStreamCompositionTool _:
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                     }
 
                     double timeAtCursor = ((CatchPlayfield)Playfield).TimeAtScreenSpacePosition(inputManager.CurrentState.Mouse.Position);
-                    return getPreviousHitObject(timeAtCursor);
+                    return getLastSnappableHitObject(timeAtCursor);
 
                 default:
                     return null;

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -152,18 +152,23 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         private void updateDistanceSnapGrid()
         {
-            var sourceHitObject = getDistanceSnapGridSourceHitObject();
-
-            if (distanceSnapToggle.Value != TernaryState.True || sourceHitObject == null)
+            if (distanceSnapToggle.Value != TernaryState.True)
             {
                 distanceSnapGrid.Hide();
+                return;
             }
-            else
+
+            var sourceHitObject = getDistanceSnapGridSourceHitObject();
+
+            if (sourceHitObject == null)
             {
-                distanceSnapGrid.Show();
-                distanceSnapGrid.StartTime = sourceHitObject.GetEndTime();
-                distanceSnapGrid.StartX = sourceHitObject.EffectiveX;
+                distanceSnapGrid.Hide();
+                return;
             }
+
+            distanceSnapGrid.Show();
+            distanceSnapGrid.StartTime = sourceHitObject.GetEndTime();
+            distanceSnapGrid.StartX = sourceHitObject.EffectiveX;
         }
     }
 }


### PR DESCRIPTION
Juice stream paths are not snapped because a path control point doesn't correspond to a hit object.
Though I wonder if it is much more intuitive if individual fruits/droplets can be moved within a juice stream (and snapped).