### PR TITLE
Add helper property to access a realm beatmap's beatmap file

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -75,6 +75,24 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
+        public void TestAccessFileAfterImport()
+        {
+            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            {
+                using var importer = new BeatmapImporter(realmFactory, storage);
+                using var store = new RealmRulesetStore(realmFactory, storage);
+
+                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+
+                var beatmap = imported.Beatmaps.First();
+                var file = beatmap.File;
+
+                Assert.NotNull(file);
+                Assert.AreEqual(beatmap.Hash, file!.File.Hash);
+            });
+        }
+
+        [Test]
         public void TestImportThenDelete()
         {
             RunTestWithRealmAsync(async (realmFactory, storage) =>

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -33,10 +33,10 @@ namespace osu.Game.Database
 
         /// <summary>
         /// Version history:
-        /// 6  First tracked version (~20211018)
-        /// 7  Changed OnlineID fields to non-nullable to add indexing support (20211018)
-        /// 8  Rebind scroll adjust keys to not have control modifier (20211029)
-        /// 9  Converted BeatmapMetadata.Author from string to RealmUser (20211104)
+        /// 6    ~2021-10-18   First tracked version.
+        /// 7    2021-10-18    Changed OnlineID fields to non-nullable to add indexing support.
+        /// 8    2021-10-29    Rebind scroll adjust keys to not have control modifier.
+        /// 9    2021-11-04    Converted BeatmapMetadata.Author from string to RealmUser.
         /// </summary>
         private const int schema_version = 9;
 

--- a/osu.Game/Models/RealmBeatmap.cs
+++ b/osu.Game/Models/RealmBeatmap.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Models
 
         public RealmBeatmapSet? BeatmapSet { get; set; }
 
+        [Ignored]
         public RealmNamedFileUsage? File => BeatmapSet?.Files.First(f => f.File.Hash == Hash);
 
         public BeatmapSetOnlineStatus Status

--- a/osu.Game/Models/RealmBeatmap.cs
+++ b/osu.Game/Models/RealmBeatmap.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Testing;
@@ -34,6 +35,8 @@ namespace osu.Game.Models
         public RealmBeatmapMetadata Metadata { get; set; } = null!;
 
         public RealmBeatmapSet? BeatmapSet { get; set; }
+
+        public RealmNamedFileUsage? File => BeatmapSet?.Files.First(f => f.File.Hash == Hash);
 
         public BeatmapSetOnlineStatus Status
         {


### PR DESCRIPTION
I started by adding a proper relation but that doesn't work because we're using `EmbeddedObject` for `RealmNamedFileInfo` (this enforces a 1:1 relationship). A helper property as per this PR should, in theory, suffice. As long as we update the hash to match the corresponding file.

Another way forward would be to not use `EmbeddedObject` and remove the `Hash` in `RealmBeatmap`, relying completely on the file. This might feel better, but it's a larger change that we can consider in the future.