### PR TITLE
Enable nullable support on `BeatmapMetadata`

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Editing.Checks
         public void TestMissing()
         {
             // While this is a problem, it is out of scope for this check and is caught by a different one.
-            beatmap.Metadata.AudioFile = null;
+            beatmap.Metadata.AudioFile = string.Empty;
 
             var mock = new Mock<IWorkingBeatmap>();
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Editing.Checks
         public void TestMissing()
         {
             // While this is a problem, it is out of scope for this check and is caught by a different one.
-            beatmap.Metadata.BackgroundFile = null;
+            beatmap.Metadata.BackgroundFile = string.Empty;
             var context = getContext(null, System.Array.Empty<byte>());
 
             Assert.That(check.Run(context), Is.Empty);

--- a/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestBackgroundNotSet()
         {
-            beatmap.Metadata.BackgroundFile = null;
+            beatmap.Metadata.BackgroundFile = string.Empty;
 
             var context = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
             var issues = check.Run(context).ToList();

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestCriteriaMatchingArtistWithNullUnicodeName(string artistName, bool filtered)
         {
             var exampleBeatmapInfo = getExampleBeatmap();
-            exampleBeatmapInfo.Metadata.ArtistUnicode = null;
+            exampleBeatmapInfo.Metadata.ArtistUnicode = string.Empty;
 
             var criteria = new FilterCriteria
             {

--- a/osu.Game.Tests/Visual/Editing/TestSceneMetadataSection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneMetadataSection.cs
@@ -23,10 +23,10 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("set metadata", () =>
             {
                 editorBeatmap.Metadata.Artist = "Example Artist";
-                editorBeatmap.Metadata.ArtistUnicode = null;
+                editorBeatmap.Metadata.ArtistUnicode = string.Empty;
 
                 editorBeatmap.Metadata.Title = "Example Title";
-                editorBeatmap.Metadata.TitleUnicode = null;
+                editorBeatmap.Metadata.TitleUnicode = string.Empty;
             });
 
             createSection();
@@ -44,10 +44,10 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("set metadata", () =>
             {
                 editorBeatmap.Metadata.ArtistUnicode = "＊なみりん";
-                editorBeatmap.Metadata.Artist = null;
+                editorBeatmap.Metadata.Artist = string.Empty;
 
                 editorBeatmap.Metadata.TitleUnicode = "コイシテイク・プラネット";
-                editorBeatmap.Metadata.Title = null;
+                editorBeatmap.Metadata.Title = string.Empty;
             });
 
             createSection();
@@ -86,10 +86,10 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("set metadata", () =>
             {
                 editorBeatmap.Metadata.ArtistUnicode = "＊なみりん";
-                editorBeatmap.Metadata.Artist = null;
+                editorBeatmap.Metadata.Artist = string.Empty;
 
                 editorBeatmap.Metadata.TitleUnicode = "コイシテイク・プラネット";
-                editorBeatmap.Metadata.Title = null;
+                editorBeatmap.Metadata.Title = string.Empty;
             });
 
             createSection();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecording.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecording.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                                 ScoreInfo = { BeatmapInfo = gameplayState.Beatmap.BeatmapInfo }
                             })
                             {
-                                ScreenSpaceToGamefield = pos => recordingManager.ToLocalSpace(pos)
+                                ScreenSpaceToGamefield = pos => recordingManager?.ToLocalSpace(pos) ?? Vector2.Zero,
                             },
                             Child = new Container
                             {
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                         {
                             ReplayInputHandler = new TestFramedReplayInputHandler(replay)
                             {
-                                GamefieldToScreenSpace = pos => playbackManager.ToScreenSpace(pos),
+                                GamefieldToScreenSpace = pos => playbackManager?.ToScreenSpace(pos) ?? Vector2.Zero,
                             },
                             Child = new Container
                             {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -258,10 +258,10 @@ namespace osu.Game.Beatmaps
                 OnlineBeatmapSetID = model.OnlineID,
                 Metadata = new BeatmapMetadata
                 {
-                    Title = model.Metadata?.Title,
-                    Artist = model.Metadata?.Artist,
-                    TitleUnicode = model.Metadata?.TitleUnicode,
-                    ArtistUnicode = model.Metadata?.ArtistUnicode,
+                    Title = model.Metadata?.Title ?? string.Empty,
+                    Artist = model.Metadata?.Artist ?? string.Empty,
+                    TitleUnicode = model.Metadata?.TitleUnicode ?? string.Empty,
+                    ArtistUnicode = model.Metadata?.ArtistUnicode ?? string.Empty,
                     Author = new User { Username = model.Metadata?.Author },
                 }
             }, minimiseDownloadSize);

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -9,6 +9,8 @@ using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Users;
 
+#nullable enable
+
 namespace osu.Game.Beatmaps
 {
     [ExcludeFromDynamicCompile]
@@ -17,21 +19,21 @@ namespace osu.Game.Beatmaps
     {
         public int ID { get; set; }
 
-        public string Title { get; set; }
+        public string Title { get; set; } = string.Empty;
 
         [JsonProperty("title_unicode")]
-        public string TitleUnicode { get; set; }
+        public string TitleUnicode { get; set; } = string.Empty;
 
-        public string Artist { get; set; }
+        public string Artist { get; set; } = string.Empty;
 
         [JsonProperty("artist_unicode")]
-        public string ArtistUnicode { get; set; }
+        public string ArtistUnicode { get; set; } = string.Empty;
 
         [JsonIgnore]
-        public List<BeatmapInfo> Beatmaps { get; set; }
+        public List<BeatmapInfo> Beatmaps { get; set; } = new List<BeatmapInfo>();
 
         [JsonIgnore]
-        public List<BeatmapSetInfo> BeatmapSets { get; set; }
+        public List<BeatmapSetInfo> BeatmapSets { get; set; } = new List<BeatmapSetInfo>();
 
         /// <summary>
         /// Helper property to deserialize a username to <see cref="User"/>.
@@ -55,7 +57,7 @@ namespace osu.Game.Beatmaps
         [Column("Author")]
         public string AuthorString
         {
-            get => Author?.Username;
+            get => Author?.Username ?? string.Empty;
             set
             {
                 Author ??= new User();
@@ -67,22 +69,22 @@ namespace osu.Game.Beatmaps
         /// The author of the beatmaps in this set.
         /// </summary>
         [JsonIgnore]
-        public User Author;
+        public User? Author;
 
-        public string Source { get; set; }
+        public string Source { get; set; } = string.Empty;
 
         [JsonProperty(@"tags")]
-        public string Tags { get; set; }
+        public string Tags { get; set; } = string.Empty;
 
         /// <summary>
         /// The time in milliseconds to begin playing the track for preview purposes.
         /// If -1, the track should begin playing at 40% of its length.
         /// </summary>
-        public int PreviewTime { get; set; }
+        public int PreviewTime { get; set; } = -1;
 
-        public string AudioFile { get; set; }
+        public string AudioFile { get; set; } = string.Empty;
 
-        public string BackgroundFile { get; set; }
+        public string BackgroundFile { get; set; } = string.Empty;
 
         public bool Equals(BeatmapMetadata other) => ((IBeatmapMetadataInfo)this).Equals(other);
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Beatmaps.Formats
         {
             writer.WriteLine("[General]");
 
-            if (beatmap.Metadata.AudioFile != null) writer.WriteLine(FormattableString.Invariant($"AudioFilename: {Path.GetFileName(beatmap.Metadata.AudioFile)}"));
+            if (!string.IsNullOrEmpty(beatmap.Metadata.AudioFile)) writer.WriteLine(FormattableString.Invariant($"AudioFilename: {Path.GetFileName(beatmap.Metadata.AudioFile)}"));
             writer.WriteLine(FormattableString.Invariant($"AudioLeadIn: {beatmap.BeatmapInfo.AudioLeadIn}"));
             writer.WriteLine(FormattableString.Invariant($"PreviewTime: {beatmap.Metadata.PreviewTime}"));
             writer.WriteLine(FormattableString.Invariant($"Countdown: {(int)beatmap.BeatmapInfo.Countdown}"));
@@ -126,13 +126,13 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine("[Metadata]");
 
             writer.WriteLine(FormattableString.Invariant($"Title: {beatmap.Metadata.Title}"));
-            if (beatmap.Metadata.TitleUnicode != null) writer.WriteLine(FormattableString.Invariant($"TitleUnicode: {beatmap.Metadata.TitleUnicode}"));
+            if (!string.IsNullOrEmpty(beatmap.Metadata.TitleUnicode)) writer.WriteLine(FormattableString.Invariant($"TitleUnicode: {beatmap.Metadata.TitleUnicode}"));
             writer.WriteLine(FormattableString.Invariant($"Artist: {beatmap.Metadata.Artist}"));
-            if (beatmap.Metadata.ArtistUnicode != null) writer.WriteLine(FormattableString.Invariant($"ArtistUnicode: {beatmap.Metadata.ArtistUnicode}"));
+            if (!string.IsNullOrEmpty(beatmap.Metadata.ArtistUnicode)) writer.WriteLine(FormattableString.Invariant($"ArtistUnicode: {beatmap.Metadata.ArtistUnicode}"));
             writer.WriteLine(FormattableString.Invariant($"Creator: {beatmap.Metadata.AuthorString}"));
             writer.WriteLine(FormattableString.Invariant($"Version: {beatmap.BeatmapInfo.Version}"));
-            if (beatmap.Metadata.Source != null) writer.WriteLine(FormattableString.Invariant($"Source: {beatmap.Metadata.Source}"));
-            if (beatmap.Metadata.Tags != null) writer.WriteLine(FormattableString.Invariant($"Tags: {beatmap.Metadata.Tags}"));
+            if (!string.IsNullOrEmpty(beatmap.Metadata.Source)) writer.WriteLine(FormattableString.Invariant($"Source: {beatmap.Metadata.Source}"));
+            if (!string.IsNullOrEmpty(beatmap.Metadata.Tags)) writer.WriteLine(FormattableString.Invariant($"Tags: {beatmap.Metadata.Tags}"));
             if (beatmap.BeatmapInfo.OnlineBeatmapID != null) writer.WriteLine(FormattableString.Invariant($"BeatmapID: {beatmap.BeatmapInfo.OnlineBeatmapID}"));
             if (beatmap.BeatmapInfo.BeatmapSet?.OnlineBeatmapSetID != null) writer.WriteLine(FormattableString.Invariant($"BeatmapSetID: {beatmap.BeatmapInfo.BeatmapSet.OnlineBeatmapSetID}"));
         }

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Beatmaps
 
             protected override Track GetBeatmapTrack()
             {
-                if (Metadata?.AudioFile == null)
+                if (string.IsNullOrEmpty(Metadata?.AudioFile))
                     return null;
 
                 try
@@ -181,7 +181,7 @@ namespace osu.Game.Beatmaps
 
             protected override Waveform GetWaveform()
             {
-                if (Metadata?.AudioFile == null)
+                if (string.IsNullOrEmpty(Metadata?.AudioFile))
                     return null;
 
                 try

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Beatmaps
 
             protected override Texture GetBackground()
             {
-                if (Metadata?.BackgroundFile == null)
+                if (string.IsNullOrEmpty(Metadata?.BackgroundFile))
                     return null;
 
                 try

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
             string audioFile = context.Beatmap.Metadata?.AudioFile;
-            if (audioFile == null)
+            if (string.IsNullOrEmpty(audioFile))
                 yield break;
 
             var track = context.WorkingBeatmap.Track;

--- a/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         {
             string filename = GetFilename(context.Beatmap);
 
-            if (filename == null)
+            if (string.IsNullOrEmpty(filename))
             {
                 yield return new IssueTemplateNoneSet(this).Create(TypeOfFile);
 

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.Select.Carousel
                     return string.Compare(BeatmapSet.Metadata.Title, otherSet.BeatmapSet.Metadata.Title, StringComparison.OrdinalIgnoreCase);
 
                 case SortMode.Author:
-                    return string.Compare(BeatmapSet.Metadata.Author.Username, otherSet.BeatmapSet.Metadata.Author.Username, StringComparison.OrdinalIgnoreCase);
+                    return string.Compare(BeatmapSet.Metadata.Author?.Username, otherSet.BeatmapSet.Metadata.Author?.Username, StringComparison.OrdinalIgnoreCase);
 
                 case SortMode.Source:
                     return string.Compare(BeatmapSet.Metadata.Source, otherSet.BeatmapSet.Metadata.Source, StringComparison.OrdinalIgnoreCase);

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Screens.Select.Carousel
                                         },
                                         new OsuSpriteText
                                         {
-                                            Text = $"{(beatmapInfo.Metadata ?? beatmapInfo.BeatmapSet.Metadata).Author.Username}",
+                                            Text = $"{(beatmapInfo.Metadata ?? beatmapInfo.BeatmapSet.Metadata).Author?.Username ?? string.Empty}",
                                             Font = OsuFont.GetFont(italics: true),
                                             Anchor = Anchor.BottomLeft,
                                             Origin = Anchor.BottomLeft

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -77,8 +77,8 @@ namespace osu.Game.Storyboards
         {
             get
             {
-                string backgroundPath = BeatmapInfo.BeatmapSet?.Metadata?.BackgroundFile?.ToLowerInvariant();
-                if (backgroundPath == null)
+                string backgroundPath = BeatmapInfo.BeatmapSet?.Metadata?.BackgroundFile.ToLowerInvariant();
+                if (string.IsNullOrEmpty(backgroundPath))
                     return false;
 
                 return GetLayer("Background").Elements.Any(e => e.Path.ToLowerInvariant() == backgroundPath);


### PR DESCRIPTION
There's probably some other classes I've recently touched that also need it applied (ie. `APIScoreInfo`), but this is an easy one. Others will probably come after further refactor work is first merged.