### PR TITLE
Fix `LegacyComboCounter` not handling non-default anchor/origin specifications correctly

### DIFF
--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -67,22 +67,32 @@ namespace osu.Game.Screens.Play.HUD
 
             Scale = new Vector2(1.2f);
 
-            InternalChild = counterContainer = new Container
+            InternalChildren = new[]
             {
-                AutoSizeAxes = Axes.Both,
-                AlwaysPresent = true,
-                Children = new[]
+                popOutCount = new LegacySpriteText(LegacyFont.Combo)
                 {
-                    popOutCount = new LegacySpriteText(LegacyFont.Combo)
+                    Alpha = 0,
+                    Margin = new MarginPadding(0.05f),
+                    Blending = BlendingParameters.Additive,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    BypassAutoSizeAxes = Axes.Both,
+                },
+                counterContainer = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    AlwaysPresent = true,
+                    Children = new[]
                     {
-                        Alpha = 0,
-                        Margin = new MarginPadding(0.05f),
-                        Blending = BlendingParameters.Additive,
-                    },
-                    displayedCountSpriteText = new LegacySpriteText(LegacyFont.Combo)
-                    {
-                        Alpha = 0,
-                    },
+                        displayedCountSpriteText = new LegacySpriteText(LegacyFont.Combo)
+                        {
+                            // Initial text and AlwaysPresent allow the counter to have a size before it first displays a combo.
+                            // This is useful for display in the skin editor.
+                            Text = formatCount(0),
+                            AlwaysPresent = true,
+                            Alpha = 0,
+                        },
+                    }
                 }
             };
         }
@@ -120,13 +130,6 @@ namespace osu.Game.Screens.Play.HUD
             base.LoadComplete();
 
             ((IHasText)displayedCountSpriteText).Text = formatCount(Current.Value);
-
-            counterContainer.Anchor = Anchor;
-            counterContainer.Origin = Origin;
-            displayedCountSpriteText.Anchor = Anchor;
-            displayedCountSpriteText.Origin = Origin;
-            popOutCount.Anchor = Anchor;
-            popOutCount.Origin = Origin;
 
             Current.BindValueChanged(combo => updateCount(combo.NewValue == 0), true);
         }


### PR DESCRIPTION
The propagation of anchor/origin to children doesn't work amazingly. Instead, let's avoid relying on this at all. This does mean that the counter now always "expands" to the top-right, whereas previously it was trying to be smart and expand away from the corner of the screen. I think this is fine, though.

I've also made sure the counter displays with a non-zero size before its first display, which I don't believe was the case until now.

Closes #15973.