### PR TITLE
Centralise all multiplayer button clicking test logic

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
@@ -20,7 +19,6 @@ using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Resources;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -86,11 +84,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
             AddWaitStep("wait for transition", 2);
 
-            AddStep("create room", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
             AddUntilStep("wait for join", () => Client.RoomJoined);
         }
@@ -104,24 +98,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
         protected void RunGameplay()
         {
             AddUntilStep("wait for idle", () => Client.LocalUser?.State == MultiplayerUserState.Idle);
-            clickReadyButton();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddUntilStep("wait for ready", () => Client.LocalUser?.State == MultiplayerUserState.Ready);
-            clickReadyButton();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddUntilStep("wait for player", () => multiplayerComponents.CurrentScreen is Player player && player.IsLoaded);
             AddStep("exit player", () => multiplayerComponents.MultiplayerScreen.MakeCurrent());
-        }
-
-        private void clickReadyButton()
-        {
-            AddUntilStep("wait for ready button to be enabled", () => this.ChildrenOfType<MultiplayerReadyButton>().Single().ChildrenOfType<Button>().Single().Enabled.Value);
-
-            AddStep("click ready button", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerReadyButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -799,6 +799,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void pressReadyButton(int? playingUserId = null)
         {
+            // Can't use ClickButtonWhenEnabled<> due to needing to store the state after the button is enabled.
+
             AddUntilStep("wait for ready button to be enabled", () => readyButton.Enabled.Value);
 
             MultiplayerUserState lastState = MultiplayerUserState.Idle;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -463,11 +463,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("delete beatmap", () => beatmaps.Delete(importedSet));
 
-            AddStep("click spectate button", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerSpectateButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
 
             AddUntilStep("wait for spectating user state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
 
@@ -501,11 +497,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 client.ChangeUserState(MultiplayerTestScene.PLAYER_1_ID, MultiplayerUserState.Ready);
             });
 
-            AddStep("click spectate button", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerSpectateButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
 
             AddUntilStep("wait for spectating user state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
 
@@ -832,11 +824,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
             AddWaitStep("wait for transition", 2);
 
-            AddStep("create room", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
             AddUntilStep("wait for join", () => client.RoomJoined);
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -14,12 +14,10 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Resources;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -62,21 +60,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestCreatedRoom()
         {
-            AddStep("create room", () =>
+            AddStep("add playlist item", () =>
             {
                 SelectedRoom.Value.Playlist.Add(new PlaylistItem
                 {
                     Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                     Ruleset = { Value = new OsuRuleset().RulesetInfo },
                 });
-
-                // Needs to run after components update with the playlist item.
-                Schedule(() =>
-                {
-                    InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
-                    InputManager.Click(MouseButton.Left);
-                });
             });
+
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
             AddUntilStep("wait for join", () => RoomJoined);
         }
@@ -110,11 +103,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 });
             });
 
-            AddStep("click create button", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
             AddUntilStep("wait for room join", () => RoomJoined);
 
@@ -124,21 +113,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Client.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready);
             });
 
-            AddStep("click spectate button", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerSpectateButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
 
             AddUntilStep("wait for spectating user state", () => Client.LocalUser?.State == MultiplayerUserState.Spectating);
 
-            AddUntilStep("wait for ready button to be enabled", () => this.ChildrenOfType<MultiplayerReadyButton>().Single().ChildrenOfType<ReadyButton>().Single().Enabled.Value);
-
-            AddStep("click ready button", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerReadyButton>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddUntilStep("match started", () => Client.Room?.State == MultiplayerRoomState.WaitingForLoad);
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -13,7 +13,6 @@ using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
-using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -22,7 +21,6 @@ using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist;
 using osu.Game.Tests.Resources;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -140,21 +138,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("item arrived in playlist", () => playlist.ChildrenOfType<RearrangeableListItem<PlaylistItem>>().Any(i => i.Model.ID == itemId));
-        }
-
-        private void deleteItem(int index)
-        {
-            OsuRearrangeableListItem<PlaylistItem> item = null;
-
-            AddStep($"move mouse to delete button {index}", () =>
-            {
-                item = playlist.ChildrenOfType<OsuRearrangeableListItem<PlaylistItem>>().ElementAt(index);
-                InputManager.MoveMouseTo(item.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistRemoveButton>().ElementAt(0));
-            });
-
-            AddStep("click", () => InputManager.Click(MouseButton.Left));
-
-            AddUntilStep("item removed from playlist", () => !playlist.ChildrenOfType<RearrangeableListItem<PlaylistItem>>().Contains(item));
         }
 
         private void assertDeleteButtonVisibility(int index, bool visible)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -9,7 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -22,7 +21,6 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Tests.Resources;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -113,10 +111,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Client.TransferHost(2);
             });
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
         }
 
