### PR TITLE
Add equality support to `ILive` types

### DIFF
--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Models;
 using Realms;
@@ -18,15 +17,15 @@ namespace osu.Game.Tests.Database
     public class RealmLiveTests : RealmTest
     {
         [Test]
-        public void TestLiveCastability()
+        public void TestLiveEquality()
         {
             RunTestWithRealm((realmFactory, _) =>
             {
-                RealmLive<RealmBeatmap> beatmap = realmFactory.CreateContext().Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata()))).ToLive();
+                ILive<RealmBeatmap> beatmap = realmFactory.CreateContext().Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata()))).ToLive();
 
-                ILive<IBeatmapInfo> iBeatmap = beatmap;
+                ILive<RealmBeatmap> beatmap2 = realmFactory.CreateContext().All<RealmBeatmap>().First().ToLive();
 
-                Assert.AreEqual(0, iBeatmap.Value.Length);
+                Assert.AreEqual(beatmap, beatmap2);
             });
         }
 

--- a/osu.Game/Database/EntityFrameworkLive.cs
+++ b/osu.Game/Database/EntityFrameworkLive.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Game.Database
 {
     public class EntityFrameworkLive<T> : ILive<T> where T : class
@@ -30,5 +32,7 @@ namespace osu.Game.Database
         }
 
         public T Value { get; }
+
+        public bool Equals(ILive<T>? other) => ID == other?.ID;
     }
 }

--- a/osu.Game/Database/ILive.cs
+++ b/osu.Game/Database/ILive.cs
@@ -9,7 +9,8 @@ namespace osu.Game.Database
     /// A wrapper to provide access to database backed classes in a thread-safe manner.
     /// </summary>
     /// <typeparam name="T">The databased type.</typeparam>
-    public interface ILive<out T> where T : class // TODO: Add IHasGuidPrimaryKey once we don't need EF support any more.
+    public interface ILive<T> : IEquatable<ILive<T>>
+        where T : class // TODO: Add IHasGuidPrimaryKey once we don't need EF support any more.
     {
         Guid ID { get; }
 

--- a/osu.Game/Database/IPostImports.cs
+++ b/osu.Game/Database/IPostImports.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace osu.Game.Database
 {
-    public interface IPostImports<out TModel>
+    public interface IPostImports<TModel>
         where TModel : class
     {
         /// <summary>

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -107,5 +107,7 @@ namespace osu.Game.Database
         // this matches realm's internal thread validation (see https://github.com/realm/realm-dotnet/blob/903b4d0b304f887e37e2d905384fb572a6496e70/Realm/Realm/Native/SynchronizationContextScheduler.cs#L72)
         private bool isCorrectThread
             => (fetchedContext != null && SynchronizationContext.Current == fetchedContext) || fetchedThreadId == Thread.CurrentThread.ManagedThreadId;
+
+        public bool Equals(ILive<T>? other) => ID == other?.ID;
     }
 }


### PR DESCRIPTION
Seems like something we want. Avoids a database access to perform equality.

Unfortunate about loss of covariance.