### PR TITLE
Fix lounge screen showing information sourced from wrong playlist item

### DIFF
--- a/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
+++ b/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Online.Rooms;
+
+namespace osu.Game.Tests.OnlinePlay
+{
+    [TestFixture]
+    public class PlaylistExtensionsTest
+    {
+        [Test]
+        public void TestPlaylistItemsInOrder()
+        {
+            var items = new[]
+            {
+                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1 },
+                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2 },
+                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
+            };
+
+            var nextItem = items.GetNextItem();
+
+            Assert.That(nextItem, Is.EqualTo(items[0]));
+        }
+
+        [Test]
+        public void TestPlaylistItemsOutOfOrder()
+        {
+            var items = new[]
+            {
+                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2 },
+                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1 },
+                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
+            };
+
+            var nextItem = items.GetNextItem();
+
+            Assert.That(nextItem, Is.EqualTo(items[1]));
+        }
+
+        [Test]
+        public void TestExpiredPlaylistItemsSkipped()
+        {
+            var items = new[]
+            {
+                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2, Expired = true },
+                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1, Expired = true },
+                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
+            };
+
+            var nextItem = items.GetNextItem();
+
+            Assert.That(nextItem, Is.EqualTo(items[2]));
+        }
+
+        [Test]
+        public void TestAllItemsExpired()
+        {
+            var items = new[]
+            {
+                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2, Expired = true },
+                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1, Expired = true },
+                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3, Expired = true },
+            };
+
+            var nextItem = items.GetNextItem();
+
+            Assert.That(nextItem, Is.Null);
+        }
+    }
+}

--- a/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
+++ b/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var nextItem = items.GetNextItem();
+            var nextItem = items.GetCurrentItem();
 
             Assert.That(nextItem, Is.EqualTo(items[0]));
         }
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var nextItem = items.GetNextItem();
+            var nextItem = items.GetCurrentItem();
 
             Assert.That(nextItem, Is.EqualTo(items[1]));
         }
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var nextItem = items.GetNextItem();
+            var nextItem = items.GetCurrentItem();
 
             Assert.That(nextItem, Is.EqualTo(items[2]));
         }
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3, Expired = true },
             };
 
-            var nextItem = items.GetNextItem();
+            var nextItem = items.GetCurrentItem();
 
             Assert.That(nextItem, Is.Null);
         }

--- a/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
+++ b/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Game.Online.Rooms;
 
@@ -9,6 +10,17 @@ namespace osu.Game.Tests.OnlinePlay
     [TestFixture]
     public class PlaylistExtensionsTest
     {
+        [Test]
+        public void TestEmpty()
+        {
+            // mostly an extreme edge case, i.e. during room creation.
+            var items = Array.Empty<PlaylistItem>();
+
+            var currentItem = items.GetCurrentItem();
+
+            Assert.That(currentItem, Is.Null);
+        }
+
         [Test]
         public void TestPlaylistItemsInOrder()
         {
@@ -19,9 +31,9 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var nextItem = items.GetCurrentItem();
+            var currentItem = items.GetCurrentItem();
 
-            Assert.That(nextItem, Is.EqualTo(items[0]));
+            Assert.That(currentItem, Is.EqualTo(items[0]));
         }
 
         [Test]
@@ -34,9 +46,9 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var nextItem = items.GetCurrentItem();
+            var currentItem = items.GetCurrentItem();
 
-            Assert.That(nextItem, Is.EqualTo(items[1]));
+            Assert.That(currentItem, Is.EqualTo(items[1]));
         }
 
         [Test]
@@ -49,9 +61,9 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var nextItem = items.GetCurrentItem();
+            var currentItem = items.GetCurrentItem();
 
-            Assert.That(nextItem, Is.EqualTo(items[2]));
+            Assert.That(currentItem, Is.EqualTo(items[2]));
         }
 
         [Test]
@@ -64,9 +76,10 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3, Expired = true },
             };
 
