### PR TITLE
Fix multiplayer score submission not working

### DIFF
--- a/osu.Game/Online/Rooms/SubmitRoomScoreRequest.cs
+++ b/osu.Game/Online/Rooms/SubmitRoomScoreRequest.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Game.Online.API;
+using osu.Game.Online.Solo;
 using osu.Game.Scoring;
 
 namespace osu.Game.Online.Rooms
@@ -14,14 +15,14 @@ namespace osu.Game.Online.Rooms
         private readonly long scoreId;
         private readonly long roomId;
         private readonly long playlistItemId;
-        private readonly ScoreInfo scoreInfo;
+        private readonly SubmittableScore score;
 
         public SubmitRoomScoreRequest(long scoreId, long roomId, long playlistItemId, ScoreInfo scoreInfo)
         {
             this.scoreId = scoreId;
             this.roomId = roomId;
             this.playlistItemId = playlistItemId;
-            this.scoreInfo = scoreInfo;
+            score = new SubmittableScore(scoreInfo);
         }
 
         protected override WebRequest CreateWebRequest()
@@ -31,7 +32,7 @@ namespace osu.Game.Online.Rooms
             req.ContentType = "application/json";
             req.Method = HttpMethod.Put;
 
-            req.AddRaw(JsonConvert.SerializeObject(scoreInfo, new JsonSerializerSettings
+            req.AddRaw(JsonConvert.SerializeObject(score, new JsonSerializerSettings
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore
             }));


### PR DESCRIPTION
Due to using the incorrect type for serialisation (thanks @smoogipoo for pointing this out calmly and stopping my headless chicken running in its tracks).

Looking at web source `SubmittableScore` [should cover all fields](https://github.com/ppy/osu-web/blob/3b889b99c07aadbc6ac1ba3ee7c98b6d7ce6b173/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php#L192-L209). I've also tested manually.

No tests because unsure how to test, short of dumping json to string and comparing that with a ground truth value.