### PR TITLE
Fix loading spinner potentially showing on statistics unavailable message

### DIFF
--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -76,6 +76,8 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             if (newScore.HitEvents == null || newScore.HitEvents.Count == 0)
             {
+                spinner.Hide();
+
                 content.Add(new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -69,6 +69,8 @@ namespace osu.Game.Screens.Ranking.Statistics
             foreach (var child in content)
                 child.FadeOut(150).Expire();
 
+            spinner.Hide();
+
             var newScore = score.NewValue;
 
             if (newScore == null)
@@ -76,8 +78,6 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             if (newScore.HitEvents == null || newScore.HitEvents.Count == 0)
             {
-                spinner.Hide();
-
                 content.Add(new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Reproduction:
- watch any replay
- in results screen, go to a different score
- open statistics (loading spinner is shown indefinitely)

Before:
![Screen Recording 2021-11-07 at 5 30 52 PM](https://user-images.githubusercontent.com/35318437/140670975-42bb2200-e4d9-401f-9ca7-62b2c42c4eeb.gif)

After:
![Screen Recording 2021-11-07 at 5 29 52 PM](https://user-images.githubusercontent.com/35318437/140670941-9e4d51c3-7cc3-46a9-a151-b3f58ce4334d.gif)
