### PR TITLE
Add better fix for intermittent multiplayer tests as a result of async room joins

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -41,7 +41,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private TestMultiplayerScreenStack multiplayerScreenStack;
 
         protected TestMultiplayerClient Client => multiplayerScreenStack.Client;
-        protected TestMultiplayerRoomManager RoomManager => multiplayerScreenStack.RoomManager;
 
         [Cached(typeof(UserLookupCache))]
         private UserLookupCache lookupCache = new TestUserLookupCache();
@@ -93,7 +92,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("wait for join", () => RoomManager.RoomJoined);
+            AddUntilStep("wait for join", () => Client.RoomJoined);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -216,7 +216,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Press select", () => InputManager.Key(Key.Enter));
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => roomManager.RoomJoined);
+            AddUntilStep("wait for join", () => client.RoomJoined);
         }
 
         [Test]
@@ -295,7 +295,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("join room", () => InputManager.Key(Key.Enter));
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => roomManager.RoomJoined);
+            AddUntilStep("wait for join", () => client.RoomJoined);
 
             AddAssert("Check participant count correct", () => client.APIRoom?.ParticipantCount.Value == 1);
             AddAssert("Check participant list contains user", () => client.APIRoom?.RecentParticipants.Count(u => u.Id == API.LocalUser.Value.Id) == 1);
@@ -353,7 +353,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("press join room button", () => passwordEntryPopover.ChildrenOfType<OsuButton>().First().TriggerClick());
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => roomManager.RoomJoined);
+            AddUntilStep("wait for join", () => client.RoomJoined);
         }
 
         [Test]
@@ -646,7 +646,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("join room", () => InputManager.Key(Key.Enter));
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => roomManager.RoomJoined);
+            AddUntilStep("wait for join", () => client.RoomJoined);
 
             AddAssert("local room has correct settings", () =>
             {
@@ -838,7 +838,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("wait for join", () => roomManager.RoomJoined);
+            AddUntilStep("wait for join", () => client.RoomJoined);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -187,7 +187,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("wait for join", () => multiplayerScreenStack.RoomManager.RoomJoined);
+            AddUntilStep("wait for join", () => client.RoomJoined);
         }
     }
 }

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         protected new MultiplayerTestSceneDependencies OnlinePlayDependencies => (MultiplayerTestSceneDependencies)base.OnlinePlayDependencies;
 
-        public bool RoomJoined => RoomManager.RoomJoined;
+        public bool RoomJoined => Client.RoomJoined;
 
         private readonly bool joinRoom;
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -31,8 +31,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private readonly Bindable<bool> isConnected = new Bindable<bool>(true);
 
         public new Room? APIRoom => base.APIRoom;
-
         public Action<MultiplayerRoom>? RoomSetupAction;
+
+        public bool RoomJoined { get; private set; }
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -49,7 +50,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private MultiplayerPlaylistItem? currentItem => Room?.Playlist[currentIndex];
         private int currentIndex;
-
         private long lastPlaylistItemId;
 
         public TestMultiplayerClient(TestMultiplayerRoomManager roomManager)
@@ -217,9 +217,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             // emulate the server sending this after the join room. scheduler required to make sure the join room event is fired first (in Join).
             changeMatchType(Room.Settings.MatchType).Wait();
+
+            RoomJoined = true;
         }
 
-        protected override Task LeaveRoomInternal() => Task.CompletedTask;
+        protected override Task LeaveRoomInternal()
+        {
+            RoomJoined = false;
+            return Task.CompletedTask;
+        }
 
         public override Task TransferHost(int userId) => ((IMultiplayerClient)this).HostChanged(userId);
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
     /// </summary>
     public class TestMultiplayerRoomManager : MultiplayerRoomManager
     {
-        public bool RoomJoined { get; private set; }
-
         private readonly TestRoomRequestsHandler requestsHandler;
 
         public TestMultiplayerRoomManager(TestRoomRequestsHandler requestsHandler)
@@ -29,28 +27,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public IReadOnlyList<Room> ServerSideRooms => requestsHandler.ServerSideRooms;
 
         public override void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
-        {
-            base.CreateRoom(room, r =>
-            {
-                onSuccess?.Invoke(r);
-                RoomJoined = true;
-            }, onError);
-        }
+            => base.CreateRoom(room, r => onSuccess?.Invoke(r), onError);
 
         public override void JoinRoom(Room room, string password = null, Action<Room> onSuccess = null, Action<string> onError = null)
-        {
-            base.JoinRoom(room, password, r =>
-            {
-                onSuccess?.Invoke(r);
-                RoomJoined = true;
-            }, onError);
-        }
-
-        public override void PartRoom()
-        {
-            base.PartRoom();
-            RoomJoined = false;
-        }
+            => base.JoinRoom(room, password, r => onSuccess?.Invoke(r), onError);
 
         /// <summary>
         /// Adds a room to a local "server-side" list that's returned when a <see cref="GetRoomsRequest"/> is fired.


### PR DESCRIPTION
Adds a better fix for test failures as a result of room joining (previously 'fixed' in https://github.com/ppy/osu/pull/15757/commits/69a9fc97328ef2bc70dddd30b76cece5b1b608c4), and fixes the newer test failure in https://github.com/ppy/osu/runs/4560184192?check_suite_focus=true as a result.