### PR TITLE
Update usages of `RulesetInfo.ID` to use `OnlineID` instead

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -108,7 +108,10 @@ namespace osu.Desktop
                 presence.Assets.LargeImageText = $"{user.Value.Username}" + (user.Value.Statistics?.GlobalRank > 0 ? $" (rank #{user.Value.Statistics.GlobalRank:N0})" : string.Empty);
 
             // update ruleset
-            presence.Assets.SmallImageKey = ruleset.Value.ID <= 3 ? $"mode_{ruleset.Value.ID}" : "mode_custom";
+            int onlineID = ruleset.Value.OnlineID;
+            bool isLegacyRuleset = onlineID >= 0 && onlineID <= ILegacyRuleset.MAX_LEGACY_RULESET_ID;
+
+            presence.Assets.SmallImageKey = isLegacyRuleset ? $"mode_{onlineID}" : "mode_custom";
             presence.Assets.SmallImageText = ruleset.Value.Name;
 
             client.SetPresence(presence);

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var score = decoder.Parse(resourceStream);
 
-                Assert.AreEqual(3, score.ScoreInfo.Ruleset.ID);
+                Assert.AreEqual(3, score.ScoreInfo.Ruleset.OnlineID);
 
                 Assert.AreEqual(2, score.ScoreInfo.Statistics[HitResult.Great]);
                 Assert.AreEqual(1, score.ScoreInfo.Statistics[HitResult.Good]);

--- a/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
+++ b/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
@@ -100,8 +100,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualsWithDifferentModInstances()
         {
-            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
-            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
 
             Assert.That(key1, Is.EqualTo(key2));
             Assert.That(key1.GetHashCode(), Is.EqualTo(key2.GetHashCode()));
@@ -110,8 +110,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualsWithDifferentModOrder()
         {
-            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
-            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
 
             Assert.That(key1, Is.EqualTo(key2));
             Assert.That(key1.GetHashCode(), Is.EqualTo(key2.GetHashCode()));
@@ -120,8 +120,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyDoesntEqualWithDifferentModSettings()
         {
-            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.1 } } });
-            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.9 } } });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.1 } } });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.9 } } });
 
             Assert.That(key1, Is.Not.EqualTo(key2));
             Assert.That(key1.GetHashCode(), Is.Not.EqualTo(key2.GetHashCode()));
@@ -130,8 +130,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualWithMatchingModSettings()
         {
-            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.25 } } });
-            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.25 } } });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.25 } } });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { OnlineID = 0 }, new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 1.25 } } });
 
             Assert.That(key1, Is.EqualTo(key2));
             Assert.That(key1.GetHashCode(), Is.EqualTo(key2.GetHashCode()));

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
     {
         private BeatmapInfo getExampleBeatmap() => new BeatmapInfo
         {
-            Ruleset = new RulesetInfo { ID = 5 },
+            Ruleset = new RulesetInfo { OnlineID = 5 },
             StarRating = 4.0d,
             BaseDifficulty = new BeatmapDifficulty
             {
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ID = 6 }
+                Ruleset = new RulesetInfo { OnlineID = 6 }
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ID = 6 },
+                Ruleset = new RulesetInfo { OnlineID = 6 },
                 AllowConvertedBeatmaps = true
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
@@ -86,7 +86,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ID = 6 },
+                Ruleset = new RulesetInfo { OnlineID = 6 },
                 AllowConvertedBeatmaps = true,
                 ApproachRate = new FilterCriteria.OptionalRange<float>
                 {
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ID = 6 },
+                Ruleset = new RulesetInfo { OnlineID = 6 },
                 AllowConvertedBeatmaps = true,
                 BPM = new FilterCriteria.OptionalRange<double>
                 {
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { ID = 6 },
+                Ruleset = new RulesetInfo { OnlineID = 6 },
                 AllowConvertedBeatmaps = true,
                 SearchText = terms
             };

