### PR TITLE
Fix labelled drawable descriptions not showing

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledDrawable.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledDrawable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
@@ -65,10 +66,10 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private void createPaddedComponent(bool hasDescription = false, bool padded = true)
         {
+            LabelledDrawable<Drawable> component = null;
+
             AddStep("create component", () =>
             {
-                LabelledDrawable<Drawable> component;
-
                 Child = new Container
                 {
                     Anchor = Anchor.Centre,
@@ -81,6 +82,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                 component.Label = "a sample component";
                 component.Description = hasDescription ? "this text describes the component" : string.Empty;
             });
+
+            AddAssert($"description {(hasDescription ? "visible" : "hidden")}", () => component.ChildrenOfType<TextFlowContainer>().ElementAt(1).IsPresent == hasDescription);
         }
 
         private class PaddedLabelledDrawable : LabelledDrawable<Drawable>

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 descriptionText.Text = value;
 
-                if (value == default)
+                if (!string.IsNullOrEmpty(value.ToString()))
                     descriptionText.Show();
                 else
                     descriptionText.Hide();


### PR DESCRIPTION
Regressed in #15440.

Not sure what to say at this point, another stupid one on my behalf. Considering taking a while off at this point to reevaluate some things because jesus christ.

Test coverage added because coverage was simple enough to add.