### PR TITLE
Split out download logic from main manager classes

### DIFF
--- a/osu.Game.Tests/Online/TestSceneBeatmapDownloading.cs
+++ b/osu.Game.Tests/Online/TestSceneBeatmapDownloading.cs
@@ -12,9 +12,9 @@ using osu.Game.Tests.Visual;
 namespace osu.Game.Tests.Online
 {
     [HeadlessTest]
-    public class TestSceneBeatmapManager : OsuTestScene
+    public class TestSceneBeatmapDownloading : OsuTestScene
     {
-        private BeatmapManager beatmaps;
+        private BeatmapModelDownloader beatmaps;
         private ProgressNotification recentNotification;
 
         private static readonly BeatmapSetInfo test_db_model = new BeatmapSetInfo
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Online
         };
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapManager beatmaps)
+        private void load(BeatmapModelDownloader beatmaps)
         {
             this.beatmaps = beatmaps;
 

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Tests.Online
         internal class TestBeatmapModelDownloader : BeatmapModelDownloader
         {
             public TestBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> importer, IAPIProvider apiProvider, GameHost gameHost)
-                : base(importer, apiProvider, gameHost)
+                : base(importer, apiProvider)
             {
             }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             dependencies.Cache(rulesetStore = new RulesetStore(ContextFactory));
             dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
-            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, null, ContextFactory, Scheduler));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, ContextFactory, Scheduler));
 
             return dependencies;
         }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             dependencies.Cache(rulesetStore = new RulesetStore(ContextFactory));
             dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
-            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, null, ContextFactory, Scheduler));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, ContextFactory, Scheduler));
 
             beatmapInfo = beatmapManager.Import(new ImportTask(TestResources.GetQuickTestBeatmapForImport())).Result.Value.Beatmaps[0];
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -29,12 +29,11 @@ namespace osu.Game.Beatmaps
     /// Handles general operations related to global beatmap management.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public class BeatmapManager : IModelDownloader<IBeatmapSetInfo>, IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache, IDisposable
+    public class BeatmapManager : IModelManager<BeatmapSetInfo>, IModelFileManager<BeatmapSetInfo, BeatmapSetFileInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache, IDisposable
     {
         public ITrackStore BeatmapTrackStore { get; }
 
         private readonly BeatmapModelManager beatmapModelManager;
-        private readonly BeatmapModelDownloader beatmapModelDownloader;
 
         private readonly WorkingBeatmapCache workingBeatmapCache;
         private readonly BeatmapOnlineLookupQueue onlineBeatmapLookupQueue;
@@ -46,7 +45,6 @@ namespace osu.Game.Beatmaps
             BeatmapTrackStore = audioManager.GetTrackStore(userResources);
 
             beatmapModelManager = CreateBeatmapModelManager(storage, contextFactory, rulesets, api, host);
-            beatmapModelDownloader = CreateBeatmapModelDownloader(beatmapModelManager, api, host);
             workingBeatmapCache = CreateWorkingBeatmapCache(audioManager, gameResources, userResources, defaultBeatmap, host);
 
             workingBeatmapCache.BeatmapManager = beatmapModelManager;
@@ -57,11 +55,6 @@ namespace osu.Game.Beatmaps
                 onlineBeatmapLookupQueue = new BeatmapOnlineLookupQueue(api, storage);
                 beatmapModelManager.OnlineLookupQueue = onlineBeatmapLookupQueue;
             }
-        }
-
-        protected virtual BeatmapModelDownloader CreateBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> modelManager, IAPIProvider api, GameHost host)
-        {
-            return new BeatmapModelDownloader(modelManager, api, host);
         }
 
         protected virtual WorkingBeatmapCache CreateWorkingBeatmapCache(AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> storage, WorkingBeatmap defaultBeatmap, GameHost host)
@@ -185,11 +178,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public Action<Notification> PostNotification
         {
-            set
-            {
-                beatmapModelManager.PostNotification = value;
-                beatmapModelDownloader.PostNotification = value;
-            }
+            set => beatmapModelManager.PostNotification = value;
         }
 
         /// <summary>
@@ -264,28 +253,6 @@ namespace osu.Game.Beatmaps
         {
             beatmapModelManager.Undelete(item);
         }
