### PR TITLE
Fix incorrect storyboard life time start with looping commands

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
@@ -85,11 +85,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             loopGroup.Scale.Add(Easing.None, -20000, -18000, 0, 1);
 
             var target = addEventToLoop ? loopGroup : sprite.TimelineGroup;
-            target.Alpha.Add(Easing.None, firstStoryboardEvent, firstStoryboardEvent + 500, 0, 1);
+            double targetTime = addEventToLoop ? 20000 : 0;
+            target.Alpha.Add(Easing.None, targetTime + firstStoryboardEvent, targetTime + firstStoryboardEvent + 500, 0, 1);
 
             // these should be ignored due to being in the future.
             sprite.TimelineGroup.Alpha.Add(Easing.None, 18000, 20000, 0, 1);
-            loopGroup.Alpha.Add(Easing.None, 18000, 20000, 0, 1);
+            loopGroup.Alpha.Add(Easing.None, 38000, 40000, 0, 1);
 
             storyboard.GetLayer("Background").Add(sprite);
 

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -33,8 +33,8 @@ namespace osu.Game.Storyboards
 
                 foreach (var l in loops)
                 {
-                    if (l.EarliestDisplayedTime != null)
-                        earliestStartTime = Math.Min(earliestStartTime, l.StartTime);
+                    if (l.EarliestDisplayedTime is double loopEarliestDisplayTime)
+                        earliestStartTime = Math.Min(earliestStartTime, l.LoopStartTime + loopEarliestDisplayTime);
                 }
 
                 if (earliestStartTime < double.MaxValue)

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -33,10 +33,8 @@ namespace osu.Game.Storyboards
 
                 foreach (var l in loops)
                 {
-                    if (!(l.EarliestDisplayedTime is double lEarliest))
-                        continue;
-
-                    earliestStartTime = Math.Min(earliestStartTime, lEarliest);
+                    if (l.EarliestDisplayedTime != null)
+                        earliestStartTime = Math.Min(earliestStartTime, l.StartTime);
                 }
 
                 if (earliestStartTime < double.MaxValue)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/6415

`EarliestDisplayedTime` doesn't include the loop's start time, so it was e.g. `0` when the loop's start time was `20000`. The tests were also doing the same miscalculation.

Also tested with:
- The beatmap in https://github.com/ppy/osu/issues/11981 (the issue that was fixed by the original implementation of this code) and it's fine.
- https://osu.ppy.sh/beatmapsets/470977#osu/1006822
- https://osu.ppy.sh/beatmapsets/1054045#osu/2202493