### PR TITLE
Move clipboard operation implementations to individual editor subscreens

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
@@ -21,6 +22,9 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
     {
         [Resolved]
         private SkinManager skins { get; set; }
+
+        [Cached(Name = nameof(Screens.Edit.Editor.Clipboard))]
+        private Bindable<string> clipboard = new Bindable<string>();
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
@@ -23,8 +22,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Resolved]
         private SkinManager skins { get; set; }
 
-        [Cached(Name = nameof(Screens.Edit.Editor.Clipboard))]
-        private Bindable<string> clipboard = new Bindable<string>();
+        [Cached]
+        private EditorClipboard clipboard = new EditorClipboard();
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
@@ -25,6 +26,9 @@ namespace osu.Game.Tests.Visual.Editing
                     Ruleset = new OsuRuleset().RulesetInfo
                 }
             });
+
+        [Cached(Name = nameof(Editor.Clipboard))]
+        private Bindable<string> clipboard = new Bindable<string>();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -3,7 +3,6 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
@@ -27,8 +26,8 @@ namespace osu.Game.Tests.Visual.Editing
                 }
             });
 
-        [Cached(Name = nameof(Editor.Clipboard))]
-        private Bindable<string> clipboard = new Bindable<string>();
+        [Cached]
+        private EditorClipboard clipboard = new EditorClipboard();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Screens.Edit.Compose
         [Resolved]
         private EditorClock clock { get; set; }
 
-        [Resolved(Name = nameof(Editor.Clipboard))]
         private Bindable<string> clipboard { get; set; }
 
         private HitObjectComposer composer;
@@ -75,6 +74,12 @@ namespace osu.Game.Screens.Edit.Compose
             Debug.Assert(ruleset != null);
 
             return new EditorSkinProvidingContainer(EditorBeatmap).WithChild(content);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(EditorClipboard clipboard)
+        {
+            this.clipboard = clipboard.Content.GetBoundCopy();
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -7,9 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -20,7 +17,7 @@ using osu.Game.Screens.Edit.Compose.Components.Timeline;
 
 namespace osu.Game.Screens.Edit.Compose
 {
-    public class ComposeScreen : EditorScreenWithTimeline, IKeyBindingHandler<PlatformAction>
+    public class ComposeScreen : EditorScreenWithTimeline
     {
         [Resolved]
         private GameHost host { get; set; }
@@ -89,35 +86,6 @@ namespace osu.Game.Screens.Edit.Compose
             clipboard.BindValueChanged(_ => updateClipboardActionAvailability(), true);
         }
 
-        #region Input Handling
-
-        public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
-        {
-            if (e.Action == PlatformAction.Copy)
-                host.GetClipboard()?.SetText(formatSelectionAsString());
-
-            return false;
-        }
-
-        public void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)
-        {
-        }
-
-        private string formatSelectionAsString()
-        {
-            if (composer == null)
-                return string.Empty;
-
-            double displayTime = EditorBeatmap.SelectedHitObjects.OrderBy(h => h.StartTime).FirstOrDefault()?.StartTime ?? clock.CurrentTime;
-            string selectionAsString = composer.ConvertSelectionToString();
-
-            return !string.IsNullOrEmpty(selectionAsString)
-                ? $"{displayTime.ToEditorFormattedString()} ({selectionAsString}) - "
-                : $"{displayTime.ToEditorFormattedString()} - ";
-        }
-
-        #endregion
-
         #region Clipboard operations
 
         protected override void PerformCut()
@@ -133,6 +101,8 @@ namespace osu.Game.Screens.Edit.Compose
             base.PerformCopy();
 
             clipboard.Value = new ClipboardContent(EditorBeatmap).Serialize();
+
+            host.GetClipboard()?.SetText(formatSelectionAsString());
         }
 
         protected override void PerformPaste()
