### PR TITLE
Fix crashes on trying to play back replays of seeded mods with seed value over 1 billion

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsNumberBox.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsNumberBox.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Settings
             currentValueIs(int.MaxValue);
             currentTextIs(int.MaxValue.ToString());
 
-            inputText((long)int.MaxValue + 1.ToString());
+            inputText(smallestOverflowValue.ToString());
             currentValueIs(int.MaxValue);
             currentTextIs(int.MaxValue.ToString());
 
@@ -74,5 +74,10 @@ namespace osu.Game.Tests.Visual.Settings
         private void inputText(string text) => AddStep($"set textbox text to {text}", () => textBox.Text = text);
         private void currentValueIs(int? value) => AddAssert($"current value is {value?.ToString() ?? "null"}", () => numberBox.Current.Value == value);
         private void currentTextIs(string value) => AddAssert($"current text is {value}", () => textBox.Text == value);
+
+        /// <summary>
+        /// The smallest number that overflows <see langword="int"/>.
+        /// </summary>
+        private static long smallestOverflowValue => 1L + int.MaxValue;
     }
 }

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsNumberBox.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsNumberBox.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Tests.Visual.Settings
+{
+    public class TestSceneSettingsNumberBox : OsuTestScene
+    {
+        [Test]
+        public void TestLargeInteger()
+        {
+            SettingsNumberBox numberBox = null;
+
+            AddStep("create number box", () => Child = numberBox = new SettingsNumberBox());
+
+            AddStep("set value to 1,000,000,000", () => numberBox.Current.Value = 1_000_000_000);
+            AddAssert("text box text is correct", () => numberBox.ChildrenOfType<OsuTextBox>().Single().Current.Value == "1000000000");
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsNumberBox.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsNumberBox.cs
@@ -11,15 +11,68 @@ namespace osu.Game.Tests.Visual.Settings
 {
     public class TestSceneSettingsNumberBox : OsuTestScene
     {
+        private SettingsNumberBox numberBox;
+        private OsuTextBox textBox;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create number box", () => Child = numberBox = new SettingsNumberBox());
+            AddStep("get inner text box", () => textBox = numberBox.ChildrenOfType<OsuTextBox>().Single());
+        }
+
         [Test]
         public void TestLargeInteger()
         {
-            SettingsNumberBox numberBox = null;
-
-            AddStep("create number box", () => Child = numberBox = new SettingsNumberBox());
-
-            AddStep("set value to 1,000,000,000", () => numberBox.Current.Value = 1_000_000_000);
-            AddAssert("text box text is correct", () => numberBox.ChildrenOfType<OsuTextBox>().Single().Current.Value == "1000000000");
+            AddStep("set current to 1,000,000,000", () => numberBox.Current.Value = 1_000_000_000);
+            AddAssert("text box text is correct", () => textBox.Text == "1000000000");
         }
+
+        [Test]
+        public void TestUserInput()
+        {
+            inputText("42");
+            currentValueIs(42);
+            currentTextIs("42");
+
+            inputText(string.Empty);
+            currentValueIs(null);
+            currentTextIs(string.Empty);
+
+            inputText("555");
+            currentValueIs(555);
+            currentTextIs("555");
+
+            inputText("-4444");
+            // attempting to input the minus will raise an input error, the rest will pass through fine.
+            currentValueIs(4444);
+            currentTextIs("4444");
+
+            // checking the upper bound.
+            inputText(int.MaxValue.ToString());
+            currentValueIs(int.MaxValue);
+            currentTextIs(int.MaxValue.ToString());
+
+            inputText((long)int.MaxValue + 1.ToString());
+            currentValueIs(int.MaxValue);
+            currentTextIs(int.MaxValue.ToString());
+
+            inputText("0");
+            currentValueIs(0);
+            currentTextIs("0");
+
+            // checking that leading zeroes are stripped.
+            inputText("00");
+            currentValueIs(0);
+            currentTextIs("0");
+
+            inputText("01");
+            currentValueIs(1);
+            currentTextIs("1");
+        }
+
+        private void inputText(string text) => AddStep($"set textbox text to {text}", () => textBox.Text = text);
+        private void currentValueIs(int? value) => AddAssert($"current value is {value?.ToString() ?? "null"}", () => numberBox.Current.Value == value);
+        private void currentTextIs(string value) => AddAssert($"current text is {value}", () => textBox.Text == value);
     }
 }

--- a/osu.Game/Overlays/Settings/SettingsNumberBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsNumberBox.cs
@@ -35,7 +35,6 @@ namespace osu.Game.Overlays.Settings
                 {
                     numberBox = new OutlinedNumberBox
                     {
-                        LengthLimit = 9, // limited to less than a value that could overflow int32 backing.
                         Margin = new MarginPadding { Top = 5 },
                         RelativeSizeAxes = Axes.X,
                         CommitOnFocusLost = true
@@ -44,12 +43,19 @@ namespace osu.Game.Overlays.Settings
 
                 numberBox.Current.BindValueChanged(e =>
                 {
-                    int? value = null;
+                    if (string.IsNullOrEmpty(e.NewValue))
+                    {
+                        Current.Value = null;
+                        return;
+                    }
 
                     if (int.TryParse(e.NewValue, out int intVal))
-                        value = intVal;
+                        Current.Value = intVal;
+                    else
+                        numberBox.NotifyInputError();
 
-                    current.Value = value;
+                    // trigger Current again to either restore the previous text box value, or to reformat the new value via .ToString().
+                    Current.TriggerChange();
                 });
 
                 Current.BindValueChanged(e =>
@@ -62,6 +68,8 @@ namespace osu.Game.Overlays.Settings
         private class OutlinedNumberBox : OutlinedTextBox
         {
             protected override bool CanAddCharacter(char character) => char.IsNumber(character);
+
+            public new void NotifyInputError() => base.NotifyInputError();
         }
     }
 }


### PR DESCRIPTION
This is a proposal of a fix for #15744.

The cause of the crash was a stack overflow, caused by the "maximum 9 digits" spec on `SettingsNumberBox`. If a value technically within `int` bounds, but larger than 1 billion (in the range [1,000,000,000; 2,147,483,647], to be more precise), a feedback loop between the setting control's `Current` and its inner text box's `Current` would occur, wherein the last digit would be trimmed and then re-appended again forevermore.

While users could not set such a seed value themselves manually via the text box, such a value could be randomly generated if the user did not specify an explicit seed:

https://github.com/ppy/osu/blob/7ce5cb61621579a142cb45741c968e68ce7ed502/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs#L43

Therefore, the reproduction steps would be:

1. Activate random mod
2. Do not set seed manually
3. Exit in and out of player loader until a seed value >1 billion is automatically picked by the mod (shouldn't take long, statistically the chance is >50%)
4. Complete a play with such a seed and attempt to view the replay of it.

The reason why I didn't just clamp that to 1 billion is the fact that there are existing plays and replays with such a value. So while I *could* clamp, that would irretrievably break those recorded replays, which seems radical and unnecessary since the text box can just be fixed to work.

In order to resolve, the offending spec is removed and `int.TryParse` is used alone to be able to discern overflow range. Additionally, UX of the text box is slightly changed to notify when the `int` range is exceeded with a red flash.

This behaviour would not have been possible to implement without recent framework-side fixes to text box (removal of text set scheduling).