### PR TITLE
Move rhythm difficulty calculation into a separate skill

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -21,6 +21,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         [JsonProperty("flashlight_difficulty")]
         public double FlashlightDifficulty { get; set; }
 
+        [JsonProperty("rhythm_difficulty")]
+        public double RhythmDifficulty { get; set; }
+
         [JsonProperty("slider_factor")]
         public double SliderFactor { get; set; }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -35,8 +35,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimRating = Math.Sqrt(skills[0].DifficultyValue()) * difficulty_multiplier;
             double aimRatingNoSliders = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
-            double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
-            double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
+            double rhythmRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
+            double speedRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
+            double flashlightRating = Math.Sqrt(skills[4].DifficultyValue()) * difficulty_multiplier;
 
             double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 
@@ -77,6 +78,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 AimDifficulty = aimRating,
                 SpeedDifficulty = speedRating,
                 FlashlightDifficulty = flashlightRating,
+                RhythmDifficulty = rhythmRating,
                 SliderFactor = sliderFactor,
                 ApproachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5,
                 OverallDifficulty = (80 - hitWindowGreat) / 6,
@@ -113,6 +115,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             {
                 new Aim(mods, true),
                 new Aim(mods, false),
+
+                // It is important to run rhythm calculation before Speed because it depends on Rhythm setting a value in OsuDifficultyHitObject
+                new Rhythm(mods, hitWindowGreat),
                 new Speed(mods, hitWindowGreat),
                 new Flashlight(mods)
             };

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Difficulty.Skills;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
@@ -69,6 +70,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         /// Calculated as the angle between the circles (current-2, current-1, current).
         /// </summary>
         public double? Angle { get; private set; }
+
+        /// <summary>
+        /// Rhythm difficulty bonus calculated by <see cref="Rhythm"/> and then used by <see cref="Speed"/>
+        /// </summary>
+        public double? RhythmDifficulty { get; set; }
 
         private readonly OsuHitObject lastLastObject;
         private readonly OsuHitObject lastObject;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Rhythm.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Rhythm.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Rulesets.Osu.Difficulty.Skills
