### PR TITLE
Rename EF properties to match underlying interface

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorSaving.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorSaving.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
                 editorBeatmap.BeatmapInfo.Metadata.Artist = "artist";
                 editorBeatmap.BeatmapInfo.Metadata.Title = "title";
             });
-            AddStep("Set difficulty name", () => editorBeatmap.BeatmapInfo.Version = "difficulty");
+            AddStep("Set difficulty name", () => editorBeatmap.BeatmapInfo.DifficultyName = "difficulty");
 
             checkMutations();
 
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
                 return Precision.AlmostEquals(taikoDifficulty.SliderMultiplier, 2);
             });
             AddAssert("Beatmap has correct metadata", () => editorBeatmap.BeatmapInfo.Metadata.Artist == "artist" && editorBeatmap.BeatmapInfo.Metadata.Title == "title");
-            AddAssert("Beatmap has correct difficulty name", () => editorBeatmap.BeatmapInfo.Version == "difficulty");
+            AddAssert("Beatmap has correct difficulty name", () => editorBeatmap.BeatmapInfo.DifficultyName == "difficulty");
         }
     }
 }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual("Soleily", metadata.Artist);
                 Assert.AreEqual("Soleily", metadata.ArtistUnicode);
                 Assert.AreEqual("Gamu", metadata.Author.Username);
-                Assert.AreEqual("Insane", beatmapInfo.Version);
+                Assert.AreEqual("Insane", beatmapInfo.DifficultyName);
                 Assert.AreEqual(string.Empty, metadata.Source);
                 Assert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", metadata.Tags);
                 Assert.AreEqual(557821, beatmapInfo.OnlineBeatmapID);

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -790,12 +790,12 @@ namespace osu.Game.Tests.Beatmaps.IO
                     // Update via the beatmap, not the beatmap info, to ensure correct linking
                     BeatmapSetInfo setToUpdate = manager.GetAllUsableBeatmapSets()[0];
                     Beatmap beatmapToUpdate = (Beatmap)manager.GetWorkingBeatmap(setToUpdate.Beatmaps.First(b => b.RulesetID == 0)).Beatmap;
-                    beatmapToUpdate.BeatmapInfo.Version = "updated";
+                    beatmapToUpdate.BeatmapInfo.DifficultyName = "updated";
 
                     manager.Update(setToUpdate);
 
                     BeatmapInfo updatedInfo = manager.QueryBeatmap(b => b.ID == beatmapToUpdate.BeatmapInfo.ID);
-                    Assert.That(updatedInfo.Version, Is.EqualTo("updated"));
+                    Assert.That(updatedInfo.DifficultyName, Is.EqualTo("updated"));
                 }
                 finally
                 {
@@ -863,7 +863,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     var beatmap = working.Beatmap;
 
-                    beatmap.BeatmapInfo.Version = "difficulty";
+                    beatmap.BeatmapInfo.DifficultyName = "difficulty";
                     beatmap.BeatmapInfo.Metadata = new BeatmapMetadata
                     {
                         Artist = "Artist/With\\Slashes",

--- a/osu.Game.Tests/Beatmaps/ToStringFormattingTest.cs
+++ b/osu.Game.Tests/Beatmaps/ToStringFormattingTest.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Beatmaps
                     Title = "title",
                     Author = new APIUser { Username = "creator" }
                 },
-                Version = "difficulty"
+                DifficultyName = "difficulty"
             };
 
             Assert.That(beatmap.ToString(), Is.EqualTo("artist - title (creator) [difficulty]"));

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         private BeatmapInfo getExampleBeatmap() => new BeatmapInfo
         {
             Ruleset = new RulesetInfo { ID = 5 },
-            StarDifficulty = 4.0d,
+            StarRating = 4.0d,
             BaseDifficulty = new BeatmapDifficulty
             {
                 ApproachRate = 5.0f,

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
                 Source = "unit tests",
                 Tags = "look for tags too",
             },
-            Version = "version as well",
+            DifficultyName = "version as well",
             Length = 2500,
             BPM = 160,
             BeatDivisor = 12,

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.Editing
                 editorBeatmap.BeatmapInfo.Metadata.Artist = "artist";
                 editorBeatmap.BeatmapInfo.Metadata.Title = "title";
             });
