### PR TITLE
Fix intermittent background screen test failures

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Tests.Visual.Background
             // of note, this needs to be a type that doesn't match BackgroundScreenDefault else it is silently not pushed by the background stack.
             AddStep("push new background to stack", () => stack.Push(nestedScreen = new BackgroundScreenBeatmap(Beatmap.Value)));
             AddUntilStep("wait for screen to load", () => nestedScreen.IsLoaded && nestedScreen.IsCurrentScreen());
+            AddUntilStep("previous background hidden", () => !screen.IsAlive);
 
             AddAssert("top level background hasn't changed yet", () => screen.CheckLastLoadChange() == null);
 


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/4577823878?check_suite_focus=true

Can be tested by increasing the duration of the `BackgroundScreen.OnSuspending()` transform.