### PR TITLE
Fix potential crash due to children being mutated after disposal

### DIFF
--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Screens.Select
             private FillFlowContainer infoLabelContainer;
             private Container bpmLabelContainer;
 
-            private readonly WorkingBeatmap beatmap;
+            private readonly WorkingBeatmap working;
             private readonly RulesetInfo ruleset;
 
             [Resolved]
@@ -171,10 +171,10 @@ namespace osu.Game.Screens.Select
 
             private ModSettingChangeTracker settingChangeTracker;
 
-            public WedgeInfoText(WorkingBeatmap beatmap, RulesetInfo userRuleset)
+            public WedgeInfoText(WorkingBeatmap working, RulesetInfo userRuleset)
             {
-                this.beatmap = beatmap;
-                ruleset = userRuleset ?? beatmap.BeatmapInfo.Ruleset;
+                this.working = working;
+                ruleset = userRuleset ?? working.BeatmapInfo.Ruleset;
             }
 
             private CancellationTokenSource cancellationSource;
@@ -183,8 +183,8 @@ namespace osu.Game.Screens.Select
             [BackgroundDependencyLoader]
             private void load(OsuColour colours, LocalisationManager localisation, BeatmapDifficultyCache difficultyCache)
             {
-                var beatmapInfo = beatmap.BeatmapInfo;
-                var metadata = beatmapInfo.Metadata ?? beatmap.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
+                var beatmapInfo = working.BeatmapInfo;
+                var metadata = beatmapInfo.Metadata ?? working.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
                 RelativeSizeAxes = Axes.Both;
 
@@ -353,7 +353,7 @@ namespace osu.Game.Screens.Select
 
             private void addInfoLabels()
             {
-                if (beatmap.Beatmap?.HitObjects?.Any() != true)
+                if (working.Beatmap?.HitObjects?.Any() != true)
                     return;
 
                 infoLabelContainer.Children = new Drawable[]
@@ -362,7 +362,7 @@ namespace osu.Game.Screens.Select
                     {
                         Name = "Length",
                         CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
-                        Content = beatmap.BeatmapInfo.Length.ToFormattedDuration().ToString(),
+                        Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
                     }),
                     bpmLabelContainer = new Container
                     {
@@ -386,12 +386,12 @@ namespace osu.Game.Screens.Select
                     try
                     {
                         // Try to get the beatmap with the user's ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(ruleset, Array.Empty<Mod>());
+                        playableBeatmap = working.GetPlayableBeatmap(ruleset, Array.Empty<Mod>());
                     }
                     catch (BeatmapInvalidForRulesetException)
                     {
                         // Can't be converted to the user's ruleset, so use the beatmap's own ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset, Array.Empty<Mod>());
+                        playableBeatmap = working.GetPlayableBeatmap(working.BeatmapInfo.Ruleset, Array.Empty<Mod>());
                     }
 
                     return playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)).ToArray();
@@ -406,8 +406,9 @@ namespace osu.Game.Screens.Select
 
             private void refreshBPMLabel()
             {
-                var b = beatmap.Beatmap;
-                if (b == null)
+                var beatmap = working.Beatmap;
+
+                if (beatmap == null || bpmLabelContainer == null)
                     return;
 
                 // this doesn't consider mods which apply variable rates, yet.
@@ -415,9 +416,9 @@ namespace osu.Game.Screens.Select
                 foreach (var mod in mods.Value.OfType<IApplicableToRate>())
                     rate = mod.ApplyToRate(0, rate);
 
-                double bpmMax = b.ControlPointInfo.BPMMaximum * rate;
-                double bpmMin = b.ControlPointInfo.BPMMinimum * rate;
-                double mostCommonBPM = 60000 / b.GetMostCommonBeatLength() * rate;
+                double bpmMax = beatmap.ControlPointInfo.BPMMaximum * rate;
+                double bpmMin = beatmap.ControlPointInfo.BPMMinimum * rate;
+                double mostCommonBPM = 60000 / beatmap.GetMostCommonBeatLength() * rate;
 
                 string labelText = Precision.AlmostEquals(bpmMin, bpmMax)
                     ? $"{bpmMin:0}"

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -330,6 +330,21 @@ namespace osu.Game.Screens.Select
                 addInfoLabels();
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                mods.BindValueChanged(m =>
+                {
+                    settingChangeTracker?.Dispose();
+
+                    refreshBPMLabel();
+
+                    settingChangeTracker = new ModSettingChangeTracker(m.NewValue);
+                    settingChangeTracker.SettingChanged += _ => refreshBPMLabel();
+                }, true);
+            }
+
             private void setMetadata(string source)
             {
                 ArtistLabel.Text = artistBinding.Value;
@@ -360,16 +375,6 @@ namespace osu.Game.Screens.Select
                         Children = getRulesetInfoLabels()
                     }
                 };
-
-                mods.BindValueChanged(m =>
-                {
-                    settingChangeTracker?.Dispose();
-
-                    refreshBPMLabel();
-
-                    settingChangeTracker = new ModSettingChangeTracker(m.NewValue);
-                    settingChangeTracker.SettingChanged += _ => refreshBPMLabel();
-                }, true);
             }
 
             private InfoLabel[] getRulesetInfoLabels()


### PR DESCRIPTION
As seen in CI failure https://github.com/ppy/osu/runs/4453854462?check_suite_focus=true.

This is a bit of an unfortunate edge case where the unbind-on-disposal doesn't help, since the binding is happening in BDL, and the usage is in a nested `LoadComponentAsync` call. Combine those and you have a recipe for disaster.