### PR TITLE
Nerf dropped sliders in osu! difficulty calculation

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -15,13 +15,13 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Osu";
 
-        [TestCase(6.6975550434910005d, "diffcalc-test")]
-        [TestCase(1.4670676815251105d, "zero-length-sliders")]
+        [TestCase(6.6972307565739273d, "diffcalc-test")]
+        [TestCase(1.4484754139145539d, "zero-length-sliders")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
 
-        [TestCase(8.9389769779826267d, "diffcalc-test")]
-        [TestCase(1.7786917985891204d, "zero-length-sliders")]
+        [TestCase(8.9382559208689809d, "diffcalc-test")]
+        [TestCase(1.7548875851757628d, "zero-length-sliders")]
         public void TestClockRateAdjusted(double expected, string name)
             => Test(expected, name, new OsuModDoubleTime());
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public double AimStrain { get; set; }
         public double SpeedStrain { get; set; }
         public double FlashlightRating { get; set; }
+        public double SliderFactor { get; set; }
         public double ApproachRate { get; set; }
         public double OverallDifficulty { get; set; }
         public double DrainRate { get; set; }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
             double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
 
-            double sliderFactor = aimRating / aimRatingNoSliders;
+            double sliderFactor = aimRatingNoSliders / aimRating;
 
             if (mods.Any(h => h is OsuModRelax))
                 speedRating = 0.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -34,8 +34,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 return new OsuDifficultyAttributes { Mods = mods, Skills = skills };
 
             double aimRating = Math.Sqrt(skills[0].DifficultyValue()) * difficulty_multiplier;
-            double speedRating = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
-            double flashlightRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
+            double aimRatingNoSliders = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
+            double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
+            double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
+
+            double sliderFactor = aimRating / aimRatingNoSliders;
 
             if (mods.Any(h => h is OsuModRelax))
                 speedRating = 0.0;
@@ -74,6 +77,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 AimStrain = aimRating,
                 SpeedStrain = speedRating,
                 FlashlightRating = flashlightRating,
+                SliderFactor = sliderFactor,
                 ApproachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5,
                 OverallDifficulty = (80 - hitWindowGreat) / 6,
                 DrainRate = drainRate,
@@ -108,7 +112,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             return new Skill[]
             {
-                new Aim(mods),
+                new Aim(mods, true),
+                new Aim(mods, false),
                 new Speed(mods, hitWindowGreat),
                 new Flashlight(mods)
             };

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
             double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
 
-            double sliderFactor = aimRatingNoSliders / aimRating;
+            double sliderFactor = (aimRating > 0) ? aimRatingNoSliders / aimRating : 1;
 
             if (mods.Any(h => h is OsuModRelax))
                 speedRating = 0.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
             double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
 
-            double sliderFactor = (aimRating > 0) ? aimRatingNoSliders / aimRating : 1;
+            double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 
             if (mods.Any(h => h is OsuModRelax))
                 speedRating = 0.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -125,13 +125,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.0 + 0.04 * (12.0 - Attributes.ApproachRate);
             }
 
-            // We assume 20% of sliders in a map are difficult since there's no way to tell from pp-side.
+            // We assume 15% of sliders in a map are difficult since there's no way to tell from the performance calculator.
             double estimateDifficultSliders = Attributes.SliderCount * 0.15;
             double estimateSliderEndsDropped = Math.Min(Attributes.SliderCount, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
 
             estimateSliderEndsDropped = Math.Min(estimateSliderEndsDropped, estimateDifficultSliders);
 
-            double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 5.5) + Attributes.SliderFactor;
+            double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 3) + Attributes.SliderFactor;
             aimValue *= Math.Max(Attributes.SliderFactor, sliderNerfFactor);
 
             aimValue *= accuracy;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -127,10 +127,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // We assume 15% of sliders in a map are difficult since there's no way to tell from the performance calculator.
             double estimateDifficultSliders = Attributes.SliderCount * 0.15;
-            double estimateSliderEndsDropped = Math.Clamp(Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo), 0, estimateDifficultSliders);
 