--- a/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
+++ b/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.Testing
             {
                 // temporary ID to let RulesetConfigCache pass our
                 // config manager to the ruleset dependencies.
-                RulesetInfo.ID = -1;
+                RulesetInfo.OnlineID = -1;
             }
 
             public override IResourceStore<byte[]> CreateResourceStore() => new NamespacedResourceStore<byte[]>(TestResources.GetStore(), @"Resources");

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -233,7 +233,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             prepareTokenResponse(true);
 
-            createPlayerTest(false, createRuleset: () => new OsuRuleset { RulesetInfo = { ID = rulesetId } });
+            createPlayerTest(false, createRuleset: () => new OsuRuleset { RulesetInfo = { OnlineID = rulesetId ?? -1 } });
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorHost.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorHost.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestClientSendsCorrectRuleset()
         {
             AddUntilStep("spectator client sending frames", () => spectatorClient.PlayingUserStates.ContainsKey(dummy_user_id));
-            AddAssert("spectator client sent correct ruleset", () => spectatorClient.PlayingUserStates[dummy_user_id].RulesetID == Ruleset.Value.ID);
+            AddAssert("spectator client sent correct ruleset", () => spectatorClient.PlayingUserStates[dummy_user_id].RulesetID == Ruleset.Value.OnlineID);
         }
 
         public override void TearDownSteps()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 InputManager.ReleaseKey(Key.ControlLeft);
             });
 
-            AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.ID == 1);
+            AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.OnlineID == 1);
 
             AddAssert("Mods overlay still visible", () => songSelect.ModSelectOverlay.State.Value == Visibility.Visible);
         }
@@ -278,7 +278,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 InputManager.ReleaseKey(Key.ControlLeft);
             });
 
-            AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.ID == 1);
+            AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.OnlineID == 1);
 
             AddAssert("Options overlay still visible", () => songSelect.BeatmapOptionsOverlay.State.Value == Visibility.Visible);
         }

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     OnlineID = i * 10,
                     DifficultyName = $"Test #{i}",
-                    RulesetID = Ruleset.Value.ID ?? -1,
+                    RulesetID = Ruleset.Value.OnlineID,
                     StarRating = 2 + i * 0.1,
                     OverallDifficulty = 3.5f,
                     FailTimes = new APIFailTimes

--- a/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     new APIBeatmap
                     {
-                        RulesetID = Ruleset.Value.ID ?? 0,
+                        RulesetID = Ruleset.Value.OnlineID,
                         DifficultyName = "Test",
                         StarRating = 6.42,
                     }

--- a/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep("Set beatmap", () => Beatmap.Value = new DummyWorkingBeatmap(Audio, null)
             {
-                BeatmapInfo = { OnlineID = hasOnlineId ? 1234 : (int?)null }
+                BeatmapInfo = { OnlineID = hasOnlineId ? 1234 : -1 }
             });
 
             AddStep("Run command", () => Add(new NowPlayingCommand()));

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     switch (req)
                     {
                         case GetUserRequest userRequest:
-                            userRequest.TriggerSuccess(getUser(userRequest.Ruleset.ID));
+                            userRequest.TriggerSuccess(getUser(userRequest.Ruleset.OnlineID));
                             return true;
                     }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -258,7 +258,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 AddStep("import multi-ruleset map", () =>
                 {
-                    var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
+                    var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
                     manager.Import(createTestBeatmapSet(usableRulesets)).Wait();
                 });
             }
@@ -354,7 +354,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 target = manager.GetAllUsableBeatmapSets()
                                 .Last(b => b.Beatmaps.Any(bi => bi.RulesetID == 0)).Beatmaps.Last();
 
-                Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == 0);
+                Ruleset.Value = rulesets.AvailableRulesets.First(r => r.OnlineID == 0);
                 Beatmap.Value = manager.GetWorkingBeatmap(target);
             });
 
@@ -385,12 +385,12 @@ namespace osu.Game.Tests.Visual.SongSelect
                                 .Last(b => b.Beatmaps.Any(bi => bi.RulesetID == 0)).Beatmaps.Last();
 
                 Beatmap.Value = manager.GetWorkingBeatmap(target);
