### PR TITLE
Move `HoverClickSounds` to cover only the clickable button in `KeyBindingRow`

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -153,12 +153,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                                         new CancelButton { Action = finalise },
                                         new ClearButton { Action = clear },
                                     },
-                                }
+                                },
+                                new HoverClickSounds()
                             }
                         }
                     }
-                },
-                new HoverClickSounds()
+                }
             };
 
             foreach (var b in bindings)


### PR DESCRIPTION
Doesn't make sense to have hover and click sounds in the `RestoreDefaultValueButton` area as that button has it's own sounds.

Current `master`
---

![image](https://user-images.githubusercontent.com/16479013/140750848-86e14dbc-87ed-41b4-a575-a853a8ca3aa2.png)

This PR
---
![image](https://user-images.githubusercontent.com/16479013/140751208-c2e1598f-1f97-4b7b-a4c3-37f150e09920.png)
