### PR TITLE
Fix PP counter not updating until next judgement when shown for the first time

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePerformancePointsCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePerformancePointsCounter.cs
@@ -1,9 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using NUnit.Framework;
-using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
@@ -20,16 +21,17 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public class TestScenePerformancePointsCounter : OsuTestScene
     {
-        [Cached]
-        private GameplayState gameplayState;
+        private DependencyProvidingContainer dependencyContainer;
 
-        [Cached]
+        private GameplayState gameplayState;
         private ScoreProcessor scoreProcessor;
 
         private int iteration;
+        private Bindable<JudgementResult> lastJudgementResult = new Bindable<JudgementResult>();
         private PerformancePointsCounter counter;
 
-        public TestScenePerformancePointsCounter()
+        [SetUpSteps]
+        public void SetUpSteps() => AddStep("create components", () =>
         {
             var ruleset = CreateRuleset();
 
@@ -38,32 +40,43 @@ namespace osu.Game.Tests.Visual.Gameplay
             var beatmap = CreateWorkingBeatmap(ruleset.RulesetInfo)
                 .GetPlayableBeatmap(ruleset.RulesetInfo);
 
+            lastJudgementResult = new Bindable<JudgementResult>();
+
             gameplayState = new GameplayState(beatmap, ruleset);
+            gameplayState.LastJudgementResult.BindTo(lastJudgementResult);
+
             scoreProcessor = new ScoreProcessor();
-        }
+
+            Child = dependencyContainer = new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(GameplayState), gameplayState),
+                    (typeof(ScoreProcessor), scoreProcessor)
+                }
+            };
+
+            iteration = 0;
+        });
 
         protected override Ruleset CreateRuleset() => new OsuRuleset();
 
-        [SetUpSteps]
-        public void SetUpSteps()
+        private void createCounter() => AddStep("Create counter", () =>
         {
-            AddStep("Create counter", () =>
+            dependencyContainer.Child = counter = new PerformancePointsCounter
             {
-                iteration = 0;
-
-                Child = counter = new PerformancePointsCounter
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(5),
-                };
-            });
-        }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(5),
+            };
+        });
 
         [Test]
         public void TestBasicCounting()
         {
             int previousValue = 0;
+            createCounter();
 
             AddAssert("counter displaying zero", () => counter.Current.Value == 0);
 
@@ -86,6 +99,17 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("counter non-zero", () => counter.Current.Value > 0);
         }
 
+        [Test]
+        public void TestCounterUpdatesWithJudgementsBeforeCreation()
+        {
+            AddRepeatStep("Add judgement", applyOneJudgement, 10);
+
+            createCounter();
+
+            AddUntilStep("counter non-zero", () => counter.Current.Value > 0);
+            AddUntilStep("counter opaque", () => counter.Child.Alpha == 1);
+        }
+
         private void applyOneJudgement()
         {
             var scoreInfo = gameplayState.Score.ScoreInfo;
@@ -94,13 +118,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             scoreInfo.Accuracy = 1;
             scoreInfo.Statistics[HitResult.Great] = iteration * 1000;
 
-            scoreProcessor.ApplyResult(new OsuJudgementResult(new HitObject
+            lastJudgementResult.Value = new OsuJudgementResult(new HitObject
             {
                 StartTime = iteration * 10000,
             }, new OsuJudgement())
             {
                 Type = HitResult.Perfect,
-            });
+            };
+            scoreProcessor.ApplyResult(lastJudgementResult.Value);
 
             iteration++;
         }

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -92,6 +92,9 @@ namespace osu.Game.Screens.Play.HUD
                 scoreProcessor.NewJudgement += onJudgementChanged;
                 scoreProcessor.JudgementReverted += onJudgementChanged;
             }
+
+            if (gameplayState?.LastJudgementResult.Value != null)
+                onJudgementChanged(gameplayState.LastJudgementResult.Value);
         }
 
         private bool isValid;

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -158,7 +158,10 @@ namespace osu.Game.Screens.Play.HUD
             base.Dispose(isDisposing);
 
             if (scoreProcessor != null)
+            {
                 scoreProcessor.NewJudgement -= onJudgementChanged;
+                scoreProcessor.JudgementReverted -= onJudgementChanged;
+            }
 
             loadCancellationSource?.Cancel();
         }


### PR DESCRIPTION
As pointed out [here](https://github.com/ppy/osu/pull/15576#issuecomment-966364004).

This case is less severe, because the value was always correct (because it was being sourced from the right places), it's just that the display didn't display until the first judgement post-`LoadComplete()`, which can happen midway through the map if the HUD was initially hidden or the skin was changed.

The diff is very similar to the other one. Most of the effort here is to ensure that each test in the test scene starts from a sane and clean state and there is no crosstalk. I have checked that the both tests look to work correctly when interleaved multiple times in any order.