### PR TITLE
Allow downloads via interface types (and remove `IModelManager:IModelImporter`)

### DIFF
--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -168,15 +168,15 @@ namespace osu.Game.Tests.Online
                 return new TestBeatmapModelManager(this, storage, contextFactory, rulesets, api, host);
             }
 
-            protected override BeatmapModelDownloader CreateBeatmapModelDownloader(IBeatmapModelManager manager, IAPIProvider api, GameHost host)
+            protected override BeatmapModelDownloader CreateBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> manager, IAPIProvider api, GameHost host)
             {
                 return new TestBeatmapModelDownloader(manager, api, host);
             }
 
             internal class TestBeatmapModelDownloader : BeatmapModelDownloader
             {
-                public TestBeatmapModelDownloader(IBeatmapModelManager modelManager, IAPIProvider apiProvider, GameHost gameHost)
-                    : base(modelManager, apiProvider, gameHost)
+                public TestBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> importer, IAPIProvider apiProvider, GameHost gameHost)
+                    : base(importer, apiProvider, gameHost)
                 {
                 }
 

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Tests.Online
                 {
                 }
 
-                protected override ArchiveDownloadRequest<BeatmapSetInfo> CreateDownloadRequest(BeatmapSetInfo set, bool minimiseDownloadSize)
+                protected override ArchiveDownloadRequest<IBeatmapSetInfo> CreateDownloadRequest(IBeatmapSetInfo set, bool minimiseDownloadSize)
                     => new TestDownloadRequest(set);
             }
 
@@ -202,12 +202,12 @@ namespace osu.Game.Tests.Online
             }
         }
 