@@ -132,7 +130,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Client.AddUser(new APIUser { Id = 2, Username = "Another user" });
             });
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
 
             verifyGameplayStartFlow();
@@ -147,7 +145,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Client.TransferHost(2);
             });
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddStep("make user host", () => Client.TransferHost(Client.Room?.Users[0].UserID ?? 0));
 
             verifyGameplayStartFlow();
@@ -162,12 +160,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Client.AddUser(new APIUser { Id = 2, Username = "Another user" });
             });
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
 
             AddStep("transfer host", () => Client.TransferHost(Client.Room?.Users[1].UserID ?? 0));
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user is idle (match not started)", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
             AddAssert("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
         }
@@ -187,7 +185,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             if (!isHost)
                 AddStep("transfer host", () => Client.TransferHost(2));
 
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddRepeatStep("change user ready state", () =>
             {
@@ -202,20 +200,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             }, users);
         }
 
-        private void addClickButtonStep()
-        {
-            AddUntilStep("wait for button to be ready", () => button.ChildrenOfType<Button>().Single().Enabled.Value);
-            AddStep("click button", () =>
-            {
-                InputManager.MoveMouseTo(button);
-                InputManager.Click(MouseButton.Left);
-            });
-        }
-
         private void verifyGameplayStartFlow()
         {
             AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
-            addClickButtonStep();
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user waiting for load", () => Client.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
 
             AddAssert("ready button disabled", () => !button.ChildrenOfType<OsuButton>().Single().Enabled.Value);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -21,7 +21,6 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Tests.Resources;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -121,10 +120,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [TestCase(MultiplayerUserState.Ready)]
         public void TestToggleWhenIdle(MultiplayerUserState initialState)
         {
-            addClickSpectateButtonStep();
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             AddUntilStep("user is spectating", () => Client.Room?.Users[0].State == MultiplayerUserState.Spectating);
 
-            addClickSpectateButtonStep();
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             AddUntilStep("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
         }
 
@@ -138,7 +137,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestReadyButtonDisabledWhenHostAndNoReadyUsers()
         {
-            addClickSpectateButtonStep();
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             assertReadyButtonEnablement(false);
         }
 
@@ -148,7 +147,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("add user", () => Client.AddUser(new APIUser { Id = PLAYER_1_ID }));
             AddStep("set user ready", () => Client.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready));
 
-            addClickSpectateButtonStep();
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             assertReadyButtonEnablement(true);
         }
 
@@ -163,15 +162,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("set user ready", () => Client.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready));
 
-            addClickSpectateButtonStep();
+            ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             assertReadyButtonEnablement(false);
         }
-
-        private void addClickSpectateButtonStep() => AddStep("click spectate button", () =>
-        {
-            InputManager.MoveMouseTo(spectateButton);
-            InputManager.Click(MouseButton.Left);
-        });
 
         private void assertSpectateButtonEnablement(bool shouldBeEnabled)
             => AddUntilStep($"spectate button {(shouldBeEnabled ? "is" : "is not")} enabled", () => spectateButton.ChildrenOfType<OsuButton>().Single().Enabled.Value == shouldBeEnabled);

--- a/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
 using osu.Framework.Testing.Input;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.Sprites;
@@ -11,6 +14,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual
 {
@@ -112,6 +116,25 @@ namespace osu.Game.Tests.Visual
                         },
                     }
                 },
+            });
+        }
+
+        /// <summary>
+        /// Wait for a button to become enabled, then click it.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        protected void ClickButtonWhenEnabled<T>()
+            where T : Drawable
+        {
+            if (typeof(T) == typeof(Button))
+                AddUntilStep($"wait for {typeof(T).Name} enabled", () => (this.ChildrenOfType<T>().Single() as Button)?.Enabled.Value == true);
+            else
+                AddUntilStep($"wait for {typeof(T).Name} enabled", () => this.ChildrenOfType<T>().Single().ChildrenOfType<Button>().Single().Enabled.Value);
+
+            AddStep($"click {typeof(T).Name}", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<T>().Single());
+                InputManager.Click(MouseButton.Left);
             });
         }
 


### PR DESCRIPTION
This adds the "wait for enabled" check in a way that can be easily reused, as it keeps getting missed in test implementations.

This particular change hopefully fixes https://github.com/ppy/osu/runs/4583845033?check_suite_focus=true.

I've probably missed some button clicks.