### PR TITLE
Allow dragging multiple slider path control points at once

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -92,6 +92,21 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertSelectionCount(1);
             assertSelected(0);
 
+            AddStep("move mouse to new point position", () =>
+            {
+                Vector2 position = slider.Position + (slider.Path.ControlPoints[2].Position + slider.Path.ControlPoints[3].Position) / 2;
+                InputManager.MoveMouseTo(drawableObject.Parent.ToScreenSpace(position));
+            });
+            AddStep("ctrl+click to create new point", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Click(MouseButton.Left);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("slider has 6 control points", () => slider.Path.ControlPoints.Count == 6);
+            assertSelectionCount(1);
+            assertSelected(3);
+
             void assertSelectionCount(int count) =>
                 AddAssert($"{count} control point pieces selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == count);
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -100,10 +100,17 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("ctrl+click to create new point", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);
-                InputManager.Click(MouseButton.Left);
-                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.PressButton(MouseButton.Left);
             });
             AddAssert("slider has 6 control points", () => slider.Path.ControlPoints.Count == 6);
+            assertSelectionCount(1);
+            assertSelected(3);
+
+            AddStep("release ctrl+click", () =>
+            {
+                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
             assertSelectionCount(1);
             assertSelected(3);
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -76,8 +78,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             moveMouseToControlPoint(2);
             AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
+
+            AddAssert("three control point pieces selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == 3);
+
             addMovementStep(new Vector2(450, 50));
             AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("three control point pieces selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == 3);
 
             assertControlPointPosition(2, new Vector2(450, 50));
             assertControlPointType(2, PathType.PerfectCurve);
@@ -87,6 +94,10 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertControlPointPosition(4, new Vector2(550, 200));
 
             AddStep("release control", () => InputManager.ReleaseKey(Key.LControl));
+
+            moveMouseToControlPoint(3);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            AddAssert("only one control point piece selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == 1);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -58,6 +58,10 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertSelectionCount(1);
             assertSelected(0);
 
+            AddStep("click right mouse", () => InputManager.Click(MouseButton.Right));
+            assertSelectionCount(1);
+            assertSelected(0);
+
             moveMouseToControlPoint(3);
             AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
             assertSelectionCount(1);
@@ -72,6 +76,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             moveMouseToControlPoint(0);
             AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            assertSelectionCount(3);
+            assertSelected(0);
+            assertSelected(2);
+            assertSelected(3);
+
+            AddStep("click right mouse", () => InputManager.Click(MouseButton.Right));
             assertSelectionCount(3);
             assertSelected(0);
             assertSelected(2);

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -61,6 +61,34 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
+        public void TestDragMultipleControlPoints()
+        {
+            moveMouseToControlPoint(2);
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            AddStep("hold control", () => InputManager.PressKey(Key.LControl));
+
+            moveMouseToControlPoint(3);
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            moveMouseToControlPoint(4);
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            moveMouseToControlPoint(2);
+            addMovementStep(new Vector2(450, 50));
+            AddStep("release", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            assertControlPointPosition(2, new Vector2(450, 50));
+            assertControlPointType(2, PathType.PerfectCurve);
+
+            assertControlPointPosition(3, new Vector2(550, 50));
+
+            assertControlPointPosition(4, new Vector2(550, 200));
+
+            AddStep("release control", () => InputManager.ReleaseKey(Key.LControl));
+        }
+
+        [Test]
         public void TestDragControlPointAlmostLinearlyExterior()
         {
             moveMouseToControlPoint(1);

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -138,6 +138,49 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
+        public void TestDragMultipleControlPointsIncludingHead()
+        {
+            moveMouseToControlPoint(0);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+
+            AddStep("hold control", () => InputManager.PressKey(Key.LControl));
+
+            moveMouseToControlPoint(3);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+
+            moveMouseToControlPoint(4);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+
+            moveMouseToControlPoint(3);
+            AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
+
+            AddAssert("three control point pieces selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == 3);
+
+            addMovementStep(new Vector2(550, 50));
+            AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("three control point pieces selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == 3);
+
+            // note: if the head is part of the selection being moved, the entire slider is moved.
+            // the unselected nodes will therefore change position relative to the slider head.
+
+            AddAssert("slider moved", () => Precision.AlmostEquals(slider.Position, new Vector2(256, 192) + new Vector2(150, 50)));
+
+            assertControlPointPosition(0, Vector2.Zero);
+            assertControlPointType(0, PathType.PerfectCurve);
+
+            assertControlPointPosition(1, new Vector2(0, 100));
+
+            assertControlPointPosition(2, new Vector2(150, -50));
+
+            assertControlPointPosition(3, new Vector2(400, 0));
+
+            assertControlPointPosition(4, new Vector2(400, 150));
+
+            AddStep("release control", () => InputManager.ReleaseKey(Key.LControl));
+        }
+
+        [Test]
         public void TestDragControlPointAlmostLinearlyExterior()
         {
             moveMouseToControlPoint(1);

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using Humanizer;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -50,6 +51,46 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         });
 
         [Test]
+        public void TestSelection()
+        {
+            moveMouseToControlPoint(0);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            assertSelectionCount(1);
+            assertSelected(0);
+
+            moveMouseToControlPoint(3);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            assertSelectionCount(1);
+            assertSelected(3);
+
+            AddStep("press control", () => InputManager.PressKey(Key.ControlLeft));
+            moveMouseToControlPoint(2);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            assertSelectionCount(2);
+            assertSelected(2);
+            assertSelected(3);
+
+            moveMouseToControlPoint(0);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            assertSelectionCount(3);
+            assertSelected(0);
+            assertSelected(2);
+            assertSelected(3);
+
+            AddStep("release control", () => InputManager.ReleaseKey(Key.ControlLeft));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            assertSelectionCount(1);
+            assertSelected(0);
+
+            void assertSelectionCount(int count) =>
+                AddAssert($"{count} control point pieces selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == count);
+
+            void assertSelected(int index) =>
+                AddAssert($"{(index + 1).ToOrdinalWords()} control point piece selected",
+                    () => this.ChildrenOfType<PathControlPointPiece>().Single(piece => piece.ControlPoint == slider.Path.ControlPoints[index]).IsSelected.Value);
+        }
+
+        [Test]
         public void TestDragControlPoint()
         {
             moveMouseToControlPoint(1);
@@ -94,10 +135,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertControlPointPosition(4, new Vector2(550, 200));
 
             AddStep("release control", () => InputManager.ReleaseKey(Key.LControl));
-
-            moveMouseToControlPoint(3);
-            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
-            AddAssert("only one control point piece selected", () => this.ChildrenOfType<PathControlPointPiece>().Count(piece => piece.IsSelected.Value) == 1);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderControlPointPiece.cs
@@ -64,19 +64,20 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         public void TestDragMultipleControlPoints()
         {
             moveMouseToControlPoint(2);
-            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
 
             AddStep("hold control", () => InputManager.PressKey(Key.LControl));
 
             moveMouseToControlPoint(3);
-            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
 
             moveMouseToControlPoint(4);
-            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
 
             moveMouseToControlPoint(2);
+            AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
             addMovementStep(new Vector2(450, 50));
-            AddStep("release", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
 
             assertControlPointPosition(2, new Vector2(450, 50));
             assertControlPointType(2, PathType.PerfectCurve);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -135,9 +135,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             updateMarkerDisplay();
         }
 
-        // Used to pair up mouse down events which caused this piece to be selected
-        // with their corresponding mouse up events.
-        private bool selectionPerformed;
+        // Used to pair up mouse down/drag events with their corresponding mouse up events,
+        // to avoid deselecting the piece by accident when the mouse up corresponding to the mouse down/drag fires.
+        private bool keepSelection;
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     if (!IsSelected.Value)
                     {
                         RequestSelection.Invoke(this, e);
-                        selectionPerformed = true;
+                        keepSelection = true;
                     }
 
                     return true;
@@ -169,11 +169,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             base.OnMouseUp(e);
 
             // ctrl+click deselects this piece, but only if this event
-            // wasn't immediately preceded by a matching mouse down.
-            if (IsSelected.Value && e.ControlPressed && !selectionPerformed)
+            // wasn't immediately preceded by a matching mouse down or drag.
+            if (IsSelected.Value && e.ControlPressed && !keepSelection)
                 IsSelected.Value = false;
 
-            selectionPerformed = false;
+            keepSelection = false;
         }
 
         protected override bool OnClick(ClickEvent e) => RequestSelection != null;
@@ -186,6 +186,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (e.Button == MouseButton.Left)
             {
                 DragStarted?.Invoke();
+                keepSelection = true;
                 return true;
             }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
     {
         public Action<PathControlPointPiece, MouseButtonEvent> RequestSelection;
 
-        public Action DragStarted;
+        public Action<PathControlPoint> DragStarted;
         public Action<DragEvent> DragInProgress;
         public Action DragEnded;
 
@@ -188,7 +188,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             if (e.Button == MouseButton.Left)
             {
-                DragStarted?.Invoke();
+                DragStarted?.Invoke(ControlPoint);
                 keepSelection = true;
                 return true;
             }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -135,6 +135,10 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             updateMarkerDisplay();
         }
 
+        // Used to pair up mouse down events which caused this piece to be selected
+        // with their corresponding mouse up events.
+        private bool selectionPerformed;
+
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             if (RequestSelection == null)
@@ -143,7 +147,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             switch (e.Button)
             {
                 case MouseButton.Left:
-                    RequestSelection.Invoke(this, e);
+                    if (!IsSelected.Value)
+                    {
+                        RequestSelection.Invoke(this, e);
+                        selectionPerformed = true;
+                    }
+
                     return true;
 
                 case MouseButton.Right:
@@ -153,6 +162,18 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
 
             return false;
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            base.OnMouseUp(e);
+
+            // ctrl+click deselects this piece, but only if this event
+            // wasn't immediately preceded by a matching mouse down.
+            if (IsSelected.Value && e.ControlPressed && !selectionPerformed)
+                IsSelected.Value = false;
+
+            selectionPerformed = false;
         }
 
         protected override bool OnClick(ClickEvent e) => RequestSelection != null;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -161,6 +161,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 case MouseButton.Right:
                     if (!IsSelected.Value)
                         RequestSelection.Invoke(this, e);
+
+                    keepSelection = true;
                     return false; // Allow context menu to show
             }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -147,11 +147,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             switch (e.Button)
             {
                 case MouseButton.Left:
-                    if (!IsSelected.Value)
-                    {
-                        RequestSelection.Invoke(this, e);
-                        keepSelection = true;
-                    }
+                    // if control is pressed, do not do anything as the user may be adding to current selection
+                    // or dragging all currently selected control points.
+                    // if it isn't and the user's intent is to deselect, deselection will happen on mouse up.
+                    if (e.ControlPressed && IsSelected.Value)
+                        return true;
+
+                    RequestSelection.Invoke(this, e);
+                    keepSelection = true;
 
                     return true;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -32,8 +32,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
     {
         public Action<PathControlPointPiece, MouseButtonEvent> RequestSelection;
 
-        public Action<PathControlPoint> DragStarted;
-        public Action<PathControlPoint, DragEvent> DragInProgress;
+        public Action DragStarted;
+        public Action<DragEvent> DragInProgress;
         public Action DragEnded;
 
         public List<PathControlPoint> PointsInSegment;
@@ -185,14 +185,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             if (e.Button == MouseButton.Left)
             {
-                DragStarted?.Invoke(ControlPoint);
+                DragStarted?.Invoke();
                 return true;
             }
 
             return false;
         }
 
-        protected override void OnDrag(DragEvent e) => DragInProgress?.Invoke(ControlPoint, e);
+        protected override void OnDrag(DragEvent e) => DragInProgress?.Invoke(e);
 
         protected override void OnDragEnd(DragEndEvent e) => DragEnded?.Invoke();
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                         Pieces.Add(new PathControlPointPiece(slider, point).With(d =>
                         {
                             if (allowSelection)
-                                d.RequestSelection = selectPiece;
+                                d.RequestSelection = selectionRequested;
 
                             d.DragStarted = dragStarted;
                             d.DragInProgress = dragInProgress;
@@ -128,6 +128,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         protected override bool OnClick(ClickEvent e)
         {
+            if (Pieces.Any(piece => piece.IsHovered))
+                return false;
+
             foreach (var piece in Pieces)
             {
                 piece.IsSelected.Value = false;
@@ -151,15 +154,22 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
         }
 
-        private void selectPiece(PathControlPointPiece piece, MouseButtonEvent e)
+        private void selectionRequested(PathControlPointPiece piece, MouseButtonEvent e)
         {
             if (e.Button == MouseButton.Left && inputManager.CurrentState.Keyboard.ControlPressed)
                 piece.IsSelected.Toggle();
             else
-            {
-                foreach (var p in Pieces)
-                    p.IsSelected.Value = p == piece;
-            }
+                SetSelectionTo(piece.ControlPoint);
+        }
+
+        /// <summary>
+        /// Selects the <see cref="PathControlPointPiece"/> corresponding to the given <paramref name="pathControlPoint"/>,
+        /// and deselects all other <see cref="PathControlPointPiece"/>s.
+        /// </summary>
+        public void SetSelectionTo(PathControlPoint pathControlPoint)
+        {
+            foreach (var p in Pieces)
+                p.IsSelected.Value = p.ControlPoint == pathControlPoint;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -167,9 +166,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         protected override void OnDrag(DragEvent e)
         {
-            Debug.Assert(placementControlPoint != null);
-
-            placementControlPoint.Position = e.MousePosition - HitObject.Position;
+            if (placementControlPoint != null)
+                placementControlPoint.Position = e.MousePosition - HitObject.Position;
         }
 
         protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 placementControlPoint.Position = e.MousePosition - HitObject.Position;
         }
 
-        protected override void OnDragEnd(DragEndEvent e)
+        protected override void OnMouseUp(MouseUpEvent e)
         {
             if (placementControlPoint != null)
             {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -139,6 +139,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 case MouseButton.Left:
                     if (e.ControlPressed && IsSelected)
                     {
+                        changeHandler?.BeginChange();
                         placementControlPoint = addControlPoint(e.MousePosition);
                         ControlPointVisualiser?.SetSelectionTo(placementControlPoint);
                         return true; // Stop input from being handled and modifying the selection
@@ -153,16 +154,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         [CanBeNull]
         private PathControlPoint placementControlPoint;
 
-        protected override bool OnDragStart(DragStartEvent e)
-        {
-            if (placementControlPoint != null)
-            {
-                changeHandler?.BeginChange();
-                return true;
-            }
-
-            return false;
-        }
+        protected override bool OnDragStart(DragStartEvent e) => placementControlPoint != null;
 
         protected override void OnDrag(DragEvent e)
         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -140,7 +140,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 case MouseButton.Left:
                     if (e.ControlPressed && IsSelected)
                     {
-                        placementControlPointIndex = addControlPoint(e.MousePosition);
+                        placementControlPoint = addControlPoint(e.MousePosition);
+                        ControlPointVisualiser?.SetSelectionTo(placementControlPoint);
                         return true; // Stop input from being handled and modifying the selection
                     }
 
@@ -150,11 +151,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return false;
         }
 
-        private int? placementControlPointIndex;
+        [CanBeNull]
+        private PathControlPoint placementControlPoint;
 
         protected override bool OnDragStart(DragStartEvent e)
         {
-            if (placementControlPointIndex != null)
+            if (placementControlPoint != null)
             {
                 changeHandler?.BeginChange();
                 return true;
@@ -165,16 +167,16 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         protected override void OnDrag(DragEvent e)
         {
-            Debug.Assert(placementControlPointIndex != null);
+            Debug.Assert(placementControlPoint != null);
 
-            HitObject.Path.ControlPoints[placementControlPointIndex.Value].Position = e.MousePosition - HitObject.Position;
+            placementControlPoint.Position = e.MousePosition - HitObject.Position;
         }
 
         protected override void OnDragEnd(DragEndEvent e)
         {
-            if (placementControlPointIndex != null)
+            if (placementControlPoint != null)
             {
-                placementControlPointIndex = null;
+                placementControlPoint = null;
                 changeHandler?.EndChange();
             }
         }
@@ -193,7 +195,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return false;
         }
 
-        private int addControlPoint(Vector2 position)
+        private PathControlPoint addControlPoint(Vector2 position)
         {
             position -= HitObject.Position;
 
@@ -211,10 +213,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 }
             }
 
-            // Move the control points from the insertion index onwards to make room for the insertion
-            controlPoints.Insert(insertionIndex, new PathControlPoint { Position = position });
+            var pathControlPoint = new PathControlPoint { Position = position };
 
-            return insertionIndex;
+            // Move the control points from the insertion index onwards to make room for the insertion
+            controlPoints.Insert(insertionIndex, pathControlPoint);
+
+            return pathControlPoint;
         }
 
         private void removeControlPoints(List<PathControlPoint> toRemove)


### PR DESCRIPTION
Select multiple control points of a slider path using <kbd>Ctrl</kbd>, then keep <kbd>Ctrl</kbd> held and drag any of the selected points to drag them all simultaneously (rather than one-at-a-time, which was the only option until this change).

https://user-images.githubusercontent.com/20418176/146836764-0b2f1645-a0cd-470c-b4f8-553e4b9700a3.mp4

I saw this suggested somewhere over the weekend, don't remember where (may have been a twitch chat message or something?) and figured that you might as well allow this. It's allowed for multiple objects anyway.

The move algorithm is largely the same, just moved to a higher level and adapted for multi-selection. I've had to make one more UX change, namely that deselection of path control points happens on mouse up rather than down as it used to. This is because a mouse down is ambiguous with this feature added - as in you don't know in advance if a mouse down is going to initiate a drag, or if it's just going to be a normal click. But as far as I can tell this behaviour is consistent with normal object selection anyhow:

https://github.com/ppy/osu/blob/698b6c4242dbc89d8b28d9b55be747505bd51796/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs#L356-L374