+{
+    public class Rhythm : OsuStrainSkill
+    {
+        private const double rhythm_multiplier = 0.75;
+        private const int history_time_max = 5000; // 5 seconds of calculatingRhythmBonus max.
+
+        private double strainDecayBase => 0.3;
+        private double currentStrain;
+
+        protected override double DecayWeight => 1.0;
+        protected override double DifficultyMultiplier => 4;
+        protected override int HistoryLength => 32;
+
+        private readonly double greatWindow;
+
+        public Rhythm(Mod[] mods, double hitWindowGreat)
+            : base(mods)
+        {
+            greatWindow = hitWindowGreat;
+        }
+
+        /// <summary>
+        /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
+        /// </summary>
+        private double calculateRhythmBonus(DifficultyHitObject current)
+        {
+            if (current.BaseObject is Spinner)
+                return 0;
+
+            int previousIslandSize = 0;
+
+            double rhythmComplexitySum = 0;
+            int islandSize = 1;
+            double startRatio = 0; // store the ratio of the current start of an island to buff for tighter rhythms
+
+            bool firstDeltaSwitch = false;
+
+            for (int i = Previous.Count - 2; i > 0; i--)
+            {
+                OsuDifficultyHitObject currObj = (OsuDifficultyHitObject)Previous[i - 1];
+                OsuDifficultyHitObject prevObj = (OsuDifficultyHitObject)Previous[i];
+                OsuDifficultyHitObject lastObj = (OsuDifficultyHitObject)Previous[i + 1];
+
+                double currHistoricalDecay = Math.Max(0, (history_time_max - (current.StartTime - currObj.StartTime))) / history_time_max; // scales note 0 to 1 from history to now
+
+                if (currHistoricalDecay != 0)
+                {
+                    currHistoricalDecay = Math.Min((double)(Previous.Count - i) / Previous.Count, currHistoricalDecay); // either we're limited by time or limited by object count.
+
+                    double currDelta = currObj.StrainTime;
+                    double prevDelta = prevObj.StrainTime;
+                    double lastDelta = lastObj.StrainTime;
+                    double currRatio = 1.0 + 6.0 * Math.Min(0.5, Math.Pow(Math.Sin(Math.PI / (Math.Min(prevDelta, currDelta) / Math.Max(prevDelta, currDelta))), 2)); // fancy function to calculate rhythmbonuses.
+
+                    double windowPenalty = Math.Min(1, Math.Max(0, Math.Abs(prevDelta - currDelta) - greatWindow * 0.6) / (greatWindow * 0.6));
+
+                    windowPenalty = Math.Min(1, windowPenalty);
+
+                    double effectiveRatio = windowPenalty * currRatio;
+
+                    if (firstDeltaSwitch)
+                    {
+                        if (!(prevDelta > 1.25 * currDelta || prevDelta * 1.25 < currDelta))
+                        {
+                            if (islandSize < 7)
+                                islandSize++; // island is still progressing, count size.
+                        }
+                        else
+                        {
+                            if (Previous[i - 1].BaseObject is Slider) // bpm change is into slider, this is easy acc window
+                                effectiveRatio *= 0.125;
+
+                            if (Previous[i].BaseObject is Slider) // bpm change was from a slider, this is easier typically than circle -> circle
+                                effectiveRatio *= 0.25;
+
+                            if (previousIslandSize == islandSize) // repeated island size (ex: triplet -> triplet)
+                                effectiveRatio *= 0.25;
+
+                            if (previousIslandSize % 2 == islandSize % 2) // repeated island polartiy (2 -> 4, 3 -> 5)
+                                effectiveRatio *= 0.50;
+
+                            if (lastDelta > prevDelta + 10 && prevDelta > currDelta + 10) // previous increase happened a note ago, 1/1->1/2-1/4, dont want to buff this.
+                                effectiveRatio *= 0.125;
+
+                            rhythmComplexitySum += Math.Sqrt(effectiveRatio * startRatio) * currHistoricalDecay * Math.Sqrt(4 + islandSize) / 2 * Math.Sqrt(4 + previousIslandSize) / 2;
+
+                            startRatio = effectiveRatio;
+
+                            previousIslandSize = islandSize; // log the last island size.
+
+                            if (prevDelta * 1.25 < currDelta) // we're slowing down, stop counting
+                                firstDeltaSwitch = false; // if we're speeding up, this stays true and  we keep counting island size.
+
+                            islandSize = 1;
+                        }
+                    }
+                    else if (prevDelta > 1.25 * currDelta) // we want to be speeding up.
+                    {
+                        // Begin counting island until we change speed again.
+                        firstDeltaSwitch = true;
+                        startRatio = effectiveRatio;
+                        islandSize = 1;
+                    }
+                }
+            }
+
+            return Math.Sqrt(4 + rhythmComplexitySum * rhythm_multiplier) / 2; // produces multiplier that can be applied to strain. range [1, infinity) (not really though)
+        }
+
+        private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
+
+        protected override double CalculateInitialStrain(double time) => currentStrain * strainDecay(time - Previous[0].StartTime);
+
+        protected override double StrainValueAt(DifficultyHitObject current)
+        {
+            double rhythmBonus = calculateRhythmBonus(current);
+            currentStrain *= strainDecay(current.DeltaTime);
+            currentStrain += rhythmBonus - 1;
+
+            if (current is OsuDifficultyHitObject osuCurrObj)
+                osuCurrObj.RhythmDifficulty = rhythmBonus;
+
+            return currentStrain;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     public class Speed : OsuStrainSkill
     {
         private const double single_spacing_threshold = 125;
-        private const double rhythm_multiplier = 0.75;
-        private const int history_time_max = 5000; // 5 seconds of calculatingRhythmBonus max.
         private const double min_speed_bonus = 75; // ~200BPM
         private const double speed_balancing_factor = 40;
 
@@ -37,96 +35,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             : base(mods)
         {
             greatWindow = hitWindowGreat;
-        }
-
-        /// <summary>
-        /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
-        /// </summary>
-        private double calculateRhythmBonus(DifficultyHitObject current)
-        {
-            if (current.BaseObject is Spinner)
-                return 0;
-
-            int previousIslandSize = 0;
-
-            double rhythmComplexitySum = 0;
-            int islandSize = 1;
-            double startRatio = 0; // store the ratio of the current start of an island to buff for tighter rhythms
-
-            bool firstDeltaSwitch = false;
-
-            int rhythmStart = 0;
-
-            while (rhythmStart < Previous.Count - 2 && current.StartTime - Previous[rhythmStart].StartTime < history_time_max)
-                rhythmStart++;
-
-            for (int i = rhythmStart; i > 0; i--)
-            {
-                OsuDifficultyHitObject currObj = (OsuDifficultyHitObject)Previous[i - 1];
-                OsuDifficultyHitObject prevObj = (OsuDifficultyHitObject)Previous[i];
-                OsuDifficultyHitObject lastObj = (OsuDifficultyHitObject)Previous[i + 1];
-
-                double currHistoricalDecay = (history_time_max - (current.StartTime - currObj.StartTime)) / history_time_max; // scales note 0 to 1 from history to now
-
-                currHistoricalDecay = Math.Min((double)(Previous.Count - i) / Previous.Count, currHistoricalDecay); // either we're limited by time or limited by object count.
-
-                double currDelta = currObj.StrainTime;
-                double prevDelta = prevObj.StrainTime;
-                double lastDelta = lastObj.StrainTime;
-                double currRatio = 1.0 + 6.0 * Math.Min(0.5, Math.Pow(Math.Sin(Math.PI / (Math.Min(prevDelta, currDelta) / Math.Max(prevDelta, currDelta))), 2)); // fancy function to calculate rhythmbonuses.
-
-                double windowPenalty = Math.Min(1, Math.Max(0, Math.Abs(prevDelta - currDelta) - greatWindow * 0.6) / (greatWindow * 0.6));
-
-                windowPenalty = Math.Min(1, windowPenalty);
-
-                double effectiveRatio = windowPenalty * currRatio;
-
-                if (firstDeltaSwitch)
-                {
-                    if (!(prevDelta > 1.25 * currDelta || prevDelta * 1.25 < currDelta))
-                    {
-                        if (islandSize < 7)
-                            islandSize++; // island is still progressing, count size.
-                    }
-                    else
-                    {
-                        if (Previous[i - 1].BaseObject is Slider) // bpm change is into slider, this is easy acc window
-                            effectiveRatio *= 0.125;
-
-                        if (Previous[i].BaseObject is Slider) // bpm change was from a slider, this is easier typically than circle -> circle
-                            effectiveRatio *= 0.25;
-
-                        if (previousIslandSize == islandSize) // repeated island size (ex: triplet -> triplet)
-                            effectiveRatio *= 0.25;
-
-                        if (previousIslandSize % 2 == islandSize % 2) // repeated island polartiy (2 -> 4, 3 -> 5)
-                            effectiveRatio *= 0.50;
-
-                        if (lastDelta > prevDelta + 10 && prevDelta > currDelta + 10) // previous increase happened a note ago, 1/1->1/2-1/4, dont want to buff this.
-                            effectiveRatio *= 0.125;
-
-                        rhythmComplexitySum += Math.Sqrt(effectiveRatio * startRatio) * currHistoricalDecay * Math.Sqrt(4 + islandSize) / 2 * Math.Sqrt(4 + previousIslandSize) / 2;
-
-                        startRatio = effectiveRatio;
-
-                        previousIslandSize = islandSize; // log the last island size.
-
-                        if (prevDelta * 1.25 < currDelta) // we're slowing down, stop counting
-                            firstDeltaSwitch = false; // if we're speeding up, this stays true and  we keep counting island size.
-
-                        islandSize = 1;
-                    }
-                }
-                else if (prevDelta > 1.25 * currDelta) // we want to be speeding up.
-                {
-                    // Begin counting island until we change speed again.
-                    firstDeltaSwitch = true;
-                    startRatio = effectiveRatio;
-                    islandSize = 1;
-                }
-            }
-
-            return Math.Sqrt(4 + rhythmComplexitySum * rhythm_multiplier) / 2; //produces multiplier that can be applied to strain. range [1, infinity) (not really though)
         }
 
         private double strainValueOf(DifficultyHitObject current)
@@ -171,7 +79,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             currentStrain *= strainDecay(current.DeltaTime);
             currentStrain += strainValueOf(current) * skillMultiplier;
 
-            currentRhythm = calculateRhythmBonus(current);
+            if (current is OsuDifficultyHitObject osuCurrObj)
+                currentRhythm = osuCurrObj.RhythmDifficulty ?? 1.0;
 
             return currentStrain * currentRhythm;
         }


### PR DESCRIPTION
This change should not change pp/sr values and is purely a refactor.

Some pp efforts require rhythm difficulty to be exposed in some way to the performance calculator, this PR is supposed to move rhythm calculation into a separate skill so that we can store its difficulty value in attributes. 

I'm not really sure if storing rhythm bonus in ODHO is a good idea, but couldn't really think of a better way without changing resulting values. Decay params and multipliers of `Rhythm` calculation are placeholders - people working with those should adjust them as they see fit.