### PR TITLE
Ensure user is returned to the `RoomSubScreen` before gameplay is started

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -420,7 +420,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 ((MultiplayerMatchSubScreen)currentSubScreen).SelectBeatmap();
             });
 
-            AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.IsLoaded == true);
+            AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);
 
             AddAssert("Beatmap matches current item", () => Beatmap.Value.BeatmapInfo.OnlineID == client.Room?.Playlist.First().BeatmapID);
 

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -319,6 +319,16 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         protected void StartPlay()
         {
+            // User may be at song select or otherwise when the host starts gameplay.
+            // Ensure that they first return to this screen, else global bindables (beatmap etc.) may be in a bad state.
+            if (!this.IsCurrentScreen())
+            {
+                this.MakeCurrent();
+
+                Schedule(StartPlay);
+                return;
+            }
+
             sampleStart?.Play();
 
             // fallback is to allow this class to operate when there is no parent OnlineScreen (testing purposes).

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -138,11 +138,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         Height = 40,
-                                        Action = () =>
-                                        {
-                                            if (this.IsCurrentScreen())
-                                                this.Push(new MultiplayerMatchSongSelect(Room));
-                                        },
+                                        Action = SelectBeatmap,
                                         Alpha = 0
                                     },
                                 },
@@ -223,6 +219,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 }
             }
         };
+
+        internal void SelectBeatmap()
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            this.Push(new MultiplayerMatchSongSelect(Room));
+        }
 
         protected override Drawable CreateFooter() => new MultiplayerMatchFooter
         {


### PR DESCRIPTION
This covers the scenario where a user may be at the song select screen while another user (the room host) starts the match. This was only made possible with the new queue modes, so is quite a recent regression.

Closes #15946.