### PR TITLE
Fix the unmute notification potentially overwriting user's volume levels unnecessarily

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -251,7 +251,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestMutedNotificationMuteButton()
         {
-            addVolumeSteps("mute button", () => volumeOverlay.IsMuted.Value = true, () => !volumeOverlay.IsMuted.Value);
+            addVolumeSteps("mute button", () =>
+            {
+                // Importantly, in the case the volume is muted but the user has a volume level set, it should be retained.
+                audioManager.VolumeTrack.Value = 0.5f;
+                volumeOverlay.IsMuted.Value = true;
+            }, () => !volumeOverlay.IsMuted.Value && audioManager.VolumeTrack.Value == 0.5f);
         }
 
         /// <remarks>

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -505,9 +505,9 @@ namespace osu.Game.Screens.Play
                     volumeOverlay.IsMuted.Value = false;
 
                     // Check values before resetting, as the user may have only had mute enabled, in which case we might not need to adjust volumes.
-                    if (audioManager.Volume.Value < volume_requirement)
+                    if (audioManager.Volume.Value <= volume_requirement)
                         audioManager.Volume.SetDefault();
-                    if (audioManager.VolumeTrack.Value < volume_requirement)
+                    if (audioManager.VolumeTrack.Value <= volume_requirement)
                         audioManager.VolumeTrack.SetDefault();
 
                     return true;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -468,12 +468,14 @@ namespace osu.Game.Screens.Play
 
         private int restartCount;
 
+        private const double volume_requirement = 0.05;
+
         private void showMuteWarningIfNeeded()
         {
             if (!muteWarningShownOnce.Value)
             {
                 // Checks if the notification has not been shown yet and also if master volume is muted, track/music volume is muted or if the whole game is muted.
-                if (volumeOverlay?.IsMuted.Value == true || audioManager.Volume.Value <= audioManager.Volume.MinValue || audioManager.VolumeTrack.Value <= audioManager.VolumeTrack.MinValue)
+                if (volumeOverlay?.IsMuted.Value == true || audioManager.Volume.Value <= volume_requirement || audioManager.VolumeTrack.Value <= volume_requirement)
                 {
                     notificationOverlay?.Post(new MutedNotification());
                     muteWarningShownOnce.Value = true;
@@ -487,7 +489,7 @@ namespace osu.Game.Screens.Play
 
             public MutedNotification()
             {
-                Text = "Your music volume is set to 0%! Click here to restore it.";
+                Text = "Your game volume is too low to hear anything! Click here to restore it.";
             }
 
             [BackgroundDependencyLoader]
@@ -501,8 +503,12 @@ namespace osu.Game.Screens.Play
                     notificationOverlay.Hide();
 
                     volumeOverlay.IsMuted.Value = false;
-                    audioManager.Volume.SetDefault();
-                    audioManager.VolumeTrack.SetDefault();
+
+                    // Check values before resetting, as the user may have only had mute enabled, in which case we might not need to adjust volumes.
+                    if (audioManager.Volume.Value < volume_requirement)
+                        audioManager.Volume.SetDefault();
+                    if (audioManager.VolumeTrack.Value < volume_requirement)
+                        audioManager.VolumeTrack.SetDefault();
 
                     return true;
                 };


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/discussions/15980.

I've also changed the cutoffs to 5% rather than zero, as this seems like a saner method of showing this dialog. With levels 5% or less, the game is basically inaudible.  Arguably, the cutoff can be increased to 10%.