### PR TITLE
Fix the local user's rank not showing on multiplayer/playlist results screen

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -157,6 +157,8 @@ namespace osu.Game.Screens.Play
             request.Success += s =>
             {
                 score.ScoreInfo.OnlineScoreID = s.ID;
+                score.ScoreInfo.Position = s.Position;
+
                 scoreSubmissionSource.SetResult(true);
             };
 


### PR DESCRIPTION
Applying the simple solution for now. Not sure how this will evolve over time, but seems sane enough.

Closes #15985.