### PR TITLE
Fix more occurring "possible null reference exception" inspections

### DIFF
--- a/osu.Game.Tests/Mods/ModDifficultyAdjustTest.cs
+++ b/osu.Game.Tests/Mods/ModDifficultyAdjustTest.cs
@@ -105,6 +105,9 @@ namespace osu.Game.Tests.Mods
             testMod.ResetSettingsToDefaults();
 
             Assert.That(testMod.DrainRate.Value, Is.Null);
+
+            // ReSharper disable once HeuristicUnreachableCode
+            // see https://youtrack.jetbrains.com/issue/RIDER-70159.
             Assert.That(testMod.OverallDifficulty.Value, Is.Null);
 
             var applied = applyDifficulty(new BeatmapDifficulty

--- a/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
+++ b/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
@@ -79,8 +79,10 @@ namespace osu.Game.Tests.NonVisual
             public List<HitObject> HitObjects;
             public override IEnumerable<HitObject> Objects => HitObjects;
 
+#pragma warning disable 67
             public override event Action<JudgementResult> NewResult;
             public override event Action<JudgementResult> RevertResult;
+#pragma warning restore 67
 
             public override Playfield Playfield { get; }
             public override Container Overlays { get; }
@@ -95,9 +97,6 @@ namespace osu.Game.Tests.NonVisual
             public TestDrawableRuleset()
                 : base(new OsuRuleset())
             {
-                // won't compile without this.
-                NewResult?.Invoke(null);
-                RevertResult?.Invoke(null);
             }
 
             public override void SetReplayScore(Score replayScore) => throw new NotImplementedException();

--- a/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
+++ b/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
@@ -79,10 +79,17 @@ namespace osu.Game.Tests.NonVisual
             public List<HitObject> HitObjects;
             public override IEnumerable<HitObject> Objects => HitObjects;
 
-#pragma warning disable 67
-            public override event Action<JudgementResult> NewResult;
-            public override event Action<JudgementResult> RevertResult;
-#pragma warning restore 67
+            public override event Action<JudgementResult> NewResult
+            {
+                add => throw new InvalidOperationException();
+                remove => throw new InvalidOperationException();
+            }
+
+            public override event Action<JudgementResult> RevertResult
+            {
+                add => throw new InvalidOperationException();
+                remove => throw new InvalidOperationException();
+            }
 
             public override Playfield Playfield { get; }
             public override Container Overlays { get; }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -235,10 +235,17 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public override IEnumerable<HitObject> Objects => new[] { new HitCircle { HitWindows = HitWindows } };
 
-#pragma warning disable 67
-            public override event Action<JudgementResult> NewResult;
-            public override event Action<JudgementResult> RevertResult;
-#pragma warning restore 67
+            public override event Action<JudgementResult> NewResult
+            {
+                add => throw new InvalidOperationException();
+                remove => throw new InvalidOperationException();
+            }
+
+            public override event Action<JudgementResult> RevertResult
+            {
+                add => throw new InvalidOperationException();
+                remove => throw new InvalidOperationException();
+            }
 
             public override Playfield Playfield { get; }
             public override Container Overlays { get; }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -235,8 +235,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public override IEnumerable<HitObject> Objects => new[] { new HitCircle { HitWindows = HitWindows } };
 
+#pragma warning disable 67
             public override event Action<JudgementResult> NewResult;
             public override event Action<JudgementResult> RevertResult;
+#pragma warning restore 67
 
             public override Playfield Playfield { get; }
             public override Container Overlays { get; }
@@ -251,9 +253,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             public TestDrawableRuleset()
                 : base(new OsuRuleset())
             {
-                // won't compile without this.
-                NewResult?.Invoke(null);
-                RevertResult?.Invoke(null);
             }
 
             public override void SetReplayScore(Score replayScore) => throw new NotImplementedException();

--- a/osu.Game/Graphics/UserInterface/LoadingButton.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingButton.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osuTK;
@@ -22,15 +24,9 @@ namespace osu.Game.Graphics.UserInterface
                 Enabled.Value = !isLoading;
 
                 if (value)
-                {
                     loading.Show();
-                    OnLoadStarted();
-                }
                 else
-                {
                     loading.Hide();
-                    OnLoadFinished();
-                }
             }
         }
 
