### PR TITLE
Fix multiplayer text flow usages incorrectly wrapping text

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
@@ -68,6 +68,36 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         }),
                         createLoungeRoom(new Room
                         {
+                            Name = { Value = "Multiplayer room" },
+                            Status = { Value = new RoomStatusOpen() },
+                            EndDate = { Value = DateTimeOffset.Now.AddDays(1) },
+                            Type = { Value = MatchType.HeadToHead },
+                            Playlist =
+                            {
+                                new PlaylistItem
+                                {
+                                    Beatmap =
+                                    {
+                                        Value = new TestBeatmap(new OsuRuleset().RulesetInfo)
+                                        {
+                                            BeatmapInfo =
+                                            {
+                                                StarDifficulty = 2.5,
+                                                Metadata =
+                                                {
+                                                    Artist = "very very very very very very very very very long artist",
+                                                    ArtistUnicode = "very very very very very very very very very long artist",
+                                                    Title = "very very very very very very very very very very very long title",
+                                                    TitleUnicode = "very very very very very very very very very very very long title",
+                                                }
+                                            }
+                                        }.BeatmapInfo,
+                                    }
+                                }
+                            }
+                        }),
+                        createLoungeRoom(new Room
+                        {
                             Name = { Value = "Playlist room with multiple beatmaps" },
                             Status = { Value = new RoomStatusPlaying() },
                             EndDate = { Value = DateTimeOffset.Now.AddDays(1) },

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -181,8 +181,11 @@ namespace osu.Game.Screens.OnlinePlay
                                     {
                                         beatmapText = new LinkFlowContainer(fontParameters)
                                         {
-                                            AutoSizeAxes = Axes.Y,
                                             RelativeSizeAxes = Axes.X,
+                                            // workaround to ensure only the first line of text shows, emulating truncation (but without ellipsis at the end).
+                                            // TODO: remove when text/link flow can support truncation with ellipsis natively.
+                                            Height = OsuFont.DEFAULT_FONT_SIZE,
+                                            Masking = true
                                         },
                                         new FillFlowContainer
                                         {

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -353,7 +353,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                             })
                             {
                                 RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y
+                                // workaround to ensure only the first line of text shows, emulating truncation (but without ellipsis at the end).
+                                // TODO: remove when text/link flow can support truncation with ellipsis natively.
+                                Height = 16,
+                                Masking = true
                             }
                         }
                     }
@@ -385,7 +388,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                         creationParameters: s =>
                         {
                             s.Truncate = true;
-                            s.RelativeSizeAxes = Axes.X;
                         });
                 }
             }


### PR DESCRIPTION
* Closes #15451
* Also closes #14965 (albeit in a workaroundy manner)

Pretty amateur hour on my behalf - didn't spot one out of these two usages at all, and failed to realise that the other one would look pretty bad if text does indeed wrap. As [I mentioned in the issue](https://github.com/ppy/osu/issues/15451#issuecomment-959721460) there are two quick ways of fixing, and this one makes it so that the clickable area is correct, but truncation is not terminated with an ellipsis (`...`). At some point that should probably be supported in text flow - I added TODOs for now.

Test coverage, by the nature of regression, is unfortunately visual-only. Playlist items already had the proper coverage (`TestSceneDrawableRoomPlaylist`), but `DrawableRoom` maybe not so much, so I copy&pasted an existing test case and made the metadata long enough to force wrapping even on my ultrawide screen.

End result should look as follows:

| drawable room | drawable playlist item |
| :-: | :-: |
| ![2021-11-03-173951_1906x730_scrot](https://user-images.githubusercontent.com/20418176/140105501-c8269da8-ce43-4d4a-89a6-b86a504a51f7.png) | ![2021-11-03-174006_711x467_scrot](https://user-images.githubusercontent.com/20418176/140105523-85691628-3e1c-4f82-8047-cfb203e9da79.png) |