-
-        #endregion
-
-        #region Implementation of IModelDownloader<BeatmapSetInfo>
-
-        public event Action<ArchiveDownloadRequest<IBeatmapSetInfo>> DownloadBegan
-        {
-            add => beatmapModelDownloader.DownloadBegan += value;
-            remove => beatmapModelDownloader.DownloadBegan -= value;
-        }
-
-        public event Action<ArchiveDownloadRequest<IBeatmapSetInfo>> DownloadFailed
-        {
-            add => beatmapModelDownloader.DownloadFailed += value;
-            remove => beatmapModelDownloader.DownloadFailed -= value;
-        }
-
-        public bool Download(IBeatmapSetInfo model, bool minimiseDownloadSize = false) =>
-            beatmapModelDownloader.Download(model, minimiseDownloadSize);
-
-        public ArchiveDownloadRequest<IBeatmapSetInfo> GetExistingDownload(IBeatmapSetInfo model) =>
-            beatmapModelDownloader.GetExistingDownload(model);
 
         #endregion
 

--- a/osu.Game/Beatmaps/BeatmapModelDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapModelDownloader.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -16,8 +15,8 @@ namespace osu.Game.Beatmaps
         public override ArchiveDownloadRequest<IBeatmapSetInfo> GetExistingDownload(IBeatmapSetInfo model)
             => CurrentDownloads.Find(r => r.Model.OnlineID == model.OnlineID);
 
-        public BeatmapModelDownloader(IModelImporter<BeatmapSetInfo> beatmapImporter, IAPIProvider api, GameHost host = null)
-            : base(beatmapImporter, api, host)
+        public BeatmapModelDownloader(IModelImporter<BeatmapSetInfo> beatmapImporter, IAPIProvider api)
+            : base(beatmapImporter, api)
         {
         }
     }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
         private Bindable<bool> preferNoVideo = null!;
 
         [Resolved]
-        private BeatmapManager beatmaps { get; set; } = null!;
+        private BeatmapModelDownloader beatmaps { get; set; } = null!;
 
         public DownloadButton(APIBeatmapSet beatmapSet)
         {

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Humanizer;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Notifications;
@@ -29,7 +28,7 @@ namespace osu.Game.Database
 
         protected readonly List<ArchiveDownloadRequest<T>> CurrentDownloads = new List<ArchiveDownloadRequest<T>>();
 
-        protected ModelDownloader(IModelImporter<TModel> importer, IAPIProvider api, IIpcHost importHost = null)
+        protected ModelDownloader(IModelImporter<TModel> importer, IAPIProvider api)
         {
             this.importer = importer;
             this.api = api;

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Online
         [Resolved(CanBeNull = true)]
         protected ScoreManager? Manager { get; private set; }
 
+        [Resolved(CanBeNull = true)]
+        protected ScoreModelDownloader? Downloader { get; private set; }
+
         private ArchiveDownloadRequest<IScoreInfo>? attachedRequest;
 
         public ScoreDownloadTracker(ScoreInfo trackedItem)
@@ -25,7 +28,7 @@ namespace osu.Game.Online
         [BackgroundDependencyLoader(true)]
         private void load()
         {
-            if (Manager == null)
+            if (Manager == null || Downloader == null)
                 return;
 
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
@@ -38,10 +41,10 @@ namespace osu.Game.Online
             if (Manager.IsAvailableLocally(scoreInfo))
                 UpdateState(DownloadState.LocallyAvailable);
             else
-                attachDownload(Manager.GetExistingDownload(scoreInfo));
+                attachDownload(Downloader.GetExistingDownload(scoreInfo));
 
-            Manager.DownloadBegan += downloadBegan;
-            Manager.DownloadFailed += downloadFailed;
+            Downloader.DownloadBegan += downloadBegan;
+            Downloader.DownloadFailed += downloadFailed;
             Manager.ItemUpdated += itemUpdated;
             Manager.ItemRemoved += itemRemoved;
         }
@@ -119,10 +122,14 @@ namespace osu.Game.Online
             base.Dispose(isDisposing);
             attachDownload(null);
 
+            if (Downloader != null)
+            {
+                Downloader.DownloadBegan -= downloadBegan;
+                Downloader.DownloadFailed -= downloadFailed;
+            }
+
             if (Manager != null)
             {
-                Manager.DownloadBegan -= downloadBegan;
-                Manager.DownloadFailed -= downloadFailed;
                 Manager.ItemUpdated -= itemUpdated;
                 Manager.ItemRemoved -= itemRemoved;
             }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -656,6 +656,7 @@ namespace osu.Game
             BeatmapManager.PostNotification = n => Notifications.Post(n);
             BeatmapManager.PostImport = items => PresentBeatmap(items.First().Value);
 
+            BeatmapDownloader.PostNotification = n => Notifications.Post(n);
             ScoreManager.PostNotification = n => Notifications.Post(n);
             ScoreManager.PostImport = items => PresentScore(items.First().Value);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -657,6 +657,8 @@ namespace osu.Game
             BeatmapManager.PostImport = items => PresentBeatmap(items.First().Value);
 
             BeatmapDownloader.PostNotification = n => Notifications.Post(n);
+            ScoreDownloader.PostNotification = n => Notifications.Post(n);
+
             ScoreManager.PostNotification = n => Notifications.Post(n);
             ScoreManager.PostImport = items => PresentScore(items.First().Value);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -100,6 +100,8 @@ namespace osu.Game
 
         protected ScoreManager ScoreManager { get; private set; }
 
+        protected ScoreModelDownloader ScoreDownloader { get; private set; }
+
         protected SkinManager SkinManager { get; private set; }
 
         protected RulesetStore RulesetStore { get; private set; }
@@ -234,10 +236,12 @@ namespace osu.Game
             dependencies.Cache(fileStore = new FileStore(contextFactory, Storage));
 
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
-            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, API, contextFactory, Scheduler, Host, () => difficultyCache, LocalConfig));
+            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, contextFactory, Scheduler, Host, () => difficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, contextFactory, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
             dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API, Host));
