### PR TITLE
Fix zero star difficulty values being cached when diffcalc was interrupted

### DIFF
--- a/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
+++ b/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
@@ -164,9 +164,9 @@ namespace osu.Game.Tests.Beatmaps
         {
             public Func<DifficultyCacheLookup, StarDifficulty> ComputeDifficulty { get; set; }
 
-            protected override Task<StarDifficulty> ComputeValueAsync(DifficultyCacheLookup lookup, CancellationToken token = default)
+            protected override Task<StarDifficulty?> ComputeValueAsync(DifficultyCacheLookup lookup, CancellationToken token = default)
             {
-                return Task.FromResult(ComputeDifficulty?.Invoke(lookup) ?? new StarDifficulty(BASE_STARS, 0));
+                return Task.FromResult<StarDifficulty?>(ComputeDifficulty?.Invoke(lookup) ?? new StarDifficulty(BASE_STARS, 0));
             }
         }
     }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapMetadataDisplay.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 }
             }
 
-            public override async Task<StarDifficulty> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo rulesetInfo = null, IEnumerable<Mod> mods = null, CancellationToken cancellationToken = default)
+            public override async Task<StarDifficulty?> GetDifficultyAsync(IBeatmapInfo beatmapInfo, IRulesetInfo rulesetInfo = null, IEnumerable<Mod> mods = null, CancellationToken cancellationToken = default)
             {
                 if (blockCalculation)
                     await calculationBlocker.Task.ConfigureAwait(false);

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -162,7 +162,12 @@ namespace osu.Game.Scoring
 
                     // We can compute the max combo locally after the async beatmap difficulty computation.
                     var difficulty = await difficulties().GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, cancellationToken).ConfigureAwait(false);
-                    beatmapMaxCombo = difficulty.MaxCombo;
+
+                    // Something failed during difficulty calculation. Fall back to provided score.
+                    if (difficulty == null)
+                        return score.TotalScore;
+
+                    beatmapMaxCombo = difficulty.Value.MaxCombo;
                 }
             }
             else

--- a/osu.Game/Scoring/ScorePerformanceCache.cs
+++ b/osu.Game/Scoring/ScorePerformanceCache.cs
@@ -37,12 +37,12 @@ namespace osu.Game.Scoring
             var attributes = await difficultyCache.GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, token).ConfigureAwait(false);
 
             // Performance calculation requires the beatmap and ruleset to be locally available. If not, return a default value.
-            if (attributes.Attributes == null)
+            if (attributes?.Attributes == null)
                 return null;
 
             token.ThrowIfCancellationRequested();
 
-            var calculator = score.Ruleset.CreateInstance().CreatePerformanceCalculator(attributes.Attributes, score);
+            var calculator = score.Ruleset.CreateInstance().CreatePerformanceCalculator(attributes.Value.Attributes, score);
 
             return calculator?.Calculate();
         }

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -143,14 +143,6 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 Origin = Anchor.TopCentre,
                                 AutoSizeAxes = Axes.Both,
                                 Spacing = new Vector2(5, 0),
-                                Children = new Drawable[]
-                                {
-                                    new StarRatingDisplay(starDifficulty)
-                                    {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft
-                                    },
-                                }
                             },
                             new FillFlowContainer
                             {
@@ -230,6 +222,15 @@ namespace osu.Game.Screens.Ranking.Expanded
 
             if (score.Date != default)
                 AddInternal(new PlayedOnText(score.Date));
+
+            if (starDifficulty != null)
+            {
+                starAndModDisplay.Add(new StarRatingDisplay(starDifficulty.Value)
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft
+                });
+            }
 
             if (score.Mods.Any())
             {

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -152,7 +152,10 @@ namespace osu.Game.Screens.Select.Details
 
             Task.WhenAll(normalStarDifficulty, moddedStarDifficulty).ContinueWith(_ => Schedule(() =>
             {
-                starDifficulty.Value = ((float)normalStarDifficulty.Result.Stars, (float)moddedStarDifficulty.Result.Stars);
+                if (normalStarDifficulty.Result == null || moddedStarDifficulty.Result == null)
+                    return;
+
+                starDifficulty.Value = ((float)normalStarDifficulty.Result.Value.Stars, (float)moddedStarDifficulty.Result.Value.Stars);
             }), starDifficultyCancellationSource.Token, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Current);
         }
 


### PR DESCRIPTION
* Closes #15699
* Closes #15700
  * See `ScorePerformanceCache`'s [usage of the difficulty cache](https://github.com/ppy/osu/blob/b1fcb840a9ff4d866aac262ace7f54fa88b5e0ce/osu.Game/Scoring/ScorePerformanceCache.cs#L39-L41) - diffcalc interruption leads to a `StarDifficulty` with no attributes being cached.
* Likely also closes #15701
  * See `ScoreManager`'s [usage of the difficulty cache](https://github.com/ppy/osu/blob/b1fcb840a9ff4d866aac262ace7f54fa88b5e0ce/osu.Game/Scoring/ScoreManager.cs#L175-L176) - diffcalc interruption leads to a `StarDifficulty` with a zero `MaxCombo` being cached.

The recent changes related to adding support for working beatmap load cancellation exposed a flaw in the beatmap difficulty cache. With the way the difficulty computation logic was written, any error in the calculation process (including difficulty attribute computation cancellation) would result in a 0.00 star rating being permanently cached in memory for the given beatmap.

To resolve, change the difficulty cache's return type to nullable. In failure scenarios, `null` is returned, rather than `default(StarDifficulty)` as done previously:

https://github.com/ppy/osu/blob/b1fcb840a9ff4d866aac262ace7f54fa88b5e0ce/osu.Game/Beatmaps/BeatmapDifficultyCache.cs#L291-L301

---

No tests here, because this is extremely annoying to test. The cancellation needs to happen *precisely* in the code block mentioned above. There are several cancellation checks preceding it which must be passed in order to expose the bug.

Probably the sanest way available for me to test this would be to write a custom test ruleset, a custom beatmap converter and a custom difficulty calculator, just for me to be able to inject the desired faults into the process. I will do this on request, but I don't know whether this is honestly worth the effort.