### PR TITLE
Avoid attempting to fetch a non-managed `RealmLive` instance from the realm backing

### DIFF
--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -31,6 +31,23 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
+        public void TestAccessNonManaged()
+        {
+            var beatmap = new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata());
+            var liveBeatmap = beatmap.ToLive();
+
+            Assert.IsFalse(beatmap.Hidden);
+            Assert.IsFalse(liveBeatmap.Value.Hidden);
+            Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+
+            Assert.Throws<InvalidOperationException>(() => liveBeatmap.PerformWrite(l => l.Hidden = true));
+
+            Assert.IsFalse(beatmap.Hidden);
+            Assert.IsFalse(liveBeatmap.Value.Hidden);
+            Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+        }
+
+        [Test]
         public void TestValueAccessWithOpenContext()
         {
             RunTestWithRealm((realmFactory, _) =>

--- a/osu.Game/Database/EntityFrameworkLive.cs
+++ b/osu.Game/Database/EntityFrameworkLive.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Database
     {
         public EntityFrameworkLive(T item)
         {
+            IsManaged = true; // no way to really know.
             Value = item;
         }
 
@@ -28,6 +29,8 @@ namespace osu.Game.Database
         {
             perform(Value);
         }
+
+        public bool IsManaged { get; }
 
         public T Value { get; }
     }

--- a/osu.Game/Database/ILive.cs
+++ b/osu.Game/Database/ILive.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Database
         void PerformWrite(Action<T> perform);
 
         /// <summary>
+        /// Whether this instance is tracking data which is managed by the database backing.
+        /// </summary>
+        bool IsManaged { get; }
+
+        /// <summary>
         /// Resolve the value of this instance on the current thread's context.
         /// </summary>
         /// <remarks>

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Database
     {
         public Guid ID { get; }
 
+        public bool IsManaged { get; }
+
         private readonly SynchronizationContext? fetchedContext;
         private readonly int fetchedThreadId;
 
@@ -33,8 +35,13 @@ namespace osu.Game.Database
         {
             this.data = data;
 
-            fetchedContext = SynchronizationContext.Current;
-            fetchedThreadId = Thread.CurrentThread.ManagedThreadId;
+            if (data.IsManaged)
+            {
+                IsManaged = true;
+
+                fetchedContext = SynchronizationContext.Current;
+                fetchedThreadId = Thread.CurrentThread.ManagedThreadId;
+            }
 
             ID = data.ID;
         }
@@ -75,13 +82,18 @@ namespace osu.Game.Database
         /// Perform a write operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        public void PerformWrite(Action<T> perform) =>
+        public void PerformWrite(Action<T> perform)
+        {
+            if (!IsManaged)
+                throw new InvalidOperationException("Can't perform writes on a non-managed underlying value");
+
             PerformRead(t =>
             {
                 var transaction = t.Realm.BeginWrite();
                 perform(t);
                 transaction.Commit();
             });
+        }
 
         public T Value
         {
@@ -102,7 +114,7 @@ namespace osu.Game.Database
             }
         }
 
-        private bool originalDataValid => isCorrectThread && data.IsValid;
+        private bool originalDataValid => !IsManaged || (isCorrectThread && data.IsValid);
 
         // this matches realm's internal thread validation (see https://github.com/realm/realm-dotnet/blob/903b4d0b304f887e37e2d905384fb572a6496e70/Realm/Realm/Native/SynchronizationContextScheduler.cs#L72)
         private bool isCorrectThread


### PR DESCRIPTION
For compatibility reasons, we quite often convert completely unmanaged instances to `ILive`s so they fit the required parameters of a property or method call. This ensures such cases will not cause any issues when trying to interact with the underlying data.

Originally I had this allowing write operations, but that seems a bit unsafe (when performing a write one would assume that the underlying data is being persisted, whereas in this case it is not). We can change this if the requirements change in the future, but I think throwing is the safest bet for now.