### PR TITLE
Add preview track playback function to beatmap card

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
@@ -23,6 +23,11 @@ namespace osu.Game.Tests.Visual.Beatmaps
 {
     public class TestSceneBeatmapCard : OsuTestScene
     {
+        /// <summary>
+        /// All cards on this scene use a common online ID to ensure that map download, preview tracks, etc. can be tested manually with online sources.
+        /// </summary>
+        private const int online_id = 163112;
+
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
         private APIBeatmapSet[] testCases;
@@ -38,7 +43,6 @@ namespace osu.Game.Tests.Visual.Beatmaps
             var normal = CreateAPIBeatmapSet(Ruleset.Value);
             normal.HasVideo = true;
             normal.HasStoryboard = true;
-            normal.OnlineID = 241526;
 
             var withStatistics = CreateAPIBeatmapSet(Ruleset.Value);
             withStatistics.Title = withStatistics.TitleUnicode = "play favourite stats";
@@ -106,6 +110,9 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 explicitFeaturedMap,
                 longName
             };
+
+            foreach (var testCase in testCases)
+                testCase.OnlineID = online_id;
         }
 
         private APIBeatmapSet getUndownloadableBeatmapSet() => new APIBeatmapSet
@@ -191,9 +198,9 @@ namespace osu.Game.Tests.Visual.Beatmaps
         private void ensureSoleilyRemoved()
         {
             AddUntilStep("ensure manager loaded", () => beatmaps != null);
-            AddStep("remove soleily", () =>
+            AddStep("remove map", () =>
             {
-                var beatmap = beatmaps.QueryBeatmapSet(b => b.OnlineID == 241526);
+                var beatmap = beatmaps.QueryBeatmapSet(b => b.OnlineID == online_id);
 
                 if (beatmap != null) beatmaps.Delete(beatmap);
             });

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
@@ -27,11 +27,17 @@ namespace osu.Game.Tests.Visual.Beatmaps
         {
             BeatmapCardThumbnail thumbnail = null;
 
-            AddStep("create thumbnail", () => Child = thumbnail = new BeatmapCardThumbnail(CreateAPIBeatmapSet(Ruleset.Value))
+            AddStep("create thumbnail", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Size = new Vector2(200)
+                var beatmapSet = CreateAPIBeatmapSet(Ruleset.Value);
+                beatmapSet.OnlineID = 241526; // ID hardcoded to ensure that the preview track exists online.
+
+                Child = thumbnail = new BeatmapCardThumbnail(beatmapSet)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(200)
+                };
             });
             AddStep("enable dim", () => thumbnail.Dimmed.Value = true);
             AddUntilStep("button visible", () => playButton.IsPresent);

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
@@ -1,17 +1,24 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Beatmaps.Drawables.Cards.Buttons;
 using osu.Game.Overlays;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Beatmaps
 {
-    public class TestSceneBeatmapCardThumbnail : OsuTestScene
+    public class TestSceneBeatmapCardThumbnail : OsuManualInputManagerTestScene
     {
+        private PlayButton playButton => this.ChildrenOfType<PlayButton>().Single();
+
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
@@ -26,7 +33,38 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 Origin = Anchor.Centre,
                 Size = new Vector2(200)
             });
-            AddToggleStep("toggle dim", dimmed => thumbnail.Dimmed.Value = dimmed);
+            AddStep("enable dim", () => thumbnail.Dimmed.Value = true);
+            AddUntilStep("button visible", () => playButton.IsPresent);
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(playButton);
+                InputManager.Click(MouseButton.Left);
+            });
+            iconIs(FontAwesome.Solid.Stop);
+
+            AddStep("click again", () =>
+            {
+                InputManager.MoveMouseTo(playButton);
+                InputManager.Click(MouseButton.Left);
+            });
+            iconIs(FontAwesome.Solid.Play);
+
+            AddStep("click again", () =>
+            {
+                InputManager.MoveMouseTo(playButton);
+                InputManager.Click(MouseButton.Left);
+            });
+            iconIs(FontAwesome.Solid.Stop);
+
+            AddStep("disable dim", () => thumbnail.Dimmed.Value = false);
+            AddWaitStep("wait some", 3);
+            AddAssert("button still visible", () => playButton.IsPresent);
+
+            AddStep("end track playback", () => playButton.Playing.Value = false);
+            AddUntilStep("button hidden", () => !playButton.IsPresent);
         }
