### PR TITLE
Add slider-to-stream conversion operation to osu! editor

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
-        public void TestConversionPreservesNewCombo()
+        public void TestConversionPreservesSliderProperties()
         {
             Slider slider = null;
 
@@ -117,7 +117,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             bool matches(HitCircle circle, double time, Vector2 position, bool startsNewCombo) =>
                 Precision.AlmostEquals(circle.StartTime, time, 1)
                 && Precision.AlmostEquals(circle.Position, position, 0.01f)
-                && circle.NewCombo == startsNewCombo;
+                && circle.NewCombo == startsNewCombo
+                && circle.Samples.SequenceEqual(slider.HeadCircle.Samples)
+                && circle.SampleControlPoint.IsRedundant(slider.SampleControlPoint);
         }
 
         private bool sliderRestored(Slider slider)

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -1,0 +1,140 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public class TestSceneSliderStreamConversion : TestSceneOsuEditor
+    {
+        private BindableBeatDivisor beatDivisor => (BindableBeatDivisor)Editor.Dependencies.Get(typeof(BindableBeatDivisor));
+
+        [Test]
+        public void TestSimpleConversion()
+        {
+            Slider slider = null;
+
+            AddStep("select first slider", () =>
+            {
+                slider = (Slider)EditorBeatmap.HitObjects.First(h => h is Slider);
+                EditorClock.Seek(slider.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(slider);
+            });
+
+            convertToStream();
+
+            AddAssert("stream created", () => streamCreatedFor(slider, 1 / 4d));
+
+            AddStep("undo", () => Editor.Undo());
+            AddAssert("slider restored", () => sliderRestored(slider));
+
+            AddStep("select first slider", () =>
+            {
+                slider = (Slider)EditorBeatmap.HitObjects.First(h => h is Slider);
+                EditorClock.Seek(slider.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(slider);
+            });
+            AddStep("change beat divisor", () => beatDivisor.Value = 8);
+
+            convertToStream();
+            AddAssert("stream created", () => streamCreatedFor(slider, 1 / 8d));
+        }
+
+        [Test]
+        public void TestConversionWithNonMatchingDivisor()
+        {
+            Slider slider = null;
+
+            AddStep("select second slider", () =>
+            {
+                slider = (Slider)EditorBeatmap.HitObjects.Where(h => h is Slider).ElementAt(1);
+                EditorClock.Seek(slider.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(slider);
+            });
+            AddStep("change beat divisor", () => beatDivisor.Value = 3);
+
+            convertToStream();
+
+            AddAssert("stream created", () => streamCreatedFor(slider, 2 / 3d));
+        }
+
+        [Test]
+        public void TestConversionPreservesNewCombo()
+        {
+            Slider slider = null;
+
+            AddStep("select second new-combo-starting slider", () =>
+            {
+                slider = (Slider)EditorBeatmap.HitObjects.Where(h => h is Slider s && s.NewCombo).ElementAt(1);
+                EditorClock.Seek(slider.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(slider);
+            });
+
+            convertToStream();
+
+            AddAssert("stream created", () => streamCreatedFor(slider, 1 / 4d));
+
+            AddStep("undo", () => Editor.Undo());
+            AddAssert("slider restored", () => sliderRestored(slider));
+        }
+
+        private void convertToStream()
+        {
+            AddStep("convert to stream", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.PressKey(Key.LShift);
+                InputManager.Key(Key.F);
+                InputManager.ReleaseKey(Key.LShift);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+        }
+
+        private bool streamCreatedFor(Slider slider, double spacing)
+        {
+            if (EditorBeatmap.HitObjects.Contains(slider))
+                return false;
+
+            for (int i = 0; i * spacing <= 1; ++i)
+            {
+                double progress = i * spacing;
+                double time = slider.StartTime + progress * slider.Duration;
+                Vector2 position = slider.Position + slider.Path.PositionAt(progress);
+
+                if (!EditorBeatmap.HitObjects.OfType<HitCircle>().Any(h => matches(h, time, position, slider.NewCombo && progress == 0)))
+                    return false;
+            }
+
+            return true;
+
+            bool matches(HitCircle circle, double time, Vector2 position, bool startsNewCombo) =>
+                Precision.AlmostEquals(circle.StartTime, time, 1)
+                && Precision.AlmostEquals(circle.Position, position, 0.01f)
+                && circle.NewCombo == startsNewCombo;
+        }
+
+        private bool sliderRestored(Slider slider)
+        {
+            var objects = EditorBeatmap.HitObjects.Where(h => h.StartTime >= slider.StartTime && h.GetEndTime() <= slider.EndTime).ToList();
+
+            if (objects.Count > 1)
+                return false;
+
+            var hitObject = objects.Single();
+            if (!(hitObject is Slider restoredSlider))
+                return false;
+
+            return Precision.AlmostEquals(slider.StartTime, restoredSlider.StartTime)
+                   && Precision.AlmostEquals(slider.GetEndTime(), restoredSlider.GetEndTime())
+                   && Precision.AlmostEquals(slider.Position, restoredSlider.Position, 0.01f)
+                   && Precision.AlmostEquals(slider.EndPosition, restoredSlider.EndPosition, 0.01f);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
@@ -268,11 +269,17 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             while (!Precision.DefinitelyBigger(time, HitObject.GetEndTime(), 1))
             {
                 Vector2 position = HitObject.Position + HitObject.Path.PositionAt((time - HitObject.StartTime) / HitObject.Duration);
+
+                var samplePoint = (SampleControlPoint)HitObject.SampleControlPoint.DeepClone();
+                samplePoint.Time = time;
+
                 editorBeatmap.Add(new HitCircle
                 {
                     StartTime = time,
                     Position = position,
-                    NewCombo = i == 0 && HitObject.NewCombo
+                    NewCombo = i == 0 && HitObject.NewCombo,
+                    SampleControlPoint = samplePoint,
+                    Samples = HitObject.HeadCircle.Samples.Select(s => s.With()).ToList()
                 });
 
                 i += 1;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -16,6 +16,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -268,7 +269,15 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             while (!Precision.DefinitelyBigger(time, HitObject.GetEndTime(), 1))
             {
-                Vector2 position = HitObject.Position + HitObject.Path.PositionAt((time - HitObject.StartTime) / HitObject.Duration);
+                // positionWithRepeats is a fractional number in the range of [0, HitObject.SpanCount()]
+                // and indicates how many fractional spans of a slider have passed up to time.
+                double positionWithRepeats = (time - HitObject.StartTime) / HitObject.Duration * HitObject.SpanCount();
+                double pathPosition = positionWithRepeats - (int)positionWithRepeats;
+                // every second span is in the reverse direction - need to reverse the path position.
+                if (Precision.AlmostBigger(positionWithRepeats % 2, 1))
+                    pathPosition = 1 - pathPosition;
+
+                Vector2 position = HitObject.Position + HitObject.Path.PositionAt(pathPosition);
 
                 var samplePoint = (SampleControlPoint)HitObject.SampleControlPoint.DeepClone();
                 samplePoint.Time = time;


### PR DESCRIPTION
https://user-images.githubusercontent.com/20418176/141378234-5e260a00-506a-44a8-b4e0-40dd694c7fd5.mp4

Addresses (closes?) #14246.

* Accessible via hotkey the same way as in stable (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>), or via the context menu on selection.
* No dialog like on stable (yet?) - always uses the current snap divisor and uses the entire duration of the slider.
* Supports sliders with repeats, contrary to stable, which seems to give up after the first span (unless I'm checking wrong?)
* Preserves new combo, samples (taken from slider head) and sample control points in the conversion process.

All of the above has corresponding test coverage.

I know a stream placement tool was proposed, but I think for proper save/load support that may need to wait for a new beatmap format, otherwise there's no real good way to tell what was a stream after saving to legacy. If waiting for new format is seen as preferable I'll close this.