-                Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == 0);
+                Ruleset.Value = rulesets.AvailableRulesets.First(r => r.OnlineID == 0);
             });
 
             AddUntilStep("has selection", () => songSelect.Carousel.SelectedBeatmapInfo.Equals(target));
 
-            AddUntilStep("has correct ruleset", () => Ruleset.Value.ID == 0);
+            AddUntilStep("has correct ruleset", () => Ruleset.Value.OnlineID == 0);
 
             // this is an important check, to make sure updateComponentFromBeatmap() was actually run
             AddUntilStep("selection shown on wedge", () => songSelect.CurrentBeatmapDetailsBeatmap.BeatmapInfo.MatchesOnlineID(target));
@@ -505,7 +505,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 // special case for converts checked here.
                 return selectedPanel.ChildrenOfType<FilterableDifficultyIcon>().All(i =>
-                    i.IsFiltered || i.Item.BeatmapInfo.Ruleset.ID == targetRuleset || i.Item.BeatmapInfo.Ruleset.ID == 0);
+                    i.IsFiltered || i.Item.BeatmapInfo.Ruleset.OnlineID == targetRuleset || i.Item.BeatmapInfo.Ruleset.OnlineID == 0);
             });
 
             AddUntilStep("carousel has correct", () => songSelect.Carousel.SelectedBeatmapInfo?.MatchesOnlineID(target) == true);
@@ -665,7 +665,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("import multi-ruleset map", () =>
             {
-                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
+                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
                 manager.Import(createTestBeatmapSet(usableRulesets)).Wait();
             });
 
@@ -676,11 +676,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("record set ID", () => previousSetID = ((IBeatmapSetInfo)Beatmap.Value.BeatmapSetInfo).OnlineID);
             AddAssert("selection changed once", () => changeCount == 1);
 
-            AddAssert("Check ruleset is osu!", () => Ruleset.Value.ID == 0);
+            AddAssert("Check ruleset is osu!", () => Ruleset.Value.OnlineID == 0);
 
             changeRuleset(3);
 
-            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);
+            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.OnlineID == 3);
 
             AddUntilStep("selection changed", () => changeCount > 1);
 
@@ -705,7 +705,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("import multi-ruleset map", () =>
             {
-                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
+                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
                 manager.Import(createTestBeatmapSet(usableRulesets)).Wait();
             });
 
@@ -720,11 +720,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("Find an icon for different ruleset", () =>
             {
                 difficultyIcon = set.ChildrenOfType<FilterableDifficultyIcon>()
-                                    .FirstOrDefault(icon => icon.Item.BeatmapInfo.Ruleset.ID == 3);
+                                    .FirstOrDefault(icon => icon.Item.BeatmapInfo.Ruleset.OnlineID == 3);
                 return difficultyIcon != null;
             });
 
-            AddAssert("Check ruleset is osu!", () => Ruleset.Value.ID == 0);
+            AddAssert("Check ruleset is osu!", () => Ruleset.Value.OnlineID == 0);
 
             int previousSetID = 0;
 
@@ -737,7 +737,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);
+            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.OnlineID == 3);
 
             AddAssert("Selected beatmap still same set", () => songSelect.Carousel.SelectedBeatmapInfo.BeatmapSet.OnlineID == previousSetID);
             AddAssert("Selected beatmap is mania", () => Beatmap.Value.BeatmapInfo.Ruleset.OnlineID == 3);
@@ -754,7 +754,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("import huge difficulty count map", () =>
             {
-                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
+                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
                 imported = manager.Import(createTestBeatmapSet(usableRulesets, 50)).Result.Value;
             });
 
@@ -771,10 +771,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("Find group icon for different ruleset", () =>
             {
                 return (groupIcon = set.ChildrenOfType<FilterableGroupedDifficultyIcon>()
-                                       .FirstOrDefault(icon => icon.Items.First().BeatmapInfo.Ruleset.ID == 3)) != null;
+                                       .FirstOrDefault(icon => icon.Items.First().BeatmapInfo.Ruleset.OnlineID == 3)) != null;
             });
 
