### PR TITLE
Fix slider paths being extended even when the last two points are equal

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -775,5 +775,22 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(seventh.ControlPoints[4].Type == null);
             }
         }
+
+        [Test]
+        public void TestSliderLengthExtensionEdgeCase()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var resStream = TestResources.OpenResource("duplicate-last-position-slider.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var decoded = decoder.Decode(stream);
+
+                var path = ((IHasPath)decoded.HitObjects[0]).Path;
+
+                Assert.That(path.ExpectedDistance.Value, Is.EqualTo(2));
+                Assert.That(path.Distance, Is.EqualTo(1));
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Resources/duplicate-last-position-slider.osu
+++ b/osu.Game.Tests/Resources/duplicate-last-position-slider.osu
@@ -1,0 +1,19 @@
+osu file format v14
+
+[Difficulty]
+HPDrainRate:7
+CircleSize:10
+OverallDifficulty:9
+ApproachRate:10
+SliderMultiplier:0.4
+SliderTickRate:1
+
+[TimingPoints]
+382,923.076923076923,3,2,1,75,1,0
+382,-1000,3,2,1,75,0,0
+
+[HitObjects]
+
+// Importantly, the last position is specified twice.
+// In this case, osu-stable doesn't extend the slider length even when the "expected" length is higher than the actual.
+261,171,25305,6,0,B|262:171|262:171|262:171,1,2,8|0,0:0|0:0,0:0:0:0:

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -460,7 +460,7 @@ namespace osu.Game.Beatmaps.Formats
             var curveData = pathData as IHasPathWithRepeats;
 
             writer.Write(FormattableString.Invariant($"{(curveData?.RepeatCount ?? 0) + 1},"));
-            writer.Write(FormattableString.Invariant($"{pathData.Path.Distance},"));
+            writer.Write(FormattableString.Invariant($"{pathData.Path.ExpectedDistance.Value ?? pathData.Path.Distance},"));
 
             if (curveData != null)
             {

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -280,6 +280,13 @@ namespace osu.Game.Rulesets.Objects
 
             if (ExpectedDistance.Value is double expectedDistance && calculatedLength != expectedDistance)
             {
+                // In osu-stable, if the last two control points of a slider are equal, extension is not performed.
+                if (ControlPoints.Count >= 2 && ControlPoints[^1].Position == ControlPoints[^2].Position && expectedDistance > calculatedLength)
+                {
+                    cumulativeLength.Add(calculatedLength);
+                    return;
+                }
+
                 // The last length is always incorrect
                 cumulativeLength.RemoveAt(cumulativeLength.Count - 1);
 


### PR DESCRIPTION
I'm not sure if this is a valid solution. We likely don't want this in `SliderPath`, but that said, it shouldn't affect any normal scenario (where a user is creating a beatmap in the lazer editor).

PRing this mainly for discussion purposes. If this is considered okay then I'll add test coverage.

Closes https://github.com/ppy/osu/issues/15109.