### PR TITLE
Fix multiplayer potentially getting incorrect beatmap availability state after changing beatmaps

### DIFF
--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -53,7 +53,10 @@ namespace osu.Game.Online.Rooms
                 downloadTracker?.RemoveAndDisposeImmediately();
 
                 downloadTracker = new BeatmapDownloadTracker(item.NewValue.Beatmap.Value.BeatmapSet);
-                downloadTracker.State.BindValueChanged(_ => updateAvailability());
+
+                AddInternal(downloadTracker);
+
+                downloadTracker.State.BindValueChanged(_ => updateAvailability(), true);
                 downloadTracker.Progress.BindValueChanged(_ =>
                 {
                     if (downloadTracker.State.Value != DownloadState.Downloading)
@@ -63,9 +66,7 @@ namespace osu.Game.Online.Rooms
                     // we don't want to flood the network with this, so rate limit how often we send progress updates.
                     if (progressUpdate?.Completed != false)
                         progressUpdate = Scheduler.AddDelayed(updateAvailability, progressUpdate == null ? 0 : 500);
-                });
-
-                AddInternal(downloadTracker);
+                }, true);
             }, true);
         }
 


### PR DESCRIPTION
Haven't found a repro case for this, but it does look like an issue. Have tested this doesn't break anything further.

Investigation triggered by discussion at https://github.com/ppy/osu/discussions/15426.