### PR TITLE
Tidy up `WorkingBeatmap`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void checkForFirstSamplePlayback()
         {
-            AddUntilStep("storyboard loaded", () => Player.Beatmap.Value.StoryboardLoaded);
+            AddAssert("storyboard loaded", () => Player.Beatmap.Value.Storyboard != null);
             AddUntilStep("any storyboard samples playing", () => allStoryboardSamples.Any(sound => sound.IsPlaying));
         }
 

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -157,12 +157,12 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("wait for fail", () => player.HasFailed);
 
             AddUntilStep("wait for track stop", () => !Game.MusicController.IsPlaying);
-            AddAssert("Ensure time before preview point", () => Game.MusicController.CurrentTrack.CurrentTime < beatmap().Metadata.PreviewTime);
+            AddAssert("Ensure time before preview point", () => Game.MusicController.CurrentTrack.CurrentTime < beatmap().BeatmapInfo.Metadata.PreviewTime);
 
             pushEscape();
 
             AddUntilStep("wait for track playing", () => Game.MusicController.IsPlaying);
-            AddAssert("Ensure time wasn't reset to preview point", () => Game.MusicController.CurrentTrack.CurrentTime < beatmap().Metadata.PreviewTime);
+            AddAssert("Ensure time wasn't reset to preview point", () => Game.MusicController.CurrentTrack.CurrentTime < beatmap().BeatmapInfo.Metadata.PreviewTime);
         }
 
         [Test]

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -30,26 +30,6 @@ namespace osu.Game.Beatmaps
         public bool BeatmapLoaded { get; }
 
         /// <summary>
-        /// Whether the Background has finished loading.
-        ///</summary>
-        public bool BackgroundLoaded { get; }
-
-        /// <summary>
-        /// Whether the Waveform has finished loading.
-        ///</summary>
-        public bool WaveformLoaded { get; }
-
-        /// <summary>
-        /// Whether the Storyboard has finished loading.
-        ///</summary>
-        public bool StoryboardLoaded { get; }
-
-        /// <summary>
-        /// Whether the Skin has finished loading.
-        ///</summary>
-        public bool SkinLoaded { get; }
-
-        /// <summary>
         /// Whether the Track has finished loading.
         ///</summary>
         public bool TrackLoaded { get; }

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -37,12 +35,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the <see cref="IBeatmap"/> which this <see cref="IWorkingBeatmap"/> represents.
         /// </summary>
-        IBeatmap? Beatmap { get; }
+        IBeatmap Beatmap { get; }
 
         /// <summary>
         /// Retrieves the background for this <see cref="IWorkingBeatmap"/>.
         /// </summary>
-        Texture? Background { get; }
+        Texture Background { get; }
 
         /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.
@@ -57,12 +55,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the <see cref="Skin"/> which this <see cref="IWorkingBeatmap"/> provides.
         /// </summary>
-        ISkin? Skin { get; }
+        ISkin Skin { get; }
 
         /// <summary>
         /// Retrieves the <see cref="Track"/> which this <see cref="IWorkingBeatmap"/> has loaded.
         /// </summary>
-        Track? Track { get; }
+        Track Track { get; }
 
         /// <summary>
         /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.
@@ -81,7 +79,7 @@ namespace osu.Game.Beatmaps
         /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod>? mods = null);
+        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null);
 
         /// <summary>
         /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.
@@ -114,7 +112,7 @@ namespace osu.Game.Beatmaps
         /// Returns the stream of the file from the given storage path.
         /// </summary>
         /// <param name="storagePath">The storage path to the file.</param>
-        Stream? GetStream(string storagePath);
+        Stream GetStream(string storagePath);
 
         /// <summary>
         /// Beings loading the contents of this <see cref="IWorkingBeatmap"/> asynchronously.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -37,12 +37,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the <see cref="IBeatmap"/> which this <see cref="IWorkingBeatmap"/> represents.
         /// </summary>
-        IBeatmap Beatmap { get; }
+        IBeatmap? Beatmap { get; }
 
         /// <summary>
         /// Retrieves the background for this <see cref="IWorkingBeatmap"/>.
         /// </summary>
-        Texture Background { get; }
+        Texture? Background { get; }
 
         /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.
