### PR TITLE
Fix incorrect logging of preview tracks without track owner

### DIFF
--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -105,7 +105,9 @@ namespace osu.Game.Audio
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                Logger.Log($"A {nameof(PreviewTrack)} was created without a containing {nameof(IPreviewTrackOwner)}. An owner should be added for correct behaviour.");
+
+                if (Owner == null)
+                    Logger.Log($"A {nameof(PreviewTrack)} was created without a containing {nameof(IPreviewTrackOwner)}. An owner should be added for correct behaviour.");
             }
 
             protected override Track GetTrack() => trackManager.Get($"https://b.ppy.sh/preview/{beatmapSetInfo.OnlineID}.mp3");


### PR DESCRIPTION
Unless I'm missing something very hidden... this was always wrong..?