### PR TITLE
Add support for enqueueing items in host-only mode, and changing arbitrary playlist items

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -87,9 +87,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void addItem(Func<BeatmapInfo> beatmap)
         {
-            AddStep("click edit button", () =>
+            AddStep("click add button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().AddOrEditPlaylistButton);
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSubScreen.AddItemButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -255,6 +255,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 p.AllowDeletion = true;
                 p.AllowShowingResults = true;
+                p.AllowEditing = true;
             });
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osuTK.Input;
 
@@ -74,11 +75,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("api room updated", () => Client.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
         }
 
+        [Test]
+        public void TestAddItemsAsHost()
+        {
+            addItem(() => OtherBeatmap);
+
+            AddAssert("playlist contains two items", () => Client.APIRoom?.Playlist.Count == 2);
+        }
+
         private void selectNewItem(Func<BeatmapInfo> beatmap)
         {
             AddStep("click edit button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSubScreen>().Single().AddOrEditPlaylistButton);
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistEditButton>().First());
                 InputManager.Click(MouseButton.Left);
             });
 
@@ -89,6 +98,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
             AddUntilStep("selected item is new beatmap", () => Client.CurrentMatchPlayingItem.Value?.Beatmap.Value?.OnlineID == otherBeatmap.OnlineID);
+        }
+
+        private void addItem(Func<BeatmapInfo> beatmap)
+        {
+            AddStep("click add button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSubScreen.AddItemButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("wait for song select", () => CurrentSubScreen is Screens.Select.SongSelect select && select.BeatmapSetsLoaded);
+            AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(beatmap()));
+            AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -416,8 +416,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Enter song select", () =>
             {
                 var currentSubScreen = ((Screens.OnlinePlay.Multiplayer.Multiplayer)multiplayerScreenStack.CurrentScreen).CurrentSubScreen;
-
-                ((MultiplayerMatchSubScreen)currentSubScreen).SelectBeatmap();
+                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.CurrentMatchPlayingItem.Value);
             });
 
             AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             public new BeatmapCarousel Carousel => base.Carousel;
 
             public TestMultiplayerMatchSongSelect(Room room, WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
-                : base(room, beatmap, ruleset)
+                : base(room, null, beatmap, ruleset)
             {
             }
         }

--- a/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
@@ -84,6 +84,12 @@ namespace osu.Game.Online.Multiplayer
         Task AddPlaylistItem(MultiplayerPlaylistItem item);
 
         /// <summary>
+        /// Edits an existing playlist item with new values.
+        /// </summary>
+        /// <param name="item">The item to edit, containing new properties. Must have an ID.</param>
+        Task EditPlaylistItem(MultiplayerPlaylistItem item);
+
+        /// <summary>
         /// Removes an item from the playlist.
         /// </summary>
         /// <param name="playlistItemId">The item to remove.</param>

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -335,6 +335,8 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task AddPlaylistItem(MultiplayerPlaylistItem item);
 
+        public abstract Task EditPlaylistItem(MultiplayerPlaylistItem item);
+
         public abstract Task RemovePlaylistItem(long playlistItemId);
 
         Task IMultiplayerClient.RoomStateChanged(MultiplayerRoomState state)

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -162,6 +162,14 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMultiplayerServer.AddPlaylistItem), item);
         }
 
+        public override Task EditPlaylistItem(MultiplayerPlaylistItem item)
+        {
+            if (!IsConnected.Value)
+                return Task.CompletedTask;
+
+            return connection.InvokeAsync(nameof(IMultiplayerServer.EditPlaylistItem), item);
+        }
+
         public override Task RemovePlaylistItem(long playlistItemId)
         {
             if (!IsConnected.Value)

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Screens.OnlinePlay
         /// </summary>
         public Action<PlaylistItem> RequestResults;
 
+        /// <summary>
+        /// Invoked when an item requests to be edited.
+        /// </summary>
+        public Action<PlaylistItem> RequestEdit;
+
         private bool allowReordering;
 
         /// <summary>
@@ -104,6 +109,24 @@ namespace osu.Game.Screens.OnlinePlay
             }
         }
 
+        private bool allowEditing;
+
+        /// <summary>
+        /// Whether to allow items to be edited.
+        /// If <c>true</c>, requests to edit items may be satisfied via <see cref="RequestEdit"/>.
+        /// </summary>
+        public bool AllowEditing
+        {
+            get => allowEditing;
+            set
+            {
+                allowEditing = value;
+
+                foreach (var item in ListContainer.OfType<DrawableRoomPlaylistItem>())
+                    item.AllowEditing = value;
+            }
+        }
+
         private bool showItemOwners;
 
         /// <summary>
