### PR TITLE
Switch realm ruleset configuration to use ruleset's `ShortName` as key

### DIFF
--- a/osu.Game/Configuration/RealmRulesetSetting.cs
+++ b/osu.Game/Configuration/RealmRulesetSetting.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using osu.Game.Database;
 using Realms;
 
 #nullable enable
@@ -10,13 +8,10 @@ using Realms;
 namespace osu.Game.Configuration
 {
     [MapTo(@"RulesetSetting")]
-    public class RealmRulesetSetting : RealmObject, IHasGuidPrimaryKey
+    public class RealmRulesetSetting : RealmObject
     {
-        [PrimaryKey]
-        public Guid ID { get; set; } = Guid.NewGuid();
-
         [Indexed]
-        public int RulesetID { get; set; }
+        public string RulesetName { get; set; } = string.Empty;
 
         [Indexed]
         public int Variant { get; set; }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Database
         }
 
         private string? getRulesetShortNameFromLegacyID(long rulesetId) =>
-            efContextFactory?.Get().RulesetInfo.First(r => r.ID == rulesetId)?.ShortName;
+            efContextFactory?.Get().RulesetInfo.FirstOrDefault(r => r.ID == rulesetId)?.ShortName;
 
         /// <summary>
         /// Flush any active contexts and block any further writes.

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -11,6 +11,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
+using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
 using osu.Game.Models;
 using osu.Game.Rulesets;
@@ -40,8 +41,9 @@ namespace osu.Game.Database
         /// 7    2021-10-18    Changed OnlineID fields to non-nullable to add indexing support.
         /// 8    2021-10-29    Rebind scroll adjust keys to not have control modifier.
         /// 9    2021-11-04    Converted BeatmapMetadata.Author from string to RealmUser.
+        /// 10   2021-11-22    Use ShortName instead of RulesetID for ruleset settings.
         /// </summary>
-        private const int schema_version = 9;
+        private const int schema_version = 10;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking context creation during blocking periods.
@@ -234,6 +236,28 @@ namespace osu.Game.Database
                         {
                             Username = username
                         };
+                    }
+
+                    break;
+
+                case 10:
+                    string rulesetSettingClassName = getMappedOrOriginalName(typeof(RealmRulesetSetting));
+
+                    var oldSettings = migration.OldRealm.DynamicApi.All(rulesetSettingClassName);
+                    var newSettings = migration.NewRealm.All<RealmRulesetSetting>().ToList();
+
+                    for (int i = 0; i < newSettings.Count; i++)
+                    {
+                        dynamic? oldItem = oldSettings.ElementAt(i);
+                        var newItem = newSettings.ElementAt(i);
+
+                        long rulesetId = oldItem.RulesetID;
+                        string? rulesetName = rulesets?.GetRuleset((int)rulesetId)?.ShortName;
+
+                        if (string.IsNullOrEmpty(rulesetName))
+                            migration.NewRealm.Remove(newItem);
+                        else
+                            newItem.RulesetName = rulesetName;
                     }
 
                     break;

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -269,14 +269,8 @@ namespace osu.Game.Database
             }
         }
 
-        private string? getRulesetShortNameFromLegacyID(long rulesetId)
-        {
-            if (efContextFactory == null)
-                return null;
-
-            using (var efContext = efContextFactory.Get())
-                return efContext.RulesetInfo.First(r => r.ID == rulesetId)?.ShortName;
-        }
+        private string? getRulesetShortNameFromLegacyID(long rulesetId) =>
+            efContextFactory?.Get().RulesetInfo.First(r => r.ID == rulesetId)?.ShortName;
 
         /// <summary>
         /// Flush any active contexts and block any further writes.

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -33,10 +33,10 @@ namespace osu.Game.Database
 
         /// <summary>
         /// Version history:
-        /// 6  First tracked version (~20211018)
-        /// 7  Changed OnlineID fields to non-nullable to add indexing support (20211018)
-        /// 8  Rebind scroll adjust keys to not have control modifier (20211029)
-        /// 9  Converted BeatmapMetadata.Author from string to RealmUser (20211104)
+        /// 6    ~2021-10-18   First tracked version.
+        /// 7    2021-10-18    Changed OnlineID fields to non-nullable to add indexing support.
+        /// 8    2021-10-29    Rebind scroll adjust keys to not have control modifier.
+        /// 9    2021-11-04    Converted BeatmapMetadata.Author from string to RealmUser.
         /// </summary>
         private const int schema_version = 9;
 

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -49,8 +49,8 @@ namespace osu.Game.Database
         /// </summary>
         private readonly SemaphoreSlim contextCreationLock = new SemaphoreSlim(1);
 
