### PR TITLE
Show a spinner instead of the download button on the new card during beatmap download

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
@@ -54,6 +54,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 
         protected readonly SpriteIcon Icon;
 
+        protected override Container<Drawable> Content => content;
+
         private readonly Container content;
 
         protected BeatmapCardIconButton()
@@ -61,7 +63,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             Origin = Anchor.Centre;
             Anchor = Anchor.Centre;
 
-            Child = content = new Container
+            base.Content.Add(content = new Container
             {
                 RelativeSizeAxes = Axes.Both,
                 Masking = true,
@@ -75,7 +77,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                         Anchor = Anchor.Centre
                     }
                 }
-            };
+            });
 
             Size = new Vector2(24);
             IconSize = 12;

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                     TooltipText = string.Empty;
                     spinner.Show();
                     Icon.Hide();
-                    return;
+                    break;
 
                 case DownloadState.LocallyAvailable:
                     Action = null;

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
@@ -3,14 +3,17 @@
 
 #nullable enable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Resources.Localisation.Web;
+using osuTK;
 
 namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 {
@@ -23,12 +26,16 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 
         private Bindable<bool> preferNoVideo = null!;
 
+        private readonly LoadingSpinner spinner;
+
         [Resolved]
         private BeatmapModelDownloader beatmaps { get; set; } = null!;
 
         public DownloadButton(APIBeatmapSet beatmapSet)
         {
             Icon.Icon = FontAwesome.Solid.Download;
+
+            Content.Add(spinner = new LoadingSpinner { Size = new Vector2(IconSize) });
 
             this.beatmapSet = beatmapSet;
         }
@@ -49,21 +56,44 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 
         private void updateState()
         {
-            this.FadeTo(state.Value != DownloadState.LocallyAvailable ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
-
-            if (beatmapSet.Availability.DownloadDisabled)
+            switch (state.Value)
             {
-                Enabled.Value = false;
-                TooltipText = BeatmapsetsStrings.AvailabilityDisabled;
-                return;
+                case DownloadState.Downloading:
+                case DownloadState.Importing:
+                    Action = null;
+                    TooltipText = string.Empty;
+                    spinner.Show();
+                    Icon.Hide();
+                    return;
+
+                case DownloadState.LocallyAvailable:
+                    Action = null;
+                    TooltipText = string.Empty;
+                    this.FadeOut(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+                    break;
+
+                case DownloadState.NotDownloaded:
+                    if (beatmapSet.Availability.DownloadDisabled)
+                    {
+                        Enabled.Value = false;
+                        TooltipText = BeatmapsetsStrings.AvailabilityDisabled;
+                        return;
+                    }
+
+                    Action = () => beatmaps.Download(beatmapSet, preferNoVideo.Value);
+                    this.FadeIn(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+                    spinner.Hide();
+                    Icon.Show();
+
+                    if (!beatmapSet.HasVideo)
+                        TooltipText = BeatmapsetsStrings.PanelDownloadAll;
+                    else
+                        TooltipText = preferNoVideo.Value ? BeatmapsetsStrings.PanelDownloadNoVideo : BeatmapsetsStrings.PanelDownloadVideo;
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"Unknown {nameof(DownloadState)} specified.");
             }
-
-            if (!beatmapSet.HasVideo)
-                TooltipText = BeatmapsetsStrings.PanelDownloadAll;
-            else
-                TooltipText = preferNoVideo.Value ? BeatmapsetsStrings.PanelDownloadNoVideo : BeatmapsetsStrings.PanelDownloadVideo;
-
-            Action = () => beatmaps.Download(beatmapSet, preferNoVideo.Value);
         }
     }
 }


### PR DESCRIPTION
Felt weird that the button just remained there in a clickable state.

https://user-images.githubusercontent.com/191335/143537452-f439b63c-e2bf-4d3a-bf4b-b49af3e9f7b1.mp4



