### PR TITLE
Run nunit in blame mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet build -c Debug -warnaserror osu.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --blame-crash --blame-hang --blame-hang-timeout 5m --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"
         shell: pwsh
 
       # Attempt to upload results even if test fails.
@@ -48,7 +48,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: osu-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
-          path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
+          path: ${{github.workspace}}/TestResults/**/*
 
   build-only-android:
     name: Build only (Android)


### PR DESCRIPTION
Doesn't seem too intrusive, so might as well have it as a standard thing.

Here's a check which crashed: https://github.com/smoogipoo/osu/runs/4261312529?check_suite_focus=true This didn't get a dump, which is unfortunate given that I seem to get dumps in a local test :(

All the other checks still work as expected: https://github.com/smoogipoo/osu/pull/96/checks?check_run_id=4261505930

Although it may not help us find crashes, I am still curious about the hang we get every once in a while. Total execution time seems within margin of error of our standard test runs, so fair to say the overhead is minimal.