### PR TITLE
Applying regex into exported maps with incompatible characters

### DIFF
--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -7,16 +7,9 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using osu.Framework.Audio.Track;
-using osu.Framework.Bindables;
-using osu.Framework.Extensions;
-using osu.Framework.Graphics.Textures;
-using osu.Framework.Logging;
-using osu.Framework.Platform;
-using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Database;
 using osu.Game.IO;
@@ -190,6 +183,9 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSkin">The beatmap <see cref="ISkin"/> content to write, null if to be omitted.</param>
         public virtual void Save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin beatmapSkin = null)
         {
+            // Regex to clean map name from incompatible characters before exporting
+            Regex charRule = new Regex(@"[/\\<>|?*"":]+", RegexOptions.Multiline);
+
             var setInfo = beatmapInfo.BeatmapSet;
 
             // Difficulty settings must be copied first due to the clone in `Beatmap<>.BeatmapInfo_Set`.
@@ -215,8 +211,9 @@ namespace osu.Game.Beatmaps
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
 
+                    // Replaceing unwanted characters.
                     // metadata may have changed; update the path with the standard format.
-                    beatmapInfo.Path = $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu";
+                    beatmapInfo.Path = charRule.Replace($"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu", string.Empty);
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 
                     // update existing or populate new file's filename.

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -219,9 +219,6 @@ namespace osu.Game.Beatmaps
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
 
-                    String name = "// LOVE; server IP=argv(HEART);(EXIT_FAILURE);";
-                    name = charRule.Replace(name, string.Empty);
-
                     // Replaceing unwanted characters.
                     // metadata may have changed; update the path with the standard format.
                     beatmapInfo.Path = charRule.Replace($"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu", string.Empty);

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -10,6 +10,14 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Database;
 using osu.Game.IO;
@@ -210,6 +218,9 @@ namespace osu.Game.Beatmaps
 
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
+
+                    String name = "// LOVE; server IP=argv(HEART);(EXIT_FAILURE);";
+                    name = charRule.Replace(name, string.Empty);
 
                     // Replaceing unwanted characters.
                     // metadata may have changed; update the path with the standard format.

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -191,9 +190,6 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSkin">The beatmap <see cref="ISkin"/> content to write, null if to be omitted.</param>
         public virtual void Save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin beatmapSkin = null)
         {
-            // Regex to clean map name from incompatible characters before exporting
-            Regex charRule = new Regex(@"[/\\<>|?*"":]+", RegexOptions.Multiline);
-
             var setInfo = beatmapInfo.BeatmapSet;
 
             // Difficulty settings must be copied first due to the clone in `Beatmap<>.BeatmapInfo_Set`.
@@ -219,9 +215,8 @@ namespace osu.Game.Beatmaps
                     // grab the original file (or create a new one if not found).
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
 
-                    // Replaceing unwanted characters.
                     // metadata may have changed; update the path with the standard format.
-                    beatmapInfo.Path = charRule.Replace($"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu", string.Empty);
+                    beatmapInfo.Path = GetValidFilename($"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu");
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 
                     // update existing or populate new file's filename.

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -466,7 +466,7 @@ namespace osu.Game.Database
             if (retrievedItem == null)
                 throw new ArgumentException(@"Specified model could not be found", nameof(item));
 
-            string filename = $"{getValidFilename(item.ToString())}{HandledExtensions.First()}";
+            string filename = $"{GetValidFilename(item.ToString())}{HandledExtensions.First()}";
 
             using (var stream = exportStorage.GetStream(filename, FileAccess.Write, FileMode.Create))
                 ExportModelTo(retrievedItem, stream);
@@ -913,7 +913,7 @@ namespace osu.Game.Database
             return Guid.NewGuid().ToString();
         }
 
-        private string getValidFilename(string filename)
+        protected static string GetValidFilename(string filename)
         {
             foreach (char c in Path.GetInvalidFileNameChars())
                 filename = filename.Replace(c, '_');


### PR DESCRIPTION
Hello, this is my first PR and first contribution ever. I saw ppy on stream yesterday on twitch and it gave me courage to take one issue to try to fix it. I know this issue already has a fix, but i thought that fix wasn't a performative one, also, string.Empty doesn't create an object, where "" creates, so it is even more performative.

The purpose of this change is to clean incompatible characters before exporting a map. Windows filesystem doesn't allows `/  \ < > | ? * " :` characters.

To remedy this i've created a regex to clean the map name before exporting it.

Example:
`// LOVE; server IP=argv(HEART);(EXIT_FAILURE);` -> ` LOVE; server IP=argv(HEART);(EXIT_FAILURE);`

Any advices are greatly appreciated!

Closes #14758