### PR TITLE
Fix being able to switch own team by clicking other players' team indicators

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -10,6 +10,7 @@ using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
@@ -97,16 +98,24 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddAssert("user on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
+            AddStep("add another user", () => client.AddUser(new APIUser { Username = "otheruser", Id = 44 }));
 
-            AddStep("press button", () =>
+            AddStep("press own button", () =>
             {
                 InputManager.MoveMouseTo(multiplayerScreenStack.ChildrenOfType<TeamDisplay>().First());
                 InputManager.Click(MouseButton.Left);
             });
             AddAssert("user on team 1", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 1);
 
-            AddStep("press button", () => InputManager.Click(MouseButton.Left));
+            AddStep("press own button again", () => InputManager.Click(MouseButton.Left));
             AddAssert("user on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
+
+            AddStep("press other user's button", () =>
+            {
+                InputManager.MoveMouseTo(multiplayerScreenStack.ChildrenOfType<TeamDisplay>().ElementAt(1));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("user still on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -51,7 +51,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                 Alpha = 0,
                 Scale = new Vector2(0, 1),
                 RelativeSizeAxes = Axes.Y,
-                Action = changeTeam,
                 Child = box = new Container
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -71,6 +71,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             // We want the user to be immediately available for testing, so force a scheduler update to run the update-bound continuation.
             Scheduler.Update();
+
+            switch (Room?.MatchState)
+            {
+                case TeamVersusRoomState teamVersus:
+                    Debug.Assert(Room != null);
+
+                    // simulate the server's automatic assignment of users to teams on join.
+                    // the "best" team is the one with the least users on it.
+                    int bestTeam = teamVersus.Teams
+                                             .Select(team => (teamID: team.ID, userCount: Room.Users.Count(u => (u.MatchState as TeamVersusUserState)?.TeamID == team.ID)))
+                                             .OrderBy(pair => pair.userCount)
+                                             .First().teamID;
+                    ((IMultiplayerClient)this).MatchUserStateChanged(user.UserID, new TeamVersusUserState { TeamID = bestTeam }).Wait();
+                    break;
+            }
         }
 
         public void RemoveUser(APIUser user)


### PR DESCRIPTION
Randomly found this when testing json serialisation with multiplayer, and it seemed like a bug. Or, simple oversight, really, the fix is a one-liner in 9664b9a. Note that the local user's indicator is receiving that same `Action` anyhow lower down:

https://github.com/ppy/osu/blob/374d1cc24131cda4aed6d426787d2f9b9905f138/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs#L73-L77

The rest of the diff is testing. As it turns out `AddUser()` was not simulating server properly in assigning new users to teams in the case of team versus, so I added that behaviour in the test client. I think that's the correct place to put it...?