-            AddStep("Set difficulty name", () => editorBeatmap.BeatmapInfo.Version = "difficulty");
+            AddStep("Set difficulty name", () => editorBeatmap.BeatmapInfo.DifficultyName = "difficulty");
 
             AddStep("Add timing point", () => editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint()));
 
@@ -85,7 +85,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("Beatmap contains single hitcircle", () => editorBeatmap.HitObjects.Count == 1);
             AddAssert("Beatmap has correct overall difficulty", () => editorBeatmap.Difficulty.OverallDifficulty == 7);
             AddAssert("Beatmap has correct metadata", () => editorBeatmap.BeatmapInfo.Metadata.Artist == "artist" && editorBeatmap.BeatmapInfo.Metadata.Title == "title");
-            AddAssert("Beatmap has correct difficulty name", () => editorBeatmap.BeatmapInfo.Version == "difficulty");
+            AddAssert("Beatmap has correct difficulty name", () => editorBeatmap.BeatmapInfo.DifficultyName == "difficulty");
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                                         {
                                             BeatmapInfo =
                                             {
-                                                StarDifficulty = 2.5
+                                                StarRating = 2.5
                                             }
                                         }.BeatmapInfo,
                                     }
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                                         {
                                             BeatmapInfo =
                                             {
-                                                StarDifficulty = 2.5,
+                                                StarRating = 2.5,
                                                 Metadata =
                                                 {
                                                     Artist = "very very very very very very very very very long artist",
@@ -111,7 +111,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                                         {
                                             BeatmapInfo =
                                             {
-                                                StarDifficulty = 2.5
+                                                StarRating = 2.5
                                             }
                                         }.BeatmapInfo,
                                     }
@@ -124,7 +124,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                                         {
                                             BeatmapInfo =
                                             {
-                                                StarDifficulty = 4.5
+                                                StarRating = 4.5
                                             }
                                         }.BeatmapInfo,
                                     }

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     Ruleset = new OsuRuleset().RulesetInfo,
                     OnlineBeatmapID = beatmapId,
-                    Version = $"{beatmapId} (length {TimeSpan.FromMilliseconds(length):m\\:ss}, bpm {bpm:0.#})",
+                    DifficultyName = $"{beatmapId} (length {TimeSpan.FromMilliseconds(length):m\\:ss}, bpm {bpm:0.#})",
                     Length = length,
                     BPM = bpm,
                     BaseDifficulty = new BeatmapDifficulty

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 SelectedRoom.Value.Playlist.AddRange(new[]
                 {
-                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarDifficulty = min } } },
-                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarDifficulty = max } } },
+                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarRating = min } } },
+                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarRating = max } } },
                 });
             });
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 OverallDifficulty = 5.7f,
                 ApproachRate = 3.5f
             },
-            StarDifficulty = 4.5f
+            StarRating = 4.5f
         };
 
         [Test]
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     OverallDifficulty = 4.5f,
                     ApproachRate = 3.1f
                 },
-                StarDifficulty = 8
+                StarRating = 8
             });
 
             AddAssert("first bar text is Key Count", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == "Key Count");

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -684,7 +684,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     set.Beatmaps.Add(new BeatmapInfo
                     {
-                        Version = $"Stars: {i}",
+                        DifficultyName = $"Stars: {i}",
                         Ruleset = new OsuRuleset().RulesetInfo,
                         StarRating = i,
                     });
@@ -868,7 +868,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 yield return new BeatmapInfo
                 {
                     OnlineBeatmapID = id++ * 10,
-                    Version = version,
+                    DifficultyName = version,
                     StarRating = diff,
                     Ruleset = new OsuRuleset().RulesetInfo,
                     BaseDifficulty = new BeatmapDifficulty
@@ -902,7 +902,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     OnlineBeatmapID = b * 10,
                     Path = $"extra{b}.osu",
-                    Version = $"Extra {b}",
+                    DifficultyName = $"Extra {b}",
                     Ruleset = rulesets.GetRuleset((b - 1) % 4),
                     StarRating = 2,
                     BaseDifficulty = new BeatmapDifficulty

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -435,8 +435,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             for (int i = 0; i < 3; i++)
             {
                 var set = createTestBeatmapSet(i);
-                set.Beatmaps[0].StarDifficulty = 3 - i;
-                set.Beatmaps[2].StarDifficulty = 6 + i;
+                set.Beatmaps[0].StarRating = 3 - i;
+                set.Beatmaps[2].StarRating = 6 + i;
                 sets.Add(set);
             }
 
@@ -686,7 +686,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Version = $"Stars: {i}",
                         Ruleset = new OsuRuleset().RulesetInfo,
-                        StarDifficulty = i,
+                        StarRating = i,
                     });
                 }
 
