### PR TITLE
Disable cancelling of update via notification

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -183,6 +183,19 @@ namespace osu.Desktop.Updater
                     }
                 });
             }
+
+            public override void Close()
+            {
+                // cancelling updates is not currently supported by the underlying updater.
+                // only allow dismissing for now.
+
+                switch (State)
+                {
+                    case ProgressNotificationState.Cancelled:
+                        base.Close();
+                        break;
+                }
+            }
         }
 
         private class SquirrelLogger : Splat.ILogger, IDisposable


### PR DESCRIPTION
Squirrel doesn't really support this. Maybe we can bring it back in the future, just a quick fix to avoid ugliness. Intentionally not hiding the close button of the notification because I don't care about that still being there and doing nothing, just fixing visual ugliness.

Addresses concerns in #15652 / #15653.