-        private class TestDownloadRequest : ArchiveDownloadRequest<BeatmapSetInfo>
+        private class TestDownloadRequest : ArchiveDownloadRequest<IBeatmapSetInfo>
         {
             public new void SetProgress(float progress) => base.SetProgress(progress);
             public new void TriggerSuccess(string filename) => base.TriggerSuccess(filename);
 
-            public TestDownloadRequest(BeatmapSetInfo model)
+            public TestDownloadRequest(IBeatmapSetInfo model)
                 : base(model)
             {
             }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Beatmaps
     /// Handles general operations related to global beatmap management.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public class BeatmapManager : IModelDownloader<BeatmapSetInfo>, IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, IWorkingBeatmapCache, IDisposable
+    public class BeatmapManager : IModelDownloader<BeatmapSetInfo>, IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache, IDisposable
     {
         private readonly BeatmapModelManager beatmapModelManager;
         private readonly BeatmapModelDownloader beatmapModelDownloader;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Beatmaps
     /// Handles general operations related to global beatmap management.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public class BeatmapManager : IModelDownloader<BeatmapSetInfo>, IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache, IDisposable
+    public class BeatmapManager : IModelDownloader<IBeatmapSetInfo>, IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache, IDisposable
     {
         private readonly BeatmapModelManager beatmapModelManager;
         private readonly BeatmapModelDownloader beatmapModelDownloader;
@@ -246,33 +246,16 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IModelDownloader<BeatmapSetInfo>
 
-        public IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> DownloadBegan => beatmapModelDownloader.DownloadBegan;
+        public IBindable<WeakReference<ArchiveDownloadRequest<IBeatmapSetInfo>>> DownloadBegan => beatmapModelDownloader.DownloadBegan;
 
-        public IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> DownloadFailed => beatmapModelDownloader.DownloadFailed;
+        public IBindable<WeakReference<ArchiveDownloadRequest<IBeatmapSetInfo>>> DownloadFailed => beatmapModelDownloader.DownloadFailed;
 
-        // Temporary method until this class supports IBeatmapSetInfo or otherwise.
         public bool Download(IBeatmapSetInfo model, bool minimiseDownloadSize = false)
-        {
-            return beatmapModelDownloader.Download(new BeatmapSetInfo
-            {
-                OnlineBeatmapSetID = model.OnlineID,
-                Metadata = new BeatmapMetadata
-                {
-                    Title = model.Metadata?.Title ?? string.Empty,
-                    Artist = model.Metadata?.Artist ?? string.Empty,
-                    TitleUnicode = model.Metadata?.TitleUnicode ?? string.Empty,
-                    ArtistUnicode = model.Metadata?.ArtistUnicode ?? string.Empty,
-                    Author = new User { Username = model.Metadata?.Author },
-                }
-            }, minimiseDownloadSize);
-        }
-
-        public bool Download(BeatmapSetInfo model, bool minimiseDownloadSize = false)
         {
             return beatmapModelDownloader.Download(model, minimiseDownloadSize);
         }
 
-        public ArchiveDownloadRequest<BeatmapSetInfo> GetExistingDownload(BeatmapSetInfo model)
+        public ArchiveDownloadRequest<IBeatmapSetInfo> GetExistingDownload(IBeatmapSetInfo model)
         {
             return beatmapModelDownloader.GetExistingDownload(model);
         }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        protected virtual BeatmapModelDownloader CreateBeatmapModelDownloader(IBeatmapModelManager modelManager, IAPIProvider api, GameHost host)
+        protected virtual BeatmapModelDownloader CreateBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> modelManager, IAPIProvider api, GameHost host)
         {
             return new BeatmapModelDownloader(modelManager, api, host);
         }

--- a/osu.Game/Beatmaps/BeatmapModelDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapModelDownloader.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Beatmaps
         public override ArchiveDownloadRequest<BeatmapSetInfo> GetExistingDownload(BeatmapSetInfo model)
             => CurrentDownloads.Find(r => r.Model.OnlineID == model.OnlineID);
 
-        public BeatmapModelDownloader(IBeatmapModelManager beatmapModelManager, IAPIProvider api, GameHost host = null)
-            : base(beatmapModelManager, api, host)
+        public BeatmapModelDownloader(IModelImporter<BeatmapSetInfo> beatmapImporter, IAPIProvider api, GameHost host = null)
+            : base(beatmapImporter, api, host)
         {
         }
     }

--- a/osu.Game/Beatmaps/BeatmapModelDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapModelDownloader.cs
@@ -8,12 +8,12 @@ using osu.Game.Online.API.Requests;
 
 namespace osu.Game.Beatmaps
 {
-    public class BeatmapModelDownloader : ModelDownloader<BeatmapSetInfo>
+    public class BeatmapModelDownloader : ModelDownloader<BeatmapSetInfo, IBeatmapSetInfo>
     {
-        protected override ArchiveDownloadRequest<BeatmapSetInfo> CreateDownloadRequest(BeatmapSetInfo set, bool minimiseDownloadSize) =>
+        protected override ArchiveDownloadRequest<IBeatmapSetInfo> CreateDownloadRequest(IBeatmapSetInfo set, bool minimiseDownloadSize) =>
             new DownloadBeatmapSetRequest(set, minimiseDownloadSize);
 
-        public override ArchiveDownloadRequest<BeatmapSetInfo> GetExistingDownload(BeatmapSetInfo model)
+        public override ArchiveDownloadRequest<IBeatmapSetInfo> GetExistingDownload(IBeatmapSetInfo model)
             => CurrentDownloads.Find(r => r.Model.OnlineID == model.OnlineID);
 
         public BeatmapModelDownloader(IModelImporter<BeatmapSetInfo> beatmapImporter, IAPIProvider api, GameHost host = null)

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Database
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
     /// <typeparam name="TFileModel">The associated file join type.</typeparam>
-    public abstract class ArchiveModelManager<TModel, TFileModel> : IModelManager<TModel>, IModelFileManager<TModel, TFileModel>
+    public abstract class ArchiveModelManager<TModel, TFileModel> : IModelImporter<TModel>, IModelManager<TModel>, IModelFileManager<TModel, TFileModel>
         where TModel : class, IHasFiles<TFileModel>, IHasPrimaryKey, ISoftDelete
         where TFileModel : class, INamedFileInfo, IHasPrimaryKey, new()
     {

--- a/osu.Game/Database/IModelDownloader.cs
+++ b/osu.Game/Database/IModelDownloader.cs
@@ -11,8 +11,9 @@ namespace osu.Game.Database
     /// Represents a <see cref="IModelManager{TModel}"/> that can download new models from an external source.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IModelDownloader<TModel> : IPostNotifications
-        where TModel : class
+    /// <typeparam name="T">The model's interface type.</typeparam>
+    public interface IModelDownloader<TModel, in T> : IPostNotifications
+        where TModel : class, T
     {
         /// <summary>
         /// Fired when a <typeparamref name="TModel"/> download begins.
@@ -32,7 +33,7 @@ namespace osu.Game.Database
         /// <param name="model">The <stypeparamref name="TModel"/> to be downloaded.</param>
         /// <param name="minimiseDownloadSize">Whether this download should be optimised for slow connections. Generally means extras are not included in the download bundle..</param>
         /// <returns>Whether the download was started.</returns>
-        bool Download(TModel model, bool minimiseDownloadSize);
+        bool Download(T model, bool minimiseDownloadSize);
 
         /// <summary>
         /// Gets an existing <typeparamref name="TModel"/> download request if it exists.

--- a/osu.Game/Database/IModelDownloader.cs
+++ b/osu.Game/Database/IModelDownloader.cs
@@ -10,36 +10,35 @@ namespace osu.Game.Database
     /// <summary>
     /// Represents a <see cref="IModelManager{TModel}"/> that can download new models from an external source.
     /// </summary>
-    /// <typeparam name="TModel">The model type.</typeparam>
-    /// <typeparam name="T">The model's interface type.</typeparam>
-    public interface IModelDownloader<TModel, in T> : IPostNotifications
-        where TModel : class, T
+    /// <typeparam name="T">The item's interface type.</typeparam>
+    public interface IModelDownloader<T> : IPostNotifications
+        where T : class
     {
         /// <summary>
-        /// Fired when a <typeparamref name="TModel"/> download begins.
+        /// Fired when a <typeparamref name="T"/> download begins.
         /// This is NOT run on the update thread and should be scheduled.
         /// </summary>
-        IBindable<WeakReference<ArchiveDownloadRequest<TModel>>> DownloadBegan { get; }
+        IBindable<WeakReference<ArchiveDownloadRequest<T>>> DownloadBegan { get; }
 
         /// <summary>
-        /// Fired when a <typeparamref name="TModel"/> download is interrupted, either due to user cancellation or failure.
+        /// Fired when a <typeparamref name="T"/> download is interrupted, either due to user cancellation or failure.
         /// This is NOT run on the update thread and should be scheduled.
         /// </summary>
-        IBindable<WeakReference<ArchiveDownloadRequest<TModel>>> DownloadFailed { get; }
+        IBindable<WeakReference<ArchiveDownloadRequest<T>>> DownloadFailed { get; }
 
         /// <summary>
-        /// Begin a download for the requested <typeparamref name="TModel"/>.
+        /// Begin a download for the requested <typeparamref name="T"/>.
         /// </summary>
-        /// <param name="model">The <stypeparamref name="TModel"/> to be downloaded.</param>
+        /// <param name="item">The <stypeparamref name="T"/> to be downloaded.</param>
         /// <param name="minimiseDownloadSize">Whether this download should be optimised for slow connections. Generally means extras are not included in the download bundle..</param>
         /// <returns>Whether the download was started.</returns>
-        bool Download(T model, bool minimiseDownloadSize);
+        bool Download(T item, bool minimiseDownloadSize);
 
         /// <summary>
-        /// Gets an existing <typeparamref name="TModel"/> download request if it exists.
+        /// Gets an existing <typeparamref name="T"/> download request if it exists.
         /// </summary>
-        /// <param name="model">The <typeparamref name="TModel"/> whose request is wanted.</param>
-        /// <returns>The <see cref="ArchiveDownloadRequest{TModel}"/> object if it exists, otherwise null.</returns>
-        ArchiveDownloadRequest<TModel> GetExistingDownload(TModel model);
+        /// <param name="item">The <typeparamref name="T"/> whose request is wanted.</param>
+        /// <returns>The <see cref="ArchiveDownloadRequest{T}"/> object if it exists, otherwise null.</returns>
+        ArchiveDownloadRequest<T> GetExistingDownload(T item);
     }
 }

--- a/osu.Game/Database/IModelManager.cs
+++ b/osu.Game/Database/IModelManager.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Database
     /// Represents a model manager that publishes events when <typeparamref name="TModel"/>s are added or removed.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IModelManager<TModel> : IModelImporter<TModel>
+    public interface IModelManager<TModel>
         where TModel : class
     {
         /// <summary>

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -27,14 +27,14 @@ namespace osu.Game.Database
 
         private readonly Bindable<WeakReference<ArchiveDownloadRequest<TModel>>> downloadFailed = new Bindable<WeakReference<ArchiveDownloadRequest<TModel>>>();
 
-        private readonly IModelManager<TModel> modelManager;
+        private readonly IModelImporter<TModel> importer;
         private readonly IAPIProvider api;
 
         protected readonly List<ArchiveDownloadRequest<TModel>> CurrentDownloads = new List<ArchiveDownloadRequest<TModel>>();
 
-        protected ModelDownloader(IModelManager<TModel> modelManager, IAPIProvider api, IIpcHost importHost = null)
+        protected ModelDownloader(IModelImporter<TModel> importer, IAPIProvider api, IIpcHost importHost = null)
         {
-            this.modelManager = modelManager;
+            this.importer = importer;
             this.api = api;
         }
 
@@ -68,7 +68,7 @@ namespace osu.Game.Database
                 Task.Factory.StartNew(async () =>
                 {
                     // This gets scheduled back to the update thread, but we want the import to run in the background.
-                    var imported = await modelManager.Import(notification, new ImportTask(filename)).ConfigureAwait(false);
+                    var imported = await importer.Import(notification, new ImportTask(filename)).ConfigureAwait(false);
 
                     // for now a failed import will be marked as a failed download for simplicity.
                     if (!imported.Any())
@@ -103,7 +103,7 @@ namespace osu.Game.Database
                 notification.State = ProgressNotificationState.Cancelled;
 
                 if (!(error is OperationCanceledException))
-                    Logger.Error(error, $"{modelManager.HumanisedModelName.Titleize()} download failed!");
+                    Logger.Error(error, $"{importer.HumanisedModelName.Titleize()} download failed!");
             }
         }
 

--- a/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
@@ -6,11 +6,11 @@ using osu.Game.Beatmaps;
 
 namespace osu.Game.Online.API.Requests
 {
-    public class DownloadBeatmapSetRequest : ArchiveDownloadRequest<BeatmapSetInfo>
+    public class DownloadBeatmapSetRequest : ArchiveDownloadRequest<IBeatmapSetInfo>
     {
         private readonly bool noVideo;
 
-        public DownloadBeatmapSetRequest(BeatmapSetInfo set, bool noVideo)
+        public DownloadBeatmapSetRequest(IBeatmapSetInfo set, bool noVideo)
             : base(set)
         {
             this.noVideo = noVideo;
@@ -25,6 +25,6 @@ namespace osu.Game.Online.API.Requests
 
         protected override string FileExtension => ".osz";
 
-        protected override string Target => $@"beatmapsets/{Model.OnlineBeatmapSetID}/download{(noVideo ? "?noVideo=1" : "")}";
+        protected override string Target => $@"beatmapsets/{Model.OnlineID}/download{(noVideo ? "?noVideo=1" : "")}";
     }
 }

--- a/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
@@ -5,15 +5,15 @@ using osu.Game.Scoring;
 
 namespace osu.Game.Online.API.Requests
 {
-    public class DownloadReplayRequest : ArchiveDownloadRequest<ScoreInfo>
+    public class DownloadReplayRequest : ArchiveDownloadRequest<IScoreInfo>
     {
-        public DownloadReplayRequest(ScoreInfo score)
+        public DownloadReplayRequest(IScoreInfo score)
             : base(score)
         {
         }
 
         protected override string FileExtension => ".osr";
 
-        protected override string Target => $@"scores/{Model.Ruleset.ShortName}/{Model.OnlineScoreID}/download";
+        protected override string Target => $@"scores/{Model.Ruleset.ShortName}/{Model.OnlineID}/download";
     }
 }

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Online
         [Resolved(CanBeNull = true)]
         protected BeatmapManager? Manager { get; private set; }
 
-        private ArchiveDownloadRequest<BeatmapSetInfo>? attachedRequest;
+        private ArchiveDownloadRequest<IBeatmapSetInfo>? attachedRequest;
 
         public BeatmapDownloadTracker(IBeatmapSetInfo trackedItem)
             : base(trackedItem)
@@ -25,8 +25,8 @@ namespace osu.Game.Online
 
         private IBindable<WeakReference<BeatmapSetInfo>>? managerUpdated;
         private IBindable<WeakReference<BeatmapSetInfo>>? managerRemoved;
-        private IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>>? managerDownloadBegan;
-        private IBindable<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>>? managerDownloadFailed;
+        private IBindable<WeakReference<ArchiveDownloadRequest<IBeatmapSetInfo>>>? managerDownloadBegan;
+        private IBindable<WeakReference<ArchiveDownloadRequest<IBeatmapSetInfo>>>? managerDownloadFailed;
 
         [BackgroundDependencyLoader(true)]
         private void load()
@@ -52,7 +52,7 @@ namespace osu.Game.Online
             managerRemoved.BindValueChanged(itemRemoved);
         }
 
-        private void downloadBegan(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> weakRequest)
+        private void downloadBegan(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<IBeatmapSetInfo>>> weakRequest)
         {
             if (weakRequest.NewValue.TryGetTarget(out var request))
             {
@@ -64,7 +64,7 @@ namespace osu.Game.Online
             }
         }
 
-        private void downloadFailed(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<BeatmapSetInfo>>> weakRequest)
+        private void downloadFailed(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<IBeatmapSetInfo>>> weakRequest)
         {
             if (weakRequest.NewValue.TryGetTarget(out var request))
             {
@@ -76,7 +76,7 @@ namespace osu.Game.Online
             }
         }
 
-        private void attachDownload(ArchiveDownloadRequest<BeatmapSetInfo>? request)
+        private void attachDownload(ArchiveDownloadRequest<IBeatmapSetInfo>? request)
         {
             if (attachedRequest != null)
             {

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Online
         [Resolved(CanBeNull = true)]
         protected ScoreManager? Manager { get; private set; }
 
-        private ArchiveDownloadRequest<ScoreInfo>? attachedRequest;
+        private ArchiveDownloadRequest<IScoreInfo>? attachedRequest;
 
         public ScoreDownloadTracker(ScoreInfo trackedItem)
             : base(trackedItem)
@@ -25,8 +25,8 @@ namespace osu.Game.Online
 
         private IBindable<WeakReference<ScoreInfo>>? managerUpdated;
         private IBindable<WeakReference<ScoreInfo>>? managerRemoved;
-        private IBindable<WeakReference<ArchiveDownloadRequest<ScoreInfo>>>? managerDownloadBegan;
-        private IBindable<WeakReference<ArchiveDownloadRequest<ScoreInfo>>>? managerDownloadFailed;
+        private IBindable<WeakReference<ArchiveDownloadRequest<IScoreInfo>>>? managerDownloadBegan;
+        private IBindable<WeakReference<ArchiveDownloadRequest<IScoreInfo>>>? managerDownloadFailed;
 
         [BackgroundDependencyLoader(true)]
         private void load()
@@ -56,7 +56,7 @@ namespace osu.Game.Online
             managerRemoved.BindValueChanged(itemRemoved);
         }
 
-        private void downloadBegan(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<ScoreInfo>>> weakRequest)
+        private void downloadBegan(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<IScoreInfo>>> weakRequest)
         {
             if (weakRequest.NewValue.TryGetTarget(out var request))
             {
@@ -68,7 +68,7 @@ namespace osu.Game.Online
             }
         }
 
-        private void downloadFailed(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<ScoreInfo>>> weakRequest)
+        private void downloadFailed(ValueChangedEvent<WeakReference<ArchiveDownloadRequest<IScoreInfo>>> weakRequest)
         {
             if (weakRequest.NewValue.TryGetTarget(out var request))
             {
@@ -80,7 +80,7 @@ namespace osu.Game.Online
             }
         }
 
-        private void attachDownload(ArchiveDownloadRequest<ScoreInfo>? request)
+        private void attachDownload(ArchiveDownloadRequest<IScoreInfo>? request)
         {
             if (attachedRequest != null)
             {
@@ -144,7 +144,7 @@ namespace osu.Game.Online
             }
         }
 
-        private bool checkEquality(ScoreInfo x, ScoreInfo y) => x.OnlineScoreID == y.OnlineScoreID;
+        private bool checkEquality(IScoreInfo x, IScoreInfo y) => x.OnlineID == y.OnlineID;
 
         #region Disposal
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -25,7 +25,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Scoring
 {
-    public class ScoreManager : IModelManager<ScoreInfo>, IModelImporter<ScoreInfo>, IModelFileManager<ScoreInfo, ScoreFileInfo>, IModelDownloader<ScoreInfo>
+    public class ScoreManager : IModelManager<ScoreInfo>, IModelImporter<ScoreInfo>, IModelFileManager<ScoreInfo, ScoreFileInfo>, IModelDownloader<IScoreInfo>
     {
         private readonly Scheduler scheduler;
         private readonly Func<BeatmapDifficultyCache> difficulties;
@@ -350,16 +350,14 @@ namespace osu.Game.Scoring
 
         #region Implementation of IModelDownloader<ScoreInfo>
 
-        public IBindable<WeakReference<ArchiveDownloadRequest<ScoreInfo>>> DownloadBegan => scoreModelDownloader.DownloadBegan;
+        public IBindable<WeakReference<ArchiveDownloadRequest<IScoreInfo>>> DownloadBegan => scoreModelDownloader.DownloadBegan;
 
-        public IBindable<WeakReference<ArchiveDownloadRequest<ScoreInfo>>> DownloadFailed => scoreModelDownloader.DownloadFailed;
+        public IBindable<WeakReference<ArchiveDownloadRequest<IScoreInfo>>> DownloadFailed => scoreModelDownloader.DownloadFailed;
 
-        public bool Download(ScoreInfo model, bool minimiseDownloadSize)
-        {
-            return scoreModelDownloader.Download(model, minimiseDownloadSize);
-        }
+        public bool Download(IScoreInfo model, bool minimiseDownloadSize) =>
+            scoreModelDownloader.Download(model, minimiseDownloadSize);
 
-        public ArchiveDownloadRequest<ScoreInfo> GetExistingDownload(ScoreInfo model)
+        public ArchiveDownloadRequest<IScoreInfo> GetExistingDownload(IScoreInfo model)
         {
             return scoreModelDownloader.GetExistingDownload(model);
         }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -25,7 +25,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Scoring
 {
-    public class ScoreManager : IModelManager<ScoreInfo>, IModelFileManager<ScoreInfo, ScoreFileInfo>, IModelDownloader<ScoreInfo>
+    public class ScoreManager : IModelManager<ScoreInfo>, IModelImporter<ScoreInfo>, IModelFileManager<ScoreInfo, ScoreFileInfo>, IModelDownloader<ScoreInfo>
     {
         private readonly Scheduler scheduler;
         private readonly Func<BeatmapDifficultyCache> difficulties;

--- a/osu.Game/Scoring/ScoreModelDownloader.cs
+++ b/osu.Game/Scoring/ScoreModelDownloader.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Scoring
 {
     public class ScoreModelDownloader : ModelDownloader<ScoreInfo>
     {
-        public ScoreModelDownloader(ScoreModelManager scoreManager, IAPIProvider api, IIpcHost importHost = null)
+        public ScoreModelDownloader(IModelImporter<ScoreInfo> scoreManager, IAPIProvider api, IIpcHost importHost = null)
             : base(scoreManager, api, importHost)
         {
         }

--- a/osu.Game/Scoring/ScoreModelDownloader.cs
+++ b/osu.Game/Scoring/ScoreModelDownloader.cs
@@ -8,16 +8,16 @@ using osu.Game.Online.API.Requests;
 
 namespace osu.Game.Scoring
 {
-    public class ScoreModelDownloader : ModelDownloader<ScoreInfo>
+    public class ScoreModelDownloader : ModelDownloader<ScoreInfo, IScoreInfo>
     {
         public ScoreModelDownloader(IModelImporter<ScoreInfo> scoreManager, IAPIProvider api, IIpcHost importHost = null)
             : base(scoreManager, api, importHost)
         {
         }
 
-        protected override ArchiveDownloadRequest<ScoreInfo> CreateDownloadRequest(ScoreInfo score, bool minimiseDownload) => new DownloadReplayRequest(score);
+        protected override ArchiveDownloadRequest<IScoreInfo> CreateDownloadRequest(IScoreInfo score, bool minimiseDownload) => new DownloadReplayRequest(score);
 
-        public override ArchiveDownloadRequest<ScoreInfo> GetExistingDownload(ScoreInfo model)
-            => CurrentDownloads.Find(r => r.Model.OnlineScoreID == model.OnlineScoreID);
+        public override ArchiveDownloadRequest<IScoreInfo> GetExistingDownload(IScoreInfo model)
+            => CurrentDownloads.Find(r => r.Model.OnlineID == model.OnlineID);
     }
 }


### PR DESCRIPTION
The `IModelImporter` inheritance only exists in legacy implementations, to reduce inheritance complexity of interfaces which are going to be used going forwards. Now all the new interfaces are at most one level deep.