### PR TITLE
Fix intermittent beatmap thumbnail test

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardThumbnail.cs
@@ -70,6 +70,11 @@ namespace osu.Game.Tests.Visual.Beatmaps
             AddWaitStep("wait some", 3);
             AddAssert("button still visible", () => playButton.IsPresent);
 
+            // The track plays in real-time, so we need to check for progress in increments to avoid timeout.
+            AddUntilStep("progress > 0.25", () => thumbnail.ChildrenOfType<PlayButton>().Single().Progress.Value > 0.25);
+            AddUntilStep("progress > 0.5", () => thumbnail.ChildrenOfType<PlayButton>().Single().Progress.Value > 0.5);
+            AddUntilStep("progress > 0.75", () => thumbnail.ChildrenOfType<PlayButton>().Single().Progress.Value > 0.75);
+
             AddUntilStep("wait for track to end", () => !playButton.Playing.Value);
             AddUntilStep("button hidden", () => !playButton.IsPresent);
         }


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/4323646627?check_suite_focus=true

By coincidence, until-steps wait for 10 seconds, which is exactly the run length of the preview track in real time.