### PR TITLE
Fix "disable beatmap hitsounds" setting also preventing storyboard samples from playing

### DIFF
--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -57,12 +57,12 @@ namespace osu.Game.Skinning
             return beatmapSkins.Value;
         }
 
-        protected override bool AllowSampleLookup(ISampleInfo componentName)
+        protected override bool AllowSampleLookup(ISampleInfo sampleInfo)
         {
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
-            return componentName is StoryboardSampleInfo || beatmapHitsounds.Value;
+            return sampleInfo is StoryboardSampleInfo || beatmapHitsounds.Value;
         }
 
         public BeatmapSkinProvidingContainer(ISkin skin)

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Audio;
 using osu.Game.Configuration;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Skinning
 {
@@ -61,7 +62,7 @@ namespace osu.Game.Skinning
             if (beatmapSkins == null)
                 throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
 
-            return beatmapHitsounds.Value;
+            return componentName is StoryboardSampleInfo || beatmapHitsounds.Value;
         }
 
         public BeatmapSkinProvidingContainer(ISkin skin)

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Skinning
 
         protected virtual bool AllowTextureLookup(string componentName) => true;
 
-        protected virtual bool AllowSampleLookup(ISampleInfo componentName) => true;
+        protected virtual bool AllowSampleLookup(ISampleInfo sampleInfo) => true;
 
         protected virtual bool AllowConfigurationLookup => true;
 


### PR DESCRIPTION
I was quite confused why storyboards samples weren't playing and would have never guessed it was due to a skin setting. So here's a PR that fixes that.

I'm not checking the storyboard setting in `BeatmapSkinProvidingContainer` because `DimmableStoryboard` is already handling it correctly. And also because if I did check it at the beatmap lookup site, then the setting could cease to work correctly (to work correctly, each sample lookup would have to occur again on the change of that setting which feels a tad wasteful otherwise).

Also renamed the argument of `AllowSampleLookup` because it was a bit weird.