### PR TITLE
Update usages of `KeyCombination.ReadableString()` to use `ReadableKeyCombinationProvider`

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1106.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1108.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Platform;
 using osu.Game.Database;
@@ -33,7 +34,7 @@ namespace osu.Game.Tests.Database
             storage = new NativeStorage(directory.FullName);
 
             realmContextFactory = new RealmContextFactory(storage, "test");
-            keyBindingStore = new RealmKeyBindingStore(realmContextFactory);
+            keyBindingStore = new RealmKeyBindingStore(realmContextFactory, new ReadableKeyCombinationProvider());
         }
 
         [Test]

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Game.Database;
 using osu.Game.Input.Bindings;
@@ -16,10 +17,12 @@ namespace osu.Game.Input
     public class RealmKeyBindingStore
     {
         private readonly RealmContextFactory realmFactory;
+        private readonly ReadableKeyCombinationProvider readableKeyCombinationProvider;
 
-        public RealmKeyBindingStore(RealmContextFactory realmFactory)
+        public RealmKeyBindingStore(RealmContextFactory realmFactory, ReadableKeyCombinationProvider readableKeyCombinationProvider)
         {
             this.realmFactory = realmFactory;
+            this.readableKeyCombinationProvider = readableKeyCombinationProvider;
         }
 
         /// <summary>
@@ -35,7 +38,7 @@ namespace osu.Game.Input
             {
                 foreach (var action in context.All<RealmKeyBinding>().Where(b => b.RulesetID == null && (GlobalAction)b.ActionInt == globalAction))
                 {
-                    string str = action.KeyCombination.ReadableString();
+                    string str = readableKeyCombinationProvider.GetReadableString(action.KeyCombination);
 
                     // even if found, the readable string may be empty for an unbound action.
                     if (str.Length > 0)

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -17,12 +17,12 @@ namespace osu.Game.Input
     public class RealmKeyBindingStore
     {
         private readonly RealmContextFactory realmFactory;
-        private readonly ReadableKeyCombinationProvider readableKeyCombinationProvider;
+        private readonly ReadableKeyCombinationProvider keyCombinationProvider;
 
-        public RealmKeyBindingStore(RealmContextFactory realmFactory, ReadableKeyCombinationProvider readableKeyCombinationProvider)
+        public RealmKeyBindingStore(RealmContextFactory realmFactory, ReadableKeyCombinationProvider keyCombinationProvider)
         {
             this.realmFactory = realmFactory;
-            this.readableKeyCombinationProvider = readableKeyCombinationProvider;
+            this.keyCombinationProvider = keyCombinationProvider;
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace osu.Game.Input
             {
                 foreach (var action in context.All<RealmKeyBinding>().Where(b => b.RulesetID == null && (GlobalAction)b.ActionInt == globalAction))
                 {
-                    string str = readableKeyCombinationProvider.GetReadableString(action.KeyCombination);
+                    string str = keyCombinationProvider.GetReadableString(action.KeyCombination);
 
                     // even if found, the readable string may be empty for an unbound action.
                     if (str.Length > 0)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -170,7 +170,7 @@ namespace osu.Game
         }
 
         [BackgroundDependencyLoader]
-        private void load(ReadableKeyCombinationProvider readableKeyCombinationProvider)
+        private void load(ReadableKeyCombinationProvider keyCombinationProvider)
         {
             try
             {
@@ -309,7 +309,7 @@ namespace osu.Game
 
             base.Content.Add(CreateScalingContainer().WithChildren(mainContent));
 
-            KeyBindingStore = new RealmKeyBindingStore(realmFactory, readableKeyCombinationProvider);
+            KeyBindingStore = new RealmKeyBindingStore(realmFactory, keyCombinationProvider);
             KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);
 
             dependencies.Cache(globalBindings);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -167,7 +167,7 @@ namespace osu.Game
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(ReadableKeyCombinationProvider readableKeyCombinationProvider)
         {
             try
             {
@@ -316,7 +316,7 @@ namespace osu.Game
 
             base.Content.Add(CreateScalingContainer().WithChildren(mainContent));
 
-            KeyBindingStore = new RealmKeyBindingStore(realmFactory);
+            KeyBindingStore = new RealmKeyBindingStore(realmFactory, readableKeyCombinationProvider);
             KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);
 
             dependencies.Cache(globalBindings);

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -473,7 +473,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     },
                     Text = new OsuSpriteText
                     {
-                        Font = OsuFont.Default,
+                        Font = OsuFont.Numeric.With(size: 10),
                         Margin = new MarginPadding(5),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -522,11 +522,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             }
 
-            private void updateKeyCombinationText()
-            {
-                Text.Text = keyCombinationProvider.GetReadableString(KeyBinding.KeyCombination);
-            }
-
             public void UpdateKeyCombination(KeyCombination newCombination)
             {
                 if (KeyBinding.RulesetID != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
@@ -534,6 +529,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
                 KeyBinding.KeyCombination = newCombination;
                 updateKeyCombinationText();
+            }
+
+            private void updateKeyCombinationText()
+            {
+                Scheduler.AddOnce(updateText);
+
+                void updateText() => Text.Text = keyCombinationProvider.GetReadableString(KeyBinding.KeyCombination);
             }
 
             protected override void Dispose(bool isDisposing)

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         public bool FilteringActive { get; set; }
 
         [Resolved]
-        private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+        private ReadableKeyCombinationProvider keyCombinationProvider { get; set; }
 
         private OsuSpriteText text;
         private FillFlowContainer cancelAndClearButtons;
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private Bindable<bool> isDefault { get; } = new BindableBool(true);
 
-        public IEnumerable<string> FilterTerms => bindings.Select(b => readableKeyCombinationProvider.GetReadableString(b.KeyCombination)).Prepend(text.Text.ToString());
+        public IEnumerable<string> FilterTerms => bindings.Select(b => keyCombinationProvider.GetReadableString(b.KeyCombination)).Prepend(text.Text.ToString());
 
         public KeyBindingRow(object action, List<RealmKeyBinding> bindings)
         {
@@ -427,7 +427,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             private OverlayColourProvider colourProvider { get; set; }
 
             [Resolved]
-            private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+            private ReadableKeyCombinationProvider keyCombinationProvider { get; set; }
 
             private bool isBinding;
 
@@ -486,7 +486,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 base.LoadComplete();
 
-                readableKeyCombinationProvider.KeymapChanged += updateKeyCombinationText;
+                keyCombinationProvider.KeymapChanged += updateKeyCombinationText;
                 updateKeyCombinationText();
             }
 
@@ -524,7 +524,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             private void updateKeyCombinationText()
             {
-                Text.Text = readableKeyCombinationProvider.GetReadableString(KeyBinding.KeyCombination);
+                Text.Text = keyCombinationProvider.GetReadableString(KeyBinding.KeyCombination);
             }
 
             public void UpdateKeyCombination(KeyCombination newCombination)
@@ -540,7 +540,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 base.Dispose(isDisposing);
 
-                readableKeyCombinationProvider.KeymapChanged -= updateKeyCombinationText;
+                keyCombinationProvider.KeymapChanged -= updateKeyCombinationText;
             }
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Database;
@@ -57,13 +58,16 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public bool FilteringActive { get; set; }
 
+        [Resolved]
+        private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+
         private OsuSpriteText text;
         private FillFlowContainer cancelAndClearButtons;
         private FillFlowContainer<KeyButton> buttons;
 
         private Bindable<bool> isDefault { get; } = new BindableBool(true);
 
-        public IEnumerable<string> FilterTerms => bindings.Select(b => b.KeyCombination.ReadableString()).Prepend(text.Text.ToString());
+        public IEnumerable<string> FilterTerms => bindings.Select(b => readableKeyCombinationProvider.GetReadableString(b.KeyCombination)).Prepend(text.Text.ToString());
 
         public KeyBindingRow(object action, List<RealmKeyBinding> bindings)
         {
@@ -422,6 +426,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; }
 
+            [Resolved]
+            private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+
             private bool isBinding;
 
             public bool IsBinding
@@ -470,10 +477,17 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         Margin = new MarginPadding(5),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Text = keyBinding.KeyCombination.ReadableString(),
                     },
                     new HoverSounds()
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                readableKeyCombinationProvider.KeymapChanged += updateKeyCombinationText;
+                updateKeyCombinationText();
             }
 
             [BackgroundDependencyLoader]
@@ -508,13 +522,25 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             }
 
+            private void updateKeyCombinationText()
+            {
+                Text.Text = readableKeyCombinationProvider.GetReadableString(KeyBinding.KeyCombination);
+            }
+
             public void UpdateKeyCombination(KeyCombination newCombination)
             {
                 if (KeyBinding.RulesetID != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
                     return;
 
                 KeyBinding.KeyCombination = newCombination;
-                Text.Text = KeyBinding.KeyCombination.ReadableString();
+                updateKeyCombinationText();
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                readableKeyCombinationProvider.KeymapChanged -= updateKeyCombinationText;
             }
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -540,7 +540,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 base.Dispose(isDisposing);
 
-                keyCombinationProvider.KeymapChanged -= updateKeyCombinationText;
+                if (keyCombinationProvider != null)
+                    keyCombinationProvider.KeymapChanged -= updateKeyCombinationText;
             }
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -473,7 +473,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     },
                     Text = new OsuSpriteText
                     {
-                        Font = OsuFont.Numeric.With(size: 10),
+                        Font = OsuFont.Default,
                         Margin = new MarginPadding(5),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays.Toolbar
         private TextureStore textures { get; set; }
 
         [Resolved]
-        private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+        private ReadableKeyCombinationProvider keyCombinationProvider { get; set; }
 
         public void SetIcon(string texture) =>
             SetIcon(new Sprite
@@ -211,7 +211,7 @@ namespace osu.Game.Overlays.Toolbar
 
             if (realmKeyBinding != null)
             {
-                string keyBindingString = readableKeyCombinationProvider.GetReadableString(realmKeyBinding.KeyCombination);
+                string keyBindingString = keyCombinationProvider.GetReadableString(realmKeyBinding.KeyCombination);
 
                 if (!string.IsNullOrEmpty(keyBindingString))
                     keyBindingTooltip.Text = $" ({keyBindingString})";

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Database;
@@ -38,6 +39,9 @@ namespace osu.Game.Overlays.Toolbar
 
         [Resolved]
         private TextureStore textures { get; set; }
+
+        [Resolved]
+        private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
 
         public void SetIcon(string texture) =>
             SetIcon(new Sprite
@@ -207,7 +211,7 @@ namespace osu.Game.Overlays.Toolbar
 
             if (realmKeyBinding != null)
             {
-                string keyBindingString = realmKeyBinding.KeyCombination.ReadableString();
+                string keyBindingString = readableKeyCombinationProvider.GetReadableString(realmKeyBinding.KeyCombination);
 
                 if (!string.IsNullOrEmpty(keyBindingString))
                     keyBindingTooltip.Text = $" ({keyBindingString})";

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1106.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1108.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
     <PackageReference Include="Sentry" Version="3.10.0" />
     <PackageReference Include="SharpCompress" Version="0.30.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1106.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1108.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.1106.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.1108.0" />
     <PackageReference Include="SharpCompress" Version="0.30.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Depends on:
- [x] framework bump

osu!-side PR for https://github.com/ppy/osu-framework/pull/4834.

Not 100% on the font change in cc286f165d9e7a693377acd8f5347d7d13e5bb31.

It's unfortunate that the sizes don't match. Maybe it would look fine with `Numeric` + `Default` for fallback if sizes had matched.
The default font does look to be a bit off center, like it's a bit too much down. The `Ž` looks centered, so at least there's that.

`OsuFont.Numeric.With(size: 10)`:

![image](https://user-images.githubusercontent.com/16479013/140691913-e859c5c4-2f0b-4704-bf2a-d90253f0ebf1.png)

`OsuFont.Default`:

![image](https://user-images.githubusercontent.com/16479013/140691921-ef1f11b7-719e-43a8-9060-68a96c900569.png)
