### PR TITLE
Fix delete button showing on current item before beatmap retrieval

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -110,6 +110,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("finish current item", () => Client.FinishCurrentItem());
             AddUntilStep("wait for next item to be selected", () => Client.Room?.Settings.PlaylistItemId == 2);
+            AddUntilStep("wait for two items in playlist", () => playlist.ChildrenOfType<DrawableRoomPlaylistItem>().Count() == 2);
 
             assertDeleteButtonVisibility(0, false);
             assertDeleteButtonVisibility(1, false);
@@ -136,7 +137,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         private void assertDeleteButtonVisibility(int index, bool visible)
-            => AddUntilStep($"delete button {index} {(visible ? "is" : "is not")} visible",
-                () => (playlist.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistRemoveButton>().ElementAt(index).Alpha > 0) == visible);
+            => AddUntilStep($"delete button {index} {(visible ? "is" : "is not")} visible", () =>
+            {
+                var button = playlist.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistRemoveButton>().ElementAtOrDefault(index);
+                return (button?.Alpha > 0) == visible;
+            });
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
@@ -26,8 +25,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerQueueList : MultiplayerTestScene
     {
-        private readonly Bindable<PlaylistItem> selectedItem = new Bindable<PlaylistItem>();
-
         [Cached(typeof(UserLookupCache))]
         private readonly TestUserLookupCache userLookupCache = new TestUserLookupCache();
 
@@ -50,14 +47,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("create playlist", () =>
             {
-                selectedItem.Value = null;
-
                 Child = playlist = new MultiplayerQueueList
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Size = new Vector2(500, 300),
-                    SelectedItem = { BindTarget = selectedItem },
                     Items = { BindTarget = Client.APIRoom!.Playlist }
                 };
             });
@@ -111,12 +105,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             addPlaylistItem(() => API.LocalUser.Value.OnlineID);
 
-            AddStep("select item 0", () => selectedItem.Value = playlist.ChildrenOfType<RearrangeableListItem<PlaylistItem>>().ElementAt(0).Model);
             assertDeleteButtonVisibility(0, false);
             assertDeleteButtonVisibility(1, true);
 
-            AddStep("select item 1", () => selectedItem.Value = playlist.ChildrenOfType<RearrangeableListItem<PlaylistItem>>().ElementAt(1).Model);
-            assertDeleteButtonVisibility(0, true);
+            AddStep("finish current item", () => Client.FinishCurrentItem());
+            AddUntilStep("wait for next item to be selected", () => Client.Room?.Settings.PlaylistItemId == 2);
+
+            assertDeleteButtonVisibility(0, false);
             assertDeleteButtonVisibility(1, false);
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
@@ -78,9 +78,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist
 
             private void updateDeleteButtonVisibility()
             {
+                if (multiplayerClient.Room == null)
+                    return;
+
                 bool isItemOwner = Item.OwnerID == api.LocalUser.Value.OnlineID || multiplayerClient.IsHost;
 
-                AllowDeletion = isItemOwner && SelectedItem.Value != Item;
+                AllowDeletion = isItemOwner && Item.ID != multiplayerClient.Room.Settings.PlaylistItemId;
                 AllowEditing = isItemOwner;
             }
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
@@ -83,8 +83,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist
 
                 bool isItemOwner = Item.OwnerID == api.LocalUser.Value.OnlineID || multiplayerClient.IsHost;
 
-                AllowDeletion = isItemOwner && Item.ID != multiplayerClient.Room.Settings.PlaylistItemId;
-                AllowEditing = isItemOwner;
+                AllowDeletion = isItemOwner && !Item.Expired && Item.ID != multiplayerClient.Room.Settings.PlaylistItemId;
+                AllowEditing = isItemOwner && !Item.Expired;
             }
         }
     }


### PR DESCRIPTION
Haven't added a test because it's hard to test this one for the time being. `SelectedItem` is `null` until the current item has had its beatmap populated, so we need to check via the room's settings instead.

I could've sworn there was an issue for this, but I can't seem to find it... Maybe it was a dream.