### PR TITLE
Prevent song progress texts from rotating/flipping when the progress bar is rotated/flipped

### DIFF
--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Screens.Play
                     Anchor = Anchor.BottomLeft,
                     RelativeSizeAxes = Axes.X,
                     Height = info_height,
+                    SongProgressParent = this
                 },
                 graph = new SongProgressGraph
                 {

--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -18,6 +18,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play
 {
+    [Cached]
     public class SongProgress : OverlayContainer, ISkinnableDrawable
     {
         public const float MAX_HEIGHT = info_height + bottom_bar_height + graph_height + handle_height;
@@ -94,7 +95,6 @@ namespace osu.Game.Screens.Play
                     Anchor = Anchor.BottomLeft,
                     RelativeSizeAxes = Axes.X,
                     Height = info_height,
-                    SongProgressParent = this
                 },
                 graph = new SongProgressGraph
                 {

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Play
 
                 bool flipVectors = (((int)Math.Floor(songProgress.Rotation / 90)) & 1) == 1;
 
-                if(!flipVectors)
+                if (!flipVectors)
                 {
                     timeCurrent.Scale = new osuTK.Vector2 { X = Math.Sign(songProgress.Scale.X), Y = Math.Sign(songProgress.Scale.Y) };
                     progress.Scale = new osuTK.Vector2 { X = Math.Sign(songProgress.Scale.X), Y = Math.Sign(songProgress.Scale.Y) };

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Screens.Play
 {
     public class SongProgressInfo : Container
     {
+        public SongProgress SongProgressParent;
+
         private OsuSpriteText timeCurrent;
         private OsuSpriteText timeLeft;
         private OsuSpriteText progress;

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -78,6 +78,28 @@ namespace osu.Game.Screens.Play
                     },
                 }
             };
+
+            SongProgressParent.OnUpdate += songProgress =>
+            {
+                timeCurrent.Rotation = -songProgress.Rotation;
+                progress.Rotation = -songProgress.Rotation;
+                timeLeft.Rotation = -songProgress.Rotation;
+
+                bool flipVectors = (((int)Math.Floor(songProgress.Rotation / 90)) & 1) == 1;
+
+                if(!flipVectors)
+                {
+                    timeCurrent.Scale = new osuTK.Vector2 { X = Math.Sign(songProgress.Scale.X), Y = Math.Sign(songProgress.Scale.Y) };
+                    progress.Scale = new osuTK.Vector2 { X = Math.Sign(songProgress.Scale.X), Y = Math.Sign(songProgress.Scale.Y) };
+                    timeLeft.Scale = new osuTK.Vector2 { X = Math.Sign(songProgress.Scale.X), Y = Math.Sign(songProgress.Scale.Y) };
+                }
+                else
+                {
+                    timeCurrent.Scale = new osuTK.Vector2 { Y = Math.Sign(songProgress.Scale.X), X = Math.Sign(songProgress.Scale.Y) };
+                    progress.Scale = new osuTK.Vector2 { Y = Math.Sign(songProgress.Scale.X), X = Math.Sign(songProgress.Scale.Y) };
+                    timeLeft.Scale = new osuTK.Vector2 { Y = Math.Sign(songProgress.Scale.X), X = Math.Sign(songProgress.Scale.Y) };
+                }
+            };
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -12,8 +12,6 @@ namespace osu.Game.Screens.Play
 {
     public class SongProgressInfo : Container
     {
-        public SongProgress SongProgressParent;
-
         private OsuSpriteText timeCurrent;
         private OsuSpriteText timeLeft;
         private OsuSpriteText progress;
@@ -39,12 +37,16 @@ namespace osu.Game.Screens.Play
         }
 
         private GameplayClock gameplayClock;
+        private SongProgress songProgressParent;
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, GameplayClock clock)
+        private void load(OsuColour colours, GameplayClock clock, SongProgress parent)
         {
             if (clock != null)
                 gameplayClock = clock;
+
+            if (parent != null)
+                songProgressParent = parent;
 
             Children = new Drawable[]
             {

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play
             {
                 timeCurrent = new OsuSpriteText
                 {
-                    Origin = Anchor.BottomLeft,
+                    Origin = Anchor.Centre,
                     Anchor = Anchor.BottomLeft,
                     Colour = colours.BlueLighter,
                     Font = OsuFont.Numeric,
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Play
                 },
                 timeLeft = new OsuSpriteText
                 {
-                    Origin = Anchor.BottomRight,
+                    Origin = Anchor.Centre,
                     Anchor = Anchor.BottomRight,
                     Colour = colours.BlueLighter,
                     Font = OsuFont.Numeric,

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -132,31 +132,22 @@ namespace osu.Game.Screens.Play
             Anchor timeLeftOriginX = Anchor.x2;
             Anchor timeLeftOriginY = Anchor.y2;
 
-            // Current Time Text
-            // Rotation : Swap Left<->Right, Rotation : Swap Bottom<->Top
-            // -90, -180/180 : flip origin horizontally, 90, 180/-180 : flip origin vertically
+            // We use a proper maths modulus (negative % positive = positive) to make the if statements smaller
+            int parentRotationInQuarterTurnsModFour = parentRotationInQuarterTurns % 4;
+            if (parentRotationInQuarterTurnsModFour < 0) parentRotationInQuarterTurnsModFour += 4;
 
-            // Time Left Text
-            // Rotation : Swap Left<->Right, Rotation : Swap Bottom<->Top
-            // 90, 180/-180 : flip origin horizontally, -90, -180/180 : flip origin vertically
-            if (parentRotationInQuarterTurns == -1 || parentRotationInQuarterTurns == 2 || parentRotationInQuarterTurns == -2)
+            // 90 & 180: flip current time origin vertically, flip time left origin horizontally
+            if (parentRotationInQuarterTurnsModFour == 3 || parentRotationInQuarterTurnsModFour == 2)
             {
                 currentTimeOriginX = flipXAnchor(currentTimeOriginX);
                 timeLeftOriginY = flipYAnchor(timeLeftOriginY);
             }
 
-            if (parentRotationInQuarterTurns == 1 || parentRotationInQuarterTurns == 2 || parentRotationInQuarterTurns == -2)
+            // 270 & 180: flip current time origin horizontally, flip time left origin vertically
+            if (parentRotationInQuarterTurnsModFour == 1 || parentRotationInQuarterTurnsModFour == 2)
             {
                 currentTimeOriginY = flipYAnchor(currentTimeOriginY);
                 timeLeftOriginX = flipXAnchor(timeLeftOriginX);
-            }
-
-            // Non-centered text pokes out of the bounding box when the progress bar is horizontal
-            // So we center it when that happens
-            if (parentRotationInQuarterTurns == -1 || parentRotationInQuarterTurns == 1)
-            {
-                currentTimeOriginX = Anchor.x1;
-                timeLeftOriginX = Anchor.x1;
             }
 
             // If parent is flipped horizontally: flip origins horizontally


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/14953.

It works, but I'm afraid it's not very reusable, since I'm not very familiar with the framework or the lazer codebase.