### PR TITLE
Implement beatmap card difficulty list

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardDifficultyList.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardDifficultyList.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Graphics;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.Beatmaps
+{
+    public class TestSceneBeatmapCardDifficultyList : OsuTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            var beatmapSet = new APIBeatmapSet
+            {
+                Beatmaps = new[]
+                {
+                    new APIBeatmap { RulesetID = 1, StarRating = 5.76, DifficultyName = "Oni" },
+                    new APIBeatmap { RulesetID = 1, StarRating = 3.20, DifficultyName = "Muzukashii" },
+                    new APIBeatmap { RulesetID = 1, StarRating = 2.45, DifficultyName = "Futsuu" },
+
+                    new APIBeatmap { RulesetID = 0, StarRating = 2.04, DifficultyName = "Normal" },
+                    new APIBeatmap { RulesetID = 0, StarRating = 3.51, DifficultyName = "Hard" },
+                    new APIBeatmap { RulesetID = 0, StarRating = 5.25, DifficultyName = "Insane" },
+
+                    new APIBeatmap { RulesetID = 2, StarRating = 2.64, DifficultyName = "Salad" },
+                    new APIBeatmap { RulesetID = 2, StarRating = 3.56, DifficultyName = "Platter" },
+                    new APIBeatmap { RulesetID = 2, StarRating = 4.65, DifficultyName = "Rain" },
+
+                    new APIBeatmap { RulesetID = 3, StarRating = 1.93, DifficultyName = "[7K] Normal" },
+                    new APIBeatmap { RulesetID = 3, StarRating = 3.18, DifficultyName = "[7K] Hyper" },
+                    new APIBeatmap { RulesetID = 3, StarRating = 4.82, DifficultyName = "[7K] Another" },
+
+                    new APIBeatmap { RulesetID = 4, StarRating = 9.99, DifficultyName = "Unknown?!" },
+                }
+            };
+
+            Child = new Container
+            {
+                Width = 300,
+                AutoSizeAxes = Axes.Y,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background2
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding(10),
+                        Child = new BeatmapCardDifficultyList(beatmapSet)
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardDifficultyList.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardDifficultyList.cs
@@ -1,0 +1,103 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online.Chat;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.Beatmaps.Drawables.Cards
+{
+    public class BeatmapCardDifficultyList : CompositeDrawable
+    {
+        public BeatmapCardDifficultyList(IBeatmapSetInfo beatmapSetInfo)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            FillFlowContainer flow;
+
+            InternalChild = flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 3)
+            };
+
+            bool firstGroup = true;
+
+            foreach (var group in beatmapSetInfo.Beatmaps.GroupBy(beatmap => beatmap.Ruleset.OnlineID).OrderBy(group => group.Key))
+            {
+                if (!firstGroup)
+                {
+                    flow.Add(Empty().With(s =>
+                    {
+                        s.RelativeSizeAxes = Axes.X;
+                        s.Height = 4;
+                    }));
+                }
+
+                foreach (var difficulty in group.OrderBy(b => b.StarRating))
+                    flow.Add(new BeatmapCardDifficultyRow(difficulty));
+
+                firstGroup = false;
+            }
+        }
+
+        private class BeatmapCardDifficultyRow : CompositeDrawable
+        {
+            private readonly IBeatmapInfo beatmapInfo;
+
+            public BeatmapCardDifficultyRow(IBeatmapInfo beatmapInfo)
+            {
+                this.beatmapInfo = beatmapInfo;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(RulesetStore rulesets)
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+
+                InternalChild = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(4, 0),
+                    Children = new[]
+                    {
+                        (rulesets.GetRuleset(beatmapInfo.Ruleset.OnlineID)?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }).With(icon =>
+                        {
+                            icon.Anchor = icon.Origin = Anchor.CentreLeft;
+                            icon.Size = new Vector2(16);
+                        }),
+                        new StarRatingDisplay(new StarDifficulty(beatmapInfo.StarRating, 0), StarRatingDisplaySize.Small)
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft
+                        },
+                        new LinkFlowContainer(s =>
+                        {
+                            s.Font = OsuFont.Default.With(size: 14, weight: FontWeight.SemiBold);
+                        }).With(d =>
+                        {
+                            d.AutoSizeAxes = Axes.Both;
+                            d.Anchor = Anchor.CentreLeft;
+                            d.Origin = Anchor.CentreLeft;
+                            d.Padding = new MarginPadding { Bottom = 2 };
+                            d.AddLink(beatmapInfo.DifficultyName, LinkAction.OpenBeatmap, beatmapInfo.OnlineID.ToString());
+                        })
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Beatmaps.Drawables
             // matching web: https://github.com/ppy/osu-web/blob/d06d8c5e735eb1f48799b1654b528e9a7afb0a35/resources/assets/lib/beatmapset-panel.tsx#L127
             bool collapsed = beatmapSet.Beatmaps.Count() > 12;
 
-            foreach (var rulesetGrouping in beatmapSet.Beatmaps.GroupBy(beatmap => beatmap.Ruleset.OnlineID))
+            foreach (var rulesetGrouping in beatmapSet.Beatmaps.GroupBy(beatmap => beatmap.Ruleset.OnlineID).OrderBy(group => group.Key))
             {
                 flow.Add(new RulesetDifficultyGroup(rulesetGrouping.Key, rulesetGrouping, collapsed));
             }


### PR DESCRIPTION
#14216 continues with work on the popup menu. This is about the only easy part of implementation, the rest I still need to go over once again and probably reimplement in a better way. And it will still likely be somewhat hacky in places.

![2021-11-29-215717_459x430_scrot](https://user-images.githubusercontent.com/20418176/143943424-a20512d9-174e-4066-bb73-69c67956c0a7.png)

In the design the text is white. But the texts are links in web, which additionally get underlined on hover (which framework can't do), and in general styling links in lazer is a terrible pain (need to override this `DrawableLinkCompiler` thing), and I kinda don't like that the text just looks like normal non-interactable text anyhow. So I left the default styling in. Will change on request.

Incidentally when comparing implementations with the difficulty spectrum display I also noticed that the latter wasn't sorting the ruleset groups by ID correctly. I've fixed that here to reduce overall red tape burden/PR count.