-            AddAssert("Check ruleset is osu!", () => Ruleset.Value.ID == 0);
+            AddAssert("Check ruleset is osu!", () => Ruleset.Value.OnlineID == 0);
 
             AddStep("Click on group", () =>
             {
@@ -783,7 +783,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);
+            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.OnlineID == 3);
 
             AddAssert("Check first item in group selected", () => Beatmap.Value.BeatmapInfo.MatchesOnlineID(groupIcon.Items.First().BeatmapInfo));
         }
@@ -817,7 +817,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("wait for results screen presented", () => !songSelect.IsCurrentScreen());
 
             AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.MatchesOnlineID(getPresentBeatmap()));
-            AddAssert("check ruleset is correct for score", () => Ruleset.Value.ID == 0);
+            AddAssert("check ruleset is correct for score", () => Ruleset.Value.OnlineID == 0);
         }
 
         [Test]
@@ -849,7 +849,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("wait for results screen presented", () => !songSelect.IsCurrentScreen());
 
             AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.MatchesOnlineID(getPresentBeatmap()));
-            AddAssert("check ruleset is correct for score", () => Ruleset.Value.ID == 0);
+            AddAssert("check ruleset is correct for score", () => Ruleset.Value.OnlineID == 0);
         }
 
         private void waitForInitialSelection()
@@ -869,7 +869,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void addRulesetImportStep(int id) => AddStep($"import test map for ruleset {id}", () => importForRuleset(id));
 
-        private void importForRuleset(int id) => manager.Import(createTestBeatmapSet(rulesets.AvailableRulesets.Where(r => r.ID == id).ToArray())).Wait();
+        private void importForRuleset(int id) => manager.Import(createTestBeatmapSet(rulesets.AvailableRulesets.Where(r => r.OnlineID == id).ToArray())).Wait();
 
         private static int importId;
 
@@ -880,7 +880,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void changeMods(params Mod[] mods) => AddStep($"change mods to {string.Join(", ", mods.Select(m => m.Acronym))}", () => SelectedMods.Value = mods);
 
