### PR TITLE
Add AbortGameplay() to fix state transition race conditions during multiplayer load

### DIFF
--- a/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
@@ -78,6 +78,11 @@ namespace osu.Game.Online.Multiplayer
         Task StartMatch();
 
         /// <summary>
+        /// Aborts an ongoing gameplay load.
+        /// </summary>
+        Task AbortLoad();
+
+        /// <summary>
         /// Adds an item to the playlist.
         /// </summary>
         /// <param name="item">The item to add.</param>

--- a/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerRoomServer.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// Aborts an ongoing gameplay load.
         /// </summary>
-        Task AbortLoad();
+        Task AbortGameplay();
 
         /// <summary>
         /// Adds an item to the playlist.

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -333,7 +333,7 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task StartMatch();
 
-        public abstract Task AbortLoad();
+        public abstract Task AbortGameplay();
 
         public abstract Task AddPlaylistItem(MultiplayerPlaylistItem item);
 

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -333,6 +333,8 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task StartMatch();
 
+        public abstract Task AbortLoad();
+
         public abstract Task AddPlaylistItem(MultiplayerPlaylistItem item);
 
         public abstract Task EditPlaylistItem(MultiplayerPlaylistItem item);

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -154,6 +154,14 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
         }
 
+        public override Task AbortLoad()
+        {
+            if (!IsConnected.Value)
+                return Task.CompletedTask;
+
+            return connection.InvokeAsync(nameof(IMultiplayerServer.AbortLoad));
+        }
+
         public override Task AddPlaylistItem(MultiplayerPlaylistItem item)
         {
             if (!IsConnected.Value)

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -154,12 +154,12 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
         }
 
-        public override Task AbortLoad()
+        public override Task AbortGameplay()
         {
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
-            return connection.InvokeAsync(nameof(IMultiplayerServer.AbortLoad));
+            return connection.InvokeAsync(nameof(IMultiplayerServer.AbortGameplay));
         }
 
         public override Task AddPlaylistItem(MultiplayerPlaylistItem item)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -30,7 +30,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     break;
 
                 case MultiplayerUserState.WaitingForLoad:
-                    client.AbortLoad();
+                case MultiplayerUserState.Loaded:
+                case MultiplayerUserState.Playing:
+                    client.AbortGameplay();
                     break;
 
                 default:

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Game.Online.Multiplayer;
@@ -18,8 +19,24 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.OnResuming(last);
 
-            if (client.Room != null && client.LocalUser?.State != MultiplayerUserState.Spectating)
-                client.ChangeState(MultiplayerUserState.Idle);
+            if (client.Room == null)
+                return;
+
+            Debug.Assert(client.LocalUser != null);
+
+            switch (client.LocalUser.State)
+            {
+                case MultiplayerUserState.Spectating:
+                    break;
+
+                case MultiplayerUserState.WaitingForLoad:
+                    client.AbortLoad();
+                    break;
+
+                default:
+                    client.ChangeState(MultiplayerUserState.Idle);
+                    break;
+            }
         }
 
         protected override string ScreenTitle => "Multiplayer";

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -128,6 +128,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     case MultiplayerRoomState.WaitingForLoad:
                         if (Room.Users.All(u => u.State != MultiplayerUserState.WaitingForLoad))
                         {
+                            var loadedUsers = Room.Users.Where(u => u.State == MultiplayerUserState.Loaded).ToArray();
+
+                            if (loadedUsers.Length == 0)
+                            {
+                                // all users have bailed from the load sequence. cancel the game start.
+                                ChangeRoomState(MultiplayerRoomState.Open);
+                                return;
+                            }
+
                             foreach (var u in Room.Users.Where(u => u.State == MultiplayerUserState.Loaded))
                                 ChangeUserState(u.UserID, MultiplayerUserState.Playing);
 
@@ -143,8 +152,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         {
                             foreach (var u in Room.Users.Where(u => u.State == MultiplayerUserState.FinishedPlay))
                                 ChangeUserState(u.UserID, MultiplayerUserState.Results);
-                            ChangeRoomState(MultiplayerRoomState.Open);
 
+                            ChangeRoomState(MultiplayerRoomState.Open);
                             ((IMultiplayerClient)this).ResultsReady();
 
                             FinishCurrentItem().Wait();

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return ((IMultiplayerClient)this).LoadRequested();
         }
 
-        public override Task AbortLoad()
+        public override Task AbortGameplay()
         {
             Debug.Assert(Room != null);
             Debug.Assert(LocalUser != null);

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -242,6 +242,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public override Task ChangeState(MultiplayerUserState newState)
         {
+            Debug.Assert(Room != null);
+
+            if (newState == MultiplayerUserState.Idle && LocalUser?.State == MultiplayerUserState.WaitingForLoad)
+                return Task.CompletedTask;
+
             ChangeUserState(api.LocalUser.Value.Id, newState);
             return Task.CompletedTask;
         }
@@ -301,6 +306,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 ChangeUserState(user.UserID, MultiplayerUserState.WaitingForLoad);
 
             return ((IMultiplayerClient)this).LoadRequested();
+        }
+
+        public override Task AbortLoad()
+        {
+            Debug.Assert(Room != null);
+            Debug.Assert(LocalUser != null);
+
+            ChangeUserState(LocalUser.UserID, MultiplayerUserState.Idle);
+
+            return Task.CompletedTask;
         }
 
         public async Task AddUserPlaylistItem(int userId, MultiplayerPlaylistItem item)


### PR DESCRIPTION
Prereqs:
- [ ] Server deploy (containing https://github.com/ppy/osu-server-spectator/pull/97)

As discussed in / resolves https://github.com/ppy/osu/issues/14181