### PR TITLE
Allow adjusting sample volume & bank of multiple objects at once

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -80,6 +80,46 @@ namespace osu.Game.Tests.Visual.Editing
             hitObjectHasSampleBank(1, "drum");
         }
 
+        [Test]
+        public void TestMultipleSelectionWithSameSampleVolume()
+        {
+            AddStep("unify sample volume", () =>
+            {
+                foreach (var h in EditorBeatmap.HitObjects)
+                    h.SampleControlPoint.SampleVolume = 50;
+            });
+
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickSamplePiece(0);
+            samplePopoverHasSingleVolume(50);
+
+            dismissPopover();
+
+            clickSamplePiece(1);
+            samplePopoverHasSingleVolume(50);
+
+            setVolumeViaPopover(75);
+            hitObjectHasSampleVolume(0, 75);
+            hitObjectHasSampleVolume(1, 75);
+        }
+
+        [Test]
+        public void TestMultipleSelectionWithDifferentSampleVolume()
+        {
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickSamplePiece(0);
+            samplePopoverHasIndeterminateVolume();
+
+            dismissPopover();
+
+            clickSamplePiece(1);
+            samplePopoverHasIndeterminateVolume();
+
+            setVolumeViaPopover(30);
+            hitObjectHasSampleVolume(0, 30);
+            hitObjectHasSampleVolume(1, 30);
+        }
+
         private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
         {
             var difficultyPiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
@@ -94,6 +134,14 @@ namespace osu.Game.Tests.Visual.Editing
             var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
 
             return slider?.Current.Value == volume;
+        });
+
+        private void samplePopoverHasIndeterminateVolume() => AddUntilStep($"sample popover has indeterminate volume", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
+            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
+
+            return slider != null && slider.Current.Value == null;
         });
 
         private void samplePopoverHasSingleBank(string bank) => AddUntilStep($"sample popover has bank {bank}", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -120,6 +120,46 @@ namespace osu.Game.Tests.Visual.Editing
             hitObjectHasSampleVolume(1, 30);
         }
 
+        [Test]
+        public void TestMultipleSelectionWithSameSampleBank()
+        {
+            AddStep("unify sample bank", () =>
+            {
+                foreach (var h in EditorBeatmap.HitObjects)
+                    h.SampleControlPoint.SampleBank = "soft";
+            });
+
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickSamplePiece(0);
+            samplePopoverHasSingleBank("soft");
+
+            dismissPopover();
+
+            clickSamplePiece(1);
+            samplePopoverHasSingleBank("soft");
+
+            setBankViaPopover("drum");
+            hitObjectHasSampleBank(0, "drum");
+            hitObjectHasSampleBank(1, "drum");
+        }
+
+        [Test]
+        public void TestMultipleSelectionWithDifferentSampleBank()
+        {
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickSamplePiece(0);
+            samplePopoverHasIndeterminateBank();
+
+            dismissPopover();
+
+            clickSamplePiece(1);
+            samplePopoverHasIndeterminateBank();
+
+            setBankViaPopover("normal");
+            hitObjectHasSampleBank(0, "normal");
+            hitObjectHasSampleBank(1, "normal");
+        }
+
         private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
         {
             var difficultyPiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
@@ -150,6 +190,14 @@ namespace osu.Game.Tests.Visual.Editing
             var textBox = popover?.ChildrenOfType<LabelledTextBox>().First();
 
             return textBox?.Current.Value == bank;
+        });
+
+        private void samplePopoverHasIndeterminateBank() => AddUntilStep($"sample popover has indeterminate bank", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
+            var textBox = popover?.ChildrenOfType<LabelledTextBox>().First();
+
+            return textBox != null && textBox.Current.Value == null;
         });
 
         private void dismissPopover()

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -237,6 +237,10 @@ namespace osu.Game.Tests.Visual.Editing
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
             var textBox = popover.ChildrenOfType<LabelledTextBox>().First();
             textBox.Current.Value = bank;
+            // force a commit via keyboard.
+            // this is needed when testing attempting to set empty bank - which should revert to the previous value, but only on commit.
+            InputManager.ChangeFocus(textBox);
+            InputManager.Key(Key.Enter);
         });
 
         private void hitObjectHasSampleBank(int objectIndex, string bank) => AddAssert($"{objectIndex.ToOrdinalWords()} has bank {bank}", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -171,15 +171,15 @@ namespace osu.Game.Tests.Visual.Editing
         private void samplePopoverHasSingleVolume(int volume) => AddUntilStep($"sample popover has volume {volume}", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
+            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
 
             return slider?.Current.Value == volume;
         });
 
