### PR TITLE
Reduce fail animation tint slightly

### DIFF
--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -10,6 +10,7 @@ using ManagedBass.Fx;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -83,7 +84,7 @@ namespace osu.Game.Screens.Play
                 Content,
                 redFlashLayer = new Box
                 {
-                    Colour = Color4.Red,
+                    Colour = Color4.Red.Opacity(0.6f),
                     RelativeSizeAxes = Axes.Both,
                     Blending = BlendingParameters.Additive,
                     Depth = float.MinValue,


### PR DESCRIPTION
General consensus from [reports](https://github.com/ppy/osu/discussions/15322#discussioncomment-1560351) and twitter is that the new fail animation is too bright, so let's reduce it slightly. Would rather it was not so bright that people are reaching to disable it immediately.