### PR TITLE
Remove decay factor in Flashlight skill

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         {
         }
 
-        private double skillMultiplier => 0.15;
+        private double skillMultiplier => 0.07;
         private double strainDecayBase => 0.15;
         protected override double DecayWeight => 1.0;
         protected override int HistoryLength => 10; // Look back for 10 notes is added for the sake of flashlight calculations.
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                     // We also want to nerf stacks so that only the first object of the stack is accounted for.
                     double stackNerf = Math.Min(1.0, (osuPrevious.JumpDistance / scalingFactor) / 25.0);
 
-                    result += Math.Pow(0.8, i) * stackNerf * scalingFactor * jumpDistance / cumulativeStrainTime;
+                    result += stackNerf * scalingFactor * jumpDistance / cumulativeStrainTime;
                 }
             }
 


### PR DESCRIPTION
In live, there is a decay factor in Flashlight strain calculation which gave a 20% nerf for every succeeding object. The original reasoning for this was that notes further ahead in the future would matter less, and the player would only focus on the first few notes. However this is unnecessary as `cumulativeStrainTime` serves this exact purpose. In fact, it proved to be detrimental as it gave unnecessary nerfs to maps which utilised lots of fast notes (mostly stream maps).

This change simply removes that factor.

Example values:
[Sidetracked Day [Infinity Inside]](https://osu.ppy.sh/beatmapsets/838182#osu/1754777) +FL: 852pp -> 952pp in this rework
[osu! Stream Compilation [EXE]](https://osu.ppy.sh/beatmapsets/25403#osu/86044) +FL: 653pp -> 743pp
[JUSTadICE [Extreme]](https://osu.ppy.sh/beatmapsets/983942#osu/2058788) +FL: 351pp -> 340pp

This change works independently, however if https://github.com/ppy/osu/pull/15665 is to be merged then `skillMultiplier` needs to be adjusted accordingly.