### PR TITLE
Fix chat tab dropdown not being reachable at default sizing

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabDropdown.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Graphics.UserInterface
                 Origin = Anchor.TopRight;
 
                 BackgroundColour = Color4.Black.Opacity(0.7f);
-                MaxHeight = 400;
+                MaxHeight = 200;
             }
 
             protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableOsuTabDropdownMenuItem(item);


### PR DESCRIPTION
Would have liked to fix this in a more local way, but the structure of the dropdowns is just a pain in the ass to work with, so this will do for now.

Before:

![20211130 130337 (osu!)](https://user-images.githubusercontent.com/191335/143983803-a915cd4a-c59b-4074-af59-7d9821dc9bf2.gif)

After:

![20211130 130100 (osu!)](https://user-images.githubusercontent.com/191335/143983687-e642a49d-d423-48af-9da7-1df8a3f537a6.gif)

The only other usage affected by this seems to be the filter selection dropdown at song select, which doesn't reach the max width in either case (yet).
