### PR TITLE
Refactor difficulty adjustment mod combinations test

### DIFF
--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
 
 namespace osu.Game.Tests.NonVisual
 {
@@ -20,8 +22,10 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator().CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(1, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) }
+            }, combinations);
         }
 
         [Test]
@@ -29,9 +33,11 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA()).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(2, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) }
+            }, combinations);
         }
 
         [Test]
@@ -39,14 +45,13 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new ModB()).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(4, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
-            Assert.IsTrue(combinations[2] is MultiMod);
-            Assert.IsTrue(combinations[3] is ModB);
-
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModA);
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModB);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) },
+                new[] { typeof(ModA), typeof(ModB) },
+                new[] { typeof(ModB) }
+            }, combinations);
         }
 
         [Test]
@@ -54,10 +59,12 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new ModIncompatibleWithA()).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(3, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
-            Assert.IsTrue(combinations[2] is ModIncompatibleWithA);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) },
+                new[] { typeof(ModIncompatibleWithA) }
+            }, combinations);
         }
 
         [Test]
@@ -65,22 +72,17 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new ModB(), new ModIncompatibleWithA(), new ModIncompatibleWithAAndB()).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(8, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
-            Assert.IsTrue(combinations[2] is MultiMod);
-            Assert.IsTrue(combinations[3] is ModB);
-            Assert.IsTrue(combinations[4] is MultiMod);
-            Assert.IsTrue(combinations[5] is ModIncompatibleWithA);
-            Assert.IsTrue(combinations[6] is MultiMod);
-            Assert.IsTrue(combinations[7] is ModIncompatibleWithAAndB);
-
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModA);
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModB);
-            Assert.IsTrue(((MultiMod)combinations[4]).Mods[0] is ModB);
-            Assert.IsTrue(((MultiMod)combinations[4]).Mods[1] is ModIncompatibleWithA);
-            Assert.IsTrue(((MultiMod)combinations[6]).Mods[0] is ModIncompatibleWithA);
-            Assert.IsTrue(((MultiMod)combinations[6]).Mods[1] is ModIncompatibleWithAAndB);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) },
+                new[] { typeof(ModA), typeof(ModB) },
+                new[] { typeof(ModB) },
+                new[] { typeof(ModB), typeof(ModIncompatibleWithA) },
+                new[] { typeof(ModIncompatibleWithA) },
+                new[] { typeof(ModIncompatibleWithA), typeof(ModIncompatibleWithAAndB) },
+                new[] { typeof(ModIncompatibleWithAAndB) },
+            }, combinations);
         }
 
         [Test]
@@ -88,10 +90,12 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModAofA(), new ModIncompatibleWithAofA()).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(3, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModAofA);
-            Assert.IsTrue(combinations[2] is ModIncompatibleWithAofA);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModAofA) },
+                new[] { typeof(ModIncompatibleWithAofA) }
+            }, combinations);
         }
 
         [Test]
@@ -99,17 +103,13 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModB(), new ModC())).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(4, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
-            Assert.IsTrue(combinations[2] is MultiMod);
-            Assert.IsTrue(combinations[3] is MultiMod);
-
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModA);
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModB);
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[2] is ModC);
-            Assert.IsTrue(((MultiMod)combinations[3]).Mods[0] is ModB);
-            Assert.IsTrue(((MultiMod)combinations[3]).Mods[1] is ModC);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) },
+                new[] { typeof(ModA), typeof(ModB), typeof(ModC) },
+                new[] { typeof(ModB), typeof(ModC) }
+            }, combinations);
         }
 
         [Test]
@@ -117,13 +117,12 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModB(), new ModIncompatibleWithA())).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(3, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
-            Assert.IsTrue(combinations[2] is MultiMod);
-
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModB);
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModIncompatibleWithA);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) },
+                new[] { typeof(ModB), typeof(ModIncompatibleWithA) }
+            }, combinations);
         }
 
         [Test]
@@ -131,13 +130,28 @@ namespace osu.Game.Tests.NonVisual
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModA(), new ModB())).CreateDifficultyAdjustmentModCombinations();
 
-            Assert.AreEqual(3, combinations.Length);
-            Assert.IsTrue(combinations[0] is ModNoMod);
-            Assert.IsTrue(combinations[1] is ModA);
-            Assert.IsTrue(combinations[2] is MultiMod);
+            assertCombinations(new[]
+            {
+                new[] { typeof(ModNoMod) },
+                new[] { typeof(ModA) },
+                new[] { typeof(ModA), typeof(ModB) }
+            }, combinations);
+        }
 
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModA);
-            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModB);
+        private void assertCombinations(Type[][] expectedCombinations, Mod[] actualCombinations)
+        {
+            Assert.AreEqual(expectedCombinations.Length, actualCombinations.Length);
+
+            foreach (Type[] expected in expectedCombinations)
+            {
+                Type[] actualTypes = ModUtils.FlattenMods(actualCombinations).Select(m => m.GetType()).ToArray();
+
+                Assert.Multiple(() =>
+                {
+                    foreach (var expectedType in expected)
+                        Assert.Contains(expectedType, actualTypes);
+                });
+            }
         }
 
         private class ModA : Mod

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -142,16 +142,16 @@ namespace osu.Game.Tests.NonVisual
         {
             Assert.AreEqual(expectedCombinations.Length, actualCombinations.Length);
 
-            foreach (Type[] expected in expectedCombinations)
+            Assert.Multiple(() =>
             {
-                Type[] actualTypes = ModUtils.FlattenMods(actualCombinations).Select(m => m.GetType()).ToArray();
-
-                Assert.Multiple(() =>
+                for (int i = 0; i < expectedCombinations.Length; ++i)
                 {
-                    foreach (var expectedType in expected)
-                        Assert.Contains(expectedType, actualTypes);
-                });
-            }
+                    Type[] expectedTypes = expectedCombinations[i];
+                    Type[] actualTypes = ModUtils.FlattenMod(actualCombinations[i]).Select(m => m.GetType()).ToArray();
+
+                    Assert.That(expectedTypes, Is.EquivalentTo(actualTypes));
+                }
+            });
         }
 
         private class ModA : Mod


### PR DESCRIPTION
I wanted to check whether this handled the `MultiMod` case correctly (see `TestMultiModFlattening`) and found that it was very hard to read.
This refactors the tests to be explicit about expected types in each mod combination.