### PR TITLE
Add automatic clean-up call for `RealmFileStore`

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -1050,7 +1050,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
         private static void checkSingleReferencedFileCount(OsuGameBase osu, int expected)
         {
-            Assert.AreEqual(expected, osu.Dependencies.Get<FileStore>().QueryFiles(f => f.ReferenceCount == 1).Count());
+            Assert.AreEqual(expected, osu.Dependencies.Get<DatabaseContextFactory>().Get().FileInfo.Count(f => f.ReferenceCount == 1));
         }
 
         private static void ensureLoaded(OsuGameBase osu, int timeout = 60000)

--- a/osu.Game/Database/DatabaseBackedStore.cs
+++ b/osu.Game/Database/DatabaseBackedStore.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Database
         /// <param name="obj">The object to use as a reference when negotiating a local instance.</param>
         /// <param name="lookupSource">An optional lookup source which will be used to query and populate a freshly retrieved replacement. If not provided, the refreshed object will still be returned but will not have any includes.</param>
         /// <typeparam name="T">A valid EF-stored type.</typeparam>
-        protected virtual void Refresh<T>(ref T obj, IQueryable<T> lookupSource = null) where T : class, IHasPrimaryKey
+        protected void Refresh<T>(ref T obj, IQueryable<T> lookupSource = null) where T : class, IHasPrimaryKey
         {
             using (var usage = ContextFactory.GetForWrite())
             {

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -14,6 +14,7 @@ using osu.Framework.Statistics;
 using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
 using osu.Game.Models;
+using osu.Game.Stores;
 using Realms;
 
 #nullable enable
@@ -106,6 +107,8 @@ namespace osu.Game.Database
 
         private void cleanupPendingDeletions()
         {
+            new RealmFileStore(this, storage).Cleanup();
+
             using (var realm = CreateContext())
             using (var transaction = realm.BeginWrite())
             {

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -107,8 +107,6 @@ namespace osu.Game.Database
 
         private void cleanupPendingDeletions()
         {
-            new RealmFileStore(this, storage).Cleanup();
-
             using (var realm = CreateContext())
             using (var transaction = realm.BeginWrite())
             {
@@ -124,6 +122,10 @@ namespace osu.Game.Database
 
                 transaction.Commit();
             }
+
+            // clean up files after dropping any pending deletions.
+            // in the future we may want to only do this when the game is idle, rather than on every startup.
+            new RealmFileStore(this, storage).Cleanup();
         }
 
         /// <summary>

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -2,11 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
@@ -30,13 +27,6 @@ namespace osu.Game.IO
         {
             Store = new StorageBackedResourceStore(Storage);
         }
-
-        /// <summary>
-        /// Perform a lookup query on available <see cref="FileInfo"/>s.
-        /// </summary>
-        /// <param name="query">The query.</param>
-        /// <returns>Results from the provided query.</returns>
-        public IEnumerable<FileInfo> QueryFiles(Expression<Func<FileInfo, bool>> query) => ContextFactory.Get().Set<FileInfo>().AsNoTracking().Where(f => f.ReferenceCount > 0).Where(query);
 
         public FileInfo Add(Stream data, bool reference = true)
         {


### PR DESCRIPTION
Also contains a couple of clean-ups on the EF `FileStore`, just to ease future migration.