### PR TITLE
Add "linear" animation style to "approach different" mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -52,23 +52,26 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             switch (style)
             {
-                default:
+                case AnimationStyle.Linear:
                     return Easing.None;
+
+                case AnimationStyle.Gravity:
+                    return Easing.InBack;
+
+                case AnimationStyle.InOut1:
+                    return Easing.InOutCubic;
+
+                case AnimationStyle.InOut2:
+                    return Easing.InOutQuint;
 
                 case AnimationStyle.Accelerate1:
                     return Easing.In;
-
-                case AnimationStyle.Linear:
-                    return Easing.None;
 
                 case AnimationStyle.Accelerate2:
                     return Easing.InCubic;
 
                 case AnimationStyle.Accelerate3:
                     return Easing.InQuint;
-
-                case AnimationStyle.Gravity:
-                    return Easing.InBack;
 
                 case AnimationStyle.Decelerate1:
                     return Easing.Out;
@@ -79,11 +82,8 @@ namespace osu.Game.Rulesets.Osu.Mods
                 case AnimationStyle.Decelerate3:
                     return Easing.OutQuint;
 
-                case AnimationStyle.InOut1:
-                    return Easing.InOutCubic;
-
-                case AnimationStyle.InOut2:
-                    return Easing.InOutQuint;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style), style, @"Unsupported animation style");
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -89,7 +89,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public enum AnimationStyle
         {
-            Linear,
             Gravity,
             InOut1,
             InOut2,
@@ -99,6 +98,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             Decelerate1,
             Decelerate2,
             Decelerate3,
+            Linear,
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -90,6 +90,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public enum AnimationStyle
         {
             Gravity,
+            Linear,
             InOut1,
             InOut2,
             Accelerate1,
@@ -98,7 +99,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             Decelerate1,
             Decelerate2,
             Decelerate3,
-            Linear,
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public enum AnimationStyle
         {
             Linear,
-            Gravity,           
+            Gravity,
             InOut1,
             InOut2,
             Accelerate1,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public BindableFloat Scale { get; } = new BindableFloat(4)
         {
             Precision = 0.1f,
-            MinValue = 2,
+            MinValue = 1.5f,
             MaxValue = 10,
         };
 
@@ -58,6 +58,9 @@ namespace osu.Game.Rulesets.Osu.Mods
                 case AnimationStyle.Accelerate1:
                     return Easing.In;
 
+                case AnimationStyle.Linear:
+                    return Easing.None;
+
                 case AnimationStyle.Accelerate2:
                     return Easing.InCubic;
 
@@ -86,6 +89,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public enum AnimationStyle
         {
+            Linear,
             Gravity,
             InOut1,
             InOut2,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         };
 
         [SettingSource("Style", "Change the animation style of the approach circles.", 1)]
-        public Bindable<AnimationStyle> Style { get; } = new Bindable<AnimationStyle>();
+        public Bindable<AnimationStyle> Style { get; } = new Bindable<AnimationStyle>(AnimationStyle.Gravity);
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {
@@ -89,8 +89,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public enum AnimationStyle
         {
-            Gravity,
             Linear,
+            Gravity,           
             InOut1,
             InOut2,
             Accelerate1,


### PR DESCRIPTION
Hello

This is a small PR aiming to fix a few things that have been bugging me whilst playtesting the approach different mod. This is not a comprehensive list of all the issues but it adresses the two most important ones.

**Changed the minimum raidus from 2 to 1.5**

this change aims to make approach different (  with the gravity option selected ) a better companion mod to traceable, with this change the smaller initial radius allows more accurate pinpointing of the circles location, before the gravity approach circle expands and proceeds to function like an approach circle.

Before(2x min):
![osu_2021-11-25_10-34-03](https://user-images.githubusercontent.com/74463310/143416236-38a88db6-435e-4b9f-8d86-c2db8e9492a2.jpg)

After(1.5x min):
![osu_2021-11-25_10-33-51](https://user-images.githubusercontent.com/74463310/143416251-2681d2c1-a9e5-4ef1-830e-c5a03033b840.jpg)

**Implemented linear approach circle**
Approach different was lacking the option to simply change the initial approach circle size without giving it any acceleration/ decceleration. This is now the default option under the name linear. Overall this is just a neat little quality of life change that allows more flexibility in how a player is displayed the approach circles.


This is by no mean the only issues approach different faces, like obscure naming (i had to go into the code to figure out what each different acceleration does and even there its not clear you need to go to another page which details it : https://easings.net/#easeOutCirc ) which i have not fixed since i am not positive about what naming scheme to apply.




