### PR TITLE
Fix intermittent test failures in `TestSceneBeatmapInfoWedge` due to async load

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 beatmaps.Add(testBeatmap);
 
-                AddStep("set ruleset", () => Ruleset.Value = rulesetInfo);
+                setRuleset(rulesetInfo);
 
                 selectBeatmap(testBeatmap);
 
@@ -165,6 +165,22 @@ namespace osu.Game.Tests.Visual.SongSelect
             void checkDisplayedBPM(float target) =>
                 AddUntilStep($"displayed bpm is {target}", () => this.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Any(
                     label => label.Statistic.Name == "BPM" && label.Statistic.Content == target.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        private void setRuleset(RulesetInfo rulesetInfo)
+        {
+            Container containerBefore = null;
+
+            AddStep("set ruleset", () =>
+            {
+                // wedge content is only refreshed if the ruleset changes, so only wait for load in that case.
+                if (!rulesetInfo.Equals(Ruleset.Value))
+                    containerBefore = infoWedge.DisplayedContent;
+
+                Ruleset.Value = rulesetInfo;
+            });
+
+            AddUntilStep("wait for async load", () => infoWedge.DisplayedContent != containerBefore);
         }
 
         private void selectBeatmap([CanBeNull] IBeatmap b)


### PR DESCRIPTION
As seen at https://github.com/ppy/osu/runs/4358685294?check_suite_focus=true

Occurs due to the wedge content also reloading on ruleset change, which wasn't being accounted for. In a fail case, the content would change during the "select beatmap" step's async load wait, causing incorrect results.

https://github.com/ppy/osu/blob/51a353e12db189f9958228d30fe045b8460c6b92/osu.Game/Screens/Select/BeatmapInfoWedge.cs#L70