### PR TITLE
Allow adjusting slider velocities of multiple objects at once

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -85,6 +85,46 @@ namespace osu.Game.Tests.Visual.Editing
             hitObjectHasVelocity(1, 5);
         }
 
+        [Test]
+        public void TestMultipleSelectionWithSameSliderVelocity()
+        {
+            AddStep("unify slider velocity", () =>
+            {
+                foreach (var h in EditorBeatmap.HitObjects)
+                    h.DifficultyControlPoint.SliderVelocity = 1.5;
+            });
+
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickDifficultyPiece(0);
+            velocityPopoverHasSingleValue(1.5);
+
+            dismissPopover();
+
+            clickDifficultyPiece(1);
+            velocityPopoverHasSingleValue(1.5);
+
+            setVelocityViaPopover(5);
+            hitObjectHasVelocity(0, 5);
+            hitObjectHasVelocity(1, 5);
+        }
+
+        [Test]
+        public void TestMultipleSelectionWithDifferentSliderVelocity()
+        {
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickDifficultyPiece(0);
+            velocityPopoverHasIndeterminateValue();
+
+            dismissPopover();
+
+            clickDifficultyPiece(1);
+            velocityPopoverHasIndeterminateValue();
+
+            setVelocityViaPopover(3);
+            hitObjectHasVelocity(0, 3);
+            hitObjectHasVelocity(1, 3);
+        }
+
         private void clickDifficultyPiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
         {
             var difficultyPiece = this.ChildrenOfType<DifficultyPointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
@@ -99,6 +139,14 @@ namespace osu.Game.Tests.Visual.Editing
             var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
 
             return slider?.Current.Value == velocity;
+        });
+
+        private void velocityPopoverHasIndeterminateValue() => AddUntilStep("velocity popover has indeterminate value", () =>
+        {
+            var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
+            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
+
+            return slider != null && slider.Current.Value == null;
         });
 
         private void dismissPopover()

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Humanizer;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osu.Game.Screens.Edit.Timing;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneHitObjectDifficultyPointAdjustments : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("add test objects", () =>
+            {
+                EditorBeatmap.Add(new Slider
+                {
+                    StartTime = 0,
+                    Position = (OsuPlayfield.BASE_SIZE - new Vector2(0, 100)) / 2,
+                    Path = new SliderPath
+                    {
+                        ControlPoints =
+                        {
+                            new PathControlPoint(new Vector2(0, 0)),
+                            new PathControlPoint(new Vector2(0, 100))
+                        }
+                    }
+                });
+
+                EditorBeatmap.Add(new Slider
+                {
+                    StartTime = 500,
+                    Position = (OsuPlayfield.BASE_SIZE - new Vector2(100, 0)) / 2,
+                    Path = new SliderPath
+                    {
+                        ControlPoints =
+                        {
+                            new PathControlPoint(new Vector2(0, 0)),
+                            new PathControlPoint(new Vector2(100, 0))
+                        }
+                    },
+                    DifficultyControlPoint = new DifficultyControlPoint
+                    {
+                        SliderVelocity = 2
+                    }
+                });
+            });
+        }
+
+        [Test]
+        public void TestSingleSelection()
+        {
+            clickDifficultyPiece(0);
+            velocityPopoverHasSingleValue(1);
+
+            dismissPopover();
+
+            // select first object to ensure that difficulty pieces for unselected objects
+            // work independently from selection state.
+            AddStep("select first object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.First()));
+
+            clickDifficultyPiece(1);
+            velocityPopoverHasSingleValue(2);
+
+            setVelocityViaPopover(5);
+            hitObjectHasVelocity(1, 5);
+        }
+
+        private void clickDifficultyPiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
+        {
+            var difficultyPiece = this.ChildrenOfType<DifficultyPointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
+
+            InputManager.MoveMouseTo(difficultyPiece);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        private void velocityPopoverHasSingleValue(double velocity) => AddUntilStep($"velocity popover has {velocity}", () =>
+        {
+            var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
+            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
+
+            return slider?.Current.Value == velocity;
+        });
+
+        private void dismissPopover()
+        {
+            AddStep("dismiss popover", () => InputManager.Key(Key.Escape));
+            AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Any(popover => popover.IsPresent));
+        }
+
+        private void setVelocityViaPopover(double velocity) => AddStep($"set {velocity} via popover", () =>
+        {
+            var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Single();
+            var slider = popover.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
+            slider.Current.Value = velocity;
+        });
+
+        private void hitObjectHasVelocity(int objectIndex, double velocity) => AddAssert($"{objectIndex.ToOrdinalWords()} has velocity {velocity}", () =>
+        {
+            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex);
+            return h.DifficultyControlPoint.SliderVelocity == velocity;
+        });
+    }
+}

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void velocityPopoverHasSingleValue(double velocity) => AddUntilStep($"velocity popover has {velocity}", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
+            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
 
             return slider?.Current.Value == velocity;
         });
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void velocityPopoverHasIndeterminateValue() => AddUntilStep("velocity popover has indeterminate value", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
+            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
 
             return slider != null && slider.Current.Value == null;
         });
