### PR TITLE
Fix instances of components adding off-thread transforms on unbind

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -214,7 +214,8 @@ namespace osu.Game.Overlays
         {
             base.LoadComplete();
 
-            beatmap.BindDisabledChanged(beatmapDisabledChanged, true);
+            beatmap.BindDisabledChanged(_ => Scheduler.AddOnce(beatmapDisabledChanged));
+            beatmapDisabledChanged();
 
             musicController.TrackChanged += trackChanged;
             trackChanged(beatmap.Value);
@@ -318,8 +319,10 @@ namespace osu.Game.Overlays
             };
         }
 
-        private void beatmapDisabledChanged(bool disabled)
+        private void beatmapDisabledChanged()
         {
+            bool disabled = beatmap.Disabled;
+
             if (disabled)
                 playlist?.Hide();
 

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
@@ -68,11 +68,17 @@ namespace osu.Game.Overlays.Toolbar
         {
             base.LoadComplete();
 
-            Current.BindDisabledChanged(disabled => this.FadeColour(disabled ? Color4.Gray : Color4.White, 300), true);
-            Current.BindValueChanged(_ => moveLineToCurrent());
+            Current.BindDisabledChanged(_ => Scheduler.AddOnce(currentDisabledChanged));
+            currentDisabledChanged();
 
+            Current.BindValueChanged(_ => moveLineToCurrent());
             // Scheduled to allow the button flow layout to be computed before the line position is updated
             ScheduleAfterChildren(moveLineToCurrent);
+        }
+
+        private void currentDisabledChanged()
+        {
+            this.FadeColour(Current.Disabled ? Color4.Gray : Color4.White, 300);
         }
 
         private bool hasInitialPosition;


### PR DESCRIPTION
Taken from logs in #15830:

<details>
<summary>Instance 1 (now playing overlay)</summary>

```
2021-11-27 07:08:09 [error]: osu.Framework.Graphics.Drawable+InvalidThreadForMutationException: Cannot mutate the Transforms of a Loaded Drawable while not on the update thread. Consider using Schedule to schedule the mutation operation.
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.Drawable.EnsureMutationAllowed(String member)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.Transforms.Transformable.AddTransform(Transform transform, Nullable`1 customTransformID)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis](TThis t, Transform transform)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.TransformableExtensions.FadeColour[T,TEasing](T drawable, ColourInfo newColour, Double duration, TEasing& easing)
2021-11-27 07:08:09 [error]: at osu.Game.Graphics.UserInterface.OsuAnimatedButton.<>c__DisplayClass10_0.<load>b__0(ValueChangedEvent`1 enabled)
(...)
2021-11-27 07:08:09 [error]: at osu.Game.Overlays.NowPlayingOverlay.beatmapDisabledChanged(Boolean disabled)
2021-11-27 07:08:09 [error]: at osu.Framework.Bindables.Bindable`1.TriggerDisabledChange(Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
2021-11-27 07:08:09 [error]: at osu.Framework.Bindables.Bindable`1.TriggerDisabledChange(Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
2021-11-27 07:08:09 [error]: at osu.Framework.Bindables.Bindable`1.TriggerDisabledChange(Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
2021-11-27 07:08:09 [error]: at osu.Framework.Bindables.LeasedBindable`1.UnbindAllInternal()
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.Drawable.<>c__DisplayClass14_0.<cacheUnbindActions>b__2(Object target)
```

</details>

and

<details>
<summary>Instance 2 (ruleset selector)</summary>

```
2021-11-27 07:08:09 [error]: osu.Framework.Graphics.Drawable+InvalidThreadForMutationException: Cannot mutate the Transforms of a Loaded Drawable while not on the update thread. Consider using Schedule to schedule the mutation operation.
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.Drawable.EnsureMutationAllowed(String member)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.Transforms.Transformable.AddTransform(Transform transform, Nullable`1 customTransformID)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis](TThis t, Transform transform)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.TransformableExtensions.FadeColour[T,TEasing](T drawable, ColourInfo newColour, Double duration, TEasing& easing)
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.TransformableExtensions.FadeColour[T](T drawable, ColourInfo newColour, Double duration, Easing easing)
2021-11-27 07:08:09 [error]: at osu.Game.Overlays.Toolbar.ToolbarRulesetSelector.<LoadComplete>b__7_0(Boolean disabled)
2021-11-27 07:08:09 [error]: at osu.Framework.Bindables.Bindable`1.TriggerDisabledChange(Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
(...)
2021-11-27 07:08:09 [error]: at osu.Framework.Bindables.LeasedBindable`1.UnbindAllInternal()
2021-11-27 07:08:09 [error]: at osu.Framework.Graphics.Drawable.<>c__DisplayClass14_0.<cacheUnbindActions>b__2(Object target)
```

</details>

Unfortunately this means that the ruleset selector animation can potentially play out later than expected if the toolbar is unhidden after a hide. But this is not easy to fix, as the ruleset selector itself is present, but its ancestor is not, so I would have to propagate the knowledge of the running transforms to the toolbar itself. Suggestions how to fix in an acceptable manner welcome.