### PR TITLE
Fix Android builds failing due to Xamarin-side regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,22 +52,29 @@ jobs:
 
   build-only-android:
     name: Build only (Android)
-    runs-on: windows-latest
+    runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      # Pin Xamarin.Android version to 11.2 for now to avoid build failures caused by a Xamarin-side regression.
+      # See: https://github.com/xamarin/xamarin-android/issues/6284
+      # This can be removed/reverted when the fix makes it to upstream and is deployed on github runners.
+      - name: Set default Xamarin SDK version
+        run: |
+            $VM_ASSETS/select-xamarin-sdk-v2.sh --mono=6.12 --android=11.2
 
       - name: Install .NET 5.0.x
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "5.0.x"
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-
+      # Contrary to seemingly any other msbuild, msbuild running on macOS/Mono
+      # cannot accept .sln(f) files as arguments.
+      # Build just the main game for now.
       - name: Build
-        run: msbuild osu.Android.slnf /restore /p:Configuration=Debug
+        run: msbuild osu.Android/osu.Android.csproj /restore /p:Configuration=Debug
 
   build-only-ios:
     # While this workflow technically *can* run, it fails as iOS builds are blocked by multiple issues.


### PR DESCRIPTION
Sometime today, GitHub runners seem to have received a Xamarin.Android bump via their `windows-latest` images. The bump in question was from version 11.4.0.5 to version 12.0.0.3. The latter version appears to contain a [Xamarin.Android regression](https://github.com/xamarin/xamarin-android/issues/6463) that is currently failing builds ([see failing run](https://github.com/ppy/osu/runs/4175565623?check_suite_focus=true)). The regression is [already fixed upstream](https://github.com/xamarin/xamarin-android/pull/6290), but in order for us to get it, it needs to trickle down to VS and then to github runners again.

The proposed fix is to switch to the older version of Xamarin. Unfortunately as far as I'm aware this is not possible to do on the `windows-latest` runner, but *is* possible on the `macos` runners ([see reference](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-xamarin-applications)). Which makes the build build, but unfortunately due to msbuild limitations (which are already in place for iOS) I've also had to drop from building the entire `.slnf` to just the main game project.

This will not affect framework, because framework-side android activities do not set `Exported` in the attribute the same way `OsuGameActivity` does.

A run with these changes and a passing build can be seen [here](https://github.com/bdach/osu/runs/4176086290?check_suite_focus=true).