### PR TITLE
Split session statics reset method to prevent unloading seasonal backgrounds

### DIFF
--- a/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
+++ b/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
@@ -3,7 +3,6 @@
 
 using NUnit.Framework;
 using osu.Game.Configuration;
-using osu.Game.Input;
 
 namespace osu.Game.Tests.NonVisual
 {
@@ -11,37 +10,28 @@ namespace osu.Game.Tests.NonVisual
     public class SessionStaticsTest
     {
         private SessionStatics sessionStatics;
-        private IdleTracker sessionIdleTracker;
 
-        [SetUp]
-        public void SetUp()
+        [Test]
+        public void TestSessionStaticsReset()
         {
             sessionStatics = new SessionStatics();
-            sessionIdleTracker = new GameIdleTracker(1000);
 
             sessionStatics.SetValue(Static.LoginOverlayDisplayed, true);
             sessionStatics.SetValue(Static.MutedAudioNotificationShownOnce, true);
             sessionStatics.SetValue(Static.LowBatteryNotificationShownOnce, true);
             sessionStatics.SetValue(Static.LastHoverSoundPlaybackTime, (double?)1d);
 
-            sessionIdleTracker.IsIdle.BindValueChanged(e =>
-            {
-                if (e.NewValue)
-                    sessionStatics.ResetAfterInactivity();
-            });
-        }
+            Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
+            Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
+            Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
+            Assert.IsFalse(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
 
-        [Test]
-        [Timeout(2000)]
-        public void TestSessionStaticsReset()
-        {
-            sessionIdleTracker.IsIdle.BindValueChanged(e =>
-            {
-                Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
-                Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
-                Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
-                Assert.IsTrue(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
-            });
+            sessionStatics.ResetAfterInactivity();
+
+            Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
+            Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
+            Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
+            Assert.IsTrue(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
+++ b/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
@@ -31,7 +31,8 @@ namespace osu.Game.Tests.NonVisual
             Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
             Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
             Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
-            Assert.IsTrue(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
+            // some statics should not reset despite inactivity.
+            Assert.IsFalse(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
+++ b/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.NonVisual
             sessionIdleTracker.IsIdle.BindValueChanged(e =>
             {
                 if (e.NewValue)
-                    sessionStatics.ResetValues();
+                    sessionStatics.ResetAfterInactivity();
             });
         }
 

--- a/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
+++ b/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Game.Configuration;
+using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Tests.NonVisual
 {
@@ -20,11 +22,13 @@ namespace osu.Game.Tests.NonVisual
             sessionStatics.SetValue(Static.MutedAudioNotificationShownOnce, true);
             sessionStatics.SetValue(Static.LowBatteryNotificationShownOnce, true);
             sessionStatics.SetValue(Static.LastHoverSoundPlaybackTime, (double?)1d);
+            sessionStatics.SetValue(Static.SeasonalBackgrounds, new APISeasonalBackgrounds { EndDate = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) });
 
             Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
             Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
             Assert.IsFalse(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
             Assert.IsFalse(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
+            Assert.IsFalse(sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).IsDefault);
 
             sessionStatics.ResetAfterInactivity();
 
@@ -33,6 +37,7 @@ namespace osu.Game.Tests.NonVisual
             Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
             // some statics should not reset despite inactivity.
             Assert.IsFalse(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
+            Assert.IsFalse(sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).IsDefault);
         }
     }
 }

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -15,23 +15,25 @@ namespace osu.Game.Configuration
     {
         protected override void InitialiseDefaults()
         {
-            ensureDefault(SetDefault(Static.LoginOverlayDisplayed, false));
-            ensureDefault(SetDefault(Static.MutedAudioNotificationShownOnce, false));
-            ensureDefault(SetDefault(Static.LowBatteryNotificationShownOnce, false));
-            ensureDefault(SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null));
-            ensureDefault(SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null));
+            SetDefault(Static.LoginOverlayDisplayed, false);
+            SetDefault(Static.MutedAudioNotificationShownOnce, false);
+            SetDefault(Static.LowBatteryNotificationShownOnce, false);
+            SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
+            SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
 
         /// <summary>
-        /// Used to revert statics to their defaults after being idle for appropiate amount of time.
-        /// Does not affect loaded seasonal backgrounds.
+        /// Revert statics to their defaults after being idle for appropriate amount of time.
         /// </summary>
-        public void ResetValues()
+        /// <remarks>
+        /// This only affects a subset of statics which the user would expect to have reset after a break.
+        /// </remarks>
+        public void ResetAfterInactivity()
         {
-            ensureDefault(GetBindable<bool>(Static.LoginOverlayDisplayed));
-            ensureDefault(GetBindable<bool>(Static.MutedAudioNotificationShownOnce));
-            ensureDefault(GetBindable<bool>(Static.LowBatteryNotificationShownOnce));
-            ensureDefault(GetBindable<double?>(Static.LastHoverSoundPlaybackTime));
+            GetBindable<bool>(Static.LoginOverlayDisplayed).SetDefault();
+            GetBindable<bool>(Static.MutedAudioNotificationShownOnce).SetDefault();
+            GetBindable<bool>(Static.LowBatteryNotificationShownOnce).SetDefault();
+            GetBindable<double?>(Static.LastHoverSoundPlaybackTime).SetDefault();
         }
 
         private void ensureDefault<T>(Bindable<T> bindable) => bindable.SetDefault();

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -13,15 +13,25 @@ namespace osu.Game.Configuration
     /// </summary>
     public class SessionStatics : InMemoryConfigManager<Static>
     {
-        protected override void InitialiseDefaults() => ResetValues();
-
-        public void ResetValues()
+        protected override void InitialiseDefaults()
         {
             ensureDefault(SetDefault(Static.LoginOverlayDisplayed, false));
             ensureDefault(SetDefault(Static.MutedAudioNotificationShownOnce, false));
             ensureDefault(SetDefault(Static.LowBatteryNotificationShownOnce, false));
             ensureDefault(SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null));
             ensureDefault(SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null));
+        }
+
+        /// <summary>
+        /// Used to revert statics to their defaults after being idle for appropiate amount of time.
+        /// Does not affect loaded seasonal backgrounds.
+        /// </summary>
+        public void ResetValues()
+        {
+            ensureDefault(GetBindable<bool>(Static.LoginOverlayDisplayed));
+            ensureDefault(GetBindable<bool>(Static.MutedAudioNotificationShownOnce));
+            ensureDefault(GetBindable<bool>(Static.LowBatteryNotificationShownOnce));
+            ensureDefault(GetBindable<double?>(Static.LastHoverSoundPlaybackTime));
         }
 
         private void ensureDefault<T>(Bindable<T> bindable) => bindable.SetDefault();

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Configuration
             GetBindable<bool>(Static.LoginOverlayDisplayed).SetDefault();
             GetBindable<bool>(Static.MutedAudioNotificationShownOnce).SetDefault();
             GetBindable<bool>(Static.LowBatteryNotificationShownOnce).SetDefault();
-            GetBindable<double?>(Static.LastHoverSoundPlaybackTime).SetDefault();
         }
     }
 

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
@@ -35,8 +34,6 @@ namespace osu.Game.Configuration
             GetBindable<bool>(Static.LowBatteryNotificationShownOnce).SetDefault();
             GetBindable<double?>(Static.LastHoverSoundPlaybackTime).SetDefault();
         }
-
-        private void ensureDefault<T>(Bindable<T> bindable) => bindable.SetDefault();
     }
 
     public enum Static

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -680,7 +680,7 @@ namespace osu.Game
             sessionIdleTracker.IsIdle.BindValueChanged(idle =>
             {
                 if (idle.NewValue)
-                    SessionStatics.ResetValues();
+                    SessionStatics.ResetAfterInactivity();
             });
 
             Add(sessionIdleTracker);


### PR DESCRIPTION
Fixes #16180