### PR TITLE
Remove the ability to specify a filename in `ReplaceFile`

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -288,9 +288,9 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IModelFileManager<in BeatmapSetInfo,in BeatmapSetFileInfo>
 
-        public void ReplaceFile(BeatmapSetInfo model, BeatmapSetFileInfo file, Stream contents, string filename = null)
+        public void ReplaceFile(BeatmapSetInfo model, BeatmapSetFileInfo file, Stream contents)
         {
-            beatmapModelManager.ReplaceFile(model, file, contents, filename);
+            beatmapModelManager.ReplaceFile(model, file, contents);
         }
 
         public void DeleteFile(BeatmapSetInfo model, BeatmapSetFileInfo file)

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -453,13 +453,12 @@ namespace osu.Game.Database
         /// <param name="model">The item to operate on.</param>
         /// <param name="file">The existing file to be replaced.</param>
         /// <param name="contents">The new file contents.</param>
-        /// <param name="filename">An optional filename for the new file. Will use the previous filename if not specified.</param>
-        public void ReplaceFile(TModel model, TFileModel file, Stream contents, string filename = null)
+        public void ReplaceFile(TModel model, TFileModel file, Stream contents)
         {
             using (ContextFactory.GetForWrite())
             {
                 DeleteFile(model, file);
-                AddFile(model, contents, filename ?? file.Filename);
+                AddFile(model, contents, file.Filename);
             }
         }
 

--- a/osu.Game/Database/IModelFileManager.cs
+++ b/osu.Game/Database/IModelFileManager.cs
@@ -15,8 +15,7 @@ namespace osu.Game.Database
         /// <param name="model">The item to operate on.</param>
         /// <param name="file">The existing file to be replaced.</param>
         /// <param name="contents">The new file contents.</param>
-        /// <param name="filename">An optional filename for the new file. Will use the previous filename if not specified.</param>
-        void ReplaceFile(TModel model, TFileModel file, Stream contents, string filename = null);
+        void ReplaceFile(TModel model, TFileModel file, Stream contents);
 
         /// <summary>
         /// Delete an existing file.

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -78,9 +78,9 @@ namespace osu.Game.Screens.Edit.Setup
             using (var stream = info.OpenRead())
             {
                 if (oldFile != null)
-                    beatmaps.ReplaceFile(set, oldFile, stream, info.Name);
-                else
-                    beatmaps.AddFile(set, stream, info.Name);
+                    beatmaps.DeleteFile(set, oldFile);
+
+                beatmaps.AddFile(set, stream, info.Name);
             }
 
             working.Value.Metadata.BackgroundFile = info.Name;
@@ -105,9 +105,8 @@ namespace osu.Game.Screens.Edit.Setup
             using (var stream = info.OpenRead())
             {
                 if (oldFile != null)
-                    beatmaps.ReplaceFile(set, oldFile, stream, info.Name);
-                else
-                    beatmaps.AddFile(set, stream, info.Name);
+                    beatmaps.DeleteFile(set, oldFile);
+                beatmaps.AddFile(set, stream, info.Name);
             }
 
             working.Value.Metadata.AudioFile = info.Name;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Skinning
                     var oldFile = skin.SkinInfo.Files.FirstOrDefault(f => f.Filename == filename);
 
                     if (oldFile != null)
-                        skinModelManager.ReplaceFile(skin.SkinInfo, oldFile, streamContent, oldFile.Filename);
+                        skinModelManager.ReplaceFile(skin.SkinInfo, oldFile, streamContent);
                     else
                         skinModelManager.AddFile(skin.SkinInfo, streamContent, filename);
                 }


### PR DESCRIPTION
Feels a bit weird to have this operation support changing the filename in the first place.