### PR TITLE
Switch realm ruleset key bindings to use ruleset's `ShortName` as key

### DIFF
--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -42,8 +42,9 @@ namespace osu.Game.Database
         /// 8    2021-10-29    Rebind scroll adjust keys to not have control modifier.
         /// 9    2021-11-04    Converted BeatmapMetadata.Author from string to RealmUser.
         /// 10   2021-11-22    Use ShortName instead of RulesetID for ruleset settings.
+        /// 11   2021-11-22    Use ShortName instead of RulesetID for ruleset key bindings.
         /// </summary>
-        private const int schema_version = 10;
+        private const int schema_version = 11;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking context creation during blocking periods.
@@ -252,6 +253,33 @@ namespace osu.Game.Database
                         var newItem = newSettings.ElementAt(i);
 
                         long rulesetId = oldItem.RulesetID;
+                        string? rulesetName = rulesets?.GetRuleset((int)rulesetId)?.ShortName;
+
+                        if (string.IsNullOrEmpty(rulesetName))
+                            migration.NewRealm.Remove(newItem);
+                        else
+                            newItem.RulesetName = rulesetName;
+                    }
+
+                    break;
+
+                case 11:
+
+                    string keyBindingClassName = getMappedOrOriginalName(typeof(RealmKeyBinding));
+
+                    var oldKeyBindings = migration.OldRealm.DynamicApi.All(keyBindingClassName);
+                    var newKeyBindings = migration.NewRealm.All<RealmKeyBinding>().ToList();
+
+                    for (int i = 0; i < newKeyBindings.Count; i++)
+                    {
+                        dynamic? oldItem = oldKeyBindings.ElementAt(i);
+                        var newItem = newKeyBindings.ElementAt(i);
+
+                        if (oldItem.RulesetID == null)
+                            continue;
+
+                        long rulesetId = oldItem.RulesetID;
+
                         string? rulesetName = rulesets?.GetRuleset((int)rulesetId)?.ShortName;
 
                         if (string.IsNullOrEmpty(rulesetName))

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -269,7 +269,6 @@ namespace osu.Game.Database
                     break;
 
                 case 11:
-
                     string keyBindingClassName = getMappedOrOriginalName(typeof(RealmKeyBinding));
 
                     var oldKeyBindings = migration.OldRealm.DynamicApi.All(keyBindingClassName);

--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -50,23 +50,20 @@ namespace osu.Game.Input.Bindings
 
         protected override void LoadComplete()
         {
-            if (ruleset == null || ruleset.ID.HasValue)
-            {
-                int? rulesetId = ruleset?.ID;
+            string rulesetName = ruleset?.ShortName;
 
-                realmKeyBindings = realmFactory.Context.All<RealmKeyBinding>()
-                                               .Where(b => b.RulesetID == rulesetId && b.Variant == variant);
+            realmKeyBindings = realmFactory.Context.All<RealmKeyBinding>()
+                                           .Where(b => b.RulesetName == rulesetName && b.Variant == variant);
 
-                realmSubscription = realmKeyBindings
-                    .SubscribeForNotifications((sender, changes, error) =>
-                    {
-                        // first subscription ignored as we are handling this in LoadComplete.
-                        if (changes == null)
-                            return;
+            realmSubscription = realmKeyBindings
+                .SubscribeForNotifications((sender, changes, error) =>
+                {
+                    // first subscription ignored as we are handling this in LoadComplete.
+                    if (changes == null)
+                        return;
 
-                        ReloadMappings();
-                    });
-            }
+                    ReloadMappings();
+                });
 
             base.LoadComplete();
         }

--- a/osu.Game/Input/Bindings/RealmKeyBinding.cs
+++ b/osu.Game/Input/Bindings/RealmKeyBinding.cs
@@ -6,6 +6,8 @@ using osu.Framework.Input.Bindings;
 using osu.Game.Database;
 using Realms;
 
+#nullable enable
+
 namespace osu.Game.Input.Bindings
 {
     [MapTo(nameof(KeyBinding))]
@@ -14,7 +16,7 @@ namespace osu.Game.Input.Bindings
         [PrimaryKey]
         public Guid ID { get; set; } = Guid.NewGuid();
 
-        public int? RulesetID { get; set; }
+        public string? RulesetName { get; set; }
 
         public int? Variant { get; set; }
 
@@ -34,6 +36,6 @@ namespace osu.Game.Input.Bindings
         public int ActionInt { get; set; }
 
         [MapTo(nameof(KeyCombination))]
-        public string KeyCombinationString { get; set; }
+        public string KeyCombinationString { get; set; } = string.Empty;
     }
 }

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Input
 
             using (var context = realmFactory.CreateContext())
             {
-                foreach (var action in context.All<RealmKeyBinding>().Where(b => b.RulesetID == null && (GlobalAction)b.ActionInt == globalAction))
+                foreach (var action in context.All<RealmKeyBinding>().Where(b => string.IsNullOrEmpty(b.RulesetName) && (GlobalAction)b.ActionInt == globalAction))
                 {
                     string str = keyCombinationProvider.GetReadableString(action.KeyCombination);
 
@@ -69,20 +69,20 @@ namespace osu.Game.Input
                 {
                     var instance = ruleset.CreateInstance();
                     foreach (int variant in instance.AvailableVariants)
-                        insertDefaults(realm, existingBindings, instance.GetDefaultKeyBindings(variant), ruleset.ID, variant);
+                        insertDefaults(realm, existingBindings, instance.GetDefaultKeyBindings(variant), ruleset.ShortName, variant);
                 }
 
                 transaction.Commit();
             }
         }
 
