### PR TITLE
Fix settings header localised text potentially overflowing out of the settings panel

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsHeader.cs
+++ b/osu.Game/Overlays/Settings/SettingsHeader.cs
@@ -48,7 +48,6 @@ namespace osu.Game.Overlays.Settings
                         subheader.Colour = colourProvider.Content2;
                         subheader.Font = OsuFont.GetFont(size: 18);
                     });
-
                 })
             };
         }

--- a/osu.Game/Overlays/Settings/SettingsHeader.cs
+++ b/osu.Game/Overlays/Settings/SettingsHeader.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -29,36 +29,27 @@ namespace osu.Game.Overlays.Settings
 
             Children = new Drawable[]
             {
-                new FillFlowContainer
+                new OsuTextFlowContainer
                 {
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
-                    Direction = FillDirection.Vertical,
-                    Children = new Drawable[]
+                    Margin = new MarginPadding
                     {
-                        new OsuSpriteText
-                        {
-                            Text = heading,
-                            Font = OsuFont.TorusAlternate.With(size: 40),
-                            Margin = new MarginPadding
-                            {
-                                Left = SettingsPanel.CONTENT_MARGINS,
-                                Top = Toolbar.Toolbar.TOOLTIP_HEIGHT
-                            },
-                        },
-                        new OsuSpriteText
-                        {
-                            Colour = colourProvider.Content2,
-                            Text = subheading,
-                            Font = OsuFont.GetFont(size: 18),
-                            Margin = new MarginPadding
-                            {
-                                Left = SettingsPanel.CONTENT_MARGINS,
-                                Bottom = 30
-                            },
-                        },
+                        Left = SettingsPanel.CONTENT_MARGINS,
+                        Top = Toolbar.Toolbar.TOOLTIP_HEIGHT,
+                        Bottom = 30
                     }
-                }
+                }.With(flow =>
+                {
+                    flow.AddText(heading, header => header.Font = OsuFont.TorusAlternate.With(size: 40));
+                    flow.NewLine();
+                    flow.AddText(subheading, subheader =>
+                    {
+                        subheader.Colour = colourProvider.Content2;
+                        subheader.Font = OsuFont.GetFont(size: 18);
+                    });
+
+                })
             };
         }
     }

--- a/osu.Game/Overlays/Settings/SettingsHeader.cs
+++ b/osu.Game/Overlays/Settings/SettingsHeader.cs
@@ -33,9 +33,9 @@ namespace osu.Game.Overlays.Settings
                 {
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
-                    Margin = new MarginPadding
+                    Padding = new MarginPadding
                     {
-                        Left = SettingsPanel.CONTENT_MARGINS,
+                        Horizontal = SettingsPanel.CONTENT_MARGINS,
                         Top = Toolbar.Toolbar.TOOLTIP_HEIGHT,
                         Bottom = 30
                     }


### PR DESCRIPTION
Fixes the settings panel header overflowing (and getting cut out) from the panel with some locales (screenshot below uses the french locale)

This screenshot also shows another issue with action names overflowing, for which I got commits under way (but that's for another pull)

![fix](https://user-images.githubusercontent.com/20256717/141147613-b620f374-0041-4fc7-b488-886e9e459562.png)