### PR TITLE
Fix incorrect state transition in score download tracker

### DIFF
--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -122,10 +122,8 @@ namespace osu.Game.Online
             {
                 Schedule(() =>
                 {
-                    if (!checkEquality(item, TrackedItem))
-                        return;
-
-                    UpdateState(DownloadState.NotDownloaded);
+                    if (checkEquality(item, TrackedItem))
+                        UpdateState(DownloadState.LocallyAvailable);
                 });
             }
         }


### PR DESCRIPTION
Regressed in #15321. Would cause the "download replay" button to revert to the "not downloaded" state upon successful download & import.

Changed to match analogous condition in `BeatmapDownloadTracker`:

https://github.com/ppy/osu/blob/f0b012ebb6855e31b8cb3a3f3bd8b03eef8591c1/osu.Game/Online/BeatmapDownloadTracker.cs#L119-L129