### PR TITLE
Start initialising `RealmRulesetStore` on startup

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -40,6 +40,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
+using osu.Game.Stores;
 using osu.Game.Utils;
 using RuntimeInfo = osu.Framework.RuntimeInfo;
 
@@ -236,6 +237,11 @@ namespace osu.Game
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
             dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, API, contextFactory, Scheduler, Host, () => difficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, contextFactory, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
+
+            // the following realm components are not actively used yet, but initialised and kept up to date for initial testing.
+            var realmRulesetStore = new RealmRulesetStore(realmFactory, Storage);
+
+            dependencies.Cache(realmRulesetStore);
 
             // this should likely be moved to ArchiveModelManager when another case appears where it is necessary
             // to have inter-dependent model managers. this could be obtained with an IHasForeign<T> interface to

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -161,6 +161,8 @@ namespace osu.Game
 
         private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(GLOBAL_TRACK_VOLUME_ADJUST);
 
+        private RealmRulesetStore realmRulesetStore;
+
         public OsuGameBase()
         {
             UseDevelopmentServer = DebugUtils.IsDebugBuild;
@@ -233,7 +235,7 @@ namespace osu.Game
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, contextFactory, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
             // the following realm components are not actively used yet, but initialised and kept up to date for initial testing.
-            var realmRulesetStore = new RealmRulesetStore(realmFactory, Storage);
+            realmRulesetStore = new RealmRulesetStore(realmFactory, Storage);
 
             dependencies.Cache(realmRulesetStore);
 
@@ -518,6 +520,8 @@ namespace osu.Game
             LocalConfig?.Dispose();
 
             contextFactory?.FlushConnections();
+
+            realmRulesetStore?.Dispose();
             realmFactory?.Dispose();
         }
     }

--- a/osu.Game/Stores/RealmRulesetStore.cs
+++ b/osu.Game/Stores/RealmRulesetStore.cs
@@ -102,75 +102,78 @@ namespace osu.Game.Stores
 
         private void addMissingRulesets()
         {
-            realmFactory.Context.Write(realm =>
+            using (var context = realmFactory.CreateContext())
             {
-                var rulesets = realm.All<RealmRuleset>();
-
-                List<Ruleset> instances = loadedAssemblies.Values
-                                                          .Select(r => Activator.CreateInstance(r) as Ruleset)
-                                                          .Where(r => r != null)
-                                                          .Select(r => r.AsNonNull())
-                                                          .ToList();
-
-                // add all legacy rulesets first to ensure they have exclusive choice of primary key.
-                foreach (var r in instances.Where(r => r is ILegacyRuleset))
+                context.Write(realm =>
                 {
-                    if (realm.All<RealmRuleset>().FirstOrDefault(rr => rr.OnlineID == r.RulesetInfo.ID) == null)
-                        realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.ID));
-                }
+                    var rulesets = realm.All<RealmRuleset>();
 
-                // add any other rulesets which have assemblies present but are not yet in the database.
-                foreach (var r in instances.Where(r => !(r is ILegacyRuleset)))
-                {
-                    if (rulesets.FirstOrDefault(ri => ri.InstantiationInfo.Equals(r.RulesetInfo.InstantiationInfo, StringComparison.Ordinal)) == null)
+                    List<Ruleset> instances = loadedAssemblies.Values
+                                                              .Select(r => Activator.CreateInstance(r) as Ruleset)
+                                                              .Where(r => r != null)
+                                                              .Select(r => r.AsNonNull())
+                                                              .ToList();
+
+                    // add all legacy rulesets first to ensure they have exclusive choice of primary key.
+                    foreach (var r in instances.Where(r => r is ILegacyRuleset))
                     {
-                        var existingSameShortName = rulesets.FirstOrDefault(ri => ri.ShortName == r.RulesetInfo.ShortName);
-
-                        if (existingSameShortName != null)
-                        {
-                            // even if a matching InstantiationInfo was not found, there may be an existing ruleset with the same ShortName.
-                            // this generally means the user or ruleset provider has renamed their dll but the underlying ruleset is *likely* the same one.
-                            // in such cases, update the instantiation info of the existing entry to point to the new one.
-                            existingSameShortName.InstantiationInfo = r.RulesetInfo.InstantiationInfo;
-                        }
-                        else
+                        if (realm.All<RealmRuleset>().FirstOrDefault(rr => rr.OnlineID == r.RulesetInfo.ID) == null)
                             realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.ID));
                     }
-                }
 
