### PR TITLE
Default legacy decoder to `General` section, rather than none

### DIFF
--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -39,6 +39,15 @@ namespace osu.Game.Tests.Skins.IO
         });
 
         [Test]
+        public Task TestSingleImportMissingSectionHeader() => runSkinTest(async osu =>
+        {
+            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner", includeSectionHeader: false), "skin.osk"));
+
+            // When the import filename doesn't match, it should be appended (and update the skin.ini).
+            assertCorrectMetadata(import1, "test skin [skin]", "skinner", osu);
+        });
+
+        [Test]
         public Task TestSingleImportMatchingFilename() => runSkinTest(async osu =>
         {
             var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "test skin.osk"));
@@ -199,21 +208,23 @@ namespace osu.Game.Tests.Skins.IO
             return zipStream;
         }
 
-        private MemoryStream createOskWithIni(string name, string author, bool makeUnique = false, string iniFilename = @"skin.ini")
+        private MemoryStream createOskWithIni(string name, string author, bool makeUnique = false, string iniFilename = @"skin.ini", bool includeSectionHeader = true)
         {
             var zipStream = new MemoryStream();
             using var zip = ZipArchive.Create();
-            zip.AddEntry(iniFilename, generateSkinIni(name, author, makeUnique));
+            zip.AddEntry(iniFilename, generateSkinIni(name, author, makeUnique, includeSectionHeader));
             zip.SaveTo(zipStream);
             return zipStream;
         }
 
-        private MemoryStream generateSkinIni(string name, string author, bool makeUnique = true)
+        private MemoryStream generateSkinIni(string name, string author, bool makeUnique = true, bool includeSectionHeader = true)
         {
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream);
 
-            writer.WriteLine("[General]");
+            if (includeSectionHeader)
+                writer.WriteLine("[General]");
+
             writer.WriteLine($"Name: {name}");
             writer.WriteLine($"Author: {author}");
 

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -47,10 +47,7 @@ namespace osu.Game.Beatmaps.Formats
                 if (line.StartsWith('[') && line.EndsWith(']'))
                 {
                     if (!Enum.TryParse(line[1..^1], out section))
-                    {
                         Logger.Log($"Unknown section \"{line}\" in \"{output}\"");
-                        section = Section.None;
-                    }
 
                     OnBeginNewSection(section);
                     continue;
@@ -148,7 +145,6 @@ namespace osu.Game.Beatmaps.Formats
 
         protected enum Section
         {
-            None,
             General,
             Editor,
             Metadata,

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Beatmaps.Formats
 
         protected override void ParseStreamInto(LineBufferedReader stream, T output)
         {
-            Section section = Section.None;
+            Section section = Section.General;
 
             string line;
 


### PR DESCRIPTION
This is mainly to reach parity with how stable handles such cases for skins specifically. It was brought to our attention after finding a skin with a malformed `\[General]` tag which did not break further parsing of the file on stable, but did on lazer.

Note that stable defaults to an "unknown" section for beatmaps, but functionally I can't think of a regression case from changing this to a "general" default.