### PR TITLE
Fix incorrect usage of `ID` in `TestSceneMultiplayerResults`

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerResults.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerResults.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 PlaylistItem playlistItem = new PlaylistItem
                 {
-                    BeatmapID = beatmapInfo.ID,
+                    BeatmapID = beatmapInfo.OnlineID ?? -1,
                 };
 
                 Stack.Push(screen = new MultiplayerResultsScreen(score, 1, playlistItem));

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerTeamResults.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerTeamResults.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 PlaylistItem playlistItem = new PlaylistItem
                 {
-                    BeatmapID = beatmapInfo.ID,
+                    BeatmapID = beatmapInfo.OnlineID ?? -1,
                 };
 
                 SortedDictionary<int, BindableInt> teamScores = new SortedDictionary<int, BindableInt>


### PR DESCRIPTION
Doesn't really affect the tests passing or otherwise, but was definitely wrong.