-        private void samplePopoverHasIndeterminateVolume() => AddUntilStep($"sample popover has indeterminate volume", () =>
+        private void samplePopoverHasIndeterminateVolume() => AddUntilStep("sample popover has indeterminate volume", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
+            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
 
             return slider != null && slider.Current.Value == null;
         });
@@ -197,7 +197,7 @@ namespace osu.Game.Tests.Visual.Editing
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
             var textBox = popover?.ChildrenOfType<LabelledTextBox>().First();
 
-            return textBox != null && textBox.Current.Value == null;
+            return textBox != null && string.IsNullOrEmpty(textBox.Current.Value);
         });
 
         private void dismissPopover()
@@ -209,7 +209,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void setVolumeViaPopover(int volume) => AddStep($"set volume {volume} via popover", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
-            var slider = popover.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
+            var slider = popover.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
             slider.Current.Value = volume;
         });
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -1,0 +1,139 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Humanizer;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osu.Game.Screens.Edit.Timing;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneHitObjectSamplePointAdjustments : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("add test objects", () =>
+            {
+                EditorBeatmap.Add(new HitCircle
+                {
+                    StartTime = 0,
+                    Position = (OsuPlayfield.BASE_SIZE - new Vector2(100, 0)) / 2,
+                    SampleControlPoint = new SampleControlPoint
+                    {
+                        SampleBank = "normal",
+                        SampleVolume = 80
+                    }
+                });
+
+                EditorBeatmap.Add(new HitCircle()
+                {
+                    StartTime = 500,
+                    Position = (OsuPlayfield.BASE_SIZE + new Vector2(100, 0)) / 2,
+                    SampleControlPoint = new SampleControlPoint
+                    {
+                        SampleBank = "soft",
+                        SampleVolume = 60
+                    }
+                });
+            });
+        }
+
+        [Test]
+        public void TestSingleSelection()
+        {
+            clickSamplePiece(0);
+            samplePopoverHasSingleBank("normal");
+            samplePopoverHasSingleVolume(80);
+
+            dismissPopover();
+
+            // select first object to ensure that sample pieces for unselected objects
+            // work independently from selection state.
+            AddStep("select first object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.First()));
+
+            clickSamplePiece(1);
+            samplePopoverHasSingleBank("soft");
+            samplePopoverHasSingleVolume(60);
+
+            setVolumeViaPopover(90);
+            hitObjectHasSampleVolume(1, 90);
+
+            setBankViaPopover("drum");
+            hitObjectHasSampleBank(1, "drum");
+        }
+
+        private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
+        {
+            var difficultyPiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
+
+            InputManager.MoveMouseTo(difficultyPiece);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        private void samplePopoverHasSingleVolume(int volume) => AddUntilStep($"sample popover has volume {volume}", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
+            var slider = popover?.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
+
+            return slider?.Current.Value == volume;
+        });
+
+        private void samplePopoverHasSingleBank(string bank) => AddUntilStep($"sample popover has bank {bank}", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
+            var textBox = popover?.ChildrenOfType<LabelledTextBox>().First();
+
+            return textBox?.Current.Value == bank;
+        });
+
+        private void dismissPopover()
+        {
+            AddStep("dismiss popover", () => InputManager.Key(Key.Escape));
+            AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Any(popover => popover.IsPresent));
+        }
+
+        private void setVolumeViaPopover(int volume) => AddStep($"set volume {volume} via popover", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
+            var slider = popover.ChildrenOfType<SliderWithTextBoxInput<int>>().Single();
+            slider.Current.Value = volume;
+        });
+
+        private void hitObjectHasSampleVolume(int objectIndex, int volume) => AddAssert($"{objectIndex.ToOrdinalWords()} has volume {volume}", () =>
+        {
+            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex);
+            return h.SampleControlPoint.SampleVolume == volume;
+        });
+
+        private void setBankViaPopover(string bank) => AddStep($"set bank {bank} via popover", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
+            var textBox = popover.ChildrenOfType<LabelledTextBox>().First();
+            textBox.Current.Value = bank;
+        });
+
+        private void hitObjectHasSampleBank(int objectIndex, string bank) => AddAssert($"{objectIndex.ToOrdinalWords()} has bank {bank}", () =>
+        {
+            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex);
+            return h.SampleControlPoint.SampleBank == bank;
+        });
+    }
+}

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
@@ -43,7 +44,7 @@ namespace osu.Game.Tests.Visual.Editing
                     }
                 });
 
