### PR TITLE
Replace existing usages of beatmap panel with new beatmap card

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -41,27 +43,23 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         private readonly BeatmapDownloadTracker downloadTracker;
 
-        private BeatmapCardThumbnail thumbnail;
-        private FillFlowContainer leftIconArea;
+        private BeatmapCardThumbnail thumbnail = null!;
 
-        private Container rightAreaBackground;
-        private Container<BeatmapCardIconButton> rightAreaButtons;
+        private Container rightAreaBackground = null!;
+        private Container<BeatmapCardIconButton> rightAreaButtons = null!;
 
-        private Container mainContent;
-        private BeatmapCardContentBackground mainContentBackground;
+        private Container mainContent = null!;
+        private BeatmapCardContentBackground mainContentBackground = null!;
+        private FillFlowContainer<BeatmapCardStatistic> statisticsContainer = null!;
 
-        private GridContainer titleContainer;
-        private GridContainer artistContainer;
-        private FillFlowContainer<BeatmapCardStatistic> statisticsContainer;
-
-        private FillFlowContainer idleBottomContent;
-        private BeatmapCardDownloadProgressBar downloadProgressBar;
+        private FillFlowContainer idleBottomContent = null!;
+        private BeatmapCardDownloadProgressBar downloadProgressBar = null!;
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         public BeatmapCard(APIBeatmapSet beatmapSet)
             : base(HoverSampleSet.Submit)
@@ -71,13 +69,17 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             downloadTracker = new BeatmapDownloadTracker(beatmapSet);
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [BackgroundDependencyLoader(true)]
+        private void load(BeatmapSetOverlay? beatmapSetOverlay)
         {
             Width = width;
             Height = height;
             CornerRadius = corner_radius;
             Masking = true;
+
+            FillFlowContainer leftIconArea;
+            GridContainer titleContainer;
+            GridContainer artistContainer;
 
             InternalChildren = new Drawable[]
             {
@@ -335,6 +337,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     Margin = new MarginPadding { Left = 5 }
                 };
             }
+
+            Action = () => beatmapSetOverlay?.FetchAndShowBeatmapSet(beatmapSet.OnlineID);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Overlays.BeatmapListing
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            sortControlBackground.Colour = colourProvider.Background5;
+            sortControlBackground.Colour = colourProvider.Background4;
         }
 
         public void Search(string query)

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -15,12 +15,11 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.Containers;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.BeatmapListing;
-using osu.Game.Overlays.BeatmapListing.Panels;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
@@ -34,7 +33,7 @@ namespace osu.Game.Overlays
 
         private Drawable currentContent;
         private Container panelTarget;
-        private FillFlowContainer<BeatmapPanel> foundContent;
+        private FillFlowContainer<BeatmapCard> foundContent;
         private NotFoundDrawable notFoundContent;
         private SupporterRequiredDrawable supporterRequiredContent;
         private BeatmapListingFilterControl filterControl;
@@ -69,7 +68,7 @@ namespace osu.Game.Overlays
                             new Box
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Colour = ColourProvider.Background4,
+                                Colour = ColourProvider.Background5,
                             },
                             panelTarget = new Container
                             {
@@ -79,7 +78,7 @@ namespace osu.Game.Overlays
                                 Padding = new MarginPadding { Horizontal = 20 },
                                 Children = new Drawable[]
                                 {
-                                    foundContent = new FillFlowContainer<BeatmapPanel>(),
+                                    foundContent = new FillFlowContainer<BeatmapCard>(),
                                     notFoundContent = new NotFoundDrawable(),
                                     supporterRequiredContent = new SupporterRequiredDrawable(),
                                 }
@@ -136,7 +135,7 @@ namespace osu.Game.Overlays
                 return;
             }
 
-            var newPanels = searchResult.Results.Select<APIBeatmapSet, BeatmapPanel>(b => new GridBeatmapPanel(b)
+            var newPanels = searchResult.Results.Select(b => new BeatmapCard(b)
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
@@ -152,7 +151,7 @@ namespace osu.Game.Overlays
                 }
 
                 // spawn new children with the contained so we only clear old content at the last moment.
-                var content = new FillFlowContainer<BeatmapPanel>
+                var content = new FillFlowContainer<BeatmapCard>
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -6,10 +6,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Overlays.BeatmapListing.Panels;
 using osuTK;
 using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
 
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
             new GetUserBeatmapsRequest(User.Value.Id, type, VisiblePages++, ItemsPerPage);
 
         protected override Drawable CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0
-            ? new GridBeatmapPanel(model)
+            ? new BeatmapCard(model)
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,

--- a/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
@@ -13,9 +13,9 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Rankings.Tables;
 using System.Linq;
 using System.Threading;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays.BeatmapListing.Panels;
 
 namespace osu.Game.Overlays.Rankings
 {
@@ -143,7 +143,7 @@ namespace osu.Game.Overlays.Rankings
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
                     Spacing = new Vector2(10),
-                    Children = response.BeatmapSets.Select(b => new GridBeatmapPanel(b)
+                    Children = response.BeatmapSets.Select(b => new BeatmapCard(b)
                     {
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -12,6 +12,7 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -20,7 +21,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Spectator;
-using osu.Game.Overlays.BeatmapListing.Panels;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Match.Components;
@@ -52,6 +53,9 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private BeatmapModelDownloader beatmapDownloader { get; set; }
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
         private Container beatmapPanelContainer;
         private TriangleButton watchButton;
         private SettingsCheckbox automaticDownload;
@@ -73,7 +77,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, OsuConfigManager config)
+        private void load(OsuConfigManager config)
         {
             InternalChild = new Container
             {
@@ -88,7 +92,7 @@ namespace osu.Game.Screens.Play
                 {
                     new Box
                     {
-                        Colour = colours.GreySeafoamDark,
+                        Colour = colourProvider.Background5,
                         RelativeSizeAxes = Axes.Both,
                     },
                     new FillFlowContainer
@@ -229,7 +233,7 @@ namespace osu.Game.Screens.Play
             onlineBeatmapRequest.Success += beatmapSet => Schedule(() =>
             {
                 this.beatmapSet = beatmapSet;
-                beatmapPanelContainer.Child = new GridBeatmapPanel(this.beatmapSet);
+                beatmapPanelContainer.Child = new BeatmapCard(this.beatmapSet);
                 checkForAutomaticDownload();
             });
 


### PR DESCRIPTION
The big one for #14216.

While there is still some work remaining to bring the cards to parity with web, they're already at feature parity with the old cards, so there is no longer any reason to stay with the old ones.

https://user-images.githubusercontent.com/20418176/143504621-3917c47c-94c6-4578-9551-06c6c012c08b.mp4

Diff is mostly uneventful, save for enabling nullability in the card itself (for the nullable BDL param) and for a few design adjustments on the beatmap listing overlay to match web and on the spectator screen to be able to replace the old panel.

The old beatmap panel will be excised in a separate pull, as I'm expecting that diff to get rather large.