### PR TITLE
Fix crash on accessing settings after moving game folder

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -56,13 +56,13 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Test]
         public void TestDefaultSkin()
         {
-            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = DefaultSkin.CreateInfo().ToLive());
+            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = DefaultSkin.CreateInfo().ToLiveUnmanaged());
         }
 
         [Test]
         public void TestLegacySkin()
         {
-            AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.CreateInfo().ToLive());
+            AddStep("set legacy skin", () => skins.CurrentSkinInfo.Value = DefaultLegacySkin.CreateInfo().ToLiveUnmanaged());
         }
     }
 }

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -22,9 +22,9 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realmFactory, _) =>
             {
-                ILive<RealmBeatmap> beatmap = realmFactory.CreateContext().Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata()))).ToLive();
+                ILive<RealmBeatmap> beatmap = realmFactory.CreateContext().Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata()))).ToLive(realmFactory);
 
-                ILive<RealmBeatmap> beatmap2 = realmFactory.CreateContext().All<RealmBeatmap>().First().ToLive();
+                ILive<RealmBeatmap> beatmap2 = realmFactory.CreateContext().All<RealmBeatmap>().First().ToLive(realmFactory);
 
                 Assert.AreEqual(beatmap, beatmap2);
             });
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Database
                 {
                     context.Write(r => r.Add(beatmap));
 
-                    liveBeatmap = beatmap.ToLive();
+                    liveBeatmap = beatmap.ToLive(realmFactory);
                 }
 
                 using (var migratedStorage = new TemporaryNativeStorage("realm-test-migration-target"))
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Database
             {
                 var beatmap = new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata());
 
-                var liveBeatmap = beatmap.ToLive();
+                var liveBeatmap = beatmap.ToLive(realmFactory);
 
                 using (var context = realmFactory.CreateContext())
                     context.Write(r => r.Add(beatmap));
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Database
         public void TestAccessNonManaged()
         {
             var beatmap = new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata());
-            var liveBeatmap = beatmap.ToLive();
+            var liveBeatmap = beatmap.ToLiveUnmanaged();
 
             Assert.IsFalse(beatmap.Hidden);
             Assert.IsFalse(liveBeatmap.Value.Hidden);
@@ -102,7 +102,7 @@ namespace osu.Game.Tests.Database
                     {
                         var beatmap = threadContext.Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive();
+                        liveBeatmap = beatmap.ToLive(realmFactory);
                     }
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).Wait();
 
@@ -131,7 +131,7 @@ namespace osu.Game.Tests.Database
                     {
                         var beatmap = threadContext.Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive();
+                        liveBeatmap = beatmap.ToLive(realmFactory);
                     }
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).Wait();
 
@@ -151,7 +151,7 @@ namespace osu.Game.Tests.Database
             RunTestWithRealm((realmFactory, _) =>
             {
                 var beatmap = new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata());
-                var liveBeatmap = beatmap.ToLive();
+                var liveBeatmap = beatmap.ToLive(realmFactory);
 
                 Assert.DoesNotThrow(() =>
                 {
@@ -173,7 +173,7 @@ namespace osu.Game.Tests.Database
                     {
                         var beatmap = threadContext.Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive();
+                        liveBeatmap = beatmap.ToLive(realmFactory);
                     }
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).Wait();
 
@@ -211,7 +211,7 @@ namespace osu.Game.Tests.Database
                     {
                         var beatmap = threadContext.Write(r => r.Add(new RealmBeatmap(CreateRuleset(), new RealmBeatmapDifficulty(), new RealmBeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive();
+                        liveBeatmap = beatmap.ToLive(realmFactory);
                     }
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).Wait();
 
@@ -250,7 +250,7 @@ namespace osu.Game.Tests.Database
                             // not just a refresh from the resolved Live.
                             threadContext.Write(r => r.Add(new RealmBeatmap(ruleset, new RealmBeatmapDifficulty(), new RealmBeatmapMetadata())));
 
-                            liveBeatmap = beatmap.ToLive();
+                            liveBeatmap = beatmap.ToLive(realmFactory);
                         }
                     }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).Wait();
 

--- a/osu.Game.Tests/Database/RealmTest.cs
+++ b/osu.Game.Tests/Database/RealmTest.cs
@@ -10,6 +10,7 @@ using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Database;
+using osu.Game.IO;
 using osu.Game.Models;
 
 #nullable enable
@@ -27,15 +28,16 @@ namespace osu.Game.Tests.Database
             storage.DeleteDirectory(string.Empty);
         }
 
