### PR TITLE
Fix multiplayer starting with own latest picked playlist item rather than the current playlist item

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -78,6 +78,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("playlist item is not expired", () => Client.APIRoom?.Playlist[1].Expired == false);
         }
 
+        [Test]
+        public void TestCorrectItemSelectedAfterNewItemAdded()
+        {
+            addItem(() => OtherBeatmap);
+            AddAssert("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
+        }
+
         private void addItem(Func<BeatmapInfo> beatmap)
         {
             AddStep("click edit button", () =>

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -302,6 +302,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
         public override void OnResuming(IScreen last)
         {
             base.OnResuming(last);
+            updateWorkingBeatmap();
             beginHandlingTrack();
             Scheduler.AddOnce(UpdateMods);
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/15764

@bdach I'm going to need you to test this, because I'm not sure if I reproduced every scenario you mentioned.