### PR TITLE
Rename beatmap card-related classes

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCard.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
         [Test]
         public void TestNormal()
         {
-            createTestCase(beatmapSetInfo => new BeatmapCard(beatmapSetInfo));
+            createTestCase(beatmapSetInfo => new BeatmapCardNormal(beatmapSetInfo));
         }
 
         [Test]
@@ -264,7 +264,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
         [Test]
         public void TestHoverState()
         {
-            AddStep("create cards", () => Child = createContent(OverlayColourScheme.Blue, s => new BeatmapCard(s)));
+            AddStep("create cards", () => Child = createContent(OverlayColourScheme.Blue, s => new BeatmapCardNormal(s)));
 
             AddStep("Hover card", () => InputManager.MoveMouseTo(firstCard()));
             AddWaitStep("wait for potential state change", 5);
@@ -281,10 +281,10 @@ namespace osu.Game.Tests.Visual.Beatmaps
             AddWaitStep("wait for potential state change", 5);
             AddAssert("card is still expanded", () => firstCard().Expanded.Value);
 
-            AddStep("Hover away", () => InputManager.MoveMouseTo(this.ChildrenOfType<BeatmapCard>().Last()));
+            AddStep("Hover away", () => InputManager.MoveMouseTo(this.ChildrenOfType<BeatmapCardNormal>().Last()));
             AddUntilStep("card is not expanded", () => !firstCard().Expanded.Value);
 
-            BeatmapCard firstCard() => this.ChildrenOfType<BeatmapCard>().First();
+            BeatmapCardNormal firstCard() => this.ChildrenOfType<BeatmapCardNormal>().First();
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -15,7 +15,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
-    public abstract class BeatmapCardBase : OsuClickableContainer
+    public abstract class BeatmapCard : OsuClickableContainer
     {
         public const float TRANSITION_DURATION = 400;
         public const float CORNER_RADIUS = 10;
@@ -30,7 +30,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         protected readonly BeatmapDownloadTracker DownloadTracker;
 
-        protected BeatmapCardBase(APIBeatmapSet beatmapSet, bool allowExpansion = true)
+        protected BeatmapCard(APIBeatmapSet beatmapSet, bool allowExpansion = true)
             : base(HoverSampleSet.Submit)
         {
             Expanded = new BindableBool { Disabled = !allowExpansion };

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                CornerRadius = BeatmapCardBase.CORNER_RADIUS,
+                CornerRadius = BeatmapCard.CORNER_RADIUS,
                 Masking = true,
                 Unhovered = _ => updateFromHoverChange(),
                 Children = new Drawable[]
@@ -67,7 +67,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = height,
-                        CornerRadius = BeatmapCardBase.CORNER_RADIUS,
+                        CornerRadius = BeatmapCard.CORNER_RADIUS,
                         Masking = true,
                     },
                     dropdownContent = new HoverHandlingContainer
@@ -91,7 +91,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     borderContainer = new Container
                     {
                         RelativeSizeAxes = Axes.Both,
-                        CornerRadius = BeatmapCardBase.CORNER_RADIUS,
+                        CornerRadius = BeatmapCard.CORNER_RADIUS,
                         Masking = true,
                         BorderThickness = 3,
                         Child = new Box
@@ -143,9 +143,9 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             // This avoids depth issues where a hovered (scaled) card to the right of another card would be beneath the card to the left.
             this.ScaleTo(Expanded.Value ? 1.03f : 1, 500, Easing.OutQuint);
 
-            background.FadeTo(Expanded.Value ? 1 : 0, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
-            dropdownContent.FadeTo(Expanded.Value ? 1 : 0, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
-            borderContainer.FadeTo(Expanded.Value ? 1 : 0, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            background.FadeTo(Expanded.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            dropdownContent.FadeTo(Expanded.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            borderContainer.FadeTo(Expanded.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
             content.TweenEdgeEffectTo(new EdgeEffectParameters
             {
@@ -154,7 +154,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 Radius = 10,
                 Colour = Colour4.Black.Opacity(Expanded.Value ? 0.3f : 0f),
                 Hollow = true,
-            }, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            }, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
 
         private class ExpandedContentScrollContainer : OsuScrollContainer

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContentBackground.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContentBackground.cs
@@ -62,10 +62,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         private void updateState() => Schedule(() =>
         {
-            background.FadeColour(Dimmed.Value ? colourProvider.Background4 : colourProvider.Background2, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            background.FadeColour(Dimmed.Value ? colourProvider.Background4 : colourProvider.Background2, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
             var gradient = ColourInfo.GradientHorizontal(Colour4.White.Opacity(0), Colour4.White.Opacity(0.2f));
-            cover.FadeColour(gradient, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            cover.FadeColour(gradient, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         });
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardDownloadProgressBar.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardDownloadProgressBar.cs
@@ -82,14 +82,14 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     break;
 
                 case DownloadState.Importing:
-                    foregroundFill.FadeColour(colours.Yellow, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+                    foregroundFill.FadeColour(colours.Yellow, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
                     break;
             }
         }
 
         private void progressChanged()
         {
-            foreground.ResizeWidthTo((float)progress.Value, progress.Value > 0 ? BeatmapCardBase.TRANSITION_DURATION : 0, Easing.OutQuint);
+            foreground.ResizeWidthTo((float)progress.Value, progress.Value > 0 ? BeatmapCard.TRANSITION_DURATION : 0, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -20,7 +20,7 @@ using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
-    public class BeatmapCardExtra : BeatmapCardBase
+    public class BeatmapCardExtra : BeatmapCard
     {
         protected override Drawable IdleContent => idleBottomContent;
         protected override Drawable DownloadInProgressContent => downloadProgressBar;

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -21,7 +21,7 @@ using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
-    public class BeatmapCard : BeatmapCardBase
+    public class BeatmapCardNormal : BeatmapCardBase
     {
         protected override Drawable IdleContent => idleBottomContent;
         protected override Drawable DownloadInProgressContent => downloadProgressBar;
@@ -43,7 +43,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
-        public BeatmapCard(APIBeatmapSet beatmapSet, bool allowExpansion = true)
+        public BeatmapCardNormal(APIBeatmapSet beatmapSet, bool allowExpansion = true)
             : base(beatmapSet, allowExpansion)
         {
             content = new BeatmapCardContent(height);

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -21,7 +21,7 @@ using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
-    public class BeatmapCardNormal : BeatmapCardBase
+    public class BeatmapCardNormal : BeatmapCard
     {
         protected override Drawable IdleContent => idleBottomContent;
         protected override Drawable DownloadInProgressContent => downloadProgressBar;

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -88,8 +88,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         {
             bool shouldDim = Dimmed.Value || playButton.Playing.Value;
 
-            playButton.FadeTo(shouldDim ? 1 : 0, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
-            cover.FadeColour(shouldDim ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            playButton.FadeTo(shouldDim ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            cover.FadeColour(shouldDim ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/BeatmapCardIconButton.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             bool isHovered = IsHovered && Enabled.Value;
 
             content.ScaleTo(isHovered ? 1.2f : 1, 500, Easing.OutQuint);
-            content.FadeColour(isHovered ? HoverColour : IdleColour, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            content.FadeColour(isHovered ? HoverColour : IdleColour, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                 case DownloadState.LocallyAvailable:
                     Action = null;
                     TooltipText = string.Empty;
-                    this.FadeOut(BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+                    this.FadeOut(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
                     break;
 
                 case DownloadState.NotDownloaded:
@@ -81,7 +81,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                     }
 
                     Action = () => beatmaps.Download(beatmapSet, preferNoVideo.Value);
-                    this.FadeIn(BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+                    this.FadeIn(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
                     spinner.Hide();
                     Icon.Show();
 

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/GoToBeatmapButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/GoToBeatmapButton.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 
         private void updateState()
         {
-            this.FadeTo(state.Value == DownloadState.LocallyAvailable ? 1 : 0, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            this.FadeTo(state.Value == DownloadState.LocallyAvailable ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
         private void toggleLoading(bool loading)
         {
             Enabled.Value = !loading;
-            icon.FadeTo(loading ? 0 : 1, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            icon.FadeTo(loading ? 0 : 1, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
             loadingSpinner.State.Value = loading ? Visibility.Visible : Visibility.Hidden;
         }
     }

--- a/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
             RelativeSizeAxes = Axes.Y;
             Masking = true;
-            CornerRadius = BeatmapCardBase.CORNER_RADIUS;
+            CornerRadius = BeatmapCard.CORNER_RADIUS;
 
             InternalChildren = new Drawable[]
             {
@@ -133,7 +133,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 {
                     Name = @"Main content",
                     RelativeSizeAxes = Axes.Y,
-                    CornerRadius = BeatmapCardBase.CORNER_RADIUS,
+                    CornerRadius = BeatmapCard.CORNER_RADIUS,
                     Masking = true,
                     Children = new Drawable[]
                     {
@@ -169,10 +169,10 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         {
             float targetWidth = Width - (ShowDetails.Value ? ButtonsExpandedWidth : ButtonsCollapsedWidth);
 
-            mainArea.ResizeWidthTo(targetWidth, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            mainArea.ResizeWidthTo(targetWidth, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
-            background.FadeColour(downloadTracker.State.Value == DownloadState.LocallyAvailable ? colours.Lime0 : colourProvider.Background3, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
-            buttons.FadeTo(ShowDetails.Value ? 1 : 0, BeatmapCardBase.TRANSITION_DURATION, Easing.OutQuint);
+            background.FadeColour(downloadTracker.State.Value == DownloadState.LocallyAvailable ? colours.Lime0 : colourProvider.Background3, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            buttons.FadeTo(ShowDetails.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
             foreach (var button in buttons)
             {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays
 
         private Drawable currentContent;
         private Container panelTarget;
-        private FillFlowContainer<BeatmapCard> foundContent;
+        private FillFlowContainer<BeatmapCardNormal> foundContent;
         private NotFoundDrawable notFoundContent;
         private SupporterRequiredDrawable supporterRequiredContent;
         private BeatmapListingFilterControl filterControl;
@@ -78,7 +78,7 @@ namespace osu.Game.Overlays
                                 Padding = new MarginPadding { Horizontal = 20 },
                                 Children = new Drawable[]
                                 {
-                                    foundContent = new FillFlowContainer<BeatmapCard>(),
+                                    foundContent = new FillFlowContainer<BeatmapCardNormal>(),
                                     notFoundContent = new NotFoundDrawable(),
                                     supporterRequiredContent = new SupporterRequiredDrawable(),
                                 }
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays
                 return;
             }
 
-            var newPanels = searchResult.Results.Select(b => new BeatmapCard(b)
+            var newPanels = searchResult.Results.Select(b => new BeatmapCardNormal(b)
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays
 
                 // spawn new children with the contained so we only clear old content at the last moment.
                 // reverse ID flow is required for correct Z-ordering of the cards' expandable content (last card should be front-most).
-                var content = new ReverseChildIDFillFlowContainer<BeatmapCard>
+                var content = new ReverseChildIDFillFlowContainer<BeatmapCardNormal>
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
             new GetUserBeatmapsRequest(User.Value.Id, type, VisiblePages++, ItemsPerPage);
 
         protected override Drawable CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0
-            ? new BeatmapCard(model)
+            ? new BeatmapCardNormal(model)
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,

--- a/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
@@ -136,12 +136,12 @@ namespace osu.Game.Overlays.Rankings
             {
                 new ScoresTable(1, response.Users),
                 // reverse ID flow is required for correct Z-ordering of the cards' expandable content (last card should be front-most).
-                new ReverseChildIDFillFlowContainer<BeatmapCard>
+                new ReverseChildIDFillFlowContainer<BeatmapCardNormal>
                 {
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
                     Spacing = new Vector2(10),
-                    Children = response.BeatmapSets.Select(b => new BeatmapCard(b)
+                    Children = response.BeatmapSets.Select(b => new BeatmapCardNormal(b)
                     {
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -228,7 +228,7 @@ namespace osu.Game.Screens.Play
             onlineBeatmapRequest.Success += beatmapSet => Schedule(() =>
             {
                 this.beatmapSet = beatmapSet;
-                beatmapPanelContainer.Child = new BeatmapCard(this.beatmapSet, allowExpansion: false);
+                beatmapPanelContainer.Child = new BeatmapCardNormal(this.beatmapSet, allowExpansion: false);
                 checkForAutomaticDownload();
             });
 


### PR DESCRIPTION
As suggested [here](https://github.com/ppy/osu/pull/16012#issuecomment-997974527):

* `BeatmapCard` => `BeatmapCardNormal`
* `BeatmapCardBase` => `BeatmapCard`

Diff is still a bit of a mess either way to look at because of the in-place replacement of `BeatmapCard`, but individual commits should be more tolerable.