### PR TITLE
Rewrite `PreviewTrackManager` to avoid constructing `TrackBass` locally

### DIFF
--- a/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
+++ b/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
@@ -13,9 +13,16 @@ namespace osu.Game.Tests.Visual.Components
 {
     public class TestScenePreviewTrackManager : OsuTestScene, IPreviewTrackOwner
     {
-        private readonly TestPreviewTrackManager trackManager = new TestPreviewTrackManager();
+        private readonly IAdjustableAudioComponent gameTrackAudio = new AudioAdjustments();
+
+        private readonly TestPreviewTrackManager trackManager;
 
         private AudioManager audio;
+
+        public TestScenePreviewTrackManager()
+        {
+            trackManager = new TestPreviewTrackManager(gameTrackAudio);
+        }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -151,19 +158,19 @@ namespace osu.Game.Tests.Visual.Components
                     audio.VolumeTrack.Value = 1;
             });
 
-            AddAssert("game not muted", () => audio.Tracks.AggregateVolume.Value != 0);
+            AddAssert("game not muted", () => gameTrackAudio.AggregateVolume.Value != 0);
 
             AddStep("get track", () => Add(owner = new TestTrackOwner(track = getTrack())));
             AddUntilStep("wait loaded", () => track.IsLoaded);
             AddStep("start track", () => track.Start());
-            AddAssert("game is muted", () => audio.Tracks.AggregateVolume.Value == 0);
+            AddAssert("game is muted", () => gameTrackAudio.AggregateVolume.Value == 0);
 
             if (stopAnyPlaying)
                 AddStep("stop any playing", () => trackManager.StopAnyPlaying(owner));
             else
                 AddStep("stop track", () => track.Stop());
 
-            AddAssert("game not muted", () => audio.Tracks.AggregateVolume.Value != 0);
+            AddAssert("game not muted", () => gameTrackAudio.AggregateVolume.Value != 0);
         }
 
         [Test]
@@ -223,6 +230,11 @@ namespace osu.Game.Tests.Visual.Components
             public bool AllowUpdate = true;
 
             public new PreviewTrack CurrentTrack => base.CurrentTrack;
+
+            public TestPreviewTrackManager(IAdjustableAudioComponent mainTrackAdjustments)
+                : base(mainTrackAdjustments)
+            {
+            }
 
             protected override TrackManagerPreviewTrack CreatePreviewTrack(IBeatmapSetInfo beatmapSetInfo, ITrackStore trackStore) => new TestPreviewTrack(beatmapSetInfo, trackStore);
 

--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Audio.Mixing;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -19,27 +14,26 @@ namespace osu.Game.Audio
 {
     public class PreviewTrackManager : Component
     {
+        private readonly IAdjustableAudioComponent mainTrackAdjustments;
+
         private readonly BindableDouble muteBindable = new BindableDouble();
 
         [Resolved]
         private AudioManager audio { get; set; }
 
-        private PreviewTrackStore trackStore;
+        private ITrackStore trackStore;
 
         protected TrackManagerPreviewTrack CurrentTrack;
 
-        private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(OsuGameBase.GLOBAL_TRACK_VOLUME_ADJUST);
+        public PreviewTrackManager(IAdjustableAudioComponent mainTrackAdjustments)
+        {
+            this.mainTrackAdjustments = mainTrackAdjustments;
+        }
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audioManager)
         {
-            // this is a temporary solution to get around muting ourselves.
-            // todo: update this once we have a BackgroundTrackManager or similar.
-            trackStore = new PreviewTrackStore(audioManager.TrackMixer, new OnlineStore());
-
-            audio.AddItem(trackStore);
-            trackStore.AddAdjustment(AdjustableProperty.Volume, globalTrackVolumeAdjust);
-            trackStore.AddAdjustment(AdjustableProperty.Volume, audio.VolumeTrack);
+            trackStore = audioManager.GetTrackStore(new OnlineStore());
         }
 
         /// <summary>
@@ -55,7 +49,7 @@ namespace osu.Game.Audio
             {
                 CurrentTrack?.Stop();
                 CurrentTrack = track;
-                audio.Tracks.AddAdjustment(AdjustableProperty.Volume, muteBindable);
+                mainTrackAdjustments.AddAdjustment(AdjustableProperty.Volume, muteBindable);
             });
 
             track.Stopped += () => Schedule(() =>
@@ -64,7 +58,7 @@ namespace osu.Game.Audio
                     return;
 
                 CurrentTrack = null;
-                audio.Tracks.RemoveAdjustment(AdjustableProperty.Volume, muteBindable);
+                mainTrackAdjustments.RemoveAdjustment(AdjustableProperty.Volume, muteBindable);
             });
 
             return track;
