### PR TITLE
Fix model download notifications not formatting model correctly

### DIFF
--- a/osu.Game.Tests/Models/DisplayStringTest.cs
+++ b/osu.Game.Tests/Models/DisplayStringTest.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Tests.Models
     {
         private static readonly object[][] test_cases =
         {
+            new object[] { makeNoMetadataMockBeatmapSet(), "unknown artist - unknown title" },
+            new object[] { makeNoAuthorMockBeatmapSet(), "artist - title" },
             new object[] { makeMockBeatmapSet(), "artist - title (author)" },
             new object[] { makeMockBeatmap(), "artist - title (author) [difficulty]" },
             new object[] { makeMockMetadata(), "artist - title (author)" },
@@ -28,6 +30,26 @@ namespace osu.Game.Tests.Models
 
         [TestCaseSource(nameof(test_cases))]
         public void TestDisplayString(object model, string expected) => Assert.That(model.GetDisplayString(), Is.EqualTo(expected));
+
+        private static IBeatmapSetInfo makeNoAuthorMockBeatmapSet()
+        {
+            var mock = new Mock<IBeatmapSetInfo>();
+
+            mock.Setup(m => m.Metadata.Artist).Returns("artist");
+            mock.Setup(m => m.Metadata.Title).Returns("title");
+            mock.Setup(m => m.Metadata.Author.Username).Returns(string.Empty);
+
+            return mock.Object;
+        }
+
+        private static IBeatmapSetInfo makeNoMetadataMockBeatmapSet()
+        {
+            var mock = new Mock<IBeatmapSetInfo>();
+
+            mock.Setup(m => m.Metadata).Returns(new BeatmapMetadata());
+
+            return mock.Object;
+        }
 
         private static IBeatmapSetInfo makeMockBeatmapSet()
         {

--- a/osu.Game.Tests/Models/DisplayStringTest.cs
+++ b/osu.Game.Tests/Models/DisplayStringTest.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Moq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Extensions;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Models
+{
+    [TestFixture]
+    public class DisplayStringTest
+    {
+        private static readonly object[][] test_cases =
+        {
+            new object[] { makeMockBeatmapSet(), "artist - title (author)" },
+            new object[] { makeMockBeatmap(), "artist - title (author) [difficulty]" },
+            new object[] { makeMockMetadata(), "artist - title (author)" },
+            new object[] { makeMockScore(), "user playing artist - title (author) [difficulty]" },
+            new object[] { makeMockRuleset(), "ruleset" },
+            new object[] { makeMockUser(), "user" },
+            new object[] { new Fallback(), "fallback" }
+        };
+
+        [TestCaseSource(nameof(test_cases))]
+        public void TestDisplayString(object model, string expected) => Assert.That(model.GetDisplayString(), Is.EqualTo(expected));
+
+        private static IBeatmapSetInfo makeMockBeatmapSet()
+        {
+            var mock = new Mock<IBeatmapSetInfo>();
+
+            mock.Setup(m => m.Metadata).Returns(makeMockMetadata);
+
+            return mock.Object;
+        }
+
+        private static IBeatmapInfo makeMockBeatmap()
+        {
+            var mock = new Mock<IBeatmapInfo>();
+
+            mock.Setup(m => m.Metadata).Returns(makeMockMetadata);
+            mock.Setup(m => m.DifficultyName).Returns("difficulty");
+
+            return mock.Object;
+        }
+
+        private static IBeatmapMetadataInfo makeMockMetadata()
+        {
+            var mock = new Mock<IBeatmapMetadataInfo>();
+
+            mock.Setup(m => m.Artist).Returns("artist");
+            mock.Setup(m => m.Title).Returns("title");
+            mock.Setup(m => m.Author.Username).Returns("author");
+
+            return mock.Object;
+        }
+
+        private static IScoreInfo makeMockScore()
+        {
+            var mock = new Mock<IScoreInfo>();
+
+            mock.Setup(m => m.User).Returns(new APIUser { Username = "user" }); // TODO: temporary.
+            mock.Setup(m => m.Beatmap).Returns(makeMockBeatmap);
+
+            return mock.Object;
+        }
+
+        private static IRulesetInfo makeMockRuleset()
+        {
+            var mock = new Mock<IRulesetInfo>();
+
+            mock.Setup(m => m.Name).Returns("ruleset");
+
+            return mock.Object;
+        }
+
+        private static IUser makeMockUser()
+        {
+            var mock = new Mock<IUser>();
+
+            mock.Setup(m => m.Username).Returns("user");
+
+            return mock.Object;
+        }
+
+        private class Fallback
+        {
+            public override string ToString() => "fallback";
+        }
+    }
+}

--- a/osu.Game.Tests/Models/DisplayStringTest.cs
+++ b/osu.Game.Tests/Models/DisplayStringTest.cs
@@ -15,23 +15,20 @@ namespace osu.Game.Tests.Models
     [TestFixture]
     public class DisplayStringTest
     {
-        private static readonly object[][] test_cases =
+        [Test]
+        public void TestBeatmapSet()
         {
-            new object[] { makeNoMetadataMockBeatmapSet(), "unknown artist - unknown title" },
-            new object[] { makeNoAuthorMockBeatmapSet(), "artist - title" },
-            new object[] { makeMockBeatmapSet(), "artist - title (author)" },
-            new object[] { makeMockBeatmap(), "artist - title (author) [difficulty]" },
-            new object[] { makeMockMetadata(), "artist - title (author)" },
-            new object[] { makeMockScore(), "user playing artist - title (author) [difficulty]" },
-            new object[] { makeMockRuleset(), "ruleset" },
-            new object[] { makeMockUser(), "user" },
-            new object[] { new Fallback(), "fallback" }
-        };
+            var mock = new Mock<IBeatmapSetInfo>();
 
-        [TestCaseSource(nameof(test_cases))]
-        public void TestDisplayString(object model, string expected) => Assert.That(model.GetDisplayString(), Is.EqualTo(expected));
+            mock.Setup(m => m.Metadata.Artist).Returns("artist");
+            mock.Setup(m => m.Metadata.Title).Returns("title");
+            mock.Setup(m => m.Metadata.Author.Username).Returns("author");
 
-        private static IBeatmapSetInfo makeNoAuthorMockBeatmapSet()
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("artist - title (author)"));
+        }
+
+        [Test]
+        public void TestBeatmapSetWithNoAuthor()
         {
             var mock = new Mock<IBeatmapSetInfo>();
 
@@ -39,38 +36,34 @@ namespace osu.Game.Tests.Models
             mock.Setup(m => m.Metadata.Title).Returns("title");
             mock.Setup(m => m.Metadata.Author.Username).Returns(string.Empty);
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("artist - title"));
         }
 
-        private static IBeatmapSetInfo makeNoMetadataMockBeatmapSet()
+        [Test]
+        public void TestBeatmapSetWithNoMetadata()
         {
             var mock = new Mock<IBeatmapSetInfo>();
 
             mock.Setup(m => m.Metadata).Returns(new BeatmapMetadata());
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("unknown artist - unknown title"));
         }
 
