### PR TITLE
Fix TestMultiplayerClient referencing the wrong playlist

### DIFF
--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -535,7 +535,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     var itemsByPriority = new List<(MultiplayerPlaylistItem item, int priority)>();
 
                     // Assign a priority for items from each user, starting from 0 and increasing in order which the user added the items.
-                    foreach (var group in room.Playlist.Where(item => !item.Expired).OrderBy(item => item.ID).GroupBy(item => item.OwnerID))
+                    foreach (var group in serverSidePlaylist.Where(item => !item.Expired).OrderBy(item => item.ID).GroupBy(item => item.OwnerID))
                     {
                         int priority = 0;
                         itemsByPriority.AddRange(group.Select(item => (item, priority++)));


### PR DESCRIPTION
`serverSidePlaylist` avoids all the async stuff of `room.Playlist`. I don't believe we've seen a test failure from this yet simply because there's no tests for round-robin mode.