### PR TITLE
Reset combo different way in NoScope mod tests (osu! ruleset)

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             AddAssert("cursor must start visible", () => cursorAlphaAlmostEquals(1));
             AddUntilStep("wait for combo", () => Player.ScoreProcessor.Combo.Value >= 2);
             AddAssert("cursor must dim after combo", () => !cursorAlphaAlmostEquals(1));
-            AddStep("break combo", () => Player.ScoreProcessor.Combo.Set(0));
+            AddStep("break combo", () => Player.ScoreProcessor.Combo.Value = 0);
             AddUntilStep("wait for cursor to show", () => cursorAlphaAlmostEquals(1));
         }
 


### PR DESCRIPTION
Same change as in https://github.com/ppy/osu/pull/15540/commits/5e3ac5ac9f4a004bca348a1f23b17f0fc6e132ed