### PR TITLE
Add better defined steps to `TestLoseHostWhileReady` ready button test

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -163,10 +163,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             addClickButtonStep();
+            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+
             AddStep("transfer host", () => Client.TransferHost(Client.Room?.Users[1].UserID ?? 0));
 
             addClickButtonStep();
-            AddAssert("match not started", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+            AddUntilStep("user is idle (match not started)", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+            AddAssert("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
         }
 
         [TestCase(true)]


### PR DESCRIPTION
Not 100% sure this will solve the issue but it's worth a try. The button state checks are using `Until` everywhere else so this brings the test in line with the standards.

As seen https://github.com/ppy/osu/runs/4579641456?check_suite_focus=true.