+
+        private void iconIs(IconUsage usage) => AddAssert("icon is correct", () => playButton.ChildrenOfType<SpriteIcon>().Single().Icon.Equals(usage));
     }
 }

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 InputManager.MoveMouseTo(playButton);
                 InputManager.Click(MouseButton.Left);
             });
+            AddUntilStep("wait for start", () => playButton.Playing.Value && playButton.Enabled.Value);
             iconIs(FontAwesome.Solid.Stop);
 
             AddStep("click again", () =>
@@ -48,6 +49,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 InputManager.MoveMouseTo(playButton);
                 InputManager.Click(MouseButton.Left);
             });
+            AddUntilStep("wait for stop", () => !playButton.Playing.Value && playButton.Enabled.Value);
             iconIs(FontAwesome.Solid.Play);
 
             AddStep("click again", () =>
@@ -55,16 +57,17 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 InputManager.MoveMouseTo(playButton);
                 InputManager.Click(MouseButton.Left);
             });
+            AddUntilStep("wait for start", () => playButton.Playing.Value && playButton.Enabled.Value);
             iconIs(FontAwesome.Solid.Stop);
 
             AddStep("disable dim", () => thumbnail.Dimmed.Value = false);
             AddWaitStep("wait some", 3);
             AddAssert("button still visible", () => playButton.IsPresent);
 
-            AddStep("end track playback", () => playButton.Playing.Value = false);
+            AddUntilStep("wait for track to end", () => !playButton.Playing.Value);
             AddUntilStep("button hidden", () => !playButton.IsPresent);
         }
 
-        private void iconIs(IconUsage usage) => AddAssert("icon is correct", () => playButton.ChildrenOfType<SpriteIcon>().Single().Icon.Equals(usage));
+        private void iconIs(IconUsage usage) => AddUntilStep("icon is correct", () => playButton.ChildrenOfType<SpriteIcon>().Any(icon => icon.Icon.Equals(usage)));
     }
 }

--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Beatmaps
+{
+    public class TestSceneBeatmapCardThumbnail : OsuTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
+        [Test]
+        public void TestThumbnailPreview()
+        {
+            BeatmapCardThumbnail thumbnail = null;
+
+            AddStep("create thumbnail", () => Child = thumbnail = new BeatmapCardThumbnail(CreateAPIBeatmapSet(Ruleset.Value))
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(200)
+            });
+            AddToggleStep("toggle dim", dimmed => thumbnail.Dimmed.Value = dimmed);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -23,7 +23,6 @@ using osu.Game.Overlays.BeatmapSet;
 using osuTK;
 using osu.Game.Overlays.BeatmapListing.Panels;
 using osu.Game.Resources.Localisation.Web;
-using osuTK.Graphics;
 using DownloadButton = osu.Game.Beatmaps.Drawables.Cards.Buttons.DownloadButton;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
@@ -42,7 +41,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         private readonly BeatmapDownloadTracker downloadTracker;
 
-        private UpdateableOnlineBeatmapSetCover leftCover;
+        private BeatmapCardThumbnail thumbnail;
         private FillFlowContainer leftIconArea;
 
         private Container rightAreaBackground;
@@ -98,24 +97,16 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                         Colour = Colour4.White
                     },
                 },
-                new Container
+                thumbnail = new BeatmapCardThumbnail(beatmapSet)
                 {
                     Name = @"Left (icon) area",
                     Size = new Vector2(height),
-                    Children = new Drawable[]
+                    Child = leftIconArea = new FillFlowContainer
                     {
-                        leftCover = new UpdateableOnlineBeatmapSetCover(BeatmapSetCoverType.List)
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            OnlineInfo = beatmapSet
-                        },
-                        leftIconArea = new FillFlowContainer
-                        {
-                            Margin = new MarginPadding(5),
-                            AutoSizeAxes = Axes.Both,
-                            Direction = FillDirection.Horizontal,
-                            Spacing = new Vector2(1)
-                        }
+                        Margin = new MarginPadding(5),
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(1)
                     }
                 },
                 new Container