-                EditorBeatmap.Add(new HitCircle()
+                EditorBeatmap.Add(new HitCircle
                 {
                     StartTime = 500,
                     Position = (OsuPlayfield.BASE_SIZE + new Vector2(100, 0)) / 2,
@@ -138,9 +139,15 @@ namespace osu.Game.Tests.Visual.Editing
             clickSamplePiece(1);
             samplePopoverHasSingleBank("soft");
 
+            setBankViaPopover(string.Empty);
+            hitObjectHasSampleBank(0, "soft");
+            hitObjectHasSampleBank(1, "soft");
+            samplePopoverHasSingleBank("soft");
+
             setBankViaPopover("drum");
             hitObjectHasSampleBank(0, "drum");
             hitObjectHasSampleBank(1, "drum");
+            samplePopoverHasSingleBank("drum");
         }
 
         [Test]
@@ -155,9 +162,15 @@ namespace osu.Game.Tests.Visual.Editing
             clickSamplePiece(1);
             samplePopoverHasIndeterminateBank();
 
+            setBankViaPopover(string.Empty);
+            hitObjectHasSampleBank(0, "normal");
+            hitObjectHasSampleBank(1, "soft");
+            samplePopoverHasIndeterminateBank();
+
             setBankViaPopover("normal");
             hitObjectHasSampleBank(0, "normal");
             hitObjectHasSampleBank(1, "normal");
+            samplePopoverHasSingleBank("normal");
         }
 
         private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
@@ -187,17 +200,17 @@ namespace osu.Game.Tests.Visual.Editing
         private void samplePopoverHasSingleBank(string bank) => AddUntilStep($"sample popover has bank {bank}", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var textBox = popover?.ChildrenOfType<LabelledTextBox>().First();
+            var textBox = popover?.ChildrenOfType<OsuTextBox>().First();
 
-            return textBox?.Current.Value == bank;
+            return textBox?.Current.Value == bank && string.IsNullOrEmpty(textBox?.PlaceholderText.ToString());
         });
 
-        private void samplePopoverHasIndeterminateBank() => AddUntilStep($"sample popover has indeterminate bank", () =>
+        private void samplePopoverHasIndeterminateBank() => AddUntilStep("sample popover has indeterminate bank", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var textBox = popover?.ChildrenOfType<LabelledTextBox>().First();
+            var textBox = popover?.ChildrenOfType<OsuTextBox>().First();
 
-            return textBox != null && string.IsNullOrEmpty(textBox.Current.Value);
+            return textBox != null && string.IsNullOrEmpty(textBox.Current.Value) && !string.IsNullOrEmpty(textBox.PlaceholderText.ToString());
         });
 
         private void dismissPopover()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public class SamplePointPiece : HitObjectPointPiece, IHasPopover
     {
-        private readonly HitObject hitObject;
+        public readonly HitObject HitObject;
 
         private readonly Bindable<string> bank;
         private readonly BindableNumber<int> volume;
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         public SamplePointPiece(HitObject hitObject)
             : base(hitObject.SampleControlPoint)
         {
-            this.hitObject = hitObject;
+            HitObject = hitObject;
             volume = hitObject.SampleControlPoint.SampleVolumeBindable.GetBoundCopy();
             bank = hitObject.SampleControlPoint.SampleBankBindable.GetBoundCopy();
         }
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             Label.Text = $"{bank.Value} {volume.Value}";
         }
 
-        public Popover GetPopover() => new SampleEditPopover(hitObject);
+        public Popover GetPopover() => new SampleEditPopover(HitObject);
 
         public class SampleEditPopover : OsuPopover
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -19,6 +19,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Timing;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
@@ -82,6 +83,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         Width = 200,
                         Direction = FillDirection.Vertical,
                         AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(0, 10),
                         Children = new Drawable[]
                         {
                             bank = new LabelledTextBox

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -11,6 +11,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
 using osu.Game.Utils;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Timing
 {
@@ -62,6 +63,7 @@ namespace osu.Game.Screens.Edit.Timing
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 5),
                     Children = new Drawable[]
                     {
                         textbox = new LabelledTextBox


### PR DESCRIPTION
Companion piece to https://github.com/ppy/osu/pull/15601.

https://user-images.githubusercontent.com/20418176/141658984-8e400758-7df2-46ca-a64e-82f66f7ed34f.mp4

For the most part, the diff is extremely similar to the aforementioned pull. The part that created the most difficulty was getting the behaviour of the sample bank text box right, especially when it comes to handling nulls/empty strings. I've opted for considering null/empty bank as always invalid and staying with/reverting to previous values when one of those is attempted to be set or committed to the text box.

I've opted not to move out the bank text box logic out to a component since it felt like maybe a bit of an overengineer. Will look into doing that if it is deemed to be the better choice, though.