### PR TITLE
Fix `bracket.json` potentially getting saved after parsing failure

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 Directory.CreateDirectory(flagsPath);
 
                 // Define testing files corresponding to the specific file migrations that are needed
-                string bracketFile = Path.Combine(osuRoot, "bracket.json");
+                string bracketFile = Path.Combine(osuRoot, TournamentGameBase.BRACKET_FILENAME);
 
                 string drawingsConfig = Path.Combine(osuRoot, "drawings.ini");
                 string drawingsFile = Path.Combine(osuRoot, "drawings.txt");
@@ -133,7 +133,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
                     Assert.That(storage.GetFullPath("."), Is.EqualTo(migratedPath));
 
-                    Assert.True(storage.Exists("bracket.json"));
+                    Assert.True(storage.Exists(TournamentGameBase.BRACKET_FILENAME));
                     Assert.True(storage.Exists("drawings.txt"));
                     Assert.True(storage.Exists("drawings_results.txt"));
 

--- a/osu.Game.Tournament/IO/TournamentStorage.cs
+++ b/osu.Game.Tournament/IO/TournamentStorage.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Tournament.IO
                 DeleteRecursive(source);
             }
 
-            moveFileIfExists("bracket.json", destination);
+            moveFileIfExists(TournamentGameBase.BRACKET_FILENAME, destination);
             moveFileIfExists("drawings.txt", destination);
             moveFileIfExists("drawings_results.txt", destination);
             moveFileIfExists("drawings.ini", destination);

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Tournament
                         loadingSpinner.Expire();
 
                         Logger.Error(t.Exception, "Couldn't load bracket with error");
-                        Add(new WarningBox("Your bracket.json file could not be parsed. Please check runtime.log for more details."));
+                        Add(new WarningBox($"Your {BRACKET_FILENAME} file could not be parsed. Please check runtime.log for more details."));
                     });
 
                     return;

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tournament
     [Cached(typeof(TournamentGameBase))]
     public class TournamentGameBase : OsuGameBase
     {
-        private const string bracket_filename = "bracket.json";
+        public const string BRACKET_FILENAME = @"bracket.json";
         private LadderInfo ladder;
         private TournamentStorage storage;
         private DependencyContainer dependencies;
@@ -71,9 +71,9 @@ namespace osu.Game.Tournament
         {
             try
             {
-                if (storage.Exists(bracket_filename))
+                if (storage.Exists(BRACKET_FILENAME))
                 {
-                    using (Stream stream = storage.GetStream(bracket_filename, FileAccess.Read, FileMode.Open))
+                    using (Stream stream = storage.GetStream(BRACKET_FILENAME, FileAccess.Read, FileMode.Open))
                     using (var sr = new StreamReader(stream))
                         ladder = JsonConvert.DeserializeObject<LadderInfo>(sr.ReadToEnd(), new JsonPointConverter());
                 }
@@ -309,7 +309,7 @@ namespace osu.Game.Tournament
                     Converters = new JsonConverter[] { new JsonPointConverter() }
                 });
 
-            using (var stream = storage.GetStream(bracket_filename, FileAccess.Write, FileMode.Create))
+            using (var stream = storage.GetStream(BRACKET_FILENAME, FileAccess.Write, FileMode.Create))
             using (var sw = new StreamWriter(stream))
                 sw.Write(serialisedLadder);
         }


### PR DESCRIPTION
I thought this is what happened to my file, but likely wasn't (and is related to the stream not being saved to a temporary file before overwriting the previous one) as the file post-failure was 0 byte, rather than containing an empty `json` structure.

Already did this work though, and seems like a good thing to guard against?