@@ -135,12 +158,14 @@ namespace osu.Game.Screens.OnlinePlay
         {
             d.SelectedItem.BindTarget = SelectedItem;
             d.RequestDeletion = i => RequestDeletion?.Invoke(i);
+            d.RequestResults = i => RequestResults?.Invoke(i);
+            d.RequestEdit = i => RequestEdit?.Invoke(i);
             d.AllowReordering = AllowReordering;
             d.AllowDeletion = AllowDeletion;
             d.AllowSelection = AllowSelection;
             d.AllowShowingResults = AllowShowingResults;
+            d.AllowEditing = AllowEditing;
             d.ShowItemOwner = ShowItemOwners;
-            d.RequestResults = i => RequestResults?.Invoke(i);
         });
 
         protected virtual DrawableRoomPlaylistItem CreateDrawablePlaylistItem(PlaylistItem item) => new DrawableRoomPlaylistItem(item);

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -52,6 +52,11 @@ namespace osu.Game.Screens.OnlinePlay
         public Action<PlaylistItem> RequestResults;
 
         /// <summary>
+        /// Invoked when this item requests to be edited.
+        /// </summary>
+        public Action<PlaylistItem> RequestEdit;
+
+        /// <summary>
         /// The currently-selected item, used to show a border around this item.
         /// May be updated by this item if <see cref="AllowSelection"/> is <c>true</c>.
         /// </summary>
@@ -74,6 +79,7 @@ namespace osu.Game.Screens.OnlinePlay
         private FillFlowContainer buttonsFlow;
         private UpdateableAvatar ownerAvatar;
         private Drawable showResultsButton;
+        private Drawable editButton;
         private Drawable removeButton;
         private PanelBackground panelBackground;
         private FillFlowContainer mainFillFlow;
@@ -210,6 +216,23 @@ namespace osu.Game.Screens.OnlinePlay
 
                 if (showResultsButton != null)
                     showResultsButton.Alpha = value ? 1 : 0;
+            }
+        }
+
+        private bool allowEditing;
+
+        /// <summary>
+        /// Whether this item can be edited.
+        /// </summary>
+        public bool AllowEditing
+        {
+            get => allowEditing;
+            set
+            {
+                allowEditing = value;
+
+                if (editButton != null)
+                    editButton.Alpha = value ? 1 : 0;
             }
         }
 
@@ -416,6 +439,13 @@ namespace osu.Game.Screens.OnlinePlay
                 TooltipText = "View results"
             },
             Item.Beatmap.Value == null ? Empty() : new PlaylistDownloadButton(Item),
