### PR TITLE
Fix failed imports being incorrectly considered as successfully importing for notification purposes

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -16,6 +16,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO.Archives;
 using osu.Game.Models;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Stores;
 using osu.Game.Tests.Resources;
 using Realms;
@@ -364,6 +365,34 @@ namespace osu.Game.Tests.Database
 
                 checkBeatmapSetCount(realmFactory.Context, 1);
                 checkSingleReferencedFileCount(realmFactory.Context, 18);
+            });
+        }
+
+        [Test]
+        public void TestModelCreationFailureDoesntReturn()
+        {
+            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            {
+                using var importer = new BeatmapImporter(realmFactory, storage);
+                using var store = new RealmRulesetStore(realmFactory, storage);
+
+                var progressNotification = new ImportProgressNotification();
+
+                var zipStream = new MemoryStream();
+
+                using (var zip = ZipArchive.Create())
+                    zip.SaveTo(zipStream, new ZipWriterOptions(CompressionType.Deflate));
+
+                var imported = await importer.Import(
+                    progressNotification,
+                    new ImportTask(zipStream, string.Empty)
+                );
+
+                checkBeatmapSetCount(realmFactory.Context, 0);
+                checkBeatmapCount(realmFactory.Context, 0);
+
+                Assert.IsEmpty(imported);
+                Assert.AreEqual(ProgressNotificationState.Cancelled, progressNotification.State);
             });
         }
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Database
                 model = CreateModel(archive);
 
                 if (model == null)
-                    return Task.FromResult<ILive<TModel>>(new EntityFrameworkLive<TModel>(null));
+                    return Task.FromResult<ILive<TModel>>(null);
             }
             catch (TaskCanceledException)
             {

--- a/osu.Game/Database/IModelImporter.cs
+++ b/osu.Game/Database/IModelImporter.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using osu.Game.IO.Archives;
 using osu.Game.Overlays.Notifications;
 
+#nullable enable
+
 namespace osu.Game.Database
 {
     /// <summary>
@@ -26,7 +28,7 @@ namespace osu.Game.Database
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The imported model, if successful.</returns>
-        Task<ILive<TModel>> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default);
+        Task<ILive<TModel>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Silently import an item from an <see cref="ArchiveReader"/>.
@@ -34,7 +36,7 @@ namespace osu.Game.Database
         /// <param name="archive">The archive to be imported.</param>
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        Task<ILive<TModel>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default);
+        Task<ILive<TModel>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Silently import an item from a <typeparamref name="TModel"/>.
@@ -43,7 +45,7 @@ namespace osu.Game.Database
         /// <param name="archive">An optional archive to use for model population.</param>
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        Task<ILive<TModel>> Import(TModel item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
+        Task<ILive<TModel>?> Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// A user displayable name for the model type associated with this manager.


### PR DESCRIPTION
Bad null check. Now protected by null hinting and tests.

Considered using `ILive<T?>` instead but this gets a bit messy when you try and make `RealmLive<T>` work with it. The `T` in that class has constraints on interfaces which limit nullability without making those interfaces optional. Which requires quite a few considerations.

- [x] Depends on #15589 (loosely, if you want to run the included tests without the fix to test regression).