### PR TITLE
Fix ruleset config cache potentially not working correctly in test contexts

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Tests.Visual;
@@ -24,9 +25,9 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         }
 
         [BackgroundDependencyLoader]
-        private void load(RulesetConfigCache configCache)
+        private void load(IRulesetConfigCache configCache)
         {
-            var config = (ManiaRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance());
+            var config = (ManiaRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
             config.BindWith(ManiaRulesetSetting.ScrollDirection, direction);
         }
     }

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         }
 
         [BackgroundDependencyLoader]
-        private void load(IRulesetConfigCache configCache)
+        private void load()
         {
-            var config = (ManiaRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
+            var config = (ManiaRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
             config.BindWith(ManiaRulesetSetting.ScrollDirection, direction);
         }
     }

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneTimingBasedNoteColouring.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneTimingBasedNoteColouring.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
@@ -25,7 +26,7 @@ namespace osu.Game.Rulesets.Mania.Tests
     public class TestSceneTimingBasedNoteColouring : OsuTestScene
     {
         [Resolved]
-        private RulesetConfigCache configCache { get; set; }
+        private IRulesetConfigCache configCache { get; set; }
 
         private Bindable<bool> configTimingBasedNoteColouring;
 
@@ -48,7 +49,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
             AddStep("retrieve config bindable", () =>
             {
-                var config = (ManiaRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance());
+                var config = (ManiaRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
                 configTimingBasedNoteColouring = config.GetBindable<bool>(ManiaRulesetSetting.TimingBasedNoteColouring);
             });
         }

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneTimingBasedNoteColouring.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneTimingBasedNoteColouring.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -25,9 +24,6 @@ namespace osu.Game.Rulesets.Mania.Tests
     [TestFixture]
     public class TestSceneTimingBasedNoteColouring : OsuTestScene
     {
-        [Resolved]
-        private IRulesetConfigCache configCache { get; set; }
-
         private Bindable<bool> configTimingBasedNoteColouring;
 
         private ManualClock clock;
@@ -49,7 +45,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
             AddStep("retrieve config bindable", () =>
             {
-                var config = (ManiaRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
+                var config = (ManiaRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
                 configTimingBasedNoteColouring = config.GetBindable<bool>(ManiaRulesetSetting.TimingBasedNoteColouring);
             });
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
@@ -46,9 +47,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             => new ClockBackedTestWorkingBeatmap(this.beatmap = beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
 
         [BackgroundDependencyLoader]
-        private void load(RulesetConfigCache configCache)
+        private void load(IRulesetConfigCache configCache)
         {
-            var config = (OsuRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance());
+            var config = (OsuRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
             config.BindWith(OsuRulesetSetting.SnakingInSliders, snakingIn);
             config.BindWith(OsuRulesetSetting.SnakingOutSliders, snakingOut);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
@@ -47,9 +47,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             => new ClockBackedTestWorkingBeatmap(this.beatmap = beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
 
         [BackgroundDependencyLoader]
-        private void load(IRulesetConfigCache configCache)
+        private void load()
         {
-            var config = (OsuRulesetConfigManager)configCache.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
+            var config = (OsuRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
             config.BindWith(OsuRulesetSetting.SnakingInSliders, snakingIn);
             config.BindWith(OsuRulesetSetting.SnakingOutSliders, snakingOut);
         }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneOsuGame.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneOsuGame.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Visual.Navigation
             typeof(FileStore),
             typeof(ScoreManager),
             typeof(BeatmapManager),
-            typeof(RulesetConfigCache),
+            typeof(IRulesetConfigCache),
             typeof(OsuColour),
             typeof(IBindable<WorkingBeatmap>),
             typeof(Bindable<WorkingBeatmap>),

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -268,7 +268,7 @@ namespace osu.Game
             dependencies.Cache(scorePerformanceManager);
             AddInternal(scorePerformanceManager);
 
-            dependencies.Cache(rulesetConfigCache = new RulesetConfigCache(realmFactory, RulesetStore));
+            dependencies.CacheAs<IRulesetConfigCache>(rulesetConfigCache = new RulesetConfigCache(realmFactory, RulesetStore));
 
             var powerStatus = CreateBatteryInfo();
             if (powerStatus != null)

--- a/osu.Game/Overlays/Settings/RulesetSettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/RulesetSettingsSubsection.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.Settings
         {
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            Config = dependencies.Get<RulesetConfigCache>().GetConfigFor(ruleset);
+            Config = dependencies.Get<IRulesetConfigCache>().GetConfigFor(ruleset);
             if (Config != null)
                 dependencies.Cache(Config);
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Edit
         [BackgroundDependencyLoader]
         private void load()
         {
-            Config = Dependencies.Get<RulesetConfigCache>().GetConfigFor(Ruleset);
+            Config = Dependencies.Get<IRulesetConfigCache>().GetConfigFor(Ruleset);
 
             try
             {

--- a/osu.Game/Rulesets/IRulesetConfigCache.cs
+++ b/osu.Game/Rulesets/IRulesetConfigCache.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using osu.Game.Rulesets.Configuration;
+
+namespace osu.Game.Rulesets
+{
+    /// <summary>
+    /// A cache that provides a single <see cref="IRulesetConfigManager"/> per-ruleset.
+    /// This is done to support referring to and updating ruleset configs from multiple locations in the absence of inter-config bindings.
+    /// </summary>
+    public interface IRulesetConfigCache
+    {
+        /// <summary>
+        /// Retrieves the <see cref="IRulesetConfigManager"/> for a <see cref="Ruleset"/>.
+        /// </summary>
+        /// <param name="ruleset">The <see cref="Ruleset"/> to retrieve the <see cref="IRulesetConfigManager"/> for.</param>
+        /// <returns>The <see cref="IRulesetConfigManager"/> defined by <paramref name="ruleset"/>, null if <paramref name="ruleset"/> doesn't define one.</returns>
+        public IRulesetConfigManager? GetConfigFor(Ruleset ruleset);
+    }
+}

--- a/osu.Game/Rulesets/RulesetConfigCache.cs
+++ b/osu.Game/Rulesets/RulesetConfigCache.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
@@ -10,11 +9,7 @@ using osu.Game.Rulesets.Configuration;
 
 namespace osu.Game.Rulesets
 {
-    /// <summary>
-    /// A cache that provides a single <see cref="IRulesetConfigManager"/> per-ruleset.
-    /// This is done to support referring to and updating ruleset configs from multiple locations in the absence of inter-config bindings.
-    /// </summary>
-    public class RulesetConfigCache : Component
+    public class RulesetConfigCache : Component, IRulesetConfigCache
     {
         private readonly RealmContextFactory realmFactory;
         private readonly RulesetStore rulesets;
@@ -43,12 +38,6 @@ namespace osu.Game.Rulesets
             }
         }
 
-        /// <summary>
-        /// Retrieves the <see cref="IRulesetConfigManager"/> for a <see cref="Ruleset"/>.
-        /// </summary>
-        /// <param name="ruleset">The <see cref="Ruleset"/> to retrieve the <see cref="IRulesetConfigManager"/> for.</param>
-        /// <returns>The <see cref="IRulesetConfigManager"/> defined by <paramref name="ruleset"/>, null if <paramref name="ruleset"/> doesn't define one.</returns>
-        /// <exception cref="InvalidOperationException">If <paramref name="ruleset"/> doesn't have a valid <see cref="RulesetInfo.ID"/>.</exception>
         public IRulesetConfigManager GetConfigFor(Ruleset ruleset)
         {
             if (!configCache.TryGetValue(ruleset.RulesetInfo.ShortName, out var config))

--- a/osu.Game/Rulesets/RulesetConfigCache.cs
+++ b/osu.Game/Rulesets/RulesetConfigCache.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Rulesets.Configuration;
 
 namespace osu.Game.Rulesets
@@ -40,10 +42,11 @@ namespace osu.Game.Rulesets
 
         public IRulesetConfigManager GetConfigFor(Ruleset ruleset)
         {
+            if (!IsLoaded)
+                throw new InvalidOperationException($@"Cannot retrieve {nameof(IRulesetConfigManager)} before {nameof(RulesetConfigCache)} has loaded");
+
             if (!configCache.TryGetValue(ruleset.RulesetInfo.ShortName, out var config))
-                // any ruleset request which wasn't initialised on startup should not be stored to realm.
-                // this should only be used by tests.
-                return ruleset.CreateConfig(null);
+                throw new InvalidOperationException($@"Attempted to retrieve {nameof(IRulesetConfigManager)} for an unavailable ruleset {ruleset.GetDisplayString()}");
 
             return config;
         }

--- a/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs
+++ b/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.UI
                 CacheAs(ShaderManager = new FallbackShaderManager(ShaderManager, parent.Get<ShaderManager>()));
             }
 
-            RulesetConfigManager = parent.Get<RulesetConfigCache>().GetConfigFor(ruleset);
+            RulesetConfigManager = parent.Get<IRulesetConfigCache>().GetConfigFor(ruleset);
             if (RulesetConfigManager != null)
                 Cache(RulesetConfigManager);
         }

--- a/osu.Game/Tests/Rulesets/TestRulesetConfigCache.cs
+++ b/osu.Game/Tests/Rulesets/TestRulesetConfigCache.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Concurrent;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Configuration;
+
+namespace osu.Game.Tests.Rulesets
+{
+    /// <summary>
+    /// Test implementation of a <see cref="IRulesetConfigCache"/>, which ensures isolation between test scenes.
+    /// </summary>
+    public class TestRulesetConfigCache : IRulesetConfigCache
+    {
+        private readonly ConcurrentDictionary<string, IRulesetConfigManager> configCache = new ConcurrentDictionary<string, IRulesetConfigManager>();
+
+        public IRulesetConfigManager GetConfigFor(Ruleset ruleset) => configCache.GetOrAdd(ruleset.ShortName, _ => ruleset.CreateConfig(null));
+    }
+}

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -95,6 +95,16 @@ namespace osu.Game.Tests.Visual
         /// </remarks>
         protected Storage LocalStorage => localStorage.Value;
 
+        /// <summary>
+        /// A cache for ruleset configurations to be used in this test scene.
+        /// </summary>
+        /// <remarks>
+        /// This <see cref="IRulesetConfigCache"/> instance is provided to the children of this test scene via DI.
+        /// It is only exposed so that test scenes themselves can access the ruleset config cache in a safe manner
+        /// (<see cref="OsuTestScene"/>s cannot use DI themselves, as they will end up accessing the real cached instance from <see cref="OsuGameBase"/>).
+        /// </remarks>
+        protected IRulesetConfigCache RulesetConfigs { get; private set; }
+
         private Lazy<Storage> localStorage;
 
         private Storage headlessHostStorage;
@@ -124,7 +134,7 @@ namespace osu.Game.Tests.Visual
             // as well as problems due to the implementation details of the "real" implementation (the configs only being available at `LoadComplete()`),
             // cache a test implementation of the ruleset config cache over the "real" one.
             var isolatedBaseDependencies = new DependencyContainer(baseDependencies);
-            isolatedBaseDependencies.CacheAs<IRulesetConfigCache>(new TestRulesetConfigCache());
+            isolatedBaseDependencies.CacheAs(RulesetConfigs = new TestRulesetConfigCache());
             baseDependencies = isolatedBaseDependencies;
 
             var providedRuleset = CreateRuleset();

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -31,6 +31,7 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Screens;
 using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Rulesets;
 
 namespace osu.Game.Tests.Visual
 {
@@ -118,6 +119,13 @@ namespace osu.Game.Tests.Visual
             RecycleLocalStorage(false);
 
             var baseDependencies = base.CreateChildDependencies(parent);
+
+            // to isolate ruleset configs in tests from the actual database and avoid state pollution problems,
+            // as well as problems due to the implementation details of the "real" implementation (the configs only being available at `LoadComplete()`),
+            // cache a test implementation of the ruleset config cache over the "real" one.
+            var isolatedBaseDependencies = new DependencyContainer(baseDependencies);
+            isolatedBaseDependencies.CacheAs<IRulesetConfigCache>(new TestRulesetConfigCache());
+            baseDependencies = isolatedBaseDependencies;
 
             var providedRuleset = CreateRuleset();
             if (providedRuleset != null)


### PR DESCRIPTION
This PR was spurred by #16204. Long and short, if you run `TestSceneSliderSnaking` locally on `master`, you should see the following failures:

![2021-12-23-203726_1327x335_scrot](https://user-images.githubusercontent.com/20418176/147284980-5cdb6174-f5f6-4784-b36c-bdd34bea9d64.png)

Those are *not* the same failures as the one [linked in the aforementioned issue](https://github.com/ppy/osu/runs/4594535663?check_suite_focus=true). On the screenshot above, `TestSnakingDisabled` is failing, while in the linked job, `TestSnakingEnabled` is failing.

The cause of the failures is that `RulesetConfigCache` is essentially a singleton (due to residing at `OsuGameBase` level), and as it is written right now, it is not guaranteed that every call to `GetConfigFor()` will return the same config instance:

https://github.com/ppy/osu/blob/33d95fbb9cfe1f87b0e3115da750810ba210824a/osu.Game/Rulesets/RulesetConfigCache.cs#L30-L60

In the case of this particular test scene, the sequence of events is as follows:

1. Headless test runner loads the test scene. `TestSceneSliderSnaking` resolves the `RulesetConfigCache` before its `LoadComplete()`, which means that ruleset configs are not yet populated, and so the special path returning a new instance is taken.
2. At some point later, `RulesetConfigCache.LoadComplete()` runs, and different ruleset config instances are stored in the cache's internal dictionary. The actual drawable sliders in the test receive that second instance.
3. Because of the two instances created, the steps in `TestSceneSliderSnaking` that are supposed to change the snaking settings change them on the instance created in point (1), while the actual drawable sliders which are being asserted upon are reading from the instance created in point (2), which has slider snaking enabled on by default, hence the test failures.

This wasn't failing in normal CI test runs both due to the global nature of the ruleset config cache and due to the timings required. For reasons that aren't entirely clear to me (and that I don't want to go looking into right now, having spent several hours on this already), when `TestSnakingDisabled` is ran alone, it just so happens that `LoadComplete()` manages to run before the test's BDL, hiding the issue, while `TestConstructor` runs with things reordered wrong as described above.

This failure scenario isn't unique to `TestSceneSliderSnaking`. Any `OsuTestScene` that resolves the `RulesetConfigCache` in BDL is susceptible to this.

As to fixing, I've written 3 separate versions and they all sucked.

1. Initially I just did the lazy thing of fixing the `RulesetConfigCache` so that `LoadComplete()` does not overwrite an already-created config (and also made the special test path in `GetConfigFor()` store the created config to cache). This works but is dangerous if anyone ever happens to access the config before `LoadComplete()`, as all further writes wouldn't ever reach realm.
2. Then I attempted to add a throw in `GetConfigFor()` if someone attempted to retrieve a config before `LoadComplete()` executed and fix all usage cases to only retrieve configs on their `LoadComplete()` / update thread. But this isn't really easily done as several places retrieve and re-cache the config inside the load process, including [things like `CreateChildDependencies()`](https://github.com/ppy/osu/blob/048ca98f4aa11c1685ee3af41fbb33429129bba4/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs#L67-L69), so this also felt unsafe / infeasible.

Thus was born this branch, which adds an `IRulesetConfigCache` interface, a special implementation for testing purposes, and code that caches the test implementation over the real `RulesetConfigCache`. This fixes the issue by ensuring that the failure scenario described above cannot happen, and has the added bonus of adding test isolation (the config cache will be instantiated for each test scene instead of being global like before).

As stated above, this does *not* close the issue linked above as this test failure was a red herring masking the one reported by CI.