### PR TITLE
Fix placeholder drawables on beatmap listing not always showing correctly

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -110,17 +111,25 @@ namespace osu.Game.Tests.Visual.Online
         public void TestNoBeatmapsPlaceholder()
         {
             AddStep("fetch for 0 beatmaps", () => fetchFor());
-            AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
+            placeholderShown();
 
-            AddStep("fetch for 1 beatmap", () => fetchFor(CreateAPIBeatmapSet(Ruleset.Value)));
+            AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 100).ToArray()));
+            AddUntilStep("wait for loaded", () => this.ChildrenOfType<BeatmapCard>().Count() == 100);
             AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
 
             AddStep("fetch for 0 beatmaps", () => fetchFor());
-            AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
+            placeholderShown();
 
             // fetch once more to ensure nothing happens in displaying placeholder again when it already is present.
             AddStep("fetch for 0 beatmaps again", () => fetchFor());
-            AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
+            placeholderShown();
+
+            void placeholderShown() =>
+                AddUntilStep("placeholder shown", () =>
+                {
+                    var notFoundDrawable = overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault();
+                    return notFoundDrawable != null && notFoundDrawable.IsPresent && notFoundDrawable.Parent.DrawHeight > 0;
+                });
         }
 
         [Test]

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -217,6 +217,10 @@ namespace osu.Game.Overlays
 
         public class NotFoundDrawable : CompositeDrawable
         {
+            // required for scheduled tasks to complete correctly
+            // (see `addContentToPlaceholder()` and the scheduled `BypassAutoSizeAxes` set during fade-out in outer class above)
+            public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
             public NotFoundDrawable()
             {
                 RelativeSizeAxes = Axes.X;
@@ -261,6 +265,10 @@ namespace osu.Game.Overlays
         // (https://github.com/ppy/osu-framework/issues/4530)
         public class SupporterRequiredDrawable : CompositeDrawable
         {
+            // required for scheduled tasks to complete correctly
+            // (see `addContentToPlaceholder()` and the scheduled `BypassAutoSizeAxes` set during fade-out in outer class above)
+            public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
             private LinkFlowContainer supporterRequiredText;
 
             public SupporterRequiredDrawable()


### PR DESCRIPTION
I wanted to write one test for something else, but then ended up finding this and wasting about 2 hours on it.

For visual explanation, see video below (captured on the test changed in this pull, `TestSceneBeatmapListingOverlay.TestNoBeatmapsPlaceholder()`):

https://user-images.githubusercontent.com/20418176/147107993-a89e9edc-af89-4a7e-a0fe-24dcf3d6197e.mp4

`BeatmapListingOverlay.addContentToPlaceholder()`, in order to make transitions between different beatmap listing content (whether it is actual cards, or placeholders for no beatmaps found/supporter-specific filters chosen), would set `BypassAutoSizeAxes = Y` on content as it is fading out, to make the transition smoother. The property in question was supposed to be getting restored to `None` on the next show.

In testing scenarios, it sometimes turned out that this wasn't the case, therefore making the placeholders effectively not show - while they were present and fully opaque, they would be the only child of an auto-sized container with `BypassAutoSizeAxes = Y` set, so the parent auto-sized to a zero height, which logically follows from the premise,
but is not what was desired.

This in turn was caused by the fact that the `BypassAutoSizeAxes = Y` set was scheduled, and sometimes it would be scheduled in such a way that the drawable would cease to be present on the next frame due to its alpha being past the cutoff point of 0.0001. Therefore the scheduled set would not execute until the *next* time the placeholder was shown,
therefore causing the bug (see following log excerpt that I captured):

```
[runtime] 2021-12-22 13:56:19 [verbose]: not found drawable: alpha = 0.39339912, pending tasks = True
[runtime] 2021-12-22 13:56:19 [verbose]: not found drawable: alpha = 0, pending tasks = True
```

<details>
<summary>Patch used to produce above output</summary>

```diff
diff --git a/osu.Game/Overlays/BeatmapListingOverlay.cs b/osu.Game/Overlays/BeatmapListingOverlay.cs
index c4d1d62250..51452afd8a 100644
--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -14,6 +14,7 @@
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
+using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics;
@@ -215,8 +216,17 @@ protected override void Dispose(bool isDisposing)
             base.Dispose(isDisposing);
         }
 
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+            if (notFoundContent.Alpha < 1)
+                Logger.Log($"not found drawable: alpha = {notFoundContent.Alpha}, pending tasks = {notFoundContent.SchedulerHasPendingTasks}");
+        }
+
         public class NotFoundDrawable : CompositeDrawable
         {
+            public bool SchedulerHasPendingTasks => Scheduler.HasPendingTasks;
+
             public NotFoundDrawable()
             {
                 RelativeSizeAxes = Axes.X;
```

</details>

Fix by ensuring that the placeholder drawables are always present if their schedulers have any tasks enqueued, on top of the usual checks of alpha and scale performed via the base implementation.

This doesn't really reproduce headless, but on 02fa1c21 I can reproduce it in test browser 9-10 times out of 10, and with 25e3856 I have not managed to see it fail yet over many repeats.