@@ -158,7 +158,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void setVelocityViaPopover(double velocity) => AddStep($"set {velocity} via popover", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Single();
-            var slider = popover.ChildrenOfType<SliderWithTextBoxInput<double>>().Single();
+            var slider = popover.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
             slider.Current.Value = velocity;
         });
 

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -19,6 +19,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Overlays;
+using osu.Game.Utils;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -219,7 +220,7 @@ namespace osu.Game.Graphics.UserInterface
                     decimal decimalPrecision = normalise(CurrentNumber.Precision.ToDecimal(NumberFormatInfo.InvariantInfo), max_decimal_digits);
 
                     // Find the number of significant digits (we could have less than 5 after normalize())
-                    int significantDigits = findPrecision(decimalPrecision);
+                    int significantDigits = FormatUtils.FindPrecision(decimalPrecision);
 
                     TooltipText = floatValue.ToString($"N{significantDigits}");
                 }
@@ -248,23 +249,5 @@ namespace osu.Game.Graphics.UserInterface
         /// <returns>The normalised decimal.</returns>
         private decimal normalise(decimal d, int sd)
             => decimal.Parse(Math.Round(d, sd).ToString(string.Concat("0.", new string('#', sd)), CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
-
-        /// <summary>
-        /// Finds the number of digits after the decimal.
-        /// </summary>
-        /// <param name="d">The value to find the number of decimal digits for.</param>
-        /// <returns>The number decimal digits.</returns>
-        private int findPrecision(decimal d)
-        {
-            int precision = 0;
-
-            while (d != Math.Round(d))
-            {
-                d *= 10;
-                precision++;
-            }
-
-            return precision;
-        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Timing;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
@@ -72,6 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         Width = 200,
                         Direction = FillDirection.Vertical,
                         AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(0, 15),
                         Children = new Drawable[]
                         {
                             sliderVelocitySlider = new IndeterminateSliderWithTextBoxInput<double>("Velocity", new DifficultyControlPoint().SliderVelocityBindable)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -49,9 +51,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         public class DifficultyEditPopover : OsuPopover
         {
             private readonly HitObject hitObject;
-            private readonly DifficultyControlPoint point;
 
-            private SliderWithTextBoxInput<double> sliderVelocitySlider;
+            private IndeterminateSliderWithTextBoxInput<double> sliderVelocitySlider;
 
             [Resolved(canBeNull: true)]
             private EditorBeatmap beatmap { get; set; }
@@ -59,7 +60,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             public DifficultyEditPopover(HitObject hitObject)
             {
                 this.hitObject = hitObject;
-                point = hitObject.DifficultyControlPoint;
             }
 
             [BackgroundDependencyLoader]
@@ -74,9 +74,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         AutoSizeAxes = Axes.Y,
                         Children = new Drawable[]
                         {
-                            sliderVelocitySlider = new SliderWithTextBoxInput<double>("Velocity")
+                            sliderVelocitySlider = new IndeterminateSliderWithTextBoxInput<double>("Velocity", new DifficultyControlPoint().SliderVelocityBindable)
                             {
-                                Current = new DifficultyControlPoint().SliderVelocityBindable,
                                 KeyboardStep = 0.1f
                             },
                             new OsuTextFlowContainer
@@ -89,17 +88,37 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     }
                 };
 
-                var selectedPointBindable = point.SliderVelocityBindable;
+                // if the piece belongs to a currently selected object, assume that the user wants to change all selected objects.
+                // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.
+                var relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).ToArray();
+                var relevantControlPoints = relevantObjects.Select(h => h.DifficultyControlPoint).ToArray();
 
-                // there may be legacy control points, which contain infinite precision for compatibility reasons (see LegacyDifficultyControlPoint).
-                // generally that level of precision could only be set by externally editing the .osu file, so at the point
-                // a user is looking to update this within the editor it should be safe to obliterate this additional precision.
-                double expectedPrecision = new DifficultyControlPoint().SliderVelocityBindable.Precision;
-                if (selectedPointBindable.Precision < expectedPrecision)
-                    selectedPointBindable.Precision = expectedPrecision;
+                // even if there are multiple objects selected, we can still display a value if they all have the same value.
+                var selectedPointBindable = relevantControlPoints.Select(point => point.SliderVelocity).Distinct().Count() == 1 ? relevantControlPoints.First().SliderVelocityBindable : null;
 
-                sliderVelocitySlider.Current = selectedPointBindable;
-                sliderVelocitySlider.Current.BindValueChanged(_ => beatmap?.Update(hitObject));
+                if (selectedPointBindable != null)
+                {
+                    // there may be legacy control points, which contain infinite precision for compatibility reasons (see LegacyDifficultyControlPoint).
+                    // generally that level of precision could only be set by externally editing the .osu file, so at the point
+                    // a user is looking to update this within the editor it should be safe to obliterate this additional precision.
+                    sliderVelocitySlider.Current.Value = selectedPointBindable.Value;
+                }
+
+                sliderVelocitySlider.Current.BindValueChanged(val =>
+                {
+                    if (val.NewValue == null)
+                        return;
+
+                    beatmap.BeginChange();
+
+                    foreach (var h in relevantObjects)
+                    {
+                        h.DifficultyControlPoint.SliderVelocity = val.NewValue.Value;
+                        beatmap.Update(h);
+                    }
+
+                    beatmap.EndChange();
+                });
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -19,14 +19,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public class DifficultyPointPiece : HitObjectPointPiece, IHasPopover
     {
-        private readonly HitObject hitObject;
+        public readonly HitObject HitObject;
 
         private readonly BindableNumber<double> speedMultiplier;
 
         public DifficultyPointPiece(HitObject hitObject)
             : base(hitObject.DifficultyControlPoint)
         {
-            this.hitObject = hitObject;
+            HitObject = hitObject;
 
             speedMultiplier = hitObject.DifficultyControlPoint.SliderVelocityBindable.GetBoundCopy();
         }
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             return true;
         }
 
-        public Popover GetPopover() => new DifficultyEditPopover(hitObject);
+        public Popover GetPopover() => new DifficultyEditPopover(HitObject);
 
         public class DifficultyEditPopover : OsuPopover
         {

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Globalization;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
+using osu.Game.Utils;
 
 namespace osu.Game.Screens.Edit.Timing
 {
@@ -65,7 +67,6 @@ namespace osu.Game.Screens.Edit.Timing
                         textbox = new LabelledTextBox
                         {
                             Label = labelText,
-                            PlaceholderText = "(multiple)"
                         },
                         slider = new SettingsSlider<T>
                         {
@@ -104,11 +105,16 @@ namespace osu.Game.Screens.Edit.Timing
             if (Current.Value is T nonNullValue)
             {
                 slider.Current.Value = nonNullValue;
-                textbox.Text = slider.Current.ToString();
+
+                // use the value from the slider to ensure that any precision/min/max set on it via the initial indeterminate value have been applied correctly.
+                decimal decimalValue = slider.Current.Value.ToDecimal(NumberFormatInfo.InvariantInfo);
+                textbox.Text = decimalValue.ToString($@"N{FormatUtils.FindPrecision(decimalValue)}");
+                textbox.PlaceholderText = string.Empty;
             }
             else
             {
                 textbox.Text = null;
+                textbox.PlaceholderText = "(multiple)";
             }
         }
     }

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    /// <summary>
+    /// Analogous to <see cref="SliderWithTextBoxInput{T}"/>, but supports scenarios
+    /// where multiple objects with multiple different property values are selected
+    /// by providing an "indeterminate state".
+    /// </summary>
+    public class IndeterminateSliderWithTextBoxInput<T> : CompositeDrawable, IHasCurrentValue<T?>
+        where T : struct, IEquatable<T>, IComparable<T>, IConvertible
+    {
+        /// <summary>
+        /// A custom step value for each key press which actuates a change on this control.
+        /// </summary>
+        public float KeyboardStep
+        {
+            get => slider.KeyboardStep;
+            set => slider.KeyboardStep = value;
+        }
+
+        private readonly BindableWithCurrent<T?> current = new BindableWithCurrent<T?>();
+
+        public Bindable<T?> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        private readonly SettingsSlider<T> slider;
+        private readonly LabelledTextBox textbox;
+
+        /// <summary>
+        /// Creates an <see cref="IndeterminateSliderWithTextBoxInput{T}"/>.
+        /// </summary>
+        /// <param name="labelText">The label text for the slider and text box.</param>
+        /// <param name="indeterminateValue">
+        /// Bindable to use for the slider until a non-null value is set for <see cref="Current"/>.
+        /// In particular, it can be used to control min/max bounds and precision in the case of <see cref="BindableNumber{T}"/>s.
+        /// </param>
+        public IndeterminateSliderWithTextBoxInput(LocalisableString labelText, Bindable<T> indeterminateValue)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        textbox = new LabelledTextBox
+                        {
+                            Label = labelText,
+                            PlaceholderText = "(multiple)"
+                        },
+                        slider = new SettingsSlider<T>
+                        {
+                            TransferValueOnCommit = true,
+                            RelativeSizeAxes = Axes.X,
+                            Current = indeterminateValue
+                        }
+                    }
+                },
+            };
+
+            textbox.OnCommit += (t, isNew) =>
+            {
+                if (!isNew) return;
+
+                try
+                {
+                    slider.Current.Parse(t.Text);
+                }
+                catch
+                {
+                    // TriggerChange below will restore the previous text value on failure.
+                }
+
+                // This is run regardless of parsing success as the parsed number may not actually trigger a change
+                // due to bindable clamping. Even in such a case we want to update the textbox to a sane visual state.
+                Current.TriggerChange();
+            };
+            slider.Current.BindValueChanged(val => Current.Value = val.NewValue);
+
+            Current.BindValueChanged(_ => updateState(), true);
+        }
+
+        private void updateState()
+        {
+            if (Current.Value is T nonNullValue)
+            {
+                slider.Current.Value = nonNullValue;
+                textbox.Text = slider.Current.ToString();
+            }
+            else
+            {
+                textbox.Text = null;
+            }
+        }
+    }
+}