-        private void changeRuleset(int id) => AddStep($"change ruleset to {id}", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == id));
+        private void changeRuleset(int id) => AddStep($"change ruleset to {id}", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.OnlineID == id));
 
         private void createSongSelect()
         {
@@ -893,7 +893,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep("import test maps", () =>
             {
-                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
+                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
 
                 for (int i = 0; i < 100; i += 10)
                     manager.Import(createTestBeatmapSet(usableRulesets)).Wait();

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -378,9 +378,9 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
         }
 
-        private void changeRuleset(int? id)
+        private void changeRuleset(int? onlineId)
         {
-            AddStep($"change ruleset to {(id?.ToString() ?? "none")}", () => { Ruleset.Value = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == id); });
+            AddStep($"change ruleset to {(onlineId?.ToString() ?? "none")}", () => { Ruleset.Value = rulesets.AvailableRulesets.FirstOrDefault(r => r.OnlineID == onlineId); });
             waitForLoad();
         }
 

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -42,7 +42,12 @@ namespace osu.Game.Tournament.Tests.Components
 
         private void success(APIBeatmap beatmap)
         {
-            var mods = rulesets.GetRuleset(Ladder.Ruleset.Value.ID ?? 0).CreateInstance().AllMods;
+            var ruleset = rulesets.GetRuleset(Ladder.Ruleset.Value.OnlineID);
+
+            if (ruleset == null)
+                return;
+
+            var mods = ruleset.CreateInstance().AllMods;
 
             foreach (var mod in mods)
             {

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Tournament.Components
 
             (string heading, string content)[] stats;
 
-            switch (ruleset.Value.ID)
+            switch (ruleset.Value.OnlineID)
             {
                 default:
                     stats = new (string heading, string content)[]

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -349,7 +349,7 @@ namespace osu.Game.Beatmaps
                 var hashCode = new HashCode();
 
                 hashCode.Add(BeatmapInfo.ID);
-                hashCode.Add(Ruleset.ID);
+                hashCode.Add(Ruleset.ShortName);
 
                 foreach (var mod in OrderedMods)
                     hashCode.Add(mod);

--- a/osu.Game/Beatmaps/DifficultyRecommender.cs
+++ b/osu.Game/Beatmaps/DifficultyRecommender.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Beatmaps
             requestedUserId = api.LocalUser.Value.Id;
 
             // only query API for built-in rulesets
-            rulesets.AvailableRulesets.Where(ruleset => ruleset.ID <= ILegacyRuleset.MAX_LEGACY_RULESET_ID).ForEach(rulesetInfo =>
+            rulesets.AvailableRulesets.Where(ruleset => ruleset.OnlineID >= 0 && ruleset.OnlineID <= ILegacyRuleset.MAX_LEGACY_RULESET_ID).ForEach(rulesetInfo =>
             {
                 var req = new GetUserRequest(api.LocalUser.Value.Id, rulesetInfo);
 

--- a/osu.Game/Models/RealmRuleset.cs
+++ b/osu.Game/Models/RealmRuleset.cs
@@ -25,12 +25,12 @@ namespace osu.Game.Models
 
         public string InstantiationInfo { get; set; } = string.Empty;
 
-        public RealmRuleset(string shortName, string name, string instantiationInfo, int? onlineID = null)
+        public RealmRuleset(string shortName, string name, string instantiationInfo, int onlineID)
         {
             ShortName = shortName;
             Name = name;
             InstantiationInfo = instantiationInfo;
-            OnlineID = onlineID ?? -1;
+            OnlineID = onlineID;
         }
 
         [UsedImplicitly]

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public string MD5Hash => Checksum;
 
-        public IRulesetInfo Ruleset => new RulesetInfo { ID = RulesetID };
+        public IRulesetInfo Ruleset => new RulesetInfo { OnlineID = RulesetID };
 
         [JsonIgnore]
         public string Hash => throw new NotImplementedException();

--- a/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Online.API.Requests.Responses
             return scoreInfo;
         }
 
-        public IRulesetInfo Ruleset => new RulesetInfo { ID = RulesetID };
+        public IRulesetInfo Ruleset => new RulesetInfo { OnlineID = RulesetID };
 
         IBeatmapInfo IScoreInfo.Beatmap => Beatmap;
     }

--- a/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
+++ b/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
@@ -86,8 +86,8 @@ namespace osu.Game.Online.API.Requests
             if (General != null && General.Any())
                 req.AddParameter("c", string.Join('.', General.Select(e => e.ToString().Underscore())));
 
-            if (ruleset.ID.HasValue)
-                req.AddParameter("m", ruleset.ID.Value.ToString());
+            if (ruleset.OnlineID >= 0)
+                req.AddParameter("m", ruleset.OnlineID.ToString());
 
             req.AddParameter("s", SearchCategory.ToString().ToLowerInvariant());
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -183,7 +183,7 @@ namespace osu.Game.Rulesets
             {
                 Name = Description,
                 ShortName = ShortName,
-                ID = (this as ILegacyRuleset)?.LegacyID,
+                OnlineID = (this as ILegacyRuleset)?.LegacyID ?? -1,
                 InstantiationInfo = GetType().GetInvariantInstantiationInfo(),
                 Available = true,
             };

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using osu.Framework.Testing;
@@ -65,7 +66,12 @@ namespace osu.Game.Rulesets
 
         #region Implementation of IHasOnlineID
 
-        public int OnlineID => ID ?? -1;
+        [NotMapped]
+        public int OnlineID
+        {
+            get => ID ?? -1;
+            set => ID = value >= 0 ? value : (int?)null;
+        }
 
         #endregion
     }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Scoring.Legacy
             int countGeki = score.GetCountGeki() ?? 0;
             int countKatu = score.GetCountKatu() ?? 0;
 
-            switch (score.Ruleset.ID)
+            switch (score.Ruleset.OnlineID)
             {
                 case 0:
                 {

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Scoring.Legacy
         {
             using (SerializationWriter sw = new SerializationWriter(stream))
             {
-                sw.Write((byte)(score.ScoreInfo.Ruleset.ID ?? 0));
+                sw.Write((byte)(score.ScoreInfo.Ruleset.OnlineID));
                 sw.Write(LATEST_VERSION);
                 sw.Write(score.ScoreInfo.BeatmapInfo.MD5Hash);
                 sw.Write(score.ScoreInfo.UserString);

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Solo;
@@ -25,10 +26,13 @@ namespace osu.Game.Screens.Play
 
         protected override APIRequest<APIScoreToken> CreateTokenRequest()
         {
-            if (!(Beatmap.Value.BeatmapInfo.OnlineID is int beatmapId))
+            int beatmapId = Beatmap.Value.BeatmapInfo.OnlineID ?? -1;
+            int rulesetId = Ruleset.Value.OnlineID;
+
+            if (beatmapId <= 0)
                 return null;
 
-            if (!(Ruleset.Value.ID is int rulesetId) || Ruleset.Value.ID > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
+            if (rulesetId < 0 || rulesetId > ILegacyRuleset.MAX_LEGACY_RULESET_ID)
                 return null;
 
             return new CreateSoloScoreRequest(beatmapId, rulesetId, Game.VersionHash);
@@ -38,13 +42,11 @@ namespace osu.Game.Screens.Play
 
         protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token)
         {
-            var beatmap = score.ScoreInfo.BeatmapInfo;
+            IBeatmapInfo beatmap = score.ScoreInfo.BeatmapInfo;
 
-            Debug.Assert(beatmap.OnlineID != null);
+            Debug.Assert(beatmap.OnlineID > 0);
 
-            int beatmapId = beatmap.OnlineID.Value;
-
-            return new SubmitSoloScoreRequest(beatmapId, token, score.ScoreInfo);
+            return new SubmitSoloScoreRequest(beatmap.OnlineID, token, score.ScoreInfo);
         }
     }
 }

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Screens.Spectate
             var user = userMap[userId];
             var spectatorState = playingUserStates[userId];
 
-            var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == spectatorState.RulesetID)?.CreateInstance();
+            var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.OnlineID == spectatorState.RulesetID)?.CreateInstance();
             if (resolvedRuleset == null)
                 return;
 

--- a/osu.Game/Stores/RealmRulesetStore.cs
+++ b/osu.Game/Stores/RealmRulesetStore.cs
@@ -117,8 +117,8 @@ namespace osu.Game.Stores
                     // add all legacy rulesets first to ensure they have exclusive choice of primary key.
                     foreach (var r in instances.Where(r => r is ILegacyRuleset))
                     {
-                        if (realm.All<RealmRuleset>().FirstOrDefault(rr => rr.OnlineID == r.RulesetInfo.ID) == null)
-                            realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.ID));
+                        if (realm.All<RealmRuleset>().FirstOrDefault(rr => rr.OnlineID == r.RulesetInfo.OnlineID) == null)
+                            realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.OnlineID));
                     }
 
                     // add any other rulesets which have assemblies present but are not yet in the database.
@@ -136,7 +136,7 @@ namespace osu.Game.Stores
                                 existingSameShortName.InstantiationInfo = r.RulesetInfo.InstantiationInfo;
                             }
                             else
-                                realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.ID));
+                                realm.Add(new RealmRuleset(r.RulesetInfo.ShortName, r.RulesetInfo.Name, r.RulesetInfo.InstantiationInfo, r.RulesetInfo.OnlineID));
                         }
                     }
 


### PR DESCRIPTION
Removes all `set` usage of `RulesetInfo.ID`.

Updates for `get` usage is non-exhaustive, but covers most scenarios that we can immediately update. Exceptions to the rule are when the involved comparison has another EF model (ie. `score.RulesetID == ruleset.ID`) which are more involved to fix.