### PR TITLE
Fix MessagePack workaround formatter potentially initializing on iOS

### DIFF
--- a/osu.Game/Online/SignalRDerivedTypeWorkaroundJsonConverter.cs
+++ b/osu.Game/Online/SignalRDerivedTypeWorkaroundJsonConverter.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Online
     public class SignalRDerivedTypeWorkaroundJsonConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType) =>
-            SignalRWorkaroundTypes.BASE_DERIVED.Any(t =>
+            SignalRWorkaroundTypes.BASE_TYPE_MAPPING.Any(t =>
                 objectType == t.baseType ||
                 objectType == t.derivedType);
 
@@ -30,7 +30,7 @@ namespace osu.Game.Online
 
             string type = (string)obj[@"$dtype"]!;
 
-            var resolvedType = SignalRWorkaroundTypes.BASE_DERIVED.Select(t => t.derivedType).Single(t => t.Name == type);
+            var resolvedType = SignalRWorkaroundTypes.BASE_TYPE_MAPPING.Select(t => t.derivedType).Single(t => t.Name == type);
 
             object? instance = Activator.CreateInstance(resolvedType);
 

--- a/osu.Game/Online/SignalRDerivedTypeWorkaroundJsonConverter.cs
+++ b/osu.Game/Online/SignalRDerivedTypeWorkaroundJsonConverter.cs
@@ -17,8 +17,9 @@ namespace osu.Game.Online
     public class SignalRDerivedTypeWorkaroundJsonConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType) =>