-        protected void RunTestWithRealm(Action<RealmContextFactory, Storage> testAction, [CallerMemberName] string caller = "")
+        protected void RunTestWithRealm(Action<RealmContextFactory, OsuStorage> testAction, [CallerMemberName] string caller = "")
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost(caller))
             {
                 host.Run(new RealmTestGame(() =>
                 {
-                    var testStorage = storage.GetStorageForDirectory(caller);
+                    // ReSharper disable once AccessToDisposedClosure
+                    var testStorage = new OsuStorage(host, storage.GetStorageForDirectory(caller));
 
-                    using (var realmFactory = new RealmContextFactory(testStorage, caller))
+                    using (var realmFactory = new RealmContextFactory(testStorage, "client"))
                     {
                         Logger.Log($"Running test using realm file {testStorage.GetFullPath(realmFactory.Filename)}");
                         testAction(realmFactory, testStorage);
@@ -58,7 +60,7 @@ namespace osu.Game.Tests.Database
                 {
                     var testStorage = storage.GetStorageForDirectory(caller);
 
-                    using (var realmFactory = new RealmContextFactory(testStorage, caller))
+                    using (var realmFactory = new RealmContextFactory(testStorage, "client"))
                     {
                         Logger.Log($"Running test using realm file {testStorage.GetFullPath(realmFactory.Filename)}");
                         await testAction(realmFactory, testStorage);

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -15,6 +15,7 @@ using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Audio;
+using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -220,6 +221,7 @@ namespace osu.Game.Tests.Gameplay
         public AudioManager AudioManager => Audio;
         public IResourceStore<byte[]> Files => null;
         public new IResourceStore<byte[]> Resources => base.Resources;
+        public RealmContextFactory RealmContextFactory => null;
         public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => null;
 
         #endregion

--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Visual.Background
         private void setCustomSkin()
         {
             // feign a skin switch. this doesn't do anything except force CurrentSkin to become a LegacySkin.
-            AddStep("set custom skin", () => skins.CurrentSkinInfo.Value = new SkinInfo().ToLive());
+            AddStep("set custom skin", () => skins.CurrentSkinInfo.Value = new SkinInfo().ToLiveUnmanaged());
         }
 
         private void setDefaultSkin() => AddStep("set default skin", () => skins.CurrentSkinInfo.SetDefault());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 AddStep("setup skins", () =>
                 {
-                    skinManager.CurrentSkinInfo.Value = gameCurrentSkin.ToLive();
+                    skinManager.CurrentSkinInfo.Value = gameCurrentSkin.ToLiveUnmanaged();
                     currentBeatmapSkin = getBeatmapSkin();
                 });
             });

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -15,6 +15,7 @@ using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
@@ -108,6 +109,7 @@ namespace osu.Game.Beatmaps
         TextureStore IBeatmapResourceProvider.LargeTextureStore => largeTextureStore;
         ITrackStore IBeatmapResourceProvider.Tracks => trackStore;
         AudioManager IStorageResourceProvider.AudioManager => audioManager;
+        RealmContextFactory IStorageResourceProvider.RealmContextFactory => null;
         IResourceStore<byte[]> IStorageResourceProvider.Files => files;
         IResourceStore<byte[]> IStorageResourceProvider.Resources => resources;
         IResourceStore<TextureUpload> IStorageResourceProvider.CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => host?.CreateTextureLoaderStore(underlyingStore);

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -24,20 +24,16 @@ namespace osu.Game.Database
         /// </summary>
         private readonly T data;
 
-        private readonly RealmContextFactory? realmFactory;
+        private readonly RealmContextFactory realmFactory;
 
         /// <summary>
         /// Construct a new instance of live realm data.
         /// </summary>
         /// <param name="data">The realm data.</param>
         /// <param name="realmFactory">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
-        public RealmLive(T data, RealmContextFactory? realmFactory)
+        public RealmLive(T data, RealmContextFactory realmFactory)
         {
             this.data = data;
-
-            if (IsManaged && realmFactory == null)
-                throw new ArgumentException(@"Realm factory must be provided for a managed instance", nameof(realmFactory));
-
             this.realmFactory = realmFactory;
 
             ID = data.ID;
@@ -55,9 +51,6 @@ namespace osu.Game.Database
                 return;
             }
 
-            if (realmFactory == null)
-                throw new ArgumentException(@"Realm factory must be provided for a managed instance", nameof(realmFactory));
-
             using (var realm = realmFactory.CreateContext())
                 perform(realm.Find<T>(ID));
         }
@@ -73,9 +66,6 @@ namespace osu.Game.Database
 
             if (!IsManaged)
                 return perform(data);
-
-            if (realmFactory == null)
-                throw new ArgumentException(@"Realm factory must be provided for a managed instance", nameof(realmFactory));
 
             using (var realm = realmFactory.CreateContext())
                 return perform(realm.Find<T>(ID));
@@ -108,7 +98,7 @@ namespace osu.Game.Database
                 if (!ThreadSafety.IsUpdateThread)
                     throw new InvalidOperationException($"Can't use {nameof(Value)} on managed objects from non-update threads");
 
-                return realmFactory!.Context.Find<T>(ID);
+                return realmFactory.Context.Find<T>(ID);
             }
         }
 

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -24,13 +24,21 @@ namespace osu.Game.Database
         /// </summary>
         private readonly T data;
 
+        private readonly RealmContextFactory? realmFactory;
+
         /// <summary>
         /// Construct a new instance of live realm data.
         /// </summary>
         /// <param name="data">The realm data.</param>
-        public RealmLive(T data)
+        /// <param name="realmFactory">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
+        public RealmLive(T data, RealmContextFactory? realmFactory)
         {
             this.data = data;
+
+            if (IsManaged && realmFactory == null)
+                throw new ArgumentException(@"Realm factory must be provided for a managed instance", nameof(realmFactory));
+
+            this.realmFactory = realmFactory;
 
             ID = data.ID;
         }
@@ -47,7 +55,10 @@ namespace osu.Game.Database
                 return;
             }
 
-            using (var realm = Realm.GetInstance(data.Realm.Config))
+            if (realmFactory == null)
+                throw new ArgumentException(@"Realm factory must be provided for a managed instance", nameof(realmFactory));
+
+            using (var realm = realmFactory.CreateContext())
                 perform(realm.Find<T>(ID));
         }
 
