### PR TITLE
Length bonus reduction

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -94,8 +94,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double aimValue = Math.Pow(5.0 * Math.Max(1.0, rawAim / 0.0675) - 4.0, 3.0) / 100000.0;
 
             // Longer maps are worth more.
-            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                 (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
+            double lengthBonus = 0.95 + 0.25 * Math.Min(1.0, totalHits / 1500.0) +
+                                 (totalHits > 1500 ? Math.Log10(totalHits / 1500.0) * 0.6 : 0.0);
 
             aimValue *= lengthBonus;
 
@@ -140,8 +140,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedValue = Math.Pow(5.0 * Math.Max(1.0, Attributes.SpeedStrain / 0.0675) - 4.0, 3.0) / 100000.0;
 
             // Longer maps are worth more.
-            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                 (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
+            double lengthBonus = 0.95 + 0.25 * Math.Min(1.0, totalHits / 1500.0) +
+                                 (totalHits > 1500 ? Math.Log10(totalHits / 1500.0) * 0.6 : 0.0);
             speedValue *= lengthBonus;
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.


### PR DESCRIPTION
This balances out rhythm complexity rework overweighting moderately long maps (or pretty much reduces the thing that makes them overweighted in the first place) 

https://www.desmos.com/calculator/fzayhuaqql
![image](https://user-images.githubusercontent.com/8269193/140166253-a0f78d5e-6c4a-4cc5-a607-85f31bc725be.png)

