### PR TITLE
Use `Ruleset`'s `ShortName` for mod caching purposes

### DIFF
--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -49,6 +49,10 @@ namespace osu.Game.Rulesets
         {
             get
             {
+                // Is the case for many test usages.
+                if (string.IsNullOrEmpty(ShortName))
+                    return CreateAllMods();
+
                 if (!mod_reference_cache.TryGetValue(ShortName, out var mods))
                     mod_reference_cache[ShortName] = mods = CreateAllMods().Cast<IMod>().ToArray();
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets
     {
         public RulesetInfo RulesetInfo { get; internal set; }
 
-        private static readonly ConcurrentDictionary<int, IMod[]> mod_reference_cache = new ConcurrentDictionary<int, IMod[]>();
+        private static readonly ConcurrentDictionary<string, IMod[]> mod_reference_cache = new ConcurrentDictionary<string, IMod[]>();
 
         /// <summary>
         /// A queryable source containing all available mods.
@@ -49,11 +49,8 @@ namespace osu.Game.Rulesets
         {
             get
             {
-                if (!(RulesetInfo.ID is int id))
-                    return CreateAllMods();
-
-                if (!mod_reference_cache.TryGetValue(id, out var mods))
-                    mod_reference_cache[id] = mods = CreateAllMods().Cast<IMod>().ToArray();
+                if (!mod_reference_cache.TryGetValue(ShortName, out var mods))
+                    mod_reference_cache[ShortName] = mods = CreateAllMods().Cast<IMod>().ToArray();
 
                 return mods;
             }


### PR DESCRIPTION
`OnlineID` is only present for legacy rulesets (for the time being). Going forward, `ShortName` is the unique identifier for mods.