### PR TITLE
Use disposal in `CheckBackgroundQuality`

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -111,6 +111,24 @@ namespace osu.Game.Tests.Editing.Checks
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooUncompressed);
         }
 
+        [Test]
+        public void TestStreamClosed()
+        {
+            var background = new Texture(1920, 1080);
+            var stream = new Mock<MemoryStream>(new byte[1024 * 1024]);
+
+            var mock = new Mock<IWorkingBeatmap>();
+            mock.SetupGet(w => w.Beatmap).Returns(beatmap);
+            mock.SetupGet(w => w.Background).Returns(background);
+            mock.Setup(w => w.GetStream(It.IsAny<string>())).Returns(stream.Object);
+
+            var context = new BeatmapVerifierContext(beatmap, mock.Object);
+
+            Assert.That(check.Run(context), Is.Empty);
+
+            stream.Verify(x => x.Close(), Times.Once());
+        }
+
         private BeatmapVerifierContext getContext(Texture background, [CanBeNull] byte[] fileBytes = null)
         {
             return new BeatmapVerifierContext(beatmap, getMockWorkingBeatmap(background, fileBytes).Object);

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.IO;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
@@ -48,10 +49,14 @@ namespace osu.Game.Rulesets.Edit.Checks
                 yield return new IssueTemplateLowResolution(this).Create(texture.Width, texture.Height);
 
             string storagePath = context.Beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
-            double filesizeMb = context.WorkingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
 
-            if (filesizeMb > max_filesize_mb)
-                yield return new IssueTemplateTooUncompressed(this).Create(filesizeMb);
+            using (Stream stream = context.WorkingBeatmap.GetStream(storagePath))
+            {
+                double filesizeMb = stream.Length / (1024d * 1024d);
+
+                if (filesizeMb > max_filesize_mb)
+                    yield return new IssueTemplateTooUncompressed(this).Create(filesizeMb);
+            }
         }
 
         public class IssueTemplateTooHighResolution : IssueTemplate


### PR DESCRIPTION
Applies https://github.com/ppy/osu/pull/13871#discussion_r726431700 to this check. Also adds a test failing prior to these changes.

(Figured I'd add such regression tests for the other checks too, but decided against it after a few attempts due to disposal being tricky to test well.)