### PR TITLE
Fix `RealmLive` not working if data is attached to realm post-`ToLive` call

### DIFF
--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -30,6 +30,22 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
+        public void TestAccessAfterAttach()
+        {
+            RunTestWithRealm((realmFactory, _) =>
+            {
+                var beatmap = new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata());
+
+                var liveBeatmap = beatmap.ToLive();
+
+                using (var context = realmFactory.CreateContext())
+                    context.Write(r => r.Add(beatmap));
+
+                Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
+            });
+        }
+
+        [Test]
         public void TestAccessNonManaged()
         {
             var beatmap = new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata());

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Database
     {
         public Guid ID { get; }
 
-        public bool IsManaged { get; }
+        public bool IsManaged => data.IsManaged;
 
         private readonly SynchronizationContext? fetchedContext;
         private readonly int fetchedThreadId;
@@ -37,8 +37,6 @@ namespace osu.Game.Database
 
             if (data.IsManaged)
             {
-                IsManaged = true;
-
                 fetchedContext = SynchronizationContext.Current;
                 fetchedThreadId = Thread.CurrentThread.ManagedThreadId;
             }


### PR DESCRIPTION
Turns out this is quite handy to have working.