### PR TITLE
Fix star rating not updating for some mods on details tab in song select

### DIFF
--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -94,9 +94,6 @@ namespace osu.Game.Screens.Select.Details
             modSettingChangeTracker = new ModSettingChangeTracker(mods.NewValue);
             modSettingChangeTracker.SettingChanged += m =>
             {
-                if (!(m is IApplicableToDifficulty))
-                    return;
-
                 debouncedStatisticsUpdate?.Cancel();
                 debouncedStatisticsUpdate = Scheduler.AddDelayed(updateStatistics, 100);
             };


### PR DESCRIPTION
- Closes #15329.
- Closes #14547.

`AdvancedStats` was locally assuming that the only changes in mods that are relevant to it are if the mods are `IApplicableToDifficulty`. This is not true, as other mods (such as `IApplicableToRate` mods, or more recently, Flashlight) can also affect star difficulty, which is shown on one of the bars in `AdvancedStats`.