### PR TITLE
Bring back iOS build-only CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,6 @@ jobs:
         run: msbuild osu.Android/osu.Android.csproj /restore /p:Configuration=Debug
 
   build-only-ios:
-    # While this workflow technically *can* run, it fails as iOS builds are blocked by multiple issues.
-    # See https://github.com/ppy/osu-framework/issues/4677 for the details.
-    # The job can be unblocked once those issues are resolved and game deployments can happen again.
-    if: false
     name: Build only (iOS)
     runs-on: macos-latest
     timeout-minutes: 60


### PR DESCRIPTION
Should now work after all the framework and osu! changes that were done for bringing back iOS into a compilable state.

Tested it to work as expected:
 - on intentional breakage: https://github.com/frenzibyte/osu/runs/4369864860?check_suite_focus=true
 - after fix: https://github.com/frenzibyte/osu/runs/4369958843?check_suite_focus=true