### PR TITLE
Fix alt-scroll not adjusting volume in gameplay when scroll wheel is disabled

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneMouseWheelVolumeAdjust.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneMouseWheelVolumeAdjust.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Configuration;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Beatmaps.IO;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public class TestSceneMouseWheelVolumeAdjust : OsuGameTestScene
+    {
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            // Headless tests are always at minimum volume. This covers interactive tests, matching that initial value.
+            AddStep("Set volume to min", () => Game.Audio.Volume.Value = 0);
+            AddAssert("Volume is min", () => Game.Audio.AggregateVolume.Value == 0);
+            AddStep("Move mouse to centre", () => InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre));
+        }
+
+        [Test]
+        public void TestAdjustVolumeFromMainMenu()
+        {
+            // First scroll makes volume controls appear, second adjusts volume.
+            AddRepeatStep("Adjust volume using mouse wheel", () => InputManager.ScrollVerticalBy(5), 2);
+            AddUntilStep("Volume is above zero", () => Game.Audio.AggregateVolume.Value > 0);
+        }
+
+        [Test]
+        public void TestAdjustVolumeFromPlayerWheelEnabled()
+        {
+            loadToPlayerNonBreakTime();
+
+            // First scroll makes volume controls appear, second adjusts volume.
+            AddRepeatStep("Adjust volume using mouse wheel", () => InputManager.ScrollVerticalBy(5), 2);
+            AddAssert("Volume is above zero", () => Game.Audio.Volume.Value > 0);
+        }
+
+        [Test]
+        public void TestAdjustVolumeFromPlayerWheelDisabled()
+        {
+            AddStep("disable wheel volume adjust", () => Game.LocalConfig.SetValue(OsuSetting.MouseDisableWheel, true));
+
+            loadToPlayerNonBreakTime();
+
+            // First scroll makes volume controls appear, second adjusts volume.
+            AddRepeatStep("Adjust volume using mouse wheel", () => InputManager.ScrollVerticalBy(5), 2);
+            AddAssert("Volume is still zero", () => Game.Audio.Volume.Value == 0);
+        }
+
+        [Test]
+        public void TestAdjustVolumeFromPlayerWheelDisabledHoldingAlt()
+        {
+            AddStep("disable wheel volume adjust", () => Game.LocalConfig.SetValue(OsuSetting.MouseDisableWheel, true));
+
+            loadToPlayerNonBreakTime();
+
+            // First scroll makes volume controls appear, second adjusts volume.
+            AddRepeatStep("Adjust volume using mouse wheel holding alt", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.ScrollVerticalBy(5);
+                InputManager.ReleaseKey(Key.AltLeft);
+            }, 2);
+
+            AddAssert("Volume is above zero", () => Game.Audio.Volume.Value > 0);
+        }
+
+        private void loadToPlayerNonBreakTime()
+        {
+            Player player = null;
+            Screens.Select.SongSelect songSelect = null;
+            PushAndConfirm(() => songSelect = new TestSceneScreenNavigation.TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
+
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadOszIntoOsu(Game, virtualTrack: true).Wait());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for player", () =>
+            {
+                // dismiss any notifications that may appear (ie. muted notification).
+                clickMouseInCentre();
+                return (player = Game.ScreenStack.CurrentScreen as Player) != null;
+            });
+
+            AddUntilStep("wait for play time active", () => !player.IsBreakTime.Value);
+        }
+
+        private void clickMouseInCentre()
+        {
+            InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre);
+            InputManager.Click(MouseButton.Left);
+        }
+    }
+}

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -35,9 +35,14 @@ namespace osu.Game.Localisation
         public static LocalisableString ConfineMouseMode => new TranslatableString(getKey(@"confine_mouse_mode"), @"Confine mouse cursor to window");
 
         /// <summary>
-        /// "Disable mouse wheel during gameplay"
+        /// "Disable mouse wheel adjusting volume during gameplay"
         /// </summary>
-        public static LocalisableString DisableMouseWheel => new TranslatableString(getKey(@"disable_mouse_wheel"), @"Disable mouse wheel during gameplay");
+        public static LocalisableString DisableMouseWheelVolumeAdjust => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust"), @"Disable mouse wheel adjusting volume during gameplay");
+
+        /// <summary>
+        /// "Volume can still be adjusted using the mouse wheel by holding "Alt""
+        /// </summary>
+        public static LocalisableString DisableMouseWheelVolumeAdjustTooltip => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust_tooltip"), @"Volume can still be adjusted using the mouse wheel by holding ""Alt""");
 
         /// <summary>
         /// "Disable mouse buttons during gameplay"

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -67,7 +67,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = MouseSettingsStrings.DisableMouseWheel,
+                    LabelText = MouseSettingsStrings.DisableMouseWheelVolumeAdjust,
+                    TooltipText = MouseSettingsStrings.DisableMouseWheelVolumeAdjustTooltip,
                     Current = osuConfig.GetBindable<bool>(OsuSetting.MouseDisableWheel)
                 },
                 new SettingsCheckbox

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -768,7 +768,15 @@ namespace osu.Game.Screens.Play
             Scheduler.Add(resultsDisplayDelegate);
         }
 
-        protected override bool OnScroll(ScrollEvent e) => mouseWheelDisabled.Value && !GameplayClockContainer.IsPaused.Value;
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            // During pause, allow global volume adjust regardless of settings.
+            if (GameplayClockContainer.IsPaused.Value)
+                return false;
+
+            // Block global volume adjust if the user has asked for it (special case when holding "Alt").
+            return mouseWheelDisabled.Value && !e.AltPressed;
+        }
 
         #region Fail Logic
 


### PR DESCRIPTION
Matches behaviour in stable. Adds test coverage.

As discussed in https://github.com/ppy/osu/discussions/15917.