+            dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API, Host));
+
             // the following realm components are not actively used yet, but initialised and kept up to date for initial testing.
             realmRulesetStore = new RealmRulesetStore(realmFactory, Storage);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -239,8 +239,8 @@ namespace osu.Game
             dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, contextFactory, Scheduler, Host, () => difficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, contextFactory, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
-            dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API, Host));
-            dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API, Host));
+            dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API));
+            dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API));
 
             // the following realm components are not actively used yet, but initialised and kept up to date for initial testing.
             realmRulesetStore = new RealmRulesetStore(realmFactory, Storage);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -96,6 +96,8 @@ namespace osu.Game
 
         protected BeatmapManager BeatmapManager { get; private set; }
 
+        protected BeatmapModelDownloader BeatmapDownloader { get; private set; }
+
         protected ScoreManager ScoreManager { get; private set; }
 
         protected SkinManager SkinManager { get; private set; }
@@ -235,6 +237,7 @@ namespace osu.Game
             dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, API, contextFactory, Scheduler, Host, () => difficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, contextFactory, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
+            dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API, Host));
             // the following realm components are not actively used yet, but initialised and kept up to date for initial testing.
             realmRulesetStore = new RealmRulesetStore(realmFactory, Storage);
 

--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuGame game, BeatmapManager beatmaps, OsuConfigManager osuConfig)
+        private void load(OsuGame game, BeatmapModelDownloader beatmaps, OsuConfigManager osuConfig)
         {
             noVideoSetting = osuConfig.GetBindable<bool>(OsuSetting.PreferNoVideo);
 

--- a/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
         }
 
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api, BeatmapManager beatmaps)
+        private void load(IAPIProvider api, BeatmapModelDownloader beatmaps)
         {
             FillFlowContainer textSprites;
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -17,7 +17,6 @@ using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
-using osu.Game.Online.API;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Judgements;
@@ -25,15 +24,14 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Scoring
 {
-    public class ScoreManager : IModelManager<ScoreInfo>, IModelImporter<ScoreInfo>, IModelDownloader<IScoreInfo>
+    public class ScoreManager : IModelManager<ScoreInfo>, IModelImporter<ScoreInfo>
     {
         private readonly Scheduler scheduler;
         private readonly Func<BeatmapDifficultyCache> difficulties;
         private readonly OsuConfigManager configManager;
         private readonly ScoreModelManager scoreModelManager;
-        private readonly ScoreModelDownloader scoreModelDownloader;
 
-        public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, IAPIProvider api, IDatabaseContextFactory contextFactory, Scheduler scheduler,
+        public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, IDatabaseContextFactory contextFactory, Scheduler scheduler,
                             IIpcHost importHost = null, Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
         {
             this.scheduler = scheduler;
@@ -41,7 +39,6 @@ namespace osu.Game.Scoring
             this.configManager = configManager;
 
             scoreModelManager = new ScoreModelManager(rulesets, beatmaps, storage, contextFactory, importHost);
-            scoreModelDownloader = new ScoreModelDownloader(scoreModelManager, api, importHost);
         }
 
         public Score GetScore(ScoreInfo score) => scoreModelManager.GetScore(score);
@@ -240,11 +237,7 @@ namespace osu.Game.Scoring
 
         public Action<Notification> PostNotification
         {
-            set
-            {
-                scoreModelManager.PostNotification = value;
-                scoreModelDownloader.PostNotification = value;
-            }
+            set => scoreModelManager.PostNotification = value;
         }
 
         #endregion
@@ -338,30 +331,6 @@ namespace osu.Game.Scoring
         public bool IsAvailableLocally(ScoreInfo model)
         {
             return scoreModelManager.IsAvailableLocally(model);
-        }
-
-        #endregion
-
-        #region Implementation of IModelDownloader<IScoreInfo>
-
-        public event Action<ArchiveDownloadRequest<IScoreInfo>> DownloadBegan
-        {
-            add => scoreModelDownloader.DownloadBegan += value;
-            remove => scoreModelDownloader.DownloadBegan -= value;
-        }
-
-        public event Action<ArchiveDownloadRequest<IScoreInfo>> DownloadFailed
-        {
-            add => scoreModelDownloader.DownloadFailed += value;
-            remove => scoreModelDownloader.DownloadFailed -= value;
-        }
-
-        public bool Download(IScoreInfo model, bool minimiseDownloadSize) =>
-            scoreModelDownloader.Download(model, minimiseDownloadSize);
-
-        public ArchiveDownloadRequest<IScoreInfo> GetExistingDownload(IScoreInfo model)
-        {
-            return scoreModelDownloader.GetExistingDownload(model);
         }
 
         #endregion

--- a/osu.Game/Scoring/ScoreModelDownloader.cs
+++ b/osu.Game/Scoring/ScoreModelDownloader.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -10,8 +9,8 @@ namespace osu.Game.Scoring
 {
     public class ScoreModelDownloader : ModelDownloader<ScoreInfo, IScoreInfo>
     {
-        public ScoreModelDownloader(IModelImporter<ScoreInfo> scoreManager, IAPIProvider api, IIpcHost importHost = null)
-            : base(scoreManager, api, importHost)
+        public ScoreModelDownloader(IModelImporter<ScoreInfo> scoreManager, IAPIProvider api)
+            : base(scoreManager, api)
         {
         }
 

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -49,6 +49,9 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 
+        [Resolved]
+        private BeatmapModelDownloader beatmapDownloader { get; set; }
+
         private Container beatmapPanelContainer;
         private TriangleButton watchButton;
         private SettingsCheckbox automaticDownload;
@@ -244,7 +247,7 @@ namespace osu.Game.Screens.Play
             if (beatmaps.IsAvailableLocally(new BeatmapSetInfo { OnlineID = beatmapSet.OnlineID }))
                 return;
 
-            beatmaps.Download(beatmapSet);
+            beatmapDownloader.Download(beatmapSet);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Ranking
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuGame game, ScoreManager scores)
+        private void load(OsuGame game, ScoreModelDownloader scores)
         {
             InternalChild = shakeContainer = new ShakeContainer
             {
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Ranking
                         break;
 
                     case DownloadState.NotDownloaded:
-                        scores.Download(Score.Value, false);
+                        scores.Download(Score.Value);
                         break;
 
                     case DownloadState.Importing:


### PR DESCRIPTION
As mentioned in discord, I'm not sure if this is the better direction, as opposed to something like:

```csharp
public class BeatmapManager
{
    public BeatmapDownloader Downloader { get; }
    public BeatmapImporter Importer { get; }
    ...
}
```

This structure may keep these components better grouped. But it can be applied down the line once realm has settled. The main purpose of this refactor is to reduce moving pieces even further in `ScoreManager` and `BeatmapManager`.