### PR TITLE
Refactor `PlaylistItem` to allow `Beatmap` to be an interfaced type

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
             HasVideo = true,
             HasStoryboard = true,
             Covers = new BeatmapSetOnlineCovers(),
-            Beatmaps = new List<APIBeatmap>
+            Beatmaps = new[]
             {
                 new APIBeatmap
                 {
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 HasVideo = true,
                 HasStoryboard = true,
                 Covers = new BeatmapSetOnlineCovers(),
-                Beatmaps = beatmaps,
+                Beatmaps = beatmaps.ToArray(),
             };
         }
 

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneDifficultySpectrumDisplay.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneDifficultySpectrumDisplay.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
             {
                 RulesetID = difficulty.rulesetId,
                 StarRating = difficulty.stars
-            }).ToList()
+            }).ToArray()
         };
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapRulesetSelector.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapRulesetSelector.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -37,7 +36,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 selector.BeatmapSet = new APIBeatmapSet
                 {
-                    Beatmaps = enabledRulesets.Select(r => new APIBeatmap { RulesetID = r.OnlineID }).ToList()
+                    Beatmaps = enabledRulesets.Select(r => new APIBeatmap { RulesetID = r.OnlineID }).ToArray()
                 };
             });
 
@@ -55,7 +54,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 selector.BeatmapSet = new APIBeatmapSet
                 {
-                    Beatmaps = new List<APIBeatmap>
+                    Beatmaps = new[]
                     {
                         new APIBeatmap
                         {
@@ -71,10 +70,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestEmptyBeatmapSet()
         {
-            AddStep("load empty beatmapset", () => selector.BeatmapSet = new APIBeatmapSet
-            {
-                Beatmaps = new List<APIBeatmap>()
-            });
+            AddStep("load empty beatmapset", () => selector.BeatmapSet = new APIBeatmapSet());
 
             AddAssert("no ruleset selected", () => selector.SelectedTab == null);
             AddAssert("all rulesets disabled", () => selector.TabContainer.TabItems.All(t => !t.Enabled.Value));

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.Online
                     Ratings = Enumerable.Range(0, 11).ToArray(),
                     HasStoryboard = true,
                     Covers = new BeatmapSetOnlineCovers(),
-                    Beatmaps = new List<APIBeatmap>
+                    Beatmaps = new[]
                     {
                         new APIBeatmap
                         {
@@ -145,7 +145,7 @@ namespace osu.Game.Tests.Visual.Online
 
                 var set = getBeatmapSet();
 
-                set.Beatmaps = beatmaps;
+                set.Beatmaps = beatmaps.ToArray();
 
                 overlay.ShowBeatmapSet(set);
             });
@@ -211,7 +211,7 @@ namespace osu.Game.Tests.Visual.Online
                 });
             }
 
-            set.Beatmaps = beatmaps;
+            set.Beatmaps = beatmaps.ToArray();
 
             return set;
         }

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlayDetails.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlayDetails.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -46,7 +45,7 @@ namespace osu.Game.Tests.Visual.Online
 
             static APIBeatmapSet createSet() => new APIBeatmapSet
             {
-                Beatmaps = new List<APIBeatmap>
+                Beatmaps = new[]
                 {
                     new APIBeatmap
                     {

--- a/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Visual.Online
                 HasVideo = true,
                 HasStoryboard = true,
                 Covers = new BeatmapSetOnlineCovers(),
-                Beatmaps = new List<APIBeatmap>
+                Beatmaps = new[]
                 {
                     new APIBeatmap
                     {
@@ -129,7 +129,7 @@ namespace osu.Game.Tests.Visual.Online
                     HasVideo = true,
                     HasStoryboard = true,
                     Covers = new BeatmapSetOnlineCovers(),
-                    Beatmaps = beatmaps,
+                    Beatmaps = beatmaps.ToArray(),
                 };
             }
         }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Beatmaps
         string IBeatmapInfo.DifficultyName => Version;
 
         [JsonIgnore]
-        IBeatmapMetadataInfo IBeatmapInfo.Metadata => Metadata;
+        IBeatmapMetadataInfo IBeatmapInfo.Metadata => Metadata ?? BeatmapSet.Metadata;
 
         [JsonIgnore]
         IBeatmapDifficultyInfo IBeatmapInfo.Difficulty => BaseDifficulty;

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Beatmaps
         string IBeatmapInfo.DifficultyName => Version;
 
         [JsonIgnore]
-        IBeatmapMetadataInfo IBeatmapInfo.Metadata => Metadata ?? BeatmapSet.Metadata;
+        IBeatmapMetadataInfo IBeatmapInfo.Metadata => Metadata ?? BeatmapSet?.Metadata ?? new BeatmapMetadata();
 
         [JsonIgnore]
         IBeatmapDifficultyInfo IBeatmapInfo.Difficulty => BaseDifficulty;

--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -11,14 +11,14 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// A user-presentable display title representing this beatmap.
         /// </summary>
-        public static string GetDisplayTitle(this IBeatmapInfo beatmapInfo) => $"{getClosestMetadata(beatmapInfo)} {getVersionString(beatmapInfo)}".Trim();
+        public static string GetDisplayTitle(this IBeatmapInfo beatmapInfo) => $"{beatmapInfo.Metadata} {getVersionString(beatmapInfo)}".Trim();
 
         /// <summary>
         /// A user-presentable display title representing this beatmap, with localisation handling for potentially romanisable fields.
         /// </summary>
         public static RomanisableString GetDisplayTitleRomanisable(this IBeatmapInfo beatmapInfo, bool includeDifficultyName = true, bool includeCreator = true)
         {
-            var metadata = getClosestMetadata(beatmapInfo).GetDisplayTitleRomanisable(includeCreator);
+            var metadata = beatmapInfo.Metadata.GetDisplayTitleRomanisable(includeCreator);
 
             if (includeDifficultyName)
             {
@@ -32,12 +32,8 @@ namespace osu.Game.Beatmaps
         public static string[] GetSearchableTerms(this IBeatmapInfo beatmapInfo) => new[]
         {
             beatmapInfo.DifficultyName
-        }.Concat(getClosestMetadata(beatmapInfo).GetSearchableTerms()).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+        }.Concat(beatmapInfo.Metadata.GetSearchableTerms()).Where(s => !string.IsNullOrEmpty(s)).ToArray();
 
         private static string getVersionString(IBeatmapInfo beatmapInfo) => string.IsNullOrEmpty(beatmapInfo.DifficultyName) ? string.Empty : $"[{beatmapInfo.DifficultyName}]";
-
-        // temporary helper methods until we figure which metadata should be where.
-        private static IBeatmapMetadataInfo getClosestMetadata(IBeatmapInfo beatmapInfo) =>
-            beatmapInfo.Metadata ?? beatmapInfo.BeatmapSet?.Metadata ?? new BeatmapMetadata();
     }
 }

--- a/osu.Game/Beatmaps/IBeatmapInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapInfo.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The metadata representing this beatmap. May be shared between multiple beatmaps.
         /// </summary>
-        IBeatmapMetadataInfo? Metadata { get; }
+        IBeatmapMetadataInfo Metadata { get; }
 
         /// <summary>
         /// The difficulty settings for this beatmap.

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public string Tags { get; set; } = string.Empty;
 
         [JsonProperty(@"beatmaps")]
-        public IEnumerable<APIBeatmap> Beatmaps { get; set; } = Array.Empty<APIBeatmap>();
+        public APIBeatmap[] Beatmaps { get; set; } = Array.Empty<APIBeatmap>();
 
         public virtual BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets)
         {

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -17,6 +17,7 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Rooms.RoomStatuses;
 using osu.Game.Rulesets;
@@ -653,15 +654,17 @@ namespace osu.Game.Online.Multiplayer
             }), TaskContinuationOptions.OnlyOnRanToCompletion);
         }, cancellationToken);
 
