### PR TITLE
Fix test failures in team versus test

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddAssert("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
+            AddUntilStep("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
             AddAssert("user state arrived", () => client.Room?.Users.FirstOrDefault()?.MatchState is TeamVersusUserState);
         }
 
@@ -162,13 +162,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddAssert("room type is head to head", () => client.Room?.Settings.MatchType == MatchType.HeadToHead);
+            AddUntilStep("room type is head to head", () => client.Room?.Settings.MatchType == MatchType.HeadToHead);
 
             AddUntilStep("team displays are not displaying teams", () => multiplayerScreenStack.ChildrenOfType<TeamDisplay>().All(d => d.DisplayedTeam == null));
 
             AddStep("change to team vs", () => client.ChangeSettings(matchType: MatchType.TeamVersus));
 
-            AddAssert("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
+            AddUntilStep("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
 
             AddUntilStep("team displays are displaying teams", () => multiplayerScreenStack.ChildrenOfType<TeamDisplay>().All(d => d.DisplayedTeam != null));
         }


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/4448261203?check_suite_focus=true

Reproduced locally with single thread mode and following patch applied:

```diff
diff --git a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
index b3ea5bdc4a..cb0baef879 100644
--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -230,6 +230,8 @@ public override async Task ChangeSettings(MultiplayerRoomSettings settings)
             // Server is authoritative for the time being.
             settings.PlaylistItemId = Room.Settings.PlaylistItemId;
 
+            await Task.Delay(1000).ConfigureAwait(false);
+
             await changeQueueMode(settings.QueueMode).ConfigureAwait(false);
 
             await ((IMultiplayerClient)this).SettingsChanged(settings).ConfigureAwait(false);
```