### PR TITLE
Fix potential wrong thread mutation in `ColourHitErrorMeter`

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -53,13 +53,13 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 LayoutEasing = Easing.OutQuint;
             }
 
-            public void Push(Color4 colour) => Schedule(() =>
+            public void Push(Color4 colour)
             {
                 Add(new HitErrorCircle(colour, drawable_judgement_size));
 
                 if (Children.Count > max_available_judgements)
                     Children.FirstOrDefault(c => !c.IsRemoved)?.Remove();
-            });
+            }
         }
 
         internal class HitErrorCircle : Container

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -53,13 +53,13 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 LayoutEasing = Easing.OutQuint;
             }
 
-            public void Push(Color4 colour)
+            public void Push(Color4 colour) => Schedule(() =>
             {
                 Add(new HitErrorCircle(colour, drawable_judgement_size));
 
                 if (Children.Count > max_available_judgements)
                     Children.FirstOrDefault(c => !c.IsRemoved)?.Remove();
-            }
+            });
         }
 
         internal class HitErrorCircle : Container

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
@@ -40,9 +40,14 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             if (gameplayClockContainer != null)
                 gameplayClockContainer.OnSeek += Clear;
 
-            processor.NewJudgement += OnNewJudgement;
+            // Scheduled as meter implementations are likely going to change/add drawables when reacting to this.
+            processor.NewJudgement += j => Schedule(() => OnNewJudgement(j));
         }
 
+        /// <summary>
+        /// Fired when a new judgement arrives.
+        /// </summary>
+        /// <param name="judgement">The new judgement.</param>
         protected abstract void OnNewJudgement(JudgementResult judgement);
 
         protected Color4 GetColourForHitResult(HitResult result)

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
@@ -40,9 +40,11 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             if (gameplayClockContainer != null)
                 gameplayClockContainer.OnSeek += Clear;
 
-            // Scheduled as meter implementations are likely going to change/add drawables when reacting to this.
-            processor.NewJudgement += j => Schedule(() => OnNewJudgement(j));
+            processor.NewJudgement += processorNewJudgement;
         }
+
+        // Scheduled as meter implementations are likely going to change/add drawables when reacting to this.
+        private void processorNewJudgement(JudgementResult j) => Schedule(() => OnNewJudgement(j));
 
         /// <summary>
         /// Fired when a new judgement arrives.
@@ -89,7 +91,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             base.Dispose(isDisposing);
 
             if (processor != null)
-                processor.NewJudgement -= OnNewJudgement;
+                processor.NewJudgement -= processorNewJudgement;
 
             if (gameplayClockContainer != null)
                 gameplayClockContainer.OnSeek -= Clear;


### PR DESCRIPTION
https://github.com/ppy/osu/runs/4583316068?check_suite_focus=true (first failure).

I've fixed this locally because it can only happen due to the `JudgementFlow` child (colour meter specifically), but if it feels more robust, the schedule can be moved to the abstract `OnNewJudgement` origin:

https://github.com/ppy/osu/blob/9a1db04920ea9034980d70bd9f0d26ad45862ca2/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs#L43