### PR TITLE
Clean up multiplayer-screen tests by removing intermediate screen

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -17,15 +17,12 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
-using osu.Game.Screens;
-using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.OnlinePlay.Match;
@@ -33,8 +30,8 @@ using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
+using osu.Game.Screens.Spectate;
 using osu.Game.Tests.Resources;
-using osu.Game.Tests.Visual.OnlinePlay;
 using osu.Game.Users;
 using osuTK.Input;
 
@@ -46,11 +43,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private RulesetStore rulesets;
         private BeatmapSetInfo importedSet;
 
-        private DependenciesScreen dependenciesScreen;
-        private TestMultiplayer multiplayerScreen;
-        private TestMultiplayerClient client;
+        private TestMultiplayerScreenStack multiplayerScreenStack;
 
-        private TestMultiplayerRoomManager roomManager => multiplayerScreen.RoomManager;
+        private TestMultiplayerClient client => multiplayerScreenStack.Client;
+        private TestMultiplayerRoomManager roomManager => multiplayerScreenStack.RoomManager;
 
         [Cached(typeof(UserLookupCache))]
         private UserLookupCache lookupCache = new TestUserLookupCache();
@@ -72,22 +68,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 importedSet = beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.All).First();
             });
 
-            AddStep("create multiplayer screen", () => multiplayerScreen = new TestMultiplayer());
-
-            AddStep("load dependencies", () =>
-            {
-                client = new TestMultiplayerClient(roomManager);
-
-                // The screen gets suspended so it stops receiving updates.
-                Child = client;
-
-                LoadScreen(dependenciesScreen = new DependenciesScreen(client));
-            });
-
-            AddUntilStep("wait for dependencies to load", () => dependenciesScreen.IsLoaded);
-
-            AddStep("load multiplayer", () => LoadScreen(multiplayerScreen));
-            AddUntilStep("wait for multiplayer to load", () => multiplayerScreen.IsLoaded);
+            AddStep("load multiplayer", () => LoadScreen(multiplayerScreenStack = new TestMultiplayerScreenStack()));
+            AddUntilStep("wait for multiplayer to load", () => multiplayerScreenStack.IsLoaded);
             AddUntilStep("wait for lounge to load", () => this.ChildrenOfType<MultiplayerLoungeSubScreen>().FirstOrDefault()?.IsLoaded == true);
         }
 
@@ -443,7 +425,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("start match externally", () => client.StartMatch());
 
-            AddAssert("play not started", () => multiplayerScreen.IsCurrentScreen());
+            AddAssert("play not started", () => multiplayerScreenStack.IsCurrentScreen());
         }
 
         [Test]
@@ -487,7 +469,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 importedSet = beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.All).First();
             });
 
-            AddUntilStep("play started", () => !multiplayerScreen.IsCurrentScreen());
+            AddUntilStep("play started", () => multiplayerScreenStack.CurrentScreen is SpectatorScreen);
         }
 
         [Test]
@@ -529,16 +511,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("open mod overlay", () => this.ChildrenOfType<RoomSubScreen.UserModSelectButton>().Single().TriggerClick());
 
-            AddStep("invoke on back button", () => multiplayerScreen.OnBackButton());
+            AddStep("invoke on back button", () => multiplayerScreenStack.OnBackButton());
 
             AddAssert("mod overlay is hidden", () => this.ChildrenOfType<UserModSelectOverlay>().Single().State.Value == Visibility.Hidden);
 
             AddAssert("dialog overlay is hidden", () => DialogOverlay.State.Value == Visibility.Hidden);
 
-            testLeave("back button", () => multiplayerScreen.OnBackButton());
+            testLeave("back button", () => multiplayerScreenStack.OnBackButton());
 
             // mimics home button and OS window close
-            testLeave("forced exit", () => multiplayerScreen.Exit());
+            testLeave("forced exit", () => multiplayerScreenStack.Exit());
 
             void testLeave(string actionName, Action action)
             {
@@ -579,7 +561,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("click start button", () => InputManager.Click(MouseButton.Left));
 
-            AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
+            AddUntilStep("wait for player", () => multiplayerScreenStack.CurrentScreen is Player);
 
             // Gameplay runs in real-time, so we need to incrementally check if gameplay has finished in order to not time out.
             for (double i = 1000; i < TestResources.QUICK_BEATMAP_LENGTH; i += 1000)
@@ -588,15 +570,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 AddUntilStep($"wait for time > {i}", () => this.ChildrenOfType<GameplayClockContainer>().SingleOrDefault()?.GameplayClock.CurrentTime > time);
             }
 