-        private void insertDefaults(Realm realm, List<RealmKeyBinding> existingBindings, IEnumerable<IKeyBinding> defaults, int? rulesetId = null, int? variant = null)
+        private void insertDefaults(Realm realm, List<RealmKeyBinding> existingBindings, IEnumerable<IKeyBinding> defaults, string? rulesetName = null, int? variant = null)
         {
             // compare counts in database vs defaults for each action type.
             foreach (var defaultsForAction in defaults.GroupBy(k => k.Action))
             {
                 // avoid performing redundant queries when the database is empty and needs to be re-filled.
-                int existingCount = existingBindings.Count(k => k.RulesetID == rulesetId && k.Variant == variant && k.ActionInt == (int)defaultsForAction.Key);
+                int existingCount = existingBindings.Count(k => k.RulesetName == rulesetName && k.Variant == variant && k.ActionInt == (int)defaultsForAction.Key);
 
                 if (defaultsForAction.Count() <= existingCount)
                     continue;
@@ -92,7 +92,7 @@ namespace osu.Game.Input
                 {
                     KeyCombinationString = k.KeyCombination.ToString(),
                     ActionInt = (int)k.Action,
-                    RulesetID = rulesetId,
+                    RulesetName = rulesetName,
                     Variant = variant
                 }));
             }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -524,7 +524,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             public void UpdateKeyCombination(KeyCombination newCombination)
             {
-                if (KeyBinding.RulesetID != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
+                if (KeyBinding.RulesetName != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
                     return;
 
                 KeyBinding.KeyCombination = newCombination;

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -32,12 +32,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         [BackgroundDependencyLoader]
         private void load(RealmContextFactory realmFactory)
         {
-            int? rulesetId = Ruleset?.ID;
+            string rulesetName = Ruleset?.ShortName;
 
             List<RealmKeyBinding> bindings;
 
             using (var realm = realmFactory.CreateContext())
-                bindings = realm.All<RealmKeyBinding>().Where(b => b.RulesetID == rulesetId && b.Variant == variant).Detach();
+                bindings = realm.All<RealmKeyBinding>().Where(b => b.RulesetName == rulesetName && b.Variant == variant).Detach();
 
             foreach (var defaultGroup in Defaults.GroupBy(d => d.Action))
             {

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -207,7 +207,7 @@ namespace osu.Game.Overlays.Toolbar
         {
             if (Hotkey == null) return;
 
-            var realmKeyBinding = realmFactory.Context.All<RealmKeyBinding>().FirstOrDefault(rkb => rkb.RulesetID == null && rkb.ActionInt == (int)Hotkey.Value);
+            var realmKeyBinding = realmFactory.Context.All<RealmKeyBinding>().FirstOrDefault(rkb => rkb.RulesetName == null && rkb.ActionInt == (int)Hotkey.Value);
 
             if (realmKeyBinding != null)
             {


### PR DESCRIPTION
- [x] Depends on #15740.

Not sure whether we should use `ShortName` or a full relation with `RealmRuleset`. Can revisit in the future if required.