### PR TITLE
Add a note about `OnlineID` potentially being zero in non-autoincrement cases

### DIFF
--- a/osu.Game/Database/IHasOnlineID.cs
+++ b/osu.Game/Database/IHasOnlineID.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Database
     public interface IHasOnlineID
     {
         /// <summary>
-        /// The server-side ID representing this instance, if one exists. Any value 0 or less denotes a missing ID.
+        /// The server-side ID representing this instance, if one exists. Any value 0 or less denotes a missing ID (except in special cases where autoincrement is not used, like rulesets).
         /// </summary>
         /// <remarks>
         /// Generally we use -1 when specifying "missing" in code, but values of 0 are also considered missing as the online source


### PR DESCRIPTION
Opening this mainly for further discussion. The one cases where this was incorrect is `RulesetID`, which is zero for osu! ruleset. It may be decided that we want to change how this xmldoc reads to allow for conformity, but the solutions I've come up with aren't great. If we want to be checking for `-1` or `< 0`, for instance, we will need to ensure all ID values are pre-populated with -1. Can get a bit messy with serialisation.