### PR TITLE
Add wait step to `TestScenePlaylistResultScreen` explicitly for screen load

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -168,12 +168,13 @@ namespace osu.Game.Tests.Visual.Playlists
                 }));
             });
 
+            AddUntilStep("wait for screen to load", () => resultsScreen.IsLoaded);
             waitForDisplay();
         }
 
         private void waitForDisplay()
         {
-            AddUntilStep("wait for load to complete", () =>
+            AddUntilStep("wait for scores loaded", () =>
                 requestComplete
                 && resultsScreen.ScorePanelList.GetScorePanels().Count() == totalCount
                 && resultsScreen.ScorePanelList.AllPanelsVisible);


### PR DESCRIPTION
I'm not sure if this failure is the same as the other multiplayer screen failures, so want to be certain.

Examples:
https://github.com/ppy/osu/runs/4574430814?check_suite_focus=true
https://github.com/ppy/osu/runs/4578509013?check_suite_focus=true