-            var nextItem = items.GetCurrentItem();
+            var currentItem = items.GetCurrentItem();
 
-            Assert.That(nextItem, Is.Null);
+            // if all items are expired, the last-played item is expected to be returned.
+            Assert.That(currentItem, Is.EqualTo(items[2]));
         }
     }
 }

--- a/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
+++ b/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
@@ -16,9 +16,12 @@ namespace osu.Game.Tests.OnlinePlay
             // mostly an extreme edge case, i.e. during room creation.
             var items = Array.Empty<PlaylistItem>();
 
-            var currentItem = items.GetCurrentItem();
-
-            Assert.That(currentItem, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(items.GetHistoricalItems(), Is.Empty);
+                Assert.That(items.GetCurrentItem(), Is.Null);
+                Assert.That(items.GetUpcomingItems(), Is.Empty);
+            });
         }
 
         [Test]
@@ -31,9 +34,12 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var currentItem = items.GetCurrentItem();
-
-            Assert.That(currentItem, Is.EqualTo(items[0]));
+            Assert.Multiple(() =>
+            {
+                Assert.That(items.GetHistoricalItems(), Is.Empty);
+                Assert.That(items.GetCurrentItem(), Is.EqualTo(items[0]));
+                Assert.That(items.GetUpcomingItems(), Is.EquivalentTo(items));
+            });
         }
 
         [Test]
@@ -46,9 +52,12 @@ namespace osu.Game.Tests.OnlinePlay
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var currentItem = items.GetCurrentItem();
-
-            Assert.That(currentItem, Is.EqualTo(items[1]));
+            Assert.Multiple(() =>
+            {
+                Assert.That(items.GetHistoricalItems(), Is.Empty);
+                Assert.That(items.GetCurrentItem(), Is.EqualTo(items[1]));
+                Assert.That(items.GetUpcomingItems(), Is.EquivalentTo(new[] { items[1], items[0], items[2] }));
+            });
         }
 
         [Test]
@@ -56,14 +65,17 @@ namespace osu.Game.Tests.OnlinePlay
         {
             var items = new[]
             {
-                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2, Expired = true },
-                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1, Expired = true },
+                new PlaylistItem { ID = 1, BeatmapID = 1001, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 55, 0, TimeSpan.Zero) },
+                new PlaylistItem { ID = 2, BeatmapID = 1002, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 53, 0, TimeSpan.Zero) },
                 new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
             };
 
-            var currentItem = items.GetCurrentItem();
-
-            Assert.That(currentItem, Is.EqualTo(items[2]));
+            Assert.Multiple(() =>
+            {
+                Assert.That(items.GetHistoricalItems(), Is.EquivalentTo(new[] { items[1], items[0] }));
+                Assert.That(items.GetCurrentItem(), Is.EqualTo(items[2]));
+                Assert.That(items.GetUpcomingItems(), Is.EquivalentTo(new[] { items[2] }));
+            });
         }
 
         [Test]
@@ -71,15 +83,18 @@ namespace osu.Game.Tests.OnlinePlay
         {
             var items = new[]
             {
-                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2, Expired = true },
-                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1, Expired = true },
-                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3, Expired = true },
+                new PlaylistItem { ID = 1, BeatmapID = 1001, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 55, 0, TimeSpan.Zero) },
+                new PlaylistItem { ID = 2, BeatmapID = 1002, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 53, 0, TimeSpan.Zero) },
+                new PlaylistItem { ID = 3, BeatmapID = 1002, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 57, 0, TimeSpan.Zero) },
             };
 
