### PR TITLE
Fix multiplayer queue list test failures

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -162,7 +162,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         private void assertDeleteButtonVisibility(int index, bool visible)
-            => AddUntilStep($"delete button {index} {(visible ? "is" : "is not")} visible",
-                () => (playlist.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistRemoveButton>().ElementAt(index).Alpha > 0) == visible);
+            => AddUntilStep($"delete button {index} {(visible ? "is" : "is not")} visible", () =>
+            {
+                var button = playlist.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistRemoveButton>().ElementAtOrDefault(index);
+                return button != null && (button.Alpha > 0) == visible;
+            });
     }
 }


### PR DESCRIPTION
As seen in [several](https://github.com/ppy/osu/runs/4503768911?check_suite_focus=true) [places](https://github.com/ppy/osu/runs/4502621838?check_suite_focus=true).

Reproduced locally (slightly earlier but with the same stack trace) with single thread mode and following diff applied:

```diff
diff --git a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
index 8042f7d772..82e965d3e0 100644
--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -292,7 +292,7 @@ private void refresh()
             modDisplay.Current.Value = requiredMods.ToArray();
 
             buttonsFlow.Clear();
-            buttonsFlow.ChildrenEnumerable = createButtons();
+            Scheduler.AddDelayed(() => buttonsFlow.ChildrenEnumerable = createButtons(), 1000);
 
             difficultyIconContainer.FadeInFromZero(500, Easing.OutQuint);
             mainFillFlow.FadeInFromZero(500, Easing.OutQuint);
```

As should be made pretty clear by the above reproduction, the cause was the until step executing too early - at that point some of the buttons hadn't been (re)created yet:

https://github.com/ppy/osu/blob/c375c8709430e573d4d2ea01e6f64dd9d8eb4dfd/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs#L432-L456

causing `ElementAt()` to throw.

The applied solution is to wait for the element to get spawned by using `ElementAtOrDefault()` instead, and only then make sure that the button is both present and in the desired state.