@@ -115,53 +109,6 @@ namespace osu.Game.Audio
             }
 
             protected override Track GetTrack() => trackManager.Get($"https://b.ppy.sh/preview/{beatmapSetInfo.OnlineID}.mp3");
-        }
-
-        private class PreviewTrackStore : AudioCollectionManager<AdjustableAudioComponent>, ITrackStore
-        {
-            private readonly AudioMixer defaultMixer;
-            private readonly IResourceStore<byte[]> store;
-
-            internal PreviewTrackStore(AudioMixer defaultMixer, IResourceStore<byte[]> store)
-            {
-                this.defaultMixer = defaultMixer;
-                this.store = store;
-            }
-
-            public Track GetVirtual(double length = double.PositiveInfinity)
-            {
-                if (IsDisposed) throw new ObjectDisposedException($"Cannot retrieve items for an already disposed {nameof(PreviewTrackStore)}");
-
-                var track = new TrackVirtual(length);
-                AddItem(track);
-                return track;
-            }
-
-            public Track Get(string name)
-            {
-                if (IsDisposed) throw new ObjectDisposedException($"Cannot retrieve items for an already disposed {nameof(PreviewTrackStore)}");
-
-                if (string.IsNullOrEmpty(name)) return null;
-
-                var dataStream = store.GetStream(name);
-
-                if (dataStream == null)
-                    return null;
-
-                // Todo: This is quite unsafe. TrackBass shouldn't be exposed as public.
-                Track track = new TrackBass(dataStream);
-
-                defaultMixer.Add(track);
-                AddItem(track);
-
-                return track;
-            }
-
-            public Task<Track> GetAsync(string name) => Task.Run(() => Get(name));
-
-            public Stream GetStream(string name) => store.GetStream(name);
-
-            public IEnumerable<string> GetAvailableResources() => store.GetAvailableResources();
         }
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Beatmaps
         [CanBeNull]
         private readonly GameHost host;
 
-        public WorkingBeatmapCache([NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> files, WorkingBeatmap defaultBeatmap = null, GameHost host = null)
+        public WorkingBeatmapCache(ITrackStore trackStore, AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> files, WorkingBeatmap defaultBeatmap = null, GameHost host = null)
         {
             DefaultBeatmap = defaultBeatmap;
 
@@ -50,7 +50,7 @@ namespace osu.Game.Beatmaps
             this.host = host;
             this.files = files;
             largeTextureStore = new LargeTextureStore(host?.CreateTextureLoaderStore(files));
-            trackStore = audioManager.GetTrackStore(files);
+            this.trackStore = trackStore;
         }
 
         public void Invalidate(BeatmapSetInfo info)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -65,7 +65,7 @@ namespace osu.Game
         /// <summary>
         /// The maximum volume at which audio tracks should playback. This can be set lower than 1 to create some head-room for sound effects.
         /// </summary>
-        internal const double GLOBAL_TRACK_VOLUME_ADJUST = 0.8;
+        private const double global_track_volume_adjust = 0.8;
 
         public bool UseDevelopmentServer { get; }
 
@@ -159,7 +159,7 @@ namespace osu.Game
 
         private Bindable<bool> fpsDisplayVisible;
 
-        private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(GLOBAL_TRACK_VOLUME_ADJUST);
+        private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(global_track_volume_adjust);
 
         private RealmRulesetStore realmRulesetStore;
 
@@ -315,7 +315,7 @@ namespace osu.Game
             dependencies.Cache(globalBindings);
 
             PreviewTrackManager previewTrackManager;
-            dependencies.Cache(previewTrackManager = new PreviewTrackManager());
+            dependencies.Cache(previewTrackManager = new PreviewTrackManager(BeatmapManager.BeatmapTrackStore));
             Add(previewTrackManager);
 
             AddInternal(MusicController = new MusicController());

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Tests.Visual
                 private readonly TestBeatmapManager testBeatmapManager;
 
                 public TestWorkingBeatmapCache(TestBeatmapManager testBeatmapManager, AudioManager audioManager, IResourceStore<byte[]> resourceStore, IResourceStore<byte[]> storage, WorkingBeatmap defaultBeatmap, GameHost gameHost)
-                    : base(audioManager, resourceStore, storage, defaultBeatmap, gameHost)
+                    : base(testBeatmapManager.BeatmapTrackStore, audioManager, resourceStore, storage, defaultBeatmap, gameHost)
                 {
                     this.testBeatmapManager = testBeatmapManager;
                 }


### PR DESCRIPTION
This paves the way for the framework code quality change (https://github.com/ppy/osu-framework/pull/4873) which stops exposing the constructor.

Most of the restructuring here is required to give `PreviewTrackManager` an adjustable target to apply the global mute. Turned out quite nicely.