### PR TITLE
Fix the taiko scroller bar appearing during cinema mod

### DIFF
--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Rulesets.Mods
             drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, drawableRuleset.Mods));
 
             // AlwaysPresent required for hitsounds
-            drawableRuleset.Playfield.AlwaysPresent = true;
-            drawableRuleset.Playfield.Hide();
+            drawableRuleset.AlwaysPresent = true;
+            drawableRuleset.Hide();
         }
     }
 


### PR DESCRIPTION
The taiko-slider is not included in  `Playfield`, so it doesn't get hidden when calling `drawableRuleSet.Playfield.Hide()`.   Calling `drawableRuleSet.Hide()` hides the taiko-slider, in addition to the rest of the `Playfield`.

Resolves #15869