### PR TITLE
Add basic elements of new beatmap cards

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
@@ -1,0 +1,162 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Beatmaps
+{
+    public class TestSceneBeatmapCard : OsuTestScene
+    {
+        private IBeatmapSetInfo[] testCases;
+
+        #region Test case generation
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var normal = CreateAPIBeatmapSet(Ruleset.Value);
+            normal.HasVideo = true;
+            normal.HasStoryboard = true;
+
+            var undownloadable = getUndownloadableBeatmapSet();
+            var manyDifficulties = getManyDifficultiesBeatmapSet();
+
+            var explicitMap = CreateAPIBeatmapSet(Ruleset.Value);
+            explicitMap.HasExplicitContent = true;
+
+            var featuredMap = CreateAPIBeatmapSet(Ruleset.Value);
+            featuredMap.TrackId = 1;
+
+            var explicitFeaturedMap = CreateAPIBeatmapSet(Ruleset.Value);
+            explicitFeaturedMap.HasExplicitContent = true;
+            explicitFeaturedMap.TrackId = 2;
+
+            testCases = new IBeatmapSetInfo[]
+            {
+                normal,
+                undownloadable,
+                manyDifficulties,
+                explicitMap,
+                featuredMap,
+                explicitFeaturedMap
+            };
+        }
+
+        private APIBeatmapSet getUndownloadableBeatmapSet() => new APIBeatmapSet
+        {
+            OnlineID = 123,
+            Title = "undownloadable beatmap",
+            Artist = "test",
+            Source = "more tests",
+            Author = new User
+            {
+                Username = "BanchoBot",
+                Id = 3,
+            },
+            Availability = new BeatmapSetOnlineAvailability
+            {
+                DownloadDisabled = true,
+            },
+            Preview = @"https://b.ppy.sh/preview/12345.mp3",
+            PlayCount = 123,
+            FavouriteCount = 456,
+            BPM = 111,
+            HasVideo = true,
+            HasStoryboard = true,
+            Covers = new BeatmapSetOnlineCovers(),
+            Beatmaps = new List<APIBeatmap>
+            {
+                new APIBeatmap
+                {
+                    RulesetID = Ruleset.Value.OnlineID,
+                    DifficultyName = "Test",
+                    StarRating = 6.42,
+                }
+            }
+        };
+
+        private static APIBeatmapSet getManyDifficultiesBeatmapSet()
+        {
+            var beatmaps = new List<APIBeatmap>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                beatmaps.Add(new APIBeatmap
+                {
+                    RulesetID = i % 4,
+                    StarRating = 2 + i % 4 * 2,
+                });
+            }
+
+            return new APIBeatmapSet
+            {
+                OnlineID = 1,
+                Title = "many difficulties beatmap",
+                Artist = "test",
+                Author = new User
+                {
+                    Username = "BanchoBot",
+                    Id = 3,
+                },
+                HasVideo = true,
+                HasStoryboard = true,
+                Covers = new BeatmapSetOnlineCovers(),
+                Beatmaps = beatmaps,
+            };
+        }
+
+        #endregion
+
+        private Drawable createContent(OverlayColourScheme colourScheme, Func<IBeatmapSetInfo, Drawable> creationFunc)
+        {
+            var colourProvider = new OverlayColourProvider(colourScheme);
+
+            return new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(OverlayColourProvider), colourProvider)
+                },
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background5
+                    },
+                    new BasicScrollContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Full,
+                            Padding = new MarginPadding(10),
+                            Spacing = new Vector2(10),
+                            ChildrenEnumerable = testCases.Select(creationFunc)
+                        }
+                    }
+                }
+            };
+        }
+
+        private void createTestCase(Func<IBeatmapSetInfo, Drawable> creationFunc)
+        {
+            foreach (var scheme in Enum.GetValues(typeof(OverlayColourScheme)).Cast<OverlayColourScheme>())
+                AddStep($"set {scheme} scheme", () => Child = createContent(scheme, creationFunc));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -247,12 +247,6 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             FinishTransforms(true);
         }
 
