### PR TITLE
Improve transition between editor and gameplay test screens

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
+using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Tests.Beatmaps.IO;
 using osuTK.Input;
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -10,10 +10,12 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Tests.Beatmaps.IO;
+using osuTK.Graphics;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
@@ -59,6 +61,11 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("player pushed", () => (editorPlayer = Stack.CurrentScreen as EditorPlayer) != null);
             AddStep("exit player", () => editorPlayer.Exit());
             AddUntilStep("current screen is editor", () => Stack.CurrentScreen is Editor);
+            AddUntilStep("background has correct params", () =>
+            {
+                var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single();
+                return background.Colour == Color4.DarkGray && background.BlurAmount.Value == 0;
+            });
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -69,6 +69,37 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestGameplayTestWhenTrackRunning()
+        {
+            AddStep("start track", () => EditorClock.Start());
+            AddAssert("sample playback enabled", () => !Editor.SamplePlaybackDisabled.Value);
+
+            AddStep("click test gameplay button", () =>
+            {
+                var button = Editor.ChildrenOfType<TestGameplayButton>().Single();
+
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            EditorPlayer editorPlayer = null;
+            AddUntilStep("player pushed", () => (editorPlayer = Stack.CurrentScreen as EditorPlayer) != null);
+            AddAssert("editor track stopped", () => !EditorClock.IsRunning);
+            AddAssert("sample playback disabled", () => Editor.SamplePlaybackDisabled.Value);
+
+            AddStep("exit player", () => editorPlayer.Exit());
+            AddUntilStep("current screen is editor", () => Stack.CurrentScreen is Editor);
+            AddUntilStep("background has correct params", () =>
+            {
+                var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single();
+                return background.Colour == Color4.DarkGray && background.BlurAmount.Value == 0;
+            });
+
+            AddStep("start track", () => EditorClock.Start());
+            AddAssert("sample playback re-enabled", () => !Editor.SamplePlaybackDisabled.Value);
+        }
+
+        [Test]
         public void TestCancelGameplayTestWithUnsavedChanges()
         {
             AddStep("delete all but first object", () => EditorBeatmap.RemoveRange(EditorBeatmap.HitObjects.Skip(1).ToList()));

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -31,6 +31,7 @@ using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Design;
+using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Edit.Timing;
 using osu.Game.Screens.Edit.Verify;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -545,9 +545,9 @@ namespace osu.Game.Screens.Edit
 
         public override void OnSuspending(IScreen next)
         {
-            refetchBeatmap();
-
             base.OnSuspending(next);
+            clock.Stop();
+            refetchBeatmap();
         }
 
         private void refetchBeatmap()

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -798,7 +798,7 @@ namespace osu.Game.Screens.Edit
                 pushEditorPlayer();
             }
 
-            void pushEditorPlayer() => this.Push(new PlayerLoader(() => new EditorPlayer()));
+            void pushEditorPlayer() => this.Push(new EditorPlayerLoader());
         }
 
         public double SnapTime(double time, double? referenceTime) => editorBeatmap.SnapTime(time, referenceTime);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -487,7 +487,18 @@ namespace osu.Game.Screens.Edit
         public override void OnEntering(IScreen last)
         {
             base.OnEntering(last);
+            dimBackground();
+            resetTrack(true);
+        }
 
+        public override void OnResuming(IScreen last)
+        {
+            base.OnResuming(last);
+            dimBackground();
+        }
+
+        private void dimBackground()
+        {
             ApplyToBackground(b =>
             {
                 // todo: temporary. we want to be applying dim using the UserDimContainer eventually.
@@ -496,8 +507,6 @@ namespace osu.Game.Screens.Edit
                 b.IgnoreUserSettings.Value = true;
                 b.BlurAmount.Value = 0;
             });
-
-            resetTrack(true);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -6,7 +6,7 @@ using osu.Framework.Screens;
 using osu.Game.Overlays;
 using osu.Game.Screens.Play;
 
-namespace osu.Game.Screens.Edit
+namespace osu.Game.Screens.Edit.GameplayTest
 {
     public class EditorPlayer : Player
     {

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayerLoader.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayerLoader.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Game.Screens.Menu;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Screens.Edit.GameplayTest
+{
+    public class EditorPlayerLoader : PlayerLoader
+    {
+        [Resolved]
+        private OsuLogo osuLogo { get; set; }
+
+        public EditorPlayerLoader()
+            : base(() => new EditorPlayer())
+        {
+        }
+
+        public override void OnEntering(IScreen last)
+        {
+            base.OnEntering(last);
+
+            MetadataInfo.FinishTransforms(true);
+        }
+
+        protected override void LogoArriving(OsuLogo logo, bool resuming)
+        {
+            // call base with resuming forcefully set to true to reduce logo movements.
+            base.LogoArriving(logo, true);
+            logo.FinishTransforms(true, nameof(Scale));
+        }
+
+        protected override void ContentOut()
+        {
+            base.ContentOut();
+            osuLogo.FadeOut(CONTENT_OUT_DURATION, Easing.OutQuint);
+        }
+
+        protected override double PlayerPushDelay => 0;
+    }
+}

--- a/osu.Game/Screens/Edit/GameplayTest/SaveBeforeGameplayTestDialog.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/SaveBeforeGameplayTestDialog.cs
@@ -5,7 +5,7 @@ using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays.Dialog;
 
-namespace osu.Game.Screens.Edit
+namespace osu.Game.Screens.Edit.GameplayTest
 {
     public class SaveBeforeGameplayTestDialog : PopupDialog
     {


### PR DESCRIPTION
This is sort of a grab-bag of assorted fixes for feedback that I've received regarding the transition between editor and gameplay test screens. Semantically this PR could have been 4 PRs, but all pieces are sort of touching each other and I don't really want to be spamming PRs per each small commit I'm making. I'll split any part on request though.

Taking it from the top: 

* a5ba3bd is just a code organisation thing - since I needed `EditorPlayerLoader` to exist later, I've extracted everything from the MVP to its own `GameplayTest` namespace, because it was getting past the point of me being comfortable with putting everything in the root `Editor` namespace.
* b47c0b6 is a response to [this review comment](https://github.com/ppy/osu/pull/15582#issuecomment-966830456) regarding the player loader transition being too slow for gameplay test purposes. To this end, the logo is fixed in place, and the metadata reveal animation is fast-forwarded via `FinishTransforms()`. The way this is done is maybe a touch ad hoc, let me know if you'd prefer that refactored somehow.
* eb8c529 resolves #15605.
* 5f2a789 is intended to fix sounds/tracks continuing to play if editor is suspended while the editor clock was running ([as reported on discord](https://discord.com/channels/188630481301012481/188630652340404224/908970792165990451)).