-        private void updatePlaylist(MultiplayerRoomSettings settings, BeatmapSetInfo beatmapSet)
+        private void updatePlaylist(MultiplayerRoomSettings settings, APIBeatmapSet beatmapSet)
         {
             if (Room == null || !Room.Settings.Equals(settings))
                 return;
 
             Debug.Assert(APIRoom != null);
 
-            var beatmap = beatmapSet.Beatmaps.Single(b => b.OnlineBeatmapID == settings.BeatmapID);
-            beatmap.MD5Hash = settings.BeatmapChecksum;
+            var beatmap = beatmapSet.Beatmaps.Single(b => b.OnlineID == settings.BeatmapID);
+
+            beatmap.Checksum = settings.BeatmapChecksum;
+            beatmap.BeatmapSet = beatmapSet;
 
             var ruleset = Rulesets.GetRuleset(settings.RulesetID).CreateInstance();
             var mods = settings.RequiredMods.Select(m => m.ToMod(ruleset));
@@ -694,12 +697,12 @@ namespace osu.Game.Online.Multiplayer
         }
 
         /// <summary>
-        /// Retrieves a <see cref="BeatmapSetInfo"/> from an online source.
+        /// Retrieves a <see cref="APIBeatmapSet"/> from an online source.
         /// </summary>
         /// <param name="beatmapId">The beatmap set ID.</param>
         /// <param name="cancellationToken">A token to cancel the request.</param>
