### PR TITLE
Fix multiplayer test failures when checking for parted room

### DIFF
--- a/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
+++ b/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
         public void TestPlayingUsersUpdatedOnJoin()
         {
             AddStep("leave room", () => Client.LeaveRoom());
-            AddUntilStep("wait for room part", () => Client.Room == null);
+            AddUntilStep("wait for room part", () => !RoomJoined);
 
             AddStep("create room initially in gameplay", () =>
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("finish current item", () => Client.FinishCurrentItem());
 
             AddStep("leave room", () => RoomManager.PartRoom());
-            AddUntilStep("wait for room part", () => Client.Room == null);
+            AddUntilStep("wait for room part", () => !RoomJoined);
 
             AddUntilStep("item 0 not in lists", () => !inHistoryList(0) && !inQueueList(0));
             AddUntilStep("item 1 not in lists", () => !inHistoryList(0) && !inQueueList(0));
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestJoinRoomWithMixedItemsAddedInCorrectLists()
         {
             AddStep("leave room", () => RoomManager.PartRoom());
-            AddUntilStep("wait for room part", () => Client.Room == null);
+            AddUntilStep("wait for room part", () => !RoomJoined);
 
             AddStep("join room with items", () =>
             {


### PR DESCRIPTION
As seen in https://github.com/peppy/osu/runs/4595957072?check_suite_focus=true

Can be reproed by adding a `Task.Delay()` in `MultiplayerClient.LeaveRoom`'s chained task.