-            double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 3) + Attributes.SliderFactor;
-            aimValue *= sliderNerfFactor;
+            if (Attributes.SliderCount > 0)
+            {
+                double estimateSliderEndsDropped = Math.Min(Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo), estimateDifficultSliders);
+                double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 3) + Attributes.SliderFactor;
+                aimValue *= sliderNerfFactor;
+            }
 
             aimValue *= accuracy;
             // It is important to also consider accuracy difficulty when doing that.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Estimate the number of sliderends dropped
             double estimateSliderEndsDropped = Math.Min(Attributes.SliderCount, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
-            aimValue *= 1 - (((1 - Attributes.SliderFactor) * estimateSliderEndsDropped) / Attributes.SliderCount); 
+            aimValue *= (1 - Attributes.SliderFactor) * Math.Pow(1 - (estimateSliderEndsDropped / Attributes.SliderCount), 5.5) + Attributes.SliderFactor;
 
             aimValue *= accuracy;
             // It is important to also consider accuracy difficulty when doing that.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -127,10 +127,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // We assume 15% of sliders in a map are difficult since there's no way to tell from the performance calculator.
             double estimateDifficultSliders = Attributes.SliderCount * 0.15;
-            double estimateSliderEndsDropped = Math.Min(estimateDifficultSliders, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
+            double estimateSliderEndsDropped = Math.Clamp(Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo), 0, estimateDifficultSliders);
 
             double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 3) + Attributes.SliderFactor;
-            aimValue *= Math.Max(Attributes.SliderFactor, sliderNerfFactor);
+            aimValue *= sliderNerfFactor;
 
             aimValue *= accuracy;
             // It is important to also consider accuracy difficulty when doing that.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -125,6 +125,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.0 + 0.04 * (12.0 - Attributes.ApproachRate);
             }
 
+            // Estimate the number of sliderends dropped
+            double estimateSliderEndsDropped = Math.Min(Attributes.SliderCount, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
+            aimValue *= 1 - (((1 - Attributes.SliderFactor) * estimateSliderEndsDropped) / Attributes.SliderCount); 
+
             aimValue *= accuracy;
             // It is important to also consider accuracy difficulty when doing that.
             aimValue *= 0.98 + Math.Pow(Attributes.OverallDifficulty, 2) / 2500;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -125,9 +125,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.0 + 0.04 * (12.0 - Attributes.ApproachRate);
             }
 
-            // Estimate the number of sliderends dropped
+            // We assume 20% of sliders in a map are difficult since there's no way to tell from pp-side.
+            double estimateDifficultSliders = Attributes.SliderCount * 0.15;
             double estimateSliderEndsDropped = Math.Min(Attributes.SliderCount, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
-            aimValue *= (1 - Attributes.SliderFactor) * Math.Pow(1 - (estimateSliderEndsDropped / Attributes.SliderCount), 5.5) + Attributes.SliderFactor;
+
+            estimateSliderEndsDropped = Math.Min(estimateSliderEndsDropped, estimateDifficultSliders);
+
+            double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 5.5) + Attributes.SliderFactor;
+            aimValue *= Math.Max(Attributes.SliderFactor, sliderNerfFactor);
 
             aimValue *= accuracy;
             // It is important to also consider accuracy difficulty when doing that.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -127,9 +127,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // We assume 15% of sliders in a map are difficult since there's no way to tell from the performance calculator.
             double estimateDifficultSliders = Attributes.SliderCount * 0.15;
