### PR TITLE
Audio feedback improvements for song select

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1112.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2021.1108.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using ManagedBass.Fx;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -67,6 +68,7 @@ namespace osu.Game.Screens.Play
         private readonly BindableDouble volumeAdjustment = new BindableDouble(1);
 
         private AudioFilter lowPassFilter;
+        private AudioFilter highPassFilter;
 
         protected bool BackgroundBrightnessReduction
         {
@@ -168,7 +170,8 @@ namespace osu.Game.Screens.Play
                     },
                     idleTracker = new IdleTracker(750),
                 }),
-                lowPassFilter = new AudioFilter(audio.TrackMixer)
+                lowPassFilter = new AudioFilter(audio.TrackMixer),
+                highPassFilter = new AudioFilter(audio.TrackMixer, BQFType.HighPass)
             };
 
             if (Beatmap.Value.BeatmapInfo.EpilepsyWarning)
@@ -239,6 +242,7 @@ namespace osu.Game.Screens.Play
             Beatmap.Value.Track.Stop();
             Beatmap.Value.Track.RemoveAdjustment(AdjustableProperty.Volume, volumeAdjustment);
             lowPassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF);
+            highPassFilter.CutoffTo(0);
         }
 
         public override bool OnExiting(IScreen next)
@@ -352,6 +356,7 @@ namespace osu.Game.Screens.Play
             content.FadeInFromZero(400);
             content.ScaleTo(1, 650, Easing.OutQuint).Then().Schedule(prepareNewPlayer);
             lowPassFilter.CutoffTo(1000, 650, Easing.OutQuint);
+            highPassFilter.CutoffTo(300);
 
             ApplyToBackground(b => b?.FadeColour(Color4.White, 800, Easing.OutQuint));
         }
@@ -364,6 +369,7 @@ namespace osu.Game.Screens.Play
             content.ScaleTo(0.7f, content_out_duration * 2, Easing.OutQuint);
             content.FadeOut(content_out_duration, Easing.OutQuint);
             lowPassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF, content_out_duration);
+            highPassFilter.CutoffTo(0, content_out_duration);
         }
 
         private void pushWhenLoaded()

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -356,7 +356,7 @@ namespace osu.Game.Screens.Play
             content.FadeInFromZero(400);
             content.ScaleTo(1, 650, Easing.OutQuint).Then().Schedule(prepareNewPlayer);
             lowPassFilter.CutoffTo(1000, 650, Easing.OutQuint);
-            highPassFilter.CutoffTo(150);
+            highPassFilter.CutoffTo(300).Then().CutoffTo(0, 1250); // 1250 is to line up with the appearance of MetadataInfo (750 delay + 500 fade-in)
 
             ApplyToBackground(b => b?.FadeColour(Color4.White, 800, Easing.OutQuint));
         }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -356,7 +356,7 @@ namespace osu.Game.Screens.Play
             content.FadeInFromZero(400);
             content.ScaleTo(1, 650, Easing.OutQuint).Then().Schedule(prepareNewPlayer);
             lowPassFilter.CutoffTo(1000, 650, Easing.OutQuint);
-            highPassFilter.CutoffTo(300);
+            highPassFilter.CutoffTo(150);
 
             ApplyToBackground(b => b?.FadeColour(Color4.White, 800, Easing.OutQuint));
         }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -270,9 +270,9 @@ namespace osu.Game.Screens.Play
 
             const double duration = 300;
 
-            if (!resuming) logo.MoveTo(new Vector2(0.5f), duration, Easing.In);
+            if (!resuming) logo.MoveTo(new Vector2(0.5f), duration, Easing.OutQuint);
 