@@ -57,12 +57,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the <see cref="Skin"/> which this <see cref="IWorkingBeatmap"/> provides.
         /// </summary>
-        ISkin Skin { get; }
+        ISkin? Skin { get; }
 
         /// <summary>
         /// Retrieves the <see cref="Track"/> which this <see cref="IWorkingBeatmap"/> has loaded.
         /// </summary>
-        Track Track { get; }
+        Track? Track { get; }
 
         /// <summary>
         /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.
@@ -114,7 +114,7 @@ namespace osu.Game.Beatmaps
         /// Returns the stream of the file from the given storage path.
         /// </summary>
         /// <param name="storagePath">The storage path to the file.</param>
-        Stream GetStream(string storagePath);
+        Stream? GetStream(string storagePath);
 
         /// <summary>
         /// Beings loading the contents of this <see cref="IWorkingBeatmap"/> asynchronously.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -37,12 +37,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the <see cref="IBeatmap"/> which this <see cref="IWorkingBeatmap"/> represents.
         /// </summary>
-        IBeatmap? Beatmap { get; }
+        IBeatmap Beatmap { get; }
 
         /// <summary>
         /// Retrieves the background for this <see cref="IWorkingBeatmap"/>.
         /// </summary>
-        Texture? Background { get; }
+        Texture Background { get; }
 
         /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.
@@ -57,12 +57,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the <see cref="Skin"/> which this <see cref="IWorkingBeatmap"/> provides.
         /// </summary>
-        ISkin? Skin { get; }
+        ISkin Skin { get; }
 
         /// <summary>
         /// Retrieves the <see cref="Track"/> which this <see cref="IWorkingBeatmap"/> has loaded.
         /// </summary>
-        Track? Track { get; }
+        Track Track { get; }
 
         /// <summary>
         /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.
@@ -114,7 +114,7 @@ namespace osu.Game.Beatmaps
         /// Returns the stream of the file from the given storage path.
         /// </summary>
         /// <param name="storagePath">The storage path to the file.</param>
-        Stream? GetStream(string storagePath);
+        Stream GetStream(string storagePath);
 
         /// <summary>
         /// Beings loading the contents of this <see cref="IWorkingBeatmap"/> asynchronously.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -15,13 +15,12 @@ using osu.Game.Storyboards;
 
 namespace osu.Game.Beatmaps
 {
+    /// <summary>
+    /// Provides access to the multiple resources offered by a beatmap model (textures, skins, playable beatmaps etc.)
+    /// </summary>
     public interface IWorkingBeatmap
     {
         IBeatmapInfo BeatmapInfo { get; }
-
-        IBeatmapSetInfo BeatmapSetInfo { get; }
-
-        IBeatmapMetadataInfo Metadata { get; }
 
         /// <summary>
         /// Whether the Beatmap has finished loading.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -99,7 +101,7 @@ namespace osu.Game.Beatmaps
         /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null);
+        IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod>? mods = null);
 
         /// <summary>
         /// Constructs a playable <see cref="IBeatmap"/> from <see cref="Beatmap"/> using the applicable converters for a specific <see cref="RulesetInfo"/>.

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -54,10 +54,6 @@ namespace osu.Game.Beatmaps
         #region Load checks
 
         public virtual bool TrackLoaded => loadedTrack != null;
-        public bool WaveformLoaded => waveform.IsResultAvailable;
-        public bool StoryboardLoaded => storyboard.IsResultAvailable;
-        public bool SkinLoaded => skin.IsResultAvailable;
-        public bool BackgroundLoaded => background.IsResultAvailable;
         public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
 
         #endregion

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -32,6 +32,14 @@ namespace osu.Game.Beatmaps
         // TODO: remove once the fallback lookup is not required (and access via `working.BeatmapInfo.Metadata` directly).
         public BeatmapMetadata Metadata => BeatmapInfo.Metadata ?? BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
+        public Waveform Waveform => waveform.Value;
+
+        public Storyboard Storyboard => storyboard.Value;
+
+        public Texture Background => GetBackground(); // Texture uses ref counting, so we want to return a new instance every usage.
+
+        public ISkin Skin => skin.Value;
+
         private AudioManager audioManager { get; }
 
         private CancellationTokenSource loadCancellationSource = new CancellationTokenSource();
