### PR TITLE
Fix online lookup caches potentially getting stuck

### DIFF
--- a/osu.Game/Database/OnlineLookupCache.cs
+++ b/osu.Game/Database/OnlineLookupCache.cs
@@ -1,0 +1,162 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Game.Online.API;
+
+namespace osu.Game.Database
+{
+    public abstract class OnlineLookupCache<TLookup, TValue, TRequest> : MemoryCachingComponent<TLookup, TValue>
+        where TLookup : IEquatable<TLookup>
+        where TValue : class, IHasOnlineID<TLookup>
+        where TRequest : APIRequest
+    {
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        /// <summary>
+        /// Creates an <see cref="APIRequest"/> to retrieve the values for a given collection of <typeparamref name="TLookup"/>s.
+        /// </summary>
+        /// <param name="ids">The IDs to perform the lookup with.</param>
+        protected abstract TRequest CreateRequest(IEnumerable<TLookup> ids);
+
+        /// <summary>
+        /// Retrieves a list of <typeparamref name="TValue"/>s from a successful <typeparamref name="TRequest"/> created by <see cref="CreateRequest"/>.
+        /// </summary>
+        [CanBeNull]
+        protected abstract IEnumerable<TValue> RetrieveResults(TRequest request);
+
+        /// <summary>
+        /// Perform a lookup using the specified <paramref name="id"/>, populating a <typeparamref name="TValue"/>.
+        /// </summary>
+        /// <param name="id">The ID to lookup.</param>
+        /// <param name="token">An optional cancellation token.</param>
+        /// <returns>The populated <typeparamref name="TValue"/>, or null if the value does not exist or the request could not be satisfied.</returns>
+        [ItemCanBeNull]
+        protected Task<TValue> LookupAsync(TLookup id, CancellationToken token = default) => GetAsync(id, token);
+
+        /// <summary>
+        /// Perform an API lookup on the specified <paramref name="ids"/>, populating a <typeparamref name="TValue"/>.
+        /// </summary>
+        /// <param name="ids">The IDs to lookup.</param>
+        /// <param name="token">An optional cancellation token.</param>
+        /// <returns>The populated values. May include null results for failed retrievals.</returns>
+        protected Task<TValue[]> LookupAsync(TLookup[] ids, CancellationToken token = default)
+        {
+            var lookupTasks = new List<Task<TValue>>();
+
+            foreach (var id in ids)
+            {
+                lookupTasks.Add(LookupAsync(id, token).ContinueWith(task =>
+                {
+                    if (!task.IsCompletedSuccessfully)
+                        return null;
+
+                    return task.Result;
+                }, token));
+            }
+
+            return Task.WhenAll(lookupTasks);
+        }
+
+        // cannot be sealed due to test usages (see TestUserLookupCache).
+        protected override async Task<TValue> ComputeValueAsync(TLookup lookup, CancellationToken token = default)
+            => await queryValue(lookup).ConfigureAwait(false);
+
+        private readonly Queue<(TLookup id, TaskCompletionSource<TValue>)> pendingTasks = new Queue<(TLookup, TaskCompletionSource<TValue>)>();
+        private Task pendingRequestTask;
+        private readonly object taskAssignmentLock = new object();
+
+        private Task<TValue> queryValue(TLookup id)
+        {
+            lock (taskAssignmentLock)
+            {
+                var tcs = new TaskCompletionSource<TValue>();
+
+                // Add to the queue.
+                pendingTasks.Enqueue((id, tcs));
+
+                // Create a request task if there's not already one.
+                if (pendingRequestTask == null)
+                    createNewTask();
+
+                return tcs.Task;
+            }
+        }
+
+        private void performLookup()
+        {
+            // contains at most 50 unique IDs from tasks, which is used to perform the lookup.
+            var nextTaskBatch = new Dictionary<TLookup, List<TaskCompletionSource<TValue>>>();
+
+            // Grab at most 50 unique IDs from the queue.
+            lock (taskAssignmentLock)
+            {
+                while (pendingTasks.Count > 0 && nextTaskBatch.Count < 50)
+                {
+                    (TLookup id, TaskCompletionSource<TValue> task) next = pendingTasks.Dequeue();
+
+                    // Perform a secondary check for existence, in case the value was queried in a previous batch.
+                    if (CheckExists(next.id, out var existing))
+                        next.task.SetResult(existing);
+                    else
+                    {
+                        if (nextTaskBatch.TryGetValue(next.id, out var tasks))
+                            tasks.Add(next.task);
+                        else
+                            nextTaskBatch[next.id] = new List<TaskCompletionSource<TValue>> { next.task };
+                    }
+                }
+            }
+
+            if (nextTaskBatch.Count == 0)
+                return;
+
+            // Query the values.
+            var request = CreateRequest(nextTaskBatch.Keys.ToArray());
+
+            // rather than queueing, we maintain our own single-threaded request stream.
+            // todo: we probably want retry logic here.
+            api.Perform(request);
+
+            // Create a new request task if there's still more values to query.
+            lock (taskAssignmentLock)
+            {
+                pendingRequestTask = null;
+                if (pendingTasks.Count > 0)
+                    createNewTask();
+            }
+
+            var foundValues = RetrieveResults(request);
+
+            if (foundValues != null)
+            {
+                foreach (var value in foundValues)
+                {
+                    if (nextTaskBatch.TryGetValue(value.OnlineID, out var tasks))
+                    {
+                        foreach (var task in tasks)
+                            task.SetResult(value);
+
+                        nextTaskBatch.Remove(value.OnlineID);
+                    }
+                }
+            }
+
+            // if any tasks remain which were not satisfied, return null.
+            foreach (var tasks in nextTaskBatch.Values)
+            {
+                foreach (var task in tasks)
+                    task.SetResult(null);
+            }
+        }
+
+        private void createNewTask() => pendingRequestTask = Task.Run(performLookup);
+    }
+}