-            AddUntilStep("wait for results", () => Stack.CurrentScreen is ResultsScreen);
+            AddUntilStep("wait for results", () => multiplayerScreenStack.CurrentScreen is ResultsScreen);
         }
 
         private MultiplayerReadyButton readyButton => this.ChildrenOfType<MultiplayerReadyButton>().Single();
 
         private void createRoom(Func<Room> room)
         {
-            AddUntilStep("wait for lounge", () => multiplayerScreen.ChildrenOfType<LoungeSubScreen>().SingleOrDefault()?.IsLoaded == true);
-            AddStep("open room", () => multiplayerScreen.ChildrenOfType<LoungeSubScreen>().Single().Open(room()));
+            AddUntilStep("wait for lounge", () => multiplayerScreenStack.ChildrenOfType<LoungeSubScreen>().SingleOrDefault()?.IsLoaded == true);
+            AddStep("open room", () => multiplayerScreenStack.ChildrenOfType<LoungeSubScreen>().Single().Open(room()));
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
             AddWaitStep("wait for transition", 2);
@@ -608,36 +590,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for join", () => client.Room != null);
-        }
-
-        /// <summary>
-        /// Used for the sole purpose of adding <see cref="TestMultiplayerClient"/> as a resolvable dependency.
-        /// </summary>
-        private class DependenciesScreen : OsuScreen
-        {
-            [Cached(typeof(MultiplayerClient))]
-            public readonly TestMultiplayerClient Client;
-
-            [Cached]
-            public readonly TestRoomRequestsHandler RequestsHandler = new TestRoomRequestsHandler();
-
-            public DependenciesScreen(TestMultiplayerClient client)
-            {
-                Client = client;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(IAPIProvider api, OsuGameBase game)
-            {
-                ((DummyAPIAccess)api).HandleRequest = request => RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
-            }
-        }
-
-        private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
-        {
-            public new TestMultiplayerRoomManager RoomManager { get; private set; }
-
-            protected override RoomManager CreateRoomManager() => RoomManager = new TestMultiplayerRoomManager();
         }
     }
 }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -9,23 +9,18 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API;
-using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Menu;
-using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Options;
 using osu.Game.Tests.Beatmaps.IO;
-using osu.Game.Tests.Visual.Multiplayer;
-using osu.Game.Tests.Visual.OnlinePlay;
 using osuTK;
 using osuTK.Input;
 
@@ -335,12 +330,12 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestPushMatchSubScreenAndPressBackButtonImmediately()
         {
-            TestMultiplayer multiplayer = null;
+            TestMultiplayerScreenStack multiplayerScreenStack = null;
 
-            PushAndConfirm(() => multiplayer = new TestMultiplayer());
+            PushAndConfirm(() => multiplayerScreenStack = new TestMultiplayerScreenStack());
 
-            AddUntilStep("wait for lounge", () => multiplayer.ChildrenOfType<LoungeSubScreen>().SingleOrDefault()?.IsLoaded == true);
-            AddStep("open room", () => multiplayer.ChildrenOfType<LoungeSubScreen>().Single().Open());
+            AddUntilStep("wait for lounge", () => multiplayerScreenStack.ChildrenOfType<LoungeSubScreen>().SingleOrDefault()?.IsLoaded == true);
+            AddStep("open room", () => multiplayerScreenStack.ChildrenOfType<LoungeSubScreen>().Single().Open());
             AddStep("press back button", () => Game.ChildrenOfType<BackButton>().First().Action());
             AddWaitStep("wait two frames", 2);
         }
@@ -454,29 +449,6 @@ namespace osu.Game.Tests.Visual.Navigation
             public BeatmapOptionsOverlay BeatmapOptionsOverlay => BeatmapOptions;
 
             protected override bool DisplayStableImportPrompt => false;
-        }
-
-        private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
-        {
-            [Cached(typeof(MultiplayerClient))]
-            public readonly TestMultiplayerClient Client;
-
-            [Cached]
-            public readonly TestRoomRequestsHandler RequestsHandler;
-
-            public TestMultiplayer()
-            {
-                Client = new TestMultiplayerClient((TestMultiplayerRoomManager)RoomManager);
-                RequestsHandler = new TestRoomRequestsHandler();
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(IAPIProvider api, OsuGameBase game)
-            {
-                ((DummyAPIAccess)api).HandleRequest = request => RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
-            }
-
-            protected override RoomManager CreateRoomManager() => new TestMultiplayerRoomManager();
         }
     }
 }

--- a/osu.Game.Tests/Visual/TestMultiplayerScreenStack.cs
+++ b/osu.Game.Tests/Visual/TestMultiplayerScreenStack.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;

