### PR TITLE
enable/disable showing followpoints

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
             SetDefault(OsuRulesetSetting.SnakingInSliders, true);
             SetDefault(OsuRulesetSetting.SnakingOutSliders, true);
             SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
+            SetDefault(OsuRulesetSetting.ShowFollowpoints, true);
             SetDefault(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
         }
     }
@@ -29,6 +30,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
         SnakingInSliders,
         SnakingOutSliders,
         ShowCursorTrail,
+        ShowFollowpoints,
         PlayfieldBorderStyle,
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Pooling;
+using osu.Game.Rulesets.Osu.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
@@ -22,12 +23,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         private DrawablePool<FollowPointConnection> connectionPool;
         private DrawablePool<FollowPoint> pointPool;
 
+        private readonly Bindable<bool> showFollowpoints = new Bindable<bool>(true);
+
         private readonly List<FollowPointLifetimeEntry> lifetimeEntries = new List<FollowPointLifetimeEntry>();
         private readonly Dictionary<HitObject, IBindable> startTimeMap = new Dictionary<HitObject, IBindable>();
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager rulesetConfig)
         {
+            rulesetConfig?.BindWith(OsuRulesetSetting.ShowFollowpoints, showFollowpoints);
+
             InternalChildren = new Drawable[]
             {
                 connectionPool = new DrawablePool<FollowPointConnection>(1, 200),
@@ -37,6 +42,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
         public void AddFollowPoints(OsuHitObject hitObject)
         {
+            if (showFollowpoints.Value == false)
+                return;
+
             addEntry(hitObject);
 
             var startTimeBindable = hitObject.StartTimeBindable.GetBoundCopy();
@@ -46,6 +54,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
         public void RemoveFollowPoints(OsuHitObject hitObject)
         {
+            if (showFollowpoints.Value == false)
+                return;
+
             removeEntry(hitObject);
 
             startTimeMap[hitObject].UnbindAll();

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -41,6 +41,11 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Cursor trail",
                     Current = config.GetBindable<bool>(OsuRulesetSetting.ShowCursorTrail)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Followpoints",
+                    Current = config.GetBindable<bool>(OsuRulesetSetting.ShowFollowpoints)
+                },
                 new SettingsEnumDropdown<PlayfieldBorderStyle>
                 {
                     LabelText = "Playfield border style",


### PR DESCRIPTION
Similar to "show cursor trail" option 

![Showcase](https://i.imgur.com/naLGya6.png)

I used to have a lot of the same copies of the skin only to delete followpoints, so I thought this could be a nice quality of life improvement.

Unfortunately this way doesn't allow followpoints to be toggled "on the fly" during gameplay (as cursor trail can be).