### PR TITLE
Avoid any potential infinite loops when re-writing `skin.ini` files

### DIFF
--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -198,48 +198,30 @@ namespace osu.Game.Skinning
 
             if (existingFile != null)
             {
-                List<string> outputLines = new List<string>();
+                List<string> additionalLines = new List<string>();
 
-                bool addedName = false;
-                bool addedAuthor = false;
-
-                using (var stream = Files.Storage.GetStream(existingFile.FileInfo.StoragePath))
-                using (var sr = new StreamReader(stream))
+                additionalLines.AddRange(new[]
                 {
-                    string line;
-
-                    while ((line = sr.ReadLine()) != null)
-                    {
-                        if (line.StartsWith(@"Name:", StringComparison.Ordinal))
-                        {
-                            outputLines.Add(nameLine);
-                            addedName = true;
-                        }
-                        else if (line.StartsWith(@"Author:", StringComparison.Ordinal))
-                        {
-                            outputLines.Add(authorLine);
-                            addedAuthor = true;
-                        }
-                        else
-                            outputLines.Add(line);
-                    }
-                }
-
-                if (!addedName || !addedAuthor)
-                {
-                    outputLines.AddRange(new[]
-                    {
-                        @"[General]",
-                        nameLine,
-                        authorLine,
-                    });
-                }
+                    @"",
+                    @"// The following content was automatically added by osu! during import, based on filename / folder metadata.",
+                    @"[General]",
+                    nameLine,
+                    authorLine,
+                });
 
                 using (Stream stream = new MemoryStream())
                 {
                     using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     {
-                        foreach (string line in outputLines)
+                        using (var existingStream = Files.Storage.GetStream(existingFile.FileInfo.StoragePath))
+                        using (var sr = new StreamReader(existingStream))
+                        {
+                            string line;
+                            while ((line = sr.ReadLine()) != null)
+                                sw.WriteLine(line);
+                        }
+
+                        foreach (string line in additionalLines)
                             sw.WriteLine(line);
                     }
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -194,55 +194,77 @@ namespace osu.Game.Skinning
             string nameLine = @$"Name: {item.Name}";
             string authorLine = @$"Author: {item.Creator}";
 
+            var newLines = new[]
+            {
+                @"// The following content was automatically added by osu! during import, based on filename / folder metadata.",
+                @"[General]",
+                nameLine,
+                authorLine,
+            };
+
             var existingFile = item.Files.SingleOrDefault(f => f.Filename.Equals(@"skin.ini", StringComparison.OrdinalIgnoreCase));
 
-            if (existingFile != null)
+            if (existingFile == null)
             {
-                List<string> additionalLines = new List<string>();
+                // In the case a skin doesn't have a skin.ini yet, let's create one.
+                writeNewSkinIni();
+                return;
+            }
 
-                additionalLines.AddRange(new[]
+            using (Stream stream = new MemoryStream())
+            {
+                using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                 {
-                    @"",
-                    @"// The following content was automatically added by osu! during import, based on filename / folder metadata.",
-                    @"[General]",
-                    nameLine,
-                    authorLine,
-                });
-
-                using (Stream stream = new MemoryStream())
-                {
-                    using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+                    using (var existingStream = Files.Storage.GetStream(existingFile.FileInfo.StoragePath))
+                    using (var sr = new StreamReader(existingStream))
                     {
-                        using (var existingStream = Files.Storage.GetStream(existingFile.FileInfo.StoragePath))
-                        using (var sr = new StreamReader(existingStream))
-                        {
-                            string line;
-                            while ((line = sr.ReadLine()) != null)
-                                sw.WriteLine(line);
-                        }
-
-                        foreach (string line in additionalLines)
+                        string line;
+                        while ((line = sr.ReadLine()) != null)
                             sw.WriteLine(line);
                     }
 
-                    ReplaceFile(item, existingFile, stream);
+                    sw.WriteLine();
+
+                    foreach (string line in newLines)
+                        sw.WriteLine(line);
+                }
+
+                ReplaceFile(item, existingFile, stream);
+
+                // can be removed 20220502.
+                if (!ensureIniWasUpdated(item))
+                {
+                    Logger.Log($"Skin {item}'s skin.ini had issues and has been removed. Please report this and provide the problematic skin.", LoggingTarget.Database, LogLevel.Important);
+
+                    DeleteFile(item, item.Files.SingleOrDefault(f => f.Filename.Equals(@"skin.ini", StringComparison.OrdinalIgnoreCase)));
+                    writeNewSkinIni();
                 }
             }
-            else
+
+            void writeNewSkinIni()
             {
                 using (Stream stream = new MemoryStream())
                 {
                     using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     {
-                        sw.WriteLine(@"[General]");
-                        sw.WriteLine(nameLine);
-                        sw.WriteLine(authorLine);
-                        sw.WriteLine(@"Version: latest");
+                        foreach (string line in newLines)
+                            sw.WriteLine(line);
                     }
 
                     AddFile(item, stream, @"skin.ini");
                 }
             }
+        }
+
+        private bool ensureIniWasUpdated(SkinInfo item)
+        {
+            // This is a final consistency check to ensure that hash computation doesn't enter an infinite loop.
+            // With other changes to the surrounding code this should never be hit, but until we are 101% sure that there
+            // are no other cases let's avoid a hard startup crash by bailing and alerting.
+
+            var instance = GetSkin(item);
+
+            return instance.Configuration.SkinInfo.Name == item.Name;
         }
 
         protected override Task Populate(SkinInfo model, ArchiveReader archive, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This PR contains two important changes which are quite intertwined, so I've batched them in a single PR.

## Always write automated changes to skin metadata at the end of the file

Apart from being cleaner (and allowing removal at the point of export, if that is ever requires), this also gives us a better guarantee that the metadata is going to take effect.

By writing the `[General]` section ourselves, we avoid any issues that may be present from a user constructing the file (incorrectly) themselves, such as multiple `Title:` entries or a malformed `[General]` marker.

The main goal is to ensure that the name is updated to what we expect it to be by writing out the full section, rather than injecting the new metadata into a user-crafted section with string manipulation logic.

## Perform a consistency check by decoding the newly written `skin.ini` during `ComputeHash`

As this has regressed twice now, let's play it safe and bail rather than stack overflowing. Note that as all the underlying issues that could trigger this have been fixed, no additional tests have been added. To test, comment out `SkinManager.cs` line 228-229 to cause a failure. The new logic will kick in and show a log output message, but all tests will still (correctly) pass.