-        private static readonly GlobalStatistic<int> refreshes = GlobalStatistics.Get<int>("Realm", "Dirty Refreshes");
-        private static readonly GlobalStatistic<int> contexts_created = GlobalStatistics.Get<int>("Realm", "Contexts (Created)");
+        private static readonly GlobalStatistic<int> refreshes = GlobalStatistics.Get<int>(@"Realm", @"Dirty Refreshes");
+        private static readonly GlobalStatistic<int> contexts_created = GlobalStatistics.Get<int>(@"Realm", @"Contexts (Created)");
 
         private readonly object contextLock = new object();
         private Realm? context;
@@ -60,14 +60,14 @@ namespace osu.Game.Database
             get
             {
                 if (!ThreadSafety.IsUpdateThread)
-                    throw new InvalidOperationException($"Use {nameof(CreateContext)} when performing realm operations from a non-update thread");
+                    throw new InvalidOperationException(@$"Use {nameof(CreateContext)} when performing realm operations from a non-update thread");
 
                 lock (contextLock)
                 {
                     if (context == null)
                     {
                         context = CreateContext();
-                        Logger.Log($"Opened realm \"{context.Config.DatabasePath}\" at version {context.Config.SchemaVersion}");
+                        Logger.Log(@$"Opened realm ""{context.Config.DatabasePath}"" at version {context.Config.SchemaVersion}");
                     }
 
                     // creating a context will ensure our schema is up-to-date and migrated.
@@ -76,6 +76,12 @@ namespace osu.Game.Database
             }
         }
 
+        /// <summary>
+        /// Construct a new instance of a realm context factory.
+        /// </summary>
+        /// <param name="storage">The game storage which will be used to create the realm backing file.</param>
+        /// <param name="filename">The filename to use for the realm backing file. A ".realm" extension will be added automatically if not specified.</param>
+        /// <param name="efContextFactory">An EF factory used only for migration purposes.</param>
         public RealmContextFactory(Storage storage, string filename, IDatabaseContextFactory? efContextFactory = null)
         {
             this.storage = storage;
@@ -83,7 +89,7 @@ namespace osu.Game.Database
 
             Filename = filename;
 
-            const string realm_extension = ".realm";
+            const string realm_extension = @".realm";
 
             if (!Filename.EndsWith(realm_extension, StringComparison.Ordinal))
                 Filename += realm_extension;
@@ -286,7 +292,7 @@ namespace osu.Game.Database
                 throw new ObjectDisposedException(nameof(RealmContextFactory));
 
             if (!ThreadSafety.IsUpdateThread)
-                throw new InvalidOperationException($"{nameof(BlockAllOperations)} must be called from the update thread.");
+                throw new InvalidOperationException(@$"{nameof(BlockAllOperations)} must be called from the update thread.");
 
             Logger.Log(@"Blocking realm operations.", LoggingTarget.Database);
 
@@ -310,7 +316,7 @@ namespace osu.Game.Database
                     timeout -= sleep_length;
 
                     if (timeout < 0)
-                        throw new TimeoutException("Took too long to acquire lock");
+                        throw new TimeoutException(@"Took too long to acquire lock");
                 }
             }
             catch

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -13,6 +13,7 @@ using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osu.Game.Input.Bindings;
 using osu.Game.Models;
+using osu.Game.Rulesets;
 using Realms;
 
 #nullable enable
@@ -30,6 +31,8 @@ namespace osu.Game.Database
         /// The filename of this realm.
         /// </summary>
         public readonly string Filename;
+
+        private readonly RulesetStore? rulesets;
 
         /// <summary>
         /// Version history:
@@ -72,9 +75,10 @@ namespace osu.Game.Database
             }
         }
 