@@ -44,16 +40,32 @@ namespace osu.Game.Graphics.UserInterface
 
         protected LoadingButton()
         {
-            AddRange(new[]
+            Add(loading = new LoadingSpinner
             {
-                CreateContent(),
-                loading = new LoadingSpinner
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Size = new Vector2(12)
-                }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(12),
+                Depth = -1,
             });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Add(CreateContent());
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            loading.State.BindValueChanged(s =>
+            {
+                if (s.NewValue == Visibility.Visible)
+                    OnLoadStarted();
+                else
+                    OnLoadFinished();
+            }, true);
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -23,8 +24,11 @@ namespace osu.Game.Overlays.BeatmapListing
         public BeatmapSearchMultipleSelectionFilterRow(LocalisableString header)
             : base(header)
         {
-            // ReSharper disable once PossibleNullReferenceException
-            // see https://youtrack.jetbrains.com/issue/RSRP-486768
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             Current.BindTo(filter.Current);
         }
 
@@ -33,6 +37,7 @@ namespace osu.Game.Overlays.BeatmapListing
         /// <summary>
         /// Creates a filter control that can be used to simultaneously select multiple values of type <typeparamref name="T"/>.
         /// </summary>
+        [NotNull]
         protected virtual MultipleSelectionFilter CreateMultipleSelectionFilter() => new MultipleSelectionFilter();
 
         protected class MultipleSelectionFilter : FillFlowContainer<MultipleSelectionFilterTabItem>

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Overlays.BeatmapListing
         public BeatmapSearchMultipleSelectionFilterRow(LocalisableString header)
             : base(header)
         {
+            // ReSharper disable once PossibleNullReferenceException
+            // see https://youtrack.jetbrains.com/issue/RSRP-486768
             Current.BindTo(filter.Current);
         }
 

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -38,14 +38,6 @@ namespace osu.Game.Overlays.Changelog
             };
 
             Build.ValueChanged += showBuild;
-
-            // ReSharper disable once PossibleNullReferenceException
-            // see https://youtrack.jetbrains.com/issue/RSRP-486768
-            Streams.Current.ValueChanged += e =>
-            {
-                if (e.NewValue?.LatestBuild != null && !e.NewValue.Equals(Build.Value?.UpdateStream))
-                    Build.Value = e.NewValue.LatestBuild;
-            };
         }
 
         [BackgroundDependencyLoader]
@@ -75,29 +67,40 @@ namespace osu.Game.Overlays.Changelog
 
         protected override Drawable CreateBackground() => new OverlayHeaderBackground(@"Headers/changelog");
 
-        protected override Drawable CreateContent() => new Container
+        protected override Drawable CreateContent()
         {
-            RelativeSizeAxes = Axes.X,
-            AutoSizeAxes = Axes.Y,
-            Children = new Drawable[]
+            var content = new Container
             {
-                streamsBackground = new Box
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both
-                },
-                new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding
+                    streamsBackground = new Box
                     {
-                        Horizontal = 65,
-                        Vertical = 20
+                        RelativeSizeAxes = Axes.Both
                     },
-                    Child = Streams = new ChangelogUpdateStreamControl()
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = 65,
+                            Vertical = 20
+                        },
+                        Child = Streams = new ChangelogUpdateStreamControl()
+                    }
                 }
-            }
-        };
+            };
+
+            Streams.Current.ValueChanged += e =>
+            {
+                if (e.NewValue?.LatestBuild != null && !e.NewValue.Equals(Build.Value?.UpdateStream))
+                    Build.Value = e.NewValue.LatestBuild;
+            };
+
+            return content;
+        }
 
         protected override OverlayTitle CreateTitle() => new ChangelogHeaderTitle();
 

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Overlays.Changelog
 
             Build.ValueChanged += showBuild;
 