-        /// <returns>The <see cref="BeatmapSetInfo"/> retrieval task.</returns>
-        protected abstract Task<BeatmapSetInfo> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default);
+        /// <returns>The <see cref="APIBeatmapSet"/> retrieval task.</returns>
+        protected abstract Task<APIBeatmapSet> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// For the provided user ID, update whether the user is included in <see cref="CurrentMatchPlayingUserIds"/>.

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -9,9 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 
 namespace osu.Game.Online.Multiplayer
@@ -148,9 +148,9 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
         }
 
-        protected override Task<BeatmapSetInfo> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default)
+        protected override Task<APIBeatmapSet> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default)
         {
-            var tcs = new TaskCompletionSource<BeatmapSetInfo>();
+            var tcs = new TaskCompletionSource<APIBeatmapSet>();
             var req = new GetBeatmapSetRequest(beatmapId, BeatmapSetLookupType.BeatmapId);
 
             req.Success += res =>
@@ -161,7 +161,7 @@ namespace osu.Game.Online.Multiplayer
                     return;
                 }
 
-                tcs.SetResult(res.ToBeatmapSet(Rulesets));
+                tcs.SetResult(res);
             };
 
             req.Failure += e => tcs.SetException(e);

--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -61,7 +62,7 @@ namespace osu.Game.Online.Rooms
         [CanBeNull]
         public MultiplayerScoresAround ScoresAround { get; set; }
 
