### PR TITLE
Fix toast popups spamming samples when adjusting osu!mania scroll speed during gameplay

### DIFF
--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays
             DisplayTemporarily(box);
         });
 
-        private void displayTrackedSettingChange(SettingDescription description) => Display(new TrackedSettingToast(description));
+        private void displayTrackedSettingChange(SettingDescription description) => Scheduler.AddOnce(Display, new TrackedSettingToast(description));
 
         private TransformSequence<Drawable> fadeIn;
         private ScheduledDelegate fadeOut;


### PR DESCRIPTION
Not the most robust of fixes, but as per the reasoning described in the issue thread, a proper fix will take considerably more effort. This intends to fix the issue first and foremost, as it sounds so bad I'd want to mute my sound before adjusting currently.

Closes #15718.