-        private static IBeatmapSetInfo makeMockBeatmapSet()
-        {
-            var mock = new Mock<IBeatmapSetInfo>();
-
-            mock.Setup(m => m.Metadata).Returns(makeMockMetadata);
-
-            return mock.Object;
-        }
-
-        private static IBeatmapInfo makeMockBeatmap()
+        [Test]
+        public void TestBeatmap()
         {
             var mock = new Mock<IBeatmapInfo>();
 
-            mock.Setup(m => m.Metadata).Returns(makeMockMetadata);
+            mock.Setup(m => m.Metadata.Artist).Returns("artist");
+            mock.Setup(m => m.Metadata.Title).Returns("title");
+            mock.Setup(m => m.Metadata.Author.Username).Returns("author");
             mock.Setup(m => m.DifficultyName).Returns("difficulty");
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("artist - title (author) [difficulty]"));
         }
 
-        private static IBeatmapMetadataInfo makeMockMetadata()
+        [Test]
+        public void TestMetadata()
         {
             var mock = new Mock<IBeatmapMetadataInfo>();
 
@@ -78,35 +71,49 @@ namespace osu.Game.Tests.Models
             mock.Setup(m => m.Title).Returns("title");
             mock.Setup(m => m.Author.Username).Returns("author");
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("artist - title (author)"));
         }
 