@@ -869,7 +869,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     OnlineBeatmapID = id++ * 10,
                     Version = version,
-                    StarDifficulty = diff,
+                    StarRating = diff,
                     Ruleset = new OsuRuleset().RulesetInfo,
                     BaseDifficulty = new BeatmapDifficulty
                     {
@@ -904,7 +904,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Path = $"extra{b}.osu",
                     Version = $"Extra {b}",
                     Ruleset = rulesets.GetRuleset((b - 1) % 4),
-                    StarDifficulty = 2,
+                    StarRating = 2,
                     BaseDifficulty = new BeatmapDifficulty
                     {
                         OverallDifficulty = 3.5f,

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                         Title = $"{ruleset.ShortName}Title"
                     },
                     Ruleset = ruleset,
-                    StarDifficulty = 6,
+                    StarRating = 6,
                     Version = $"{ruleset.ShortName}Version",
                     BaseDifficulty = new BeatmapDifficulty()
                 },

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     },
                     Ruleset = ruleset,
                     StarRating = 6,
-                    Version = $"{ruleset.ShortName}Version",
+                    DifficultyName = $"{ruleset.ShortName}Version",
                     BaseDifficulty = new BeatmapDifficulty()
                 },
                 HitObjects = objects
@@ -219,7 +219,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                         Source = "Verrrrry long Source",
                         Title = "Verrrrry long Title"
                     },
-                    Version = "Verrrrrrrrrrrrrrrrrrrrrrrrrrrrry long Version",
+                    DifficultyName = "Verrrrrrrrrrrrrrrrrrrrrrrrrrrrry long Version",
                     Status = BeatmapSetOnlineStatus.Graveyard,
                 },
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Title = title,
                     },
-                    Version = version,
+                    DifficultyName = version,
                     StarRating = RNG.NextDouble(0, 10),
                 }
             }));
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Title = "Heavy beatmap",
                     },
-                    Version = "10k objects",
+                    DifficultyName = "10k objects",
                     StarRating = 99.99f,
                 }
             }));

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                         Title = title,
                     },
                     Version = version,
-                    StarDifficulty = RNG.NextDouble(0, 10),
+                    StarRating = RNG.NextDouble(0, 10),
                 }
             }));
         }
@@ -65,7 +65,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                         Title = "Heavy beatmap",
                     },
                     Version = "10k objects",
-                    StarDifficulty = 99.99f,
+                    StarRating = 99.99f,
                 }
             }));
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     BaseDifficulty = new BeatmapDifficulty(),
                     Ruleset = ruleset,
                     StarRating = difficultyIndex + 1,
-                    Version = $"SR{difficultyIndex + 1}"
+                    DifficultyName = $"SR{difficultyIndex + 1}"
                 }).ToList()
             };
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Metadata = metadata,
                     BaseDifficulty = new BeatmapDifficulty(),
                     Ruleset = ruleset,
-                    StarDifficulty = difficultyIndex + 1,
+                    StarRating = difficultyIndex + 1,
                     Version = $"SR{difficultyIndex + 1}"
                 }).ToList()
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -919,7 +919,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Ruleset = getRuleset(),
                     OnlineBeatmapID = beatmapId,
-                    Version = $"{beatmapId} (length {TimeSpan.FromMilliseconds(length):m\\:ss}, bpm {bpm:0.#})",
+                    DifficultyName = $"{beatmapId} (length {TimeSpan.FromMilliseconds(length):m\\:ss}, bpm {bpm:0.#})",
                     Length = length,
                     BPM = bpm,
                     BaseDifficulty = new BeatmapDifficulty

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                                     Username = "TestAuthor"
                                 },
                             },
-                            Version = "Insane"
+                            DifficultyName = "Insane"
                         },
                     }
                 },

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Beatmaps
                     Title = @"Unknown",
                     AuthorString = @"Unknown Creator",
                 },
