### PR TITLE
Move realm data migrations inside the `RealmContextFactory`

### DIFF
--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -96,6 +96,9 @@ namespace osu.Game.Database
                 Filename += realm_extension;
 
             cleanupPendingDeletions();
+
+            // run after the above operation to ensure realm is already in a good (fully migrated) state.
+            migrateDataFromEF();
         }
 
         private void cleanupPendingDeletions()
@@ -161,6 +164,54 @@ namespace osu.Game.Database
                 SchemaVersion = schema_version,
                 MigrationCallback = onMigration,
             };
+        }
+
+        private void migrateDataFromEF()
+        {
+            if (efContextFactory == null)
+                return;
+
+            using (var db = efContextFactory.GetForWrite())
+            {
+                // migrate ruleset settings. can be removed 20220315.
+                var existingSettings = db.Context.DatabasedSetting;
+
+                // previous entries in EF are removed post migration.
+                if (!existingSettings.Any())
+                    return;
+
+                using (var realm = CreateContext())
+                using (var transaction = realm.BeginWrite())
+                {
+                    // only migrate data if the realm database is empty.
+                    if (!realm.All<RealmRulesetSetting>().Any())
+                    {
+                        foreach (var dkb in existingSettings)
+                        {
+                            if (dkb.RulesetID == null)
+                                continue;
+
+                            string? shortName = getRulesetShortNameFromLegacyID(dkb.RulesetID.Value);
+
+                            if (string.IsNullOrEmpty(shortName))
+                                continue;
+
+                            realm.Add(new RealmRulesetSetting
+                            {
+                                Key = dkb.Key,
+                                Value = dkb.StringValue,
+                                // important: this RulesetStore must be the EF one.
+                                RulesetName = shortName,
+                                Variant = dkb.Variant ?? 0,
+                            });
+                        }
+                    }
+
+                    db.Context.RemoveRange(existingSettings);
+
+                    transaction.Commit();
+                }
+            }
         }
 
         private void onMigration(Migration migration, ulong lastSchemaVersion)

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -95,9 +95,11 @@ namespace osu.Game.Database
             if (!Filename.EndsWith(realm_extension, StringComparison.Ordinal))
                 Filename += realm_extension;
 
+            // This method triggers the first `CreateContext` call, which will implicitly run realm migrations and bring the schema up-to-date.
             cleanupPendingDeletions();
 
-            // run after the above operation to ensure realm is already in a good (fully migrated) state.
+            // Data migration is handled separately from schema migrations.
+            // This is required as the user may be initialising realm for the first time ever, which would result in no schema migrations running.
             migrateDataFromEF();
         }
 

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -200,7 +200,6 @@ namespace osu.Game.Database
                             {
                                 Key = dkb.Key,
                                 Value = dkb.StringValue,
-                                // important: this RulesetStore must be the EF one.
                                 RulesetName = shortName,
                                 Variant = dkb.Variant ?? 0,
                             });

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -262,8 +262,6 @@ namespace osu.Game
             dependencies.Cache(scorePerformanceManager);
             AddInternal(scorePerformanceManager);
 
-            migrateDataToRealm();
-
             dependencies.Cache(rulesetConfigCache = new RulesetConfigCache(realmFactory, RulesetStore));
 
             var powerStatus = CreateBatteryInfo();
@@ -439,35 +437,6 @@ namespace osu.Game
 
         private void migrateDataToRealm()
         {
-            using (var db = contextFactory.GetForWrite())
-            using (var realm = realmFactory.CreateContext())
-            using (var transaction = realm.BeginWrite())
-            {
-                // migrate ruleset settings. can be removed 20220315.
-                var existingSettings = db.Context.DatabasedSetting;
-
-                // only migrate data if the realm database is empty.
-                if (!realm.All<RealmRulesetSetting>().Any())
-                {
-                    foreach (var dkb in existingSettings)
-                    {
-                        if (dkb.RulesetID == null) continue;
-
-                        realm.Add(new RealmRulesetSetting
-                        {
-                            Key = dkb.Key,
-                            Value = dkb.StringValue,
-                            // important: this RulesetStore must be the EF one.
-                            RulesetName = RulesetStore.GetRuleset(dkb.RulesetID.Value).ShortName,
-                            Variant = dkb.Variant ?? 0,
-                        });
-                    }
-                }
-
-                db.Context.RemoveRange(existingSettings);
-
-                transaction.Commit();
-            }
         }
 
         private void onRulesetChanged(ValueChangedEvent<RulesetInfo> r)

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -311,6 +311,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AABB/@EntryIndexedValue">AABB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=API/@EntryIndexedValue">API</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BPM/@EntryIndexedValue">BPM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EF/@EntryIndexedValue">EF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FPS/@EntryIndexedValue">FPS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GC/@EntryIndexedValue">GC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GL/@EntryIndexedValue">GL</s:String>


### PR DESCRIPTION
Feels like a better location. Can also use the helper method to centralise the ruleset lookup logic. Will become more important as we begin to migrate more data across.

I've tested this manually with an empty and non-empty realm database (and ensured that settings still do migrate as expected).

- [x] Depends on https://github.com/ppy/osu/pull/15741.