### PR TITLE
Fix legacy combo counter not fully hiding for rulesets that implement their own

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableComboCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableComboCounter.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play.HUD;
 
@@ -23,6 +24,18 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddRepeatStep("increase combo", () => scoreProcessor.Combo.Value++, 10);
 
             AddStep("reset combo", () => scoreProcessor.Combo.Value = 0);
+        }
+
+        [Test]
+        public void TestLegacyComboCounterHiddenByRulesetImplementation()
+        {
+            AddToggleStep("toggle legacy hidden by ruleset", visible =>
+            {
+                foreach (var legacyCounter in this.ChildrenOfType<LegacyComboCounter>())
+                    legacyCounter.HiddenByRulesetImplementation = visible;
+            });
+
+            AddRepeatStep("increase combo", () => scoreProcessor.Combo.Value++, 10);
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -69,21 +69,21 @@ namespace osu.Game.Screens.Play.HUD
 
             InternalChildren = new[]
             {
-                popOutCount = new LegacySpriteText(LegacyFont.Combo)
-                {
-                    Alpha = 0,
-                    Margin = new MarginPadding(0.05f),
-                    Blending = BlendingParameters.Additive,
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    BypassAutoSizeAxes = Axes.Both,
-                },
                 counterContainer = new Container
                 {
                     AutoSizeAxes = Axes.Both,
                     AlwaysPresent = true,
                     Children = new[]
                     {
+                        popOutCount = new LegacySpriteText(LegacyFont.Combo)
+                        {
+                            Alpha = 0,
+                            Margin = new MarginPadding(0.05f),
+                            Blending = BlendingParameters.Additive,
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            BypassAutoSizeAxes = Axes.Both,
+                        },
                         displayedCountSpriteText = new LegacySpriteText(LegacyFont.Combo)
                         {
                             // Initial text and AlwaysPresent allow the counter to have a size before it first displays a combo.


### PR DESCRIPTION
Closes #16250.

Regressed in #16000 due to taking the `popOutCount` out of `counterContainer`. Fixed by putting it back in there, *but* keeping the anchor/origin and `BypassAutoSizeAxes = Axes.Both` to not regress #15973.

Test coverage added but it's purely visual. I can add asserts but due to the fact that both sprite texts have their own alpha transforms and their parent is what controls the flag seems kind of flaky to depend on implementation details of the counter (if such a test checking the parent's alpha existed, it could have not even failed with the changes at #16000, as only _one_ of the sprite texts was taken out of its hidden parent).