### PR TITLE
Add difficulty attribute formatting

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
 {
     public class CatchDifficultyAttributes : DifficultyAttributes
     {
+        [JsonProperty("approach_rate")]
         public double ApproachRate { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
@@ -10,5 +11,25 @@ namespace osu.Game.Rulesets.Catch.Difficulty
     {
         [JsonProperty("approach_rate")]
         public double ApproachRate { get; set; }
+
+        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        {
+            foreach (var v in base.ToDatabase())
+                yield return v;
+
+            // Todo: Catch should not output star rating in the 'aim' attribute.
+            yield return (1, StarRating);
+            yield return (7, ApproachRate);
+            yield return (9, MaxCombo);
+        }
+
+        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        {
+            base.FromDatabase(values, hitCircleCount, spinnerCount);
+
+            StarRating = values[1];
+            ApproachRate = values[7];
+            MaxCombo = (int)values[9];
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -17,19 +17,19 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
-            // Todo: Catch should not output star rating in the 'aim' attribute.
-            yield return (1, StarRating);
-            yield return (7, ApproachRate);
-            yield return (9, MaxCombo);
+            // Todo: osu!catch should not output star rating in the 'aim' attribute.
+            yield return (ATTRIB_ID_AIM, StarRating);
+            yield return (ATTRIB_ID_APPROACH_RATE, ApproachRate);
+            yield return (ATTRIB_ID_MAX_COMBO, MaxCombo);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
             base.FromDatabaseAttributes(values);
 
-            StarRating = values[1];
-            ApproachRate = values[7];
-            MaxCombo = (int)values[9];
+            StarRating = values[ATTRIB_ID_AIM];
+            ApproachRate = values[ATTRIB_ID_APPROACH_RATE];
+            MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -12,9 +12,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         [JsonProperty("approach_rate")]
         public double ApproachRate { get; set; }
 
-        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {
-            foreach (var v in base.ToDatabase())
+            foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
             // Todo: Catch should not output star rating in the 'aim' attribute.
@@ -23,9 +23,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             yield return (9, MaxCombo);
         }
 
-        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
-            base.FromDatabase(values, hitCircleCount, spinnerCount);
+            base.FromDatabaseAttributes(values);
 
             StarRating = values[1];
             ApproachRate = values[7];

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
@@ -13,5 +14,25 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
         [JsonProperty("score_multiplier")]
         public double ScoreMultiplier { get; set; }
+
+        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        {
+            foreach (var v in base.ToDatabase())
+                yield return v;
+
+            // Todo: Mania doesn't output MaxCombo attribute for some reason.
+            yield return (11, StarRating);
+            yield return (13, GreatHitWindow);
+            yield return (15, ScoreMultiplier);
+        }
+
+        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        {
+            base.FromDatabase(values, hitCircleCount, spinnerCount);
+
+            StarRating = values[11];
+            GreatHitWindow = values[13];
+            ScoreMultiplier = values[15];
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Mania.Difficulty
 {
     public class ManiaDifficultyAttributes : DifficultyAttributes
     {
+        [JsonProperty("great_hit_window")]
         public double GreatHitWindow { get; set; }
+
+        [JsonProperty("score_multiplier")]
         public double ScoreMultiplier { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -20,19 +20,19 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
-            // Todo: Mania doesn't output MaxCombo attribute for some reason.
-            yield return (11, StarRating);
-            yield return (13, GreatHitWindow);
-            yield return (15, ScoreMultiplier);
+            // Todo: osu!mania doesn't output MaxCombo attribute for some reason.
+            yield return (ATTRIB_ID_STRAIN, StarRating);
+            yield return (ATTRIB_ID_GREAT_HIT_WINDOW, GreatHitWindow);
+            yield return (ATTRIB_ID_SCORE_MULTIPLIER, ScoreMultiplier);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
             base.FromDatabaseAttributes(values);
 
-            StarRating = values[11];
-            GreatHitWindow = values[13];
-            ScoreMultiplier = values[15];
+            StarRating = values[ATTRIB_ID_STRAIN];
+            GreatHitWindow = values[ATTRIB_ID_GREAT_HIT_WINDOW];
+            ScoreMultiplier = values[ATTRIB_ID_SCORE_MULTIPLIER];
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         [JsonProperty("score_multiplier")]
         public double ScoreMultiplier { get; set; }
 
-        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {
-            foreach (var v in base.ToDatabase())
+            foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
             // Todo: Mania doesn't output MaxCombo attribute for some reason.
@@ -26,9 +26,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             yield return (15, ScoreMultiplier);
         }
 
-        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
-            base.FromDatabase(values, hitCircleCount, spinnerCount);
+            base.FromDatabaseAttributes(values);
 
             StarRating = values[11];
             GreatHitWindow = values[13];

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Difficulty
 {
@@ -37,5 +40,39 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         [JsonProperty("spinner_count")]
         public int SpinnerCount { get; set; }
+
+        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        {
+            foreach (var v in base.ToDatabase())
+                yield return v;
+
+            yield return (1, AimStrain);
+            yield return (3, SpeedStrain);
+            yield return (5, OverallDifficulty);
+            yield return (7, ApproachRate);
+            yield return (9, MaxCombo);
+            yield return (11, StarRating);
+
+            if (Mods.Any(m => m is ModFlashlight))
+                yield return (17, FlashlightRating);
+
+            yield return (19, SliderFactor);
+        }
+
+        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        {
+            base.FromDatabase(values, hitCircleCount, spinnerCount);
+
+            AimStrain = values[1];
+            SpeedStrain = values[3];
+            OverallDifficulty = values[5];
+            ApproachRate = values[7];
+            MaxCombo = (int)values[9];
+            StarRating = values[11];
+            FlashlightRating = values.GetValueOrDefault(17);
+            SliderFactor = values[19];
+            HitCircleCount = hitCircleCount;
+            SpinnerCount = spinnerCount;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -1,21 +1,41 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Osu.Difficulty
 {
     public class OsuDifficultyAttributes : DifficultyAttributes
     {
+        [JsonProperty("aim_strain")]
         public double AimStrain { get; set; }
+
+        [JsonProperty("speed_strain")]
         public double SpeedStrain { get; set; }
+
+        [JsonProperty("flashlight_rating")]
         public double FlashlightRating { get; set; }
+
+        [JsonProperty("slider_factor")]
         public double SliderFactor { get; set; }
+
+        [JsonProperty("approach_rate")]
         public double ApproachRate { get; set; }
+
+        [JsonProperty("overall_difficulty")]
         public double OverallDifficulty { get; set; }
+
+        [JsonProperty("drain_rate")]
         public double DrainRate { get; set; }
+
+        [JsonProperty("hit_circle_count")]
         public int HitCircleCount { get; set; }
+
+        [JsonProperty("slider_count")]
         public int SliderCount { get; set; }
+
+        [JsonProperty("spinner_count")]
         public int SpinnerCount { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             yield return (9, MaxCombo);
             yield return (11, StarRating);
 
-            if (Mods.Any(m => m is ModFlashlight))
+            if (ShouldSerializeFlashlightRating())
                 yield return (17, FlashlightRating);
 
             yield return (19, SliderFactor);
@@ -72,6 +72,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         // Used implicitly by Newtonsoft.Json to not serialize flashlight property in some cases.
         [UsedImplicitly]
-        public bool ShouldSerializeFlashlightRating() => Mods.OfType<ModFlashlight>().Any();
+        public bool ShouldSerializeFlashlightRating() => Mods.Any(m => m is ModFlashlight);
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -43,31 +43,31 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
-            yield return (1, AimStrain);
-            yield return (3, SpeedStrain);
-            yield return (5, OverallDifficulty);
-            yield return (7, ApproachRate);
-            yield return (9, MaxCombo);
-            yield return (11, StarRating);
+            yield return (ATTRIB_ID_AIM, AimStrain);
+            yield return (ATTRIB_ID_SPEED, SpeedStrain);
+            yield return (ATTRIB_ID_OVERALL_DIFFICULTY, OverallDifficulty);
+            yield return (ATTRIB_ID_APPROACH_RATE, ApproachRate);
+            yield return (ATTRIB_ID_MAX_COMBO, MaxCombo);
+            yield return (ATTRIB_ID_STRAIN, StarRating);
 
             if (ShouldSerializeFlashlightRating())
-                yield return (17, FlashlightRating);
+                yield return (ATTRIB_ID_FLASHLIGHT, FlashlightRating);
 
-            yield return (19, SliderFactor);
+            yield return (ATTRIB_ID_SLIDER_FACTOR, SliderFactor);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
             base.FromDatabaseAttributes(values);
 
-            AimStrain = values[1];
-            SpeedStrain = values[3];
-            OverallDifficulty = values[5];
-            ApproachRate = values[7];
-            MaxCombo = (int)values[9];
-            StarRating = values[11];
-            FlashlightRating = values.GetValueOrDefault(17);
-            SliderFactor = values[19];
+            AimStrain = values[ATTRIB_ID_AIM];
+            SpeedStrain = values[ATTRIB_ID_SPEED];
+            OverallDifficulty = values[ATTRIB_ID_OVERALL_DIFFICULTY];
+            ApproachRate = values[ATTRIB_ID_APPROACH_RATE];
+            MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
+            StarRating = values[ATTRIB_ID_STRAIN];
+            FlashlightRating = values.GetValueOrDefault(ATTRIB_ID_FLASHLIGHT);
+            SliderFactor = values[ATTRIB_ID_SLIDER_FACTOR];
         }
 
         // Used implicitly by Newtonsoft.Json to not serialize flashlight property in some cases.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -30,16 +30,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         [JsonProperty("overall_difficulty")]
         public double OverallDifficulty { get; set; }
 
-        [JsonIgnore]
         public double DrainRate { get; set; }
 
-        [JsonIgnore]
         public int HitCircleCount { get; set; }
 
-        [JsonIgnore]
         public int SliderCount { get; set; }
 
-        [JsonIgnore]
         public int SpinnerCount { get; set; }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -74,5 +75,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             HitCircleCount = hitCircleCount;
             SpinnerCount = spinnerCount;
         }
+
+        [UsedImplicitly]
+        public bool ShouldSerializeFlashlightRating() => Mods.OfType<ModFlashlight>().Any();
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             SliderFactor = values[19];
         }
 
+        // Used implicitly by Newtonsoft.Json to not serialize flashlight property in some cases.
         [UsedImplicitly]
         public bool ShouldSerializeFlashlightRating() => Mods.OfType<ModFlashlight>().Any();
     }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -29,16 +29,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         [JsonProperty("overall_difficulty")]
         public double OverallDifficulty { get; set; }
 
-        [JsonProperty("drain_rate")]
+        [JsonIgnore]
         public double DrainRate { get; set; }
 
-        [JsonProperty("hit_circle_count")]
+        [JsonIgnore]
         public int HitCircleCount { get; set; }
 
-        [JsonProperty("slider_count")]
+        [JsonIgnore]
         public int SliderCount { get; set; }
 
-        [JsonProperty("spinner_count")]
+        [JsonIgnore]
         public int SpinnerCount { get; set; }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabase()

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         [JsonIgnore]
         public int SpinnerCount { get; set; }
 
-        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {
-            foreach (var v in base.ToDatabase())
+            foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
             yield return (1, AimStrain);
@@ -60,9 +60,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             yield return (19, SliderFactor);
         }
 
-        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
-            base.FromDatabase(values, hitCircleCount, spinnerCount);
+            base.FromDatabaseAttributes(values);
 
             AimStrain = values[1];
             SpeedStrain = values[3];
@@ -72,8 +72,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             StarRating = values[11];
             FlashlightRating = values.GetValueOrDefault(17);
             SliderFactor = values[19];
-            HitCircleCount = hitCircleCount;
-            SpinnerCount = spinnerCount;
         }
 
         [UsedImplicitly]

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
@@ -22,5 +23,24 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         [JsonProperty("great_hit_window")]
         public double GreatHitWindow { get; set; }
+
+        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        {
+            foreach (var v in base.ToDatabase())
+                yield return v;
+
+            yield return (9, MaxCombo);
+            yield return (11, StarRating);
+            yield return (13, GreatHitWindow);
+        }
+
+        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        {
+            base.FromDatabase(values, hitCircleCount, spinnerCount);
+
+            MaxCombo = (int)values[9];
+            StarRating = values[11];
+            GreatHitWindow = values[13];
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -1,16 +1,26 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty
 {
     public class TaikoDifficultyAttributes : DifficultyAttributes
     {
+        [JsonProperty("stamina_strain")]
         public double StaminaStrain { get; set; }
+
+        [JsonProperty("rhythm_strain")]
         public double RhythmStrain { get; set; }
+
+        [JsonProperty("colour_strain")]
         public double ColourStrain { get; set; }
+
+        [JsonProperty("approach_rate")]
         public double ApproachRate { get; set; }
+
+        [JsonProperty("great_hit_window")]
         public double GreatHitWindow { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -29,18 +29,18 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
-            yield return (9, MaxCombo);
-            yield return (11, StarRating);
-            yield return (13, GreatHitWindow);
+            yield return (ATTRIB_ID_MAX_COMBO, MaxCombo);
+            yield return (ATTRIB_ID_STRAIN, StarRating);
+            yield return (ATTRIB_ID_GREAT_HIT_WINDOW, GreatHitWindow);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
             base.FromDatabaseAttributes(values);
 
-            MaxCombo = (int)values[9];
-            StarRating = values[11];
-            GreatHitWindow = values[13];
+            MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
+            StarRating = values[ATTRIB_ID_STRAIN];
+            GreatHitWindow = values[ATTRIB_ID_GREAT_HIT_WINDOW];
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -24,9 +24,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("great_hit_window")]
         public double GreatHitWindow { get; set; }
 
-        public override IEnumerable<(int attributeId, object value)> ToDatabase()
+        public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {
-            foreach (var v in base.ToDatabase())
+            foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
             yield return (9, MaxCombo);
@@ -34,9 +34,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             yield return (13, GreatHitWindow);
         }
 
-        public override void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
-            base.FromDatabase(values, hitCircleCount, spinnerCount);
+            base.FromDatabaseAttributes(values);
 
             MaxCombo = (int)values[9];
             StarRating = values[11];

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
@@ -30,6 +32,12 @@ namespace osu.Game.Rulesets.Difficulty
             Mods = mods;
             Skills = skills;
             StarRating = starRating;
+        }
+
+        public virtual IEnumerable<(int attributeId, object value)> ToDatabase() => Enumerable.Empty<(int, object)>();
+
+        public virtual void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        {
         }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 
@@ -8,10 +9,16 @@ namespace osu.Game.Rulesets.Difficulty
 {
     public class DifficultyAttributes
     {
+        [JsonIgnore]
         public Mod[] Mods { get; set; }
+
+        [JsonIgnore]
         public Skill[] Skills { get; set; }
 
+        [JsonProperty("star_rating")]
         public double StarRating { get; set; }
+
+        [JsonProperty("max_combo")]
         public int MaxCombo { get; set; }
 
         public DifficultyAttributes()

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Rulesets.Difficulty
             StarRating = starRating;
         }
 
-        public virtual IEnumerable<(int attributeId, object value)> ToDatabase() => Enumerable.Empty<(int, object)>();
+        public virtual IEnumerable<(int attributeId, object value)> ToDatabaseAttributes() => Enumerable.Empty<(int, object)>();
 
-        public virtual void FromDatabase(IReadOnlyDictionary<int, double> values, int hitCircleCount, int spinnerCount)
+        public virtual void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
         }
     }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -9,23 +9,47 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Difficulty
 {
+    /// <summary>
+    /// Describes the difficulty of a beatmap, as output by a <see cref="DifficultyCalculator"/>.
+    /// </summary>
     [JsonObject(MemberSerialization.OptIn)]
     public class DifficultyAttributes
     {
+        /// <summary>
+        /// The mods which were applied to the beatmap.
+        /// </summary>
         public Mod[] Mods { get; set; }
 
+        /// <summary>
+        /// The skills resulting from the difficulty calculation.
+        /// </summary>
         public Skill[] Skills { get; set; }
 
+        /// <summary>
+        /// The combined star rating of all skill.
+        /// </summary>
         [JsonProperty("star_rating", Order = -3)]
         public double StarRating { get; set; }
 
+        /// <summary>
+        /// The maximum achievable combo.
+        /// </summary>
         [JsonProperty("max_combo", Order = -2)]
         public int MaxCombo { get; set; }
 
+        /// <summary>
+        /// Creates new <see cref="DifficultyAttributes"/>.
+        /// </summary>
         public DifficultyAttributes()
         {
         }
 
+        /// <summary>
+        /// Creates new <see cref="DifficultyAttributes"/>.
+        /// </summary>
+        /// <param name="mods">The mods which were applied to the beatmap.</param>
+        /// <param name="skills">The skills resulting from the difficulty calculation.</param>
+        /// <param name="starRating">The combined star rating of all skills.</param>
         public DifficultyAttributes(Mod[] mods, Skill[] skills, double starRating)
         {
             Mods = mods;
@@ -33,8 +57,18 @@ namespace osu.Game.Rulesets.Difficulty
             StarRating = starRating;
         }
 
+        /// <summary>
+        /// Converts this <see cref="DifficultyAttributes"/> to osu-web compatible database attribute mappings.
+        /// </summary>
+        /// <remarks>
+        /// See: osu_difficulty_attribs table.
+        /// </remarks>
         public virtual IEnumerable<(int attributeId, object value)> ToDatabaseAttributes() => Enumerable.Empty<(int, object)>();
 
+        /// <summary>
+        /// Reads osu-web database attribute mappings into this <see cref="DifficultyAttributes"/> object.
+        /// </summary>
+        /// <param name="values">The attribute mappings.</param>
         public virtual void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
         }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -15,6 +15,17 @@ namespace osu.Game.Rulesets.Difficulty
     [JsonObject(MemberSerialization.OptIn)]
     public class DifficultyAttributes
     {
+        protected const int ATTRIB_ID_AIM = 1;
+        protected const int ATTRIB_ID_SPEED = 3;
+        protected const int ATTRIB_ID_OVERALL_DIFFICULTY = 5;
+        protected const int ATTRIB_ID_APPROACH_RATE = 7;
+        protected const int ATTRIB_ID_MAX_COMBO = 9;
+        protected const int ATTRIB_ID_STRAIN = 11;
+        protected const int ATTRIB_ID_GREAT_HIT_WINDOW = 13;
+        protected const int ATTRIB_ID_SCORE_MULTIPLIER = 15;
+        protected const int ATTRIB_ID_FLASHLIGHT = 17;
+        protected const int ATTRIB_ID_SLIDER_FACTOR = 19;
+
         /// <summary>
         /// The mods which were applied to the beatmap.
         /// </summary>
@@ -72,16 +83,5 @@ namespace osu.Game.Rulesets.Difficulty
         public virtual void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
         }
-
-        protected const int ATTRIB_ID_AIM = 1;
-        protected const int ATTRIB_ID_SPEED = 3;
-        protected const int ATTRIB_ID_OVERALL_DIFFICULTY = 5;
-        protected const int ATTRIB_ID_APPROACH_RATE = 7;
-        protected const int ATTRIB_ID_MAX_COMBO = 9;
-        protected const int ATTRIB_ID_STRAIN = 11;
-        protected const int ATTRIB_ID_GREAT_HIT_WINDOW = 13;
-        protected const int ATTRIB_ID_SCORE_MULTIPLIER = 15;
-        protected const int ATTRIB_ID_FLASHLIGHT = 17;
-        protected const int ATTRIB_ID_SLIDER_FACTOR = 19;
     }
 }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -72,5 +72,16 @@ namespace osu.Game.Rulesets.Difficulty
         public virtual void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
         {
         }
+
+        protected const int ATTRIB_ID_AIM = 1;
+        protected const int ATTRIB_ID_SPEED = 3;
+        protected const int ATTRIB_ID_OVERALL_DIFFICULTY = 5;
+        protected const int ATTRIB_ID_APPROACH_RATE = 7;
+        protected const int ATTRIB_ID_MAX_COMBO = 9;
+        protected const int ATTRIB_ID_STRAIN = 11;
+        protected const int ATTRIB_ID_GREAT_HIT_WINDOW = 13;
+        protected const int ATTRIB_ID_SCORE_MULTIPLIER = 15;
+        protected const int ATTRIB_ID_FLASHLIGHT = 17;
+        protected const int ATTRIB_ID_SLIDER_FACTOR = 19;
     }
 }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -9,12 +9,11 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Difficulty
 {
+    [JsonObject(MemberSerialization.OptIn)]
     public class DifficultyAttributes
     {
-        [JsonIgnore]
         public Mod[] Mods { get; set; }
 
-        [JsonIgnore]
         public Skill[] Skills { get; set; }
 
         [JsonProperty("star_rating", Order = -3)]

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -17,10 +17,10 @@ namespace osu.Game.Rulesets.Difficulty
         [JsonIgnore]
         public Skill[] Skills { get; set; }
 
-        [JsonProperty("star_rating")]
+        [JsonProperty("star_rating", Order = -3)]
         public double StarRating { get; set; }
 
-        [JsonProperty("max_combo")]
+        [JsonProperty("max_combo", Order = -2)]
         public int MaxCombo { get; set; }
 
         public DifficultyAttributes()


### PR DESCRIPTION
## Motivation

I want to remove/reduce the burden of (de)serialising `DifficultyAttribute`s from a variety of projects, which are constantly getting out of sync every time diffcalc is updated.

Please review this in the context of PRs across other repos as well:
- https://github.com/ppy/osu-queue-score-statistics/pull/15 (particularly important)
- https://github.com/ppy/osu-tools/pull/134
- https://github.com/ppy/osu-difficulty-calculator/pull/206

## Cleaned up `DifficultyAttribute` JSON output

1. We usually try to stick to `snake_case` for keys. The one exception to this, for technical reasons more than anything, is `HitResult`, which eventually needs to be fixed also as it has caused score-statistics-processor issues in the past.
2. The JSON output contained weird attributes like `Mod`s which do not serialise cleanly (only `APIMod` is guaranteed to), and `Skill`s. Some form of `Skill`s could be serialised in the future in addition to this.

## Removed mappings to readable formats and the database across multiple projects

`osu-queue-score-statistics`
- https://github.com/ppy/osu-queue-score-statistics/blob/master/osu.Server.Queues.ScoreStatisticsProcessor/DifficultyAttributeExtensions.cs
- **New implementation**: https://github.com/ppy/osu-queue-score-statistics/compare/master...smoogipoo:remove-difficulty-attribute-extensions?expand=1

`osu-difficulty-calculator`:
- https://github.com/ppy/osu-difficulty-calculator/blob/master/osu.Server.DifficultyCalculator/DifficultyAttributeExtensions.cs
- **New implementation**: https://github.com/smoogipoo/osu-difficulty-calculator/tree/remove-difficulty-attribute-extensions

`osu-tools`:
- https://github.com/ppy/osu-tools/blob/2f505441ba5a17320be0b27cb05c12c8357aa4a4/PerformanceCalculator/Difficulty/DifficultyCommand.cs#L118-L160
- New mappings wanting to be added in https://github.com/ppy/osu-tools/pull/133 (I've replaced this PR already for the example results below)

`osu-performance-calculator` (if we ever need to use this project):
- https://github.com/smoogipoo/osu-performance-calculator/blob/137d3c8bbe67fedd314e991191af85e007a5cf06/osu.Server.PerformanceCalculator/DifficultyAttributeExtensions.cs#L17-L62

While we still have to update nupkgs in projects, we won't have to synchronize attribute changes (e.g. https://github.com/ppy/osu-difficulty-calculator/pull/205, https://github.com/ppy/osu-tools/pull/121).  
From a testing perspective, you should be able to just replace the osu! references via the `UseLocalOsu` scripts and already have everything you need.

## Example output

Can be found at https://github.com/ppy/osu-tools/pull/134

## Remarks

If anyone is already parsing the JSON output, they will have to change their mappings to the new `snake_case` ones.