### PR TITLE
Clean up cancellation handling in `WorkingBeatmap.GetPlayableBeatmap()`

### DIFF
--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapTest.cs
@@ -9,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -40,7 +41,7 @@ namespace osu.Game.Tests.Beatmaps
             Task.Factory.StartNew(() =>
             {
                 loadStarted.Set();
-                Assert.Throws<OperationCanceledException>(() => working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, cancellationToken: cts.Token));
+                Assert.Throws<OperationCanceledException>(() => working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>(), cts.Token));
                 loadCompleted.Set();
             }, TaskCreationOptions.LongRunning);
 
@@ -58,7 +59,7 @@ namespace osu.Game.Tests.Beatmaps
         {
             var working = new TestNeverLoadsWorkingBeatmap();
 
-            Assert.Throws<OperationCanceledException>(() => working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
+            Assert.Throws(Is.InstanceOf<TimeoutException>(), () => working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
 
             working.ResetEvent.Set();
         }

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -294,15 +294,22 @@ namespace osu.Game.Beatmaps
 
                 return new StarDifficulty(attributes);
             }
-            catch (BeatmapInvalidForRulesetException e)
+            catch (OperationCanceledException)
+            {
+                // no need to log, cancellations are expected as part of normal operation.
+                return null;
+            }
+            catch (BeatmapInvalidForRulesetException invalidForRuleset)
             {
                 if (rulesetInfo.Equals(beatmapInfo.Ruleset))
-                    Logger.Error(e, $"Failed to convert {beatmapInfo.OnlineID} to the beatmap's default ruleset ({beatmapInfo.Ruleset}).");
+                    Logger.Error(invalidForRuleset, $"Failed to convert {beatmapInfo.OnlineID} to the beatmap's default ruleset ({beatmapInfo.Ruleset}).");
 
                 return null;
             }
-            catch
+            catch (Exception unknownException)
             {
+                Logger.Error(unknownException, "Failed to calculate beatmap difficulty");
+
                 return null;
             }
         }

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -90,12 +90,31 @@ namespace osu.Game.Beatmaps
         /// have been applied, and <see cref="HitObject"/>s have been fully constructed.
         /// </para>
         /// </summary>
+        /// <remarks>
+        /// By default, the beatmap load process will be interrupted after 10 seconds.
+        /// For finer-grained control over the load process, use the
+        /// <see cref="GetPlayableBeatmap(osu.Game.Rulesets.IRulesetInfo,System.Collections.Generic.IReadOnlyList{osu.Game.Rulesets.Mods.Mod},System.Threading.CancellationToken)"/>
+        /// overload instead.
+        /// </remarks>
         /// <param name="ruleset">The <see cref="RulesetInfo"/> to create a playable <see cref="IBeatmap"/> for.</param>
         /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
-        /// <param name="cancellationToken">Cancellation token that cancels the beatmap loading process. If not provided, a default timeout of 10,000ms will be applied to the load process.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null, CancellationToken? cancellationToken = null);
+        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, params Mod[] mods);
+
+        /// <summary>
+        /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.
+        /// <para>
+        /// The returned <see cref="IBeatmap"/> is in a playable state - all <see cref="HitObject"/> and <see cref="BeatmapDifficulty"/> <see cref="Mod"/>s
+        /// have been applied, and <see cref="HitObject"/>s have been fully constructed.
+        /// </para>
+        /// </summary>
+        /// <param name="ruleset">The <see cref="RulesetInfo"/> to create a playable <see cref="IBeatmap"/> for.</param>
+        /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
+        /// <param name="cancellationToken">Cancellation token that cancels the beatmap loading process.</param>
+        /// <returns>The converted <see cref="IBeatmap"/>.</returns>
+        /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
+        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods, CancellationToken cancellationToken);
 
         /// <summary>
         /// Load a new audio track instance for this beatmap. This should be called once before accessing <see cref="Track"/>.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Beatmaps
         /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, params Mod[] mods);
+        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null);
 
         /// <summary>
         /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -79,14 +79,14 @@ namespace osu.Game.Beatmaps
         /// <returns>The applicable <see cref="IBeatmapConverter"/>.</returns>
         protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
 
-        public IBeatmap GetPlayableBeatmap([NotNull] IRulesetInfo ruleset, params Mod[] mods)
+        public IBeatmap GetPlayableBeatmap([NotNull] IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
         {
             try
             {
                 using (var cancellationTokenSource = new CancellationTokenSource(10_000))
                 {
                     // don't apply the default timeout when debugger is attached (may be breakpointing / debugging).
-                    return GetPlayableBeatmap(ruleset, mods, Debugger.IsAttached ? new CancellationToken() : cancellationTokenSource.Token);
+                    return GetPlayableBeatmap(ruleset, mods ?? Array.Empty<Mod>(), Debugger.IsAttached ? new CancellationToken() : cancellationTokenSource.Token);
                 }
             }
             catch (OperationCanceledException)

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -216,7 +216,7 @@ namespace osu.Game.Screens.Play.HUD
                 this.gameplayBeatmap = gameplayBeatmap;
             }
 
-            public override IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null, CancellationToken? cancellationToken = null)
+            public override IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods, CancellationToken cancellationToken)
                 => gameplayBeatmap;
 
             protected override IBeatmap GetBeatmap() => gameplayBeatmap;


### PR DESCRIPTION
- [x] Depends on #15705.

After the recent changes introducing cancellation support to `WorkingBeatmap`, it turned out that if the cancellation support was used, `GetPlayableBeatmap()` would raise timeout exceptions rather than the expected `OperationCanceledException`, even when called from a context where there wasn't really any timeout (rather than an explicit cancellation from some other higher-up operation).

To that end, split off a separate overload for the typical usage, that catches `OperationCanceledException` and converts them to beatmap load timeout exceptions, and use normal `OperationCanceledException`s in the overload that requires a cancellation token to work.

---

The main goal here is to clean up the haphazard handling of cancellation (some places in `GetPlayableBeatmap()` were catching and converting, some places were using `ThrowIfCancellationRequested()` raw), and ship off the timeout path to a separate overload, which [was also suggested at review time](https://github.com/ppy/osu/pull/15494#discussion_r751860044).

Doing this also allows to limit the badness of the difficulty cache's current exception swallowing:

https://github.com/ppy/osu/blob/b1fcb840a9ff4d866aac262ace7f54fa88b5e0ce/osu.Game/Beatmaps/BeatmapDifficultyCache.cs#L298-L301

to just the cancellation path. Everything else that is an "unexpected" error will now get logged for us to know about it.

No (new) tests here again because this is again quite annoying to test (would have to exercise the specific paths that would throw timeouts rather than doing what `TestWorkingBeatmap` already does).