@@ -162,6 +132,19 @@ namespace osu.Game.Screens.Edit.Compose
         {
             CanCut.Value = CanCopy.Value = EditorBeatmap.SelectedHitObjects.Any();
             CanPaste.Value = !string.IsNullOrEmpty(clipboard.Value);
+        }
+
+        private string formatSelectionAsString()
+        {
+            if (composer == null)
+                return string.Empty;
+
+            double displayTime = EditorBeatmap.SelectedHitObjects.OrderBy(h => h.StartTime).FirstOrDefault()?.StartTime ?? clock.CurrentTime;
+            string selectionAsString = composer.ConvertSelectionToString();
+
+            return !string.IsNullOrEmpty(selectionAsString)
+                ? $"{displayTime.ToEditorFormattedString()} ({selectionAsString}) - "
+                : $"{displayTime.ToEditorFormattedString()} - ";
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -103,8 +103,8 @@ namespace osu.Game.Screens.Edit
         [Resolved]
         private MusicController music { get; set; }
 
-        [Cached(Name = nameof(Clipboard))]
-        public readonly Bindable<string> Clipboard = new Bindable<string>();
+        [Cached]
+        public readonly EditorClipboard Clipboard = new EditorClipboard();
 
         public Editor(EditorLoader loader = null)
         {
@@ -317,7 +317,7 @@ namespace osu.Game.Screens.Edit
         public void RestoreState([NotNull] EditorState state) => Schedule(() =>
         {
             clock.Seek(state.Time);
-            Clipboard.Value = state.ClipboardContent;
+            Clipboard.Content.Value = state.ClipboardContent;
         });
 
         protected void Save()
@@ -743,7 +743,7 @@ namespace osu.Game.Screens.Edit
         protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, new EditorState
         {
             Time = clock.CurrentTimeAccurate,
-            ClipboardContent = editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? Clipboard.Value : string.Empty
+            ClipboardContent = editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? Clipboard.Content.Value : string.Empty
         });
 
         private void cancelExit()

--- a/osu.Game/Screens/Edit/EditorClipboard.cs
+++ b/osu.Game/Screens/Edit/EditorClipboard.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// Wraps the contents of the editor clipboard.
+    /// </summary>
+    public class EditorClipboard
+    {
+        public Bindable<string> Content { get; } = new Bindable<string>();
+    }
+}

--- a/osu.Game/Screens/Edit/EditorScreen.cs
+++ b/osu.Game/Screens/Edit/EditorScreen.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -52,25 +53,49 @@ namespace osu.Game.Screens.Edit
 
         #region Clipboard operations
 
+        public BindableBool CanCut { get; } = new BindableBool();
+
         /// <summary>
         /// Performs a "cut to clipboard" operation appropriate for the given screen.
         /// </summary>
-        public virtual void Cut()
+        protected virtual void PerformCut()
         {
         }
+
+        public void Cut()
+        {
+            if (CanCut.Value)
+                PerformCut();
+        }
+
+        public BindableBool CanCopy { get; } = new BindableBool();
 
         /// <summary>
         /// Performs a "copy to clipboard" operation appropriate for the given screen.
         /// </summary>
-        public virtual void Copy()
+        protected virtual void PerformCopy()
         {
         }
+
+        public virtual void Copy()
+        {
+            if (CanCopy.Value)
+                PerformCopy();
+        }
+
+        public BindableBool CanPaste { get; } = new BindableBool();
 
         /// <summary>
         /// Performs a "paste from clipboard" operation appropriate for the given screen.
         /// </summary>
+        protected virtual void PerformPaste()
+        {
+        }
+
         public virtual void Paste()
         {
+            if (CanPaste.Value)
+                PerformPaste();
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/EditorScreen.cs
+++ b/osu.Game/Screens/Edit/EditorScreen.cs
@@ -49,5 +49,30 @@ namespace osu.Game.Screens.Edit
             this.ScaleTo(0.98f, 200, Easing.OutQuint)
                 .FadeOut(200, Easing.OutQuint);
         }
+
+        #region Clipboard operations
+
+        /// <summary>
+        /// Performs a "cut to clipboard" operation appropriate for the given screen.
+        /// </summary>
+        public virtual void Cut()
+        {
+        }
+
+        /// <summary>
+        /// Performs a "copy to clipboard" operation appropriate for the given screen.
+        /// </summary>
+        public virtual void Copy()
+        {
+        }
+
+        /// <summary>
+        /// Performs a "paste from clipboard" operation appropriate for the given screen.
+        /// </summary>
+        public virtual void Paste()
+        {
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Closes #14756 by implementing [the proposal given therein](https://github.com/ppy/osu/issues/14756#issuecomment-957209214). This also paves the way for potentially having screen-specific clipboard functionality, like being able to copy & paste timing points. Was a pretty easy refactor and I think this came out pretty well.

The one thing I am not sure of is leaving editor-global `Clipboard` and resolving it in screens. I could move it down to the compose screen (which is the only user now), but that would mean that clipboard becomes screen-contextual. Which simplifies some things - no need to check whether data in clipboard is valid for a given screen (which is not a concern now but will become one later) - but also maybe complicates UX. Will apply the above on request.

One semi-accidental consequence of this change is that all clipboard operations are now disabled on all screens except compose. I think that makes sense, anyway - being able to copy an object on compose screen, move to timing and then paste an object in at that time via <kbd>Ctrl</kbd>+<kbd>V</kbd> is arguably a bug.