### PR TITLE
Fix score tracker not tracking non-online scores correctly

### DIFF
--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -35,7 +35,11 @@ namespace osu.Game.Online
                 return;
 
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
-            var scoreInfo = new ScoreInfo { OnlineScoreID = TrackedItem.OnlineScoreID };
+            var scoreInfo = new ScoreInfo
+            {
+                ID = TrackedItem.ID,
+                OnlineScoreID = TrackedItem.OnlineScoreID
+            };
 
             if (Manager.IsAvailableLocally(scoreInfo))
                 UpdateState(DownloadState.LocallyAvailable);


### PR DESCRIPTION
Fixes #15438.

Another awkward regression in transition... Because the code is marked as temporary (and it's getting late here) I'm not adding tests right now, but I will do so on request.

I guess I could also use `TrackedItem` directly there? Unsure what the way forward with that is, so I'm just going with the minimal change that preserves the shape of that temporary code there.