-        public RealmContextFactory(Storage storage, string filename)
+        public RealmContextFactory(Storage storage, string filename, RulesetStore? rulesets = null)
         {
             this.storage = storage;
+            this.rulesets = rulesets;
 
             Filename = filename;
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -192,7 +192,7 @@ namespace osu.Game
 
             dependencies.Cache(RulesetStore = new RulesetStore(contextFactory, Storage));
 
-            dependencies.Cache(realmFactory = new RealmContextFactory(Storage, "client", RulesetStore));
+            dependencies.Cache(realmFactory = new RealmContextFactory(Storage, "client", contextFactory));
 
             dependencies.CacheAs(Storage);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -187,8 +187,9 @@ namespace osu.Game
             Resources.AddStore(new DllResourceStore(OsuResources.ResourceAssembly));
 
             dependencies.Cache(contextFactory = new DatabaseContextFactory(Storage));
+            dependencies.Cache(RulesetStore = new RulesetStore(contextFactory, Storage));
 
-            dependencies.Cache(realmFactory = new RealmContextFactory(Storage, "client"));
+            dependencies.Cache(realmFactory = new RealmContextFactory(Storage, "client", RulesetStore));
 
             dependencies.CacheAs(Storage);
 
@@ -227,7 +228,6 @@ namespace osu.Game
 
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 
-            dependencies.Cache(RulesetStore = new RulesetStore(contextFactory, Storage));
             dependencies.Cache(fileStore = new FileStore(contextFactory, Storage));
 
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -187,6 +187,9 @@ namespace osu.Game
             Resources.AddStore(new DllResourceStore(OsuResources.ResourceAssembly));
 
             dependencies.Cache(contextFactory = new DatabaseContextFactory(Storage));
+
+            runMigrations();
+
             dependencies.Cache(RulesetStore = new RulesetStore(contextFactory, Storage));
 
             dependencies.Cache(realmFactory = new RealmContextFactory(Storage, "client", RulesetStore));
@@ -203,8 +206,6 @@ namespace osu.Game
             InitialiseFonts();
 
             Audio.Samples.PlaybackConcurrency = SAMPLE_CONCURRENCY;
-
-            runMigrations();
 
             dependencies.Cache(SkinManager = new SkinManager(Storage, contextFactory, Host, Resources, Audio));
             dependencies.CacheAs<ISkinSource>(SkinManager);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -456,7 +456,8 @@ namespace osu.Game
                         {
                             Key = dkb.Key,
                             Value = dkb.StringValue,
-                            RulesetID = dkb.RulesetID.Value,
+                            // important: this RulesetStore must be the EF one.
+                            RulesetName = RulesetStore.GetRuleset(dkb.RulesetID.Value).ShortName,
                             Variant = dkb.Variant ?? 0,
                         });
                     }

--- a/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
+++ b/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
@@ -20,16 +20,13 @@ namespace osu.Game.Rulesets.Configuration
 
         private List<RealmRulesetSetting> databasedSettings = new List<RealmRulesetSetting>();
 
-        private readonly int rulesetId;
+        private readonly string rulesetName;
 
         protected RulesetConfigManager(SettingsStore store, RulesetInfo ruleset, int? variant = null)
         {
             realmFactory = store?.Realm;
 
-            if (realmFactory != null && !ruleset.ID.HasValue)
-                throw new InvalidOperationException("Attempted to add databased settings for a non-databased ruleset");
-
-            rulesetId = ruleset.ID ?? -1;
+            rulesetName = ruleset.ShortName;
 
             this.variant = variant ?? 0;
 
@@ -43,7 +40,7 @@ namespace osu.Game.Rulesets.Configuration
             if (realmFactory != null)
             {
                 // As long as RulesetConfigCache exists, there is no need to subscribe to realm events.
-                databasedSettings = realmFactory.Context.All<RealmRulesetSetting>().Where(b => b.RulesetID == rulesetId && b.Variant == variant).ToList();
+                databasedSettings = realmFactory.Context.All<RealmRulesetSetting>().Where(b => b.RulesetName == rulesetName && b.Variant == variant).ToList();
             }
         }
 
@@ -68,7 +65,7 @@ namespace osu.Game.Rulesets.Configuration
                 {
                     foreach (var c in changed)
                     {
-                        var setting = realm.All<RealmRulesetSetting>().First(s => s.RulesetID == rulesetId && s.Variant == variant && s.Key == c.ToString());
+                        var setting = realm.All<RealmRulesetSetting>().First(s => s.RulesetName == rulesetName && s.Variant == variant && s.Key == c.ToString());
 
                         setting.Value = ConfigStore[c].ToString();
                     }
@@ -94,7 +91,7 @@ namespace osu.Game.Rulesets.Configuration
                 {
                     Key = lookup.ToString(),
                     Value = bindable.Value.ToString(),
-                    RulesetID = rulesetId,
+                    RulesetName = rulesetName,
                     Variant = variant,
                 };
 


### PR DESCRIPTION
- [x] Depends on #15739.

Not sure whether we should use `ShortName` or a full relation with `RealmRuleset`. Can revisit in the future if required.

Unfortunate to have to pass in the `RulesetStore`. If only it was static..