### PR TITLE
Separate hold-to-confirm activation time for pausing and restarting map

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -55,7 +55,6 @@ using osu.Game.IO;
 using osu.Game.Localisation;
 using osu.Game.Performance;
 using osu.Game.Skinning.Editor;
-using osu.Framework.Extensions;
 
 namespace osu.Game
 {

--- a/osu.Game/Performance/HighPerformanceSession.cs
+++ b/osu.Game/Performance/HighPerformanceSession.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Runtime;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -11,7 +10,6 @@ namespace osu.Game.Performance
     public class HighPerformanceSession : Component
     {
         private readonly IBindable<bool> localUserPlaying = new Bindable<bool>();
-        private GCLatencyMode originalGCMode;
 
         [BackgroundDependencyLoader]
         private void load(OsuGame game)
@@ -34,14 +32,10 @@ namespace osu.Game.Performance
 
         protected virtual void EnableHighPerformanceSession()
         {
-            originalGCMode = GCSettings.LatencyMode;
-            GCSettings.LatencyMode = GCLatencyMode.LowLatency;
         }
 
         protected virtual void DisableHighPerformanceSession()
         {
-            if (GCSettings.LatencyMode == GCLatencyMode.LowLatency)
-                GCSettings.LatencyMode = originalGCMode;
         }
     }
 }


### PR DESCRIPTION
I think laser should have separated hold-to-confirm activation time for both pausing and restarting the map, because its very unfamilliar when, on stable, you used to hold your map restart button, and not used to hold esc button for pausing game, and you cant do something with that in laser