### PR TITLE
Add card size switcher to beatmap listing overlay

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingCardSizeTabControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingCardSizeTabControl.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapListing;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneBeatmapListingCardSizeTabControl : OsuTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
+        private readonly Bindable<BeatmapCardSize> cardSize = new Bindable<BeatmapCardSize>();
+
+        private SpriteText cardSizeText;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    cardSizeText = new OsuSpriteText
+                    {
+                        Font = OsuFont.Default.With(size: 24)
+                    },
+                    new BeatmapListingCardSizeTabControl
+                    {
+                        Current = cardSize,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            cardSize.BindValueChanged(size => cardSizeText.Text = $"Current size: {size.NewValue}", true);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         public IBindable<bool> Expanded { get; }
 
-        protected readonly APIBeatmapSet BeatmapSet;
+        public readonly APIBeatmapSet BeatmapSet;
+
         protected readonly Bindable<BeatmapSetFavouriteState> FavouriteState;
 
         protected abstract Drawable IdleContent { get; }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -75,6 +76,24 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
             IdleContent.FadeTo(showProgress ? 0 : 1, TRANSITION_DURATION, Easing.OutQuint);
             DownloadInProgressContent.FadeTo(showProgress ? 1 : 0, TRANSITION_DURATION, Easing.OutQuint);
+        }
+
+        /// <summary>
+        /// Creates a beatmap card of the given <paramref name="size"/> for the supplied <paramref name="beatmapSet"/>.
+        /// </summary>
+        public static BeatmapCard Create(APIBeatmapSet beatmapSet, BeatmapCardSize size, bool allowExpansion = true)
+        {
+            switch (size)
+            {
+                case BeatmapCardSize.Normal:
+                    return new BeatmapCardNormal(beatmapSet, allowExpansion);
+
+                case BeatmapCardSize.Extra:
+                    return new BeatmapCardExtra(beatmapSet, allowExpansion);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(size), size, @"Unsupported card size");
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         public const float TRANSITION_DURATION = 400;
         public const float CORNER_RADIUS = 10;
 
+        protected const float WIDTH = 430;
+
         public IBindable<bool> Expanded { get; }
 
         public readonly APIBeatmapSet BeatmapSet;

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected override Drawable IdleContent => idleBottomContent;
         protected override Drawable DownloadInProgressContent => downloadProgressBar;
 
-        private const float width = 475;
         private const float height = 140;
 
         [Cached]
@@ -51,7 +50,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         [BackgroundDependencyLoader(true)]
         private void load(BeatmapSetOverlay? beatmapSetOverlay)
         {
-            Width = width;
+            Width = WIDTH;
             Height = height;
 
             FillFlowContainer leftIconArea = null!;
@@ -81,7 +80,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                         buttonContainer = new CollapsibleButtonContainer(BeatmapSet)
                         {
                             X = height - CORNER_RADIUS,
-                            Width = width - height + CORNER_RADIUS,
+                            Width = WIDTH - height + CORNER_RADIUS,
                             FavouriteState = { BindTarget = FavouriteState },
                             ButtonsCollapsedWidth = CORNER_RADIUS,
                             ButtonsExpandedWidth = 30,

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -26,7 +26,6 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected override Drawable IdleContent => idleBottomContent;
         protected override Drawable DownloadInProgressContent => downloadProgressBar;
 
-        private const float width = 408;
         private const float height = 100;
 
         [Cached]
@@ -52,7 +51,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         [BackgroundDependencyLoader]
         private void load()
         {
-            Width = width;
+            Width = WIDTH;
             Height = height;
 
             FillFlowContainer leftIconArea = null!;
@@ -82,7 +81,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                         buttonContainer = new CollapsibleButtonContainer(BeatmapSet)
                         {
                             X = height - CORNER_RADIUS,
-                            Width = width - height + CORNER_RADIUS,
+                            Width = WIDTH - height + CORNER_RADIUS,
                             FavouriteState = { BindTarget = FavouriteState },
                             ButtonsCollapsedWidth = CORNER_RADIUS,
                             ButtonsExpandedWidth = 30,

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardSize.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardSize.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Beatmaps.Drawables.Cards
+{
+    /// <summary>
+    /// Enumeration for all available sizes of <see cref="BeatmapCard"/>.
+    /// </summary>
+    public enum BeatmapCardSize
+    {
+        Normal,
+        Extra
+    }
+}

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingCardSizeTabControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingCardSizeTabControl.cs
@@ -1,0 +1,134 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Game.Overlays.BeatmapListing
+{
+    public class BeatmapListingCardSizeTabControl : OsuTabControl<BeatmapCardSize>
+    {
+        public BeatmapListingCardSizeTabControl()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        protected override TabFillFlowContainer CreateTabFlow() => new TabFillFlowContainer
+        {
+            AutoSizeAxes = Axes.Both,
+            Direction = FillDirection.Horizontal,
+            Spacing = new Vector2(10, 0),
+        };
+
+        protected override Dropdown<BeatmapCardSize> CreateDropdown() => null;
+
+        protected override TabItem<BeatmapCardSize> CreateTabItem(BeatmapCardSize value) => new TabItem(value);
+
+        private class TabItem : TabItem<BeatmapCardSize>
+        {
+            private Box background;
+            private SpriteIcon icon;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
+
+            public TabItem(BeatmapCardSize value)
+                : base(value)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 4;
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background3
+                    },
+                    new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = 10,
+                            Vertical = 5,
+                        },
+                        Child = icon = new SpriteIcon
+                        {
+                            Size = new Vector2(12),
+                            Icon = getIconForCardSize(Value)
+                        }
+                    }
+                };
+            }
+
+            private static IconUsage getIconForCardSize(BeatmapCardSize cardSize)
+            {
+                switch (cardSize)
+                {
+                    case BeatmapCardSize.Normal:
+                        return FontAwesome.Solid.Th;
+
+                    case BeatmapCardSize.Extra:
+                        return FontAwesome.Solid.ThLarge;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(cardSize), cardSize, "Unsupported card size");
+                }
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                updateState();
+                FinishTransforms(true);
+            }
+
+            protected override void OnActivated()
+            {
+                if (IsLoaded)
+                    updateState();
+            }
+
+            protected override void OnDeactivated()
+            {
+                if (IsLoaded)
+                    updateState();
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                updateState();
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                updateState();
+                base.OnHoverLost(e);
+            }
+
+            private const double fade_time = 200;
+
+            private void updateState()
+            {
+                background.FadeTo(IsHovered || Active.Value ? 1 : 0, fade_time, Easing.OutQuint);
+                icon.FadeColour(Active.Value && !IsHovered ? colourProvider.Light1 : colourProvider.Content1, fade_time, Easing.OutQuint);
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -12,6 +13,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -47,6 +49,11 @@ namespace osu.Game.Overlays.BeatmapListing
         /// The current page fetched of results (zero index).
         /// </summary>
         public int CurrentPage { get; private set; }
+
+        /// <summary>
+        /// The currently selected <see cref="BeatmapCardSize"/>.
+        /// </summary>
+        public IBindable<BeatmapCardSize> CardSize { get; } = new Bindable<BeatmapCardSize>();
 
         private readonly BeatmapListingSearchControl searchControl;
         private readonly BeatmapListingSortTabControl sortControl;
@@ -105,6 +112,13 @@ namespace osu.Game.Overlays.BeatmapListing
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 Margin = new MarginPadding { Left = 20 }
+                            },
+                            new BeatmapListingCardSizeTabControl
+                            {
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Margin = new MarginPadding { Right = 20 },
+                                Current = { BindTarget = CardSize }
                             }
                         }
                     }
