### PR TITLE
Fix android score imports not working

### DIFF
--- a/osu.Game/IO/Archives/LegacyByteArrayReader.cs
+++ b/osu.Game/IO/Archives/LegacyByteArrayReader.cs
@@ -7,7 +7,7 @@ using System.IO;
 namespace osu.Game.IO.Archives
 {
     /// <summary>
-    /// Allows reading a single file from the provided stream.
+    /// Allows reading a single file from the provided byte array.
     /// </summary>
     public class LegacyByteArrayReader : ArchiveReader
     {

--- a/osu.Game/Utils/ZipUtils.cs
+++ b/osu.Game/Utils/ZipUtils.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Utils
 {
     public static class ZipUtils
     {
-        public static bool IsZipArchive(Stream stream)
+        public static bool IsZipArchive(MemoryStream stream)
         {
             try
             {

--- a/osu.Game/Utils/ZipUtils.cs
+++ b/osu.Game/Utils/ZipUtils.cs
@@ -9,6 +9,34 @@ namespace osu.Game.Utils
 {
     public static class ZipUtils
     {
+        public static bool IsZipArchive(Stream stream)
+        {
+            try
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (var arc = ZipArchive.Open(stream))
+                {
+                    foreach (var entry in arc.Entries)
+                    {
+                        using (entry.OpenEntryStream())
+                        {
+                        }
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            finally
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+        }
+
         public static bool IsZipArchive(string path)
         {
             if (!File.Exists(path))


### PR DESCRIPTION
- [x] Depends on #15590
- Closes #15588

Score import tests don't work with a file right now, so it's not that easy to add a test for this (without adding an `.osu` to resources. Might look at improving that with the realm edition of the importer, but this fix can be tested using the following diff on a desktop platform:

```diff
diff --git a/osu.Game/Database/ArchiveModelManager.cs b/osu.Game/Database/ArchiveModelManager.cs
index e8b6996869..51f87cc687 100644
--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -116,7 +116,13 @@ public Task Import(params string[] paths)
 
             PostNotification?.Invoke(notification);
 
-            return Import(notification, paths.Select(p => new ImportTask(p)).ToArray());
+            return Import(notification, paths.Select(p =>
+            {
+                // for testing purposes
+                var stream = new MemoryStream(File.ReadAllBytes(p));
+
+                return new ImportTask(stream, p);
+            }).ToArray());
         }
 
         public Task Import(params ImportTask[] tasks)
```