### PR TITLE
Add sanity check in Relax's effectiveMissCount calculation

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                     comboBasedMissCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);
             }
 
-            // We're clamping misscount because since its derived from combo it can be higher than total hits and that breaks some calculations
+            // Clamp misscount since it's derived from combo and can be higher than total hits and that breaks some calculations
             comboBasedMissCount = Math.Min(comboBasedMissCount, totalHits);
 
             return Math.Max(countMiss, (int)Math.Floor(comboBasedMissCount));

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -54,7 +54,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(h => h is OsuModRelax))
             {
+                // As we're adding Oks and Mehs to an approximated number of combo breaks the result can be higher than total hits in specific scenarios (which breaks some calculations) so we need to clamp it.
                 effectiveMissCount = Math.Min(effectiveMissCount + countOk + countMeh, totalHits);
+
                 multiplier *= 0.6;
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private int calculateEffectiveMissCount()
         {
-            // guess the number of misses + slider breaks from combo
+            // Guess the number of misses + slider breaks from combo
             double comboBasedMissCount = 0.0;
 
             if (Attributes.SliderCount > 0)
@@ -267,7 +267,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                     comboBasedMissCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);
             }
 
-            // we're clamping misscount because since its derived from combo it can be higher than total hits and that breaks some calculations
+            // We're clamping misscount because since its derived from combo it can be higher than total hits and that breaks some calculations
             comboBasedMissCount = Math.Min(comboBasedMissCount, totalHits);
 
             return Math.Max(countMiss, (int)Math.Floor(comboBasedMissCount));

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(h => h is OsuModRelax))
             {
-                effectiveMissCount += countOk + countMeh;
+                effectiveMissCount = Math.Min(effectiveMissCount + countOk + countMeh, totalHits);
                 multiplier *= 0.6;
             }
 


### PR DESCRIPTION
Fixes #15486

![osu_2021-11-07_06-02-55](https://user-images.githubusercontent.com/5307179/140633024-32f75547-b42e-49b5-a6ad-ee443927a29e.jpg)