### PR TITLE
Update `TextFlowContainer` usages to consume `LocalisableString`s

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1029.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1103.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -7,12 +7,10 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using System.Collections.Generic;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Users;
 
 namespace osu.Game.Graphics.Containers
@@ -58,23 +56,14 @@ namespace osu.Game.Graphics.Containers
             AddText(text.Substring(previousLinkEnd));
         }
 
-        public void AddLink(string text, string url, Action<SpriteText> creationParameters = null) =>
+        public void AddLink(LocalisableString text, string url, Action<SpriteText> creationParameters = null) =>
             createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.External, url), url);
 
-        public void AddLink(string text, Action action, string tooltipText = null, Action<SpriteText> creationParameters = null)
+        public void AddLink(LocalisableString text, Action action, string tooltipText = null, Action<SpriteText> creationParameters = null)
             => createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.Custom, string.Empty), tooltipText, action);
 
-        public void AddLink(string text, LinkAction action, string argument, string tooltipText = null, Action<SpriteText> creationParameters = null)
-            => createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(action, argument), tooltipText);
-
         public void AddLink(LocalisableString text, LinkAction action, string argument, string tooltipText = null, Action<SpriteText> creationParameters = null)
-        {
-            var spriteText = new OsuSpriteText { Text = text };
-
-            AddText(spriteText, creationParameters);
-            RemoveInternal(spriteText); // TODO: temporary, will go away when TextParts support localisation properly.
-            createLink(new TextPartManual(spriteText.Yield()), new LinkDetails(action, argument), tooltipText);
-        }
+            => createLink(CreateChunkFor(text, true, CreateSpriteText, creationParameters), new LinkDetails(action, argument), tooltipText);
 
         public void AddLink(IEnumerable<SpriteText> text, LinkAction action, string linkArgument, string tooltipText = null)
         {

--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Graphics.UserInterface
@@ -19,7 +20,7 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         protected virtual bool PlaySoundsOnUserChange => true;
 
-        public string LabelText
+        public LocalisableString LabelText
         {
             set
             {

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
@@ -8,6 +8,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osuTK;
@@ -156,18 +157,18 @@ namespace osu.Game.Graphics.UserInterfaceV2
             descriptionText.Colour = osuColour.Yellow;
         }
 
-        public string Label
+        public LocalisableString Label
         {
             set => labelText.Text = value;
         }
 
-        public string Description
+        public LocalisableString Description
         {
             set
             {
                 descriptionText.Text = value;
 
-                if (!string.IsNullOrEmpty(value))
+                if (value == default)
                     descriptionText.Show();
                 else
                     descriptionText.Hide();

--- a/osu.Game/Online/Placeholders/ClickablePlaceholder.cs
+++ b/osu.Game/Online/Placeholders/ClickablePlaceholder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 
@@ -12,7 +13,7 @@ namespace osu.Game.Online.Placeholders
     {
         public Action Action;
 
-        public ClickablePlaceholder(string actionMessage, IconUsage icon)
+        public ClickablePlaceholder(LocalisableString actionMessage, IconUsage icon)
         {
             OsuTextFlowContainer textFlow;
 

--- a/osu.Game/Online/Placeholders/MessagePlaceholder.cs
+++ b/osu.Game/Online/Placeholders/MessagePlaceholder.cs
@@ -3,14 +3,15 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Online.Placeholders
 {
     public class MessagePlaceholder : Placeholder
     {
-        private readonly string message;
+        private readonly LocalisableString message;
 
-        public MessagePlaceholder(string message)
+        public MessagePlaceholder(LocalisableString message)
         {
             AddIcon(FontAwesome.Solid.ExclamationCircle, cp =>
             {

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
@@ -135,7 +134,16 @@ namespace osu.Game.Overlays.AccountCreation
             characterCheckText = passwordDescription.AddText("8 characters long");
             passwordDescription.AddText(". Choose something long but also something you will remember, like a line from your favourite song.");
 
-            passwordTextBox.Current.ValueChanged += password => { characterCheckText.Drawables.ForEach(s => s.Colour = password.NewValue.Length == 0 ? Color4.White : Interpolation.ValueAt(password.NewValue.Length, Color4.OrangeRed, Color4.YellowGreen, 0, 8, Easing.In)); };
+            passwordTextBox.Current.BindValueChanged(_ => updateCharacterCheckTextColour(), true);
+            characterCheckText.DrawablePartsRecreated += _ => updateCharacterCheckTextColour();
+        }
+
+        private void updateCharacterCheckTextColour()
+        {
+            string password = passwordTextBox.Text;
+
+            foreach (var d in characterCheckText.Drawables)
+                d.Colour = password.Length == 0 ? Color4.White : Interpolation.ValueAt(password.Length, Color4.OrangeRed, Color4.YellowGreen, 0, 8, Easing.In);
         }
 
         public override void OnEntering(IScreen last)

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.Changelog
                                             t.Colour = colour.PinkLighter;
                                         })
                                         {
-                                            Text = ChangelogStrings.SupportText2.ToString(),
+                                            Text = ChangelogStrings.SupportText2,
                                             Margin = new MarginPadding { Top = 10 },
                                             RelativeSizeAxes = Axes.X,
                                             AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osuTK;
@@ -42,9 +43,9 @@ namespace osu.Game.Overlays.Dialog
             set => icon.Icon = value;
         }
 
-        private string headerText;
+        private LocalisableString headerText;
 
-        public string HeaderText
+        public LocalisableString HeaderText
         {
             get => headerText;
             set
@@ -57,9 +58,9 @@ namespace osu.Game.Overlays.Dialog
             }
         }
 
-        private string bodyText;
+        private LocalisableString bodyText;
 
-        public string BodyText
+        public LocalisableString BodyText
         {
             get => bodyText;
             set

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Overlays.Music
             artistColour = colours.Gray9;
             HandleColour = colours.Gray5;
 
-            title = localisation.GetLocalisedString(new RomanisableString(Model.Metadata.TitleUnicode, Model.Metadata.Title));
-            artist = localisation.GetLocalisedString(new RomanisableString(Model.Metadata.ArtistUnicode, Model.Metadata.Artist));
+            title = localisation.GetLocalisedBindableString(new RomanisableString(Model.Metadata.TitleUnicode, Model.Metadata.Title));
+            artist = localisation.GetLocalisedBindableString(new RomanisableString(Model.Metadata.ArtistUnicode, Model.Metadata.Artist));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -25,9 +25,6 @@ namespace osu.Game.Overlays.Music
         private TextFlowContainer text;
         private ITextPart titlePart;
 
-        private ILocalisedBindableString title;
-        private ILocalisedBindableString artist;
-
         private Color4 selectedColour;
         private Color4 artistColour;
 
@@ -45,16 +42,11 @@ namespace osu.Game.Overlays.Music
             selectedColour = colours.Yellow;
             artistColour = colours.Gray9;
             HandleColour = colours.Gray5;
-
-            title = localisation.GetLocalisedBindableString(new RomanisableString(Model.Metadata.TitleUnicode, Model.Metadata.Title));
-            artist = localisation.GetLocalisedBindableString(new RomanisableString(Model.Metadata.ArtistUnicode, Model.Metadata.Artist));
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            artist.BindValueChanged(_ => recreateText(), true);
 
             SelectedSet.BindValueChanged(set =>
             {
@@ -71,26 +63,31 @@ namespace osu.Game.Overlays.Music
                 s.FadeColour(SelectedSet.Value?.Equals(Model) == true ? selectedColour : Color4.White, instant ? 0 : FADE_DURATION);
         }
 
-        protected override Drawable CreateContent() => text = new OsuTextFlowContainer
+        protected override Drawable CreateContent()
         {
-            RelativeSizeAxes = Axes.X,
-            AutoSizeAxes = Axes.Y,
-        };
+            text = new OsuTextFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+            };
 
-        private void recreateText()
-        {
-            text.Clear();
+            var title = new RomanisableString(Model.Metadata.TitleUnicode, Model.Metadata.Title);
+            var artist = new RomanisableString(Model.Metadata.ArtistUnicode, Model.Metadata.Artist);
 
-            // space after the title to put a space between the title and artist
-            titlePart = text.AddText(title.Value + @"  ", sprite => sprite.Font = OsuFont.GetFont(weight: FontWeight.Regular));
+            titlePart = text.AddText(title, sprite => sprite.Font = OsuFont.GetFont(weight: FontWeight.Regular));
             updateSelectionState(true);
+            titlePart.DrawablePartsRecreated += _ => updateSelectionState(true);
 
-            text.AddText(artist.Value, sprite =>
+            text.AddText(@"  "); // to separate the title from the artist.
+
+            text.AddText(artist, sprite =>
             {
                 sprite.Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold);
                 sprite.Colour = artistColour;
                 sprite.Padding = new MarginPadding { Top = 1 };
             });
+
+            return text;
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Overlays.Music
         private TextFlowContainer text;
         private ITextPart titlePart;
 
-        private Color4 selectedColour;
-        private Color4 artistColour;
+        [Resolved]
+        private OsuColour colours { get; set; }
 
         public PlaylistItem(BeatmapSetInfo item)
             : base(item)
@@ -37,10 +37,8 @@ namespace osu.Game.Overlays.Music
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, LocalisationManager localisation)
+        private void load()
         {
-            selectedColour = colours.Yellow;
-            artistColour = colours.Gray9;
             HandleColour = colours.Gray5;
         }
 
@@ -60,16 +58,18 @@ namespace osu.Game.Overlays.Music
         private void updateSelectionState(bool instant)
         {
             foreach (Drawable s in titlePart.Drawables)
-                s.FadeColour(SelectedSet.Value?.Equals(Model) == true ? selectedColour : Color4.White, instant ? 0 : FADE_DURATION);
+                s.FadeColour(SelectedSet.Value?.Equals(Model) == true ? colours.Yellow : Color4.White, instant ? 0 : FADE_DURATION);
         }
 
-        protected override Drawable CreateContent()
+        protected override Drawable CreateContent() => text = new OsuTextFlowContainer
         {
-            text = new OsuTextFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-            };
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+        };
+
+        protected override void LoadAsyncComplete()
+        {
+            base.LoadAsyncComplete();
 
             var title = new RomanisableString(Model.Metadata.TitleUnicode, Model.Metadata.Title);
             var artist = new RomanisableString(Model.Metadata.ArtistUnicode, Model.Metadata.Artist);
@@ -83,11 +83,9 @@ namespace osu.Game.Overlays.Music
             text.AddText(artist, sprite =>
             {
                 sprite.Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold);
-                sprite.Colour = artistColour;
+                sprite.Colour = colours.Gray9;
                 sprite.Padding = new MarginPadding { Top = 1 };
             });
-
-            return text;
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -22,7 +23,7 @@ namespace osu.Game.Overlays.Notifications
     {
         private const float loading_spinner_size = 22;
 
-        public string Text
+        public LocalisableString Text
         {
             set => Schedule(() => textDrawable.Text = value);
         }

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osuTK;
@@ -15,9 +16,9 @@ namespace osu.Game.Overlays.Notifications
 {
     public class SimpleNotification : Notification
     {
-        private string text = string.Empty;
+        private LocalisableString text;
 
-        public string Text
+        public LocalisableString Text
         {
             get => text;
             set

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/DirectorySelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/DirectorySelectScreen.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                                     cp.Font = OsuFont.Default.With(size: 24);
                                 })
                                 {
-                                    Text = HeaderText.ToString(),
+                                    Text = HeaderText,
                                     TextAnchor = Anchor.TopCentre,
                                     Margin = new MarginPadding(10),
                                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Settings/SettingsCheckbox.cs
+++ b/osu.Game/Overlays/Settings/SettingsCheckbox.cs
@@ -16,8 +16,7 @@ namespace osu.Game.Overlays.Settings
         public override LocalisableString LabelText
         {
             get => labelText;
-            // checkbox doesn't properly support localisation yet.
-            set => ((OsuCheckbox)Control).LabelText = (labelText = value).ToString();
+            set => ((OsuCheckbox)Control).LabelText = labelText = value;
         }
     }
 }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays.Settings
         {
             set
             {
-                bool hasValue = !string.IsNullOrWhiteSpace(value.ToString());
+                bool hasValue = value != default;
 
                 if (warningText == null)
                 {
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Settings
                 }
 
                 warningText.Alpha = hasValue ? 1 : 0;
-                warningText.Text = value.ToString(); // TODO: Remove ToString() call after TextFlowContainer supports localisation (see https://github.com/ppy/osu-framework/issues/4636).
+                warningText.Text = value ?? default;
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
 
@@ -16,7 +17,7 @@ namespace osu.Game.Screens.Edit.Timing
     {
         private readonly SettingsSlider<T> slider;
 
-        public SliderWithTextBoxInput(string labelText)
+        public SliderWithTextBoxInput(LocalisableString labelText)
         {
             LabelledTextBox textbox;
 

--- a/osu.Game/Screens/OnlinePlay/Components/BeatmapTitle.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/BeatmapTitle.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Chat;
 
 namespace osu.Game.Screens.OnlinePlay.Components
@@ -69,24 +68,14 @@ namespace osu.Game.Screens.OnlinePlay.Components
             }
             else
             {
-                textFlow.AddLink(new[]
-                {
-                    new OsuSpriteText
-                    {
-                        Text = new RomanisableString(beatmap.Value.Metadata.ArtistUnicode, beatmap.Value.Metadata.Artist),
-                        Font = OsuFont.GetFont(size: TextSize),
-                    },
-                    new OsuSpriteText
-                    {
-                        Text = " - ",
-                        Font = OsuFont.GetFont(size: TextSize),
-                    },
-                    new OsuSpriteText
-                    {
-                        Text = new RomanisableString(beatmap.Value.Metadata.TitleUnicode, beatmap.Value.Metadata.Title),
-                        Font = OsuFont.GetFont(size: TextSize),
-                    }
-                }, LinkAction.OpenBeatmap, beatmap.Value.OnlineID.ToString(), "Open beatmap");
+                var metadataInfo = beatmap.Value.Metadata;
+
+                string artistUnicode = string.IsNullOrEmpty(metadataInfo.ArtistUnicode) ? metadataInfo.Artist : metadataInfo.ArtistUnicode;
+                string titleUnicode = string.IsNullOrEmpty(metadataInfo.TitleUnicode) ? metadataInfo.Title : metadataInfo.TitleUnicode;
+
+                var title = new RomanisableString($"{artistUnicode} - {titleUnicode}".Trim(), $"{metadataInfo.Artist} - {metadataInfo.Title}".Trim());
+
+                textFlow.AddLink(title, LinkAction.OpenBeatmap, beatmap.Value.OnlineID.ToString(), "Open beatmap");
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -111,7 +111,6 @@ namespace osu.Game.Screens.OnlinePlay
             beatmapText.AddLink(Item.Beatmap.Value.GetDisplayTitleRomanisable(), LinkAction.OpenBeatmap, Item.Beatmap.Value.OnlineBeatmapID.ToString(), null, text =>
             {
                 text.Truncate = true;
-                text.RelativeSizeAxes = Axes.X;
             });
 
             authorText.Clear();

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/PlaylistCountPill.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/PlaylistCountPill.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using Humanizer;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -46,7 +47,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
         private void updateCount(object sender, NotifyCollectionChangedEventArgs e)
         {
             count.Clear();
-            count.AddText(Playlist.Count.ToString(), s => s.Font = s.Font.With(weight: FontWeight.Bold));
+            count.AddText(Playlist.Count.ToLocalisableString(), s => s.Font = s.Font.With(weight: FontWeight.Bold));
             count.AddText(" ");
             count.AddText("Beatmap".ToQuantity(Playlist.Count, ShowQuantityAs.None));
         }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -188,8 +188,8 @@ namespace osu.Game.Screens.Select
 
                 RelativeSizeAxes = Axes.Both;
 
-                titleBinding = localisation.GetLocalisedString(new RomanisableString(metadata.TitleUnicode, metadata.Title));
-                artistBinding = localisation.GetLocalisedString(new RomanisableString(metadata.ArtistUnicode, metadata.Artist));
+                titleBinding = localisation.GetLocalisedBindableString(new RomanisableString(metadata.TitleUnicode, metadata.Title));
+                artistBinding = localisation.GetLocalisedBindableString(new RomanisableString(metadata.ArtistUnicode, metadata.Artist));
 
                 const float top_height = 0.7f;
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1029.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1103.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
     <PackageReference Include="Sentry" Version="3.10.0" />
     <PackageReference Include="SharpCompress" Version="0.30.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1029.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1103.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1029.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1103.0" />
     <PackageReference Include="SharpCompress" Version="0.30.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Depends on framework bump.
- Soft-depends on https://github.com/ppy/osu-framework/pull/4856 (will compile without, but probably worth getting that in before the bump).

Companion piece to https://github.com/ppy/osu-framework/pull/4849. Most changes should be self-explanatory - all places I found and that could easily support `LocalisableString`s now do, and I also cleaned up some local hackery in places that tried to roll its own handling.

This has an immediate effect in a few places, like the settings panel, for instance:

| master | this PR |
| :-: | :-: |
| ![osu_2021-11-02_23-21-35](https://user-images.githubusercontent.com/20418176/139961592-1f7df970-325d-4df1-bb4c-801fe7405da0.jpg) |![osu_2021-11-02_23-21-02](https://user-images.githubusercontent.com/20418176/139961598-0c4e7828-fdaf-44e5-a7f8-3f94949a0d94.jpg) |