### PR TITLE
Rename `Debug` namespace to avoid collisions

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -5,7 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Localisation;
-using osu.Game.Overlays.Settings.Sections.Debug;
+using osu.Game.Overlays.Settings.Sections.DebugSettings;
 
 namespace osu.Game.Overlays.Settings.Sections
 {

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -9,7 +9,7 @@ using osu.Framework.Screens;
 using osu.Game.Localisation;
 using osu.Game.Screens.Import;
 
-namespace osu.Game.Overlays.Settings.Sections.Debug
+namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public class GeneralSettings : SettingsSubsection
     {

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -8,7 +8,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Localisation;
 
-namespace osu.Game.Overlays.Settings.Sections.Debug
+namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public class MemorySettings : SettingsSubsection
     {


### PR DESCRIPTION
I like to be able to use `Debug.Assert` without being required to include the full namespace qualification.