@@ -54,11 +62,6 @@ namespace osu.Game.Beatmaps
             storyboard = new Lazy<Storyboard>(GetStoryboard);
             skin = new Lazy<ISkin>(GetSkin);
         }
-
-        public Waveform Waveform => waveform.Value;
-        public Storyboard Storyboard => storyboard.Value;
-        public Texture Background => GetBackground(); // Texture uses ref counting, so we want to return a new instance every usage.
-        public ISkin Skin => skin.Value;
 
         #region Resource getters
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -51,6 +51,110 @@ namespace osu.Game.Beatmaps
             skin = new RecyclableLazy<ISkin>(GetSkin);
         }
 
+        #region Load checks
+
+        public virtual bool TrackLoaded => loadedTrack != null;
+        public bool WaveformLoaded => waveform.IsResultAvailable;
+        public bool StoryboardLoaded => storyboard.IsResultAvailable;
+        public bool SkinLoaded => skin.IsResultAvailable;
+        public bool BackgroundLoaded => background.IsResultAvailable;
+        public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
+
+        #endregion
+
+        #region Resource getters
+
+        protected virtual Waveform GetWaveform() => new Waveform(null);
+        protected virtual Storyboard GetStoryboard() => new Storyboard { BeatmapInfo = BeatmapInfo };
+
+        protected abstract IBeatmap GetBeatmap();
+        protected abstract Texture GetBackground();
+        protected abstract Track GetBeatmapTrack();
+
+        /// <summary>
+        /// Creates a new skin instance for this beatmap.
+        /// </summary>
+        /// <remarks>
+        /// This should only be called externally in scenarios where it is explicitly desired to get a new instance of a skin
+        /// (e.g. for editing purposes, to avoid state pollution).
+        /// For standard reading purposes, <see cref="Skin"/> should always be used directly.
+        /// </remarks>
+        protected internal abstract ISkin GetSkin();
+
+        #endregion
+
+        #region Async load control
+
+        public void BeginAsyncLoad() => loadBeatmapAsync();
+
+        public void CancelAsyncLoad()
+        {
+            lock (beatmapFetchLock)
+            {
+                loadCancellationSource?.Cancel();
+                loadCancellationSource = new CancellationTokenSource();
+
+                if (beatmapLoadTask?.IsCompleted != true)
+                    beatmapLoadTask = null;
+            }
+        }
+
+        #endregion
+
+        #region Background
+
+        public Texture Background => background.Value;
+        private readonly RecyclableLazy<Texture> background;
+
+        protected virtual bool BackgroundStillValid(Texture b) => b == null || b.Available;
+
+        #endregion
+
+        #region Track
+
+        private Track loadedTrack;
+
+        public Track LoadTrack() => loadedTrack = GetBeatmapTrack() ?? GetVirtualTrack(1000);
+
+        public void PrepareTrackForPreviewLooping()
+        {
+            Track.Looping = true;
+            Track.RestartPoint = Metadata.PreviewTime;
+
+            if (Track.RestartPoint == -1)
+            {
+                if (!Track.IsLoaded)
+                {
+                    // force length to be populated (https://github.com/ppy/osu-framework/issues/4202)
+                    Track.Seek(Track.CurrentTime);
+                }
+
+                Track.RestartPoint = 0.4f * Track.Length;
+            }
+        }
+
+        /// <summary>
+        /// Transfer a valid audio track into this working beatmap. Used as an optimisation to avoid reload / track swap
+        /// across difficulties in the same beatmap set.
+        /// </summary>
+        /// <param name="track">The track to transfer.</param>
+        public void TransferTrack([NotNull] Track track) => loadedTrack = track ?? throw new ArgumentNullException(nameof(track));
+
+        /// <summary>
+        /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.
+        /// This generally happens via MusicController when changing the global beatmap.
+        /// </summary>
+        public Track Track
+        {
+            get
+            {
+                if (!TrackLoaded)
+                    throw new InvalidOperationException($"Cannot access {nameof(Track)} without first calling {nameof(LoadTrack)}.");
+
+                return loadedTrack;
+            }
+        }
+
         protected Track GetVirtualTrack(double emptyLength = 0)
         {
             const double excess_length = 1000;
@@ -77,13 +181,82 @@ namespace osu.Game.Beatmaps
             return audioManager.Tracks.GetVirtual(length);
         }
 