-        public ScoreInfo CreateScoreInfo(PlaylistItem playlistItem)
+        public ScoreInfo CreateScoreInfo(PlaylistItem playlistItem, [NotNull] BeatmapInfo beatmap)
         {
             var rulesetInstance = playlistItem.Ruleset.Value.CreateInstance();
 
@@ -70,7 +71,7 @@ namespace osu.Game.Online.Rooms
                 OnlineScoreID = ID,
                 TotalScore = TotalScore,
                 MaxCombo = MaxCombo,
-                BeatmapInfo = playlistItem.Beatmap.Value,
+                BeatmapInfo = beatmap,
                 BeatmapInfoID = playlistItem.BeatmapID,
                 Ruleset = playlistItem.Ruleset.Value,
                 RulesetID = playlistItem.RulesetID,

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -51,6 +52,8 @@ namespace osu.Game.Online.Rooms
                     return;
 
                 downloadTracker?.RemoveAndDisposeImmediately();
+
+                Debug.Assert(item.NewValue.Beatmap.Value.BeatmapSet != null);
 
                 downloadTracker = new BeatmapDownloadTracker(item.NewValue.Beatmap.Value.BeatmapSet);
 

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Online.Rooms
         public readonly BindableList<Mod> RequiredMods = new BindableList<Mod>();
 
         [JsonProperty("beatmap")]
-        public APIBeatmap APIBeatmap { get; set; }
+        private APIBeatmap apiBeatmap { get; set; }
 
         private APIMod[] allowedModsBacking;
 
@@ -71,7 +71,7 @@ namespace osu.Game.Online.Rooms
 
         public void MapObjects(RulesetStore rulesets)
         {
-            Beatmap.Value ??= APIBeatmap;
+            Beatmap.Value ??= apiBeatmap;
             Ruleset.Value ??= rulesets.GetRuleset(RulesetID);
 
             Ruleset rulesetInstance = Ruleset.Value.CreateInstance();

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Online.Rooms
             Ruleset.BindValueChanged(ruleset => RulesetID = ruleset.NewValue?.ID ?? 0);
         }
 
-        public void MapObjects(BeatmapManager beatmaps, RulesetStore rulesets)
+        public void MapObjects(RulesetStore rulesets)
         {
             Beatmap.Value ??= APIBeatmap;
             Ruleset.Value ??= rulesets.GetRuleset(RulesetID);

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Online.Rooms
         public bool Expired { get; set; }
 
         [JsonIgnore]
-        public readonly Bindable<BeatmapInfo> Beatmap = new Bindable<BeatmapInfo>();
+        public readonly Bindable<IBeatmapInfo> Beatmap = new Bindable<IBeatmapInfo>();
 
         [JsonIgnore]
         public readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
@@ -65,13 +65,13 @@ namespace osu.Game.Online.Rooms
 
         public PlaylistItem()
         {
-            Beatmap.BindValueChanged(beatmap => BeatmapID = beatmap.NewValue?.OnlineBeatmapID ?? 0);
+            Beatmap.BindValueChanged(beatmap => BeatmapID = beatmap.NewValue?.OnlineID ?? -1);
             Ruleset.BindValueChanged(ruleset => RulesetID = ruleset.NewValue?.ID ?? 0);
         }
 
         public void MapObjects(BeatmapManager beatmaps, RulesetStore rulesets)
         {
-            Beatmap.Value ??= APIBeatmap.ToBeatmapInfo(rulesets);
+            Beatmap.Value ??= APIBeatmap;
             Ruleset.Value ??= rulesets.GetRuleset(RulesetID);
 
             Ruleset rulesetInstance = Ruleset.Value.CreateInstance();

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Online.Rooms
         public readonly BindableList<Mod> RequiredMods = new BindableList<Mod>();
 
         [JsonProperty("beatmap")]
-        private APIBeatmap apiBeatmap { get; set; }
+        public APIBeatmap APIBeatmap { get; set; }
 
         private APIMod[] allowedModsBacking;
 
@@ -71,7 +71,7 @@ namespace osu.Game.Online.Rooms
 
         public void MapObjects(BeatmapManager beatmaps, RulesetStore rulesets)
         {
-            Beatmap.Value ??= apiBeatmap.ToBeatmapInfo(rulesets);
+            Beatmap.Value ??= APIBeatmap.ToBeatmapInfo(rulesets);
             Ruleset.Value ??= rulesets.GetRuleset(RulesetID);
 
             Ruleset rulesetInstance = Ruleset.Value.CreateInstance();

--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         {
             var icons = new List<DifficultyIcon>();
 
-            if (SetInfo.Beatmaps.Count() > maximum_difficulty_icons)
+            if (SetInfo.Beatmaps.Length > maximum_difficulty_icons)
             {
                 foreach (var ruleset in SetInfo.Beatmaps.Select(b => b.Ruleset).Distinct())
                     icons.Add(new GroupedDifficultyIcon(SetInfo.Beatmaps.Where(b => b.RulesetID == ruleset.OnlineID).ToList(), ruleset, this is ListBeatmapPanel ? Color4.White : colours.Gray5));

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Online.Rooms;
 using osuTK;
 using osuTK.Graphics;
@@ -59,9 +60,12 @@ namespace osu.Game.Screens.OnlinePlay.Components
         {
             Schedule(() =>
             {
-                var beatmap = playlistItem?.Beatmap.Value;
+                var beatmap = playlistItem?.APIBeatmap;
 
-                if (background?.BeatmapInfo?.BeatmapSet?.OnlineInfo?.Covers.Cover == beatmap?.BeatmapSet?.OnlineInfo?.Covers.Cover)
+                string? lastCover = (background?.Beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
+                string? newCover = beatmap?.BeatmapSet?.Covers.Cover;
+
+                if (lastCover == newCover)
                     return;
 
                 cancellationSource?.Cancel();

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
@@ -60,8 +60,10 @@ namespace osu.Game.Screens.OnlinePlay.Components
         {
             Schedule(() =>
             {
+                var beatmap = playlistItem?.Beatmap.Value;
+
                 string? lastCover = (background?.Beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
-                string? newCover = (background?.Beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
+                string? newCover = (beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
 
                 if (lastCover == newCover)
                     return;

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
@@ -60,10 +60,8 @@ namespace osu.Game.Screens.OnlinePlay.Components
         {
             Schedule(() =>
             {
-                var beatmap = playlistItem?.APIBeatmap;
-
                 string? lastCover = (background?.Beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
-                string? newCover = beatmap?.BeatmapSet?.Covers.Cover;
+                string? newCover = (background?.Beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
 
                 if (lastCover == newCover)
                     return;

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         private void updateBeatmap()
         {
-            sprite.Beatmap.Value = Playlist.FirstOrDefault()?.APIBeatmap;
+            sprite.Beatmap.Value = Playlist.FirstOrDefault()?.Beatmap.Value;
         }
 
         protected virtual UpdateableBeatmapBackgroundSprite CreateBackgroundSprite() => new UpdateableBeatmapBackgroundSprite(BeatmapSetCoverType) { RelativeSizeAxes = Axes.Both };

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         private void updateBeatmap()
         {
-            sprite.Beatmap.Value = Playlist.FirstOrDefault()?.Beatmap.Value;
+            sprite.Beatmap.Value = Playlist.FirstOrDefault()?.APIBeatmap;
         }
 
         protected virtual UpdateableBeatmapBackgroundSprite CreateBackgroundSprite() => new UpdateableBeatmapBackgroundSprite(BeatmapSetCoverType) { RelativeSizeAxes = Axes.Both };

--- a/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         public PlaylistItemBackground(PlaylistItem? playlistItem)
         {
-            Beatmap = playlistItem?.APIBeatmap;
+            Beatmap = playlistItem?.Beatmap.Value;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
@@ -13,11 +13,11 @@ namespace osu.Game.Screens.OnlinePlay.Components
 {
     public class PlaylistItemBackground : Background
     {
-        public readonly BeatmapInfo? BeatmapInfo;
+        public readonly IBeatmapInfo? Beatmap;
 
         public PlaylistItemBackground(PlaylistItem? playlistItem)
         {
-            BeatmapInfo = playlistItem?.Beatmap.Value;
+            Beatmap = playlistItem?.APIBeatmap;
         }
 
         [BackgroundDependencyLoader]
@@ -26,8 +26,8 @@ namespace osu.Game.Screens.OnlinePlay.Components
             Texture? texture = null;
 
             // prefer online cover where available.
-            if (BeatmapInfo?.BeatmapSet?.OnlineInfo?.Covers.Cover != null)
-                texture = textures.Get(BeatmapInfo.BeatmapSet.OnlineInfo.Covers.Cover);
+            if (Beatmap?.BeatmapSet is IBeatmapSetOnlineInfo online)
+                texture = textures.Get(online.Covers.Cover);
 
             Sprite.Texture = texture ?? beatmaps.DefaultBeatmap.Background;
         }
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             if (ReferenceEquals(this, other)) return true;
 
             return other.GetType() == GetType()
-                   && ((PlaylistItemBackground)other).BeatmapInfo == BeatmapInfo;
+                   && ((PlaylistItemBackground)other).Beatmap == Beatmap;
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             try
             {
                 foreach (var pi in room.Playlist)
-                    pi.MapObjects(beatmaps, rulesets);
+                    pi.MapObjects(rulesets);
 
                 var existing = rooms.FirstOrDefault(e => e.RoomID.Value == room.RoomID.Value);
                 if (existing == null)

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -80,10 +80,10 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         private void updateRange(object sender, NotifyCollectionChangedEventArgs e)
         {
-            var orderedDifficulties = Playlist.Select(p => p.Beatmap.Value).OrderBy(b => b.StarDifficulty).ToArray();
+            var orderedDifficulties = Playlist.Select(p => p.Beatmap.Value).OrderBy(b => b.StarRating).ToArray();
 
-            StarDifficulty minDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[0].StarDifficulty : 0, 0);
-            StarDifficulty maxDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[^1].StarDifficulty : 0, 0);
+            StarDifficulty minDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[0].StarRating : 0, 0);
+            StarDifficulty maxDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[^1].StarRating : 0, 0);
 
             minDisplay.Current.Value = minDifficulty;
             maxDisplay.Current.Value = maxDifficulty;

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.OnlinePlay
 
             authorText.Clear();
 
-            if (Item.Beatmap.Value?.Metadata?.Author != null)
+            if (!string.IsNullOrEmpty(Item.Beatmap.Value?.Metadata.Author))
             {
                 authorText.AddText("mapped by ");
                 authorText.AddUserLink(new User { Username = Item.Beatmap.Value.Metadata.Author });

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -384,7 +384,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     statusText.Text = "Currently playing ";
                     beatmapText.AddLink(item.NewValue.Beatmap.Value.GetDisplayTitleRomanisable(),
                         LinkAction.OpenBeatmap,
-                        item.NewValue.Beatmap.Value.OnlineBeatmapID.ToString(),
+                        item.NewValue.Beatmap.Value.OnlineID.ToString(),
                         creationParameters: s =>
                         {
                             s.Truncate = true;

--- a/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             if (editButton != null)
                 host.BindValueChanged(h => editButton.Alpha = h.NewValue?.Equals(api.LocalUser.Value) == true ? 1 : 0, true);
 
-            SelectedItem.BindValueChanged(item => background.Beatmap.Value = item.NewValue?.Beatmap.Value, true);
+            SelectedItem.BindValueChanged(item => background.Beatmap.Value = item.NewValue?.APIBeatmap, true);
         }
 
         protected override Drawable CreateBackground() => background = new BackgroundSprite();

--- a/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             if (editButton != null)
                 host.BindValueChanged(h => editButton.Alpha = h.NewValue?.Equals(api.LocalUser.Value) == true ? 1 : 0, true);
 
-            SelectedItem.BindValueChanged(item => background.Beatmap.Value = item.NewValue?.APIBeatmap, true);
+            SelectedItem.BindValueChanged(item => background.Beatmap.Value = item.NewValue?.Beatmap.Value, true);
         }
 
         protected override Drawable CreateBackground() => background = new BackgroundSprite();

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -369,7 +369,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             var beatmap = SelectedItem.Value?.Beatmap.Value;
 
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info
-            var localBeatmap = beatmap == null ? null : beatmapManager.QueryBeatmap(b => b.OnlineBeatmapID == beatmap.OnlineBeatmapID);
+            var localBeatmap = beatmap == null ? null : beatmapManager.QueryBeatmap(b => b.OnlineBeatmapID == beatmap.OnlineID);
 
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
         }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         private void load(IBindable<RulesetInfo> ruleset)
         {
             // Sanity checks to ensure that PlaylistsPlayer matches the settings for the current PlaylistItem
-            if (Beatmap.Value.BeatmapInfo.OnlineBeatmapID != PlaylistItem.Beatmap.Value.OnlineBeatmapID)
+            if (Beatmap.Value.BeatmapInfo.OnlineBeatmapID != PlaylistItem.Beatmap.Value.OnlineID)
                 throw new InvalidOperationException("Current Beatmap does not match PlaylistItem's Beatmap");
 
             if (ruleset.Value.ID != PlaylistItem.Ruleset.Value.ID)

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         /// <param name="pivot">An optional pivot around which the scores were retrieved.</param>
         private void performSuccessCallback([NotNull] Action<IEnumerable<ScoreInfo>> callback, [NotNull] List<MultiplayerScore> scores, [CanBeNull] MultiplayerScores pivot = null)
         {
-            var scoreInfos = scores.Select(s => s.CreateScoreInfo(playlistItem)).ToArray();
+            var scoreInfos = scores.Select(s => s.CreateScoreInfo(playlistItem, Beatmap.Value.BeatmapInfo)).ToArray();
 
             // Score panels calculate total score before displaying, which can take some time. In order to count that calculation as part of the loading spinner display duration,
             // calculate the total scores locally before invoking the success callback.

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -18,6 +18,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Spectator;
 using osu.Game.Overlays.BeatmapListing.Panels;
 using osu.Game.Overlays.Settings;
@@ -50,7 +51,7 @@ namespace osu.Game.Screens.Play
         private Container beatmapPanelContainer;
         private TriangleButton watchButton;
         private SettingsCheckbox automaticDownload;
-        private BeatmapSetInfo onlineBeatmap;
+        private APIBeatmapSet onlineBeatmap;
 
         /// <summary>
         /// The player's immediate online gameplay state.
@@ -222,8 +223,8 @@ namespace osu.Game.Screens.Play
             onlineBeatmapRequest = new GetBeatmapSetRequest(state.BeatmapID.Value, BeatmapSetLookupType.BeatmapId);
             onlineBeatmapRequest.Success += res => Schedule(() =>
             {
-                onlineBeatmap = res.ToBeatmapSet(rulesets);
-                beatmapPanelContainer.Child = new GridBeatmapPanel(res);
+                onlineBeatmap = res;
+                beatmapPanelContainer.Child = new GridBeatmapPanel(onlineBeatmap);
                 checkForAutomaticDownload();
             });
 
@@ -238,10 +239,13 @@ namespace osu.Game.Screens.Play
             if (!automaticDownload.Current.Value)
                 return;
 
-            if (beatmaps.IsAvailableLocally(onlineBeatmap))
+            // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
+            var beatmapSetInfo = new BeatmapSetInfo { OnlineBeatmapSetID = onlineBeatmap.OnlineID };
+
+            if (beatmaps.IsAvailableLocally(beatmapSetInfo))
                 return;
 
-            beatmaps.Download(onlineBeatmap);
+            beatmaps.Download(beatmapSetInfo);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -51,7 +51,6 @@ namespace osu.Game.Screens.Play
         private Container beatmapPanelContainer;
         private TriangleButton watchButton;
         private SettingsCheckbox automaticDownload;
-        private APIBeatmapSet onlineBeatmap;
 
         /// <summary>
         /// The player's immediate online gameplay state.
@@ -60,6 +59,8 @@ namespace osu.Game.Screens.Play
         private SpectatorGameplayState immediateSpectatorGameplayState;
 
         private GetBeatmapSetRequest onlineBeatmapRequest;
+
+        private APIBeatmapSet beatmapSet;
 
         public SoloSpectator([NotNull] User targetUser)
             : base(targetUser.Id)
@@ -221,10 +222,10 @@ namespace osu.Game.Screens.Play
             Debug.Assert(state.BeatmapID != null);
 
             onlineBeatmapRequest = new GetBeatmapSetRequest(state.BeatmapID.Value, BeatmapSetLookupType.BeatmapId);
-            onlineBeatmapRequest.Success += res => Schedule(() =>
+            onlineBeatmapRequest.Success += beatmapSet => Schedule(() =>
             {
-                onlineBeatmap = res;
-                beatmapPanelContainer.Child = new GridBeatmapPanel(onlineBeatmap);
+                this.beatmapSet = beatmapSet;
+                beatmapPanelContainer.Child = new GridBeatmapPanel(this.beatmapSet);
                 checkForAutomaticDownload();
             });
 
@@ -233,14 +234,14 @@ namespace osu.Game.Screens.Play
 
         private void checkForAutomaticDownload()
         {
-            if (onlineBeatmap == null)
+            if (beatmapSet == null)
                 return;
 
             if (!automaticDownload.Current.Value)
                 return;
 
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
-            var beatmapSetInfo = new BeatmapSetInfo { OnlineBeatmapSetID = onlineBeatmap.OnlineID };
+            var beatmapSetInfo = new BeatmapSetInfo { OnlineBeatmapSetID = beatmapSet.OnlineID };
 
             if (beatmaps.IsAvailableLocally(beatmapSetInfo))
                 return;

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -240,13 +240,10 @@ namespace osu.Game.Screens.Play
             if (!automaticDownload.Current.Value)
                 return;
 
-            // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
-            var beatmapSetInfo = new BeatmapSetInfo { OnlineBeatmapSetID = beatmapSet.OnlineID };
-
-            if (beatmaps.IsAvailableLocally(beatmapSetInfo))
+            if (beatmaps.IsAvailableLocally(new BeatmapSetInfo { OnlineBeatmapSetID = beatmapSet.OnlineID }))
                 return;
 
-            beatmaps.Download(beatmapSetInfo);
+            beatmaps.Download(beatmapSet);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -13,6 +13,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
@@ -265,18 +266,24 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return ((IMultiplayerClient)this).LoadRequested();
         }
 
-        protected override Task<BeatmapSetInfo> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default)
+        protected override Task<APIBeatmapSet> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default)
         {
             Debug.Assert(Room != null);
 
             var apiRoom = roomManager.ServerSideRooms.Single(r => r.RoomID.Value == Room.RoomID);
-            var set = apiRoom.Playlist.FirstOrDefault(p => p.BeatmapID == beatmapId)?.Beatmap.Value.BeatmapSet
-                      ?? beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == beatmapId)?.BeatmapSet;
+            IBeatmapSetInfo? set = apiRoom.Playlist.FirstOrDefault(p => p.BeatmapID == beatmapId)?.Beatmap.Value.BeatmapSet
+                                   ?? beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == beatmapId)?.BeatmapSet;
 
             if (set == null)
                 throw new InvalidOperationException("Beatmap not found.");
 
-            return Task.FromResult(set);
+            var apiSet = new APIBeatmapSet
+            {
+                OnlineID = set.OnlineID,
+                Beatmaps = set.Beatmaps.Select(b => new APIBeatmap { OnlineID = b.OnlineID })
+            };
+
+            return Task.FromResult(apiSet);
         }
 
         private async Task changeMatchType(MatchType type)

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             var apiSet = new APIBeatmapSet
             {
                 OnlineID = set.OnlineID,
-                Beatmaps = set.Beatmaps.Select(b => new APIBeatmap { OnlineID = b.OnlineID })
+                Beatmaps = set.Beatmaps.Select(b => new APIBeatmap { OnlineID = b.OnlineID }).ToArray(),
             };
 
             return Task.FromResult(apiSet);


### PR DESCRIPTION
- Also fixes a regression with solo spectator download logic (which would have caused a similar issue to what was fixed in https://github.com/ppy/osu/pull/1542), see https://github.com/ppy/osu/commit/0df339d0b8a08a4042f50375428d3fe8d9af928a.
- Also makes `IBeatmapInfo.Metadata` non-nullable. Can be split out into a separate PR if required.