-            SignalRUnionWorkaroundResolver.BASE_TYPES.Contains(objectType) ||
-            SignalRUnionWorkaroundResolver.DERIVED_TYPES.Contains(objectType);
+            SignalRWorkaroundTypes.BASE_DERIVED.Any(t =>
+                objectType == t.baseType ||
+                objectType == t.derivedType);
 
         public override object? ReadJson(JsonReader reader, Type objectType, object? o, JsonSerializer jsonSerializer)
         {
@@ -29,7 +30,7 @@ namespace osu.Game.Online
 
             string type = (string)obj[@"$dtype"]!;
 
-            var resolvedType = SignalRUnionWorkaroundResolver.DERIVED_TYPES.Single(t => t.Name == type);
+            var resolvedType = SignalRWorkaroundTypes.BASE_DERIVED.Select(t => t.derivedType).Single(t => t.Name == type);
 
             object? instance = Activator.CreateInstance(resolvedType);
 

--- a/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
+++ b/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
@@ -23,13 +23,13 @@ namespace osu.Game.Online
 
         private static IReadOnlyDictionary<Type, IMessagePackFormatter> createFormatterMap()
         {
-            IEnumerable<(Type derivedType, Type baseType)> baseDerived = SignalRWorkaroundTypes.BASE_DERIVED;
+            IEnumerable<(Type derivedType, Type baseType)> baseMap = SignalRWorkaroundTypes.BASE_TYPE_MAPPING;
 
             // This should not be required. The fallback should work. But something is weird with the way caching is done.
             // For future adventurers, I would not advise looking into this further. It's likely not worth the effort.
-            baseDerived = baseDerived.Concat(baseDerived.Select(t => (t.baseType, t.baseType))).Distinct();
+            baseMap = baseMap.Concat(baseMap.Select(t => (t.baseType, t.baseType)));
 
-            return new Dictionary<Type, IMessagePackFormatter>(baseDerived.Select(t =>
+            return new Dictionary<Type, IMessagePackFormatter>(baseMap.Select(t =>
             {
                 var formatter = (IMessagePackFormatter)Activator.CreateInstance(typeof(TypeRedirectingFormatter<,>).MakeGenericType(t.derivedType, t.baseType));
                 return new KeyValuePair<Type, IMessagePackFormatter>(t.derivedType, formatter);

--- a/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
+++ b/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
@@ -35,7 +35,9 @@ namespace osu.Game.Online
             typeof(TeamVersusUserState),
         };
 
-        private static readonly IReadOnlyDictionary<Type, IMessagePackFormatter> formatter_map = new Dictionary<Type, IMessagePackFormatter>
+        private static IReadOnlyDictionary<Type, IMessagePackFormatter> formatterMapBacking;
+
+        private static IReadOnlyDictionary<Type, IMessagePackFormatter> formatterMap => formatterMapBacking ??= new Dictionary<Type, IMessagePackFormatter>
         {
             { typeof(TeamVersusUserState), new TypeRedirectingFormatter<TeamVersusUserState, MatchUserState>() },
             { typeof(TeamVersusRoomState), new TypeRedirectingFormatter<TeamVersusRoomState, MatchRoomState>() },
@@ -51,7 +53,7 @@ namespace osu.Game.Online
 
         public IMessagePackFormatter<T> GetFormatter<T>()
         {
-            if (formatter_map.TryGetValue(typeof(T), out var formatter))
+            if (formatterMap.TryGetValue(typeof(T), out var formatter))
                 return (IMessagePackFormatter<T>)formatter;
 
             return StandardResolver.Instance.GetFormatter<T>();

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// A static class providing the list of types requiring workarounds for serialisation in SignalR.
+    /// </summary>
+    /// <seealso cref="SignalRUnionWorkaroundResolver"/>
+    /// <seealso cref="SignalRDerivedTypeWorkaroundJsonConverter"/>
+    internal static class SignalRWorkaroundTypes
+    {
+        internal static readonly IReadOnlyList<(Type derivedType, Type baseType)> BASE_DERIVED = new[]
+        {
+            (typeof(ChangeTeamRequest), typeof(MatchUserRequest)),
+            (typeof(TeamVersusRoomState), typeof(MatchRoomState)),
+            (typeof(TeamVersusUserState), typeof(MatchUserState)),
+            (typeof(MatchServerEvent), typeof(MatchServerEvent)),
+        };
+    }
+}

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Online
     /// <seealso cref="SignalRDerivedTypeWorkaroundJsonConverter"/>
     internal static class SignalRWorkaroundTypes
     {
-        internal static readonly IReadOnlyList<(Type derivedType, Type baseType)> BASE_DERIVED = new[]
+        internal static readonly IReadOnlyList<(Type derivedType, Type baseType)> BASE_TYPE_MAPPING = new[]
         {
             (typeof(ChangeTeamRequest), typeof(MatchUserRequest)),
             (typeof(TeamVersusRoomState), typeof(MatchRoomState)),

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Online
             (typeof(ChangeTeamRequest), typeof(MatchUserRequest)),
             (typeof(TeamVersusRoomState), typeof(MatchRoomState)),
             (typeof(TeamVersusUserState), typeof(MatchUserState)),
-            (typeof(MatchServerEvent), typeof(MatchServerEvent)),
         };
     }
 }


### PR DESCRIPTION
Since the JSON version (`SignalRDerivedTypeWorkaroundJsonConverter`) references the messagepack workaround to retrieve the base and derived types, `formatter_map` initializes and instantiates `TypeRedirectingFormatter`, which would actually retrieve the base formatter by `StandardResolver.Instance.GetFormatter<TBase>()`, and that's not supported on iOS:
```
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: Failed to join multiplayer room.
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: System.AggregateException: One or more errors occurred. (One or more errors occurred. (The type initializer for 'osu.Game.Online.SignalRUnionWorkaroundResolver' threw an exception.)) ---> System.AggregateException: One or more errors occurred. (The type initializer for 'osu.Game.Online.SignalRUnionWorkaroundResolver' threw an exception.) ---> System.TypeInitializationException: The type initializer for 'osu.Game.Online.SignalRUnionWorkaroundResolver' threw an exception. ---> System.TypeInitializationException: The type initializer for 'FormatterCache`1' threw an exception. ---> System.TypeInitializationException: The type initializer for 'FormatterCache`1' threw an exception. ---> System.PlatformNotSupportedException: Operation is not supported on this platform.
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: at System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly (System.Reflection.AssemblyName name, System.Reflection.Emit.AssemblyBuilderAccess access) [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/src/Xamarin.iOS/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.pns.cs:129
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: at MessagePack.Internal.DynamicAssembly..ctor (System.String moduleName) [0x00010] in <e372d2478807460eabc86dc315aa3ac8>:0
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: at MessagePack.Resolvers.DynamicUnionResolver+<>c.<.cctor>b__6_0 () [0x00000] in <e372d2478807460eabc86dc315aa3ac8>:0
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: at System.Lazy`1[T].ViaFactory (System.Threading.LazyThreadSafetyMode mode) [0x00043] in <25bf495f7d6b4944aa395b3ab5293479>:0
2021-11-19 18:27:47.291 osu.iOS[2480:623532] [runtime] 2021-11-19 15:27:47 [error]: at System.Lazy`1[T].ExecutionAndPublication (System.LazyHelper executionAndPublication, System.Boolean useDefaultConstructor) [0x00022] in <25bf495f7d6b4944aa395b3ab5293479>:0
```

Resolved this by changing the static `formatter_map` field into a property that initializes itself when the resolver gets actually used.