### PR TITLE
Fix realm migration failures when upgrading from old versions

### DIFF
--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -307,6 +307,9 @@ namespace osu.Game.Database
                 case 10:
                     string rulesetSettingClassName = getMappedOrOriginalName(typeof(RealmRulesetSetting));
 
+                    if (!migration.OldRealm.Schema.TryFindObjectSchema(rulesetSettingClassName, out _))
+                        return;
+
                     var oldSettings = migration.OldRealm.DynamicApi.All(rulesetSettingClassName);
                     var newSettings = migration.NewRealm.All<RealmRulesetSetting>().ToList();
 
@@ -328,6 +331,9 @@ namespace osu.Game.Database
 
                 case 11:
                     string keyBindingClassName = getMappedOrOriginalName(typeof(RealmKeyBinding));
+
+                    if (!migration.OldRealm.Schema.TryFindObjectSchema(keyBindingClassName, out _))
+                        return;
 
                     var oldKeyBindings = migration.OldRealm.DynamicApi.All(keyBindingClassName);
                     var newKeyBindings = migration.NewRealm.All<RealmKeyBinding>().ToList();


### PR DESCRIPTION
Originally reported privately via email to @peppy via a Windows event log file with the following stack trace:

```
Exception Info: System.ArgumentException: The class RulesetSetting is not in the limited set of classes for this realm (Parameter 'className')
   at Realms.Helpers.Argument.Ensure(Boolean condition, String message, String paramName)
   at Realms.Realm.Dynamic.All(String className)
   at osu.Game.Database.RealmContextFactory.applyMigrationsForVersion(Migration migration, UInt64 targetVersion)
   at osu.Game.Database.RealmContextFactory.onMigration(Migration migration, UInt64 lastSchemaVersion)
   at Realms.Migration.Execute(Realm oldRealm, Realm newRealm, IntPtr migrationSchema)
```

The fix is basically reapplying #15533 again for two more classes which may potentially not exist in realm databases of users who haven't ran lazer for a long time, or to be more specific:

* Versions below 2021.916.0 - would fail due to lack of `RealmRulesetSetting`.
* Versions below 2021.703.0 - would fail due to lack of  `RealmKeyBinding`.

The one remaining issue is that the realm migration failures do not log correctly to files. I've opened an issue tracking this at https://github.com/ppy/osu-framework/issues/4920.