--- a/osu.Game.Tests/Visual/TestMultiplayerScreenStack.cs
+++ b/osu.Game.Tests/Visual/TestMultiplayerScreenStack.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Screens;
+using osu.Game.Screens.OnlinePlay.Components;
+using osu.Game.Tests.Visual.Multiplayer;
+using osu.Game.Tests.Visual.OnlinePlay;
+
+namespace osu.Game.Tests.Visual
+{
+    /// <summary>
+    /// An <see cref="OsuScreen"/> loadable into <see cref="ScreenTestScene"/>s via <see cref="ScreenTestScene.LoadScreen"/>,
+    /// which provides dependencies for and loads an isolated <see cref="Screens.OnlinePlay.Multiplayer.Multiplayer"/> screen.
+    /// <p>
+    /// This screen:
+    /// <list type="bullet">
+    /// <item>Provides a <see cref="TestMultiplayerClient"/> to be resolved as a dependency in the <see cref="Screens.OnlinePlay.Multiplayer.Multiplayer"/> screen,
+    /// which is typically a part of <see cref="OsuGameBase"/>.</item>
+    /// <item>Rebinds the <see cref="DummyAPIAccess"/> to handle requests via a <see cref="TestRoomRequestsHandler"/>.</item>
+    /// <item>Provides a <see cref="TestMultiplayerRoomManager"/> for the <see cref="Screens.OnlinePlay.Multiplayer.Multiplayer"/> screen.</item>
+    /// </list>
+    /// </p>
+    /// </summary>
+    public class TestMultiplayerScreenStack : OsuScreen
+    {
+        public Screens.OnlinePlay.Multiplayer.Multiplayer MultiplayerScreen => multiplayerScreen;
+
+        public TestMultiplayerRoomManager RoomManager => multiplayerScreen.RoomManager;
+
+        public IScreen CurrentScreen => screenStack.CurrentScreen;
+
+        public new bool IsLoaded => base.IsLoaded && MultiplayerScreen.IsLoaded;
+
+        [Cached(typeof(MultiplayerClient))]
+        public readonly TestMultiplayerClient Client;
+
+        private readonly OsuScreenStack screenStack;
+        private readonly TestMultiplayer multiplayerScreen;
+
+        public TestMultiplayerScreenStack()
+        {
+            multiplayerScreen = new TestMultiplayer();
+
+            InternalChildren = new Drawable[]
+            {
+                Client = new TestMultiplayerClient(RoomManager),
+                screenStack = new OsuScreenStack { RelativeSizeAxes = Axes.Both }
+            };
+
+            screenStack.Push(multiplayerScreen);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IAPIProvider api, OsuGameBase game)
+        {
+            ((DummyAPIAccess)api).HandleRequest = request => multiplayerScreen.RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
+        }
+
+        public override bool OnBackButton() => multiplayerScreen.OnBackButton();
+
+        public override bool OnExiting(IScreen next)
+        {
+            if (screenStack.CurrentScreen == null)
+                return base.OnExiting(next);
+
+            screenStack.Exit();
+            return true;
+        }
+
+        private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
+        {
+            public new TestMultiplayerRoomManager RoomManager { get; private set; }
+            public TestRoomRequestsHandler RequestsHandler { get; private set; }
+
+            protected override RoomManager CreateRoomManager() => RoomManager = new TestMultiplayerRoomManager(RequestsHandler = new TestRoomRequestsHandler());
+        }
+    }
+}

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             CacheAs<SpectatorClient>(SpectatorClient);
         }
 
-        protected override IRoomManager CreateRoomManager() => new TestMultiplayerRoomManager();
+        protected override IRoomManager CreateRoomManager() => new TestMultiplayerRoomManager(RequestsHandler);
 
         protected virtual TestSpectatorClient CreateSpectatorClient() => new TestSpectatorClient();
     }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Allocation;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
@@ -16,8 +15,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
     /// </summary>
     public class TestMultiplayerRoomManager : MultiplayerRoomManager
     {
-        [Resolved]
-        private TestRoomRequestsHandler requestsHandler { get; set; }
+        private readonly TestRoomRequestsHandler requestsHandler;
+
+        public TestMultiplayerRoomManager(TestRoomRequestsHandler requestsHandler)
+        {
+            this.requestsHandler = requestsHandler;
+        }
 
         public IReadOnlyList<Room> ServerSideRooms => requestsHandler.ServerSideRooms;
 

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
@@ -34,10 +34,10 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public OnlinePlayTestSceneDependencies()
         {
             SelectedRoom = new Bindable<Room>();
-            RoomManager = CreateRoomManager();
+            RequestsHandler = new TestRoomRequestsHandler();
             OngoingOperationTracker = new OngoingOperationTracker();
             AvailabilityTracker = new OnlinePlayBeatmapAvailabilityTracker();
-            RequestsHandler = new TestRoomRequestsHandler();
+            RoomManager = CreateRoomManager();
 
             dependencies = new DependencyContainer(new CachedModelDependencyContainer<Room>(null) { Model = { BindTarget = SelectedRoom } });
 


### PR DESCRIPTION
I didn't like the setup code with the intermediate "DependenciesScreen" which was duplicated across 3 classes.

This PR restructures things such that a `TestMultiplayerScreenStack` (I don't have a better name, suggestions welcome) screen is now loaded via `ScreenTestScene.LoadScreen()`, which sets everything up internally and loads a `Multiplayer` screen in an internal screen stack.