### PR TITLE
Fix unstable rate counter not including judgements before show in calculations

### DIFF
--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -22,7 +22,8 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            Assert.IsTrue(Precision.AlmostEquals(unstableRate.Value, 10 * Math.Sqrt(10)));
+            Assert.IsNotNull(unstableRate.Value);
+            Assert.IsTrue(Precision.AlmostEquals(unstableRate.Value.Value, 10 * Math.Sqrt(10)));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneUnstableRateCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneUnstableRateCounter.cs
@@ -61,6 +61,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddRepeatStep("Bring UR to 100", () => applyJudgement(-10, false), 10);
         }
 
+        [Test]
+        public void TestCounterReceivesJudgementsBeforeCreation()
+        {
+            AddRepeatStep("Set UR to 250", () => applyJudgement(25, true), 4);
+
+            AddStep("Create Display", recreateDisplay);
+
+            AddUntilStep("UR = 250", () => counter.Current.Value == 250.0);
+        }
+
         private void recreateDisplay()
         {
             Clear();

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Scoring
+{
+    public static class HitEventExtensions
+    {
+        /// <summary>
+        /// Calculates the "unstable rate" for a sequence of <see cref="HitEvent"/>s.
+        /// </summary>
+        /// <returns>
+        /// A non-null <see langword="double"/> value if unstable rate could be calculated,
+        /// and <see langword="null"/> if unstable rate cannot be calculated due to <paramref name="hitEvents"/> being empty.
+        /// </returns>
+        public static double? CalculateUnstableRate(this IEnumerable<HitEvent> hitEvents)
+        {
+            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset).ToArray();
+            return 10 * standardDeviation(timeOffsets);
+        }
+
+        private static bool affectsUnstableRate(HitEvent e) => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit();
+
+        private static double? standardDeviation(double[] timeOffsets)
+        {
+            if (timeOffsets.Length == 0)
+                return null;
+
+            double mean = timeOffsets.Average();
+            double squares = timeOffsets.Select(offset => Math.Pow(offset - mean, 2)).Sum();
+            return Math.Sqrt(squares / timeOffsets.Length);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -54,6 +54,12 @@ namespace osu.Game.Rulesets.Scoring
         public readonly Bindable<ScoringMode> Mode = new Bindable<ScoringMode>();
 
         /// <summary>
+        /// The <see cref="HitEvent"/>s collected during gameplay thus far.
+        /// Intended for use with various statistics displays.
+        /// </summary>
+        public IReadOnlyList<HitEvent> HitEvents => hitEvents;
+
+        /// <summary>
         /// The default portion of <see cref="max_score"/> awarded for hitting <see cref="HitObject"/>s accurately. Defaults to 30%.
         /// </summary>
         protected virtual double DefaultAccuracyPortion => 0.3;

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -62,7 +63,7 @@ namespace osu.Game.Screens.Play.HUD
 
             valid.Value = unstableRate != null;
             if (unstableRate != null)
-                Current.Value = (int)unstableRate.Value;
+                Current.Value = (int)Math.Round(unstableRate.Value);
         }
 
         protected override IHasText CreateText() => new TextComponent

--- a/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
+++ b/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Screens.Ranking.Statistics
@@ -11,7 +9,7 @@ namespace osu.Game.Screens.Ranking.Statistics
     /// <summary>
     /// Displays the unstable rate statistic for a given play.
     /// </summary>
-    public class UnstableRate : SimpleStatisticItem<double>
+    public class UnstableRate : SimpleStatisticItem<double?>
     {
         /// <summary>
         /// Creates and computes an <see cref="UnstableRate"/> statistic.
@@ -20,21 +18,9 @@ namespace osu.Game.Screens.Ranking.Statistics
         public UnstableRate(IEnumerable<HitEvent> hitEvents)
             : base("Unstable Rate")
         {
-            double[] timeOffsets = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit())
-                                            .Select(ev => ev.TimeOffset).ToArray();
-            Value = 10 * standardDeviation(timeOffsets);
+            Value = hitEvents.CalculateUnstableRate();
         }
 
-        private static double standardDeviation(double[] timeOffsets)
-        {
-            if (timeOffsets.Length == 0)
-                return double.NaN;
-
-            double mean = timeOffsets.Average();
-            double squares = timeOffsets.Select(offset => Math.Pow(offset - mean, 2)).Sum();
-            return Math.Sqrt(squares / timeOffsets.Length);
-        }
-
-        protected override string DisplayValue(double value) => double.IsNaN(value) ? "(not available)" : value.ToString("N2");
+        protected override string DisplayValue(double? value) => value == null ? "(not available)" : value.Value.ToString(@"N2");
     }
 }


### PR DESCRIPTION
Closes #15560.

Root cause is that the counter's subscription to `ScoreProcessor` would run in `LoadComplete()`:

https://github.com/ppy/osu/blob/de4f7fa2f36fa0e6c3d03b044ae2e4fa8705578c/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs#L53-L59

which - in the case of hidden HUD - happens only when the counter is first shown, therefore dropping all judgements prior to that point from UR calculation. (Note that this would also fail in the case of a skin change.)

The fix is to do [what was already proposed during review](https://github.com/ppy/osu/pull/15470#discussion_r744125697), namely immutably exposing the `ScoreProcessor`'s `HitEvents` as public and using that for calculation.

This pull additionally unifies handling of the UR HUD counter and the results screen statistic by splitting the actual calculation to an extension method. It's a bit heavy allocation-wise but it wasn't much better before due to LINQ usage, so it can be optimised later if deemed a problem. I added an `.AddOnce()` that wasn't there for good measure anyhow.

One more tiny change is d690e5c - noticed that the HUD display could look "off by one" when compared to the results screen display sometimes, hence rounding instead of truncating (`.ToString()` - which is used by the results screen one - rounds).