### PR TITLE
Improve contrast of timeline blueprint foreground content for pastel combo colours

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -177,8 +177,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             else
                 circle.Colour = colour;
 
-            var col = circle.Colour.TopLeft.Linear;
-            colouredComponents.Colour = OsuColour.ForegroundTextColourFor(col);
+            var averageColour = Interpolation.ValueAt(0.5, circle.Colour.TopLeft, circle.Colour.TopRight, 0, 1);
+            colouredComponents.Colour = OsuColour.ForegroundTextColourFor(averageColour);
         }
 
         private SamplePointPiece sampleOverrideDisplay;


### PR DESCRIPTION
Just a small quality of life change for the editor timeline. The duration-having timeline blueprints could turn unreadable with some pastel colours sometimes (screenshot provided by @Walavouchey):

![image](https://user-images.githubusercontent.com/20418176/146926725-4c05a176-0d89-4de4-873f-f9acd7ad61c8.png)

This is because of the gradient applied to the duration blueprint, and the fact that for selecting the foreground colour, the top left colour is picked (which is going to be the darkest one). Therefore the proposal is to go for a middle ground and pick a foreground colour based on the average colour of the gradient.

Compare the screenshot above with this one, taken for the same combo colour but with this change applied:

![2021-12-21-130401_691x126_scrot](https://user-images.githubusercontent.com/20418176/146927094-bc57c774-9704-4912-b49b-d322992bdf1b.png)