### PR TITLE
Adds quick exit and current position exit hotkeys to the test player

### DIFF
--- a/osu.Game/Graphics/Containers/TapToConfirmContainer.cs
+++ b/osu.Game/Graphics/Containers/TapToConfirmContainer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Graphics.Containers
+{
+    public class TapToConfirmContainer : Container
+    {
+        public Action Action;
+
+        /// <summary>
+        /// Whether currently in a fired state (and the confirm <see cref="Action"/> has been sent).
+        /// </summary>
+        private bool fired { get; set; }
+
+        protected void BeginConfirm()
+        {
+            if (fired) return;
+
+            Action?.Invoke();
+            fired = true;
+        }
+    }
+}

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
+            new KeyBinding(new[] { InputKey.F1 }, GlobalAction.EditorTestQuickExit),
+            new KeyBinding(new[] { InputKey.F2 }, GlobalAction.EditorTestCurrentPositionExit),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -292,6 +294,12 @@ namespace osu.Game.Input.Bindings
         EditorCycleGridDisplayMode,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTestGameplay))]
-        EditorTestGameplay
+        EditorTestGameplay,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTestQuickExit))]
+        EditorTestQuickExit,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTestCurrentPositionExit))]
+        EditorTestCurrentPositionExit
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -175,6 +175,16 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorTestGameplay => new TranslatableString(getKey(@"editor_test_gameplay"), @"Test gameplay");
 
         /// <summary>
+        /// "Test quick exit"
+        /// </summary>
+        public static LocalisableString EditorTestQuickExit => new TranslatableString(getKey(@"editor_test_quick_exit"), @"Test quick exit");
+
+        /// <summary>
+        /// "Test current position exit"
+        /// </summary>
+        public static LocalisableString EditorTestCurrentPositionExit => new TranslatableString(getKey(@"editor_test_current_position_exit"), @"Test current position exit");
+
+        /// <summary>
         /// "Hold for HUD"
         /// </summary>
         public static LocalisableString HoldForHUD => new TranslatableString(getKey(@"hold_for_hud"), @"Hold for HUD");

--- a/osu.Game/Screens/Edit/GameplayTest/EditorHotkeyCurrentPositionExitContainer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorHotkeyCurrentPositionExitContainer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.Containers;
+using osu.Game.Input.Bindings;
+
+namespace osu.Game.Screens.Edit.GameplayTest
+{
+    public class EditorHotkeyCurrentPositionExitContainer : TapToConfirmContainer, IKeyBindingHandler<GlobalAction>
+    {
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat || e.Action != GlobalAction.EditorTestCurrentPositionExit)
+                return false;
+
+            BeginConfirm();
+            return true;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/GameplayTest/EditorHotkeyQuickExitContainer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorHotkeyQuickExitContainer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.Containers;
+using osu.Game.Input.Bindings;
+
+namespace osu.Game.Screens.Edit.GameplayTest
+{
+    public class EditorHotkeyQuickExitContainer : TapToConfirmContainer, IKeyBindingHandler<GlobalAction>
+    {
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat || e.Action != GlobalAction.EditorTestQuickExit)
+                return false;
+
+            BeginConfirm();
+            return true;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -44,6 +46,25 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
         protected override bool CheckModsAllowFailure() => false; // never fail.
 
+        protected override IEnumerable<Container> GetCustomRulesetHotkeys() => new Container[]
+        {
+            new EditorHotkeyCurrentPositionExitContainer
+            {
+                Action = () =>
+                {
+                    editorState.Time = GameplayClockContainer.CurrentTime;
+                    PerformExit(false);
+                }
+            },
+            new EditorHotkeyQuickExitContainer
+            {
+                Action = () =>
+                {
+                    PerformExit(false);
+                }
+            }
+        };
+
         public override void OnEntering(IScreen last)
         {
             base.OnEntering(last);
@@ -58,7 +79,6 @@ namespace osu.Game.Screens.Edit.GameplayTest
         {
             musicController.Stop();
 
-            editorState.Time = GameplayClockContainer.CurrentTime;
             editor.RestoreState(editorState);
             return base.OnExiting(next);
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -129,6 +130,11 @@ namespace osu.Game.Screens.Play
         /// By default, this checks whether all selected mods allow failing.
         /// </summary>
         protected virtual bool CheckModsAllowFailure() => GameplayState.Mods.OfType<IApplicableFailOverride>().All(m => m.PerformFail());
+
+        /// <summary>
+        /// Custom hotkeys which will be added to the <see cref="RulesetSkinProvidingContainer"/>.
+        /// </summary>
+        protected virtual IEnumerable<Container> GetCustomRulesetHotkeys() => Array.Empty<Container>();
 
         public readonly PlayerConfiguration Configuration;
 
@@ -274,6 +280,8 @@ namespace osu.Game.Screens.Play
                     },
                 });
             }
+
+            rulesetSkinProvider.AddRange(GetCustomRulesetHotkeys());
 
             // add the overlay components as a separate step as they proxy some elements from the above underlay/gameplay components.
             // also give the overlays the ruleset skin provider to allow rulesets to potentially override HUD elements (used to disable combo counters etc.)


### PR DESCRIPTION
Adds the following functionality while testing a map in the editor:

- `F1` Quick exit the TestPlayer at the test start position.
- `F2` Exit the TestPlayer at the current position.

This change also fixes an inconsistency with stable were exiting the TestPlayer the normal way would send you to the current position instead of the start position.