### PR TITLE
Fix editor crashing if paste is performed while composer is loading

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Beatmaps.IO;
 
@@ -89,6 +90,7 @@ namespace osu.Game.Tests.Visual.Editing
             confirmEditingBeatmap(() => targetDifficulty);
 
             AddAssert("no objects selected", () => !EditorBeatmap.SelectedHitObjects.Any());
+            AddUntilStep("wait for drawable ruleset", () => Editor.ChildrenOfType<DrawableRuleset>().SingleOrDefault()?.IsLoaded == true);
             AddStep("paste object", () => Editor.Paste());
 
             if (sameRuleset)

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -83,7 +83,9 @@ namespace osu.Game.Screens.Edit.Compose
         {
             base.LoadComplete();
             EditorBeatmap.SelectedHitObjects.BindCollectionChanged((_, __) => updateClipboardActionAvailability());
-            clipboard.BindValueChanged(_ => updateClipboardActionAvailability(), true);
+            clipboard.BindValueChanged(_ => updateClipboardActionAvailability());
+            composer.OnLoadComplete += _ => updateClipboardActionAvailability();
+            updateClipboardActionAvailability();
         }
 
         #region Clipboard operations
@@ -131,7 +133,7 @@ namespace osu.Game.Screens.Edit.Compose
         private void updateClipboardActionAvailability()
         {
             CanCut.Value = CanCopy.Value = EditorBeatmap.SelectedHitObjects.Any();
-            CanPaste.Value = !string.IsNullOrEmpty(clipboard.Value);
+            CanPaste.Value = composer.IsLoaded && !string.IsNullOrEmpty(clipboard.Value);
         }
 
         private string formatSelectionAsString()


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/4448261518?check_suite_focus=true

Reproduced locally with single thread mode and following patch applied:

```diff
diff --git a/osu.Game/Rulesets/UI/DrawableRuleset.cs b/osu.Game/Rulesets/UI/DrawableRuleset.cs
index 29559f5036..5c5db5ef32 100644
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -207,6 +207,7 @@ private void loadObjects(CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 AddHitObject(h);
+                Thread.Sleep(5);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
```

This one warrants a smidge more of a description. The hope was that #15545 would fix this, but as written it never had a chance to, because as usual, there's always one more async load:

https://github.com/ppy/osu/blob/74db8da11b05684ee60efa72111afbb159c2629b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs#L125-L142

In the case of the compose screen, the "main content" is the composer, which nests `DrawableEditorRulesetWrapper`, which nests a `DrawableRuleset`. And that last one is pretty sensitive to having its hit objects mutated under it during load:

https://github.com/ppy/osu/blob/74db8da11b05684ee60efa72111afbb159c2629b/osu.Game/Rulesets/UI/DrawableRuleset.cs#L206-L210

The solution proposed here is to politely convey to the user that they need to wait longer by disabling the paste action until the composer has loaded. The test change is to make sure that the test does not attempt to paste too early.