+            // ReSharper disable once PossibleNullReferenceException
+            // see https://youtrack.jetbrains.com/issue/RSRP-486768
             Streams.Current.ValueChanged += e =>
             {
                 if (e.NewValue?.LatestBuild != null && !e.NewValue.Equals(Build.Value?.UpdateStream))

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Overlays.Changelog
 
         public static LocalisableString ListingString => LayoutStrings.HeaderChangelogIndex;
 
+        private readonly Bindable<APIUpdateStream> currentStream = new Bindable<APIUpdateStream>();
+
         private Box streamsBackground;
 
         public ChangelogHeader()
@@ -38,6 +40,12 @@ namespace osu.Game.Overlays.Changelog
             };
 
             Build.ValueChanged += showBuild;
+
+            currentStream.ValueChanged += e =>
+            {
+                if (e.NewValue?.LatestBuild != null && !e.NewValue.Equals(Build.Value?.UpdateStream))
+                    Build.Value = e.NewValue.LatestBuild;
+            };
         }
 
         [BackgroundDependencyLoader]
@@ -61,7 +69,7 @@ namespace osu.Game.Overlays.Changelog
             else
             {
                 Current.Value = ListingString;
-                Streams.Current.Value = null;
+                currentStream.Value = null;
             }
         }
 
@@ -88,15 +96,9 @@ namespace osu.Game.Overlays.Changelog
                             Horizontal = 65,
                             Vertical = 20
                         },
-                        Child = Streams = new ChangelogUpdateStreamControl()
+                        Child = Streams = new ChangelogUpdateStreamControl { Current = currentStream },
                     }
                 }
-            };
-
-            Streams.Current.ValueChanged += e =>
-            {
-                if (e.NewValue?.LatestBuild != null && !e.NewValue.Equals(Build.Value?.UpdateStream))
-                    Build.Value = e.NewValue.LatestBuild;
             };
 
             return content;
@@ -115,7 +117,7 @@ namespace osu.Game.Overlays.Changelog
             if (Build.Value == null)
                 return;
 
-            Streams.Current.Value = Streams.Items.FirstOrDefault(s => s.Name == Build.Value.UpdateStream.Name);
+            currentStream.Value = Streams.Items.FirstOrDefault(s => s.Name == Build.Value.UpdateStream.Name);
         }
 
         private class ChangelogHeaderTitle : OverlayTitle

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -75,34 +75,29 @@ namespace osu.Game.Overlays.Changelog
 
         protected override Drawable CreateBackground() => new OverlayHeaderBackground(@"Headers/changelog");
 
-        protected override Drawable CreateContent()
+        protected override Drawable CreateContent() => new Container
         {
-            var content = new Container
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Children = new Drawable[]
+                streamsBackground = new Box
                 {
-                    streamsBackground = new Box
+                    RelativeSizeAxes = Axes.Both
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding
                     {
-                        RelativeSizeAxes = Axes.Both
+                        Horizontal = 65,
+                        Vertical = 20
                     },
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Padding = new MarginPadding
-                        {
-                            Horizontal = 65,
-                            Vertical = 20
-                        },
-                        Child = Streams = new ChangelogUpdateStreamControl { Current = currentStream },
-                    }
+                    Child = Streams = new ChangelogUpdateStreamControl { Current = currentStream },
                 }
-            };
-
-            return content;
-        }
+            }
+        };
 
         protected override OverlayTitle CreateTitle() => new ChangelogHeaderTitle();
 

--- a/osu.Game/Overlays/Comments/CommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CommentEditor.cs
@@ -187,6 +187,8 @@ namespace osu.Game.Overlays.Comments
                 AutoSizeAxes = Axes.Both;
                 LoadingAnimationSize = new Vector2(10);
 
+                // ReSharper disable once PossibleNullReferenceException
+                // see https://youtrack.jetbrains.com/issue/RSRP-486768
                 drawableText.Text = text;
             }
 

--- a/osu.Game/Overlays/Comments/CommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CommentEditor.cs
@@ -175,6 +175,8 @@ namespace osu.Game.Overlays.Comments
 
             protected override IEnumerable<Drawable> EffectTargets => new[] { background };
 
+            private readonly string text;
+
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; }
 