@@ -58,12 +69,15 @@ namespace osu.Game.Database
         public TReturn PerformRead<TReturn>(Func<T, TReturn> perform)
         {
             if (typeof(RealmObjectBase).IsAssignableFrom(typeof(TReturn)))
-                throw new InvalidOperationException($"Realm live objects should not exit the scope of {nameof(PerformRead)}.");
+                throw new InvalidOperationException(@$"Realm live objects should not exit the scope of {nameof(PerformRead)}.");
 
             if (!IsManaged)
                 return perform(data);
 
-            using (var realm = Realm.GetInstance(data.Realm.Config))
+            if (realmFactory == null)
+                throw new ArgumentException(@"Realm factory must be provided for a managed instance", nameof(realmFactory));
+
+            using (var realm = realmFactory.CreateContext())
                 return perform(realm.Find<T>(ID));
         }
 
@@ -74,7 +88,7 @@ namespace osu.Game.Database
         public void PerformWrite(Action<T> perform)
         {
             if (!IsManaged)
-                throw new InvalidOperationException("Can't perform writes on a non-managed underlying value");
+                throw new InvalidOperationException(@"Can't perform writes on a non-managed underlying value");
 
             PerformRead(t =>
             {
@@ -94,11 +108,7 @@ namespace osu.Game.Database
                 if (!ThreadSafety.IsUpdateThread)
                     throw new InvalidOperationException($"Can't use {nameof(Value)} on managed objects from non-update threads");
 
-                // When using Value, we rely on garbage collection for the realm instance used to retrieve the instance.
-                // As we are sure that this is on the update thread, there should always be an open and constantly refreshing realm instance to ensure file size growth is a non-issue.
-                var realm = Realm.GetInstance(data.Realm.Config);
-
-                return realm.Find<T>(ID);
+                return realmFactory!.Context.Find<T>(ID);
             }
         }
 

--- a/osu.Game/Database/RealmLiveUnmanaged.cs
+++ b/osu.Game/Database/RealmLiveUnmanaged.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Realms;
+
+#nullable enable
+
+namespace osu.Game.Database
+{
+    /// <summary>
+    /// Provides a method of working with unmanaged realm objects.
+    /// Usually used for testing purposes where the instance is never required to be managed.
+    /// </summary>
+    /// <typeparam name="T">The underlying object type.</typeparam>
+    public class RealmLiveUnmanaged<T> : ILive<T> where T : RealmObjectBase, IHasGuidPrimaryKey
+    {
+        /// <summary>
+        /// Construct a new instance of live realm data.
+        /// </summary>
+        /// <param name="data">The realm data.</param>
+        public RealmLiveUnmanaged(T data)
+        {
+            Value = data;
+        }
+
+        public bool Equals(ILive<T>? other) => ID == other?.ID;
+
+        public Guid ID => Value.ID;
+
+        public void PerformRead(Action<T> perform) => perform(Value);
+
+        public TReturn PerformRead<TReturn>(Func<T, TReturn> perform) => perform(Value);
+
+        public void PerformWrite(Action<T> perform) => throw new InvalidOperationException(@"Can't perform writes on a non-managed underlying value");
+
+        public bool IsManaged => false;
+
+        /// <summary>
+        /// The original live data used to create this instance.
+        /// </summary>
+        public T Value { get; }
+    }
+}

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -53,16 +53,28 @@ namespace osu.Game.Database
             return mapper.Map<T>(item);
         }
 
