### PR TITLE
Improve appearance of player-wide background after failing with low background dim

### DIFF
--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Screens.Play
             Content.RotateTo(1, duration, Easing.OutQuart);
             Content.FadeColour(Color4.Gray, duration);
 
+            // Will be restored by `ApplyToBackground` logic in `SongSelect`.
             Background?.FadeColour(OsuColour.Gray(0.3f), 60);
         }
 

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Game.Rulesets.UI;
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using ManagedBass.Fx;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
@@ -18,6 +19,7 @@ using osu.Framework.Utils;
 using osu.Game.Audio.Effects;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
@@ -57,6 +59,12 @@ namespace osu.Game.Screens.Play
             Origin = Anchor.Centre,
             RelativeSizeAxes = Axes.Both,
         };
+
+        /// <summary>
+        /// The player screen background, used to adjust appearance on failing.
+        /// </summary>
+        [CanBeNull]
+        public BackgroundScreen Background { private get; set; }
 
         public FailAnimation(DrawableRuleset drawableRuleset)
         {
@@ -136,6 +144,8 @@ namespace osu.Game.Screens.Play
             Content.ScaleTo(0.85f, duration, Easing.OutQuart);
             Content.RotateTo(1, duration, Easing.OutQuart);
             Content.FadeColour(Color4.Gray, duration);
+
+            Background?.FadeColour(OsuColour.Gray(0.3f), 60);
         }
 
         public void RemoveFilters(bool resetTrackFrequency = true)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -921,6 +921,8 @@ namespace osu.Game.Screens.Play
                 b.IsBreakTime.BindTo(breakTracker.IsBreakTime);
 
                 b.StoryboardReplacesBackground.BindTo(storyboardReplacesBackground);
+
+                failAnimationLayer.Background = b;
             });
 
             HUDOverlay.IsBreakTime.BindTo(breakTracker.IsBreakTime);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/16066. Would have liked to scale the background, but this gets a bit convoluted due to having to undo the scale on leaving player.

Before:

https://user-images.githubusercontent.com/191335/145759122-06cf388a-2552-4210-9a96-56d8fc55adee.mp4


After:

https://user-images.githubusercontent.com/191335/145759332-327d32c2-1533-4030-a4dd-a181f03ad045.mp4