-            double estimateSliderEndsDropped = Math.Min(Attributes.SliderCount, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
-
-            estimateSliderEndsDropped = Math.Min(estimateSliderEndsDropped, estimateDifficultSliders);
+            double estimateSliderEndsDropped = Math.Min(estimateDifficultSliders, Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo));
 
             double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 3) + Attributes.SliderFactor;
             aimValue *= Math.Max(Attributes.SliderFactor, sliderNerfFactor);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (Attributes.SliderCount > 0)
             {
-                double estimateSliderEndsDropped = Math.Min(Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo), estimateDifficultSliders);
+                double estimateSliderEndsDropped = Math.Clamp(Math.Min(countOk + countMeh + countMiss, Attributes.MaxCombo - scoreMaxCombo), 0, estimateDifficultSliders);
                 double sliderNerfFactor = (1 - Attributes.SliderFactor) * Math.Pow(1 - estimateSliderEndsDropped / estimateDifficultSliders, 3) + Attributes.SliderFactor;
                 aimValue *= sliderNerfFactor;
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         private const int normalized_radius = 50; // Change radius to 50 to make 100 the diameter. Easier for mental maths.
         private const int min_delta_time = 25;
         private const float maximum_slider_radius = normalized_radius * 2.4f;
-        private const float assumed_slider_radius = normalized_radius * 1.65f;
+        private const float assumed_slider_radius = normalized_radius * 1.8f;
 
         protected new OsuHitObject BaseObject => (OsuHitObject)base.BaseObject;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             this.withSliders = withSliders;
         }
 
+        private readonly bool withSliders;
+
         protected override int HistoryLength => 2;
 
         private const double wide_angle_multiplier = 1.5;
@@ -31,8 +33,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double skillMultiplier => 23.25;
         private double strainDecayBase => 0.15;
-
-        private bool withSliders = true;
 
         private double strainValueOf(DifficultyHitObject current)
         {

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double currVelocity = osuCurrObj.JumpDistance / osuCurrObj.StrainTime;
 
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
-            if (osuLastObj.BaseObject is Slider)
+            if (osuLastObj.BaseObject is Slider && withSliders)
             {
                 double movementVelocity = osuCurrObj.MovementDistance / osuCurrObj.MovementTime; // calculate the movement velocity from slider end to current object
                 double travelVelocity = osuCurrObj.TravelDistance / osuCurrObj.TravelTime; // calculate the slider velocity from slider head to slider end.
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             // As above, do the same for the previous hitobject.
             double prevVelocity = osuLastObj.JumpDistance / osuLastObj.StrainTime;
 
-            if (osuLastLastObj.BaseObject is Slider)
+            if (osuLastLastObj.BaseObject is Slider && withSliders)
             {
                 double movementVelocity = osuLastObj.MovementDistance / osuLastObj.MovementTime;
                 double travelVelocity = osuLastObj.TravelDistance / osuLastObj.TravelTime;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -14,9 +14,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Aim : OsuStrainSkill
     {
-        public Aim(Mod[] mods)
+        public Aim(Mod[] mods, bool withSliders)
             : base(mods)
         {
+            this.withSliders = withSliders;
         }
 
         protected override int HistoryLength => 2;
@@ -30,6 +31,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double skillMultiplier => 23.25;
         private double strainDecayBase => 0.15;
+
+        private bool withSliders = true;
 
         private double strainValueOf(DifficultyHitObject current)
         {
@@ -135,7 +138,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             aimStrain += Math.Max(acuteAngleBonus * acute_angle_multiplier, wideAngleBonus * wide_angle_multiplier + velocityChangeBonus * velocity_change_multiplier);
 
             // Add in additional slider velocity bonus.
-            aimStrain += sliderBonus * slider_multiplier;
+            if (withSliders)
+                aimStrain += sliderBonus * slider_multiplier;
 
             return aimStrain;
         }


### PR DESCRIPTION
In response to the feedback from the recent response to the rework, we're going to nerf plays on slideraim-heavy maps which are very likely to have dropped sliders. This is done via a new attribute, which describes the ratio from the aim difficulty of a map with sliders to the map without sliders. This is used with in conjunction with a formula that estimates dropped slider ends in a play to nerf aim pp!

This proposal also ships a slight nerf to sliders, by increasing `assumed_slider_radius` from `1.65` to `1.8`.

Example scores affected by this: https://www.toptal.com/developers/hastebin/raw/qicelanoza

This is the only intended hotfix for this deployment, any further work will happen next wave.