-                Version = @"Normal",
+                DifficultyName = @"Normal",
                 BaseDifficulty = Difficulty,
             };
         }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -134,9 +134,8 @@ namespace osu.Game.Beatmaps
         public double TimelineZoom { get; set; }
 
         // Metadata
-        public string Version { get; set; }
-
-        private string versionString => string.IsNullOrEmpty(Version) ? string.Empty : $"[{Version}]";
+        [Column("Version")]
+        public string DifficultyName { get; set; }
 
         [JsonProperty("difficulty_rating")]
         [Column("StarDifficulty")]
@@ -182,9 +181,6 @@ namespace osu.Game.Beatmaps
         #endregion
 
         #region Implementation of IBeatmapInfo
-
-        [JsonIgnore]
-        string IBeatmapInfo.DifficultyName => Version;
 
         [JsonIgnore]
         IBeatmapMetadataInfo IBeatmapInfo.Metadata => Metadata ?? BeatmapSet?.Metadata ?? new BeatmapMetadata();

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -139,7 +139,8 @@ namespace osu.Game.Beatmaps
         private string versionString => string.IsNullOrEmpty(Version) ? string.Empty : $"[{Version}]";
 
         [JsonProperty("difficulty_rating")]
-        public double StarDifficulty { get; set; }
+        [Column("StarDifficulty")]
+        public double StarRating { get; set; }
 
         /// <summary>
         /// Currently only populated for beatmap deletion. Use <see cref="ScoreManager"/> to query scores.
@@ -147,7 +148,7 @@ namespace osu.Game.Beatmaps
         public List<ScoreInfo> Scores { get; set; }
 
         [JsonIgnore]
-        public DifficultyRating DifficultyRating => BeatmapDifficultyCache.GetDifficultyRating(StarDifficulty);
+        public DifficultyRating DifficultyRating => BeatmapDifficultyCache.GetDifficultyRating(StarRating);
 
         public override string ToString() => this.GetDisplayTitle();
 
@@ -196,9 +197,6 @@ namespace osu.Game.Beatmaps
 
         [JsonIgnore]
         IRulesetInfo IBeatmapInfo.Ruleset => Ruleset;
-
-        [JsonIgnore]
-        double IBeatmapInfo.StarRating => StarDifficulty;
 
         #endregion
     }

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -407,7 +407,7 @@ namespace osu.Game.Beatmaps
                     beatmap.BeatmapInfo.Ruleset = ruleset;
 
                     // TODO: this should be done in a better place once we actually need to dynamically update it.
-                    beatmap.BeatmapInfo.StarDifficulty = ruleset?.CreateInstance().CreateDifficultyCalculator(new DummyConversionBeatmap(beatmap)).Calculate().StarRating ?? 0;
+                    beatmap.BeatmapInfo.StarRating = ruleset?.CreateInstance().CreateDifficultyCalculator(new DummyConversionBeatmap(beatmap)).Calculate().StarRating ?? 0;
                     beatmap.BeatmapInfo.Length = calculateLength(beatmap);
                     beatmap.BeatmapInfo.BPM = 60000 / beatmap.GetMostCommonBeatLength();
 

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -215,7 +215,7 @@ namespace osu.Game.Beatmaps
                     var fileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase)) ?? new BeatmapSetFileInfo();
 
                     // metadata may have changed; update the path with the standard format.
-                    beatmapInfo.Path = GetValidFilename($"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.Version}].osu");
+                    beatmapInfo.Path = GetValidFilename($"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.DifficultyName}].osu");
 
                     beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
 

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The maximum star difficulty of all beatmaps in this set.
         /// </summary>
-        public double MaxStarDifficulty => Beatmaps?.Max(b => b.StarDifficulty) ?? 0;
+        public double MaxStarDifficulty => Beatmaps?.Max(b => b.StarRating) ?? 0;
 
         /// <summary>
         /// The maximum playable length in milliseconds of all beatmaps in this set.

--- a/osu.Game/Beatmaps/DifficultyRecommender.cs
+++ b/osu.Game/Beatmaps/DifficultyRecommender.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps
 
                 BeatmapInfo beatmapInfo = beatmaps.Where(b => b.Ruleset.Equals(r)).OrderBy(b =>
                 {
-                    double difference = b.StarDifficulty - recommendation;
+                    double difference = b.StarRating - recommendation;
                     return difference >= 0 ? difference * 2 : difference * -1; // prefer easier over harder
                 }).FirstOrDefault();
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Beatmaps.Formats
                     break;
 
                 case @"Version":
