### PR TITLE
Show remaining attempts again on playlist screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Components/ReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/ReadyButton.cs
@@ -3,13 +3,15 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Online.Rooms;
 
 namespace osu.Game.Screens.OnlinePlay.Components
 {
-    public abstract class ReadyButton : TriangleButton
+    public abstract class ReadyButton : TriangleButton, IHasTooltip
     {
         public new readonly BindableBool Enabled = new BindableBool();
 
@@ -24,6 +26,18 @@ namespace osu.Game.Screens.OnlinePlay.Components
             Enabled.BindValueChanged(_ => updateState(), true);
         }
 
-        private void updateState() => base.Enabled.Value = availability.Value.State == DownloadState.LocallyAvailable && Enabled.Value;
+        private void updateState() =>
+            base.Enabled.Value = availability.Value.State == DownloadState.LocallyAvailable && Enabled.Value;
+
+        public virtual LocalisableString TooltipText
+        {
+            get
+            {
+                if (Enabled.Value)
+                    return string.Empty;
+
+                return "Beatmap not downloaded";
+            }
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Components/RoomLocalUserInfo.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomLocalUserInfo.cs
@@ -14,6 +14,9 @@ namespace osu.Game.Screens.OnlinePlay.Components
     {
         private OsuSpriteText attemptDisplay;
 
+        [Resolved]
+        private OsuColour colours { get; set; }
+
         public RoomLocalUserInfo()
         {
             AutoSizeAxes = Axes.Both;
@@ -54,6 +57,9 @@ namespace osu.Game.Screens.OnlinePlay.Components
                 {
                     int remaining = MaxAttempts.Value.Value - UserScore.Value.PlaylistItemAttempts.Sum(a => a.Attempts);
                     attemptDisplay.Text += $" ({remaining} remaining)";
+
+                    if (remaining == 0)
+                        attemptDisplay.Colour = colours.RedLight;
                 }
             }
             else

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsReadyButton.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
@@ -15,6 +17,12 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
     {
         [Resolved(typeof(Room), nameof(Room.EndDate))]
         private Bindable<DateTimeOffset?> endDate { get; set; }
+
+        [Resolved(typeof(Room), nameof(Room.MaxAttempts))]
+        private Bindable<int?> maxAttempts { get; set; }
+
+        [Resolved(typeof(Room), nameof(Room.UserScore))]
+        private Bindable<PlaylistAggregateScore> userScore { get; set; }
 
         [Resolved]
         private IBindable<WorkingBeatmap> gameBeatmap { get; set; }
@@ -54,6 +62,23 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             base.Update();
 
             Enabled.Value = hasRemainingAttempts && enoughTimeLeft;
+        }
+
+        public override LocalisableString TooltipText
+        {
+            get
+            {
+                if (Enabled.Value)
+                    return string.Empty;
+
+                if (!enoughTimeLeft)
+                    return "No time left!";
+
+                if (!hasRemainingAttempts)
+                    return "Attempts exhausted!";
+
+                return base.TooltipText;
+            }
         }
 
         private bool enoughTimeLeft =>

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsReadyButton.cs
@@ -32,11 +32,32 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             Triangles.ColourLight = colours.GreenLight;
         }
 
+        private bool hasRemainingAttempts = true;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            userScore.BindValueChanged(aggregate =>
+            {
+                if (maxAttempts.Value == null)
+                    return;
+
+                int remaining = maxAttempts.Value.Value - aggregate.NewValue.PlaylistItemAttempts.Sum(a => a.Attempts);
+
+                hasRemainingAttempts = remaining > 0;
+            });
+        }
+
         protected override void Update()
         {
             base.Update();
 
-            Enabled.Value = endDate.Value != null && DateTimeOffset.UtcNow.AddSeconds(30).AddMilliseconds(gameBeatmap.Value.Track.Length) < endDate.Value;
+            Enabled.Value = hasRemainingAttempts && enoughTimeLeft;
         }
+
+        private bool enoughTimeLeft =>
+            // This should probably consider the length of the currently selected item, rather than a constant 30 seconds.
+            endDate.Value != null && DateTimeOffset.UtcNow.AddSeconds(30).AddMilliseconds(gameBeatmap.Value.Track.Length) < endDate.Value;
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -154,6 +154,22 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                             },
                             new Drawable[]
                             {
+                                new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Alpha = Room.MaxAttempts.Value != null ? 1 : 0,
+                                    Margin = new MarginPadding { Bottom = 10 },
+                                    Direction = FillDirection.Vertical,
+                                    Children = new Drawable[]
+                                    {
+                                        new OverlinedHeader("Progress"),
+                                        new RoomLocalUserInfo(),
+                                    }
+                                },
+                            },
+                            new Drawable[]
+                            {
                                 new OverlinedHeader("Leaderboard")
                             },
                             new Drawable[] { leaderboard = new MatchLeaderboard { RelativeSizeAxes = Axes.Both }, },
@@ -162,6 +178,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                         },
                         RowDimensions = new[]
                         {
+                            new Dimension(GridSizeMode.AutoSize),
                             new Dimension(GridSizeMode.AutoSize),
                             new Dimension(GridSizeMode.AutoSize),
                             new Dimension(),

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         private MatchLeaderboard leaderboard;
         private SelectionPollingComponent selectionPollingComponent;
 
+        private FillFlowContainer progressSection;
+
         public PlaylistsRoomSubScreen(Room room)
             : base(room, false) // Editing is temporarily not allowed.
         {
@@ -67,6 +69,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                     Schedule(() => SelectedItem.Value = Room.Playlist.FirstOrDefault());
                 }
             }, true);
+
+            Room.MaxAttempts.BindValueChanged(attempts => progressSection.Alpha = Room.MaxAttempts.Value != null ? 1 : 0, true);
         }
 
         protected override Drawable CreateMainContent() => new GridContainer
@@ -154,11 +158,11 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                             },
                             new Drawable[]
                             {
-                                new FillFlowContainer
+                                progressSection = new FillFlowContainer
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Alpha = Room.MaxAttempts.Value != null ? 1 : 0,
+                                    Alpha = 0,
                                     Margin = new MarginPadding { Bottom = 10 },
                                     Direction = FillDirection.Vertical,
                                     Children = new Drawable[]


### PR DESCRIPTION
Also adds tooltips and disabled state to the ready button in the case of exhausted attempts.

No tests yet because the existing test scenes aren't flexible enough to add them. I'll look into adding tests later today unless it's deemed that they aren't required.

Closes https://github.com/ppy/osu/issues/15274.