### PR TITLE
Expose more of `WorkingBeatmap` via interface

### DIFF
--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -17,33 +17,69 @@ namespace osu.Game.Beatmaps
 {
     public interface IWorkingBeatmap
     {
+        IBeatmapInfo BeatmapInfo { get; }
+
+        IBeatmapSetInfo BeatmapSetInfo => BeatmapInfo.BeatmapSet;
+
+        IBeatmapMetadataInfo Metadata => BeatmapInfo.Metadata;
+
         /// <summary>
-        /// Retrieves the <see cref="IBeatmap"/> which this <see cref="WorkingBeatmap"/> represents.
+        /// Whether the Beatmap has finished loading.
+        ///</summary>
+        public bool BeatmapLoaded { get; }
+
+        /// <summary>
+        /// Whether the Background has finished loading.
+        ///</summary>
+        public bool BackgroundLoaded { get; }
+
+        /// <summary>
+        /// Whether the Waveform has finished loading.
+        ///</summary>
+        public bool WaveformLoaded { get; }
+
+        /// <summary>
+        /// Whether the Storyboard has finished loading.
+        ///</summary>
+        public bool StoryboardLoaded { get; }
+
+        /// <summary>
+        /// Whether the Skin has finished loading.
+        ///</summary>
+        public bool SkinLoaded { get; }
+
+        /// <summary>
+        /// Whether the Track has finished loading.
+        ///</summary>
+        public bool TrackLoaded { get; }
+
+        /// <summary>
+        /// Retrieves the <see cref="IBeatmap"/> which this <see cref="IWorkingBeatmap"/> represents.
         /// </summary>
         IBeatmap Beatmap { get; }
 
         /// <summary>
-        /// Retrieves the background for this <see cref="WorkingBeatmap"/>.
+        /// Retrieves the background for this <see cref="IWorkingBeatmap"/>.
         /// </summary>
         Texture Background { get; }
 
         /// <summary>
-        /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="WorkingBeatmap"/>.
+        /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.
         /// </summary>
         Waveform Waveform { get; }
 
         /// <summary>
-        /// Retrieves the <see cref="Storyboard"/> which this <see cref="WorkingBeatmap"/> provides.
+        /// Retrieves the <see cref="Storyboard"/> which this <see cref="IWorkingBeatmap"/> provides.
         /// </summary>
         Storyboard Storyboard { get; }
 
         /// <summary>
-        /// Retrieves the <see cref="Skin"/> which this <see cref="WorkingBeatmap"/> provides.
+        /// Retrieves the <see cref="Skin"/> which this <see cref="IWorkingBeatmap"/> provides.
         /// </summary>
         ISkin Skin { get; }
 
         /// <summary>
-        /// Retrieves the <see cref="Track"/> which this <see cref="WorkingBeatmap"/> has loaded.
+        /// Retrieves the <see cref="Track"/> which this <see cref="IWorkingBeatmap"/> has loaded.
         /// </summary>
         Track Track { get; }
 
@@ -67,7 +103,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <remarks>
         /// In a standard game context, the loading of the track is managed solely by MusicController, which will
-        /// automatically load the track of the current global IBindable WorkingBeatmap.
+        /// automatically load the track of the current global IBindable IWorkingBeatmap.
         /// As such, this method should only be called in very special scenarios, such as external tests or apps which are
         /// outside of the game context.
         /// </remarks>
@@ -79,5 +115,20 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="storagePath">The storage path to the file.</param>
         Stream GetStream(string storagePath);
+
+        /// <summary>
+        /// Beings loading the contents of this <see cref="IWorkingBeatmap"/> asynchronously.
+        /// </summary>
+        public void BeginAsyncLoad();
+
+        /// <summary>
+        /// Cancels the asynchronous loading of the contents of this <see cref="IWorkingBeatmap"/>.
+        /// </summary>
+        public void CancelAsyncLoad();
+
+        /// <summary>
+        /// Reads the correct track restart point from beatmap metadata and sets looping to enabled.
+        /// </summary>
+        void PrepareTrackForPreviewLooping();
     }
 }

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -19,9 +19,9 @@ namespace osu.Game.Beatmaps
     {
         IBeatmapInfo BeatmapInfo { get; }
 
-        IBeatmapSetInfo BeatmapSetInfo => BeatmapInfo.BeatmapSet;
+        IBeatmapSetInfo BeatmapSetInfo { get; }
 
-        IBeatmapMetadataInfo Metadata => BeatmapInfo.Metadata;
+        IBeatmapMetadataInfo Metadata { get; }
 
         /// <summary>
         /// Whether the Beatmap has finished loading.

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -27,11 +27,7 @@ namespace osu.Game.Beatmaps
     public abstract class WorkingBeatmap : IWorkingBeatmap
     {
         public readonly BeatmapInfo BeatmapInfo;
-
-        // ReSharper disable once FieldHidesInterfacePropertyWithDefaultImplementation
         public readonly BeatmapSetInfo BeatmapSetInfo;
-
-        // ReSharper disable once FieldHidesInterfacePropertyWithDefaultImplementation
         public readonly BeatmapMetadata Metadata;
 
         protected AudioManager AudioManager { get; }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -231,6 +231,8 @@ namespace osu.Game.Beatmaps
         public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
 
         IBeatmapInfo IWorkingBeatmap.BeatmapInfo => BeatmapInfo;
+        IBeatmapMetadataInfo IWorkingBeatmap.Metadata => Metadata;
+        IBeatmapSetInfo IWorkingBeatmap.BeatmapSetInfo => BeatmapSetInfo;
 
         public IBeatmap Beatmap
         {

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -28,8 +28,10 @@ namespace osu.Game.Beatmaps
     {
         public readonly BeatmapInfo BeatmapInfo;
 
+        // ReSharper disable once FieldHidesInterfacePropertyWithDefaultImplementation
         public readonly BeatmapSetInfo BeatmapSetInfo;
 
+        // ReSharper disable once FieldHidesInterfacePropertyWithDefaultImplementation
         public readonly BeatmapMetadata Metadata;
 
         protected AudioManager AudioManager { get; }
@@ -88,6 +90,9 @@ namespace osu.Game.Beatmaps
                 mods ??= Array.Empty<Mod>();
 
                 var rulesetInstance = ruleset.CreateInstance();
+
+                if (rulesetInstance == null)
+                    throw new RulesetLoadException("Creating ruleset instance failed when attempting to create playable beatmap.");
 
                 IBeatmapConverter converter = CreateBeatmapConverter(Beatmap, rulesetInstance);
 
@@ -176,17 +181,8 @@ namespace osu.Game.Beatmaps
 
         private CancellationTokenSource loadCancellation = new CancellationTokenSource();
 
-        /// <summary>
-        /// Beings loading the contents of this <see cref="WorkingBeatmap"/> asynchronously.
-        /// </summary>
-        public void BeginAsyncLoad()
-        {
-            loadBeatmapAsync();
-        }
+        public void BeginAsyncLoad() => loadBeatmapAsync();
 
-        /// <summary>
-        /// Cancels the asynchronous loading of the contents of this <see cref="WorkingBeatmap"/>.
-        /// </summary>
         public void CancelAsyncLoad()
         {
             lock (beatmapFetchLock)
@@ -234,6 +230,8 @@ namespace osu.Game.Beatmaps
 
         public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
 
+        IBeatmapInfo IWorkingBeatmap.BeatmapInfo => BeatmapInfo;
+
         public IBeatmap Beatmap
         {
             get
@@ -273,9 +271,6 @@ namespace osu.Game.Beatmaps
         [NotNull]
         public Track LoadTrack() => loadedTrack = GetBeatmapTrack() ?? GetVirtualTrack(1000);
 
-        /// <summary>
-        /// Reads the correct track restart point from beatmap metadata and sets looping to enabled.
-        /// </summary>
         public void PrepareTrackForPreviewLooping()
         {
             Track.Looping = true;


### PR DESCRIPTION
This exposes all methods and metadata required to propagate `IWorkingBeatmap` usage out further (around 90% of usages game-wide).