### PR TITLE
Fix lazer replays not importing correctly on some locales

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -2,14 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Scoring;
@@ -21,6 +27,14 @@ namespace osu.Game.Tests.Beatmaps.Formats
     [TestFixture]
     public class LegacyScoreDecoderTest
     {
+        private CultureInfo originalCulture;
+
+        [SetUp]
+        public void SetUp()
+        {
+            originalCulture = CultureInfo.CurrentCulture;
+        }
+
         [Test]
         public void TestDecodeManiaReplay()
         {
@@ -42,6 +56,59 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 Assert.That(score.Replay.Frames, Is.Not.Empty);
             }
+        }
+
+        [Test]
+        public void TestCultureInvariance()
+        {
+            var ruleset = new OsuRuleset().RulesetInfo;
+            var scoreInfo = new TestScoreInfo(ruleset);
+            var beatmap = new TestBeatmap(ruleset);
+            var score = new Score
+            {
+                ScoreInfo = scoreInfo,
+                Replay = new Replay
+                {
+                    Frames = new List<ReplayFrame>
+                    {
+                        new OsuReplayFrame(2000, OsuPlayfield.BASE_SIZE / 2, OsuAction.LeftButton)
+                    }
+                }
+            };
+
+            // the "se" culture is used here, as it encodes the negative number sign as U+2212 MINUS SIGN,
+            // rather than the classic ASCII U+002D HYPHEN-MINUS.
+            CultureInfo.CurrentCulture = new CultureInfo("se");
+
+            var encodeStream = new MemoryStream();
+
+            var encoder = new LegacyScoreEncoder(score, beatmap);
+            encoder.Encode(encodeStream);
+
+            var decodeStream = new MemoryStream(encodeStream.GetBuffer());
+
+            var decoder = new TestLegacyScoreDecoder();
+            var decodedAfterEncode = decoder.Parse(decodeStream);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decodedAfterEncode, Is.Not.Null);
+
+                Assert.That(decodedAfterEncode.ScoreInfo.User.Username, Is.EqualTo(scoreInfo.User.Username));
+                Assert.That(decodedAfterEncode.ScoreInfo.BeatmapInfoID, Is.EqualTo(scoreInfo.BeatmapInfoID));
+                Assert.That(decodedAfterEncode.ScoreInfo.Ruleset, Is.EqualTo(scoreInfo.Ruleset));
+                Assert.That(decodedAfterEncode.ScoreInfo.TotalScore, Is.EqualTo(scoreInfo.TotalScore));
+                Assert.That(decodedAfterEncode.ScoreInfo.MaxCombo, Is.EqualTo(scoreInfo.MaxCombo));
+                Assert.That(decodedAfterEncode.ScoreInfo.Date, Is.EqualTo(scoreInfo.Date));
+
+                Assert.That(decodedAfterEncode.Replay.Frames.Count, Is.EqualTo(1));
+            });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            CultureInfo.CurrentCulture = originalCulture;
         }
 
         private class TestLegacyScoreDecoder : LegacyScoreDecoder

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Scoring.Legacy
                 sw.Write(LATEST_VERSION);
                 sw.Write(score.ScoreInfo.BeatmapInfo.MD5Hash);
                 sw.Write(score.ScoreInfo.UserString);
-                sw.Write($"lazer-{score.ScoreInfo.UserString}-{score.ScoreInfo.Date}".ComputeMD5Hash());
+                sw.Write(FormattableString.Invariant($"lazer-{score.ScoreInfo.UserString}-{score.ScoreInfo.Date}").ComputeMD5Hash());
                 sw.Write((ushort)(score.ScoreInfo.GetCount300() ?? 0));
                 sw.Write((ushort)(score.ScoreInfo.GetCount100() ?? 0));
                 sw.Write((ushort)(score.ScoreInfo.GetCount50() ?? 0));
@@ -110,7 +110,9 @@ namespace osu.Game.Scoring.Legacy
                     }
                 }
 
-                replayData.AppendFormat(@"{0}|{1}|{2}|{3},", -12345, 0, 0, 0);
+                // Warning: this is purposefully hardcoded as a string rather than interpolating, as in some cultures the minus sign is not encoded as the standard ASCII U+00C2 codepoint,
+                // which then would break decoding.
+                replayData.Append(@"-12345|0|0|0");
                 return replayData.ToString();
             }
         }


### PR DESCRIPTION
Closes #15933.

As in the attached logs:

```
2021-12-04 14:20:50 [error]: An unhandled error has occurred.
2021-12-04 14:20:50 [error]: System.FormatException: Input string was not in a correct format.
2021-12-04 14:20:50 [error]: at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
2021-12-04 14:20:50 [error]: at System.Single.Parse(String s, IFormatProvider provider)
2021-12-04 14:20:50 [error]: at osu.Game.Beatmaps.Formats.Parsing.ParseFloat(String input, Single parseLimit) in C:\Users\walav\Desktop\Proj\osu\osu.Game\Beatmaps\Formats\Parsing.cs:line 20
2021-12-04 14:20:50 [error]: at osu.Game.Scoring.Legacy.LegacyScoreDecoder.readLegacyReplay(Replay replay, StreamReader reader) in C:\Users\walav\Desktop\Proj\osu\osu.Game\Scoring\Legacy\LegacyScoreDecoder.cs:line 246
```

As it turns out, on some cultures, the "negative integer" sign is not encoded using the U+002D HYPHEN-MINUS codepoint. For instance, Swedish uses U+2212 MINUS SIGN instead. This was confusing the legacy decoder, since it is correctly depending on the serialisation being culture-independent.

To fix, ensure that the special "end replay" frame, as well as the replay MD5 hash, are generated in a culture-invariant manner.

Thankfully the replay MD5 hash is currently being discarded in `LegacyScoreDecoder`, so it changing in future scores should not have any negative effect on lazer operation:

https://github.com/ppy/osu/blob/70e818ff8f5f5e54aca55752b37d71e46115de73/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L50-L51