### PR TITLE
Improve reliability of exiting gameplay in multiplayer

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -70,5 +70,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override RoomManager CreateRoomManager() => new MultiplayerRoomManager();
 
         protected override LoungeSubScreen CreateLounge() => new MultiplayerLoungeSubScreen();
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (client != null)
+                client.RoomUpdated -= onRoomUpdated;
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -15,6 +15,26 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            client.RoomUpdated += onRoomUpdated;
+            onRoomUpdated();
+        }
+
+        private void onRoomUpdated()
+        {
+            if (client.Room == null)
+                return;
+
+            Debug.Assert(client.LocalUser != null);
+
+            // If the user exits gameplay before score submission completes, we'll transition to idle when results has been prepared.
+            if (client.LocalUser.State == MultiplayerUserState.Results && this.IsCurrentScreen())
+                transitionFromResults();
+        }
+
         public override void OnResuming(IScreen last)
         {
             base.OnResuming(last);
@@ -22,23 +42,27 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (client.Room == null)
                 return;
 
+            if (!(last is MultiplayerPlayerLoader playerLoader))
+                return;
+
+            // If gameplay wasn't finished, then we have a simple path back to the idle state by aborting gameplay.
+            if (!playerLoader.GameplayCompleted)
+            {
+                client.AbortGameplay();
+                return;
+            }
+
+            // If gameplay was completed and the user went all the way to results, we'll transition to idle here.
+            // Otherwise, the transition will happen in onRoomUpdated().
+            transitionFromResults();
+        }
+
+        private void transitionFromResults()
+        {
             Debug.Assert(client.LocalUser != null);
 
-            switch (client.LocalUser.State)
-            {
-                case MultiplayerUserState.Spectating:
-                    break;
-
-                case MultiplayerUserState.WaitingForLoad:
-                case MultiplayerUserState.Loaded:
-                case MultiplayerUserState.Playing:
-                    client.AbortGameplay();
-                    break;
-
-                default:
-                    client.ChangeState(MultiplayerUserState.Idle);
-                    break;
-            }
+            if (client.LocalUser.State == MultiplayerUserState.Results)
+                client.ChangeState(MultiplayerUserState.Idle);
         }
 
         protected override string ScreenTitle => "Multiplayer";

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
 
             // If gameplay wasn't finished, then we have a simple path back to the idle state by aborting gameplay.
-            if (!playerLoader.GameplayCompleted)
+            if (!playerLoader.GameplayPassed)
             {
                 client.AbortGameplay();
                 return;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -30,7 +30,6 @@ using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Participants;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
-using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
 using osuTK;
@@ -478,7 +477,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     return new MultiSpectatorScreen(users.Take(PlayerGrid.MAX_PLAYERS).ToArray());
 
                 default:
-                    return new PlayerLoader(() => new MultiplayerPlayer(Room, SelectedItem.Value, users));
+                    return new MultiplayerPlayerLoader(() => new MultiplayerPlayer(Room, SelectedItem.Value, users));
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Screens;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer
+{
+    public class MultiplayerPlayerLoader : PlayerLoader
+    {
+        public bool GameplayCompleted => player?.GameplayCompleted == true;
+
+        private Player player;
+
+        public MultiplayerPlayerLoader(Func<Player> createPlayer)
+            : base(createPlayer)
+        {
+        }
+
+        public override void OnSuspending(IScreen next)
+        {
+            base.OnSuspending(next);
+            player = (Player)next;
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     public class MultiplayerPlayerLoader : PlayerLoader
     {
-        public bool GameplayCompleted => player?.GameplayCompleted == true;
+        public bool GameplayPassed => player?.GameplayPassed == true;
 
         private Player player;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Whether gameplay has completed without the user having failed.
         /// </summary>
-        public bool GameplayCompleted { get; private set; }
+        public bool GameplayPassed { get; private set; }
 
         public Action RestartRequested;
 
@@ -671,6 +671,7 @@ namespace osu.Game.Screens.Play
                 resultsDisplayDelegate?.Cancel();
                 resultsDisplayDelegate = null;
 
+                GameplayPassed = false;
                 ValidForResume = true;
                 skipOutroOverlay.Hide();
                 return;
@@ -680,7 +681,7 @@ namespace osu.Game.Screens.Play
             if (HealthProcessor.HasFailed)
                 return;
 
-            GameplayCompleted = true;
+            GameplayPassed = true;
 
             // Setting this early in the process means that even if something were to go wrong in the order of events following, there
             // is no chance that a user could return to the (already completed) Player instance from a child screen.

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -66,6 +66,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual bool PauseOnFocusLost => true;
 
+        /// <summary>
+        /// Whether gameplay has completed without the user having failed.
+        /// </summary>
+        public bool GameplayCompleted { get; private set; }
+
         public Action RestartRequested;
 
         public bool HasFailed { get; private set; }
@@ -674,6 +679,8 @@ namespace osu.Game.Screens.Play
             // Only show the completion screen if the player hasn't failed
             if (HealthProcessor.HasFailed)
                 return;
+
+            GameplayCompleted = true;
 
             // Setting this early in the process means that even if something were to go wrong in the order of events following, there
             // is no chance that a user could return to the (already completed) Player instance from a child screen.


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/16236

This one's not easy to test for the time being because `TestMultiplayerClient` assumes `UserStateChanged` completes instantly...

Can be tested by exiting immediately after gameplay finishes with the following:
```diff
diff --git a/osu.Game/Online/Multiplayer/MultiplayerClient.cs b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
index 903aaa89e3..630f080f09 100644
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -478,10 +478,13 @@ Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
             return Task.CompletedTask;
         }

-        Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
+        async Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
         {
             if (Room == null)
-                return Task.CompletedTask;
+                return;
+
+            if (state == MultiplayerUserState.FinishedPlay)
+                await Task.Delay(5000).ConfigureAwait(false);

             Scheduler.Add(() =>
             {
@@ -494,8 +497,6 @@ Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)

                 RoomUpdated?.Invoke();
             }, false);
-
-            return Task.CompletedTask;
         }

         Task IMultiplayerClient.MatchUserStateChanged(int userId, MatchUserState state)
```
