### PR TITLE
Fix BeatSyncedContainer using wrong EffectControlPoint when early activating

### DIFF
--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Graphics.Containers
             if (clock == null)
                 return;
 
-            double currentTrackTime = clock.CurrentTime;
+            double currentTrackTime = clock.CurrentTime + EarlyActivationMilliseconds;
 
             if (Beatmap.Value.TrackLoaded && Beatmap.Value.BeatmapLoaded)
             {
@@ -132,12 +132,10 @@ namespace osu.Game.Graphics.Containers
             {
                 // this may be the case where the beat syncing clock has been paused.
                 // we still want to show an idle animation, so use this container's time instead.
-                currentTrackTime = Clock.CurrentTime;
+                currentTrackTime = Clock.CurrentTime + EarlyActivationMilliseconds;
                 timingPoint = TimingControlPoint.DEFAULT;
                 effectPoint = EffectControlPoint.DEFAULT;
             }
-
-            currentTrackTime += EarlyActivationMilliseconds;
 
             double beatLength = timingPoint.BeatLength / Divisor;
 


### PR DESCRIPTION
As it stands right now, the effect point used in all `BeatSyncedContainer`s with EarlyActivationMilliseconds set is not the one in which the beat is supposed to happen, this is most visible on the main menu and logo when a beatmap goes into or out of Kiai Mode, in which the side bars and logo take an extra beat to make the transition.

Before (note in the top left a snippet of the control points used in the BSC):
https://www.youtube.com/watch?v=49R_dwvShtk
After:
https://www.youtube.com/watch?v=Ba3O4nhOBeY

Beatmaps used for testing:
https://osu.ppy.sh/beatmapsets/186318#osu/462168
intro beatmaps