-        private LocalisableString createArtistText()
-        {
-            var romanisableArtist = new RomanisableString(beatmapSet.ArtistUnicode, beatmapSet.Artist);
-            return BeatmapsetsStrings.ShowDetailsByArtist(romanisableArtist);
-        }
-
         protected override bool OnHover(HoverEvent e)
         {
             updateState();
@@ -263,6 +257,12 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         {
             updateState();
             base.OnHoverLost(e);
+        }
+
+        private LocalisableString createArtistText()
+        {
+            var romanisableArtist = new RomanisableString(beatmapSet.ArtistUnicode, beatmapSet.Artist);
+            return BeatmapsetsStrings.ShowDetailsByArtist(romanisableArtist);
         }
 
         private void updateState()

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
@@ -26,11 +24,11 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 {
     public class BeatmapCard : OsuClickableContainer
     {
+        public const float TRANSITION_DURATION = 400;
+
         private const float width = 408;
         private const float height = 100;
         private const float corner_radius = 10;
-
-        private const float transition_duration = 400;
 
         private readonly APIBeatmapSet beatmapSet;
 
@@ -38,7 +36,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         private FillFlowContainer iconArea;
 
         private Container mainContent;
-        private Box foregroundGradient;
+        private BeatmapCardContentBackground mainContentBackground;
 
         private GridContainer titleContainer;
         private GridContainer artistContainer;
@@ -96,14 +94,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     Masking = true,
                     Children = new Drawable[]
                     {
-                        new UpdateableOnlineBeatmapSetCover
+                        mainContentBackground = new BeatmapCardContentBackground
                         {
                             RelativeSizeAxes = Axes.Both,
-                            OnlineInfo = beatmapSet,
-                        },
-                        foregroundGradient = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
+                            BeatmapSet = beatmapSet,
                         },
                         new FillFlowContainer
                         {
@@ -278,13 +272,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             if (IsHovered)
                 targetWidth -= 20;
 
-            mainContent.ResizeWidthTo(targetWidth, transition_duration, Easing.OutQuint);
+            mainContent.ResizeWidthTo(targetWidth, TRANSITION_DURATION, Easing.OutQuint);
+            mainContentBackground.Dimmed.Value = IsHovered;
 
-            var foregroundColour = IsHovered ? colourProvider.Background4 : colourProvider.Background2;
-            var foregroundGradientColour = ColourInfo.GradientHorizontal(foregroundColour, foregroundColour.Opacity(0.8f));
-            foregroundGradient.FadeColour(foregroundGradientColour, transition_duration, Easing.OutQuint);
-
-            leftCover.FadeColour(IsHovered ? OsuColour.Gray(0.2f) : Color4.White, transition_duration, Easing.OutQuint);
+            leftCover.FadeColour(IsHovered ? OsuColour.Gray(0.2f) : Color4.White, TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -94,10 +94,9 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     Masking = true,
                     Children = new Drawable[]
                     {
-                        mainContentBackground = new BeatmapCardContentBackground
+                        mainContentBackground = new BeatmapCardContentBackground(beatmapSet)
                         {
                             RelativeSizeAxes = Axes.Both,
-                            BeatmapSet = beatmapSet,
                         },
                         new FillFlowContainer
                         {

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -1,0 +1,248 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapSet;
+using osuTK;
+using osu.Game.Overlays.BeatmapListing.Panels;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Beatmaps.Drawables.Cards
+{
+    public class BeatmapCard : OsuClickableContainer
+    {
+        private const float width = 408;
+        private const float height = 100;
+        private const float corner_radius = 10;
+
+        private readonly APIBeatmapSet beatmapSet;
+        private FillFlowContainer iconArea;
+        private GridContainer titleContainer;
+        private GridContainer artistContainer;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; }
+
+        public BeatmapCard(APIBeatmapSet beatmapSet)
+            : base(HoverSampleSet.Submit)
+        {
+            this.beatmapSet = beatmapSet;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Width = width;
+            Height = height;
+            CornerRadius = corner_radius;
+            Masking = true;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background3
+                },
+                new Container
+                {
+                    Name = @"Left (icon) area",
+                    Size = new Vector2(height),
+                    Children = new Drawable[]
+                    {
+                        new UpdateableOnlineBeatmapSetCover(BeatmapSetCoverType.List)
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            OnlineInfo = beatmapSet
+                        },
+                        iconArea = new FillFlowContainer
+                        {
+                            Margin = new MarginPadding(5),
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(1)
+                        }
+                    }
+                },
+                new Container
+                {
+                    Name = @"Main content",
+                    X = height - corner_radius,
+                    Width = width - height,
+                    Height = height,
+                    CornerRadius = corner_radius,
+                    Masking = true,
+                    Children = new Drawable[]
+                    {
+                        new UpdateableOnlineBeatmapSetCover
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            OnlineInfo = beatmapSet,
+                        },
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background2, colourProvider.Background2.Opacity(0.8f)),
+                        },
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding
+                            {
+                                Horizontal = 10,
+                                Vertical = 4
+                            },
+                            Direction = FillDirection.Vertical,
+                            Children = new Drawable[]
+                            {
+                                titleContainer = new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    ColumnDimensions = new[]
+                                    {
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    RowDimensions = new[]
+                                    {
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    Content = new[]
+                                    {
+                                        new[]
+                                        {
+                                            new OsuSpriteText
+                                            {
+                                                Text = new RomanisableString(beatmapSet.TitleUnicode, beatmapSet.Title),
+                                                Font = OsuFont.Default.With(size: 22.5f, weight: FontWeight.SemiBold),
+                                                RelativeSizeAxes = Axes.X,
+                                                Truncate = true
+                                            },
+                                            Empty()
+                                        }
+                                    }
+                                },
+                                artistContainer = new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    ColumnDimensions = new[]
+                                    {
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    RowDimensions = new[]
+                                    {
+                                        new Dimension(GridSizeMode.AutoSize)
+                                    },
+                                    Content = new[]
+                                    {
+                                        new[]
+                                        {
+                                            new OsuSpriteText
+                                            {
+                                                Text = createArtistText(),
+                                                Font = OsuFont.Default.With(size: 17.5f, weight: FontWeight.SemiBold),
+                                                RelativeSizeAxes = Axes.X,
+                                                Truncate = true
+                                            },
+                                            Empty()
+                                        },
+                                    }
+                                },
+                                new LinkFlowContainer(s =>
+                                {
+                                    s.Shadow = false;
+                                    s.Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold);
+                                }).With(d =>
+                                {
+                                    d.AutoSizeAxes = Axes.Both;
+                                    d.Margin = new MarginPadding { Top = 2 };
+                                    d.AddText("mapped by ", t => t.Colour = colourProvider.Content2);
+                                    d.AddUserLink(beatmapSet.Author);
+                                }),
+                            }
+                        },
+                        new FillFlowContainer
+                        {
+                            Name = @"Bottom content",
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Padding = new MarginPadding
+                            {
+                                Horizontal = 10,
+                                Vertical = 4
+                            },
+                            Spacing = new Vector2(4, 0),
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            Children = new Drawable[]
+                            {
+                                new BeatmapSetOnlineStatusPill
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Status = beatmapSet.Status,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft
+                                },
+                                new DifficultySpectrumDisplay(beatmapSet)
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    DotSize = new Vector2(6, 12)
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            if (beatmapSet.HasVideo)
+                iconArea.Add(new IconPill(FontAwesome.Solid.Film));
+
+            if (beatmapSet.HasStoryboard)
+                iconArea.Add(new IconPill(FontAwesome.Solid.Image));
+
+            if (beatmapSet.HasExplicitContent)
+            {
+                titleContainer.Content[0][1] = new ExplicitContentBeatmapPill
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding { Left = 5 }
+                };
+            }
+
+            if (beatmapSet.TrackId != null)
+            {
+                artistContainer.Content[0][1] = new FeaturedArtistBeatmapPill
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding { Left = 5 }
+                };
+            }
+        }
+
+        private LocalisableString createArtistText()
+        {
+            var romanisableArtist = new RomanisableString(beatmapSet.ArtistUnicode, beatmapSet.Artist);
+            return BeatmapsetsStrings.ShowDetailsByArtist(romanisableArtist);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContentBackground.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContentBackground.cs
@@ -1,0 +1,125 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays;
+
+namespace osu.Game.Beatmaps.Drawables.Cards
+{
+    public class BeatmapCardContentBackground : ModelBackedDrawable<IBeatmapSetOnlineInfo>
+    {
+        public IBeatmapSetOnlineInfo BeatmapSet
+        {
+            get => Model;
+            set => Model = value;
+        }
+
+        public new bool Masking
+        {
+            get => base.Masking;
+            set => base.Masking = value;
+        }
+
+        public BindableBool Dimmed { get; private set; } = new BindableBool();
+
+        protected override double LoadDelay => 500;
+
+        protected override double TransformDuration => 400;
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChild = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colourProvider.Background2
+            };
+        }
+
+        protected override DelayedLoadWrapper CreateDelayedLoadWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad)
+            => new DelayedLoadUnloadWrapper(createContentFunc, timeBeforeLoad);
+
+        protected override Drawable? CreateDrawable(IBeatmapSetOnlineInfo? model)
+        {
+            if (model == null)
+                return null;
+
+            return new BufferedBackground(model)
+            {
+                RelativeSizeAxes = Axes.Both,
+                Dimmed = { BindTarget = Dimmed }
+            };
+        }
+
+        private class BufferedBackground : BufferedContainer
+        {
+            public BindableBool Dimmed { get; } = new BindableBool();
+
+            private readonly IBeatmapSetOnlineInfo onlineInfo;
+
+            private readonly Box background;
+            private OnlineBeatmapSetCover? cover;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            public BufferedBackground(IBeatmapSetOnlineInfo onlineInfo)
+            {
+                this.onlineInfo = onlineInfo;
+
+                RelativeSizeAxes = Axes.Both;
+                InternalChild = background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                background.Colour = colourProvider.Background2;
+
+                LoadComponentAsync(new OnlineBeatmapSetCover(onlineInfo)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    FillMode = FillMode.Fill
+                }, loaded =>
+                {
+                    cover = loaded;
+                    cover.Colour = Colour4.Transparent;
+                    AddInternal(cover);
+                    FinishTransforms(true);
+                    updateState();
+                });
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                Dimmed.BindValueChanged(_ => updateState(), true);
+                FinishTransforms(true);
+            }
+
+            private void updateState()
+            {
+                if (cover == null)
+                    return;
+
+                background.FadeColour(Dimmed.Value ? colourProvider.Background4 : colourProvider.Background2, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+
+                var gradient = ColourInfo.GradientHorizontal(Colour4.White.Opacity(0), Colour4.White.Opacity(0.2f));
+                cover.FadeColour(gradient, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Another piece of #14216.

Based on designs from https://www.figma.com/file/oYJ9WkzXGvbPWBz6NxeyGr/UI%2FBeatmap-Card?node-id=112%3A2350 and current web appearance. Wherever there were conflicts between the two, web took precedence.

https://user-images.githubusercontent.com/20418176/139729830-9a511e7b-45c7-4939-9a6f-aac0c15793c1.mp4

A few pre-emptive notes, as some parts of this may seem controversial:

* I am doing this as a completely separate parallel implementation, alongside `BeatmapPanel`. The plan I was aiming for was to complete the parallel implementation, then replace existing usages of `BeatmapPanel`, then remove all of `BeatmapPanel` and its subcomponents that aren't used anywhere else.
  
  The reason why I am doing it this way is because on the designs above, there are 6 sizes of the card in total. I think that making them using the same inheritance-based paradigm as `BeatmapPanel` is not feasible and would be actively detrimental for code quality, so I want to do these ones using more duplication where necessary and composition of the true shared pieces.
* Font sizing was ballparked to match. I'm not really interested in getting into the CSS-compatible text sizing stuff as @frenzibyte was already elbow deep in it already, from what I recall.
* Due to size, statistics display on hover and button behaviour was cut from this diff. They will be coming as follow-up.
* There are two grid usages here. They are used to make truncation of artist and title sprite texts work properly. They can be removed on request in favour of an `Update()`-based solution.
* There is also a `BufferedContainer` usage for the main content background. The reason why I used it is that without it, there are ugly borders on the main content (especially visible when hovered) due to multiple layers not being flattened before masking:

  ![2021-11-01-195008_374x180_scrot](https://user-images.githubusercontent.com/20418176/139730481-3fbec3ff-c2fb-4ef5-a448-f0a4c4b90cd6.png)

  If you want to take a closer look at them locally, check out a59f2d7.