### PR TITLE
Fix banana showers not clearing the plate when missing the last banana

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -169,6 +169,17 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
+        public void TestLastBananaShouldClearPlate()
+        {
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            checkPlate(1);
+            AddStep("miss banana", () => attemptCatch(new Banana { X = 100 }));
+            checkPlate(1);
+            AddStep("miss last banana", () => attemptCatch(new Banana { LastInCombo = true, X = 100 }));
+            checkPlate(0);
+        }
+
+        [Test]
         public void TestCatcherRandomStacking()
         {
             AddStep("catch more fruits", () => attemptCatch(() => new Fruit

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -169,13 +169,24 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestLastBananaShouldClearPlate()
+        public void TestLastBananaShouldClearPlateOnMiss()
         {
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             checkPlate(1);
             AddStep("miss banana", () => attemptCatch(new Banana { X = 100 }));
             checkPlate(1);
             AddStep("miss last banana", () => attemptCatch(new Banana { LastInCombo = true, X = 100 }));
+            checkPlate(0);
+        }
+
+        [Test]
+        public void TestLastBananaShouldClearPlateOnCatch()
+        {
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            checkPlate(1);
+            AddStep("catch banana", () => attemptCatch(new Banana()));
+            checkPlate(2);
+            AddStep("catch last banana", () => attemptCatch(new Banana { LastInCombo = true }));
             checkPlate(0);
         }
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -210,7 +210,16 @@ namespace osu.Game.Rulesets.Catch.UI
             catchResult.CatcherAnimationState = CurrentState;
             catchResult.CatcherHyperDash = HyperDashing;
 
+            // Ignore JuiceStreams and BananaShowers
             if (!(drawableObject is DrawablePalpableCatchHitObject palpableObject)) return;
+
+            if (palpableObject.HitObject.LastInCombo)
+            {
+                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
+                    Explode();
+                else
+                    Drop();
+            }
 
             var hitObject = palpableObject.HitObject;
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -213,14 +213,6 @@ namespace osu.Game.Rulesets.Catch.UI
             // Ignore JuiceStreams and BananaShowers
             if (!(drawableObject is DrawablePalpableCatchHitObject palpableObject)) return;
 
-            if (palpableObject.HitObject.LastInCombo)
-            {
-                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
-                    Explode();
-                else
-                    Drop();
-            }
-
             var hitObject = palpableObject.HitObject;
 
             if (result.IsHit)
@@ -253,6 +245,14 @@ namespace osu.Game.Rulesets.Catch.UI
                 CurrentState = hitObject.Kiai ? CatcherAnimationState.Kiai : CatcherAnimationState.Idle;
             else if (!(hitObject is Banana))
                 CurrentState = CatcherAnimationState.Fail;
+
+            if (palpableObject.HitObject.LastInCombo)
+            {
+                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
+                    Explode();
+                else
+                    Drop();
+            }
         }
 
         public void OnRevertResult(DrawableCatchHitObject drawableObject, JudgementResult result)

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osuTK;
 
@@ -73,8 +72,8 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             Catcher.OnNewResult(hitObject, result);
 
-            if (!result.Type.IsScorable())
-                return;
+            // Ignore JuiceStreams and BananaShowers
+            if (!(hitObject is DrawablePalpableCatchHitObject)) return;
 
             if (hitObject.HitObject.LastInCombo)
             {

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Judgements;
@@ -71,18 +70,6 @@ namespace osu.Game.Rulesets.Catch.UI
         public void OnNewResult(DrawableCatchHitObject hitObject, JudgementResult result)
         {
             Catcher.OnNewResult(hitObject, result);
-
-            // Ignore JuiceStreams and BananaShowers
-            if (!(hitObject is DrawablePalpableCatchHitObject)) return;
-
-            if (hitObject.HitObject.LastInCombo)
-            {
-                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
-                    Catcher.Explode();
-                else
-                    Catcher.Drop();
-            }
-
             comboDisplay.OnNewResult(hitObject, result);
         }
 


### PR DESCRIPTION
Fixes #13326

I figured we should only explode the plate of the catcher or update the combo display if we have a `PalpableCatchHitObject`.
Because of this, checking the type is much better than calling the `IsScorable` method (which created issues). We could alternatively check if the `result.Judgement` is an `IgnoreJudgement`, although now the check is the same as how `Catcher.OnNewResult` does it.