--- a/osu.Game/Database/UserLookupCache.cs
+++ b/osu.Game/Database/UserLookupCache.cs
@@ -6,18 +6,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using osu.Framework.Allocation;
-using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Database
 {
-    public class UserLookupCache : MemoryCachingComponent<int, APIUser>
+    public class UserLookupCache : OnlineLookupCache<int, APIUser, GetUsersRequest>
     {
-        [Resolved]
-        private IAPIProvider api { get; set; }
-
         /// <summary>
         /// Perform an API lookup on the specified user, populating a <see cref="APIUser"/> model.
         /// </summary>
@@ -25,7 +20,7 @@ namespace osu.Game.Database
         /// <param name="token">An optional cancellation token.</param>
         /// <returns>The populated user, or null if the user does not exist or the request could not be satisfied.</returns>
         [ItemCanBeNull]
-        public Task<APIUser> GetUserAsync(int userId, CancellationToken token = default) => GetAsync(userId, token);
+        public Task<APIUser> GetUserAsync(int userId, CancellationToken token = default) => LookupAsync(userId, token);
 
         /// <summary>
         /// Perform an API lookup on the specified users, populating a <see cref="APIUser"/> model.
@@ -33,115 +28,10 @@ namespace osu.Game.Database
         /// <param name="userIds">The users to lookup.</param>
         /// <param name="token">An optional cancellation token.</param>
         /// <returns>The populated users. May include null results for failed retrievals.</returns>
-        public Task<APIUser[]> GetUsersAsync(int[] userIds, CancellationToken token = default)
-        {
-            var userLookupTasks = new List<Task<APIUser>>();
+        public Task<APIUser[]> GetUsersAsync(int[] userIds, CancellationToken token = default) => LookupAsync(userIds, token);
 
-            foreach (int u in userIds)
-            {
-                userLookupTasks.Add(GetUserAsync(u, token).ContinueWith(task =>
-                {
-                    if (!task.IsCompletedSuccessfully)
-                        return null;
+        protected override GetUsersRequest CreateRequest(IEnumerable<int> ids) => new GetUsersRequest(ids.ToArray());
 
-                    return task.Result;
-                }, token));
-            }
-
-            return Task.WhenAll(userLookupTasks);
-        }
-
-        protected override async Task<APIUser> ComputeValueAsync(int lookup, CancellationToken token = default)
-            => await queryUser(lookup).ConfigureAwait(false);
-
-        private readonly Queue<(int id, TaskCompletionSource<APIUser>)> pendingUserTasks = new Queue<(int, TaskCompletionSource<APIUser>)>();
-        private Task pendingRequestTask;
-        private readonly object taskAssignmentLock = new object();
-
-        private Task<APIUser> queryUser(int userId)
-        {
-            lock (taskAssignmentLock)
-            {
-                var tcs = new TaskCompletionSource<APIUser>();
-
-                // Add to the queue.
-                pendingUserTasks.Enqueue((userId, tcs));
-
-                // Create a request task if there's not already one.
-                if (pendingRequestTask == null)
-                    createNewTask();
-
-                return tcs.Task;
-            }
-        }
-
-        private void performLookup()
-        {
-            // contains at most 50 unique user IDs from userTasks, which is used to perform the lookup.
-            var userTasks = new Dictionary<int, List<TaskCompletionSource<APIUser>>>();
-
-            // Grab at most 50 unique user IDs from the queue.
-            lock (taskAssignmentLock)
-            {
-                while (pendingUserTasks.Count > 0 && userTasks.Count < 50)
-                {
-                    (int id, TaskCompletionSource<APIUser> task) next = pendingUserTasks.Dequeue();
-
-                    // Perform a secondary check for existence, in case the user was queried in a previous batch.
-                    if (CheckExists(next.id, out var existing))
-                        next.task.SetResult(existing);
-                    else
-                    {
-                        if (userTasks.TryGetValue(next.id, out var tasks))
-                            tasks.Add(next.task);
-                        else
-                            userTasks[next.id] = new List<TaskCompletionSource<APIUser>> { next.task };
-                    }
-                }
-            }
-
-            if (userTasks.Count == 0)
-                return;
-
-            // Query the users.
-            var request = new GetUsersRequest(userTasks.Keys.ToArray());
-
-            // rather than queueing, we maintain our own single-threaded request stream.
-            // todo: we probably want retry logic here.
-            api.Perform(request);
-
-            // Create a new request task if there's still more users to query.
-            lock (taskAssignmentLock)
-            {
-                pendingRequestTask = null;
-                if (pendingUserTasks.Count > 0)
-                    createNewTask();
-            }
-
-            List<APIUser> foundUsers = request.Response?.Users;
-
-            if (foundUsers != null)
-            {
-                foreach (var user in foundUsers)
-                {
-                    if (userTasks.TryGetValue(user.Id, out var tasks))
-                    {
-                        foreach (var task in tasks)
-                            task.SetResult(user);
-
-                        userTasks.Remove(user.Id);
-                    }
-                }
-            }
-
-            // if any tasks remain which were not satisfied, return null.
-            foreach (var tasks in userTasks.Values)
-            {
-                foreach (var task in tasks)
-                    task.SetResult(null);
-            }
-        }
-
-        private void createNewTask() => pendingRequestTask = Task.Run(performLookup);
+        protected override IEnumerable<APIUser> RetrieveResults(GetUsersRequest request) => request.Response?.Users;
     }
 }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/16136.

This actually regressed with bf5a186. The early returns did not run the following logic:

https://github.com/ppy/osu/blob/4ba5a939db07f6c55cbe1a585a1d6cfbd96c1ea4/osu.Game/Database/BeatmapLookupCache.cs#L115-L121

And due to that, `pendingRequestTask` would be a completed non-null task, and the following check in the query method:

https://github.com/ppy/osu/blob/4ba5a939db07f6c55cbe1a585a1d6cfbd96c1ea4/osu.Game/Database/BeatmapLookupCache.cs#L72-L74

would fail, therefore stalling all requests going via the lookup cache permanently until a restart.

As for the fix:
* 6848c9b is a refactor commit to unify the two existing lookup queues into one, to avoid copying fixes back and forth. I can split this into a separate pull on request.
* 5a94610 is the actual fix - the early return clears the task, therefore preventing this scenario from happening.

The bug itself is indeterministic and not easily testable, but I have good evidence that this early return is indeed what causes it (to test, breakpoint on it on `master`, and add/edit playlist items until you get a hit on that early return; after getting a hit on it, all lookups will stop working).