-                    beatmap.BeatmapInfo.Version = pair.Value;
+                    beatmap.BeatmapInfo.DifficultyName = pair.Value;
                     break;
 
                 case @"Source":

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine(FormattableString.Invariant($"Artist: {beatmap.Metadata.Artist}"));
             if (!string.IsNullOrEmpty(beatmap.Metadata.ArtistUnicode)) writer.WriteLine(FormattableString.Invariant($"ArtistUnicode: {beatmap.Metadata.ArtistUnicode}"));
             writer.WriteLine(FormattableString.Invariant($"Creator: {beatmap.Metadata.Author.Username}"));
-            writer.WriteLine(FormattableString.Invariant($"Version: {beatmap.BeatmapInfo.Version}"));
+            writer.WriteLine(FormattableString.Invariant($"Version: {beatmap.BeatmapInfo.DifficultyName}"));
             if (!string.IsNullOrEmpty(beatmap.Metadata.Source)) writer.WriteLine(FormattableString.Invariant($"Source: {beatmap.Metadata.Source}"));
             if (!string.IsNullOrEmpty(beatmap.Metadata.Tags)) writer.WriteLine(FormattableString.Invariant($"Tags: {beatmap.Metadata.Tags}"));
             if (beatmap.BeatmapInfo.OnlineBeatmapID != null) writer.WriteLine(FormattableString.Invariant($"BeatmapID: {beatmap.BeatmapInfo.OnlineBeatmapID}"));

--- a/osu.Game/Screens/Edit/Components/Menus/DifficultyMenuItem.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/DifficultyMenuItem.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.Edit.Components.Menus
         public BeatmapInfo BeatmapInfo { get; }
 
         public DifficultyMenuItem(BeatmapInfo beatmapInfo, bool selected, Action<BeatmapInfo> difficultyChangeFunc)
-            : base(beatmapInfo.Version ?? "(unnamed)", null)
+            : base(beatmapInfo.DifficultyName ?? "(unnamed)", null)
         {
             BeatmapInfo = beatmapInfo;
             State.Value = selected;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -723,7 +723,7 @@ namespace osu.Game.Screens.Edit
                 if (difficultyItems.Count > 0)
                     difficultyItems.Add(new EditorMenuItemSpacer());
 
-                foreach (var beatmap in rulesetBeatmaps.OrderBy(b => b.StarDifficulty))
+                foreach (var beatmap in rulesetBeatmaps.OrderBy(b => b.StarRating))
                     difficultyItems.Add(createDifficultyMenuItem(beatmap));
             }
 

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Edit.Setup
                 Empty(),
 
                 creatorTextBox = createTextBox<LabelledTextBox>("Creator", metadata.Author.Username),
-                difficultyTextBox = createTextBox<LabelledTextBox>("Difficulty Name", Beatmap.BeatmapInfo.Version),
+                difficultyTextBox = createTextBox<LabelledTextBox>("Difficulty Name", Beatmap.BeatmapInfo.DifficultyName),
                 sourceTextBox = createTextBox<LabelledTextBox>("Source", metadata.Source),
                 tagsTextBox = createTextBox<LabelledTextBox>("Tags", metadata.Tags)
             };
@@ -111,7 +111,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.Metadata.Title = RomanisedTitleTextBox.Current.Value;
 
             Beatmap.Metadata.AuthorString = creatorTextBox.Current.Value;