-        public static List<ILive<T>> ToLive<T>(this IEnumerable<T> realmList)
+        public static List<ILive<T>> ToLiveUnmanaged<T>(this IEnumerable<T> realmList)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return realmList.Select(l => new RealmLive<T>(l)).Cast<ILive<T>>().ToList();
+            return realmList.Select(l => new RealmLive<T>(l, null)).Cast<ILive<T>>().ToList();
         }
 
-        public static ILive<T> ToLive<T>(this T realmObject)
+        public static ILive<T> ToLiveUnmanaged<T>(this T realmObject)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return new RealmLive<T>(realmObject);
+            return new RealmLive<T>(realmObject, null);
+        }
+
+        public static List<ILive<T>> ToLive<T>(this IEnumerable<T> realmList, RealmContextFactory realmContextFactory)
+            where T : RealmObject, IHasGuidPrimaryKey
+        {
+            return realmList.Select(l => new RealmLive<T>(l, realmContextFactory)).Cast<ILive<T>>().ToList();
+        }
+
+        public static ILive<T> ToLive<T>(this T realmObject, RealmContextFactory realmContextFactory)
+            where T : RealmObject, IHasGuidPrimaryKey
+        {
+            return new RealmLive<T>(realmObject, realmContextFactory);
         }
 
         /// <summary>

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -56,13 +56,13 @@ namespace osu.Game.Database
         public static List<ILive<T>> ToLiveUnmanaged<T>(this IEnumerable<T> realmList)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return realmList.Select(l => new RealmLive<T>(l, null)).Cast<ILive<T>>().ToList();
+            return realmList.Select(l => new RealmLiveUnmanaged<T>(l)).Cast<ILive<T>>().ToList();
         }
 
         public static ILive<T> ToLiveUnmanaged<T>(this T realmObject)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return new RealmLive<T>(realmObject, null);
+            return new RealmLiveUnmanaged<T>(realmObject);
         }
 
         public static List<ILive<T>> ToLive<T>(this IEnumerable<T> realmList, RealmContextFactory realmContextFactory)

--- a/osu.Game/IO/IStorageResourceProvider.cs
+++ b/osu.Game/IO/IStorageResourceProvider.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Audio;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Game.Database;
 
 namespace osu.Game.IO
 {
@@ -23,6 +24,11 @@ namespace osu.Game.IO
         /// Access game-wide resources.
         /// </summary>
         IResourceStore<byte[]> Resources { get; }
+
+        /// <summary>
+        /// Access realm.
+        /// </summary>
+        RealmContextFactory RealmContextFactory { get; }
 
         /// <summary>
         /// Create a texture loader store based on an underlying data store.

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -255,10 +255,10 @@ namespace osu.Game
                 if (skinInfo == null)
                 {
                     if (guid == SkinInfo.CLASSIC_SKIN)
-                        skinInfo = DefaultLegacySkin.CreateInfo().ToLive();
+                        skinInfo = DefaultLegacySkin.CreateInfo().ToLiveUnmanaged();
                 }
 
-                SkinManager.CurrentSkinInfo.Value = skinInfo ?? DefaultSkin.CreateInfo().ToLive();
+                SkinManager.CurrentSkinInfo.Value = skinInfo ?? DefaultSkin.CreateInfo().ToLiveUnmanaged();
             };
             configSkin.TriggerChange();
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -32,14 +32,14 @@ namespace osu.Game.Overlays.Settings.Sections
             Icon = FontAwesome.Solid.PaintBrush
         };
 