-        private static IScoreInfo makeMockScore()
+        [Test]
+        public void TestScore()
         {
             var mock = new Mock<IScoreInfo>();
 
             mock.Setup(m => m.User).Returns(new APIUser { Username = "user" }); // TODO: temporary.
-            mock.Setup(m => m.Beatmap).Returns(makeMockBeatmap);
+            mock.Setup(m => m.Beatmap.Metadata.Artist).Returns("artist");
+            mock.Setup(m => m.Beatmap.Metadata.Title).Returns("title");
+            mock.Setup(m => m.Beatmap.Metadata.Author.Username).Returns("author");
+            mock.Setup(m => m.Beatmap.DifficultyName).Returns("difficulty");
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("user playing artist - title (author) [difficulty]"));
         }
 
-        private static IRulesetInfo makeMockRuleset()
+        [Test]
+        public void TestRuleset()
         {
             var mock = new Mock<IRulesetInfo>();
 
             mock.Setup(m => m.Name).Returns("ruleset");
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("ruleset"));
         }
 
-        private static IUser makeMockUser()
+        [Test]
+        public void TestUser()
         {
             var mock = new Mock<IUser>();
 
             mock.Setup(m => m.Username).Returns("user");
 
-            return mock.Object;
+            Assert.That(mock.Object.GetDisplayString(), Is.EqualTo("user"));
+        }
+
+        [Test]
+        public void TestFallback()
+        {
+            var fallback = new Fallback();
+
+            Assert.That(fallback.GetDisplayString(), Is.EqualTo("fallback"));
         }
 
         private class Fallback

--- a/osu.Game.Tests/Online/TestSceneBeatmapManager.cs
+++ b/osu.Game.Tests/Online/TestSceneBeatmapManager.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Tests.Visual;
 
@@ -16,7 +17,30 @@ namespace osu.Game.Tests.Online
         private BeatmapManager beatmaps;
         private ProgressNotification recentNotification;
 
-        private static readonly BeatmapSetInfo test_model = new BeatmapSetInfo { OnlineBeatmapSetID = 1 };
+        private static readonly BeatmapSetInfo test_db_model = new BeatmapSetInfo
+        {
+            OnlineBeatmapSetID = 1,
+            Metadata = new BeatmapMetadata
+            {
+                Artist = "test author",
+                Title = "test title",
+                Author = new APIUser
+                {
+                    Username = "mapper"
+                }
+            }
+        };
+
+        private static readonly APIBeatmapSet test_online_model = new APIBeatmapSet
+        {
+            OnlineID = 2,
+            Artist = "test author",
+            Title = "test title",
+            Author = new APIUser
+            {
+                Username = "mapper"
+            }
+        };
 
         [BackgroundDependencyLoader]
         private void load(BeatmapManager beatmaps)
@@ -26,25 +50,41 @@ namespace osu.Game.Tests.Online
             beatmaps.PostNotification = n => recentNotification = n as ProgressNotification;
         }
 
