### PR TITLE
Fix occasional test failure due to default value oversight in `TestSceneBeatmapCarousel`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -572,7 +572,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("add mixed ruleset beatmapset", () =>
             {
-                testMixed = TestResources.CreateTestBeatmapSetInfo();
+                testMixed = TestResources.CreateTestBeatmapSetInfo(3);
 
                 for (int i = 0; i <= 2; i++)
                 {
@@ -595,7 +595,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             BeatmapSetInfo testSingle = null;
             AddStep("add single ruleset beatmapset", () =>
             {
-                testSingle = TestResources.CreateTestBeatmapSetInfo();
+                testSingle = TestResources.CreateTestBeatmapSetInfo(3);
                 testSingle.Beatmaps.ForEach(b =>
                 {
                     b.Ruleset = rulesets.AvailableRulesets.ElementAt(1);
@@ -615,7 +615,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             List<BeatmapSetInfo> manySets = new List<BeatmapSetInfo>();
 
             for (int i = 1; i <= 50; i++)
-                manySets.Add(TestResources.CreateTestBeatmapSetInfo(i));
+                manySets.Add(TestResources.CreateTestBeatmapSetInfo(3));
 
             loadBeatmaps(manySets);
 


### PR DESCRIPTION
Got this one locally.

```csharp
TearDown : System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'ind...

TearDown : System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
--TearDown
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at osu.Game.Tests.Visual.SongSelect.TestSceneBeatmapCarousel.<>c__DisplayClass25_0.<TestSelectingFilteredRuleset>b__0() in /Users/dean/Projects/osu/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs:line 579
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 462
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()

-----

One or more child tests had errors
  Exception doesn't have a stacktrace



5454099: Running BeatmapCarousel (TestSceneBeatmapCarousel) visual test cases...
5454099: TestSceneBeatmapCarousel
5454333: step 1 Create carousel
```