-                List<RealmRuleset> detachedRulesets = new List<RealmRuleset>();
-
-                // perform a consistency check and detach final rulesets from realm for cross-thread runtime usage.
-                foreach (var r in rulesets)
-                {
-                    try
+                    // add any other rulesets which have assemblies present but are not yet in the database.
+                    foreach (var r in instances.Where(r => !(r is ILegacyRuleset)))
                     {
-                        var type = Type.GetType(r.InstantiationInfo);
+                        if (rulesets.FirstOrDefault(ri => ri.InstantiationInfo.Equals(r.RulesetInfo.InstantiationInfo, StringComparison.Ordinal)) == null)
+                        {
+                            var existingSameShortName = rulesets.FirstOrDefault(ri => ri.ShortName == r.RulesetInfo.ShortName);
 
-                        if (type == null)
-                            throw new InvalidOperationException(@"Type resolution failure.");
-
-                        var rInstance = (Activator.CreateInstance(type) as Ruleset)?.RulesetInfo;
-
-                        if (rInstance == null)
-                            throw new InvalidOperationException(@"Instantiation failure.");
-
-                        r.Name = rInstance.Name;
-                        r.ShortName = rInstance.ShortName;
-                        r.InstantiationInfo = rInstance.InstantiationInfo;
-                        r.Available = true;
-
-                        detachedRulesets.Add(r.Clone());
+                            if (existingSameShortName != null)
+                            {
+                                // even if a matching InstantiationInfo was not found, there may be an existing ruleset with the same ShortName.
+                                // this generally means the user or ruleset provider has renamed their dll but the underlying ruleset is *likely* the same one.
+                                // in such cases, update the instantiation info of the existing entry to point to the new one.
+                                existingSameShortName.InstantiationInfo = r.RulesetInfo.InstantiationInfo;
+                            }
+                            else
+                                realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.ID));
+                        }
                     }
-                    catch (Exception ex)
+
+                    List<RealmRuleset> detachedRulesets = new List<RealmRuleset>();
+
+                    // perform a consistency check and detach final rulesets from realm for cross-thread runtime usage.
+                    foreach (var r in rulesets)
                     {
-                        r.Available = false;
-                        Logger.Log($"Could not load ruleset {r}: {ex.Message}");
-                    }
-                }
+                        try
+                        {
+                            var type = Type.GetType(r.InstantiationInfo);
 
-                availableRulesets.AddRange(detachedRulesets);
-            });
+                            if (type == null)
+                                throw new InvalidOperationException(@"Type resolution failure.");
+
+                            var rInstance = (Activator.CreateInstance(type) as Ruleset)?.RulesetInfo;
+
+                            if (rInstance == null)
+                                throw new InvalidOperationException(@"Instantiation failure.");
+
+                            r.Name = rInstance.Name;
+                            r.ShortName = rInstance.ShortName;
+                            r.InstantiationInfo = rInstance.InstantiationInfo;
+                            r.Available = true;
+
+                            detachedRulesets.Add(r.Clone());
+                        }
+                        catch (Exception ex)
+                        {
+                            r.Available = false;
+                            Logger.Log($"Could not load ruleset {r}: {ex.Message}");
+                        }
+                    }
+
+                    availableRulesets.AddRange(detachedRulesets);
+                });
+            }
         }
 
         private void loadFromAppDomain()


### PR DESCRIPTION
This isn't being used anywhere, but is a prerequisite for getting realm beatmap support online.

The context retrieval change is important as this code is run inline in `OsuGameBase`'s `load`, which is not on the update thread and would throw on accessing the main context as it previously was.