### PR TITLE
Add logging of `MultiplayerMatchSubScreen` exiting from room loss

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
@@ -434,6 +435,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void handleRoomLost() => Schedule(() =>
         {
+            Logger.Log($"{nameof(MultiplayerMatchSubScreen)} exiting due to loss of room or connection");
+
             if (this.IsCurrentScreen())
                 this.Exit();
             else

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -435,7 +435,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void handleRoomLost() => Schedule(() =>
         {
-            Logger.Log($"{nameof(MultiplayerMatchSubScreen)} exiting due to loss of room or connection");
+            Logger.Log($"{this} exiting due to loss of room or connection");
 
             if (this.IsCurrentScreen())
                 this.Exit();

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -95,6 +95,8 @@ namespace osu.Game.Screens.OnlinePlay
 
         private void forcefullyExit()
         {
+            Logger.Log($"{this} forcefully exiting due to loss of API connection");
+
             // This is temporary since we don't currently have a way to force screens to be exited
             if (this.IsCurrentScreen())
             {


### PR DESCRIPTION
Kinda fishy, but need more logging to say anything. Good log output to have around regardless.