### PR TITLE
Migrate custom tournament client assets to uppercased directories

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -87,9 +87,9 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 // Recreate the old setup that uses "tournament" as the base path.
                 string oldPath = Path.Combine(osuRoot, "tournament");
 
-                string videosPath = Path.Combine(oldPath, "videos");
-                string modsPath = Path.Combine(oldPath, "mods");
-                string flagsPath = Path.Combine(oldPath, "flags");
+                string videosPath = Path.Combine(oldPath, "Videos");
+                string modsPath = Path.Combine(oldPath, "Mods");
+                string flagsPath = Path.Combine(oldPath, "Flags");
 
                 Directory.CreateDirectory(videosPath);
                 Directory.CreateDirectory(modsPath);
@@ -123,9 +123,9 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
                     string migratedPath = Path.Combine(host.Storage.GetFullPath("."), "tournaments", "default");
 
-                    videosPath = Path.Combine(migratedPath, "videos");
-                    modsPath = Path.Combine(migratedPath, "mods");
-                    flagsPath = Path.Combine(migratedPath, "flags");
+                    videosPath = Path.Combine(migratedPath, "Videos");
+                    modsPath = Path.Combine(migratedPath, "Mods");
+                    flagsPath = Path.Combine(migratedPath, "Flags");
 
                     videoFile = Path.Combine(videosPath, "video.mp4");
                     modFile = Path.Combine(modsPath, "mod.png");

--- a/osu.Game.Tournament/Components/TournamentModIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentModIcon.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Tournament.Components
         [BackgroundDependencyLoader]
         private void load(TextureStore textures, LadderInfo ladderInfo)
         {
-            var customTexture = textures.Get($"mods/{modAcronym}");
+            var customTexture = textures.Get($"Mods/{modAcronym}");
 
             if (customTexture != null)
             {

--- a/osu.Game.Tournament/IO/TournamentStorage.cs
+++ b/osu.Game.Tournament/IO/TournamentStorage.cs
@@ -51,6 +51,23 @@ namespace osu.Game.Tournament.IO
             Logger.Log("Changing tournament storage: " + GetFullPath(string.Empty));
         }
 
+        protected override void ChangeTargetStorage(Storage newStorage)
+        {
+            // due to an unfortunate oversight, on OSes that are sensitive to pathname casing
+            // the custom flags directory needed to be named `Flags` (uppercase),
+            // while custom mods and videos directories needed to be named `mods` and `videos` respectively (lowercase).
+            // to unify handling to uppercase, move any non-compliant directories automatically for the user to migrate.
+            // can be removed 20220528
+            if (newStorage.ExistsDirectory("flags"))
+                AttemptOperation(() => Directory.Move(newStorage.GetFullPath("flags"), newStorage.GetFullPath("Flags")));
+            if (newStorage.ExistsDirectory("mods"))
+                AttemptOperation(() => Directory.Move(newStorage.GetFullPath("mods"), newStorage.GetFullPath("Mods")));
+            if (newStorage.ExistsDirectory("videos"))
+                AttemptOperation(() => Directory.Move(newStorage.GetFullPath("videos"), newStorage.GetFullPath("Videos")));
+
+            base.ChangeTargetStorage(newStorage);
+        }
+
         public IEnumerable<string> ListTournaments() => AllTournaments.GetDirectories(string.Empty);
 
         public override void Migrate(Storage newStorage)

--- a/osu.Game.Tournament/IO/TournamentVideoResourceStore.cs
+++ b/osu.Game.Tournament/IO/TournamentVideoResourceStore.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Tournament.IO
     public class TournamentVideoResourceStore : NamespacedResourceStore<byte[]>
     {
         public TournamentVideoResourceStore(Storage storage)
-            : base(new StorageBackedResourceStore(storage), "videos")
+            : base(new StorageBackedResourceStore(storage), "Videos")
         {
             AddExtension("m4v");
             AddExtension("avi");

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                     {
                         row.Add(new Sprite
                         {
-                            Texture = textures.Get($"mods/{mods.ToLower()}"),
+                            Texture = textures.Get($"Mods/{mods.ToLower()}"),
                             Scale = new Vector2(0.5f)
                         });
                     }


### PR DESCRIPTION
This is a follow-up to #15837.

It has transpired that on filename-case-sensitive filesystems, the tournament client does not consistently handle custom asset paths. Videos and mods could only be looked up from `videos` and `mods` directories (lowercase), while flags could only be looked up from the `Flags` directory (uppercase).

A complicating circumstance is that default country flags, coming from osu-resources, also depend on the flag lookup being uppercased.

To attempt to clean up the handling as much as it appears to be possible, automatically move user-supplied lowercase directories to uppercase.

Have tested this manually using some local files, seems to migrate fine. If this change is accepted, I will also update the relevant wiki article to match.