### PR TITLE
Fix results sometimes showing incorrect score position

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Tests.Visual.Playlists
     public class TestScenePlaylistsResultsScreen : ScreenTestScene
     {
         private const int scores_per_result = 10;
+        private const int real_user_position = 200;
 
         private TestResultsScreen resultsScreen;
 
@@ -58,6 +59,8 @@ namespace osu.Game.Tests.Visual.Playlists
             createResults(() => userScore);
 
             AddAssert("user score selected", () => this.ChildrenOfType<ScorePanel>().Single(p => p.Score.OnlineID == userScore.OnlineID).State == PanelState.Expanded);
+            AddAssert($"score panel position is {real_user_position}",
+                () => this.ChildrenOfType<ScorePanel>().Single(p => p.Score.OnlineID == userScore.OnlineID).ScorePosition.Value == real_user_position);
         }
 
         [Test]
@@ -236,7 +239,7 @@ namespace osu.Game.Tests.Visual.Playlists
                 EndedAt = userScore.Date,
                 Passed = userScore.Passed,
                 Rank = userScore.Rank,
-                Position = 200,
+                Position = real_user_position,
                 MaxCombo = userScore.MaxCombo,
                 TotalScore = userScore.TotalScore,
                 User = userScore.User,

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
@@ -87,6 +87,13 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             {
                 var allScores = new List<MultiplayerScore> { userScore };
 
+                // Other scores could have arrived between score submission and entering the results screen. Ensure the local player score position is up to date.
+                if (Score != null)
+                {
+                    Score.Position = userScore.Position;
+                    ScorePanelList.GetPanelForScore(Score).ScorePosition.Value = userScore.Position;
+                }
+
                 if (userScore.ScoresAround?.Higher != null)
                 {
                     allScores.AddRange(userScore.ScoresAround.Higher.Scores);

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelTopContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelTopContent.cs
@@ -2,36 +2,42 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Ranking.Contracted
 {
     public class ContractedPanelTopContent : CompositeDrawable
     {
-        private readonly ScoreInfo score;
+        public readonly Bindable<int?> ScorePosition = new Bindable<int?>();
 
-        public ContractedPanelTopContent(ScoreInfo score)
+        private OsuSpriteText text;
+
+        public ContractedPanelTopContent()
         {
-            this.score = score;
-
             RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = new OsuSpriteText
+            InternalChild = text = new OsuSpriteText
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
                 Y = 6,
-                Text = score.Position != null ? $"#{score.Position}" : string.Empty,
                 Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold)
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ScorePosition.BindValueChanged(pos => text.Text = pos.NewValue != null ? $"#{pos.NewValue}" : string.Empty, true);
         }
     }
 }

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -79,6 +80,11 @@ namespace osu.Game.Screens.Ranking
         public event Action<PanelState> StateChanged;
 
         /// <summary>
+        /// The position of the score in the rankings.
+        /// </summary>
+        public readonly Bindable<int?> ScorePosition = new Bindable<int?>();
+
+        /// <summary>
         /// An action to be invoked if this <see cref="ScorePanel"/> is clicked while in an expanded state.
         /// </summary>
         public Action PostExpandAction;
@@ -103,6 +109,8 @@ namespace osu.Game.Screens.Ranking
         {
             Score = score;
             displayWithFlair = isNewLocalScore;
+
+            ScorePosition.Value = score.Position;
         }
 
         [BackgroundDependencyLoader]
@@ -211,8 +219,8 @@ namespace osu.Game.Screens.Ranking
                     topLayerBackground.FadeColour(expanded_top_layer_colour, RESIZE_DURATION, Easing.OutQuint);
                     middleLayerBackground.FadeColour(expanded_middle_layer_colour, RESIZE_DURATION, Easing.OutQuint);
 
-                    topLayerContentContainer.Add(topLayerContent = new ExpandedPanelTopContent(Score.User).With(d => d.Alpha = 0));
-                    middleLayerContentContainer.Add(middleLayerContent = new ExpandedPanelMiddleContent(Score, displayWithFlair).With(d => d.Alpha = 0));
+                    topLayerContentContainer.Add(topLayerContent = new ExpandedPanelTopContent(Score.User) { Alpha = 0 });
+                    middleLayerContentContainer.Add(middleLayerContent = new ExpandedPanelMiddleContent(Score, displayWithFlair) { Alpha = 0 });
 
                     // only the first expanded display should happen with flair.
                     displayWithFlair = false;
@@ -224,8 +232,13 @@ namespace osu.Game.Screens.Ranking
                     topLayerBackground.FadeColour(contracted_top_layer_colour, RESIZE_DURATION, Easing.OutQuint);
                     middleLayerBackground.FadeColour(contracted_middle_layer_colour, RESIZE_DURATION, Easing.OutQuint);
 
-                    topLayerContentContainer.Add(topLayerContent = new ContractedPanelTopContent(Score).With(d => d.Alpha = 0));
-                    middleLayerContentContainer.Add(middleLayerContent = new ContractedPanelMiddleContent(Score).With(d => d.Alpha = 0));
+                    topLayerContentContainer.Add(topLayerContent = new ContractedPanelTopContent
+                    {
+                        ScorePosition = { BindTarget = ScorePosition },
+                        Alpha = 0
+                    });
+
+                    middleLayerContentContainer.Add(middleLayerContent = new ContractedPanelMiddleContent(Score) { Alpha = 0 });
                     break;
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/16060

The position is updated once upon score submission, but since multiple users are submitting simultaneously the position can be out of date by the time the results screen is pushed. This most commonly happens with multiplayer, but is feasible to also occur with playlists.