@@ -184,12 +186,10 @@ namespace osu.Game.Overlays.Comments
 
             public CommitButton(string text)
             {
+                this.text = text;
+
                 AutoSizeAxes = Axes.Both;
                 LoadingAnimationSize = new Vector2(10);
-
-                // ReSharper disable once PossibleNullReferenceException
-                // see https://youtrack.jetbrains.com/issue/RSRP-486768
-                drawableText.Text = text;
             }
 
             [BackgroundDependencyLoader]
@@ -198,6 +198,8 @@ namespace osu.Game.Overlays.Comments
                 IdleColour = colourProvider.Light4;
                 HoverColour = colourProvider.Light3;
                 blockedBackground.Colour = colourProvider.Background5;
+
+                drawableText.Text = text;
             }
 
             protected override void LoadComplete()
@@ -234,7 +236,7 @@ namespace osu.Game.Overlays.Comments
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                        Margin = new MarginPadding { Horizontal = 20 }
+                        Margin = new MarginPadding { Horizontal = 20 },
                     }
                 }
             };

--- a/osu.Game/Overlays/Comments/CommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CommentEditor.cs
@@ -198,8 +198,6 @@ namespace osu.Game.Overlays.Comments
                 IdleColour = colourProvider.Light4;
                 HoverColour = colourProvider.Light3;
                 blockedBackground.Colour = colourProvider.Background5;
-
-                drawableText.Text = text;
             }
 
             protected override void LoadComplete()
@@ -237,6 +235,7 @@ namespace osu.Game.Overlays.Comments
                         Origin = Anchor.Centre,
                         Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                         Margin = new MarginPadding { Horizontal = 20 },
+                        Text = text,
                     }
                 }
             };

--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -37,11 +37,7 @@ namespace osu.Game.Overlays
                 Anchor = Anchor.BottomRight,
                 Origin = Anchor.BottomRight,
                 Margin = new MarginPadding(20),
-                Action = () =>
-                {
-                    ScrollToStart();
-                    Button.State = Visibility.Hidden;
-                }
+                Action = scrollToTop
             });
         }
 
@@ -56,6 +52,12 @@ namespace osu.Game.Overlays
             }
 
             Button.State = Target > button_scroll_position ? Visibility.Visible : Visibility.Hidden;
+        }
+
+        private void scrollToTop()
+        {
+            ScrollToStart();
+            Button.State = Visibility.Hidden;
         }
 
         public class ScrollToTopButton : OsuHoverContainer


### PR DESCRIPTION
## https://github.com/ppy/osu/commit/af6ae1cce560faa31fd4033c4678054050e99a7c

<img width="500" alt="CleanShot 2021-11-05 at 04 58 11@2x" src="https://user-images.githubusercontent.com/22781491/140445510-ef11b55e-aa14-4f10-85b2-a47b4c7d699a.png">

Resolved by removing that code and instead using `#pragma warning disable` to actually disable the underlying warning (`NewResult` and `RevertResult` overriden but never invoked).

This is one case where having an `IDrawableRuleset` interface would be better than a `DrawableRuleset` class, as the test class can explicitly implement the events rather than having to override them.

## https://github.com/ppy/osu/commit/6197ef426dd1a70e1240e7a9ea0eb83b837f61df

<img width="500" alt="CleanShot 2021-11-05 at 05 07 09@2x" src="https://user-images.githubusercontent.com/22781491/140446308-020e24ee-4aa3-4b60-8142-85ee411ac96e.png">

Similar to https://github.com/ppy/osu/commit/09f9731d74fb021188b98190dac6bfba0b105cc4 in another test case. Tracked in https://youtrack.jetbrains.com/issue/RIDER-70159.

## https://github.com/ppy/osu/commit/36d99a2e34297f1a2c7f0dacb2704ab8e61a463f

<img width="500" alt="CleanShot 2021-11-05 at 05 07 54@2x" src="https://user-images.githubusercontent.com/22781491/140446370-6c0c7971-3d2e-4c84-8987-d1cba91c8dcc.png">

I've moved it to a separate named function to hide the null inspection, similar to how it's done elsewhere IIRC.