### PR TITLE
Fix editor not resetting mods when entering

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -9,6 +9,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
@@ -44,6 +45,7 @@ namespace osu.Game.Tests.Visual.Editing
         protected override void LoadEditor()
         {
             Beatmap.Value = beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First(b => b.RulesetID == 0));
+            SelectedMods.Value = new[] { new ModCinema() };
             base.LoadEditor();
         }
 
@@ -67,6 +69,7 @@ namespace osu.Game.Tests.Visual.Editing
                 var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single();
                 return background.Colour == Color4.DarkGray && background.BlurAmount.Value == 0;
             });
+            AddAssert("no mods selected", () => SelectedMods.Value.Count == 0);
         }
 
         [Test]

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Edit
             base.LoadComplete();
 
             // will be restored via lease, see `DisallowExternalBeatmapRulesetChanges`.
-            Mods.Value = ArraySegment<Mod>.Empty;
+            Mods.Value = Array.Empty<Mod>();
         }
 
         protected virtual Editor CreateEditor() => new Editor(this);

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -9,6 +10,7 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 
@@ -51,6 +53,14 @@ namespace osu.Game.Screens.Edit
                     State = { Value = Visibility.Visible },
                 }
             });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // will be restored via lease, see `DisallowExternalBeatmapRulesetChanges`.
+            Mods.Value = ArraySegment<Mod>.Empty;
         }
 
         protected virtual Editor CreateEditor() => new Editor(this);


### PR DESCRIPTION
Would leave the user potentially in a test mode that is in a weird state (ie. if cinema mod was enabled). Eventually we'll add the ability to choose mods for test play, but that will be done in a saner way.

Closes #15870.