--- a/osu.Game/Utils/FormatUtils.cs
+++ b/osu.Game/Utils/FormatUtils.cs
@@ -31,5 +31,23 @@ namespace osu.Game.Utils
         /// </summary>
         /// <param name="rank">The rank/position to be formatted.</param>
         public static string FormatRank(this int rank) => rank.ToMetric(decimals: rank < 100_000 ? 1 : 0);
+
+        /// <summary>
+        /// Finds the number of digits after the decimal.
+        /// </summary>
+        /// <param name="d">The value to find the number of decimal digits for.</param>
+        /// <returns>The number decimal digits.</returns>
+        public static int FindPrecision(decimal d)
+        {
+            int precision = 0;
+
+            while (d != Math.Round(d))
+            {
+                d *= 10;
+                precision++;
+            }
+
+            return precision;
+        }
     }
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/20418176/141562187-5896d09b-83bd-46bb-8ede-b0fe9aa75411.mp4

The sample control points are next, but this diff is moderately large already and I wanted to test the waters with this simpler one first as to whether the direction is correct/acceptable UX-wise, as sample control points have more potentially-indeterminate fields than one (both bank and volume can differ across a selection).

Pretty much all of the proposed UX is covered in the tests. This pull also contains some assorted spacing (e1c28dd) and number formatting (d567d2b) fixes that I will be porting across wherever necessary.