### PR TITLE
Remove all remaining calls to `ToBeatmapInfo`/`ToBeatmapSetInfo`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -81,34 +81,6 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public double BPM { get; set; }
 
-        public virtual BeatmapInfo ToBeatmapInfo(RulesetStore rulesets)
-        {
-            var set = BeatmapSet?.ToBeatmapSet(rulesets);
-
-            return new BeatmapInfo
-            {
-                Metadata = set?.Metadata ?? new BeatmapMetadata(),
-                Ruleset = rulesets.GetRuleset(RulesetID),
-                StarDifficulty = StarRating,
-                OnlineBeatmapID = OnlineID,
-                Version = DifficultyName,
-                // this is actually an incorrect mapping (Length is calculated as drain length in lazer's import process, see BeatmapManager.calculateLength).
-                Length = Length,
-                Status = Status,
-                MD5Hash = Checksum,
-                BeatmapSet = set,
-                MaxCombo = MaxCombo,
-                BaseDifficulty = new BeatmapDifficulty
-                {
-                    DrainRate = DrainRate,
-                    CircleSize = CircleSize,
-                    ApproachRate = ApproachRate,
-                    OverallDifficulty = OverallDifficulty,
-                },
-                OnlineInfo = this,
-            };
-        }
-
         #region Implementation of IBeatmapInfo
 
         public IBeatmapMetadataInfo Metadata => (BeatmapSet as IBeatmapSetInfo)?.Metadata ?? new BeatmapMetadata();

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
-using osu.Game.Rulesets;
 using osu.Game.Users;
 
 #nullable enable
@@ -120,26 +118,6 @@ namespace osu.Game.Online.API.Requests.Responses
 
         [JsonProperty(@"beatmaps")]
         public APIBeatmap[] Beatmaps { get; set; } = Array.Empty<APIBeatmap>();
-
-        public virtual BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets)
-        {
-            var beatmapSet = new BeatmapSetInfo
-            {
-                OnlineBeatmapSetID = OnlineID,
-                Metadata = metadata,
-                Status = Status,
-            };
-
-            beatmapSet.Beatmaps = Beatmaps.Select(b =>
-            {
-                var beatmap = b.ToBeatmapInfo(rulesets);
-                beatmap.BeatmapSet = beatmapSet;
-                beatmap.Metadata = beatmapSet.Metadata;
-                return beatmap;
-            }).ToList();
-
-            return beatmapSet;
-        }
 
         private BeatmapMetadata metadata => new BeatmapMetadata
         {

--- a/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Online.API.Requests.Responses
             {
                 TotalScore = TotalScore,
                 MaxCombo = MaxCombo,
-                BeatmapInfo = Beatmap?.ToBeatmapInfo(rulesets),
+                BeatmapInfo = beatmap,
                 User = User,
                 Accuracy = Accuracy,
                 OnlineScoreID = OnlineID,
@@ -110,9 +110,6 @@ namespace osu.Game.Online.API.Requests.Responses
                 Ruleset = ruleset,
                 Mods = modInstances,
             };
-
-            if (beatmap != null)
-                scoreInfo.BeatmapInfo = beatmap;
 
             if (Statistics != null)
             {

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -66,7 +66,10 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 if (value?.Scores.Any() != true)
                     return;
 
-                scoreManager.OrderByTotalScoreAsync(value.Scores.Select(s => s.CreateScoreInfo(rulesets, Beatmap.Value.ToBeatmapInfo(rulesets))).ToArray(), loadCancellationSource.Token)
+                // TODO: temporary. should be removed once `OrderByTotalScore` can accept `IScoreInfo`.
+                var beatmapInfo = new BeatmapInfo { MaxCombo = Beatmap.Value.MaxCombo };
+
+                scoreManager.OrderByTotalScoreAsync(value.Scores.Select(s => s.CreateScoreInfo(rulesets, beatmapInfo)).ToArray(), loadCancellationSource.Token)
                             .ContinueWith(ordered => Schedule(() =>
                             {
                                 if (loadCancellationSource.IsCancellationRequested)
@@ -78,7 +81,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 scoreTable.Show();
 
                                 var userScore = value.UserScore;
-                                var userScoreInfo = userScore?.Score.CreateScoreInfo(rulesets, Beatmap.Value.ToBeatmapInfo(rulesets));
+                                var userScoreInfo = userScore?.Score.CreateScoreInfo(rulesets, beatmapInfo);
 
                                 topScoresContainer.Add(new DrawableTopScore(topScore));
 

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,8 +67,16 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 if (value?.Scores.Any() != true)
                     return;
 
+                var apiBeatmap = Beatmap.Value;
+
+                Debug.Assert(apiBeatmap != null);
+
                 // TODO: temporary. should be removed once `OrderByTotalScore` can accept `IScoreInfo`.
-                var beatmapInfo = new BeatmapInfo { MaxCombo = Beatmap.Value.MaxCombo };
+                var beatmapInfo = new BeatmapInfo
+                {
+                    MaxCombo = apiBeatmap.MaxCombo,
+                    Status = apiBeatmap.Status
+                };
 
                 scoreManager.OrderByTotalScoreAsync(value.Scores.Select(s => s.CreateScoreInfo(rulesets, beatmapInfo)).ToArray(), loadCancellationSource.Token)
                             .ContinueWith(ordered => Schedule(() =>
@@ -77,7 +86,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
 
                                 var topScore = ordered.Result.First();
 
-                                scoreTable.DisplayScores(ordered.Result, topScore.BeatmapInfo?.Status.GrantsPerformancePoints() == true);
+                                scoreTable.DisplayScores(ordered.Result, apiBeatmap.Status.GrantsPerformancePoints());
                                 scoreTable.Show();
 
                                 var userScore = value.UserScore;


### PR DESCRIPTION
This is the end of the line of my outstanding refactors. Which isn't to say everything is in a good state, but we're getting there. Note that there's one weird usage which suggests where the remaining work to be done is (`ScoreManager.OrderByTotalScoreAsync` and related classes need to handle `IScoreInfo`). There's also some remaining tidy-up work to be done on user representations in model classes, which will come next.

- [x] Depends on #15458 
- [x] Depends on #15459 