### PR TITLE
Update text flow usages to use `ITextPart`

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1029.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Sprites;
 using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Graphics.Sprites;
@@ -71,26 +72,20 @@ namespace osu.Game.Graphics.Containers
             var spriteText = new OsuSpriteText { Text = text };
 
             AddText(spriteText, creationParameters);
-            createLink(spriteText.Yield(), new LinkDetails(action, argument), tooltipText);
+            createLink(new TextPartManual(spriteText.Yield()), new LinkDetails(action, argument), tooltipText);
         }
 
         public void AddLink(IEnumerable<SpriteText> text, LinkAction action, string linkArgument, string tooltipText = null)
         {
-            foreach (var t in text)
-                AddArbitraryDrawable(t);
-
-            createLink(text, new LinkDetails(action, linkArgument), tooltipText);
+            createLink(new TextPartManual(text), new LinkDetails(action, linkArgument), tooltipText);
         }
 
         public void AddUserLink(User user, Action<SpriteText> creationParameters = null)
             => createLink(AddText(user.Username, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user.Id.ToString()), "view profile");
 
-        private void createLink(IEnumerable<Drawable> drawables, LinkDetails link, string tooltipText, Action action = null)
+        private void createLink(ITextPart textPart, LinkDetails link, LocalisableString tooltipText, Action action = null)
         {
-            var linkCompiler = CreateLinkCompiler(drawables.OfType<SpriteText>());
-            linkCompiler.RelativeSizeAxes = Axes.Both;
-            linkCompiler.TooltipText = tooltipText;
-            linkCompiler.Action = () =>
+            Action onClickAction = () =>
             {
                 if (action != null)
                     action();
@@ -101,10 +96,41 @@ namespace osu.Game.Graphics.Containers
                     host.OpenUrlExternally(link.Argument);
             };
 
-            AddInternal(linkCompiler);
+            AddPart(new TextLink(textPart, tooltipText, onClickAction));
         }
 
-        protected virtual DrawableLinkCompiler CreateLinkCompiler(IEnumerable<SpriteText> parts) => new DrawableLinkCompiler(parts);
+        private class TextLink : TextPart
+        {
+            private readonly ITextPart innerPart;
+            private readonly LocalisableString tooltipText;
+            private readonly Action action;
+
+            public TextLink(ITextPart innerPart, LocalisableString tooltipText, Action action)
+            {
+                this.innerPart = innerPart;
+                this.tooltipText = tooltipText;
+                this.action = action;
+            }
+
+            protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)
+            {
+                var linkFlowContainer = (LinkFlowContainer)textFlowContainer;
+
+                innerPart.RecreateDrawablesFor(linkFlowContainer);
+                var drawables = innerPart.Drawables.ToList();
+
+                drawables.Add(linkFlowContainer.CreateLinkCompiler(innerPart).With(c =>
+                {
+                    c.RelativeSizeAxes = Axes.Both;
+                    c.TooltipText = tooltipText;
+                    c.Action = action;
+                }));
+
+                return drawables;
+            }
+        }
+
+        protected virtual DrawableLinkCompiler CreateLinkCompiler(ITextPart textPart) => new DrawableLinkCompiler(textPart);
 
         // We want the compilers to always be visible no matter where they are, so RelativeSizeAxes is used.
         // However due to https://github.com/ppy/osu-framework/issues/2073, it's possible for the compilers to be relative size in the flow's auto-size axes - an unsupported operation.

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -59,19 +59,20 @@ namespace osu.Game.Graphics.Containers
         }
 
         public void AddLink(string text, string url, Action<SpriteText> creationParameters = null) =>
-            createLink(AddText(text, creationParameters), new LinkDetails(LinkAction.External, url), url);
+            createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.External, url), url);
 
         public void AddLink(string text, Action action, string tooltipText = null, Action<SpriteText> creationParameters = null)
-            => createLink(AddText(text, creationParameters), new LinkDetails(LinkAction.Custom, string.Empty), tooltipText, action);
+            => createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.Custom, string.Empty), tooltipText, action);
 
         public void AddLink(string text, LinkAction action, string argument, string tooltipText = null, Action<SpriteText> creationParameters = null)
-            => createLink(AddText(text, creationParameters), new LinkDetails(action, argument), tooltipText);
+            => createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(action, argument), tooltipText);
 
         public void AddLink(LocalisableString text, LinkAction action, string argument, string tooltipText = null, Action<SpriteText> creationParameters = null)
         {
             var spriteText = new OsuSpriteText { Text = text };
 
             AddText(spriteText, creationParameters);
+            RemoveInternal(spriteText); // TODO: temporary, will go away when TextParts support localisation properly.
             createLink(new TextPartManual(spriteText.Yield()), new LinkDetails(action, argument), tooltipText);
         }
 