-            Beatmap.BeatmapInfo.Version = difficultyTextBox.Current.Value;
+            Beatmap.BeatmapInfo.DifficultyName = difficultyTextBox.Current.Value;
             Beatmap.Metadata.Source = sourceTextBox.Current.Value;
             Beatmap.Metadata.Tags = tagsTextBox.Current.Value;
         }

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.Play
                             {
                                 new OsuSpriteText
                                 {
-                                    Text = beatmap?.BeatmapInfo?.Version,
+                                    Text = beatmap?.BeatmapInfo?.DifficultyName,
                                     Font = OsuFont.GetFont(size: 26, italics: true),
                                     Anchor = Anchor.TopCentre,
                                     Origin = Anchor.TopCentre,

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                     {
                                         Anchor = Anchor.TopCentre,
                                         Origin = Anchor.TopCentre,
-                                        Text = beatmap.Version,
+                                        Text = beatmap.DifficultyName,
                                         Font = OsuFont.Torus.With(size: 16, weight: FontWeight.SemiBold),
                                     },
                                     new OsuTextFlowContainer(s => s.Font = OsuFont.Torus.With(size: 12))

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Screens.Select
                         {
                             VersionLabel = new OsuSpriteText
                             {
-                                Text = beatmapInfo.Version,
+                                Text = beatmapInfo.DifficultyName,
                                 Font = OsuFont.GetFont(size: 24, italics: true),
                                 RelativeSizeAxes = Axes.X,
                                 Truncate = true,
@@ -324,7 +324,7 @@ namespace osu.Game.Screens.Select
                 });
 
                 // no difficulty means it can't have a status to show
-                if (beatmapInfo.Version == null)
+                if (beatmapInfo.DifficultyName == null)
                     StatusPill.Hide();
 
                 addInfoLabels();

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Select.Carousel
                 return;
             }
 
-            match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(BeatmapInfo.StarDifficulty);
+            match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(BeatmapInfo.StarRating);
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(BeatmapInfo.BaseDifficulty.ApproachRate);
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(BeatmapInfo.BaseDifficulty.DrainRate);
             match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(BeatmapInfo.BaseDifficulty.CircleSize);
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Select.Carousel
             match &= !criteria.Artist.HasFilter || criteria.Artist.Matches(BeatmapInfo.Metadata.Artist) ||
                      criteria.Artist.Matches(BeatmapInfo.Metadata.ArtistUnicode);
 
-            match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarDifficulty);
+            match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarRating);
 
             if (match)
             {
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Select.Carousel
                     int ruleset = BeatmapInfo.RulesetID.CompareTo(otherBeatmap.BeatmapInfo.RulesetID);
                     if (ruleset != 0) return ruleset;
 
-                    return BeatmapInfo.StarDifficulty.CompareTo(otherBeatmap.BeatmapInfo.StarDifficulty);
+                    return BeatmapInfo.StarRating.CompareTo(otherBeatmap.BeatmapInfo.StarRating);
             }
         }
 

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Screens.Select.Carousel
                     return compareUsingAggregateMax(otherSet, b => b.Length);
 
                 case SortMode.Difficulty:
-                    return compareUsingAggregateMax(otherSet, b => b.StarDifficulty);
+                    return compareUsingAggregateMax(otherSet, b => b.StarRating);
             }
         }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Screens.Select.Carousel
                                     {
                                         new OsuSpriteText
                                         {
-                                            Text = beatmapInfo.Version,
+                                            Text = beatmapInfo.DifficultyName,
                                             Font = OsuFont.GetFont(size: 20),
                                             Anchor = Anchor.BottomLeft,
                                             Origin = Anchor.BottomLeft

--- a/osu.Game/Stores/BeatmapImporter.cs
+++ b/osu.Game/Stores/BeatmapImporter.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Stores
                     var beatmap = new RealmBeatmap(ruleset, difficulty, metadata)
                     {
                         Hash = hash,
-                        DifficultyName = decodedInfo.Version,
+                        DifficultyName = decodedInfo.DifficultyName,
                         OnlineID = decodedInfo.OnlineBeatmapID ?? -1,
                         AudioLeadIn = decodedInfo.AudioLeadIn,
                         StackLeniency = decodedInfo.StackLeniency,

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Tests.Visual
                         AuthorID = beatmap.Metadata.Author.OnlineID,
                         RulesetID = beatmap.RulesetID,
                         StarRating = beatmap.StarRating,
-                        DifficultyName = beatmap.Version,
+                        DifficultyName = beatmap.DifficultyName,
                     }
                 }
             };

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -228,7 +228,7 @@ namespace osu.Game.Tests.Visual
                         Checksum = beatmap.MD5Hash,
                         AuthorID = beatmap.Metadata.Author.OnlineID,
                         RulesetID = beatmap.RulesetID,
-                        StarRating = beatmap.StarDifficulty,
+                        StarRating = beatmap.StarRating,
                         DifficultyName = beatmap.Version,
                     }
                 }


### PR DESCRIPTION
As I continue moving more existing classes to accepting interface versions, these are the cases where manual intervention is most required. Makes sense to make them match at the model level.