@@ -395,10 +386,11 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             if (IsHovered)
                 targetWidth = targetWidth - icon_area_width + corner_radius;
 
+            thumbnail.Dimmed.Value = IsHovered;
+
             mainContent.ResizeWidthTo(targetWidth, TRANSITION_DURATION, Easing.OutQuint);
             mainContentBackground.Dimmed.Value = IsHovered;
 
-            leftCover.FadeColour(IsHovered ? OsuColour.Gray(0.2f) : Color4.White, TRANSITION_DURATION, Easing.OutQuint);
             statisticsContainer.FadeTo(IsHovered ? 1 : 0, TRANSITION_DURATION, Easing.OutQuint);
 
             rightAreaBackground.FadeColour(downloadTracker.State.Value == DownloadState.LocallyAvailable ? colours.Lime0 : colourProvider.Background3, TRANSITION_DURATION, Easing.OutQuint);

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -101,6 +101,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 {
                     Name = @"Left (icon) area",
                     Size = new Vector2(height),
+                    Padding = new MarginPadding { Right = corner_radius },
                     Child = leftIconArea = new FillFlowContainer
                     {
                         Margin = new MarginPadding(5),
@@ -310,10 +311,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             };
 
             if (beatmapSet.HasVideo)
-                leftIconArea.Add(new IconPill(FontAwesome.Solid.Film));
+                leftIconArea.Add(new IconPill(FontAwesome.Solid.Film) { IconSize = new Vector2(20) });
 
             if (beatmapSet.HasStoryboard)
-                leftIconArea.Add(new IconPill(FontAwesome.Solid.Image));
+                leftIconArea.Add(new IconPill(FontAwesome.Solid.Image) { IconSize = new Vector2(20) });
 
             if (beatmapSet.HasExplicitContent)
             {

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Online.API.Requests.Responses;
+using osuTK.Graphics;
+
+namespace osu.Game.Beatmaps.Drawables.Cards
+{
+    public class BeatmapCardThumbnail : Container
+    {
+        public BindableBool Dimmed { get; } = new BindableBool();
+
+        private readonly APIBeatmapSet beatmapSetInfo;
+
+        private readonly UpdateableOnlineBeatmapSetCover cover;
+        private readonly Container content;
+
+        protected override Container<Drawable> Content => content;
+
+        public BeatmapCardThumbnail(APIBeatmapSet beatmapSetInfo)
+        {
+            this.beatmapSetInfo = beatmapSetInfo;
+
+            InternalChildren = new Drawable[]
+            {
+                cover = new UpdateableOnlineBeatmapSetCover(BeatmapSetCoverType.List)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    OnlineInfo = beatmapSetInfo
+                },
+                content = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Dimmed.BindValueChanged(_ => updateState(), true);
+            FinishTransforms(true);
+        }
+
+        private void updateState()
+        {
+            cover.FadeColour(Dimmed.Value ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps.Drawables.Cards.Buttons;
 using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osuTK.Graphics;
@@ -33,7 +34,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     RelativeSizeAxes = Axes.Both,
                     OnlineInfo = beatmapSetInfo
                 },
-                playButton = new PlayButton(),
+                playButton = new PlayButton(beatmapSetInfo)
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
                 content = new Container
                 {
                     RelativeSizeAxes = Axes.Both
@@ -44,14 +48,17 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            Dimmed.BindValueChanged(_ => updateState(), true);
+            Dimmed.BindValueChanged(_ => updateState());
+            playButton.Playing.BindValueChanged(_ => updateState(), true);
             FinishTransforms(true);
         }
 
         private void updateState()
         {
-            playButton.FadeTo(Dimmed.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
-            cover.FadeColour(Dimmed.Value ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            bool shouldDim = Dimmed.Value || playButton.Playing.Value;
+
+            playButton.FadeTo(shouldDim ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            cover.FadeColour(shouldDim ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -1,12 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.Drawables.Cards.Buttons;
 using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Screens.Ranking.Expanded.Accuracy;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
@@ -15,18 +19,22 @@ namespace osu.Game.Beatmaps.Drawables.Cards
     {
         public BindableBool Dimmed { get; } = new BindableBool();
 
-        private readonly APIBeatmapSet beatmapSetInfo;
+        public new MarginPadding Padding
+        {
+            get => foreground.Padding;
+            set => foreground.Padding = value;
+        }
 
         private readonly UpdateableOnlineBeatmapSetCover cover;
+        private readonly Container foreground;
         private readonly PlayButton playButton;
+        private readonly SmoothCircularProgress progress;
         private readonly Container content;
 
         protected override Container<Drawable> Content => content;
 
         public BeatmapCardThumbnail(APIBeatmapSet beatmapSetInfo)
         {
-            this.beatmapSetInfo = beatmapSetInfo;
-
             InternalChildren = new Drawable[]
             {
                 cover = new UpdateableOnlineBeatmapSetCover(BeatmapSetCoverType.List)
@@ -34,22 +42,45 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     RelativeSizeAxes = Axes.Both,
                     OnlineInfo = beatmapSetInfo
                 },
-                playButton = new PlayButton(beatmapSetInfo)
+                foreground = new Container
                 {
-                    RelativeSizeAxes = Axes.Both
-                },
-                content = new Container
-                {
-                    RelativeSizeAxes = Axes.Both
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        playButton = new PlayButton(beatmapSetInfo)
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        },
+                        progress = new SmoothCircularProgress
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(50),
+                            InnerRadius = 0.2f
+                        },
+                        content = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        }
+                    }
                 }
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            progress.Colour = colourProvider.Highlight1;
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
             Dimmed.BindValueChanged(_ => updateState());
+
             playButton.Playing.BindValueChanged(_ => updateState(), true);
+            ((IBindable<double>)progress.Current).BindTo(playButton.Progress);
+
             FinishTransforms(true);
         }
 

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         private readonly APIBeatmapSet beatmapSetInfo;
 
         private readonly UpdateableOnlineBeatmapSetCover cover;
+        private readonly PlayButton playButton;
         private readonly Container content;
 
         protected override Container<Drawable> Content => content;
@@ -32,6 +33,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     RelativeSizeAxes = Axes.Both,
                     OnlineInfo = beatmapSetInfo
                 },
+                playButton = new PlayButton(),
                 content = new Container
                 {
                     RelativeSizeAxes = Axes.Both
@@ -48,6 +50,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         private void updateState()
         {
+            playButton.FadeTo(Dimmed.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
             cover.FadeColour(Dimmed.Value ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -1,25 +1,43 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osuTK;
 
 namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 {
     public class PlayButton : OsuHoverContainer
     {
+        public IBindable<double> Progress => progress;
+        private readonly BindableDouble progress = new BindableDouble();
+
         public BindableBool Playing { get; } = new BindableBool();
 
-        private readonly BeatmapSetInfo beatmapSetInfo;
+        private readonly IBeatmapSetInfo beatmapSetInfo;
+
+        protected override IEnumerable<Drawable> EffectTargets => icon.Yield();
 
         private readonly SpriteIcon icon;
+        private readonly LoadingSpinner loadingSpinner;
 
-        public PlayButton(BeatmapSetInfo beatmapSetInfo)
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; } = null!;
+
+        private PreviewTrack? previewTrack;
+
+        public PlayButton(IBeatmapSetInfo beatmapSetInfo)
         {
             this.beatmapSetInfo = beatmapSetInfo;
 
@@ -34,6 +52,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                     Icon = FontAwesome.Solid.Play,
                     Size = new Vector2(14)
                 },
+                loadingSpinner = new LoadingSpinner
+                {
+                    Size = new Vector2(14)
+                }
             };
 
             Action = () => Playing.Toggle();
@@ -49,12 +71,72 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
         {
             base.LoadComplete();
 
-            Playing.BindValueChanged(_ => updateState(), true);
+            Playing.BindValueChanged(updateState, true);
         }
 
-        private void updateState()
+        protected override void Update()
         {
-            icon.Icon = Playing.Value ? FontAwesome.Solid.Stop : FontAwesome.Solid.Play;
+            base.Update();
+
+            if (Playing.Value && previewTrack != null && previewTrack.TrackLoaded)
+                progress.Value = previewTrack.CurrentTime / previewTrack.Length;
+            else
+                progress.Value = 0;
+        }
+
+        private void updateState(ValueChangedEvent<bool> playing)
+        {
+            icon.Icon = playing.NewValue ? FontAwesome.Solid.Stop : FontAwesome.Solid.Play;
+
+            if (!playing.NewValue)
+            {
+                stopPreview();
+                return;
+            }
+
+            if (previewTrack == null)
+            {
+                toggleLoading(true);
+                LoadComponentAsync(previewTrack = previewTrackManager.Get(beatmapSetInfo), onPreviewLoaded);
+            }
+            else
+                tryStartPreview();
+        }
+
+        private void stopPreview()
+        {
+            toggleLoading(false);
+            Playing.Value = false;
+            previewTrack?.Stop();
+        }
+
+        private void onPreviewLoaded(PreviewTrack loadedPreview)
+        {
+            // another async load might have completed before this one.
+            // if so, do not make any changes.
+            if (loadedPreview != previewTrack)
+                return;
+
+            AddInternal(loadedPreview);
+            toggleLoading(false);
+
+            loadedPreview.Stopped += () => Schedule(() => Playing.Value = false);
+
+            if (Playing.Value)
+                tryStartPreview();
+        }
+
+        private void tryStartPreview()
+        {
+            if (previewTrack?.Start() == false)
+                Playing.Value = false;
+        }
+
+        private void toggleLoading(bool loading)
+        {
+            Enabled.Value = !loading;
+            icon.FadeTo(loading ? 0 : 1, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            loadingSpinner.State.Value = loading ? Visibility.Visible : Visibility.Hidden;
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
@@ -12,23 +13,48 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 {
     public class PlayButton : OsuHoverContainer
     {
-        public PlayButton()
+        public BindableBool Playing { get; } = new BindableBool();
+
+        private readonly BeatmapSetInfo beatmapSetInfo;
+
+        private readonly SpriteIcon icon;
+
+        public PlayButton(BeatmapSetInfo beatmapSetInfo)
         {
+            this.beatmapSetInfo = beatmapSetInfo;
+
             Anchor = Origin = Anchor.Centre;
 
-            Child = new SpriteIcon
+            Children = new Drawable[]
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Icon = FontAwesome.Solid.Play,
-                Size = new Vector2(14)
+                icon = new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Solid.Play,
+                    Size = new Vector2(14)
+                },
             };
+
+            Action = () => Playing.Toggle();
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             HoverColour = colours.Yellow;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Playing.BindValueChanged(_ => updateState(), true);
+        }
+
+        private void updateState()
+        {
+            icon.Icon = Playing.Value ? FontAwesome.Solid.Stop : FontAwesome.Solid.Play;
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
+{
+    public class PlayButton : OsuHoverContainer
+    {
+        public PlayButton()
+        {
+            Anchor = Origin = Anchor.Centre;
+
+            Child = new SpriteIcon
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Icon = FontAwesome.Solid.Play,
+                Size = new Vector2(14)
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            HoverColour = colours.Yellow;
+        }
+    }
+}


### PR DESCRIPTION
More of #14216.

https://user-images.githubusercontent.com/20418176/143139100-4160fd4c-a74e-4c6c-b6d1-cc545e00f107.mp4

This is actually the last part of the card that is needed to achieve function/information parity with the current panels, so my planned next steps after this are integration of the card in existing views and cleaning up old code.

There are some things missing for parity with web, still - like the ["difficulty hover"](https://www.figma.com/file/oYJ9WkzXGvbPWBz6NxeyGr/UI%2FBeatmap-Card?node-id=112%3A2038) state, or the ["extra" card size](https://www.figma.com/file/oYJ9WkzXGvbPWBz6NxeyGr/UI%2FBeatmap-Card?node-id=112%3A1049) (web has a toggle to switch between normal and extra). I may try to tackle those this weekend, although admittedly the hover state scares me as framework doesn't support overhanging content like that super well (and the popovers don't really fit that usecase all that well, either - although maybe it could be jerry-rigged to work somehow).

The preview logic is mostly ~~stolen~~ borrowed from [the old play button](https://github.com/ppy/osu/blob/master/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs). I could try to split the shared code out to some component but I wasn't super sure it was worth the hassle. It's like 10-20 lines of shared code at most, and I am very wary of the consequences of sharing too much as it often devolves into a mess of layers if too much is permitted to be shared.