-        private readonly Bindable<ILive<SkinInfo>> dropdownBindable = new Bindable<ILive<SkinInfo>> { Default = DefaultSkin.CreateInfo().ToLive() };
+        private readonly Bindable<ILive<SkinInfo>> dropdownBindable = new Bindable<ILive<SkinInfo>> { Default = DefaultSkin.CreateInfo().ToLiveUnmanaged() };
         private readonly Bindable<string> configBindable = new Bindable<string>();
 
         private static readonly ILive<SkinInfo> random_skin_info = new SkinInfo
         {
             ID = SkinInfo.RANDOM_SKIN,
             Name = "<Random Skin>",
-        }.ToLive();
+        }.ToLiveUnmanaged();
 
         private List<ILive<SkinInfo>> skinItems;
 
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             int protectedCount = realmSkins.Count(s => s.Protected);
 
-            skinItems = realmSkins.ToLive();
+            skinItems = realmSkins.ToLive(realmFactory);
 
             skinItems.Insert(protectedCount, random_skin_info);
 

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -43,7 +43,11 @@ namespace osu.Game.Skinning
 
         protected Skin(SkinInfo skin, IStorageResourceProvider resources, [CanBeNull] Stream configurationStream = null)
         {
-            SkinInfo = skin.ToLive(resources.RealmContextFactory);
+            SkinInfo = resources?.RealmContextFactory != null
+                ? skin.ToLive(resources.RealmContextFactory)
+                // This path should only be used in some tests.
+                : skin.ToLiveUnmanaged();
+
             this.resources = resources;
 
             configurationStream ??= getConfigurationStream();

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Skinning
 
         protected Skin(SkinInfo skin, IStorageResourceProvider resources, [CanBeNull] Stream configurationStream = null)
         {
-            SkinInfo = skin.ToLive();
+            SkinInfo = skin.ToLive(resources.RealmContextFactory);
             this.resources = resources;
 
             configurationStream ??= getConfigurationStream();

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -352,7 +352,7 @@ namespace osu.Game.Stores
                                 transaction.Commit();
                             }
 
-                            return existing.ToLive();
+                            return existing.ToLive(ContextFactory);
                         }
 
                         LogForModel(item, @"Found existing (optimised) but failed pre-check.");
@@ -387,7 +387,7 @@ namespace osu.Game.Stores
                                 existing.DeletePending = false;
                                 transaction.Commit();
 
-                                return existing.ToLive();
+                                return existing.ToLive(ContextFactory);
                             }
 
                             LogForModel(item, @"Found existing but failed re-use check.");
@@ -416,7 +416,7 @@ namespace osu.Game.Stores
                     throw;
                 }
 
-                return item.ToLive();
+                return item.ToLive(ContextFactory);
             }
         }
 

--- a/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
+++ b/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
@@ -14,6 +14,7 @@ using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Models;
 using osu.Game.Rulesets;
@@ -118,6 +119,7 @@ namespace osu.Game.Tests.Beatmaps
         public IResourceStore<byte[]> Files => userSkinResourceStore;
         public new IResourceStore<byte[]> Resources => base.Resources;
         public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => null;
+        RealmContextFactory IStorageResourceProvider.RealmContextFactory => null;
 
         #endregion
 

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Graphics.Sprites;
 using osu.Game.IO;
 using osu.Game.Rulesets;
@@ -158,6 +159,7 @@ namespace osu.Game.Tests.Visual
         public IResourceStore<byte[]> Files => null;
         public new IResourceStore<byte[]> Resources => base.Resources;
         public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => host.CreateTextureLoaderStore(underlyingStore);
+        RealmContextFactory IStorageResourceProvider.RealmContextFactory => null;
 
         #endregion
 


### PR DESCRIPTION
Bit of an unfortunate one, but in theory the usage of `ToLive` should be quite isolated. If anything, i can see us reducing the number of places it is used from the current usages.

Closes #16074