### PR TITLE
Fix logo sample always playing in main menu when initially logged out

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -214,10 +215,16 @@ namespace osu.Game.Screens.Menu
             }
             else if (!api.IsLoggedIn)
             {
-                logo.Action += displayLogin;
+                // copy out old action to avoid accidentally capturing logo.Action in closure, causing a self-reference loop.
+                var previousAction = logo.Action;
+
+                // we want to hook into logo.Action to display the login overlay, but also preserve the return value of the old action.
+                // therefore pass the old action to displayLogin, so that it can return that value.
+                // this ensures that the OsuLogo sample does not play when it is not desired.
+                logo.Action = () => displayLogin(previousAction);
             }
 
-            bool displayLogin()
+            bool displayLogin(Func<bool> originalAction)
             {
                 if (!loginDisplayed.Value)
                 {
@@ -225,7 +232,7 @@ namespace osu.Game.Screens.Menu
                     loginDisplayed.Value = true;
                 }
 
-                return true;
+                return originalAction.Invoke();
             }
         }
 


### PR DESCRIPTION
Closes #15554.

The required reproduction step was indeed to start the game when logged out. And the cause was some significant delegate shenanigans.

`OsuLogo` uses the return value of its `Action` delegate to determine whether to play the logo sample:

https://github.com/ppy/osu/blob/b1e13e2d63e9d5c92cff6165cb12486b0f8cf43c/osu.Game/Screens/Menu/OsuLogo.cs#L373-L374

Note that it is not an `event`, and that it has a return value.

Now here's a fun fact: what happens when you take two `Func<bool>` delegates and combine them using `+` (or, in the case of `MainMenu`, `+=`)?  The answer to that is that the first delegate's return value is *discarded*. And the second one's is returned. (See [sharplab](https://sharplab.io/#v2:D4AQTADAsAUOCMtYCMD2qA2ACAKgUwGcAXeACgEosBeAPiwDMBDDAvAbhXW32LAurpEATgFd2SOAFYAPGkx0eRalgB2eAO5YQMuRhqlF8SgGpchImA4xYIeAE4D5gHQBJFQDdUAazwVybIA=).) Which, in this case, was always `true`, and caused the logo sample to play back *over* the `ButtonSystem` samples.

The fix is to store the old `Action` and wrap it properly to preserve return value. Fix is additionally complicated by implicit capture rules (was causing a stack overflow when called directly without copying out to a local).

No tests because I can't even begin to think how to test this.