### PR TITLE
Fix occasional failures in `TestScenePlaySongSelect`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -883,7 +883,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
 
-                for (int i = 0; i < 100; i += 10)
+                for (int i = 0; i < 10; i++)
                     manager.Import(TestResources.CreateTestBeatmapSetInfo(rulesets: usableRulesets)).Wait();
             });
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -466,7 +466,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestExternalBeatmapChangeWhileFiltered(bool differentRuleset)
         {
             createSongSelect();
-            addManyTestMaps();
+            // ensure there is at least 1 difficulty for each of the rulesets
+            // (catch is excluded inside of addManyTestMaps).
+            addManyTestMaps(3);
 
             changeRuleset(0);
 
@@ -519,7 +521,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestExternalBeatmapChangeWhileFilteredThenRefilter()
         {
             createSongSelect();
-            addManyTestMaps();
+            // ensure there is at least 1 difficulty for each of the rulesets
+            // (catch is excluded inside of addManyTestMaps).
+            addManyTestMaps(3);
 
             changeRuleset(0);
 
@@ -880,14 +884,21 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("wait for carousel loaded", () => songSelect.Carousel.IsAlive);
         }
 
-        private void addManyTestMaps()
+        /// <summary>
+        /// Imports test beatmap sets to show in the carousel.
+        /// </summary>
+        /// <param name="difficultyCountPerSet">
+        /// The exact count of difficulties to create for each beatmap set.
+        /// A <see langword="null"/> value causes the count of difficulties to be selected randomly.
+        /// </param>
+        private void addManyTestMaps(int? difficultyCountPerSet = null)
         {
             AddStep("import test maps", () =>
             {
                 var usableRulesets = rulesets.AvailableRulesets.Where(r => r.OnlineID != 2).ToArray();
 
                 for (int i = 0; i < 10; i++)
-                    manager.Import(TestResources.CreateTestBeatmapSetInfo(rulesets: usableRulesets)).Wait();
+                    manager.Import(TestResources.CreateTestBeatmapSetInfo(difficultyCountPerSet, usableRulesets)).Wait();
             });
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -488,8 +488,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select beatmap externally", () =>
             {
                 target = manager.GetAllUsableBeatmapSets()
-                                .Where(b => b.Beatmaps.Any(bi => bi.RulesetID == targetRuleset))
-                                .ElementAt(5).Beatmaps.First(bi => bi.RulesetID == targetRuleset);
+                                .First(b => b.Beatmaps.Any(bi => bi.RulesetID == targetRuleset))
+                                .Beatmaps
+                                .First(bi => bi.RulesetID == targetRuleset);
 
                 Beatmap.Value = manager.GetWorkingBeatmap(target);
             });
@@ -534,8 +535,10 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("select beatmap externally", () =>
             {
-                target = manager.GetAllUsableBeatmapSets().Where(b => b.Beatmaps.Any(bi => bi.RulesetID == 1))
-                                .ElementAt(5).Beatmaps.First();
+                target = manager
+                         .GetAllUsableBeatmapSets()
+                         .First(b => b.Beatmaps.Any(bi => bi.RulesetID == 1))
+                         .Beatmaps.First();
 
                 Beatmap.Value = manager.GetWorkingBeatmap(target);
             });


### PR DESCRIPTION
We created 10 sets, which can have random difficulty counts of between 1 and 20. Each difficulty increments the ruleset used. In an.. (un)lucky dealt hand, the correct sequence of difficulty counts could mean there are not enough sets containing the target ruleset for the fixed tests.

As seen [here](https://github.com/ppy/osu/runs/4559182594?check_suite_focus=true).