-            logo.ScaleTo(new Vector2(0.15f), duration, Easing.In);
+            logo.ScaleTo(new Vector2(0.15f), duration, Easing.OutQuint);
             logo.FadeIn(350);
 
             Scheduler.AddDelayed(() =>

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Screens.Play
                 colourNormal = colours.Yellow;
                 colourHover = colours.YellowDark;
 
-                sampleConfirm = audio.Samples.Get(@"SongSelect/confirm-selection");
+                sampleConfirm = audio.Samples.Get(@"UI/submit-select");
 
                 Children = new Drawable[]
                 {

--- a/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Select.Carousel
                     RelativeSizeAxes = Axes.Both,
                 };
 
-                sampleHover = audio.Samples.Get("SongSelect/song-ping");
+                sampleHover = audio.Samples.Get("UI/default-hover");
             }
 
             public bool InsetForBorder

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -435,6 +435,7 @@ namespace osu.Game.Screens.Select
         }
 
         // We need to keep track of the last selected beatmap ignoring debounce to play the correct selection sounds.
+        private BeatmapInfo beatmapInfoPrevious;
         private BeatmapInfo beatmapInfoNoDebounce;
         private RulesetInfo rulesetNoDebounce;
 
@@ -477,6 +478,19 @@ namespace osu.Game.Screens.Select
             else
                 selectionChangedDebounce = Scheduler.AddDelayed(run, 200);
 
+            if (beatmap != beatmapInfoPrevious)
+            {
+                if (beatmap != null && beatmapInfoPrevious != null)
+                {
+                    if (beatmap.BeatmapSetInfoID == beatmapInfoPrevious.BeatmapSetInfoID)
+                        sampleChangeDifficulty.Play();
+                    else
+                        sampleChangeBeatmap.Play();
+                }
+
+                beatmapInfoPrevious = beatmap;
+            }
+
             void run()
             {
                 // clear pending task immediately to track any potential nested debounce operation.
@@ -508,18 +522,7 @@ namespace osu.Game.Screens.Select
                 if (!EqualityComparer<BeatmapInfo>.Default.Equals(beatmap, Beatmap.Value.BeatmapInfo))
                 {
                     Logger.Log($"beatmap changed from \"{Beatmap.Value.BeatmapInfo}\" to \"{beatmap}\"");
-
-                    int? lastSetID = Beatmap.Value?.BeatmapInfo.BeatmapSetInfoID;
-
                     Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap);
-
-                    if (beatmap != null)
-                    {
-                        if (beatmap.BeatmapSetInfoID == lastSetID)
-                            sampleChangeDifficulty.Play();
-                        else
-                            sampleChangeBeatmap.Play();
-                    }
                 }
 
                 if (this.IsCurrentScreen())

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -105,6 +105,8 @@ namespace osu.Game.Screens.Select
 
         private readonly Bindable<RulesetInfo> decoupledRuleset = new Bindable<RulesetInfo>();
 
+        private double audioFeedbackLastPlaybackTime;
+
         [Resolved]
         private MusicController music { get; set; }
 
@@ -480,12 +482,14 @@ namespace osu.Game.Screens.Select
 
             if (beatmap != beatmapInfoPrevious)
             {
-                if (beatmap != null && beatmapInfoPrevious != null)
+                if (beatmap != null && beatmapInfoPrevious != null && Time.Current - audioFeedbackLastPlaybackTime >= 50)
                 {
                     if (beatmap.BeatmapSetInfoID == beatmapInfoPrevious.BeatmapSetInfoID)
                         sampleChangeDifficulty.Play();
                     else
                         sampleChangeBeatmap.Play();
+
+                    audioFeedbackLastPlaybackTime = Time.Current;
                 }
 
                 beatmapInfoPrevious = beatmap;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.6.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.1108.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1112.0" />
     <PackageReference Include="Sentry" Version="3.10.0" />
     <PackageReference Include="SharpCompress" Version="0.30.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.1108.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1026.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2021.1112.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Tweaks to make song select feel better with the new incoming song-select samples (ppy/osu-resources#161)

Specifically:
- Removes the delay before audio feedback is played on beatmap/difficulty change
- Adds a high-pass filter to when song choice is confirmed (frees up room for the confirmation sample bass-frequencies)
- Changes the skip intro button to not re-use the `confirm-selection`

(Not sure how safe it is to _completely_ remove the beatmap/difficulty change audio feedback debounce... can add an independent one if there are issues I guess?)