### PR TITLE
Fix skin setting resetting every launch

### DIFF
--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -35,6 +35,16 @@ namespace osu.Game.Database
 
         private void migrateSkins(DatabaseWriteUsage db)
         {
+            // can be removed 20220530.
+            var existingSkins = db.Context.SkinInfo
+                                  .Include(s => s.Files)
+                                  .ThenInclude(f => f.FileInfo)
+                                  .ToList();
+
+            // previous entries in EF are removed post migration.
+            if (!existingSkins.Any())
+                return;
+
             var userSkinChoice = config.GetBindable<string>(OsuSetting.Skin);
             int.TryParse(userSkinChoice.Value, out int userSkinInt);
 
@@ -48,16 +58,6 @@ namespace osu.Game.Database
                     userSkinChoice.Value = SkinInfo.CLASSIC_SKIN.ToString();
                     break;
             }
-
-            // migrate ruleset settings. can be removed 20220530.
-            var existingSkins = db.Context.SkinInfo
-                                  .Include(s => s.Files)
-                                  .ThenInclude(f => f.FileInfo)
-                                  .ToList();
-
-            // previous entries in EF are removed post migration.
-            if (!existingSkins.Any())
-                return;
 
             using (var realm = realmContextFactory.CreateContext())
             using (var transaction = realm.BeginWrite())


### PR DESCRIPTION
Fixes #15958

The reason this was happening was an unfortunate oversight in the migration logic. The code that was attempting to parse the skin settings as `int` was firing regardless of whether a skin migration from EF to realm had already occurred. If it had occurred, the skin setting would contain a GUID rather than an integer, and therefore fail to parse, and therefore implicitly fallback to an EF skin ID of 0 (default value for the `out` variable) which would be the default skin.

Fix by not running the setting migrating logic at all when there are no EF skins to migrate.

I considered adding tests for this for like five minutes but concluded it wasn't really feasible or worth it since the logic is intended to be temporary. I've tested manually that this doesn't look to break migration from EF, though.