### PR TITLE
Fix `ImportCollectionsTest.TestSaveAndReload` not cleaning up before run

### DIFF
--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Collections.IO
         [Test]
         public async Task TestSaveAndReload()
         {
-            using (HeadlessGameHost host = new TestRunHeadlessGameHost("TestSaveAndReload", bypassCleanup: true))
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost(bypassCleanup: true))
             {
                 try
                 {
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Collections.IO
                 }
             }
 
-            using (HeadlessGameHost host = new TestRunHeadlessGameHost("TestSaveAndReload"))
+            using (HeadlessGameHost host = new TestRunHeadlessGameHost(nameof(TestSaveAndReload)))
             {
                 try
                 {

--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -149,6 +149,7 @@ namespace osu.Game.Tests.Collections.IO
                 }
             }
 
+            // Name matches the automatically chosen name from `CleanRunHeadlessGameHost` above, so we end up using the same storage location.
             using (HeadlessGameHost host = new TestRunHeadlessGameHost(nameof(TestSaveAndReload)))
             {
                 try

--- a/osu.Game/Tests/CleanRunHeadlessGameHost.cs
+++ b/osu.Game/Tests/CleanRunHeadlessGameHost.cs
@@ -17,9 +17,10 @@ namespace osu.Game.Tests
         /// <param name="gameSuffix">An optional suffix which will isolate this host from others called from the same method source.</param>
         /// <param name="bindIPC">Whether to bind IPC channels.</param>
         /// <param name="realtime">Whether the host should be forced to run in realtime, rather than accelerated test time.</param>
+        /// <param name="bypassCleanup">Whether to bypass directory cleanup on host disposal. Should be used only if a subsequent test relies on the files still existing.</param>
         /// <param name="callingMethodName">The name of the calling method, used for test file isolation and clean-up.</param>
-        public CleanRunHeadlessGameHost(string gameSuffix = @"", bool bindIPC = false, bool realtime = true, [CallerMemberName] string callingMethodName = @"")
-            : base(callingMethodName + gameSuffix, bindIPC, realtime)
+        public CleanRunHeadlessGameHost(string gameSuffix = @"", bool bindIPC = false, bool realtime = true, bool bypassCleanup = false, [CallerMemberName] string callingMethodName = @"")
+            : base(callingMethodName + gameSuffix, bindIPC, realtime, bypassCleanup: bypassCleanup)
         {
         }
 


### PR DESCRIPTION
Could cause local test failures if tests were run against an old realm version, due to the temporary folder never being cleaned up for the test (requiring manual intervention).