+            editButton = new PlaylistEditButton
+            {
+                Size = new Vector2(30, 30),
+                Alpha = AllowEditing ? 1 : 0,
+                Action = () => RequestEdit?.Invoke(Item),
+                TooltipText = "Edit"
+            },
             removeButton = new PlaylistRemoveButton
             {
                 Size = new Vector2(30, 30),
@@ -430,6 +460,14 @@ namespace osu.Game.Screens.OnlinePlay
             if (AllowSelection && valid.Value)
                 SelectedItem.Value = Model;
             return true;
+        }
+
+        public class PlaylistEditButton : GrayButton
+        {
+            public PlaylistEditButton()
+                : base(FontAwesome.Solid.Edit)
+            {
+            }
         }
 
         public class PlaylistRemoveButton : GrayButton

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerPlaylist.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -18,6 +19,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist
     public class MultiplayerPlaylist : MultiplayerRoomComposite
     {
         public readonly Bindable<MultiplayerPlaylistDisplayMode> DisplayMode = new Bindable<MultiplayerPlaylistDisplayMode>();
+
+        /// <summary>
+        /// Invoked when an item requests to be edited.
+        /// </summary>
+        public Action<PlaylistItem> RequestEdit;
 
         private MultiplayerQueueList queueList;
         private MultiplayerHistoryList historyList;
@@ -46,7 +52,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist
                         queueList = new MultiplayerQueueList
                         {
                             RelativeSizeAxes = Axes.Both,
-                            SelectedItem = { BindTarget = SelectedItem }
+                            SelectedItem = { BindTarget = SelectedItem },
+                            RequestEdit = item => RequestEdit?.Invoke(item)
                         },
                         historyList = new MultiplayerHistoryList
                         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
@@ -78,8 +78,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist
 
             private void updateDeleteButtonVisibility()
             {
-                AllowDeletion = (Item.OwnerID == api.LocalUser.Value.OnlineID || multiplayerClient.IsHost)
-                                && SelectedItem.Value != Item;
+                bool isItemOwner = Item.OwnerID == api.LocalUser.Value.OnlineID || multiplayerClient.IsHost;
+
+                AllowDeletion = isItemOwner && SelectedItem.Value != Item;
+                AllowEditing = isItemOwner;
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
@@ -64,7 +65,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             {
                 loadingLayer.Show();
 
-                client.AddPlaylistItem(new MultiplayerPlaylistItem
+                var multiplayerItem = new MultiplayerPlaylistItem
                 {
                     ID = itemToEdit?.ID ?? 0,
                     BeatmapID = item.BeatmapID,
@@ -72,7 +73,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     RulesetID = item.RulesetID,
                     RequiredMods = item.RequiredMods.Select(m => new APIMod(m)).ToArray(),
                     AllowedMods = item.AllowedMods.Select(m => new APIMod(m)).ToArray()
-                }).ContinueWith(t =>
+                };
+
+                Task task = itemToEdit != null ? client.EditPlaylistItem(multiplayerItem) : client.AddPlaylistItem(multiplayerItem);
+
+                task.ContinueWith(t =>
                 {
                     Schedule(() =>
                     {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -24,17 +24,22 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
+        private readonly PlaylistItem itemToEdit;
+
         private LoadingLayer loadingLayer;
 
         /// <summary>
         /// Construct a new instance of multiplayer song select.
         /// </summary>
         /// <param name="room">The room.</param>
+        /// <param name="itemToEdit">The item to be edited. May be null, in which case a new item will be added to the playlist.</param>
         /// <param name="beatmap">An optional initial beatmap selection to perform.</param>
         /// <param name="ruleset">An optional initial ruleset selection to perform.</param>
-        public MultiplayerMatchSongSelect(Room room, WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
+        public MultiplayerMatchSongSelect(Room room, PlaylistItem itemToEdit = null, WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
             : base(room)
         {
+            this.itemToEdit = itemToEdit;
+
             if (beatmap != null || ruleset != null)
             {
                 Schedule(() =>
@@ -61,6 +66,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
                 client.AddPlaylistItem(new MultiplayerPlaylistItem
                 {
+                    ID = itemToEdit?.ID ?? 0,
                     BeatmapID = item.BeatmapID,
                     BeatmapChecksum = item.Beatmap.Value.MD5Hash,
                     RulesetID = item.RulesetID,

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -14,7 +14,6 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -44,8 +43,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         public override string ShortTitle => "room";
 
-        public OsuButton AddOrEditPlaylistButton { get; private set; }
-
         [Resolved]
         private MultiplayerClient client { get; set; }
 
@@ -56,6 +53,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         [CanBeNull]
         private IDisposable readyClickOperation;
+
+        private AddItemButton addItemButton;
 
         public MultiplayerMatchSubScreen(Room room)
             : base(room)
@@ -134,12 +133,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                 new Drawable[] { new OverlinedHeader("Beatmap") },
                                 new Drawable[]
                                 {
-                                    AddOrEditPlaylistButton = new PurpleTriangleButton
+                                    addItemButton = new AddItemButton
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         Height = 40,
-                                        Action = SelectBeatmap,
-                                        Alpha = 0
+                                        Text = "Add item",
+                                        Action = () => OpenSongSelection(null)
                                     },
                                 },
                                 null,
@@ -147,7 +146,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                 {
                                     new MultiplayerPlaylist
                                     {
-                                        RelativeSizeAxes = Axes.Both
+                                        RelativeSizeAxes = Axes.Both,
+                                        RequestEdit = OpenSongSelection
                                     }
                                 },
                                 new[]
@@ -220,12 +220,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }
         };
 
-        internal void SelectBeatmap()
+        internal void OpenSongSelection(PlaylistItem itemToEdit)
         {
             if (!this.IsCurrentScreen())
                 return;
 
-            this.Push(new MultiplayerMatchSongSelect(Room));
+            this.Push(new MultiplayerMatchSongSelect(Room, itemToEdit));
         }
 
         protected override Drawable CreateFooter() => new MultiplayerMatchFooter
@@ -385,23 +385,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
-            switch (client.Room.Settings.QueueMode)
-            {
-                case QueueMode.HostOnly:
-                    AddOrEditPlaylistButton.Text = "Edit beatmap";
-                    AddOrEditPlaylistButton.Alpha = client.IsHost ? 1 : 0;
-                    break;
-
-                case QueueMode.AllPlayers:
-                case QueueMode.AllPlayersRoundRobin:
-                    AddOrEditPlaylistButton.Text = "Add beatmap";
-                    AddOrEditPlaylistButton.Alpha = 1;
-                    break;
-
-                default:
-                    AddOrEditPlaylistButton.Alpha = 0;
-                    break;
-            }
+            addItemButton.Alpha = client.IsHost || Room.QueueMode.Value != QueueMode.HostOnly ? 1 : 0;
 
             Scheduler.AddOnce(UpdateMods);
         }
@@ -466,7 +450,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
-            this.Push(new MultiplayerMatchSongSelect(Room, beatmap, ruleset));
+            this.Push(new MultiplayerMatchSongSelect(Room, SelectedItem.Value, beatmap, ruleset));
         }
 
         protected override void Dispose(bool isDisposing)
@@ -480,6 +464,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }
 
             modSettingChangeTracker?.Dispose();
+        }
+
+        public class AddItemButton : PurpleTriangleButton
+        {
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                         RelativeSizeAxes = Axes.X,
                                         Height = 40,
                                         Text = "Add item",
-                                        Action = () => OpenSongSelection(null)
+                                        Action = () => OpenSongSelection()
                                     },
                                 },
                                 null,
@@ -220,7 +220,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }
         };
 
-        internal void OpenSongSelection(PlaylistItem itemToEdit)
+        /// <summary>
+        /// Opens the song selection screen to add or edit an item.
+        /// </summary>
+        /// <param name="itemToEdit">An optional playlist item to edit. If null, a new item will be added instead.</param>
+        internal void OpenSongSelection([CanBeNull] PlaylistItem itemToEdit = null)
         {
             if (!this.IsCurrentScreen())
                 return;

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -33,13 +33,13 @@ namespace osu.Game.Screens.OnlinePlay
         [Resolved(typeof(Room), nameof(Room.Playlist))]
         protected BindableList<PlaylistItem> Playlist { get; private set; }
 
+        [CanBeNull]
+        [Resolved(CanBeNull = true)]
+        protected IBindable<PlaylistItem> SelectedItem { get; private set; }
+
         protected override UserActivity InitialActivity => new UserActivity.InLobby(room);
 
         protected readonly Bindable<IReadOnlyList<Mod>> FreeMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
-
-        [CanBeNull]
-        [Resolved(CanBeNull = true)]
-        private IBindable<PlaylistItem> selectedItem { get; set; }
 
         private readonly FreeModSelectOverlay freeModSelectOverlay;
         private readonly Room room;
@@ -80,8 +80,8 @@ namespace osu.Game.Screens.OnlinePlay
 
             // At this point, Mods contains both the required and allowed mods. For selection purposes, it should only contain the required mods.
             // Similarly, freeMods is currently empty but should only contain the allowed mods.
-            Mods.Value = selectedItem?.Value?.RequiredMods.Select(m => m.DeepClone()).ToArray() ?? Array.Empty<Mod>();
-            FreeMods.Value = selectedItem?.Value?.AllowedMods.Select(m => m.DeepClone()).ToArray() ?? Array.Empty<Mod>();
+            Mods.Value = SelectedItem?.Value?.RequiredMods.Select(m => m.DeepClone()).ToArray() ?? Array.Empty<Mod>();
+            FreeMods.Value = SelectedItem?.Value?.AllowedMods.Select(m => m.DeepClone()).ToArray() ?? Array.Empty<Mod>();
 
             Mods.BindValueChanged(onModsChanged);
             Ruleset.BindValueChanged(onRulesetChanged);


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/16019
- [ ] https://github.com/ppy/osu-server-spectator/pull/95

Resolves the first two remaining items from https://github.com/ppy/osu/pull/15640.

https://user-images.githubusercontent.com/1329837/145434566-7dc4df3a-4bd0-407e-b39c-381ef60ef553.mp4

- The host is always able to change and remove items.
- Upon changing an item, the host takes ownership of the item.
- Users are able to change any items they own.

I'm not sure about the UX of this whole thing - perhaps the button is too small and we want another button alongside the big "add" button...? I had this in a previous branch so I can bring it back if needed.

Mergeable without the osu-server-spectator changes (https://github.com/ppy/osu-server-spectator/pull/95), in which case the edit button just acts as an edit button (using existing replace-via-add logic).