### PR TITLE
adding hitwindow for nerfing kick slider spam

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -112,8 +112,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             return new Skill[]
             {
-                new Aim(mods, true),
-                new Aim(mods, false),
+                new Aim(mods, true, hitWindowGreat),
+                new Aim(mods, false, hitWindowGreat),
                 new Speed(mods, hitWindowGreat),
                 new Flashlight(mods)
             };

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -14,13 +14,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Aim : OsuStrainSkill
     {
-        public Aim(Mod[] mods, bool withSliders)
+        public Aim(Mod[] mods, bool withSliders, double hitWindowGreat)
             : base(mods)
         {
             this.withSliders = withSliders;
+
+            windowGreat = hitWindowGreat;
         }
 
         private readonly bool withSliders;
+        private readonly double windowGreat;
 
         protected override int HistoryLength => 2;
 
@@ -49,7 +52,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             // But if the last object is a slider, then we extend the travel velocity through the slider into the current object.
             if (osuLastObj.BaseObject is Slider && withSliders)
             {
-                double movementVelocity = osuCurrObj.MovementDistance / osuCurrObj.MovementTime; // calculate the movement velocity from slider end to current object
+                double sliderStartNerf = osuCurrObj.BaseObject is Slider ? windowGreat : 0; // nerf time from last sliderend to current sliderstart
+
+                double movementVelocity = osuCurrObj.MovementDistance / (osuCurrObj.MovementTime + sliderStartNerf); // calculate the movement velocity from slider end to current object
                 double travelVelocity = osuCurrObj.TravelDistance / osuCurrObj.TravelTime; // calculate the slider velocity from slider head to slider end.
 
                 currVelocity = Math.Max(currVelocity, movementVelocity + travelVelocity); // take the larger total combined velocity.
@@ -60,7 +65,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             if (osuLastLastObj.BaseObject is Slider && withSliders)
             {
-                double movementVelocity = osuLastObj.MovementDistance / osuLastObj.MovementTime;
+                double sliderStartNerf = osuLastObj.BaseObject is Slider ? windowGreat : 0;
+
+                double movementVelocity = osuLastObj.MovementDistance / (osuLastObj.MovementTime + sliderStartNerf);
                 double travelVelocity = osuLastObj.TravelDistance / osuLastObj.TravelTime;
 
                 prevVelocity = Math.Max(prevVelocity, movementVelocity + travelVelocity);


### PR DESCRIPTION
One of abusing slider pattern:
![screenshot046](https://user-images.githubusercontent.com/27873716/142446167-705b3680-91a6-4574-bc16-21ea2ba9dd26.jpg)
Because we are calculating velocity between sliderend and next note.
In brief, the more the gap is shorter, the more pp-abusing is increased.

So, to alleviate this, i add hitwindow on movementTime if the next note is slider.  

![screenshot047](https://user-images.githubusercontent.com/27873716/142448848-cf71f3b6-c98b-48f4-9b88-10240585da6a.jpg)
additional example (umbrella)
it nerfs 50pp.

