### PR TITLE
Transfer beatmap track time between editor and gameplay test screens

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -326,6 +326,19 @@ namespace osu.Game.Screens.Edit
         public void UpdateClockSource() => clock.ChangeSource(Beatmap.Value.Track);
 
         /// <summary>
+        /// Creates an <see cref="EditorState"/> instance representing the current state of the editor.
+        /// </summary>
+        /// <param name="nextBeatmap">
+        /// The next beatmap to be shown, in the case of difficulty switch.
+        /// <see langword="null"/> indicates that the beatmap will not be changing.
+        /// </param>
+        private EditorState getState([CanBeNull] BeatmapInfo nextBeatmap = null) => new EditorState
+        {
+            Time = clock.CurrentTimeAccurate,
+            ClipboardContent = nextBeatmap == null || editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? Clipboard.Content.Value : string.Empty
+        };
+
+        /// <summary>
         /// Restore the editor to a provided state.
         /// </summary>
         /// <param name="state">The state to restore.</param>
@@ -780,11 +793,7 @@ namespace osu.Game.Screens.Edit
             return new DifficultyMenuItem(beatmapInfo, isCurrentDifficulty, SwitchToDifficulty);
         }
 
-        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, new EditorState
-        {
-            Time = clock.CurrentTimeAccurate,
-            ClipboardContent = editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? Clipboard.Content.Value : string.Empty
-        });
+        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, getState(nextBeatmap));
 
         private void cancelExit()
         {
@@ -807,7 +816,7 @@ namespace osu.Game.Screens.Edit
                 pushEditorPlayer();
             }
 
-            void pushEditorPlayer() => this.Push(new EditorPlayerLoader());
+            void pushEditorPlayer() => this.Push(new EditorPlayerLoader(getState()));
         }
 
         public double SnapTime(double time, double? referenceTime) => editorBeatmap.SnapTime(time, referenceTime);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -332,7 +332,7 @@ namespace osu.Game.Screens.Edit
         /// The next beatmap to be shown, in the case of difficulty switch.
         /// <see langword="null"/> indicates that the beatmap will not be changing.
         /// </param>
-        private EditorState getState([CanBeNull] BeatmapInfo nextBeatmap = null) => new EditorState
+        public EditorState GetState([CanBeNull] BeatmapInfo nextBeatmap = null) => new EditorState
         {
             Time = clock.CurrentTimeAccurate,
             ClipboardContent = nextBeatmap == null || editorBeatmap.BeatmapInfo.RulesetID == nextBeatmap.RulesetID ? Clipboard.Content.Value : string.Empty
@@ -793,7 +793,7 @@ namespace osu.Game.Screens.Edit
             return new DifficultyMenuItem(beatmapInfo, isCurrentDifficulty, SwitchToDifficulty);
         }
 
-        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, getState(nextBeatmap));
+        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, GetState(nextBeatmap));
 
         private void cancelExit()
         {
@@ -816,7 +816,7 @@ namespace osu.Game.Screens.Edit
                 pushEditorPlayer();
             }
 
-            void pushEditorPlayer() => this.Push(new EditorPlayerLoader(getState()));
+            void pushEditorPlayer() => this.Push(new EditorPlayerLoader(this));
         }
 
         public double SnapTime(double time, double? referenceTime) => editorBeatmap.SnapTime(time, referenceTime);

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Screens.Play;
 
@@ -10,13 +11,19 @@ namespace osu.Game.Screens.Edit.GameplayTest
 {
     public class EditorPlayer : Player
     {
-        public EditorPlayer()
-            : base(new PlayerConfiguration { ShowResults = false })
-        {
-        }
+        private readonly EditorState editorState;
 
         [Resolved]
         private MusicController musicController { get; set; }
+
+        public EditorPlayer(EditorState editorState)
+            : base(new PlayerConfiguration { ShowResults = false })
+        {
+            this.editorState = editorState;
+        }
+
+        protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart)
+            => new MasterGameplayClockContainer(beatmap, editorState.Time, true);
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -44,6 +44,16 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
         protected override bool CheckModsAllowFailure() => false; // never fail.
 
+        public override void OnEntering(IScreen last)
+        {
+            base.OnEntering(last);
+
+            // finish alpha transforms on entering to avoid gameplay starting in a half-hidden state.
+            // the finish calls are purposefully not propagated to children to avoid messing up their state.
+            FinishTransforms();
+            GameplayClockContainer.FinishTransforms(false, nameof(Alpha));
+        }
+
         public override bool OnExiting(IScreen next)
         {
             musicController.Stop();

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -11,15 +11,17 @@ namespace osu.Game.Screens.Edit.GameplayTest
 {
     public class EditorPlayer : Player
     {
+        private readonly Editor editor;
         private readonly EditorState editorState;
 
         [Resolved]
         private MusicController musicController { get; set; }
 
-        public EditorPlayer(EditorState editorState)
+        public EditorPlayer(Editor editor)
             : base(new PlayerConfiguration { ShowResults = false })
         {
-            this.editorState = editorState;
+            this.editor = editor;
+            editorState = editor.GetState();
         }
 
         protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart)
@@ -45,6 +47,9 @@ namespace osu.Game.Screens.Edit.GameplayTest
         public override bool OnExiting(IScreen next)
         {
             musicController.Stop();
+
+            editorState.Time = GameplayClockContainer.CurrentTime;
+            editor.RestoreState(editorState);
             return base.OnExiting(next);
         }
     }

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayerLoader.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayerLoader.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Screens.Edit.GameplayTest
         [Resolved]
         private OsuLogo osuLogo { get; set; }
 
-        public EditorPlayerLoader()
-            : base(() => new EditorPlayer())
+        public EditorPlayerLoader(EditorState editorState)
+            : base(() => new EditorPlayer(editorState))
         {
         }
 

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayerLoader.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayerLoader.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Screens.Edit.GameplayTest
         [Resolved]
         private OsuLogo osuLogo { get; set; }
 
-        public EditorPlayerLoader(EditorState editorState)
-            : base(() => new EditorPlayer(editorState))
+        public EditorPlayerLoader(Editor editor)
+            : base(() => new EditorPlayer(editor))
         {
         }
 


### PR DESCRIPTION
By which I mean that gameplay test will start where the editor clock was at the time of editor suspension, and upon exiting the gameplay test the editor clock will pick up where gameplay left off.

https://user-images.githubusercontent.com/20418176/141659959-09b01403-d2c7-48fa-a64a-dca1621ccab2.mp4

Interested in thoughts about the way of passing state here. Initially I thought I could avoid passing `Editor` to the `EditorPlayer` and use the `OnExiting`-supplied next screen, but I forgot that `EditorPlayerLoader` is sandwiched in between them. So it came to passing `Editor`.

This pull also locally removes some on-enter transitions in `EditorPlayer` (in 6b4b6de), because they made it look like the time didn't transfer correctly between the screens. Gameplay was starting from the time given by the editor, but several components of the player would be in a partially-faded-out state for a grand total of 750ms:

https://github.com/ppy/osu/blob/91a21152dff2ac77b45450edfb73692d2860a13d/osu.Game/Screens/Play/Player.cs#L899-L904
https://github.com/ppy/osu/blob/91a21152dff2ac77b45450edfb73692d2860a13d/osu.Game/Screens/Play/Player.cs#L940