### PR TITLE
Allow setting of `APIBeatmap.Length` (and don't serialise twice)

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
 
-            AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 10).ToArray()));
+            AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 100).ToArray()));
 
             AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
 

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -54,10 +54,15 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"accuracy")]
         private float overallDifficulty { get; set; }
 
-        public double Length => TimeSpan.FromSeconds(lengthInSeconds).TotalMilliseconds;
+        [JsonIgnore]
+        public double Length { get; set; }
 
         [JsonProperty(@"total_length")]
-        private double lengthInSeconds { get; set; }
+        private double lengthInSeconds
+        {
+            get => TimeSpan.FromMilliseconds(Length).TotalSeconds;
+            set => Length = TimeSpan.FromSeconds(value).TotalMilliseconds;
+        }
 
         [JsonProperty(@"count_circles")]
         public int CircleCount { get; set; }


### PR DESCRIPTION
In tests we regularly want to construct `APIBeatmap`s and set all their properties. With recently changes `Length` was missing this ability.

I've also fixed a test that was recently changed unintentionally.