+        private static readonly object[][] notification_test_cases =
+        {
+            new object[] { test_db_model },
+            new object[] { test_online_model }
+        };
+
+        [TestCaseSource(nameof(notification_test_cases))]
+        public void TestNotificationMessage(IBeatmapSetInfo model)
+        {
+            AddStep("clear recent notification", () => recentNotification = null);
+            AddStep("download beatmap", () => beatmaps.Download(model));
+
+            AddUntilStep("wait for notification", () => recentNotification != null);
+            AddUntilStep("notification text correct", () => recentNotification.Text.ToString() == "Downloading test author - test title (mapper)");
+        }
+
         [Test]
         public void TestCancelDownloadFromRequest()
         {
-            AddStep("download beatmap", () => beatmaps.Download(test_model));
+            AddStep("download beatmap", () => beatmaps.Download(test_db_model));
 
-            AddStep("cancel download from request", () => beatmaps.GetExistingDownload(test_model).Cancel());
+            AddStep("cancel download from request", () => beatmaps.GetExistingDownload(test_db_model).Cancel());
 
-            AddUntilStep("is removed from download list", () => beatmaps.GetExistingDownload(test_model) == null);
+            AddUntilStep("is removed from download list", () => beatmaps.GetExistingDownload(test_db_model) == null);
             AddAssert("is notification cancelled", () => recentNotification.State == ProgressNotificationState.Cancelled);
         }
 
         [Test]
         public void TestCancelDownloadFromNotification()
         {
-            AddStep("download beatmap", () => beatmaps.Download(test_model));
+            AddStep("download beatmap", () => beatmaps.Download(test_db_model));
 
             AddStep("cancel download from notification", () => recentNotification.Close());
 
-            AddUntilStep("is removed from download list", () => beatmaps.GetExistingDownload(test_model) == null);
+            AddUntilStep("is removed from download list", () => beatmaps.GetExistingDownload(test_db_model) == null);
             AddAssert("is notification cancelled", () => recentNotification.State == ProgressNotificationState.Cancelled);
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -175,7 +175,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     Id = 39828,
                     Username = @"WubWoofWolf",
                 }
-            }.CreateScoreInfo(rulesets);
+            }.CreateScoreInfo(rulesets, CreateBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo);
         }
 
         private class TestReplayDownloadButton : ReplayDownloadButton

--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// A user-presentable display title representing this beatmap.
         /// </summary>
-        public static string GetDisplayTitle(this IBeatmapInfo beatmapInfo) => $"{beatmapInfo.Metadata} {getVersionString(beatmapInfo)}".Trim();
+        public static string GetDisplayTitle(this IBeatmapInfo beatmapInfo) => $"{beatmapInfo.Metadata.GetDisplayTitle()} {getVersionString(beatmapInfo)}".Trim();
 
         /// <summary>
         /// A user-presentable display title representing this beatmap, with localisation handling for potentially romanisable fields.

--- a/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public static string GetDisplayTitle(this IBeatmapMetadataInfo metadataInfo)
         {
-            string author = string.IsNullOrEmpty(metadataInfo.Author.Username) ? string.Empty : $"({metadataInfo.Author})";
+            string author = string.IsNullOrEmpty(metadataInfo.Author.Username) ? string.Empty : $"({metadataInfo.Author.Username})";
             return $"{metadataInfo.Artist} - {metadataInfo.Title} {author}".Trim();
         }
 

--- a/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
@@ -27,8 +27,12 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public static string GetDisplayTitle(this IBeatmapMetadataInfo metadataInfo)
         {
-            string author = string.IsNullOrEmpty(metadataInfo.Author.Username) ? string.Empty : $"({metadataInfo.Author.Username})";
-            return $"{metadataInfo.Artist} - {metadataInfo.Title} {author}".Trim();
+            string author = string.IsNullOrEmpty(metadataInfo.Author.Username) ? string.Empty : $" ({metadataInfo.Author.Username})";
+
+            string artist = string.IsNullOrEmpty(metadataInfo.Artist) ? "unknown artist" : metadataInfo.Artist;
+            string title = string.IsNullOrEmpty(metadataInfo.Title) ? "unknown title" : metadataInfo.Title;
+
+            return $"{artist} - {title}{author}".Trim();
         }
 
         /// <summary>

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -15,6 +15,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
+using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
 using osu.Game.IPC;
