### PR TITLE
Ensure all test beatmaps have unique OnlineIDs to avoid import conflicts

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -38,8 +38,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-
-            manager.Import(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet).Wait();
         }
 
         [Test]
@@ -204,7 +202,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestDownloadButtonHiddenWhenBeatmapExists()
         {
-            createPlaylist(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo);
+            var beatmap = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo;
+
+            AddStep("import beatmap", () => manager.Import(beatmap.BeatmapSet).Wait());
+
+            createPlaylist(beatmap);
 
             assertDownloadButtonVisible(false);
 

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -144,10 +144,7 @@ namespace osu.Game.Tests.Visual.Playlists
             });
         }
 
-        private void importBeatmap()
-        {
-            AddStep("import beatmap", () => importedBeatmap = manager.Import(CreateBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet).Result);
-        }
+        private void importBeatmap() => AddStep("import beatmap", () => importedBeatmap = manager.Import(CreateBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet).Result);
 
         private class TestPlaylistsRoomSubScreen : PlaylistsRoomSubScreen
         {

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -91,26 +91,15 @@ namespace osu.Game.Tests.Visual.Playlists
         {
             BeatmapSetInfo importedSet = null;
 
-            // this step is required to make sure the further imports actually get online IDs.
-            // all the playlist logic relies on online ID matching.
-            AddStep("remove all matching online IDs", () =>
-            {
-                var existing = manager.QueryBeatmapSets(s => s.OnlineBeatmapSetID == importedBeatmap.Value.OnlineBeatmapSetID).ToList();
-
-                foreach (var s in existing)
-                {
-                    s.OnlineBeatmapSetID = null;
-                    foreach (var b in s.Beatmaps)
-                        b.OnlineBeatmapID = null;
-                    manager.Update(s);
-                }
-            });
-
             AddStep("import altered beatmap", () =>
             {
                 IBeatmap beatmap = CreateBeatmap(new OsuRuleset().RulesetInfo);
 
                 beatmap.BeatmapInfo.BaseDifficulty.CircleSize = 1;
+
+                // intentionally increment online IDs to clash with import below.
+                beatmap.BeatmapInfo.OnlineBeatmapID++;
+                beatmap.BeatmapInfo.BeatmapSet.OnlineBeatmapSetID++;
 
                 importedSet = manager.Import(beatmap.BeatmapInfo.BeatmapSet).Result.Value;
             });

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -15,6 +15,7 @@ using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual.OnlinePlay;
@@ -65,8 +66,31 @@ namespace osu.Game.Tests.Visual.Playlists
                 });
             });
 
+            AddUntilStep("Progress details are hidden", () => match.ChildrenOfType<RoomLocalUserInfo>().FirstOrDefault()?.Parent.Alpha == 0);
+
             AddStep("start match", () => match.ChildrenOfType<PlaylistsReadyButton>().First().TriggerClick());
             AddUntilStep("player loader loaded", () => Stack.CurrentScreen is PlayerLoader);
+        }
+
+        [Test]
+        public void TestAttemptLimitedMatch()
+        {
+            setupAndCreateRoom(room =>
+            {
+                room.RoomID.Value = 1; // forces room creation.
+                room.Name.Value = "my awesome room";
+                room.MaxAttempts.Value = 5;
+                room.Host.Value = API.LocalUser.Value;
+                room.RecentParticipants.Add(room.Host.Value);
+                room.EndDate.Value = DateTimeOffset.Now.AddMinutes(5);
+                room.Playlist.Add(new PlaylistItem
+                {
+                    Beatmap = { Value = importedBeatmap.Value.Beatmaps.First() },
+                    Ruleset = { Value = new OsuRuleset().RulesetInfo }
+                });
+            });
+
+            AddUntilStep("Progress details are visible", () => match.ChildrenOfType<RoomLocalUserInfo>().FirstOrDefault()?.Parent.Alpha == 1);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -77,7 +77,6 @@ namespace osu.Game.Tests.Visual.Playlists
         {
             setupAndCreateRoom(room =>
             {
-                room.RoomID.Value = 1; // forces room creation.
                 room.Name.Value = "my awesome room";
                 room.MaxAttempts.Value = 5;
                 room.Host.Value = API.LocalUser.Value;

--- a/osu.Game/Tests/Beatmaps/TestBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestBeatmap.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.IO;
@@ -16,6 +17,9 @@ namespace osu.Game.Tests.Beatmaps
 {
     public class TestBeatmap : Beatmap
     {
+        private static int onlineSetID;
+        private static int onlineBeatmapID;
+
         public TestBeatmap(RulesetInfo ruleset, bool withHitObjects = true)
         {
             var baseBeatmap = CreateBeatmap();
@@ -31,8 +35,10 @@ namespace osu.Game.Tests.Beatmaps
             BeatmapInfo.RulesetID = ruleset.ID ?? 0;
             BeatmapInfo.BeatmapSet.Metadata = BeatmapInfo.Metadata;
             BeatmapInfo.BeatmapSet.Beatmaps = new List<BeatmapInfo> { BeatmapInfo };
+            BeatmapInfo.BeatmapSet.OnlineBeatmapSetID = Interlocked.Increment(ref onlineSetID);
             BeatmapInfo.Length = 75000;
             BeatmapInfo.OnlineInfo = new APIBeatmap();
+            BeatmapInfo.OnlineBeatmapID = Interlocked.Increment(ref onlineBeatmapID);
             BeatmapInfo.BeatmapSet.OnlineInfo = new APIBeatmapSet
             {
                 Status = BeatmapSetOnlineStatus.Ranked,


### PR DESCRIPTION
The order of operation of imports means that the already-imported instances are considered most correct (they have usually been populated using an online source, although that is skipped in tests), so on two consecutive test imports in a test scene, the second will lose its online IDs completely.

This aims to ensure that all test beatmaps will have online IDs, which is the general expected behaviour, fixing the issue mentioned in https://github.com/ppy/osu/pull/15316#issuecomment-953550837.

Also adds missing test coverage for attempt count display (see https://github.com/ppy/osu/pull/15307#issuecomment-952561400).