### PR TITLE
Fix crash when attempting to view global leaderboards

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public DateTimeOffset Date { get; set; }
 
         [JsonProperty(@"beatmap")]
+        [CanBeNull]
         public APIBeatmap Beatmap { get; set; }
 
         [JsonProperty("accuracy")]
@@ -46,6 +47,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public double? PP { get; set; }
 
         [JsonProperty(@"beatmapset")]
+        [CanBeNull]
         public APIBeatmapSet BeatmapSet
         {
             set
@@ -96,7 +98,7 @@ namespace osu.Game.Online.API.Requests.Responses
             {
                 TotalScore = TotalScore,
                 MaxCombo = MaxCombo,
-                BeatmapInfo = Beatmap.ToBeatmapInfo(rulesets),
+                BeatmapInfo = Beatmap?.ToBeatmapInfo(rulesets),
                 User = User,
                 Accuracy = Accuracy,
                 OnlineScoreID = OnlineID,


### PR DESCRIPTION
Pretty obvious failure. Should be fine without tests due to added null inference.

The plan was to make the whole class `#nullable` but that is a bit more high-effort (have this done on a branch that isn't ready yet).

As reported at https://github.com/ppy/osu/discussions/15422.