### PR TITLE
Fix realm migration potentially failing for users that haven't run osu! in a long time

### DIFF
--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -209,7 +209,13 @@ namespace osu.Game.Database
 
                 case 9:
                     // Pretty pointless to do this as beatmaps aren't really loaded via realm yet, but oh well.
-                    var oldMetadata = migration.OldRealm.DynamicApi.All(getMappedOrOriginalName(typeof(RealmBeatmapMetadata)));
+                    string className = getMappedOrOriginalName(typeof(RealmBeatmapMetadata));
+
+                    // May be coming from a version before `RealmBeatmapMetadata` existed.
+                    if (!migration.OldRealm.Schema.TryFindObjectSchema(className, out _))
+                        return;
+
+                    var oldMetadata = migration.OldRealm.DynamicApi.All(className);
                     var newMetadata = migration.NewRealm.All<RealmBeatmapMetadata>();
 
                     int metadataCount = newMetadata.Count();

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -209,13 +209,13 @@ namespace osu.Game.Database
 
                 case 9:
                     // Pretty pointless to do this as beatmaps aren't really loaded via realm yet, but oh well.
-                    string className = getMappedOrOriginalName(typeof(RealmBeatmapMetadata));
+                    string metadataClassName = getMappedOrOriginalName(typeof(RealmBeatmapMetadata));
 
                     // May be coming from a version before `RealmBeatmapMetadata` existed.
-                    if (!migration.OldRealm.Schema.TryFindObjectSchema(className, out _))
+                    if (!migration.OldRealm.Schema.TryFindObjectSchema(metadataClassName, out _))
                         return;
 
-                    var oldMetadata = migration.OldRealm.DynamicApi.All(className);
+                    var oldMetadata = migration.OldRealm.DynamicApi.All(metadataClassName);
                     var newMetadata = migration.NewRealm.All<RealmBeatmapMetadata>();
 
                     int metadataCount = newMetadata.Count();


### PR DESCRIPTION
As reported at https://github.com/ppy/osu/discussions/15530.

We need better safeties around failed migration applications (probably backup and start with a fresh database at least) but I plan on looking at that separately in the future. Along with probably storing separate development realms per schema version to better handle reviewing changes which bring the realm to a newer schema version.