### PR TITLE
Fix testable online IDs starting at 0

### DIFF
--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Tests.Visual.OnlinePlay
 
         private readonly List<Room> serverSideRooms = new List<Room>();
 
-        private int currentRoomId;
-        private int currentPlaylistItemId;
-        private int currentScoreId;
+        private int currentRoomId = 1;
+        private int currentPlaylistItemId = 1;
+        private int currentScoreId = 1;
 
         /// <summary>
         /// Handles an API request, while also updating the local state to match


### PR DESCRIPTION
Mostly in line with what we've come to expect in the last recent while. No functional differences.