-            var currentItem = items.GetCurrentItem();
-
-            // if all items are expired, the last-played item is expected to be returned.
-            Assert.That(currentItem, Is.EqualTo(items[2]));
+            Assert.Multiple(() =>
+            {
+                Assert.That(items.GetHistoricalItems(), Is.EquivalentTo(new[] { items[1], items[0], items[2] }));
+                // if all items are expired, the last-played item is expected to be returned.
+                Assert.That(items.GetCurrentItem(), Is.EqualTo(items[2]));
+                Assert.That(items.GetUpcomingItems(), Is.Empty);
+            });
         }
     }
 }

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -14,6 +14,18 @@ namespace osu.Game.Online.Rooms
     public static class PlaylistExtensions
     {
         /// <summary>
+        /// Returns all historical/expired items from the <paramref name="playlist"/>, in the order in which they were played.
+        /// </summary>
+        public static IEnumerable<PlaylistItem> GetHistoricalItems(this IEnumerable<PlaylistItem> playlist)
+            => playlist.Where(item => item.Expired).OrderBy(item => item.PlayedAt);
+
+        /// <summary>
+        /// Returns all non-expired items from the <paramref name="playlist"/>, in the order in which they are to be played.
+        /// </summary>
+        public static IEnumerable<PlaylistItem> GetUpcomingItems(this IEnumerable<PlaylistItem> playlist)
+            => playlist.Where(item => !item.Expired).OrderBy(item => item.PlaylistOrder);
+
+        /// <summary>
         /// Returns the first non-expired <see cref="PlaylistItem"/> in playlist order from the supplied <paramref name="playlist"/>,
         /// or the last-played <see cref="PlaylistItem"/> if all items are expired,
         /// or <see langword="null"/> if <paramref name="playlist"/> was empty.
@@ -24,8 +36,8 @@ namespace osu.Game.Online.Rooms
                 return null;
 
             return playlist.All(item => item.Expired)
-                ? playlist.OrderByDescending(item => item.PlaylistOrder).First()
-                : playlist.OrderBy(item => item.PlaylistOrder).First(item => !item.Expired);
+                ? GetHistoricalItems(playlist).Last()
+                : GetUpcomingItems(playlist).First();
         }
 
         public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -15,10 +15,18 @@ namespace osu.Game.Online.Rooms
     {
         /// <summary>
         /// Returns the first non-expired <see cref="PlaylistItem"/> in playlist order from the supplied <paramref name="playlist"/>,
-        /// or <see langword="null"/> if all items are expired.
+        /// or the last-played <see cref="PlaylistItem"/> if all items are expired,
+        /// or <see langword="null"/> if <paramref name="playlist"/> was empty.
         /// </summary>
-        public static PlaylistItem? GetCurrentItem(this IEnumerable<PlaylistItem> playlist) =>
-            playlist.OrderBy(item => item.PlaylistOrder).FirstOrDefault(item => !item.Expired);
+        public static PlaylistItem? GetCurrentItem(this ICollection<PlaylistItem> playlist)
+        {
+            if (playlist.Count == 0)
+                return null;
+
+            return playlist.All(item => item.Expired)
+                ? playlist.OrderByDescending(item => item.PlaylistOrder).First()
+                : playlist.OrderBy(item => item.PlaylistOrder).First(item => !item.Expired);
+        }
 
         public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>
             playlist.Select(p => p.Beatmap.Value.Length).Sum().Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2);

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -14,10 +14,10 @@ namespace osu.Game.Online.Rooms
     public static class PlaylistExtensions
     {
         /// <summary>
-        /// Returns the next <see cref="PlaylistItem"/> to be played from the supplied <paramref name="playlist"/>,
+        /// Returns the first non-expired <see cref="PlaylistItem"/> in playlist order from the supplied <paramref name="playlist"/>,
         /// or <see langword="null"/> if all items are expired.
         /// </summary>
-        public static PlaylistItem? GetNextItem(this IEnumerable<PlaylistItem> playlist) =>
+        public static PlaylistItem? GetCurrentItem(this IEnumerable<PlaylistItem> playlist) =>
             playlist.OrderBy(item => item.PlaylistOrder).FirstOrDefault(item => !item.Expired);
 
         public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
+using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
 using Humanizer.Localisation;
@@ -10,6 +13,13 @@ namespace osu.Game.Online.Rooms
 {
     public static class PlaylistExtensions
     {
+        /// <summary>
+        /// Returns the next <see cref="PlaylistItem"/> to be played from the supplied <paramref name="playlist"/>,
+        /// or <see langword="null"/> if all items are expired.
+        /// </summary>
+        public static PlaylistItem? GetNextItem(this IEnumerable<PlaylistItem> playlist) =>
+            playlist.OrderBy(item => item.PlaylistOrder).FirstOrDefault(item => !item.Expired);
+
         public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>
             playlist.Select(p => p.Beatmap.Value.Length).Sum().Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2);
     }

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.Drawables;
+using osu.Game.Online.Rooms;
 
 namespace osu.Game.Screens.OnlinePlay.Components
 {
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         private void updateBeatmap()
         {
-            sprite.Beatmap.Value = Playlist.FirstOrDefault()?.Beatmap.Value;
+            sprite.Beatmap.Value = Playlist.GetCurrentItem()?.Beatmap.Value;
         }
 
         protected virtual UpdateableBeatmapBackgroundSprite CreateBackgroundSprite() => new UpdateableBeatmapBackgroundSprite(BeatmapSetCoverType) { RelativeSizeAxes = Axes.Both };

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeBackgroundScreen.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Screens;
 using osu.Game.Online.Rooms;
@@ -20,7 +19,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         public LoungeBackgroundScreen()
         {
             SelectedRoom.BindValueChanged(onSelectedRoomChanged);
-            playlist.BindCollectionChanged((_, __) => PlaylistItem = playlist.FirstOrDefault());
+            playlist.BindCollectionChanged((_, __) => PlaylistItem = playlist.GetCurrentItem());
         }
 
         private void onSelectedRoomChanged(ValueChangedEvent<Room> room)

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -73,7 +72,7 @@ namespace osu.Game.Screens.OnlinePlay
         private IBindable<PlaylistItem> subScreenSelectedItem { get; set; }
 
         /// <summary>
-        /// The currently selected item in the <see cref="RoomSubScreen"/>, or the last item from <see cref="Playlist"/>
+        /// The currently selected item in the <see cref="RoomSubScreen"/>, or the current item from <see cref="Playlist"/>
         /// if this <see cref="OnlinePlayComposite"/> is not within a <see cref="RoomSubScreen"/>.
         /// </summary>
         protected readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
@@ -88,7 +87,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         protected virtual void UpdateSelectedItem()
             => SelectedItem.Value = RoomID.Value == null || subScreenSelectedItem == null
-                ? Playlist.LastOrDefault()
+                ? Playlist.GetCurrentItem()
                 : subScreenSelectedItem.Value;
     }
 }


### PR DESCRIPTION
Closes #16115.

Turns out it wasn't only the background, but the "currently playing item" text too sometimes. Recommended testing scenario is: creating a room with round robin, creating 2 items as player A, and then one as player B. Current master will show the second player A item rather than the player B one on backgrounds after the first player A item is played.

Fixed by implementing a new `GetCurrentItem()` extension method that is supposed to return the right map. Tests are indirect (i.e. the extension is tested rather than its consumers), I've tested that this visually looks correct manually. Will attempt to add visual test cases for this on request but it's bound to be rather finicky due to things tested being mostly visual.

Note that while the extension method has special handling for the "all items expired" case, it won't actually be visible in the lounge because of the following call:

https://github.com/ppy/osu/blob/8acfefed1b1346430c68b14d922f27ebe0ac1ffd/osu.Game/Screens/OnlinePlay/Components/ListingPollingComponent.cs#L59-L63

I'm told that is going to be changing and web is going to be sending just the one valid playlist item eventually, at which point this problem goes away entirely client-side, so I didn't bother to fix that case (and behaviour is not changed from current `master`). But I'll revisit that on request.