@@ -81,7 +82,7 @@ namespace osu.Game.Graphics.Containers
         }
 
         public void AddUserLink(User user, Action<SpriteText> creationParameters = null)
-            => createLink(AddText(user.Username, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user.Id.ToString()), "view profile");
+            => createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user.Id.ToString()), "view profile");
 
         private void createLink(ITextPart textPart, LinkDetails link, LocalisableString tooltipText, Action action = null)
         {

--- a/osu.Game/Graphics/Containers/OsuTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuTextFlowContainer.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -19,8 +19,8 @@ namespace osu.Game.Graphics.Containers
 
         protected override SpriteText CreateSpriteText() => new OsuSpriteText();
 
-        public void AddArbitraryDrawable(Drawable drawable) => AddInternal(drawable);
+        public ITextPart AddArbitraryDrawable(Drawable drawable) => AddPart(new TextPartManual(drawable.Yield()));
 
-        public IEnumerable<Drawable> AddIcon(IconUsage icon, Action<SpriteText> creationParameters = null) => AddText(icon.Icon.ToString(), creationParameters);
+        public ITextPart AddIcon(IconUsage icon, Action<SpriteText> creationParameters = null) => AddText(icon.Icon.ToString(), creationParameters);
     }
 }

--- a/osu.Game/Graphics/ErrorTextFlowContainer.cs
+++ b/osu.Game/Graphics/ErrorTextFlowContainer.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
 using osuTK.Graphics;
 
@@ -10,7 +10,7 @@ namespace osu.Game.Graphics
 {
     public class ErrorTextFlowContainer : OsuTextFlowContainer
     {
-        private readonly List<Drawable> errorDrawables = new List<Drawable>();
+        private readonly List<ITextPart> errorTextParts = new List<ITextPart>();
 
         public ErrorTextFlowContainer()
             : base(cp => cp.Font = cp.Font.With(size: 12))
@@ -19,7 +19,8 @@ namespace osu.Game.Graphics
 
         public void ClearErrors()
         {
-            errorDrawables.ForEach(d => d.Expire());
+            foreach (var textPart in errorTextParts)
+                RemovePart(textPart);
         }
 
         public void AddErrors(string[] errors)
@@ -29,7 +30,7 @@ namespace osu.Game.Graphics
             if (errors == null) return;
 
             foreach (string error in errors)
-                errorDrawables.AddRange(AddParagraph(error, cp => cp.Colour = Color4.Red));
+                errorTextParts.Add(AddParagraph(error, cp => cp.Colour = Color4.Red));
         }
     }
 }

--- a/osu.Game/Online/Chat/DrawableLinkCompiler.cs
+++ b/osu.Game/Online/Chat/DrawableLinkCompiler.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -29,6 +31,11 @@ namespace osu.Game.Online.Chat
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parts.Any(d => d.ReceivePositionalInputAt(screenSpacePos));
 
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new LinkHoverSounds(sampleSet, Parts);
+
+        public DrawableLinkCompiler(ITextPart part)
+            : this(part.Drawables.OfType<SpriteText>())
+        {
+        }
 
         public DrawableLinkCompiler(IEnumerable<Drawable> parts)
             : base(HoverSampleSet.Submit)

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -37,7 +36,7 @@ namespace osu.Game.Overlays.AccountCreation
         private IAPIProvider api { get; set; }
 
         private ShakeContainer registerShake;
-        private IEnumerable<Drawable> characterCheckText;
+        private ITextPart characterCheckText;
 
         private OsuTextBox[] textboxes;
         private LoadingLayer loadingLayer;
@@ -136,7 +135,7 @@ namespace osu.Game.Overlays.AccountCreation
             characterCheckText = passwordDescription.AddText("8 characters long");
             passwordDescription.AddText(". Choose something long but also something you will remember, like a line from your favourite song.");
 
-            passwordTextBox.Current.ValueChanged += password => { characterCheckText.ForEach(s => s.Colour = password.NewValue.Length == 0 ? Color4.White : Interpolation.ValueAt(password.NewValue.Length, Color4.OrangeRed, Color4.YellowGreen, 0, 8, Easing.In)); };
+            passwordTextBox.Current.ValueChanged += password => { characterCheckText.Drawables.ForEach(s => s.Colour = password.NewValue.Length == 0 ? Color4.White : Interpolation.ValueAt(password.NewValue.Length, Color4.OrangeRed, Color4.YellowGreen, 0, 8, Easing.In)); };
         }
 
         public override void OnEntering(IScreen last)

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -166,12 +165,12 @@ namespace osu.Game.Overlays.Changelog
             {
             }
 
