### PR TITLE
Fix online play request handling in tests

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneLoungeRoomsContainer : OnlinePlayTestScene
     {
-        protected new TestRequestHandlingRoomManager RoomManager => (TestRequestHandlingRoomManager)base.RoomManager;
+        protected new TestRoomManager RoomManager => (TestRoomManager)base.RoomManager;
 
         private RoomsContainer container;
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -18,6 +18,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Mods;
@@ -34,6 +35,7 @@ using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Tests.Resources;
+using osu.Game.Tests.Visual.OnlinePlay;
 using osu.Game.Users;
 using osuTK.Input;
 
@@ -617,9 +619,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
             [Cached(typeof(MultiplayerClient))]
             public readonly TestMultiplayerClient Client;
 
+            [Cached]
+            public readonly TestRoomRequestsHandler RequestsHandler = new TestRoomRequestsHandler();
+
             public DependenciesScreen(TestMultiplayerClient client)
             {
                 Client = client;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(IAPIProvider api, OsuGameBase game)
+            {
+                ((DummyAPIAccess)api).HandleRequest = request => RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
             }
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -48,7 +49,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private TestMultiplayer multiplayerScreen;
         private TestMultiplayerClient client;
 
-        private TestRequestHandlingMultiplayerRoomManager roomManager => multiplayerScreen.RoomManager;
+        private TestMultiplayerRoomManager roomManager => multiplayerScreen.RoomManager;
 
         [Cached(typeof(UserLookupCache))]
         private UserLookupCache lookupCache = new TestUserLookupCache();
@@ -624,9 +625,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
         {
-            public new TestRequestHandlingMultiplayerRoomManager RoomManager { get; private set; }
+            public new TestMultiplayerRoomManager RoomManager { get; private set; }
 
-            protected override RoomManager CreateRoomManager() => RoomManager = new TestRequestHandlingMultiplayerRoomManager();
+            protected override RoomManager CreateRoomManager() => RoomManager = new TestMultiplayerRoomManager();
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUpSteps]
         public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
             AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = LookupCache.GetUserAsync(1).Result);
 
             AddStep("create leaderboard", () =>

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Online.API;
@@ -40,7 +39,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(config = new OsuConfigManager(LocalStorage));
         }
 
-        [SetUpSteps]
         public override void SetUpSteps()
         {
             base.SetUpSteps();

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
@@ -44,9 +43,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return room;
         }
 
-        [SetUpSteps]
         public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
             AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = LookupCache.GetUserAsync(1).Result);
 
             AddStep("create leaderboard", () =>

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerLoungeSubScreen.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerLoungeSubScreen : OnlinePlayTestScene
     {
-        protected new TestRequestHandlingRoomManager RoomManager => (TestRequestHandlingRoomManager)base.RoomManager;
+        protected new TestRoomManager RoomManager => (TestRoomManager)base.RoomManager;
 
         private LoungeSubScreen loungeScreen;
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -4,7 +4,6 @@
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -14,8 +13,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUp]
         public new void Setup() => Schedule(() =>
         {
-            SelectedRoom.Value = new Room();
-
             Child = new Container
             {
                 Anchor = Anchor.Centre,

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -184,9 +184,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
         {
-            public new TestRequestHandlingMultiplayerRoomManager RoomManager { get; private set; }
+            public new TestMultiplayerRoomManager RoomManager { get; private set; }
 
-            protected override RoomManager CreateRoomManager() => RoomManager = new TestRequestHandlingMultiplayerRoomManager();
+            protected override RoomManager CreateRoomManager() => RoomManager = new TestMultiplayerRoomManager();
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -11,6 +11,7 @@ using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
@@ -23,6 +24,7 @@ using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Participants;
 using osu.Game.Tests.Resources;
+using osu.Game.Tests.Visual.OnlinePlay;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -176,9 +178,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
             [Cached(typeof(MultiplayerClient))]
             public readonly TestMultiplayerClient Client;
 
+            [Cached]
+            public readonly TestRoomRequestsHandler RequestsHandler = new TestRoomRequestsHandler();
+
             public DependenciesScreen(TestMultiplayerClient client)
             {
                 Client = client;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(IAPIProvider api, OsuGameBase game)
+            {
+                ((DummyAPIAccess)api).HandleRequest = request => RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
             }
         }
 

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -461,10 +461,10 @@ namespace osu.Game.Tests.Visual.Navigation
 
             public TestMultiplayer()
             {
-                Client = new TestMultiplayerClient((TestRequestHandlingMultiplayerRoomManager)RoomManager);
+                Client = new TestMultiplayerClient((TestMultiplayerRoomManager)RoomManager);
             }
 
-            protected override RoomManager CreateRoomManager() => new TestRequestHandlingMultiplayerRoomManager();
+            protected override RoomManager CreateRoomManager() => new TestMultiplayerRoomManager();
         }
     }
 }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -9,6 +9,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -24,6 +25,7 @@ using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Options;
 using osu.Game.Tests.Beatmaps.IO;
 using osu.Game.Tests.Visual.Multiplayer;
+using osu.Game.Tests.Visual.OnlinePlay;
 using osuTK;
 using osuTK.Input;
 
@@ -459,9 +461,19 @@ namespace osu.Game.Tests.Visual.Navigation
             [Cached(typeof(MultiplayerClient))]
             public readonly TestMultiplayerClient Client;
 
+            [Cached]
+            public readonly TestRoomRequestsHandler RequestsHandler;
+
             public TestMultiplayer()
             {
                 Client = new TestMultiplayerClient((TestMultiplayerRoomManager)RoomManager);
+                RequestsHandler = new TestRoomRequestsHandler();
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(IAPIProvider api, OsuGameBase game)
+            {
+                ((DummyAPIAccess)api).HandleRequest = request => RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
             }
 
             protected override RoomManager CreateRoomManager() => new TestMultiplayerRoomManager();

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual.Playlists
 {
     public class TestScenePlaylistsLoungeSubScreen : OnlinePlayTestScene
     {
-        protected new TestRequestHandlingRoomManager RoomManager => (TestRequestHandlingRoomManager)base.RoomManager;
+        protected new TestRoomManager RoomManager => (TestRoomManager)base.RoomManager;
 
         private TestLoungeSubScreen loungeScreen;
 

--- a/osu.Game/Tests/Visual/Multiplayer/IMultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/IMultiplayerTestSceneDependencies.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         /// <summary>
         /// The cached <see cref="IRoomManager"/>.
         /// </summary>
-        new TestRequestHandlingMultiplayerRoomManager RoomManager { get; }
+        new TestMultiplayerRoomManager RoomManager { get; }
 
         /// <summary>
         /// The cached <see cref="UserLookupCache"/>.

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public const int PLAYER_2_ID = 56;
 
         public TestMultiplayerClient Client => OnlinePlayDependencies.Client;
-        public new TestRequestHandlingMultiplayerRoomManager RoomManager => OnlinePlayDependencies.RoomManager;
+        public new TestMultiplayerRoomManager RoomManager => OnlinePlayDependencies.RoomManager;
         public TestUserLookupCache LookupCache => OnlinePlayDependencies?.LookupCache;
         public TestSpectatorClient SpectatorClient => OnlinePlayDependencies?.SpectatorClient;
 
@@ -35,12 +35,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public new void Setup() => Schedule(() =>
         {
             if (joinRoom)
-            {
-                var room = CreateRoom();
-
-                RoomManager.CreateRoom(room);
-                SelectedRoom.Value = room;
-            }
+                SelectedRoom.Value = CreateRoom();
         });
 
         protected virtual Room CreateRoom()
@@ -64,7 +59,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             base.SetUpSteps();
 
             if (joinRoom)
+            {
+                AddStep("join room", () => RoomManager.CreateRoom(SelectedRoom.Value));
                 AddUntilStep("wait for room join", () => Client.Room != null);
+            }
         }
 
         protected override OnlinePlayTestSceneDependencies CreateOnlinePlayDependencies() => new MultiplayerTestSceneDependencies();

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public TestMultiplayerClient Client { get; }
         public TestUserLookupCache LookupCache { get; }
         public TestSpectatorClient SpectatorClient { get; }
-        public new TestRequestHandlingMultiplayerRoomManager RoomManager => (TestRequestHandlingMultiplayerRoomManager)base.RoomManager;
+        public new TestMultiplayerRoomManager RoomManager => (TestMultiplayerRoomManager)base.RoomManager;
 
         public MultiplayerTestSceneDependencies()
         {
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             CacheAs<SpectatorClient>(SpectatorClient);
         }
 
-        protected override IRoomManager CreateRoomManager() => new TestRequestHandlingMultiplayerRoomManager();
+        protected override IRoomManager CreateRoomManager() => new TestMultiplayerRoomManager();
 
         protected virtual TestSpectatorClient CreateSpectatorClient() => new TestSpectatorClient();
     }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -39,9 +39,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Resolved]
         private BeatmapManager beatmaps { get; set; } = null!;
 
-        private readonly TestRequestHandlingMultiplayerRoomManager roomManager;
+        private readonly TestMultiplayerRoomManager roomManager;
 
-        public TestMultiplayerClient(TestRequestHandlingMultiplayerRoomManager roomManager)
+        public TestMultiplayerClient(TestMultiplayerRoomManager roomManager)
         {
             this.roomManager = roomManager;
         }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
-using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
@@ -12,25 +11,20 @@ using osu.Game.Tests.Visual.OnlinePlay;
 namespace osu.Game.Tests.Visual.Multiplayer
 {
     /// <summary>
-    /// A <see cref="RoomManager"/> for use in multiplayer test scenes, backed by a <see cref="TestRoomRequestsHandler"/>.
+    /// A <see cref="RoomManager"/> for use in multiplayer test scenes.
     /// Should generally not be used by itself outside of a <see cref="MultiplayerTestScene"/>.
     /// </summary>
-    public class TestRequestHandlingMultiplayerRoomManager : MultiplayerRoomManager
+    public class TestMultiplayerRoomManager : MultiplayerRoomManager
     {
-        public IReadOnlyList<Room> ServerSideRooms => handler.ServerSideRooms;
+        [Resolved]
+        private TestRoomRequestsHandler requestsHandler { get; set; }
 
-        private readonly TestRoomRequestsHandler handler = new TestRoomRequestsHandler();
-
-        [BackgroundDependencyLoader]
-        private void load(IAPIProvider api, OsuGameBase game)
-        {
-            ((DummyAPIAccess)api).HandleRequest = request => handler.HandleRequest(request, api.LocalUser.Value, game);
-        }
+        public IReadOnlyList<Room> ServerSideRooms => requestsHandler.ServerSideRooms;
 
         /// <summary>
         /// Adds a room to a local "server-side" list that's returned when a <see cref="GetRoomsRequest"/> is fired.
         /// </summary>
         /// <param name="room">The room.</param>
-        public void AddServerSideRoom(Room room) => handler.AddServerSideRoom(room);
+        public void AddServerSideRoom(Room room) => requestsHandler.AddServerSideRoom(room);
     }
 }

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         private readonly Container content;
         private readonly Container drawableDependenciesContainer;
         private DelegatedDependencyContainer dependencies;
-        private TestRoomRequestsHandler requestsHandler;
 
         protected OnlinePlayTestScene()
         {
@@ -65,12 +64,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public override void SetUpSteps()
         {
             base.SetUpSteps();
-
-            AddStep("setup API", () =>
-            {
-                requestsHandler = new TestRoomRequestsHandler();
-                ((DummyAPIAccess)API).HandleRequest = request => requestsHandler.HandleRequest(request, API.LocalUser.Value, game);
-            });
+            AddStep("setup API", () => ((DummyAPIAccess)API).HandleRequest = request => OnlinePlayDependencies.RequestsHandler.HandleRequest(request, API.LocalUser.Value, game));
         }
 
         /// <summary>

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay;
 
@@ -27,11 +28,15 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         /// </summary>
         protected OnlinePlayTestSceneDependencies OnlinePlayDependencies => dependencies?.OnlinePlayDependencies;
 
-        private DelegatedDependencyContainer dependencies;
-
         protected override Container<Drawable> Content => content;
+
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
         private readonly Container content;
         private readonly Container drawableDependenciesContainer;
+        private DelegatedDependencyContainer dependencies;
+        private TestRoomRequestsHandler requestsHandler;
 
         protected OnlinePlayTestScene()
         {
@@ -56,6 +61,17 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             dependencies.OnlinePlayDependencies = CreateOnlinePlayDependencies();
             drawableDependenciesContainer.AddRange(OnlinePlayDependencies.DrawableComponents);
         });
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("setup API", () =>
+            {
+                requestsHandler = new TestRoomRequestsHandler();
+                ((DummyAPIAccess)API).HandleRequest = request => requestsHandler.HandleRequest(request, API.LocalUser.Value, game);
+            });
+        }
 
         /// <summary>
         /// Creates the room dependencies. Called every <see cref="Setup"/>.

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public IRoomManager RoomManager { get; }
         public OngoingOperationTracker OngoingOperationTracker { get; }
         public OnlinePlayBeatmapAvailabilityTracker AvailabilityTracker { get; }
+        public TestRoomRequestsHandler RequestsHandler { get; }
 
         /// <summary>
         /// All cached dependencies which are also <see cref="Drawable"/> components.
@@ -36,9 +37,11 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             RoomManager = CreateRoomManager();
             OngoingOperationTracker = new OngoingOperationTracker();
             AvailabilityTracker = new OnlinePlayBeatmapAvailabilityTracker();
+            RequestsHandler = new TestRoomRequestsHandler();
 
             dependencies = new DependencyContainer(new CachedModelDependencyContainer<Room>(null) { Model = { BindTarget = SelectedRoom } });
 
+            CacheAs(RequestsHandler);
             CacheAs(SelectedRoom);
             CacheAs(RoomManager);
             CacheAs(OngoingOperationTracker);
@@ -71,6 +74,6 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                 drawableComponents.Add(drawable);
         }
 