-        /// <summary>
-        /// Creates a <see cref="IBeatmapConverter"/> to convert a <see cref="IBeatmap"/> for a specified <see cref="Ruleset"/>.
-        /// </summary>
-        /// <param name="beatmap">The <see cref="IBeatmap"/> to be converted.</param>
-        /// <param name="ruleset">The <see cref="Ruleset"/> for which <paramref name="beatmap"/> should be converted.</param>
-        /// <returns>The applicable <see cref="IBeatmapConverter"/>.</returns>
-        protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
+        #endregion
+
+        #region Waveform
+
+        public Waveform Waveform => waveform.Value;
+        private readonly RecyclableLazy<Waveform> waveform;
+
+        #endregion
+
+        #region Storyboard
+
+        public Storyboard Storyboard => storyboard.Value;
+        private readonly RecyclableLazy<Storyboard> storyboard;
+
+        #endregion
+
+        #region Skin
+
+        private readonly RecyclableLazy<ISkin> skin;
+
+        public ISkin Skin => skin.Value;
+
+        #endregion
+
+        #region Beatmap
+
+        public IBeatmap Beatmap
+        {
+            get
+            {
+                try
+                {
+                    return loadBeatmapAsync().Result;
+                }
+                catch (AggregateException ae)
+                {
+                    // This is the exception that is generally expected here, which occurs via natural cancellation of the asynchronous load
+                    if (ae.InnerExceptions.FirstOrDefault() is TaskCanceledException)
+                        return null;
+
+                    Logger.Error(ae, "Beatmap failed to load");
+                    return null;
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "Beatmap failed to load");
+                    return null;
+                }
+            }
+        }
+
+        private Task<IBeatmap> beatmapLoadTask;
+
+        private Task<IBeatmap> loadBeatmapAsync()
+        {
+            lock (beatmapFetchLock)
+            {
+                return beatmapLoadTask ??= Task.Factory.StartNew(() =>
+                {
+                    // Todo: Handle cancellation during beatmap parsing
+                    var b = GetBeatmap() ?? new Beatmap();
+
+                    // The original beatmap version needs to be preserved as the database doesn't contain it
+                    BeatmapInfo.BeatmapVersion = b.BeatmapInfo.BeatmapVersion;
+
+                    // Use the database-backed info for more up-to-date values (beatmap id, ranked status, etc)
+                    b.BeatmapInfo = BeatmapInfo;
+
+                    return b;
+                }, loadCancellationSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            }
+        }
+
+        #endregion
+
+        #region Playable beatmap
 
         public IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
         {
@@ -101,7 +274,7 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        public virtual IBeatmap GetPlayableBeatmap([NotNull] IRulesetInfo ruleset, [NotNull] IReadOnlyList<Mod> mods, CancellationToken token)
+        public virtual IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods, CancellationToken token)
         {
             var rulesetInstance = ruleset.CreateInstance();
 
@@ -175,154 +348,19 @@ namespace osu.Game.Beatmaps
             return converted;
         }
 
-        public void BeginAsyncLoad() => loadBeatmapAsync();
+        /// <summary>
+        /// Creates a <see cref="IBeatmapConverter"/> to convert a <see cref="IBeatmap"/> for a specified <see cref="Ruleset"/>.
+        /// </summary>
+        /// <param name="beatmap">The <see cref="IBeatmap"/> to be converted.</param>
+        /// <param name="ruleset">The <see cref="Ruleset"/> for which <paramref name="beatmap"/> should be converted.</param>
+        /// <returns>The applicable <see cref="IBeatmapConverter"/>.</returns>
+        protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
 
-        public void CancelAsyncLoad()
-        {
-            lock (beatmapFetchLock)
-            {
-                loadCancellationSource?.Cancel();
-                loadCancellationSource = new CancellationTokenSource();
-
-                if (beatmapLoadTask?.IsCompleted != true)
-                    beatmapLoadTask = null;
-            }
-        }
-
-        private Task<IBeatmap> loadBeatmapAsync()
-        {
-            lock (beatmapFetchLock)
-            {
-                return beatmapLoadTask ??= Task.Factory.StartNew(() =>
-                {
-                    // Todo: Handle cancellation during beatmap parsing
-                    var b = GetBeatmap() ?? new Beatmap();
-
-                    // The original beatmap version needs to be preserved as the database doesn't contain it
-                    BeatmapInfo.BeatmapVersion = b.BeatmapInfo.BeatmapVersion;
-
-                    // Use the database-backed info for more up-to-date values (beatmap id, ranked status, etc)
-                    b.BeatmapInfo = BeatmapInfo;
-
-                    return b;
-                }, loadCancellationSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
-            }
-        }
+        #endregion
 
         public override string ToString() => BeatmapInfo.ToString();
 
-        public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
-
         IBeatmapInfo IWorkingBeatmap.BeatmapInfo => BeatmapInfo;
-
-        public IBeatmap Beatmap
-        {
-            get
-            {
-                try
-                {
-                    return loadBeatmapAsync().Result;
-                }
-                catch (AggregateException ae)
-                {
-                    // This is the exception that is generally expected here, which occurs via natural cancellation of the asynchronous load
-                    if (ae.InnerExceptions.FirstOrDefault() is TaskCanceledException)
-                        return null;
-
-                    Logger.Error(ae, "Beatmap failed to load");
-                    return null;
-                }
-                catch (Exception e)
-                {
-                    Logger.Error(e, "Beatmap failed to load");
-                    return null;
-                }
-            }
-        }
-
-        protected abstract IBeatmap GetBeatmap();
-        private Task<IBeatmap> beatmapLoadTask;
-
-        public bool BackgroundLoaded => background.IsResultAvailable;
-        public Texture Background => background.Value;
-        protected virtual bool BackgroundStillValid(Texture b) => b == null || b.Available;
-        protected abstract Texture GetBackground();
-        private readonly RecyclableLazy<Texture> background;
-
-        private Track loadedTrack;
-
-        public Track LoadTrack() => loadedTrack = GetBeatmapTrack() ?? GetVirtualTrack(1000);
-
-        public void PrepareTrackForPreviewLooping()
-        {
-            Track.Looping = true;
-            Track.RestartPoint = Metadata.PreviewTime;
-
-            if (Track.RestartPoint == -1)
-            {
-                if (!Track.IsLoaded)
-                {
-                    // force length to be populated (https://github.com/ppy/osu-framework/issues/4202)
-                    Track.Seek(Track.CurrentTime);
-                }
-
-                Track.RestartPoint = 0.4f * Track.Length;
-            }
-        }
-
-        /// <summary>
-        /// Transfer a valid audio track into this working beatmap. Used as an optimisation to avoid reload / track swap
-        /// across difficulties in the same beatmap set.
-        /// </summary>
-        /// <param name="track">The track to transfer.</param>
-        public void TransferTrack([NotNull] Track track) => loadedTrack = track ?? throw new ArgumentNullException(nameof(track));
-
-        /// <summary>
-        /// Whether this beatmap's track has been loaded via <see cref="LoadTrack"/>.
-        /// </summary>
-        public virtual bool TrackLoaded => loadedTrack != null;
-
-        /// <summary>
-        /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.
-        /// This generally happens via MusicController when changing the global beatmap.
-        /// </summary>
-        public Track Track
-        {
-            get
-            {
-                if (!TrackLoaded)
-                    throw new InvalidOperationException($"Cannot access {nameof(Track)} without first calling {nameof(LoadTrack)}.");
-
-                return loadedTrack;
-            }
-        }
-
-        protected abstract Track GetBeatmapTrack();
-
-        public bool WaveformLoaded => waveform.IsResultAvailable;
-        public Waveform Waveform => waveform.Value;
-        protected virtual Waveform GetWaveform() => new Waveform(null);
-        private readonly RecyclableLazy<Waveform> waveform;
-
-        public bool StoryboardLoaded => storyboard.IsResultAvailable;
-        public Storyboard Storyboard => storyboard.Value;
-        protected virtual Storyboard GetStoryboard() => new Storyboard { BeatmapInfo = BeatmapInfo };
-        private readonly RecyclableLazy<Storyboard> storyboard;
-
-        public bool SkinLoaded => skin.IsResultAvailable;
-        public ISkin Skin => skin.Value;
-
-        /// <summary>
-        /// Creates a new skin instance for this beatmap.
-        /// </summary>
-        /// <remarks>
-        /// This should only be called externally in scenarios where it is explicitly desired to get a new instance of a skin
-        /// (e.g. for editing purposes, to avoid state pollution).
-        /// For standard reading purposes, <see cref="Skin"/> should always be used directly.
-        /// </remarks>
-        protected internal abstract ISkin GetSkin();
-
-        private readonly RecyclableLazy<ISkin> skin;
 
         public abstract Stream GetStream(string storagePath);
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Beatmaps
         /// <returns>The applicable <see cref="IBeatmapConverter"/>.</returns>
         protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
 
-        public IBeatmap GetPlayableBeatmap([NotNull] IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
+        public IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
         {
             try
             {
@@ -251,7 +251,6 @@ namespace osu.Game.Beatmaps
 
         private Track loadedTrack;
 
-        [NotNull]
         public Track LoadTrack() => loadedTrack = GetBeatmapTrack() ?? GetVirtualTrack(1000);
 
         public void PrepareTrackForPreviewLooping()

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -214,8 +214,6 @@ namespace osu.Game.Beatmaps
         public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
 
         IBeatmapInfo IWorkingBeatmap.BeatmapInfo => BeatmapInfo;
-        IBeatmapMetadataInfo IWorkingBeatmap.Metadata => Metadata;
-        IBeatmapSetInfo IWorkingBeatmap.BeatmapSetInfo => BeatmapSetInfo;
 
         public IBeatmap Beatmap
         {

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
@@ -21,6 +20,8 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
 
+#nullable enable
+
 namespace osu.Game.Beatmaps
 {
     [ExcludeFromDynamicCompile]
@@ -30,28 +31,28 @@ namespace osu.Game.Beatmaps
         public readonly BeatmapSetInfo BeatmapSetInfo;
 
         // TODO: remove once the fallback lookup is not required (and access via `working.BeatmapInfo.Metadata` directly).
-        public BeatmapMetadata Metadata => BeatmapInfo.Metadata ?? BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
+        public BeatmapMetadata Metadata => BeatmapInfo.Metadata ?? BeatmapSetInfo.Metadata;
 
         public Waveform Waveform => waveform.Value;
 
         public Storyboard Storyboard => storyboard.Value;
 
-        public Texture Background => GetBackground(); // Texture uses ref counting, so we want to return a new instance every usage.
+        public Texture? Background => GetBackground(); // Texture uses ref counting, so we want to return a new instance every usage.
 
-        public ISkin Skin => skin.Value;
+        public ISkin? Skin => skin.Value;
 
-        private AudioManager audioManager { get; }
+        private AudioManager? audioManager { get; }
 
-        private CancellationTokenSource loadCancellationSource = new CancellationTokenSource();
+        private CancellationTokenSource? loadCancellationSource;
 
         private readonly object beatmapFetchLock = new object();
 
         private readonly Lazy<Waveform> waveform;
         private readonly Lazy<Storyboard> storyboard;
-        private readonly Lazy<ISkin> skin;
-        private Track track; // track is not Lazy as we allow transferring and loading multiple times.
+        private readonly Lazy<ISkin?> skin;
+        private Track? track; // track is not Lazy as we allow transferring and loading multiple times.
 
-        protected WorkingBeatmap(BeatmapInfo beatmapInfo, AudioManager audioManager)
+        protected WorkingBeatmap(BeatmapInfo beatmapInfo, AudioManager? audioManager)
         {
             this.audioManager = audioManager;
 
@@ -60,7 +61,7 @@ namespace osu.Game.Beatmaps
 
             waveform = new Lazy<Waveform>(GetWaveform);
             storyboard = new Lazy<Storyboard>(GetStoryboard);
-            skin = new Lazy<ISkin>(GetSkin);
+            skin = new Lazy<ISkin?>(GetSkin);
         }
 
         #region Resource getters
@@ -68,9 +69,9 @@ namespace osu.Game.Beatmaps
         protected virtual Waveform GetWaveform() => new Waveform(null);
         protected virtual Storyboard GetStoryboard() => new Storyboard { BeatmapInfo = BeatmapInfo };
 
-        protected abstract IBeatmap GetBeatmap();
-        protected abstract Texture GetBackground();
-        protected abstract Track GetBeatmapTrack();
+        protected abstract IBeatmap? GetBeatmap();
+        protected abstract Texture? GetBackground();
+        protected abstract Track? GetBeatmapTrack();
 
         /// <summary>
         /// Creates a new skin instance for this beatmap.
@@ -80,7 +81,7 @@ namespace osu.Game.Beatmaps
         /// (e.g. for editing purposes, to avoid state pollution).
         /// For standard reading purposes, <see cref="Skin"/> should always be used directly.
         /// </remarks>
-        protected internal abstract ISkin GetSkin();
+        protected internal abstract ISkin? GetSkin();
 
         #endregion
 
@@ -93,7 +94,6 @@ namespace osu.Game.Beatmaps
             lock (beatmapFetchLock)
             {
                 loadCancellationSource?.Cancel();
-                loadCancellationSource = new CancellationTokenSource();
 
                 if (beatmapLoadTask?.IsCompleted != true)
                     beatmapLoadTask = null;
@@ -130,7 +130,7 @@ namespace osu.Game.Beatmaps
         /// across difficulties in the same beatmap set.
         /// </summary>
         /// <param name="track">The track to transfer.</param>
-        public void TransferTrack([NotNull] Track track) => this.track = track ?? throw new ArgumentNullException(nameof(track));
+        public void TransferTrack(Track track) => this.track = track ?? throw new ArgumentNullException(nameof(track));
 
         /// <summary>
         /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.
@@ -142,6 +142,9 @@ namespace osu.Game.Beatmaps
             {
                 if (!TrackLoaded)
                     throw new InvalidOperationException($"Cannot access {nameof(Track)} without first calling {nameof(LoadTrack)}.");
+
+                // Covered by TrackLoaded call above.
+                Debug.Assert(track != null);
 
                 return track;
             }
@@ -170,7 +173,7 @@ namespace osu.Game.Beatmaps
                     break;
             }
 
-            return audioManager.Tracks.GetVirtual(length);
+            return audioManager?.Tracks.GetVirtual(length) ?? throw new InvalidOperationException($"Attempted to get virtual track without providing an {nameof(AudioManager)}");
         }
 
         #endregion
@@ -179,7 +182,7 @@ namespace osu.Game.Beatmaps
 
         public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
 
-        public IBeatmap Beatmap
+        public IBeatmap? Beatmap
         {
             get
             {
@@ -204,7 +207,7 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        private Task<IBeatmap> beatmapLoadTask;
+        private Task<IBeatmap>? beatmapLoadTask;
 
         private Task<IBeatmap> loadBeatmapAsync()
         {
@@ -222,7 +225,7 @@ namespace osu.Game.Beatmaps
                     b.BeatmapInfo = BeatmapInfo;
 
                     return b;
-                }, loadCancellationSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                }, (loadCancellationSource = new CancellationTokenSource()).Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
         }
 
@@ -230,7 +233,7 @@ namespace osu.Game.Beatmaps
 
         #region Playable beatmap
 
-        public IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
+        public IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod>? mods = null)
         {
             try
             {
@@ -252,6 +255,9 @@ namespace osu.Game.Beatmaps
 
             if (rulesetInstance == null)
                 throw new RulesetLoadException("Creating ruleset instance failed when attempting to create playable beatmap.");
+
+            if (Beatmap == null)
+                throw new InvalidOperationException("Beatmap could not be loaded.");
 
             IBeatmapConverter converter = CreateBeatmapConverter(Beatmap, rulesetInstance);
 
@@ -332,7 +338,7 @@ namespace osu.Game.Beatmaps
 
         public override string ToString() => BeatmapInfo.ToString();
 
-        public abstract Stream GetStream(string storagePath);
+        public abstract Stream? GetStream(string storagePath);
 
         IBeatmapInfo IWorkingBeatmap.BeatmapInfo => BeatmapInfo;
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -28,7 +28,9 @@ namespace osu.Game.Beatmaps
     {
         public readonly BeatmapInfo BeatmapInfo;
         public readonly BeatmapSetInfo BeatmapSetInfo;
-        public readonly BeatmapMetadata Metadata;
+
+        // TODO: remove once the fallback lookup is not required (and access via `working.BeatmapInfo.Metadata` directly).
+        public BeatmapMetadata Metadata => BeatmapInfo.Metadata ?? BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
         protected AudioManager AudioManager { get; }
 
@@ -37,7 +39,6 @@ namespace osu.Game.Beatmaps
             AudioManager = audioManager;
             BeatmapInfo = beatmapInfo;
             BeatmapSetInfo = beatmapInfo.BeatmapSet;
-            Metadata = beatmapInfo.Metadata ?? BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
             background = new RecyclableLazy<Texture>(GetBackground, BackgroundStillValid);
             waveform = new RecyclableLazy<Waveform>(GetWaveform);

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -145,8 +145,6 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            protected override bool BackgroundStillValid(Texture b) => false; // bypass lazy logic. we want to return a new background each time for refcounting purposes.
-
             protected override Texture GetBackground()
             {
                 if (string.IsNullOrEmpty(Metadata?.BackgroundFile))

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -180,17 +180,17 @@ namespace osu.Game.Beatmaps
             protected override Waveform GetWaveform()
             {
                 if (string.IsNullOrEmpty(Metadata?.AudioFile))
-                    return null;
+                    return base.GetWaveform();
 
                 try
                 {
                     var trackData = GetStream(BeatmapSetInfo.GetPathForFile(Metadata.AudioFile));
-                    return trackData == null ? null : new Waveform(trackData);
+                    return trackData == null ? base.GetWaveform() : new Waveform(trackData);
                 }
                 catch (Exception e)
                 {
                     Logger.Error(e, "Waveform failed to load");
-                    return null;
+                    return base.GetWaveform();
                 }
             }
 

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -180,17 +180,17 @@ namespace osu.Game.Beatmaps
             protected override Waveform GetWaveform()
             {
                 if (string.IsNullOrEmpty(Metadata?.AudioFile))
-                    return base.GetWaveform();
+                    return null;
 
                 try
                 {
                     var trackData = GetStream(BeatmapSetInfo.GetPathForFile(Metadata.AudioFile));
-                    return trackData == null ? base.GetWaveform() : new Waveform(trackData);
+                    return trackData == null ? null : new Waveform(trackData);
                 }
                 catch (Exception e)
                 {
                     Logger.Error(e, "Waveform failed to load");
-                    return base.GetWaveform();
+                    return null;
                 }
             }
 

--- a/osu.Game/Stores/BeatmapImporter.cs
+++ b/osu.Game/Stores/BeatmapImporter.cs
@@ -324,7 +324,7 @@ namespace osu.Game.Stores
 
             protected override IBeatmap GetBeatmap() => beatmap;
             protected override Texture? GetBackground() => null;
-            protected override Track GetBeatmapTrack() => null!;
+            protected override Track? GetBeatmapTrack() => null;
             protected internal override ISkin? GetSkin() => null;
             public override Stream? GetStream(string storagePath) => null;
         }

--- a/osu.Game/Stores/BeatmapImporter.cs
+++ b/osu.Game/Stores/BeatmapImporter.cs
@@ -324,7 +324,7 @@ namespace osu.Game.Stores
 
             protected override IBeatmap GetBeatmap() => beatmap;
             protected override Texture? GetBackground() => null;
-            protected override Track? GetBeatmapTrack() => null;
+            protected override Track GetBeatmapTrack() => null!;
             protected internal override ISkin? GetSkin() => null;
             public override Stream? GetStream(string storagePath) => null;
         }


### PR DESCRIPTION
I need to do some intensive operations to make this thing work with realm, and the class was a mess to the point it was blocking forward progress.

- Removed `RecyclableLazy` (we weren't using it for any useful purpose)
- Reordered methods to something hopefully agreeable. Left longer stuff like `GetPlayable` at the bottom of the file (would propose splitting that out in the future to its own class or something).
- Removed some interface properties which don't need to exist
- Turned on nullableness

Individual commits may make going through these changes easier. Maybe.