### PR TITLE
Replace usage of `TypeNameHandling.All` with custom type converter

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -161,9 +162,10 @@ namespace osu.Game.Online
                 builder.AddNewtonsoftJsonProtocol(options =>
                 {
                     options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
-                    // TODO: This should only be required to be `TypeNameHandling.Auto`.
-                    // See usage in osu-server-spectator for further documentation as to why this is required.
-                    options.PayloadSerializerSettings.TypeNameHandling = TypeNameHandling.All;
+                    options.PayloadSerializerSettings.Converters = new List<JsonConverter>
+                    {
+                        new SignalRDerivedTypeWorkaroundJsonConverter(),
+                    };
                 });
             }
 

--- a/osu.Game/Online/Multiplayer/MatchRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchRoomState.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Online.Multiplayer
     [Serializable]
     [MessagePackObject]
     [Union(0, typeof(TeamVersusRoomState))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
-    // TODO: abstract breaks json serialisation. attention will be required for iOS support (unless we get messagepack AOT working instead).
     public abstract class MatchRoomState
     {
     }

--- a/osu.Game/Online/Multiplayer/MatchUserState.cs
+++ b/osu.Game/Online/Multiplayer/MatchUserState.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Online.Multiplayer
     [Serializable]
     [MessagePackObject]
     [Union(0, typeof(TeamVersusUserState))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
-    // TODO: abstract breaks json serialisation. attention will be required for iOS support (unless we get messagepack AOT working instead).
     public abstract class MatchUserState
     {
     }

--- a/osu.Game/Online/SignalRDerivedTypeWorkaroundJsonConverter.cs
+++ b/osu.Game/Online/SignalRDerivedTypeWorkaroundJsonConverter.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// A type of <see cref="JsonConverter"/> that serializes a subset of types used in multiplayer/spectator communication that
+    /// derive from a known base type. This is a safe alternative to using <see cref="TypeNameHandling.Auto"/> or <see cref="TypeNameHandling.All"/>,
+    /// which are known to have security issues.
+    /// </summary>
+    public class SignalRDerivedTypeWorkaroundJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) =>
+            SignalRUnionWorkaroundResolver.BASE_TYPES.Contains(objectType) ||
+            SignalRUnionWorkaroundResolver.DERIVED_TYPES.Contains(objectType);
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? o, JsonSerializer jsonSerializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            JObject obj = JObject.Load(reader);
+
+            string type = (string)obj[@"$dtype"]!;
+
+            var resolvedType = SignalRUnionWorkaroundResolver.DERIVED_TYPES.Single(t => t.Name == type);
+
+            object? instance = Activator.CreateInstance(resolvedType);
+
+            jsonSerializer.Populate(obj["$value"]!.CreateReader(), instance);
+
+            return instance;
+        }
+
+        public override void WriteJson(JsonWriter writer, object? o, JsonSerializer serializer)
+        {
+            if (o == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(@"$dtype");
+            serializer.Serialize(writer, o.GetType().Name);
+
+            writer.WritePropertyName(@"$value");
+            writer.WriteRawValue(JsonConvert.SerializeObject(o));
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
+++ b/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
@@ -20,7 +20,22 @@ namespace osu.Game.Online
         public static readonly MessagePackSerializerOptions OPTIONS =
             MessagePackSerializerOptions.Standard.WithResolver(new SignalRUnionWorkaroundResolver());
 
-        private static readonly Dictionary<Type, IMessagePackFormatter> formatter_map = new Dictionary<Type, IMessagePackFormatter>
+        public static readonly IReadOnlyList<Type> BASE_TYPES = new[]
+        {
+            typeof(MatchServerEvent),
+            typeof(MatchUserRequest),
+            typeof(MatchRoomState),
+            typeof(MatchUserState),
+        };
+
+        public static readonly IReadOnlyList<Type> DERIVED_TYPES = new[]
+        {
+            typeof(ChangeTeamRequest),
+            typeof(TeamVersusRoomState),
+            typeof(TeamVersusUserState),
+        };
+
+        private static readonly IReadOnlyDictionary<Type, IMessagePackFormatter> formatter_map = new Dictionary<Type, IMessagePackFormatter>
         {
             { typeof(TeamVersusUserState), new TypeRedirectingFormatter<TeamVersusUserState, MatchUserState>() },
             { typeof(TeamVersusRoomState), new TypeRedirectingFormatter<TeamVersusRoomState, MatchRoomState>() },


### PR DESCRIPTION
While we are defaulting to messagepack on all current production platforms, this is worthwhile fixing. Google the mentioned enum for a good idea of why we shouldn't be using it. This was reported via a responsible disclosure email.

This solution was come to over multiple iterations, including input from @bdach. I also attempted using `SerializationBinder` and `ContractResolvers`, but while potentially being a clean implementation fall short of solving the issue. As with serialisation issues, usual disclaimer that reviewers shouldn't delve too deep into this - if you plan on doing so please ask questions first as I likely have detailed answers which will save review time.

Have tested this against full stack. There is also new test coverage on the `osu-server-spectator` side (coming soon).

This is not backwards compatible, but again, as the default is messagepack this should affect few to zero users. May change when we begin to deploy iOS releases again (special attention is required to make iOS work with messagepack).