### PR TITLE
Use explicit constants for catcher dashing and walking speeds

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -233,7 +233,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 int thisDirection = nextObject.EffectiveX > currentObject.EffectiveX ? 1 : -1;
                 double timeToNext = nextObject.StartTime - currentObject.StartTime - 1000f / 60f / 4; // 1/4th of a frame of grace time, taken from osu-stable
                 double distanceToNext = Math.Abs(nextObject.EffectiveX - currentObject.EffectiveX) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
-                float distanceToHyper = (float)(timeToNext * Catcher.BASE_SPEED - distanceToNext);
+                float distanceToHyper = (float)(timeToNext * Catcher.BASE_DASH_SPEED - distanceToNext);
 
                 if (distanceToHyper < 0)
                 {

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapGrid.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public float StartX { get; set; }
 
-        private const double max_vertical_line_length_in_time = CatchPlayfield.WIDTH / Catcher.BASE_SPEED * 2;
+        private const double max_vertical_line_length_in_time = CatchPlayfield.WIDTH / Catcher.BASE_WALK_SPEED;
 
         private readonly double[] velocities;
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -51,8 +51,8 @@ namespace osu.Game.Rulesets.Catch.Edit
             LayerBelowRuleset.Add(distanceSnapGrid = new CatchDistanceSnapGrid(new[]
             {
                 0.0,
-                Catcher.BASE_SPEED, -Catcher.BASE_SPEED,
-                Catcher.BASE_SPEED / 2, -Catcher.BASE_SPEED / 2,
+                Catcher.BASE_DASH_SPEED, -Catcher.BASE_DASH_SPEED,
+                Catcher.BASE_WALK_SPEED, -Catcher.BASE_WALK_SPEED,
             }));
         }
 

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Rulesets.Catch.Replays
             if (Beatmap.HitObjects.Count == 0)
                 return;
 
-            // todo: add support for HT DT
-            const double dash_speed = Catcher.BASE_SPEED;
-            const double movement_speed = dash_speed / 2;
             float lastPosition = CatchPlayfield.CENTER_X;
             double lastTime = 0;
 
@@ -47,8 +44,8 @@ namespace osu.Game.Rulesets.Catch.Replays
                 // The case where positionChange > 0 and timeAvailable == 0 results in PositiveInfinity which provides expected beheaviour.
                 double speedRequired = positionChange == 0 ? 0 : positionChange / timeAvailable;
 
-                bool dashRequired = speedRequired > movement_speed;
-                bool impossibleJump = speedRequired > movement_speed * 2;
+                bool dashRequired = speedRequired > Catcher.BASE_WALK_SPEED;
+                bool impossibleJump = speedRequired > Catcher.BASE_DASH_SPEED;
 
                 // todo: get correct catcher size, based on difficulty CS.
                 const float catcher_width_half = Catcher.BASE_SIZE * 0.3f * 0.5f;
@@ -73,7 +70,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 else if (dashRequired)
                 {
                     // we do a movement in two parts - the dash part then the normal part...
-                    double timeAtNormalSpeed = positionChange / movement_speed;
+                    double timeAtNormalSpeed = positionChange / Catcher.BASE_WALK_SPEED;
                     double timeWeNeedToSave = timeAtNormalSpeed - timeAvailable;
                     double timeAtDashSpeed = timeWeNeedToSave / 2;
 
@@ -86,7 +83,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 }
                 else
                 {
-                    double timeBefore = positionChange / movement_speed;
+                    double timeBefore = positionChange / Catcher.BASE_WALK_SPEED;
 
                     addFrame(h.StartTime - timeBefore, lastPosition);
                     addFrame(h.StartTime, h.EffectiveX);

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -57,14 +57,19 @@ namespace osu.Game.Rulesets.Catch.UI
         public bool CatchFruitOnPlate { get; set; } = true;
 
         /// <summary>
-        /// The relative space to cover in 1 millisecond. based on 1 game pixel per millisecond as in osu-stable.
+        /// The speed of the catcher when the catcher is dashing.
         /// </summary>
-        public const double BASE_SPEED = 1.0;
+        public const double BASE_DASH_SPEED = 1.0;
 
         /// <summary>
-        /// The current speed of the catcher.
+        /// The speed of the catcher when the catcher is not dashing.
         /// </summary>
-        public double Speed => (Dashing ? 1 : 0.5) * BASE_SPEED * hyperDashModifier;
+        public const double BASE_WALK_SPEED = 0.5;
+
+        /// <summary>
+        /// The current speed of the catcher with the hyper-dash modifier applied.
+        /// </summary>
+        public double Speed => (Dashing ? BASE_DASH_SPEED : BASE_WALK_SPEED) * hyperDashModifier;
 
         /// <summary>
         /// The amount by which caught fruit should be scaled down to fit on the plate.
@@ -230,7 +235,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 double positionDifference = target.EffectiveX - X;
                 var velocity = positionDifference / Math.Max(1.0, timeDifference - 1000.0 / 60.0);
 
-                SetHyperDashState(Math.Abs(velocity), target.EffectiveX);
+                SetHyperDashState(Math.Abs(velocity) / BASE_DASH_SPEED, target.EffectiveX);
             }
             else
                 SetHyperDashState();


### PR DESCRIPTION
Ideally, the code should be working with variable catcher speed but that is not supported here (though it seems working if I change the constants manually, except the difficulty calculator).
Note that the catcher speed doesn't change when DT/HT is applied, as the mods only change the clock rate (how in-game time unit is related to the real-time clock). And I removed a misleading "todo" in `CatchAutoGenerator.cs `.