-            protected override DrawableLinkCompiler CreateLinkCompiler(IEnumerable<SpriteText> parts) => new SupporterPromoLinkCompiler(parts);
+            protected override DrawableLinkCompiler CreateLinkCompiler(ITextPart textPart) => new SupporterPromoLinkCompiler(textPart);
 
             private class SupporterPromoLinkCompiler : DrawableLinkCompiler
             {
-                public SupporterPromoLinkCompiler(IEnumerable<Drawable> parts)
-                    : base(parts)
+                public SupporterPromoLinkCompiler(ITextPart part)
+                    : base(part)
                 {
                 }
 

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
@@ -25,7 +23,7 @@ namespace osu.Game.Overlays.Music
         public Action<BeatmapSetInfo> RequestSelection;
 
         private TextFlowContainer text;
-        private IEnumerable<Drawable> titleSprites;
+        private ITextPart titlePart;
 
         private ILocalisedBindableString title;
         private ILocalisedBindableString artist;
@@ -63,9 +61,14 @@ namespace osu.Game.Overlays.Music
                 if (set.OldValue?.Equals(Model) != true && set.NewValue?.Equals(Model) != true)
                     return;
 
-                foreach (Drawable s in titleSprites)
-                    s.FadeColour(set.NewValue.Equals(Model) ? selectedColour : Color4.White, FADE_DURATION);
+                updateSelectionState(false);
             }, true);
+        }
+
+        private void updateSelectionState(bool instant)
+        {
+            foreach (Drawable s in titlePart.Drawables)
+                s.FadeColour(SelectedSet.Value?.Equals(Model) == true ? selectedColour : Color4.White, instant ? 0 : FADE_DURATION);
         }
 
         protected override Drawable CreateContent() => text = new OsuTextFlowContainer
@@ -79,7 +82,8 @@ namespace osu.Game.Overlays.Music
             text.Clear();
 
             // space after the title to put a space between the title and artist
-            titleSprites = text.AddText(title.Value + @"  ", sprite => sprite.Font = OsuFont.GetFont(weight: FontWeight.Regular)).OfType<SpriteText>();
+            titlePart = text.AddText(title.Value + @"  ", sprite => sprite.Font = OsuFont.GetFont(weight: FontWeight.Regular));
+            updateSelectionState(true);
 
             text.AddText(artist.Value, sprite =>
             {

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Menu
         private readonly Bindable<User> currentUser = new Bindable<User>();
         private FillFlowContainer fill;
 
-        private readonly List<Drawable> expendableText = new List<Drawable>();
+        private readonly List<ITextPart> expendableText = new List<ITextPart>();
 
         public Disclaimer(OsuScreen nextScreen = null)
         {
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Menu
 
             textFlow.AddText("this is osu!", t => t.Font = t.Font.With(Typeface.Torus, 30, FontWeight.Regular));
 
-            expendableText.AddRange(textFlow.AddText("lazer", t =>
+            expendableText.Add(textFlow.AddText("lazer", t =>
             {
                 t.Font = t.Font.With(Typeface.Torus, 30, FontWeight.Regular);
                 t.Colour = colours.PinkLight;
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Menu
                 t.Font = t.Font.With(Typeface.Torus, 20, FontWeight.SemiBold);
                 t.Colour = colours.Pink;
             });
-            expendableText.AddRange(textFlow.AddText(" coming to osu!", formatRegular));
+            expendableText.Add(textFlow.AddText(" coming to osu!", formatRegular));
             textFlow.AddText(".", formatRegular);
 
             textFlow.NewParagraph();
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Menu
                     t.Font = t.Font.With(size: 20);
                     t.Origin = Anchor.Centre;
                     t.Colour = colours.Pink;
-                }).First();
+                }).Drawables.First();
 
                 if (IsLoaded)
                     animateHeart();
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Menu
                 using (BeginDelayedSequence(520 + 160))
                 {
                     fill.MoveToOffset(new Vector2(0, 15), 160, Easing.OutQuart);
-                    Schedule(() => expendableText.ForEach(t =>
+                    Schedule(() => expendableText.SelectMany(t => t.Drawables).ForEach(t =>
                     {
                         t.FadeOut(100);
                         t.ScaleTo(new Vector2(0, 1), 100, Easing.OutQuart);

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1029.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1029.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1029.0" />
     <PackageReference Include="SharpCompress" Version="0.28.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Companion piece to / depends on https://github.com/ppy/osu-framework/pull/4703.

Mostly looks like a refactoring pull at this stage because this is only part 1 of 2 as stated on the framework-side pull, the text flow doesn't accept `LocalisableString`s just yet.

There is one ugly usage in the `LinkFlowContainer.AddLink()` usage that tries to roll its own local localisable string handling but that one is going away when all of this is supported properly at the ground level.