### PR TITLE
Fix score panels sometimes jumping when toggling statistics fast

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -311,10 +311,10 @@ namespace osu.Game.Screens.Ranking
                 ScorePanelList.Attach(detachedPanel);
 
                 // Move into its original location in the attached container first, then to the final location.
-                var origLocation = detachedPanel.Parent.ToLocalSpace(screenSpacePos);
-                detachedPanel.MoveTo(origLocation)
+                float origLocation = detachedPanel.Parent.ToLocalSpace(screenSpacePos).X;
+                detachedPanel.MoveToX(origLocation)
                              .Then()
-                             .MoveTo(new Vector2(0, origLocation.Y), 150, Easing.OutQuint);
+                             .MoveToX(0, 150, Easing.OutQuint);
 
                 // Show contracted panels.
                 foreach (var contracted in ScorePanelList.GetScorePanels().Where(p => p.State == PanelState.Contracted))


### PR DESCRIPTION
Noticed in https://github.com/ppy/osu/pull/15668. You can notice it easily if you press space twice or double click fast.

Before:
![Screen Recording 2021-11-17 at 11 23 14 PM](https://user-images.githubusercontent.com/35318437/142370959-42d31193-c1c6-4f8d-83e5-22092f0e12fe.gif)

After:
![Screen Recording 2021-11-17 at 11 16 50 PM](https://user-images.githubusercontent.com/35318437/142370984-34fa3055-458e-4a5b-85c8-2de3a023a038.gif)
