### PR TITLE
Gracefully handle missing type rather than triggering `ArgumentNullException`

### DIFF
--- a/osu.Game/Rulesets/RulesetLoadException.cs
+++ b/osu.Game/Rulesets/RulesetLoadException.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets
+{
+    public class RulesetLoadException : Exception
+    {
+        public RulesetLoadException(string message)
+            : base(@$"Ruleset could not be loaded ({message})")
+        {
+        }
+    }
+}

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using osu.Framework;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Database;

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -129,13 +129,18 @@ namespace osu.Game.Rulesets
                 {
                     try
                     {
-                        var instanceInfo = ((Ruleset)Activator.CreateInstance(Type.GetType(r.InstantiationInfo).AsNonNull())).RulesetInfo;
+                        var resolvedType = Type.GetType(r.InstantiationInfo);
 
-                        r.Name = instanceInfo.Name;
-                        r.ShortName = instanceInfo.ShortName;
-                        r.InstantiationInfo = instanceInfo.InstantiationInfo;
+                        if (resolvedType != null)
+                        {
+                            var instanceInfo = ((Ruleset)Activator.CreateInstance(resolvedType)).RulesetInfo;
 
-                        r.Available = true;
+                            r.Name = instanceInfo.Name;
+                            r.ShortName = instanceInfo.ShortName;
+                            r.InstantiationInfo = instanceInfo.InstantiationInfo;
+
+                            r.Available = true;
+                        }
                     }
                     catch
                     {

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -128,18 +128,16 @@ namespace osu.Game.Rulesets
                 {
                     try
                     {
-                        var resolvedType = Type.GetType(r.InstantiationInfo);
+                        var resolvedType = Type.GetType(r.InstantiationInfo)
+                                           ?? throw new RulesetLoadException(@"Type could not be resolved");
 
-                        if (resolvedType != null)
-                        {
-                            var instanceInfo = ((Ruleset)Activator.CreateInstance(resolvedType)).RulesetInfo;
+                        var instanceInfo = (Activator.CreateInstance(resolvedType) as Ruleset)?.RulesetInfo
+                                           ?? throw new RulesetLoadException(@"Instantiation failure");
 
-                            r.Name = instanceInfo.Name;
-                            r.ShortName = instanceInfo.ShortName;
-                            r.InstantiationInfo = instanceInfo.InstantiationInfo;
-
-                            r.Available = true;
-                        }
+                        r.Name = instanceInfo.Name;
+                        r.ShortName = instanceInfo.ShortName;
+                        r.InstantiationInfo = instanceInfo.InstantiationInfo;
+                        r.Available = true;
                     }
                     catch
                     {

--- a/osu.Game/Stores/RealmRulesetStore.cs
+++ b/osu.Game/Stores/RealmRulesetStore.cs
@@ -147,19 +147,15 @@ namespace osu.Game.Stores
                     {
                         try
                         {
-                            var type = Type.GetType(r.InstantiationInfo);
+                            var resolvedType = Type.GetType(r.InstantiationInfo)
+                                               ?? throw new RulesetLoadException(@"Type could not be resolved");
 
-                            if (type == null)
-                                throw new InvalidOperationException(@"Type resolution failure.");
+                            var instanceInfo = (Activator.CreateInstance(resolvedType) as Ruleset)?.RulesetInfo
+                                               ?? throw new RulesetLoadException(@"Instantiation failure");
 
-                            var rInstance = (Activator.CreateInstance(type) as Ruleset)?.RulesetInfo;
-
-                            if (rInstance == null)
-                                throw new InvalidOperationException(@"Instantiation failure.");
-
-                            r.Name = rInstance.Name;
-                            r.ShortName = rInstance.ShortName;
-                            r.InstantiationInfo = rInstance.InstantiationInfo;
+                            r.Name = instanceInfo.Name;
+                            r.ShortName = instanceInfo.ShortName;
+                            r.InstantiationInfo = instanceInfo.InstantiationInfo;
                             r.Available = true;
 
                             detachedRulesets.Add(r.Clone());


### PR DESCRIPTION
Mainly to silence exceptions during debug, which can commonly appear:

![20211111 144404 (JetBrains Rider-EAP)](https://user-images.githubusercontent.com/191335/141244583-e8de1583-3925-49e8-9ce9-2217daa13df2.png)