@@ -192,7 +193,7 @@ namespace osu.Game.Database
             else
             {
                 notification.CompletionText = imported.Count == 1
-                    ? $"Imported {imported.First().Value}!"
+                    ? $"Imported {imported.First().Value.GetDisplayString()}!"
                     : $"Imported {imported.Count} {HumanisedModelName}s!";
 
                 if (imported.Count > 0 && PostImport != null)

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Humanizer;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Notifications;
 
@@ -50,7 +51,7 @@ namespace osu.Game.Database
 
             DownloadNotification notification = new DownloadNotification
             {
-                Text = $"Downloading {request.Model}",
+                Text = $"Downloading {request.Model.GetDisplayString()}",
             };
 
             request.DownloadProgressed += progress =>

--- a/osu.Game/Extensions/ModelExtensions.cs
+++ b/osu.Game/Extensions/ModelExtensions.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Extensions
+{
+    public static class ModelExtensions
+    {
+        /// <summary>
+        /// Returns a user-facing string representing the <paramref name="model"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Non-interface types without special handling will fall back to <see cref="object.ToString()"/>.
+        /// </para>
+        /// <para>
+        /// Warning: This method is _purposefully_ not called <c>GetDisplayTitle()</c> like the others, because otherwise
+        /// extension method type inference rules cause this method to call itself and cause a stack overflow.
+        /// </para>
+        /// </remarks>
+        public static string GetDisplayString(this object model)
+        {
+            string result = null;
+
+            switch (model)
+            {
+                case IBeatmapSetInfo beatmapSetInfo:
+                    result = beatmapSetInfo.Metadata?.GetDisplayTitle();
+                    break;
+
+                case IBeatmapInfo beatmapInfo:
+                    result = beatmapInfo.GetDisplayTitle();
+                    break;
+
+                case IBeatmapMetadataInfo metadataInfo:
+                    result = metadataInfo.GetDisplayTitle();
+                    break;
+
+                case IScoreInfo scoreInfo:
+                    result = scoreInfo.GetDisplayTitle();
+                    break;
+
+                case IRulesetInfo rulesetInfo:
+                    result = rulesetInfo.Name;
+                    break;
+
+                case IUser user:
+                    result = user.Username;
+                    break;
+            }
+
+            // fallback in case none of the above happens to match.
+            result ??= model.ToString();
+            return result;
+        }
+    }
+}

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -23,9 +23,16 @@ namespace osu.Game.Overlays.Notifications
     {
         private const float loading_spinner_size = 22;
 
+        private LocalisableString text;
+
         public LocalisableString Text
         {
-            set => Schedule(() => textDrawable.Text = value);
+            get => text;
+            set
+            {
+                text = value;
+                Schedule(() => textDrawable.Text = text);
+            }
         }
 
         public string CompletionText { get; set; } = "Task has completed!";

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Scoring
             return clone;
         }
 
-        public override string ToString() => $"{User} playing {BeatmapInfo}";
+        public override string ToString() => this.GetDisplayTitle();
 
         public bool Equals(ScoreInfo other)
         {

--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Scoring
+{
+    public static class ScoreInfoExtensions
+    {
+        /// <summary>
+        /// A user-presentable display title representing this score.
+        /// </summary>
+        public static string GetDisplayTitle(this IScoreInfo scoreInfo) => $"{scoreInfo.User.Username} playing {scoreInfo.Beatmap.GetDisplayTitle()}";
+    }
+}


### PR DESCRIPTION
Closes #15421 again, and more.

This change was intended to cut off this entire class of bugs. The intention was to add *something* that would magically know how to format each model type correctly regardless of which interface implementation was being used. That _almost_ materialised with `GetDisplayString()`, an extension method that does this.

The one painful part is that I had to name it `GetDisplayString()`, rather than `GetDisplayText()` like the existing ones. The reason for that is that if I name it the same, _something_ with method resolution rules makes it so it calls itself and stack overflows. I tried adding a marker interface, didn't help.

As to why that isn't just a separate interface implemented by all the models - not only do the extension methods have [local](https://github.com/ppy/osu/blob/baa5285b59911efa1433a298f365133254a96874/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs#L37) [flags](https://github.com/ppy/osu/blob/baa5285b59911efa1433a298f365133254a96874/osu.Game/Beatmaps/BeatmapInfoExtensions.cs#L19) that make unification harder, but I would also have to bring back default interface implementations, which [were also stack overflow footguns](https://github.com/ppy/osu/pull/14917#discussion_r721629165) and were removed for this reason.

I dunno, `ToString()` is bad. I tried banning it globally for kicks, but usages within string interpolation don't get reported anyhow. Speaking of which, when adding testing, it turned out that `GetDisplayTitle()` implementations were relying on `ToString()` themselves. Which is fixed in 3d148ae.