-        protected virtual IRoomManager CreateRoomManager() => new TestRequestHandlingRoomManager();
+        protected virtual IRoomManager CreateRoomManager() => new TestRoomManager();
     }
 }

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRequestHandlingRoomManager.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRequestHandlingRoomManager.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Components;
@@ -20,14 +18,6 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public Action<Room, string> JoinRoomRequested;
 
         private int currentRoomId;
-
-        private readonly TestRoomRequestsHandler handler = new TestRoomRequestsHandler();
-
-        [BackgroundDependencyLoader]
-        private void load(IAPIProvider api, OsuGameBase game)
-        {
-            ((DummyAPIAccess)api).HandleRequest = request => handler.HandleRequest(request, api.LocalUser.Value, game);
-        }
 
         public override void JoinRoom(Room room, string password = null, Action<Room> onSuccess = null, Action<string> onError = null)
         {

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
     /// <summary>
     /// A very simple <see cref="RoomManager"/> for use in online play test scenes.
     /// </summary>
-    public class TestRequestHandlingRoomManager : RoomManager
+    public class TestRoomManager : RoomManager
     {
         public Action<Room, string> JoinRoomRequested;
 


### PR DESCRIPTION
An easy way to reproduce failures is to run `TestScenePlaylistsRoomSubScreen.BeatmapUpdatedOnReImport()` until just before the last `exit all screens` step, and then press the `[SetUp]` step and wait.

The reason is because `TestRequestHandlingMultiplayerRoomManager` and `TestRequestHandlingRoomManager` were both changing the dummy api request handler in `load()`, which occurs in `[SetUp]` prior to `[SetUpSteps]` where the `exit all screens` step lies.

My fix is to move the handler adjustment to `[SetUpSteps]`, and to do so I've put the request handler in `OnlinePlayDependencies`.