### PR TITLE
Fix undelete on existing model not committing transaction

### DIFF
--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -387,7 +387,9 @@ namespace osu.Game.Stores
                             if (CanReuseExisting(existing, item))
                             {
                                 LogForModel(item, @$"Found existing {HumanisedModelName} for {item} (ID {existing.ID}) – skipping import.");
+
                                 existing.DeletePending = false;
+                                transaction.Commit();
 
                                 return existing.ToLive();
                             }


### PR DESCRIPTION
Only missing on the non-optimised path (not used by beatmaps, but will be used for skins). Meant that the undeleted model was never actually marked as undeleted.