@@ -227,12 +241,14 @@ namespace osu.Game.Overlays.BeatmapListing
 
                     if (filters.Any())
                     {
-                        SearchFinished?.Invoke(SearchResult.SupporterOnlyFilters(filters));
+                        var supporterOnlyFilters = SearchResult.SupporterOnlyFilters(filters);
+                        SearchFinished?.Invoke(supporterOnlyFilters);
                         return;
                     }
                 }
 
-                SearchFinished?.Invoke(SearchResult.ResultsReturned(sets));
+                var resultsReturned = SearchResult.ResultsReturned(sets);
+                SearchFinished?.Invoke(resultsReturned);
             };
 
             api.Queue(getSetsRequest);
@@ -296,7 +312,7 @@ namespace osu.Game.Overlays.BeatmapListing
             public static SearchResult ResultsReturned(List<APIBeatmapSet> results) => new SearchResult
             {
                 Type = SearchResultType.ResultsReturned,
-                Results = results
+                Results = results,
             };
 
             public static SearchResult SupporterOnlyFilters(List<LocalisableString> filters) => new SearchResult

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -121,6 +121,8 @@ namespace osu.Game.Overlays
 
         private CancellationTokenSource cancellationToken;
 
+        private Task panelLoadTask;
+
         private void onSearchStarted()
         {
             cancellationToken?.Cancel();
@@ -131,10 +133,10 @@ namespace osu.Game.Overlays
                 Loading.Show();
         }
 
