### PR TITLE
Don't debounce `MultiplayerRoomComposite` events

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomComposite.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         }
 
         private void invokeOnRoomUpdated() => Scheduler.AddOnce(OnRoomUpdated);
-        private void invokeUserJoined(MultiplayerRoomUser user) => Scheduler.AddOnce(UserJoined, user);
-        private void invokeUserKicked(MultiplayerRoomUser user) => Scheduler.AddOnce(UserKicked, user);
-        private void invokeUserLeft(MultiplayerRoomUser user) => Scheduler.AddOnce(UserLeft, user);
+        private void invokeUserJoined(MultiplayerRoomUser user) => Scheduler.Add(() => UserJoined(user));
+        private void invokeUserKicked(MultiplayerRoomUser user) => Scheduler.Add(() => UserKicked(user));
+        private void invokeUserLeft(MultiplayerRoomUser user) => Scheduler.Add(() => UserLeft(user));
         private void invokeItemAdded(MultiplayerPlaylistItem item) => Schedule(() => PlaylistItemAdded(item));
         private void invokeItemRemoved(long item) => Schedule(() => PlaylistItemRemoved(item));
         private void invokeItemChanged(MultiplayerPlaylistItem item) => Schedule(() => PlaylistItemChanged(item));


### PR DESCRIPTION
This avoids accidental usage which could result in data being lost or ignored (as only the last `user` in a single frame would arrive).

This was added specifically to debounce sample playback, but given that it's only debouncing on a single frame (hardly noticeable) I'm not going to add back support for that yet. It should be handled by sample playback concurrency or something more local to the usage.