### PR TITLE
Rework multiplayer's current item tracking

### DIFF
--- a/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
+++ b/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
             AddRepeatStep("add some users", () => Client.AddUser(new APIUser { Id = id++ }), 5);
             checkPlayingUserCount(0);
 
-            AddAssert("playlist item is available", () => Client.CurrentMatchPlayingItem.Value != null);
-
             changeState(3, MultiplayerUserState.WaitingForLoad);
             checkPlayingUserCount(3);
 
@@ -64,8 +62,6 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
 
             AddStep("leave room", () => Client.LeaveRoom());
             checkPlayingUserCount(0);
-
-            AddAssert("playlist item is null", () => Client.CurrentMatchPlayingItem.Value == null);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestFirstItemSelectedByDefault()
         {
-            AddAssert("first item selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("first item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -27,13 +27,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             addItem(() => OtherBeatmap);
             AddAssert("playlist has 2 items", () => Client.APIRoom?.Playlist.Count == 2);
-            AddAssert("last playlist item is different", () => Client.APIRoom?.Playlist[1].Beatmap.Value.OnlineID == OtherBeatmap.OnlineID);
 
             addItem(() => InitialBeatmap);
             AddAssert("playlist has 3 items", () => Client.APIRoom?.Playlist.Count == 3);
-            AddAssert("last playlist item is different", () => Client.APIRoom?.Playlist[2].Beatmap.Value.OnlineID == InitialBeatmap.OnlineID);
 
-            AddAssert("first item still selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("first item still selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -43,7 +41,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddAssert("playlist has only one item", () => Client.APIRoom?.Playlist.Count == 1);
             AddAssert("playlist item is expired", () => Client.APIRoom?.Playlist[0].Expired == true);
-            AddAssert("last item selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("last item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -55,12 +53,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             RunGameplay();
 
             AddAssert("first item expired", () => Client.APIRoom?.Playlist[0].Expired == true);
-            AddAssert("next item selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[1].ID);
+            AddAssert("next item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[1].ID);
 
             RunGameplay();
 
             AddAssert("second item expired", () => Client.APIRoom?.Playlist[1].Expired == true);
-            AddAssert("next item selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[2].ID);
+            AddAssert("next item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[2].ID);
         }
 
         [Test]
@@ -74,8 +72,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("change queue mode", () => Client.ChangeSettings(queueMode: QueueMode.HostOnly));
             AddAssert("playlist has 3 items", () => Client.APIRoom?.Playlist.Count == 3);
-            AddAssert("playlist item is the other beatmap", () => Client.CurrentMatchPlayingItem.Value?.BeatmapID == OtherBeatmap.OnlineID);
-            AddAssert("playlist item is not expired", () => Client.APIRoom?.Playlist[1].Expired == false);
+            AddAssert("item 2 is not expired", () => Client.APIRoom?.Playlist[1].Expired == false);
+            AddAssert("current item is the other beatmap", () => Client.Room?.Settings.PlaylistItemId == 2);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestCorrectItemSelectedAfterNewItemAdded()
         {
             addItem(() => OtherBeatmap);
-            AddAssert("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
+            AddUntilStep("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
         }
 
         private void addItem(Func<BeatmapInfo> beatmap)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestFirstItemSelectedByDefault()
         {
-            AddAssert("first item selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("first item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             selectNewItem(() => InitialBeatmap);
 
-            AddAssert("playlist item still selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("playlist item still selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             selectNewItem(() => OtherBeatmap);
 
-            AddAssert("playlist item still selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("playlist item still selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("playlist contains two items", () => Client.APIRoom?.Playlist.Count == 2);
             AddAssert("first playlist item expired", () => Client.APIRoom?.Playlist[0].Expired == true);
             AddAssert("second playlist item not expired", () => Client.APIRoom?.Playlist[1].Expired == false);
-            AddAssert("second playlist item selected", () => Client.CurrentMatchPlayingItem.Value?.ID == Client.APIRoom?.Playlist[1].ID);
+            AddAssert("second playlist item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[1].ID);
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(otherBeatmap = beatmap()));
 
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
-            AddUntilStep("selected item is new beatmap", () => Client.CurrentMatchPlayingItem.Value?.Beatmap.Value?.OnlineID == otherBeatmap.OnlineID);
+            AddUntilStep("selected item is new beatmap", () => (CurrentSubScreen as MultiplayerMatchSubScreen)?.SelectedItem.Value.BeatmapID == otherBeatmap.OnlineID);
         }
 
         private void addItem(Func<BeatmapInfo> beatmap)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -9,6 +9,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -85,6 +86,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void selectNewItem(Func<BeatmapInfo> beatmap)
         {
+            AddUntilStep("wait for playlist panels to load", () =>
+            {
+                var queueList = this.ChildrenOfType<MultiplayerQueueList>().Single();
+                return queueList.ChildrenOfType<DrawableRoomPlaylistItem>().Count() == queueList.Items.Count;
+            });
+
             AddStep("click edit button", () =>
             {
                 InputManager.MoveMouseTo(this.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistEditButton>().First());

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(otherBeatmap = beatmap()));
 
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
-            AddUntilStep("selected item is new beatmap", () => (CurrentSubScreen as MultiplayerMatchSubScreen)?.SelectedItem.Value.BeatmapID == otherBeatmap.OnlineID);
+            AddUntilStep("selected item is new beatmap", () => (CurrentSubScreen as MultiplayerMatchSubScreen)?.SelectedItem.Value?.BeatmapID == otherBeatmap.OnlineID);
         }
 
         private void addItem(Func<BeatmapInfo> beatmap)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -416,7 +416,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Enter song select", () =>
             {
                 var currentSubScreen = ((Screens.OnlinePlay.Multiplayer.Multiplayer)multiplayerScreenStack.CurrentScreen).CurrentSubScreen;
-                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.CurrentMatchPlayingItem.Value);
+                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.Room?.Settings.PlaylistItemId);
             });
 
             AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 
@@ -27,7 +28,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("initialise gameplay", () =>
             {
-                Stack.Push(player = new MultiplayerPlayer(Client.APIRoom, Client.CurrentMatchPlayingItem.Value, Client.Room?.Users.ToArray()));
+                Stack.Push(player = new MultiplayerPlayer(Client.APIRoom, new PlaylistItem
+                {
+                    Beatmap = { Value = Beatmap.Value.BeatmapInfo },
+                    Ruleset = { Value = Beatmap.Value.BeatmapInfo.Ruleset }
+                }, Client.Room?.Users.ToArray()));
             });
 
             AddUntilStep("wait for player to be current", () => player.IsCurrentScreen() && player.IsLoaded);

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -109,42 +109,6 @@ namespace osu.Game.Tests.Visual.Playlists
             AddAssert("first playlist item selected", () => match.SelectedItem.Value == SelectedRoom.Value.Playlist[0]);
         }
 
-        [Test]
-        public void TestBeatmapUpdatedOnReImport()
-        {
-            BeatmapSetInfo importedSet = null;
-
-            AddStep("import altered beatmap", () =>
-            {
-                IBeatmap beatmap = CreateBeatmap(new OsuRuleset().RulesetInfo);
-
-                beatmap.BeatmapInfo.BaseDifficulty.CircleSize = 1;
-
-                // intentionally increment online IDs to clash with import below.
-                beatmap.BeatmapInfo.OnlineID++;
-                beatmap.BeatmapInfo.BeatmapSet.OnlineID++;
-
-                importedSet = manager.Import(beatmap.BeatmapInfo.BeatmapSet).Result.Value;
-            });
-
-            setupAndCreateRoom(room =>
-            {
-                room.Name.Value = "my awesome room";
-                room.Host.Value = API.LocalUser.Value;
-                room.Playlist.Add(new PlaylistItem
-                {
-                    Beatmap = { Value = importedSet.Beatmaps[0] },
-                    Ruleset = { Value = new OsuRuleset().RulesetInfo }
-                });
-            });
-
-            AddAssert("match has altered beatmap", () => match.Beatmap.Value.Beatmap.Difficulty.CircleSize == 1);
-
-            importBeatmap();
-
-            AddAssert("match has original beatmap", () => match.Beatmap.Value.Beatmap.Difficulty.CircleSize != 1);
-        }
-
         private void setupAndCreateRoom(Action<Room> room)
         {
             AddStep("setup room", () => room(SelectedRoom.Value));

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -95,8 +95,6 @@ namespace osu.Game.Online.Multiplayer
 
         protected readonly BindableList<int> PlayingUserIds = new BindableList<int>();
 
-        public readonly Bindable<PlaylistItem?> CurrentMatchPlayingItem = new Bindable<PlaylistItem?>();
-
         /// <summary>
         /// The <see cref="MultiplayerRoomUser"/> corresponding to the local player, if available.
         /// </summary>
@@ -162,9 +160,6 @@ namespace osu.Game.Online.Multiplayer
                 var joinedRoom = await JoinRoom(room.RoomID.Value.Value, password ?? room.Password.Value).ConfigureAwait(false);
                 Debug.Assert(joinedRoom != null);
 
-                // Populate playlist items.
-                var playlistItems = await Task.WhenAll(joinedRoom.Playlist.Select(item => createPlaylistItem(item, item.ID == joinedRoom.Settings.PlaylistItemId))).ConfigureAwait(false);
-
                 // Populate users.
                 Debug.Assert(joinedRoom.Users != null);
                 await Task.WhenAll(joinedRoom.Users.Select(PopulateUser)).ConfigureAwait(false);
@@ -176,7 +171,7 @@ namespace osu.Game.Online.Multiplayer
                     APIRoom = room;
 
                     APIRoom.Playlist.Clear();
-                    APIRoom.Playlist.AddRange(playlistItems);
+                    APIRoom.Playlist.AddRange(joinedRoom.Playlist.Select(createPlaylistItem));
 
                     Debug.Assert(LocalUser != null);
                     addUserToAPIRoom(LocalUser);
@@ -219,7 +214,6 @@ namespace osu.Game.Online.Multiplayer
             {
                 APIRoom = null;
                 Room = null;
-                CurrentMatchPlayingItem.Value = null;
                 PlayingUserIds.Clear();
 
                 RoomUpdated?.Invoke();
@@ -477,28 +471,7 @@ namespace osu.Game.Online.Multiplayer
             Debug.Assert(APIRoom != null);
             Debug.Assert(Room != null);
 
-            Scheduler.Add(() =>
-            {
-                // ensure the new selected item is populated immediately.
-                var playlistItem = APIRoom.Playlist.Single(p => p.ID == newSettings.PlaylistItemId);
-
-                if (playlistItem != null)
-                {
-                    GetAPIBeatmap(playlistItem.BeatmapID).ContinueWith(b =>
-                    {
-                        // Should be called outside of the `Scheduler` logic (and specifically accessing `Exception`) to suppress an exception from firing outwards.
-                        bool success = b.Exception == null;
-
-                        Scheduler.Add(() =>
-                        {
-                            if (success)
-                                playlistItem.Beatmap.Value = b.Result;
-
-                            updateLocalRoomSettings(newSettings);
-                        });
-                    });
-                }
-            });
+            Scheduler.Add(() => updateLocalRoomSettings(newSettings));
 
             return Task.CompletedTask;
         }
@@ -653,12 +626,10 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
-        public async Task PlaylistItemAdded(MultiplayerPlaylistItem item)
+        public Task PlaylistItemAdded(MultiplayerPlaylistItem item)
         {
             if (Room == null)
-                return;
-
-            var playlistItem = await createPlaylistItem(item, true).ConfigureAwait(false);
+                return Task.CompletedTask;
 
             Scheduler.Add(() =>
             {
@@ -668,11 +639,13 @@ namespace osu.Game.Online.Multiplayer
                 Debug.Assert(APIRoom != null);
 
                 Room.Playlist.Add(item);
-                APIRoom.Playlist.Add(playlistItem);
+                APIRoom.Playlist.Add(createPlaylistItem(item));
 
                 ItemAdded?.Invoke(item);
                 RoomUpdated?.Invoke();
             });
+
+            return Task.CompletedTask;
         }
 
         public Task PlaylistItemRemoved(long playlistItemId)
@@ -697,12 +670,10 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
-        public async Task PlaylistItemChanged(MultiplayerPlaylistItem item)
+        public Task PlaylistItemChanged(MultiplayerPlaylistItem item)
         {
             if (Room == null)
-                return;
-
-            var playlistItem = await createPlaylistItem(item, true).ConfigureAwait(false);
+                return Task.CompletedTask;
 
             Scheduler.Add(() =>
             {
@@ -715,15 +686,13 @@ namespace osu.Game.Online.Multiplayer
 
                 int existingIndex = APIRoom.Playlist.IndexOf(APIRoom.Playlist.Single(existing => existing.ID == item.ID));
                 APIRoom.Playlist.RemoveAt(existingIndex);
-                APIRoom.Playlist.Insert(existingIndex, playlistItem);
-
-                // If the currently-selected item was the one that got replaced, update the selected item to the new one.
-                if (CurrentMatchPlayingItem.Value?.ID == playlistItem.ID)
-                    CurrentMatchPlayingItem.Value = playlistItem;
+                APIRoom.Playlist.Insert(existingIndex, createPlaylistItem(item));
 
                 ItemChanged?.Invoke(item);
                 RoomUpdated?.Invoke();
             });
+
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -752,12 +721,11 @@ namespace osu.Game.Online.Multiplayer
             APIRoom.Password.Value = Room.Settings.Password;
             APIRoom.Type.Value = Room.Settings.MatchType;
             APIRoom.QueueMode.Value = Room.Settings.QueueMode;
-            RoomUpdated?.Invoke();
 
-            CurrentMatchPlayingItem.Value = APIRoom.Playlist.SingleOrDefault(p => p.ID == settings.PlaylistItemId);
+            RoomUpdated?.Invoke();
         }
 
-        private async Task<PlaylistItem> createPlaylistItem(MultiplayerPlaylistItem item, bool populateBeatmapImmediately)
+        private PlaylistItem createPlaylistItem(MultiplayerPlaylistItem item)
         {
             var ruleset = Rulesets.GetRuleset(item.RulesetID);
 
@@ -779,9 +747,6 @@ namespace osu.Game.Online.Multiplayer
             playlistItem.RequiredMods.AddRange(item.RequiredMods.Select(m => m.ToMod(rulesetInstance)));
             playlistItem.AllowedMods.AddRange(item.AllowedMods.Select(m => m.ToMod(rulesetInstance)));
 
-            if (populateBeatmapImmediately)
-                playlistItem.Beatmap.Value = await GetAPIBeatmap(item.BeatmapID).ConfigureAwait(false);
-
             return playlistItem;
         }
 
@@ -791,7 +756,7 @@ namespace osu.Game.Online.Multiplayer
         /// <param name="beatmapId">The beatmap ID.</param>
         /// <param name="cancellationToken">A token to cancel the request.</param>
         /// <returns>The <see cref="APIBeatmap"/> retrieval task.</returns>
-        protected abstract Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default);
+        public abstract Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// For the provided user ID, update whether the user is included in <see cref="CurrentMatchPlayingUserIds"/>.

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMultiplayerServer.RemovePlaylistItem), playlistItemId);
         }
 
-        protected override Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default)
+        public override Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default)
         {
             return beatmapLookupCache.GetBeatmapAsync(beatmapId, cancellationToken);
         }

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -24,6 +25,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Online.Chat;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Rulesets;
@@ -89,6 +91,10 @@ namespace osu.Game.Screens.OnlinePlay
 
         [Resolved]
         private UserLookupCache userLookupCache { get; set; }
+
+        [CanBeNull]
+        [Resolved(CanBeNull = true)]
+        private MultiplayerClient multiplayerClient { get; set; }
 
         [Resolved]
         private BeatmapLookupCache beatmapLookupCache { get; set; }
@@ -157,7 +163,13 @@ namespace osu.Game.Screens.OnlinePlay
 
                         if (Item.Beatmap.Value == null)
                         {
-                            var foundBeatmap = await beatmapLookupCache.GetBeatmapAsync(Item.BeatmapID).ConfigureAwait(false);
+                            IBeatmapInfo foundBeatmap;
+
+                            if (multiplayerClient != null)
+                                foundBeatmap = await multiplayerClient.GetAPIBeatmap(Item.BeatmapID).ConfigureAwait(false);
+                            else
+                                foundBeatmap = await beatmapLookupCache.GetBeatmapAsync(Item.BeatmapID).ConfigureAwait(false);
+
                             Schedule(() => Item.Beatmap.Value = foundBeatmap);
                         }
                     }

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -166,6 +166,8 @@ namespace osu.Game.Screens.OnlinePlay
                             IBeatmapInfo foundBeatmap;
 
                             if (multiplayerClient != null)
+                                // This call can eventually go away (and use the else case below).
+                                // Currently required only due to the method being overridden to provide special behaviour in tests.
                                 foundBeatmap = await multiplayerClient.GetAPIBeatmap(Item.BeatmapID).ConfigureAwait(false);
                             else
                                 foundBeatmap = await beatmapLookupCache.GetBeatmapAsync(Item.BeatmapID).ConfigureAwait(false);

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
     public abstract class RoomSubScreen : OnlinePlaySubScreen, IPreviewTrackOwner
     {
         [Cached(typeof(IBindable<PlaylistItem>))]
-        protected readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
+        public readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
 
         public override bool? AllowTrackAdjustments => true;
 

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -302,7 +302,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
         public override void OnResuming(IScreen last)
         {
             base.OnResuming(last);
-            updateWorkingBeatmap();
+            UpdateWorkingBeatmap();
             beginHandlingTrack();
             Scheduler.AddOnce(UpdateMods);
         }
@@ -345,7 +345,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         private void selectedItemChanged()
         {
-            updateWorkingBeatmap();
+            UpdateWorkingBeatmap();
 
             var selected = SelectedItem.Value;
 
@@ -374,9 +374,9 @@ namespace osu.Game.Screens.OnlinePlay.Match
             }
         }
 
-        private void beatmapUpdated(BeatmapSetInfo set) => Schedule(updateWorkingBeatmap);
+        private void beatmapUpdated(BeatmapSetInfo set) => Schedule(UpdateWorkingBeatmap);
 
-        private void updateWorkingBeatmap()
+        protected virtual void UpdateWorkingBeatmap()
         {
             var beatmap = SelectedItem.Value?.Beatmap.Value;
 

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
+using osu.Game.Online;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -378,6 +379,12 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         protected virtual void UpdateWorkingBeatmap()
         {
+            if (BeatmapAvailability.Value.State != DownloadState.LocallyAvailable)
+            {
+                Beatmap.Value = beatmapManager.GetWorkingBeatmap(null);
+                return;
+            }
+
             var beatmap = SelectedItem.Value?.Beatmap.Value;
 
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -63,6 +63,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             sampleUnready = audio.Samples.Get(@"Multiplayer/player-unready");
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            SelectedItem.BindValueChanged(_ => updateState());
+        }
+
         protected override void OnRoomUpdated()
         {
             base.OnRoomUpdated();
@@ -104,7 +111,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
             bool enableButton =
                 Room?.State == MultiplayerRoomState.Open
-                && Client.CurrentMatchPlayingItem.Value?.Expired == false
+                && SelectedItem.Value?.ID == Room.Settings.PlaylistItemId
+                && !Room.Playlist.Single(i => i.ID == Room.Settings.PlaylistItemId).Expired
                 && !operationInProgress.Value;
 
             // When the local user is the host and spectating the match, the "start match" state should be enabled if any users are ready.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
-        private readonly PlaylistItem itemToEdit;
+        private readonly long? itemToEdit;
 
         private LoadingLayer loadingLayer;
 
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// <param name="itemToEdit">The item to be edited. May be null, in which case a new item will be added to the playlist.</param>
         /// <param name="beatmap">An optional initial beatmap selection to perform.</param>
         /// <param name="ruleset">An optional initial ruleset selection to perform.</param>
-        public MultiplayerMatchSongSelect(Room room, PlaylistItem itemToEdit = null, WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
+        public MultiplayerMatchSongSelect(Room room, long? itemToEdit = null, WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
             : base(room)
         {
             this.itemToEdit = itemToEdit;
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
                 var multiplayerItem = new MultiplayerPlaylistItem
                 {
-                    ID = itemToEdit?.ID ?? 0,
+                    ID = itemToEdit ?? 0,
                     BeatmapID = item.BeatmapID,
                     BeatmapChecksum = item.Beatmap.Value.MD5Hash,
                     RulesetID = item.RulesetID,

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -337,9 +337,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             base.UpdateWorkingBeatmap();
 
+            // Nothing to do if the beatmap hasn't changed.
             if (Beatmap.Value.BeatmapInfo.MatchesOnlineID(lastBeatmap.BeatmapInfo))
                 return;
 
+            // The selected item is nulled during the beatmap query. During this, the working beatmap will be the dummy beatmap.
+            // We don't want to enter spectate mode with the dummy beatmap.
             if (!Beatmap.Value.BeatmapInfo.MatchesOnlineID(SelectedItem.Value?.Beatmap.Value))
                 return;
 
@@ -421,9 +424,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (expectedSelectedItem == null)
                 return;
 
+            // There's no reason to renew the selected item if its content hasn't changed.
             if (SelectedItem.Value?.Equals(expectedSelectedItem) == true && expectedSelectedItem.Beatmap.Value != null)
                 return;
 
+            // Clear the selected item while the lookup is performed, so components like the ready button can enter their disabled states.
             SelectedItem.Value = null;
 
             if (expectedSelectedItem.Beatmap.Value == null)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -15,6 +15,7 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -326,10 +327,24 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 if (client.LocalUser?.State == MultiplayerUserState.Ready)
                     client.ChangeState(MultiplayerUserState.Idle);
             }
-            else
+        }
+
+        protected override void UpdateWorkingBeatmap()
+        {
+            var lastBeatmap = Beatmap.Value;
+
+            base.UpdateWorkingBeatmap();
+
+            if (Beatmap.Value.BeatmapInfo.MatchesOnlineID(lastBeatmap.BeatmapInfo))
+                return;
+
+            if (!Beatmap.Value.BeatmapInfo.MatchesOnlineID(SelectedItem.Value?.Beatmap.Value))
+                return;
+
+            if (client.LocalUser?.State == MultiplayerUserState.Spectating
+                && (client.Room?.State == MultiplayerRoomState.WaitingForLoad || client.Room?.State == MultiplayerRoomState.Playing))
             {
-                if (client.LocalUser?.State == MultiplayerUserState.Spectating && (client.Room?.State == MultiplayerRoomState.WaitingForLoad || client.Room?.State == MultiplayerRoomState.Playing))
-                    onLoadRequested();
+                onLoadRequested();
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -66,8 +67,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            SelectedItem.BindTo(client.CurrentMatchPlayingItem);
 
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
             UserMods.BindValueChanged(onUserModsChanged);
@@ -147,7 +146,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                     new MultiplayerPlaylist
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        RequestEdit = OpenSongSelection
+                                        RequestEdit = item => OpenSongSelection(item.ID)
                                     }
                                 },
                                 new[]
@@ -224,7 +223,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// Opens the song selection screen to add or edit an item.
         /// </summary>
         /// <param name="itemToEdit">An optional playlist item to edit. If null, a new item will be added instead.</param>
-        internal void OpenSongSelection([CanBeNull] PlaylistItem itemToEdit = null)
+        internal void OpenSongSelection(long? itemToEdit = null)
         {
             if (!this.IsCurrentScreen())
                 return;
@@ -389,9 +388,46 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
+            updateCurrentItem();
+
             addItemButton.Alpha = client.IsHost || Room.QueueMode.Value != QueueMode.HostOnly ? 1 : 0;
 
             Scheduler.AddOnce(UpdateMods);
+        }
+
+        private void updateCurrentItem()
+        {
+            Debug.Assert(client.Room != null);
+
+            var expectedSelectedItem = Room.Playlist.SingleOrDefault(i => i.ID == client.Room.Settings.PlaylistItemId);
+
+            if (expectedSelectedItem == null)
+                return;
+
+            if (SelectedItem.Value?.Equals(expectedSelectedItem) == true && expectedSelectedItem.Beatmap.Value != null)
+                return;
+
+            SelectedItem.Value = null;
+
+            if (expectedSelectedItem.Beatmap.Value == null)
+            {
+                Task.Run(async () =>
+                {
+                    var beatmap = await client.GetAPIBeatmap(expectedSelectedItem.BeatmapID).ConfigureAwait(false);
+
+                    Schedule(() =>
+                    {
+                        expectedSelectedItem.Beatmap.Value = beatmap;
+
+                        if (Room.Playlist.SingleOrDefault(i => i.ID == client.Room?.Settings.PlaylistItemId)?.Equals(expectedSelectedItem) == true)
+                            applyCurrentItem();
+                    });
+                });
+            }
+            else
+                applyCurrentItem();
+
+            void applyCurrentItem() => SelectedItem.Value = expectedSelectedItem;
         }
 
         private void handleRoomLost() => Schedule(() =>
@@ -446,6 +482,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!this.IsCurrentScreen())
                 return;
 
+            if (client.Room == null)
+                return;
+
             if (!client.IsHost)
             {
                 // todo: should handle this when the request queue is implemented.
@@ -454,7 +493,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
-            this.Push(new MultiplayerMatchSongSelect(Room, SelectedItem.Value, beatmap, ruleset));
+            this.Push(new MultiplayerMatchSongSelect(Room, client.Room.Settings.PlaylistItemId, beatmap, ruleset));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -327,6 +327,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 if (client.LocalUser?.State == MultiplayerUserState.Ready)
                     client.ChangeState(MultiplayerUserState.Idle);
             }
+
+            UpdateWorkingBeatmap();
         }
 
         protected override void UpdateWorkingBeatmap()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -15,7 +15,6 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Extensions;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -327,27 +326,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 if (client.LocalUser?.State == MultiplayerUserState.Ready)
                     client.ChangeState(MultiplayerUserState.Idle);
             }
-
-            UpdateWorkingBeatmap();
-        }
-
-        protected override void UpdateWorkingBeatmap()
-        {
-            var lastBeatmap = Beatmap.Value;
-
-            base.UpdateWorkingBeatmap();
-
-            // Nothing to do if the beatmap hasn't changed.
-            if (Beatmap.Value.BeatmapInfo.MatchesOnlineID(lastBeatmap.BeatmapInfo))
-                return;
-
-            // The selected item is nulled during the beatmap query. During this, the working beatmap will be the dummy beatmap.
-            // We don't want to enter spectate mode with the dummy beatmap.
-            if (!Beatmap.Value.BeatmapInfo.MatchesOnlineID(SelectedItem.Value?.Beatmap.Value))
-                return;
-
-            if (client.LocalUser?.State == MultiplayerUserState.Spectating
-                && (client.Room?.State == MultiplayerRoomState.WaitingForLoad || client.Room?.State == MultiplayerRoomState.Playing))
+            else if (client.LocalUser?.State == MultiplayerUserState.Spectating
+                     && (client.Room?.State == MultiplayerRoomState.WaitingForLoad || client.Room?.State == MultiplayerRoomState.Playing))
             {
                 onLoadRequested();
             }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -376,7 +376,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public override Task RemovePlaylistItem(long playlistItemId) => RemoveUserPlaylistItem(api.LocalUser.Value.OnlineID, playlistItemId);
 
-        protected override Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default)
+        public override Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default)
         {
             IBeatmapSetInfo? set = roomManager.ServerSideRooms.SelectMany(r => r.Playlist)
                                               .FirstOrDefault(p => p.BeatmapID == beatmapId)?.Beatmap.Value.BeatmapSet


### PR DESCRIPTION
I've wanted to get rid of `MultiplayerClient.CurrentMatchPlayingItem` bindable for quite a while now, and given the recent test failures I thought it would be a good time to finally get around to doing it.

- The `MultiplayerClient.CurrentMatchPlayingItem` bindable has been removed.
- `MultiplayerMatchSubScreen` performs an API beatmap requests and sets the screen's `SelectedItem` bindable when it completes.
- The immediate beatmap lookup for the current item has been removed from `MultiplayerClient`, replaced by the above.
- Several test fixes, by adding sleeps inside the above beatmap lookup and `DrawablePlaylistItem.load()`.