### PR TITLE
Fix rank graph showing for unranked users on profile overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -2,84 +2,51 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
+using osu.Framework.Testing;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Profile;
-using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
     public class TestSceneUserProfileHeader : OsuTestScene
     {
-        protected override bool UseOnlineAPI => true;
-
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
 
-        [Resolved]
-        private IAPIProvider api { get; set; }
+        private ProfileHeader header;
 
-        private readonly ProfileHeader header;
-
-        public TestSceneUserProfileHeader()
+        [SetUpSteps]
+        public void SetUpSteps()
         {
-            header = new ProfileHeader();
-            Add(header);
+            AddStep("create header", () => Child = header = new ProfileHeader());
+        }
 
-            AddStep("Show test dummy", () => header.User.Value = TestSceneUserProfileOverlay.TEST_USER);
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("Show example user", () => header.User.Value = TestSceneUserProfileOverlay.TEST_USER);
+        }
 
-            AddStep("Show null dummy", () => header.User.Value = new APIUser
+        [Test]
+        public void TestOnlineState()
+        {
+            AddStep("Show online user", () => header.User.Value = new APIUser
             {
-                Username = "Null"
-            });
-
-            AddStep("Show online dummy", () => header.User.Value = new APIUser
-            {
+                Id = 1001,
                 Username = "IAmOnline",
                 LastVisit = DateTimeOffset.Now,
                 IsOnline = true,
             });
 
-            AddStep("Show offline dummy", () => header.User.Value = new APIUser
+            AddStep("Show offline user", () => header.User.Value = new APIUser
             {
+                Id = 1002,
                 Username = "IAmOffline",
-                LastVisit = DateTimeOffset.Now,
+                LastVisit = DateTimeOffset.Now.AddDays(-10),
                 IsOnline = false,
-            });
-
-            addOnlineStep("Show ppy", new APIUser
-            {
-                Username = @"peppy",
-                Id = 2,
-                IsSupporter = true,
-                Country = new Country { FullName = @"Australia", FlagName = @"AU" },
-                CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg"
-            });
-
-            addOnlineStep("Show flyte", new APIUser
-            {
-                Username = @"flyte",
-                Id = 3103765,
-                Country = new Country { FullName = @"Japan", FlagName = @"JP" },
-                CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c6.jpg"
-            });
-        }
-
-        private void addOnlineStep(string name, APIUser fallback)
-        {
-            AddStep(name, () =>
-            {
-                if (api.IsLoggedIn)
-                {
-                    var request = new GetUserRequest(fallback.Id);
-                    request.Success += user => header.User.Value = user;
-                    api.Queue(request);
-                }
-                else
-                    header.User.Value = fallback;
             });
         }
     }

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Profile;
+using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
@@ -47,6 +49,43 @@ namespace osu.Game.Tests.Visual.Online
                 Username = "IAmOffline",
                 LastVisit = DateTimeOffset.Now.AddDays(-10),
                 IsOnline = false,
+            });
+        }
+
+        [Test]
+        public void TestRankedState()
+        {
+            AddStep("Show ranked user", () => header.User.Value = new APIUser
+            {
+                Id = 2001,
+                Username = "RankedUser",
+                Statistics = new UserStatistics
+                {
+                    IsRanked = true,
+                    GlobalRank = 15000,
+                    CountryRank = 1500,
+                    RankHistory = new APIRankHistory
+                    {
+                        Mode = @"osu",
+                        Data = Enumerable.Range(2345, 45).Concat(Enumerable.Range(2109, 40)).ToArray()
+                    },
+                }
+            });
+
+            AddStep("Show unranked user", () => header.User.Value = new APIUser
+            {
+                Id = 2002,
+                Username = "UnrankedUser",
+                Statistics = new UserStatistics
+                {
+                    IsRanked = false,
+                    // web will sometimes return non-empty rank history even for unranked users.
+                    RankHistory = new APIRankHistory
+                    {
+                        Mode = @"osu",
+                        Data = Enumerable.Range(2345, 85).ToArray()
+                    },
+                }
             });
         }
     }

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Tests.Visual.Online
             ProfileOrder = new[] { "me" },
             Statistics = new UserStatistics
             {
+                IsRanked = true,
                 GlobalRank = 2148,
                 CountryRank = 1,
                 PP = 4567.89m,

--- a/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
@@ -42,7 +42,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         private void updateStatistics(UserStatistics statistics)
         {
-            int[] userRanks = statistics?.RankHistory?.Data;
+            // checking both IsRanked and RankHistory is required.
+            // see https://github.com/ppy/osu-web/blob/154ceafba0f35a1dd935df53ec98ae2ea5615f9f/resources/assets/lib/profile-page/rank-chart.tsx#L46
+            int[] userRanks = statistics?.IsRanked == true ? statistics.RankHistory?.Data : null;
             Data = userRanks?.Select((x, index) => new KeyValuePair<int, int>(index, x)).Where(x => x.Value != 0).ToArray();
         }
 

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Users
             public int Progress;
         }
 
+        [JsonProperty(@"is_ranked")]
+        public bool IsRanked;
+
         [JsonProperty(@"global_rank")]
         public int? GlobalRank;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/discussions/16156

As per [web behaviour](https://github.com/ppy/osu-web/blob/154ceafba0f35a1dd935df53ec98ae2ea5615f9f/resources/assets/lib/profile-page/rank-chart.tsx#L46), the `is_ranked` field received from web is checked to determine if the rank graph should be shown in addition to checking that the graph is non-null.

Most of the diff is fixing up the existing half-broken (and online-coupled) test.