-        private Task panelLoadTask;
-
         private void onSearchFinished(BeatmapListingFilterControl.SearchResult searchResult)
         {
+            cancellationToken?.Cancel();
+
             if (searchResult.Type == BeatmapListingFilterControl.SearchResultType.SupporterOnlyFilters)
             {
                 supporterRequiredContent.UpdateText(searchResult.SupporterOnlyFiltersUsed);
@@ -238,6 +240,8 @@ namespace osu.Game.Overlays
             Loading.Show();
 
             var newCards = createCardsFor(foundContent.Reverse().Select(card => card.BeatmapSet));
+
+            cancellationToken?.Cancel();
 
             panelLoadTask = LoadComponentsAsync(newCards, cards =>
             {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays
 
         private Drawable currentContent;
         private Container panelTarget;
-        private FillFlowContainer<BeatmapCardNormal> foundContent;
+        private FillFlowContainer<BeatmapCard> foundContent;
         private NotFoundDrawable notFoundContent;
         private SupporterRequiredDrawable supporterRequiredContent;
         private BeatmapListingFilterControl filterControl;
@@ -78,7 +78,7 @@ namespace osu.Game.Overlays
                                 Padding = new MarginPadding { Horizontal = 20 },
                                 Children = new Drawable[]
                                 {
-                                    foundContent = new FillFlowContainer<BeatmapCardNormal>(),
+                                    foundContent = new FillFlowContainer<BeatmapCard>(),
                                     notFoundContent = new NotFoundDrawable(),
                                     supporterRequiredContent = new SupporterRequiredDrawable(),
                                 }
@@ -135,11 +135,11 @@ namespace osu.Game.Overlays
                 return;
             }
 
-            var newPanels = searchResult.Results.Select(b => new BeatmapCardNormal(b)
+            var newPanels = searchResult.Results.Select(b => BeatmapCard.Create(b, filterControl.CardSize.Value).With(card =>
             {
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.TopCentre,
-            });
+                card.Anchor = Anchor.TopCentre;
+                card.Origin = Anchor.TopCentre;
+            }));
 
             if (filterControl.CurrentPage == 0)
             {
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays
 
                 // spawn new children with the contained so we only clear old content at the last moment.
                 // reverse ID flow is required for correct Z-ordering of the cards' expandable content (last card should be front-most).
-                var content = new ReverseChildIDFillFlowContainer<BeatmapCardNormal>
+                var content = new ReverseChildIDFillFlowContainer<BeatmapCard>
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Overlays
                 Loading.Show();
         }
 
-        private Task panelLoadDelegate;
+        private Task panelLoadTask;
 
         private void onSearchFinished(BeatmapListingFilterControl.SearchResult searchResult)
         {
@@ -155,16 +155,16 @@ namespace osu.Game.Overlays
 
                 var content = createCardContainerFor(newCards);
 
-                panelLoadDelegate = LoadComponentAsync(foundContent = content, addContentToPlaceholder, (cancellationToken = new CancellationTokenSource()).Token);
+                panelLoadTask = LoadComponentAsync(foundContent = content, addContentToPlaceholder, (cancellationToken = new CancellationTokenSource()).Token);
             }
             else
             {
-                panelLoadDelegate = LoadComponentsAsync(newCards, loaded =>
+                panelLoadTask = LoadComponentsAsync(newCards, loaded =>
                 {
                     lastFetchDisplayedTime = Time.Current;
                     foundContent.AddRange(loaded);
                     loaded.ForEach(p => p.FadeIn(200, Easing.OutQuint));
-                });
+                }, (cancellationToken = new CancellationTokenSource()).Token);
             }
         }
 
@@ -239,7 +239,7 @@ namespace osu.Game.Overlays
 
             var newCards = createCardsFor(foundContent.Reverse().Select(card => card.BeatmapSet));
 
-            panelLoadDelegate = LoadComponentsAsync(newCards, cards =>
+            panelLoadTask = LoadComponentsAsync(newCards, cards =>
             {
                 foundContent.Clear();
                 foundContent.AddRange(cards);
@@ -374,7 +374,7 @@ namespace osu.Game.Overlays
 
             const int pagination_scroll_distance = 500;
 
-            bool shouldShowMore = panelLoadDelegate?.IsCompleted != false
+            bool shouldShowMore = panelLoadTask?.IsCompleted != false
                                   && Time.Current - lastFetchDisplayedTime > time_between_fetches
                                   && (ScrollFlow.ScrollableExtent > 0 && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance));
 


### PR DESCRIPTION
Probably going to call wraps on #14216 with this one, if it passes review.

https://user-images.githubusercontent.com/20418176/147287819-75576386-cc46-4214-97dd-7af219bbb9a9.mp4

I'm not happy with the fact that this adds another async process to the beatmap listing overlay. I know that web does this instantly, but on the other side, for there to be *no* loads, all card sizes would have to reside in one drawable and change on the fly, [judging by the designs](https://www.figma.com/file/bONtBvDRWNfOuiYpueD2ms/Web%2FSearch-Result-(with-Beatmap-Listing)?node-id=46%3A248). And there are [six card sizes designed](https://www.figma.com/file/oYJ9WkzXGvbPWBz6NxeyGr/UI%2FBeatmap-Card?node-id=112%3A2350), with quite subtle but substantial differences in appearance and behaviour. As such, my confidence of making all six work in a single drawable implementation without it devolving to an inscrutable mess is near zero, unless they are substantially streamlined to make this more feasible.

I also toyed with another approach, namely adding a `SwitchableBeatmapCard` that would nest a card of the correct size and `LoadComponentAsync()` the right one once a card size switch was requested ([see this branch](https://github.com/ppy/osu/compare/master...bdach:beatmap-card/extra-on-listing-BUSTED-2?expand=1)), but unfortunately that turned out to be prohibitively slow to the point of dipping FPS into the single digits, most likely due to incurring hundreds of individual `LoadComponentAsync()` calls, saturating the thread pool and causing extensive CPU load.

Note that the card size setting is not persisted anywhere. Web seems to silently persist it in local storage, without a visible setting in the account settings screen, but then also uses that local storage value on other screens (like the user profile) that don't have a size switcher. Not super sure about this behaviour so I didn't implement it.