### PR TITLE
Fix and normalise most identifier names in code

### DIFF
--- a/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
+++ b/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
@@ -76,7 +76,7 @@ namespace osu.Desktop.Security
             private void load(OsuColour colours, NotificationOverlay notificationOverlay)
             {
                 Icon = FontAwesome.Solid.ShieldAlt;
-                IconBackgound.Colour = colours.YellowDark;
+                IconBackground.Colour = colours.YellowDark;
             }
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestJuicestream()
+        public void TestJuiceStream()
         {
             AddStep("hit juicestream", () => spawnJuiceStream(true));
             AddUntilStep("wait for completion", () => playfieldIsEmpty);

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -37,20 +37,20 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddStep("show hyperdash droplet", () => SetContents(_ => createDrawableDroplet(true)));
         }
 
-        private Drawable createDrawableFruit(int indexInBeatmap, bool hyperdash = false) =>
+        private Drawable createDrawableFruit(int indexInBeatmap, bool hyperDash = false) =>
             new TestDrawableCatchHitObjectSpecimen(new DrawableFruit(new Fruit
             {
                 IndexInBeatmap = indexInBeatmap,
-                HyperDashBindable = { Value = hyperdash }
+                HyperDashBindable = { Value = hyperDash }
             }));
 
         private Drawable createDrawableBanana() =>
             new TestDrawableCatchHitObjectSpecimen(new DrawableBanana(new Banana()));
 
-        private Drawable createDrawableDroplet(bool hyperdash = false) =>
+        private Drawable createDrawableDroplet(bool hyperDash = false) =>
             new TestDrawableCatchHitObjectSpecimen(new DrawableDroplet(new Droplet
             {
-                HyperDashBindable = { Value = hyperdash }
+                HyperDashBindable = { Value = hyperDash }
             }));
 
         private Drawable createDrawableTinyDroplet() => new TestDrawableCatchHitObjectSpecimen(new DrawableTinyDroplet(new TinyDroplet()));

--- a/osu.Game.Rulesets.Catch/Skinning/Default/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/DefaultHitExplosion.cs
@@ -90,9 +90,9 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
                 .ResizeTo(largeFaint.Size * new Vector2(5, 1), duration, Easing.OutQuint)
                 .FadeOut(duration * 2);
 
-            const float angle_variable = 15; // should be less than 45
-            directionalGlow1.Rotation = StatelessRNG.NextSingle(-angle_variable, angle_variable, randomSeed, 4);
-            directionalGlow2.Rotation = StatelessRNG.NextSingle(-angle_variable, angle_variable, randomSeed, 5);
+            const float angle_variance = 15; // should be less than 45
+            directionalGlow1.Rotation = StatelessRNG.NextSingle(-angle_variance, angle_variance, randomSeed, 4);
+            directionalGlow2.Rotation = StatelessRNG.NextSingle(-angle_variance, angle_variance, randomSeed, 5);
 
             this.FadeInFromZero(50).Then().FadeOut(duration, Easing.Out);
         }

--- a/osu.Game.Rulesets.Catch/Skinning/Default/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/DefaultHitExplosion.cs
@@ -90,9 +90,9 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
                 .ResizeTo(largeFaint.Size * new Vector2(5, 1), duration, Easing.OutQuint)
                 .FadeOut(duration * 2);
 
-            const float angle_variangle = 15; // should be less than 45
-            directionalGlow1.Rotation = StatelessRNG.NextSingle(-angle_variangle, angle_variangle, randomSeed, 4);
-            directionalGlow2.Rotation = StatelessRNG.NextSingle(-angle_variangle, angle_variangle, randomSeed, 5);
+            const float angle_variable = 15; // should be less than 45
+            directionalGlow1.Rotation = StatelessRNG.NextSingle(-angle_variable, angle_variable, randomSeed, 4);
+            directionalGlow2.Rotation = StatelessRNG.NextSingle(-angle_variable, angle_variable, randomSeed, 5);
 
             this.FadeInFromZero(50).Then().FadeOut(duration, Easing.Out);
         }

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHitExplosion.cs
@@ -24,13 +24,13 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
 
         public TestSceneHitExplosion()
         {
-            int runcount = 0;
+            int runCount = 0;
 
             AddRepeatStep("explode", () =>
             {
-                runcount++;
+                runCount++;
 
-                if (runcount % 15 > 12)
+                if (runCount % 15 > 12)
                     return;
 
                 int poolIndex = 0;
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                 {
                     c.Add(hitExplosionPools[poolIndex].Get(e =>
                     {
-                        e.Apply(new JudgementResult(new HitObject(), runcount % 6 == 0 ? new HoldNoteTickJudgement() : new ManiaJudgement()));
+                        e.Apply(new JudgementResult(new HitObject(), runCount % 6 == 0 ? new HoldNoteTickJudgement() : new ManiaJudgement()));
 
                         e.Anchor = Anchor.Centre;
                         e.Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
             int notes = HitObjects.Count(s => s is Note);
-            int holdnotes = HitObjects.Count(s => s is HoldNote);
+            int holdNotes = HitObjects.Count(s => s is HoldNote);
 
             return new[]
             {
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 {
                     Name = @"Hold Note Count",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
-                    Content = holdnotes.ToString(),
+                    Content = holdNotes.ToString(),
                 },
             };
         }

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         /// Mapping of <see cref="HitResult"/> to their corresponding
         /// <see cref="LegacyManiaSkinConfigurationLookups"/> value.
         /// </summary>
-        private static readonly IReadOnlyDictionary<HitResult, LegacyManiaSkinConfigurationLookups> hitresult_mapping
+        private static readonly IReadOnlyDictionary<HitResult, LegacyManiaSkinConfigurationLookups> hit_result_mapping
             = new Dictionary<HitResult, LegacyManiaSkinConfigurationLookups>
             {
                 { HitResult.Perfect, LegacyManiaSkinConfigurationLookups.Hit300g },
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         /// Mapping of <see cref="HitResult"/> to their corresponding
         /// default filenames.
         /// </summary>
-        private static readonly IReadOnlyDictionary<HitResult, string> default_hitresult_skin_filenames
+        private static readonly IReadOnlyDictionary<HitResult, string> default_hit_result_skin_filenames
             = new Dictionary<HitResult, string>
             {
                 { HitResult.Perfect, "mania-hit300g" },
@@ -126,11 +126,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private Drawable getResult(HitResult result)
         {
-            if (!hitresult_mapping.ContainsKey(result))
+            if (!hit_result_mapping.ContainsKey(result))
                 return null;
 
-            string filename = this.GetManiaSkinConfig<string>(hitresult_mapping[result])?.Value
-                              ?? default_hitresult_skin_filenames[result];
+            string filename = this.GetManiaSkinConfig<string>(hit_result_mapping[result])?.Value
+                              ?? default_hit_result_skin_filenames[result];
 
             var animation = this.GetAnimation(filename, true, true);
             return animation == null ? null : new LegacyManiaJudgementPiece(result, animation);

--- a/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Mania.UI
         [BackgroundDependencyLoader]
         private void load(IScrollingInfo scrollingInfo)
         {
-            const float angle_variangle = 15; // should be less than 45
+            const float angle_variable = 15; // should be less than 45
             const float roundness = 80;
             const float initial_height = 10;
 
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Mania.UI
                     Masking = true,
                     Size = new Vector2(0.01f, initial_height),
                     Blending = BlendingParameters.Additive,
-                    Rotation = RNG.NextSingle(-angle_variangle, angle_variangle),
+                    Rotation = RNG.NextSingle(-angle_variable, angle_variable),
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Mania.UI
                     Masking = true,
                     Size = new Vector2(0.01f, initial_height),
                     Blending = BlendingParameters.Additive,
-                    Rotation = RNG.NextSingle(-angle_variangle, angle_variangle),
+                    Rotation = RNG.NextSingle(-angle_variable, angle_variable),
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,

--- a/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Mania.UI
         [BackgroundDependencyLoader]
         private void load(IScrollingInfo scrollingInfo)
         {
-            const float angle_variable = 15; // should be less than 45
+            const float angle_variance = 15; // should be less than 45
             const float roundness = 80;
             const float initial_height = 10;
 
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Mania.UI
                     Masking = true,
                     Size = new Vector2(0.01f, initial_height),
                     Blending = BlendingParameters.Additive,
-                    Rotation = RNG.NextSingle(-angle_variable, angle_variable),
+                    Rotation = RNG.NextSingle(-angle_variance, angle_variance),
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Mania.UI
                     Masking = true,
                     Size = new Vector2(0.01f, initial_height),
                     Blending = BlendingParameters.Additive,
-                    Rotation = RNG.NextSingle(-angle_variable, angle_variable),
+                    Rotation = RNG.NextSingle(-angle_variance, angle_variance),
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public override bool Remove(DrawableHitObject h) => getStageByColumn(((ManiaHitObject)h.HitObject).Column).Remove(h);
 
-        public void Add(BarLine barline) => stages.ForEach(s => s.Add(barline));
+        public void Add(BarLine barLine) => stages.ForEach(s => s.Add(barLine));
 
         /// <summary>
         /// Retrieves a column from a screen-space position.

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public override bool Remove(DrawableHitObject h) => Columns.ElementAt(((ManiaHitObject)h.HitObject).Column - firstColumnIndex).Remove(h);
 
-        public void Add(BarLine barline) => base.Add(new DrawableBarLine(barline));
+        public void Add(BarLine barLine) => base.Add(new DrawableBarLine(barLine));
 
         internal void OnNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             switch (pathType)
             {
                 case PathType.Catmull:
-                    return colours.Seafoam;
+                    return colours.SeaFoam;
 
                 case PathType.Bezier:
                     return colours.Pink;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Spun Out";
         public override string Acronym => "SO";
-        public override IconUsage? Icon => OsuIcon.ModSpunout;
+        public override IconUsage? Icon => OsuIcon.ModSpunOut;
         public override ModType Type => ModType.Automation;
         public override string Description => @"Spinners will be automatically completed.";
         public override double ScoreMultiplier => 0.9;

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableBarLine.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableBarLine.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 
         private BarLine createBarLineAtCurrentTime(bool major = false)
         {
-            var barline = new BarLine
+            var barLine = new BarLine
             {
                 Major = major,
                 StartTime = Time.Current + 2000,
@@ -92,9 +92,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             var cpi = new ControlPointInfo();
             cpi.Add(0, new TimingControlPoint { BeatLength = 500 });
 
-            barline.ApplyDefaults(cpi, new BeatmapDifficulty());
+            barLine.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            return barline;
+            return barLine;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
             int hits = HitObjects.Count(s => s is Hit);
-            int drumrolls = HitObjects.Count(s => s is DrumRoll);
+            int drumRolls = HitObjects.Count(s => s is DrumRoll);
             int swells = HitObjects.Count(s => s is Swell);
 
             return new[]
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 {
                     Name = @"Drumroll Count",
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
-                    Content = drumrolls.ToString(),
+                    Content = drumRolls.ToString(),
                 },
                 new BeatmapStatistic
                 {

--- a/osu.Game.Tests/Editing/Checks/CheckMutedObjectsTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckMutedObjectsTest.cs
@@ -40,80 +40,80 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestNormalControlPointVolume()
         {
-            var hitcircle = new HitCircle
+            var hitCircle = new HitCircle
             {
                 StartTime = 0,
                 Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
             };
-            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+            hitCircle.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            assertOk(new List<HitObject> { hitcircle });
+            assertOk(new List<HitObject> { hitCircle });
         }
 
         [Test]
         public void TestLowControlPointVolume()
         {
-            var hitcircle = new HitCircle
+            var hitCircle = new HitCircle
             {
                 StartTime = 1000,
                 Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
             };
-            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+            hitCircle.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            assertLowVolume(new List<HitObject> { hitcircle });
+            assertLowVolume(new List<HitObject> { hitCircle });
         }
 
         [Test]
         public void TestMutedControlPointVolume()
         {
-            var hitcircle = new HitCircle
+            var hitCircle = new HitCircle
             {
                 StartTime = 2000,
                 Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
             };
-            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+            hitCircle.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            assertMuted(new List<HitObject> { hitcircle });
+            assertMuted(new List<HitObject> { hitCircle });
         }
 
         [Test]
         public void TestNormalSampleVolume()
         {
             // The sample volume should take precedence over the control point volume.
-            var hitcircle = new HitCircle
+            var hitCircle = new HitCircle
             {
                 StartTime = 2000,
                 Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_regular) }
             };
-            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+            hitCircle.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            assertOk(new List<HitObject> { hitcircle });
+            assertOk(new List<HitObject> { hitCircle });
         }
 
         [Test]
         public void TestLowSampleVolume()
         {
-            var hitcircle = new HitCircle
+            var hitCircle = new HitCircle
             {
                 StartTime = 2000,
                 Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_low) }
             };
-            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+            hitCircle.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            assertLowVolume(new List<HitObject> { hitcircle });
+            assertLowVolume(new List<HitObject> { hitCircle });
         }
 
         [Test]
         public void TestMutedSampleVolume()
         {
-            var hitcircle = new HitCircle
+            var hitCircle = new HitCircle
             {
                 StartTime = 0,
                 Samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, volume: volume_muted) }
             };
-            hitcircle.ApplyDefaults(cpi, new BeatmapDifficulty());
+            hitCircle.ApplyDefaults(cpi, new BeatmapDifficulty());
 
-            assertMuted(new List<HitObject> { hitcircle });
+            assertMuted(new List<HitObject> { hitCircle });
         }
 
         [Test]

--- a/osu.Game.Tests/Mods/ModSettingsEqualityComparison.cs
+++ b/osu.Game.Tests/Mods/ModSettingsEqualityComparison.cs
@@ -34,20 +34,20 @@ namespace osu.Game.Tests.Mods
             var mod3 = new OsuModDoubleTime { SpeedChange = { Value = 1.26 } };
 
             var doubleConvertedMod1 = new APIMod(mod1).ToMod(ruleset);
-            var doulbeConvertedMod2 = new APIMod(mod2).ToMod(ruleset);
-            var doulbeConvertedMod3 = new APIMod(mod3).ToMod(ruleset);
+            var doubleConvertedMod2 = new APIMod(mod2).ToMod(ruleset);
+            var doubleConvertedMod3 = new APIMod(mod3).ToMod(ruleset);
 
             Assert.That(mod1, Is.Not.EqualTo(mod2));
-            Assert.That(doubleConvertedMod1, Is.Not.EqualTo(doulbeConvertedMod2));
+            Assert.That(doubleConvertedMod1, Is.Not.EqualTo(doubleConvertedMod2));
 
             Assert.That(mod2, Is.EqualTo(mod2));
-            Assert.That(doulbeConvertedMod2, Is.EqualTo(doulbeConvertedMod2));
+            Assert.That(doubleConvertedMod2, Is.EqualTo(doubleConvertedMod2));
 
             Assert.That(mod2, Is.EqualTo(mod3));
-            Assert.That(doulbeConvertedMod2, Is.EqualTo(doulbeConvertedMod3));
+            Assert.That(doubleConvertedMod2, Is.EqualTo(doubleConvertedMod3));
 
             Assert.That(mod3, Is.EqualTo(mod2));
-            Assert.That(doulbeConvertedMod3, Is.EqualTo(doulbeConvertedMod2));
+            Assert.That(doubleConvertedMod3, Is.EqualTo(doubleConvertedMod2));
         }
     }
 }

--- a/osu.Game.Tests/Online/TestMultiplayerMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestMultiplayerMessagePackSerialization.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Online
         }
 
         [Test]
-        public void TestSerialiseUnionFailsWithSingalR()
+        public void TestSerialiseUnionFailsWithSignalR()
         {
             var state = new TeamVersusUserState();
 

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -20,30 +20,30 @@ namespace osu.Game.Tests.Visual.Navigation
         public void TestFromMainMenu()
         {
             var firstImport = importBeatmap(1);
-            var secondimport = importBeatmap(3);
+            var secondImport = importBeatmap(3);
 
             presentAndConfirm(firstImport);
             returnToMenu();
-            presentAndConfirm(secondimport);
+            presentAndConfirm(secondImport);
             returnToMenu();
             presentSecondDifficultyAndConfirm(firstImport, 1);
             returnToMenu();
-            presentSecondDifficultyAndConfirm(secondimport, 3);
+            presentSecondDifficultyAndConfirm(secondImport, 3);
         }
 
         [Test]
         public void TestFromMainMenuDifferentRuleset()
         {
             var firstImport = importBeatmap(1);
-            var secondimport = importBeatmap(3, new ManiaRuleset().RulesetInfo);
+            var secondImport = importBeatmap(3, new ManiaRuleset().RulesetInfo);
 
             presentAndConfirm(firstImport);
             returnToMenu();
-            presentAndConfirm(secondimport);
+            presentAndConfirm(secondImport);
             returnToMenu();
             presentSecondDifficultyAndConfirm(firstImport, 1);
             returnToMenu();
-            presentSecondDifficultyAndConfirm(secondimport, 3);
+            presentSecondDifficultyAndConfirm(secondImport, 3);
         }
 
         [Test]
@@ -52,17 +52,17 @@ namespace osu.Game.Tests.Visual.Navigation
             var firstImport = importBeatmap(1);
             presentAndConfirm(firstImport);
 
-            var secondimport = importBeatmap(3);
-            presentAndConfirm(secondimport);
+            var secondImport = importBeatmap(3);
+            presentAndConfirm(secondImport);
 
             // Test presenting same beatmap more than once
-            presentAndConfirm(secondimport);
+            presentAndConfirm(secondImport);
 
             presentSecondDifficultyAndConfirm(firstImport, 1);
-            presentSecondDifficultyAndConfirm(secondimport, 3);
+            presentSecondDifficultyAndConfirm(secondImport, 3);
 
             // Test presenting same beatmap more than once
-            presentSecondDifficultyAndConfirm(secondimport, 3);
+            presentSecondDifficultyAndConfirm(secondImport, 3);
         }
 
         [Test]
@@ -71,11 +71,11 @@ namespace osu.Game.Tests.Visual.Navigation
             var firstImport = importBeatmap(1);
             presentAndConfirm(firstImport);
 
-            var secondimport = importBeatmap(3, new ManiaRuleset().RulesetInfo);
-            presentAndConfirm(secondimport);
+            var secondImport = importBeatmap(3, new ManiaRuleset().RulesetInfo);
+            presentAndConfirm(secondImport);
 
             presentSecondDifficultyAndConfirm(firstImport, 1);
-            presentSecondDifficultyAndConfirm(secondimport, 3);
+            presentSecondDifficultyAndConfirm(secondImport, 3);
         }
 
         private void returnToMenu()

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
@@ -65,11 +65,11 @@ namespace osu.Game.Tests.Visual.Navigation
         public void TestFromMainMenu([Values] ScorePresentType type)
         {
             var firstImport = importScore(1);
-            var secondimport = importScore(3);
+            var secondImport = importScore(3);
 
             presentAndConfirm(firstImport, type);
             returnToMenu();
-            presentAndConfirm(secondimport, type);
+            presentAndConfirm(secondImport, type);
             returnToMenu();
             returnToMenu();
         }
@@ -78,11 +78,11 @@ namespace osu.Game.Tests.Visual.Navigation
         public void TestFromMainMenuDifferentRuleset([Values] ScorePresentType type)
         {
             var firstImport = importScore(1);
-            var secondimport = importScore(3, new ManiaRuleset().RulesetInfo);
+            var secondImport = importScore(3, new ManiaRuleset().RulesetInfo);
 
             presentAndConfirm(firstImport, type);
             returnToMenu();
-            presentAndConfirm(secondimport, type);
+            presentAndConfirm(secondImport, type);
             returnToMenu();
             returnToMenu();
         }
@@ -93,8 +93,8 @@ namespace osu.Game.Tests.Visual.Navigation
             var firstImport = importScore(1);
             presentAndConfirm(firstImport, type);
 
-            var secondimport = importScore(3);
-            presentAndConfirm(secondimport, type);
+            var secondImport = importScore(3);
+            presentAndConfirm(secondImport, type);
         }
 
         [Test]
@@ -103,8 +103,8 @@ namespace osu.Game.Tests.Visual.Navigation
             var firstImport = importScore(1);
             presentAndConfirm(firstImport, type);
 
-            var secondimport = importScore(3, new ManiaRuleset().RulesetInfo);
-            presentAndConfirm(secondimport, type);
+            var secondImport = importScore(3, new ManiaRuleset().RulesetInfo);
+            presentAndConfirm(secondImport, type);
         }
 
         private void returnToMenu()

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapAvailability.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapAvailability.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Online
                 },
             });
 
-            visiblityAssert(true);
+            visibilityAssert(true);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Online
                 },
             });
 
-            visiblityAssert(true);
+            visibilityAssert(true);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Online
                 },
             });
 
-            visiblityAssert(true);
+            visibilityAssert(true);
         }
 
         [Test]
@@ -73,10 +73,10 @@ namespace osu.Game.Tests.Visual.Online
                 },
             });
 
-            visiblityAssert(false);
+            visibilityAssert(false);
         }
 
-        private void visiblityAssert(bool shown)
+        private void visibilityAssert(bool shown)
         {
             AddAssert($"is container {(shown ? "visible" : "hidden")}", () => container.Alpha == (shown ? 1 : 0));
         }

--- a/osu.Game.Tests/Visual/Online/TestSceneKudosuHistory.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneKudosuHistory.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Online
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            background.Colour = colours.GreySeafoam;
+            background.Colour = colours.GreySeaFoam;
         }
 
         private readonly IEnumerable<APIKudosuHistory> items = new[]

--- a/osu.Game.Tests/Visual/Online/TestScenePlayHistorySubsection.cs
+++ b/osu.Game.Tests/Visual/Online/TestScenePlayHistorySubsection.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Load user", () => user.Value = user_with_filled_values);
             AddAssert("Section is visible", () => section.Alpha == 1);
-            AddAssert("Array length is the same", () => user_with_filled_values.MonthlyPlaycounts.Length == getChartValuesLength());
+            AddAssert("Array length is the same", () => user_with_filled_values.MonthlyPlayCounts.Length == getChartValuesLength());
         }
 
         [Test]
@@ -108,13 +108,13 @@ namespace osu.Game.Tests.Visual.Online
         private static readonly APIUser user_with_empty_values = new APIUser
         {
             Id = 2,
-            MonthlyPlaycounts = Array.Empty<APIUserHistoryCount>()
+            MonthlyPlayCounts = Array.Empty<APIUserHistoryCount>()
         };
 
         private static readonly APIUser user_with_one_value = new APIUser
         {
             Id = 3,
-            MonthlyPlaycounts = new[]
+            MonthlyPlayCounts = new[]
             {
                 new APIUserHistoryCount { Date = new DateTime(2010, 5, 1), Count = 100 }
             }
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Visual.Online
         private static readonly APIUser user_with_two_values = new APIUser
         {
             Id = 4,
-            MonthlyPlaycounts = new[]
+            MonthlyPlayCounts = new[]
             {
                 new APIUserHistoryCount { Date = new DateTime(2010, 5, 1), Count = 1 },
                 new APIUserHistoryCount { Date = new DateTime(2010, 6, 1), Count = 2 }
@@ -133,7 +133,7 @@ namespace osu.Game.Tests.Visual.Online
         private static readonly APIUser user_with_constant_values = new APIUser
         {
             Id = 5,
-            MonthlyPlaycounts = new[]
+            MonthlyPlayCounts = new[]
             {
                 new APIUserHistoryCount { Date = new DateTime(2010, 5, 1), Count = 5 },
                 new APIUserHistoryCount { Date = new DateTime(2010, 6, 1), Count = 5 },
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Online
         private static readonly APIUser user_with_zero_values = new APIUser
         {
             Id = 6,
-            MonthlyPlaycounts = new[]
+            MonthlyPlayCounts = new[]
             {
                 new APIUserHistoryCount { Date = new DateTime(2010, 5, 1), Count = 0 },
                 new APIUserHistoryCount { Date = new DateTime(2010, 6, 1), Count = 0 },
@@ -155,7 +155,7 @@ namespace osu.Game.Tests.Visual.Online
         private static readonly APIUser user_with_filled_values = new APIUser
         {
             Id = 7,
-            MonthlyPlaycounts = new[]
+            MonthlyPlayCounts = new[]
             {
                 new APIUserHistoryCount { Date = new DateTime(2010, 5, 1), Count = 1000 },
                 new APIUserHistoryCount { Date = new DateTime(2010, 6, 1), Count = 20 },
@@ -170,7 +170,7 @@ namespace osu.Game.Tests.Visual.Online
         private static readonly APIUser user_with_missing_values = new APIUser
         {
             Id = 8,
-            MonthlyPlaycounts = new[]
+            MonthlyPlayCounts = new[]
             {
                 new APIUserHistoryCount { Date = new DateTime(2020, 1, 1), Count = 100 },
                 new APIUserHistoryCount { Date = new DateTime(2020, 7, 1), Count = 200 }

--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -309,8 +309,8 @@ namespace osu.Game.Tests.Visual.Online
 
         private class TestStandAloneChatDisplay : StandAloneChatDisplay
         {
-            public TestStandAloneChatDisplay(bool textbox = false)
-                : base(textbox)
+            public TestStandAloneChatDisplay(bool textBox = false)
+                : base(textBox)
             {
             }
 

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsMatchSettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsMatchSettingsOverlay.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Visual.Playlists
         {
             const string not_found_prefix = "beatmaps not found:";
 
-            string errorMesage = null;
+            string errorMessage = null;
 
             AddStep("setup", () =>
             {
@@ -96,9 +96,9 @@ namespace osu.Game.Tests.Visual.Playlists
                 SelectedRoom.Value.Name.Value = "Test Room";
                 SelectedRoom.Value.Playlist.Add(new PlaylistItem { Beatmap = { Value = beatmap } });
 
-                errorMesage = $"{not_found_prefix} {beatmap.OnlineID}";
+                errorMessage = $"{not_found_prefix} {beatmap.OnlineID}";
 
-                RoomManager.CreateRequested = _ => errorMesage;
+                RoomManager.CreateRequested = _ => errorMessage;
             });
 
             AddAssert("error not displayed", () => !settings.ErrorText.IsPresent);
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.Playlists
             AddStep("create room", () => settings.ApplyButton.Action.Invoke());
 
             AddAssert("error displayed", () => settings.ErrorText.IsPresent);
-            AddAssert("error has custom text", () => settings.ErrorText.Text != errorMesage);
+            AddAssert("error has custom text", () => settings.ErrorText.Text != errorMessage);
             AddAssert("playlist item marked invalid", () => !SelectedRoom.Value.Playlist[0].Valid.Value);
         }
 

--- a/osu.Game.Tests/Visual/Settings/TestSceneRestoreDefaultValueButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRestoreDefaultValueButton.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Settings
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = colours.GreySeafoam
+                        Colour = colours.GreySeaFoam
                     },
                     restoreDefaultValueButton = new RestoreDefaultValueButton<float>
                     {

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual.Settings
             };
 
             [SettingSource("Sample number textbox", "Textbox number entry", SettingControlType = typeof(SettingsNumberBox))]
-            public Bindable<int?> IntTextboxBindable { get; } = new Bindable<int?>
+            public Bindable<int?> IntTextBoxBindable { get; } = new Bindable<int?>
             {
                 Default = null,
                 Value = null

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
@@ -29,10 +29,10 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("Display toast with lengthy text", () => osd.Display(new LengthyToast()));
             AddAssert("Toast width is greater than 240", () => osd.Child.Width > 240);
 
-            AddRepeatStep("Change toggle (no bind)", () => config.ToggleSetting(TestConfigSetting.ToggleSettingNoKeybind), 2);
-            AddRepeatStep("Change toggle (with bind)", () => config.ToggleSetting(TestConfigSetting.ToggleSettingWithKeybind), 2);
-            AddRepeatStep("Change enum (no bind)", () => config.IncrementEnumSetting(TestConfigSetting.EnumSettingNoKeybind), 3);
-            AddRepeatStep("Change enum (with bind)", () => config.IncrementEnumSetting(TestConfigSetting.EnumSettingWithKeybind), 3);
+            AddRepeatStep("Change toggle (no bind)", () => config.ToggleSetting(TestConfigSetting.ToggleSettingNoKeyBind), 2);
+            AddRepeatStep("Change toggle (with bind)", () => config.ToggleSetting(TestConfigSetting.ToggleSettingWithKeyBind), 2);
+            AddRepeatStep("Change enum (no bind)", () => config.IncrementEnumSetting(TestConfigSetting.EnumSettingNoKeyBind), 3);
+            AddRepeatStep("Change enum (with bind)", () => config.IncrementEnumSetting(TestConfigSetting.EnumSettingWithKeyBind), 3);
         }
 
         private class TestConfigManager : ConfigManager<TestConfigSetting>
@@ -44,10 +44,10 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             protected override void InitialiseDefaults()
             {
-                SetDefault(TestConfigSetting.ToggleSettingNoKeybind, false);
-                SetDefault(TestConfigSetting.EnumSettingNoKeybind, EnumSetting.Setting1);
-                SetDefault(TestConfigSetting.ToggleSettingWithKeybind, false);
-                SetDefault(TestConfigSetting.EnumSettingWithKeybind, EnumSetting.Setting1);
+                SetDefault(TestConfigSetting.ToggleSettingNoKeyBind, false);
+                SetDefault(TestConfigSetting.EnumSettingNoKeyBind, EnumSetting.Setting1);
+                SetDefault(TestConfigSetting.ToggleSettingWithKeyBind, false);
+                SetDefault(TestConfigSetting.EnumSettingWithKeyBind, EnumSetting.Setting1);
 
                 base.InitialiseDefaults();
             }
@@ -64,10 +64,10 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
             {
-                new TrackedSetting<bool>(TestConfigSetting.ToggleSettingNoKeybind, b => new SettingDescription(b, "toggle setting with no keybind", b ? "enabled" : "disabled")),
-                new TrackedSetting<EnumSetting>(TestConfigSetting.EnumSettingNoKeybind, v => new SettingDescription(v, "enum setting with no keybind", v.ToString())),
-                new TrackedSetting<bool>(TestConfigSetting.ToggleSettingWithKeybind, b => new SettingDescription(b, "toggle setting with keybind", b ? "enabled" : "disabled", "fake keybind")),
-                new TrackedSetting<EnumSetting>(TestConfigSetting.EnumSettingWithKeybind, v => new SettingDescription(v, "enum setting with keybind", v.ToString(), "fake keybind")),
+                new TrackedSetting<bool>(TestConfigSetting.ToggleSettingNoKeyBind, b => new SettingDescription(b, "toggle setting with no keybind", b ? "enabled" : "disabled")),
+                new TrackedSetting<EnumSetting>(TestConfigSetting.EnumSettingNoKeyBind, v => new SettingDescription(v, "enum setting with no keybind", v.ToString())),
+                new TrackedSetting<bool>(TestConfigSetting.ToggleSettingWithKeyBind, b => new SettingDescription(b, "toggle setting with keybind", b ? "enabled" : "disabled", "fake keybind")),
+                new TrackedSetting<EnumSetting>(TestConfigSetting.EnumSettingWithKeyBind, v => new SettingDescription(v, "enum setting with keybind", v.ToString(), "fake keybind")),
             };
 
             protected override void PerformLoad()
@@ -79,10 +79,10 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private enum TestConfigSetting
         {
-            ToggleSettingNoKeybind,
-            EnumSettingNoKeybind,
-            ToggleSettingWithKeybind,
-            EnumSettingWithKeybind
+            ToggleSettingNoKeyBind,
+            EnumSettingNoKeyBind,
+            ToggleSettingWithKeyBind,
+            EnumSettingWithKeyBind
         }
 
         private enum EnumSetting

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuTextBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuTextBox.cs
@@ -62,6 +62,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         private void clearTextboxes(IEnumerable<OsuTextBox> textBoxes) => AddStep("clear textbox", () => textBoxes.ForEach(textBox => textBox.Text = null));
-        private void expectedValue(IEnumerable<OsuTextBox> textBoxes, string value) => AddAssert("expected textbox value", () => textBoxes.All(textbox => textbox.Text == value));
+        private void expectedValue(IEnumerable<OsuTextBox> textBoxes, string value) => AddAssert("expected textbox value", () => textBoxes.All(textBox => textBox.Text == value));
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
+++ b/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.GreySeafoam
+                    Colour = colours.GreySeaFoam
                 },
                 CreateContent()
             });

--- a/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
@@ -85,14 +85,14 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
         private ScrollState scrollState;
 
-        private void setScrollState(ScrollState newstate)
+        private void setScrollState(ScrollState newState)
         {
-            if (scrollState == newstate)
+            if (scrollState == newState)
                 return;
 
             delayedStateChangeDelegate?.Cancel();
 
-            switch (scrollState = newstate)
+            switch (scrollState = newState)
             {
                 case ScrollState.Scrolling:
                     resetSelected();

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -208,10 +208,10 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         {
             if (Match.Round.Value == null) return;
 
-            int instaWinAmount = Match.Round.Value.BestOf.Value / 2;
+            int instantWinAmount = Match.Round.Value.BestOf.Value / 2;
 
             Match.Completed.Value = Match.Round.Value.BestOf.Value > 0
-                                    && (Match.Team1Score.Value + Match.Team2Score.Value >= Match.Round.Value.BestOf.Value || Match.Team1Score.Value > instaWinAmount || Match.Team2Score.Value > instaWinAmount);
+                                    && (Match.Team1Score.Value + Match.Team2Score.Value >= Match.Round.Value.BestOf.Value || Match.Team1Score.Value > instantWinAmount || Match.Team2Score.Value > instantWinAmount);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tournament.Screens.Setup
                     {
                         new Box
                         {
-                            Colour = colours.GreySeafoamDark,
+                            Colour = colours.GreySeaFoamDark,
                             RelativeSizeAxes = Axes.Both,
                         },
                         new GridContainer

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -94,9 +94,9 @@ namespace osu.Game.Beatmaps.Drawables
             if (colourProvider != null)
                 statusText.Colour = status == BeatmapOnlineStatus.Graveyard ? colourProvider.Background1 : colourProvider.Background3;
             else
-                statusText.Colour = status == BeatmapOnlineStatus.Graveyard ? colours.GreySeafoamLight : Color4.Black;
+                statusText.Colour = status == BeatmapOnlineStatus.Graveyard ? colours.GreySeaFoamLight : Color4.Black;
 
-            background.Colour = OsuColour.ForBeatmapSetOnlineStatus(Status) ?? colourProvider?.Light1 ?? colours.GreySeafoamLighter;
+            background.Colour = OsuColour.ForBeatmapSetOnlineStatus(Status) ?? colourProvider?.Light1 ?? colours.GreySeaFoamLighter;
         }
     }
 }

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -146,8 +146,8 @@ namespace osu.Game.Collections
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                BackgroundUnfocused = colours.GreySeafoamDarker.Darken(0.5f);
-                BackgroundFocused = colours.GreySeafoam;
+                BackgroundUnfocused = colours.GreySeaFoamDarker.Darken(0.5f);
+                BackgroundFocused = colours.GreySeaFoam;
             }
         }
 

--- a/osu.Game/Collections/ManageCollectionsDialog.cs
+++ b/osu.Game/Collections/ManageCollectionsDialog.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Collections
             {
                 new Box
                 {
-                    Colour = colours.GreySeafoamDark,
+                    Colour = colours.GreySeaFoamDark,
                     RelativeSizeAxes = Axes.Both,
                 },
                 new Container
@@ -82,7 +82,7 @@ namespace osu.Game.Collections
                                             Anchor = Anchor.CentreRight,
                                             Origin = Anchor.CentreRight,
                                             Icon = FontAwesome.Solid.Times,
-                                            Colour = colours.GreySeafoamDarker,
+                                            Colour = colours.GreySeaFoamDarker,
                                             Scale = new Vector2(0.8f),
                                             X = -10,
                                             Action = () => State.Value = Visibility.Hidden
@@ -100,7 +100,7 @@ namespace osu.Game.Collections
                                         new Box
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            Colour = colours.GreySeafoamDarker
+                                            Colour = colours.GreySeaFoamDarker
                                         },
                                         new DrawableCollectionList
                                         {

--- a/osu.Game/Graphics/DateTooltip.cs
+++ b/osu.Game/Graphics/DateTooltip.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Graphics
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            background.Colour = colours.GreySeafoamDarker;
+            background.Colour = colours.GreySeaFoamDarker;
             timeText.Colour = colours.BlueLighter;
         }
 

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -212,12 +212,12 @@ namespace osu.Game.Graphics
         public readonly Color4 GreySkyDark = Color4Extensions.FromHex(@"303d47");
         public readonly Color4 GreySkyDarker = Color4Extensions.FromHex(@"21272c");
 
-        public readonly Color4 Seafoam = Color4Extensions.FromHex(@"05ffa2");
-        public readonly Color4 GreySeafoamLighter = Color4Extensions.FromHex(@"9ebab1");
-        public readonly Color4 GreySeafoamLight = Color4Extensions.FromHex(@"4d7365");
-        public readonly Color4 GreySeafoam = Color4Extensions.FromHex(@"33413c");
-        public readonly Color4 GreySeafoamDark = Color4Extensions.FromHex(@"2c3532");
-        public readonly Color4 GreySeafoamDarker = Color4Extensions.FromHex(@"1e2422");
+        public readonly Color4 SeaFoam = Color4Extensions.FromHex(@"05ffa2");
+        public readonly Color4 GreySeaFoamLighter = Color4Extensions.FromHex(@"9ebab1");
+        public readonly Color4 GreySeaFoamLight = Color4Extensions.FromHex(@"4d7365");
+        public readonly Color4 GreySeaFoam = Color4Extensions.FromHex(@"33413c");
+        public readonly Color4 GreySeaFoamDark = Color4Extensions.FromHex(@"2c3532");
+        public readonly Color4 GreySeaFoamDarker = Color4Extensions.FromHex(@"1e2422");
 
         public readonly Color4 Cyan = Color4Extensions.FromHex(@"05f4fd");
         public readonly Color4 GreyCyanLighter = Color4Extensions.FromHex(@"77b1b3");

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -39,10 +39,10 @@ namespace osu.Game.Graphics
         public static IconUsage ListSearch => Get(0xe032);
 
         //osu! playstyles
-        public static IconUsage PlaystyleTablet => Get(0xe02a);
-        public static IconUsage PlaystyleMouse => Get(0xe029);
-        public static IconUsage PlaystyleKeyboard => Get(0xe02b);
-        public static IconUsage PlaystyleTouch => Get(0xe02c);
+        public static IconUsage PlayStyleTablet => Get(0xe02a);
+        public static IconUsage PlayStyleMouse => Get(0xe029);
+        public static IconUsage PlayStyleKeyboard => Get(0xe02b);
+        public static IconUsage PlayStyleTouch => Get(0xe02c);
 
         // osu! difficulties
         public static IconUsage EasyOsu => Get(0xe015);
@@ -77,17 +77,17 @@ namespace osu.Game.Graphics
         public static IconUsage ModAutopilot => Get(0xe03a);
         public static IconUsage ModAuto => Get(0xe03b);
         public static IconUsage ModCinema => Get(0xe03c);
-        public static IconUsage ModDoubletime => Get(0xe03d);
+        public static IconUsage ModDoubleTime => Get(0xe03d);
         public static IconUsage ModEasy => Get(0xe03e);
         public static IconUsage ModFlashlight => Get(0xe03f);
         public static IconUsage ModHalftime => Get(0xe040);
-        public static IconUsage ModHardrock => Get(0xe041);
+        public static IconUsage ModHardRock => Get(0xe041);
         public static IconUsage ModHidden => Get(0xe042);
         public static IconUsage ModNightcore => Get(0xe043);
-        public static IconUsage ModNofail => Get(0xe044);
+        public static IconUsage ModNoFail => Get(0xe044);
         public static IconUsage ModRelax => Get(0xe045);
-        public static IconUsage ModSpunout => Get(0xe046);
-        public static IconUsage ModSuddendeath => Get(0xe047);
+        public static IconUsage ModSpunOut => Get(0xe046);
+        public static IconUsage ModSuddenDeath => Get(0xe047);
         public static IconUsage ModTarget => Get(0xe048);
         public static IconUsage ModBg => Get(0xe04a);
     }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                 InternalChild = new Box
                 {
-                    Colour = colours.GreySeafoamDarker,
+                    Colour = colours.GreySeaFoamDarker,
                     RelativeSizeAxes = Axes.Both,
                 };
             }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuHSVColourPicker.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuHSVColourPicker.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] OverlayColourProvider colourProvider, OsuColour osuColour)
         {
-            Background.Colour = colourProvider?.Dark5 ?? osuColour.GreySeafoamDark;
+            Background.Colour = colourProvider?.Dark5 ?? osuColour.GreySeaFoamDark;
 
             Content.Padding = new MarginPadding(spacing);
             Content.Spacing = new Vector2(0, spacing);

--- a/osu.Game/Graphics/UserInterfaceV2/OsuHexColourPicker.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuHexColourPicker.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour osuColour)
         {
-            Background.Colour = overlayColourProvider?.Dark6 ?? osuColour.GreySeafoamDarker;
+            Background.Colour = overlayColourProvider?.Dark6 ?? osuColour.GreySeaFoamDarker;
         }
 
         protected override TextBox CreateHexCodeTextBox() => new OsuTextBox();

--- a/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] OverlayColourProvider colourProvider, OsuColour colours)
         {
-            Background.Colour = Arrow.Colour = colourProvider?.Background4 ?? colours.GreySeafoamDarker;
+            Background.Colour = Arrow.Colour = colourProvider?.Background4 ?? colours.GreySeaFoamDarker;
         }
 
         protected override Drawable CreateArrow() => Empty();

--- a/osu.Game/IO/Legacy/SerializationReader.cs
+++ b/osu.Game/IO/Legacy/SerializationReader.cs
@@ -235,9 +235,9 @@ namespace osu.Game.IO.Legacy
 
                     if (typeName.Contains("System.Collections.Generic") && typeName.Contains("[["))
                     {
-                        string[] splitTyps = typeName.Split('[');
+                        string[] splitTypes = typeName.Split('[');
 
-                        foreach (string typ in splitTyps)
+                        foreach (string typ in splitTypes)
                         {
                             if (typ.Contains("Version"))
                             {

--- a/osu.Game/Online/API/APIException.cs
+++ b/osu.Game/Online/API/APIException.cs
@@ -7,8 +7,8 @@ namespace osu.Game.Online.API
 {
     public class APIException : InvalidOperationException
     {
-        public APIException(string messsage, Exception innerException)
-            : base(messsage, innerException)
+        public APIException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"beatmap_playcounts_count")]
         public int BeatmapPlayCountsCount;
 
-        [JsonProperty]
+        [JsonProperty(@"playstyle")]
         private string[] playStyle
         {
             set => PlayStyles = value?.Select(str => Enum.Parse(typeof(APIPlayStyle), str, true)).Cast<APIPlayStyle>().ToArray();

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -152,10 +152,10 @@ namespace osu.Game.Online.API.Requests.Responses
         public int ScoresRecentCount;
 
         [JsonProperty(@"beatmap_playcounts_count")]
-        public int BeatmapPlaycountsCount;
+        public int BeatmapPlayCountsCount;
 
         [JsonProperty]
-        private string[] playstyle
+        private string[] playStyle
         {
             set => PlayStyles = value?.Select(str => Enum.Parse(typeof(APIPlayStyle), str, true)).Cast<APIPlayStyle>().ToArray();
         }
@@ -213,7 +213,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public APIUserAchievement[] Achievements;
 
         [JsonProperty("monthly_playcounts")]
-        public APIUserHistoryCount[] MonthlyPlaycounts;
+        public APIUserHistoryCount[] MonthlyPlayCounts;
 
         [JsonProperty("replays_watched_counts")]
         public APIUserHistoryCount[] ReplaysWatchedCounts;

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -335,7 +335,7 @@ namespace osu.Game.Online.Chat
         /// right now it caps out at 50 messages and therefore only returns one channel's worth of content.
         /// </summary>
         /// <param name="channel">The channel </param>
-        private void fetchInitalMessages(Channel channel)
+        private void fetchInitialMessages(Channel channel)
         {
             if (channel.Id <= 0 || channel.MessagesLoaded) return;
 
@@ -441,7 +441,7 @@ namespace osu.Game.Online.Chat
             else
             {
                 if (fetchInitialMessages)
-                    fetchInitalMessages(channel);
+                    this.fetchInitialMessages(channel);
             }
 
             CurrentChannel.Value ??= channel;

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Online.Chat
             [BackgroundDependencyLoader]
             private void load(OsuColour colours, ChatOverlay chatOverlay, NotificationOverlay notificationOverlay, ChannelManager channelManager)
             {
-                IconBackgound.Colour = colours.PurpleDark;
+                IconBackground.Colour = colours.PurpleDark;
 
                 Activated = delegate
                 {

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -23,27 +23,27 @@ namespace osu.Game.Online.Chat
     {
         public readonly Bindable<Channel> Channel = new Bindable<Channel>();
 
-        protected readonly ChatTextBox Textbox;
+        protected readonly ChatTextBox TextBox;
 
         protected ChannelManager ChannelManager;
 
         private StandAloneDrawableChannel drawableChannel;
 
-        private readonly bool postingTextbox;
+        private readonly bool postingTextBox;
 
         protected readonly Box Background;
 
-        private const float textbox_height = 30;
+        private const float text_box_height = 30;
 
         /// <summary>
         /// Construct a new instance.
         /// </summary>
-        /// <param name="postingTextbox">Whether a textbox for posting new messages should be displayed.</param>
-        public StandAloneChatDisplay(bool postingTextbox = false)
+        /// <param name="postingTextBox">Whether a textbox for posting new messages should be displayed.</param>
+        public StandAloneChatDisplay(bool postingTextBox = false)
         {
             const float corner_radius = 10;
 
-            this.postingTextbox = postingTextbox;
+            this.postingTextBox = postingTextBox;
             CornerRadius = corner_radius;
             Masking = true;
 
@@ -57,12 +57,12 @@ namespace osu.Game.Online.Chat
                 },
             };
 
-            if (postingTextbox)
+            if (postingTextBox)
             {
-                AddInternal(Textbox = new ChatTextBox
+                AddInternal(TextBox = new ChatTextBox
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = textbox_height,
+                    Height = text_box_height,
                     PlaceholderText = "type your message",
                     CornerRadius = corner_radius,
                     ReleaseFocusOnCommit = false,
@@ -71,7 +71,7 @@ namespace osu.Game.Online.Chat
                     Origin = Anchor.BottomLeft,
                 });
 
-                Textbox.OnCommit += postMessage;
+                TextBox.OnCommit += postMessage;
             }
 
             Channel.BindValueChanged(channelChanged);
@@ -86,9 +86,9 @@ namespace osu.Game.Online.Chat
         protected virtual StandAloneDrawableChannel CreateDrawableChannel(Channel channel) =>
             new StandAloneDrawableChannel(channel);
 
-        private void postMessage(TextBox sender, bool newtext)
+        private void postMessage(TextBox sender, bool newText)
         {
-            string text = Textbox.Text.Trim();
+            string text = TextBox.Text.Trim();
 
             if (string.IsNullOrWhiteSpace(text))
                 return;
@@ -98,7 +98,7 @@ namespace osu.Game.Online.Chat
             else
                 ChannelManager?.PostMessage(text, target: Channel.Value);
 
-            Textbox.Text = string.Empty;
+            TextBox.Text = string.Empty;
         }
 
         protected virtual ChatLine CreateMessage(Message message) => new StandAloneMessage(message);
@@ -111,7 +111,7 @@ namespace osu.Game.Online.Chat
 
             drawableChannel = CreateDrawableChannel(e.NewValue);
             drawableChannel.CreateChatLineAction = CreateMessage;
-            drawableChannel.Padding = new MarginPadding { Bottom = postingTextbox ? textbox_height : 0 };
+            drawableChannel.Padding = new MarginPadding { Bottom = postingTextBox ? text_box_height : 0 };
 
             AddInternal(drawableChannel);
         }

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Online.Rooms
         }
 
         public bool ShouldSerializeID() => false;
-        public bool ShouldSerializeapiBeatmap() => false;
+        public bool ShouldSerializeAPIBeatmap() => false;
 
         public bool Equals(PlaylistItem other)
             => ID == other?.ID

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -152,12 +152,12 @@ namespace osu.Game.Overlays.AccountCreation
             loadingLayer.Hide();
 
             if (host?.OnScreenKeyboardOverlapsGameWindow != true)
-                focusNextTextbox();
+                focusNextTextBox();
         }
 
         private void performRegistration()
         {
-            if (focusNextTextbox())
+            if (focusNextTextBox())
             {
                 registerShake.Shake();
                 return;
@@ -209,19 +209,19 @@ namespace osu.Game.Overlays.AccountCreation
             });
         }
 
-        private bool focusNextTextbox()
+        private bool focusNextTextBox()
         {
-            var nextTextbox = nextUnfilledTextbox();
+            var nextTextBox = nextUnfilledTextBox();
 
-            if (nextTextbox != null)
+            if (nextTextBox != null)
             {
-                Schedule(() => GetContainingInputManager().ChangeFocus(nextTextbox));
+                Schedule(() => GetContainingInputManager().ChangeFocus(nextTextBox));
                 return true;
             }
 
             return false;
         }
 
-        private OsuTextBox nextUnfilledTextbox() => textboxes.FirstOrDefault(t => string.IsNullOrEmpty(t.Text));
+        private OsuTextBox nextUnfilledTextBox() => textboxes.FirstOrDefault(t => string.IsNullOrEmpty(t.Text));
     }
 }

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays
         public LocalisableString Title => ChatStrings.HeaderTitle;
         public LocalisableString Description => ChatStrings.HeaderDescription;
 
-        private const float textbox_height = 60;
+        private const float text_box_height = 60;
         private const float channel_selection_min_height = 0.3f;
 
         [Resolved]
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays
 
         private LoadingSpinner loading;
 
-        private FocusedTextBox textbox;
+        private FocusedTextBox textBox;
 
         private const int transition_length = 500;
 
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays
                                             RelativeSizeAxes = Axes.Both,
                                             Padding = new MarginPadding
                                             {
-                                                Bottom = textbox_height
+                                                Bottom = text_box_height
                                             },
                                         },
                                         new Container
@@ -141,7 +141,7 @@ namespace osu.Game.Overlays
                                             Anchor = Anchor.BottomLeft,
                                             Origin = Anchor.BottomLeft,
                                             RelativeSizeAxes = Axes.X,
-                                            Height = textbox_height,
+                                            Height = text_box_height,
                                             Padding = new MarginPadding
                                             {
                                                 Top = padding * 2,
@@ -151,7 +151,7 @@ namespace osu.Game.Overlays
                                             },
                                             Children = new Drawable[]
                                             {
-                                                textbox = new FocusedTextBox
+                                                textBox = new FocusedTextBox
                                                 {
                                                     RelativeSizeAxes = Axes.Both,
                                                     Height = 1,
@@ -197,7 +197,7 @@ namespace osu.Game.Overlays
                 },
             };
 
-            textbox.OnCommit += postMessage;
+            textBox.OnCommit += postMessage;
 
             ChannelTabControl.Current.ValueChanged += current => channelManager.CurrentChannel.Value = current.NewValue;
             ChannelTabControl.ChannelSelectorActive.ValueChanged += active => ChannelSelectionOverlay.State.Value = active.NewValue ? Visibility.Visible : Visibility.Hidden;
@@ -208,12 +208,12 @@ namespace osu.Game.Overlays
 
                 if (state.NewValue == Visibility.Visible)
                 {
-                    textbox.HoldFocus = false;
+                    textBox.HoldFocus = false;
                     if (1f - ChatHeight.Value < channel_selection_min_height)
                         this.TransformBindableTo(ChatHeight, 1f - channel_selection_min_height, 800, Easing.OutQuint);
                 }
                 else
-                    textbox.HoldFocus = true;
+                    textBox.HoldFocus = true;
             };
 
             ChannelSelectionOverlay.OnRequestJoin = channel => channelManager.JoinChannel(channel);
@@ -253,7 +253,7 @@ namespace osu.Game.Overlays
         {
             if (e.NewValue == null)
             {
-                textbox.Current.Disabled = true;
+                textBox.Current.Disabled = true;
                 currentChannelContainer.Clear(false);
                 ChannelSelectionOverlay.Show();
                 return;
@@ -262,7 +262,7 @@ namespace osu.Game.Overlays
             if (e.NewValue is ChannelSelectorTabItem.ChannelSelectorTabChannel)
                 return;
 
-            textbox.Current.Disabled = e.NewValue.ReadOnly;
+            textBox.Current.Disabled = e.NewValue.ReadOnly;
 
             if (ChannelTabControl.Current.Value != e.NewValue)
                 Scheduler.Add(() => ChannelTabControl.Current.Value = e.NewValue);
@@ -402,7 +402,7 @@ namespace osu.Game.Overlays
         protected override void OnFocus(FocusEvent e)
         {
             // this is necessary as textbox is masked away and therefore can't get focus :(
-            textbox.TakeFocus();
+            textBox.TakeFocus();
             base.OnFocus(e);
         }
 
@@ -411,7 +411,7 @@ namespace osu.Game.Overlays
             this.MoveToY(0, transition_length, Easing.OutQuint);
             this.FadeIn(transition_length, Easing.OutQuint);
 
-            textbox.HoldFocus = true;
+            textBox.HoldFocus = true;
 
             base.PopIn();
         }
@@ -423,7 +423,7 @@ namespace osu.Game.Overlays
 
             ChannelSelectionOverlay.Hide();
 
-            textbox.HoldFocus = false;
+            textBox.HoldFocus = false;
             base.PopOut();
         }
 
@@ -481,9 +481,9 @@ namespace osu.Game.Overlays
             }
         }
 
-        private void postMessage(TextBox textbox, bool newText)
+        private void postMessage(TextBox textBox, bool newText)
         {
-            string text = textbox.Text.Trim();
+            string text = textBox.Text.Trim();
 
             if (string.IsNullOrWhiteSpace(text))
                 return;
@@ -493,7 +493,7 @@ namespace osu.Game.Overlays
             else
                 channelManager.PostMessage(text);
 
-            textbox.Text = string.Empty;
+            textBox.Text = string.Empty;
         }
 
         private class TabsArea : Container

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -362,15 +362,15 @@ namespace osu.Game.Overlays.Comments
 
         private void updateButtonsState()
         {
-            int loadedReplesCount = loadedReplies.Count;
-            bool hasUnloadedReplies = loadedReplesCount != Comment.RepliesCount;
+            int loadedRepliesCount = loadedReplies.Count;
+            bool hasUnloadedReplies = loadedRepliesCount != Comment.RepliesCount;
 
-            loadRepliesButton.FadeTo(hasUnloadedReplies && loadedReplesCount == 0 ? 1 : 0);
-            showMoreButton.FadeTo(hasUnloadedReplies && loadedReplesCount > 0 ? 1 : 0);
-            showRepliesButton.FadeTo(loadedReplesCount != 0 ? 1 : 0);
+            loadRepliesButton.FadeTo(hasUnloadedReplies && loadedRepliesCount == 0 ? 1 : 0);
+            showMoreButton.FadeTo(hasUnloadedReplies && loadedRepliesCount > 0 ? 1 : 0);
+            showRepliesButton.FadeTo(loadedRepliesCount != 0 ? 1 : 0);
 
             if (Comment.IsTopLevel)
-                chevronButton.FadeTo(loadedReplesCount != 0 ? 1 : 0);
+                chevronButton.FadeTo(loadedRepliesCount != 0 ? 1 : 0);
 
             showMoreButton.IsLoading = loadRepliesButton.IsLoading = false;
         }

--- a/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Overlays.Notifications
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            IconBackgound.Colour = ColourInfo.GradientVertical(colours.GreenDark, colours.GreenLight);
+            IconBackground.Colour = ColourInfo.GradientVertical(colours.GreenDark, colours.GreenLight);
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -43,13 +43,13 @@ namespace osu.Game.Overlays.Notifications
         private readonly TextFlowContainer textDrawable;
         private readonly SpriteIcon iconDrawable;
 
-        protected Box IconBackgound;
+        protected Box IconBackground;
 
         public SimpleNotification()
         {
             IconContent.AddRange(new Drawable[]
             {
-                IconBackgound = new Box
+                IconBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.6f))

--- a/osu.Game/Overlays/Profile/Header/Components/PreviousUsernames.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/PreviousUsernames.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            background.Colour = colours.GreySeafoamDarker;
+            background.Colour = colours.GreySeaFoamDarker;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
             ItemsContainer.Direction = FillDirection.Vertical;
         }
 
-        protected override int GetCount(APIUser user) => user.BeatmapPlaycountsCount;
+        protected override int GetCount(APIUser user) => user.BeatmapPlayCountsCount;
 
         protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest() =>
             new GetUserMostPlayedBeatmapsRequest(User.Value.Id, VisiblePages++, ItemsPerPage);

--- a/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
@@ -17,6 +17,6 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
         {
         }
 
-        protected override APIUserHistoryCount[] GetValues(APIUser user) => user?.MonthlyPlaycounts;
+        protected override APIUserHistoryCount[] GetValues(APIUser user) => user?.MonthlyPlayCounts;
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/DrawableKudosuHistoryItem.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/DrawableKudosuHistoryItem.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
         [BackgroundDependencyLoader]
         private void load()
         {
-            date.Colour = colours.GreySeafoamLighter;
+            date.Colour = colours.GreySeaFoamLighter;
             var formattedSource = MessageFormatter.FormatText(getString(historyItem));
             linkFlowContainer.AddLinks(formattedSource.Text, formattedSource.Links);
         }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/DirectorySelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/DirectorySelectScreen.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = colours.GreySeafoamDark
+                        Colour = colours.GreySeaFoamDark
                     },
                     new GridContainer
                     {

--- a/osu.Game/Rulesets/Mods/ModBlockFail.cs
+++ b/osu.Game/Rulesets/Mods/ModBlockFail.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
 
         public void ApplyToHUD(HUDOverlay overlay)
         {
-            overlay.ShowHealthbar.BindTo(showHealthBar);
+            overlay.ShowHealthBar.BindTo(showHealthBar);
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Double Time";
         public override string Acronym => "DT";
-        public override IconUsage? Icon => OsuIcon.ModDoubletime;
+        public override IconUsage? Icon => OsuIcon.ModDoubleTime;
         public override ModType Type => ModType.DifficultyIncrease;
         public override string Description => "Zoooooooooom...";
 

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Hard Rock";
         public override string Acronym => "HR";
-        public override IconUsage? Icon => OsuIcon.ModHardrock;
+        public override IconUsage? Icon => OsuIcon.ModHardRock;
         public override ModType Type => ModType.DifficultyIncrease;
         public override string Description => "Everything just got a bit harder...";
         public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust) };

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "No Fail";
         public override string Acronym => "NF";
-        public override IconUsage? Icon => OsuIcon.ModNofail;
+        public override IconUsage? Icon => OsuIcon.ModNoFail;
         public override ModType Type => ModType.DifficultyReduction;
         public override string Description => "You can't fail, no matter what.";
         public override double ScoreMultiplier => 0.5;

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Sudden Death";
         public override string Acronym => "SD";
-        public override IconUsage? Icon => OsuIcon.ModSuddendeath;
+        public override IconUsage? Icon => OsuIcon.ModSuddenDeath;
         public override ModType Type => ModType.DifficultyIncrease;
         public override string Description => "Miss and fail.";
         public override double ScoreMultiplier => 1;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -188,12 +188,12 @@ namespace osu.Game.Rulesets.Objects.Legacy
             string[] split = str.Split(':');
 
             var bank = (LegacySampleBank)Parsing.ParseInt(split[0]);
-            var addbank = (LegacySampleBank)Parsing.ParseInt(split[1]);
+            var addBank = (LegacySampleBank)Parsing.ParseInt(split[1]);
 
             string stringBank = bank.ToString().ToLowerInvariant();
             if (stringBank == @"none")
                 stringBank = null;
-            string stringAddBank = addbank.ToString().ToLowerInvariant();
+            string stringAddBank = addBank.ToString().ToLowerInvariant();
             if (stringAddBank == @"none")
                 stringAddBank = null;
 

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -250,13 +250,13 @@ namespace osu.Game.Rulesets.Objects
                     if (subControlPoints.Length != 3)
                         break;
 
-                    List<Vector2> subpath = PathApproximator.ApproximateCircularArc(subControlPoints);
+                    List<Vector2> subPath = PathApproximator.ApproximateCircularArc(subControlPoints);
 
                     // If for some reason a circular arc could not be fit to the 3 given points, fall back to a numerically stable bezier approximation.
-                    if (subpath.Count == 0)
+                    if (subPath.Count == 0)
                         break;
 
-                    return subpath;
+                    return subPath;
 
                 case PathType.Catmull:
                     return PathApproximator.ApproximateCatmull(subControlPoints);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             TriggerOperationStarted();
             Action?.Invoke();
-            TriggerOperatoinEnded();
+            TriggerOperationEnded();
             return true;
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxControl.cs
@@ -92,6 +92,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected void TriggerOperationStarted() => OperationStarted?.Invoke();
 
-        protected void TriggerOperatoinEnded() => OperationEnded?.Invoke();
+        protected void TriggerOperationEnded() => OperationEnded?.Invoke();
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxDragHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxDragHandle.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void OnDragEnd(DragEndEvent e)
         {
-            TriggerOperatoinEnded();
+            TriggerOperationEnded();
 
             UpdateHoverState();
             base.OnDragEnd(e);

--- a/osu.Game/Screens/Edit/Setup/SetupScreenHeaderBackground.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreenHeaderBackground.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.Edit.Setup
                     {
                         new Box
                         {
-                            Colour = colours.GreySeafoamDarker,
+                            Colour = colours.GreySeaFoamDarker,
                             RelativeSizeAxes = Axes.Both,
                         },
                         new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 24))

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Edit.Timing
         }
 
         private readonly SettingsSlider<T> slider;
-        private readonly LabelledTextBox textbox;
+        private readonly LabelledTextBox textBox;
 
         /// <summary>
         /// Creates an <see cref="IndeterminateSliderWithTextBoxInput{T}"/>.
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Edit.Timing
                     Spacing = new Vector2(0, 5),
                     Children = new Drawable[]
                     {
-                        textbox = new LabelledTextBox
+                        textBox = new LabelledTextBox
                         {
                             Label = labelText,
                         },
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Timing
                 },
             };
 
-            textbox.OnCommit += (t, isNew) =>
+            textBox.OnCommit += (t, isNew) =>
             {
                 if (!isNew) return;
 
@@ -110,13 +110,13 @@ namespace osu.Game.Screens.Edit.Timing
 
                 // use the value from the slider to ensure that any precision/min/max set on it via the initial indeterminate value have been applied correctly.
                 decimal decimalValue = slider.Current.Value.ToDecimal(NumberFormatInfo.InvariantInfo);
-                textbox.Text = decimalValue.ToString($@"N{FormatUtils.FindPrecision(decimalValue)}");
-                textbox.PlaceholderText = string.Empty;
+                textBox.Text = decimalValue.ToString($@"N{FormatUtils.FindPrecision(decimalValue)}");
+                textBox.PlaceholderText = string.Empty;
             }
             else
             {
-                textbox.Text = null;
-                textbox.PlaceholderText = "(multiple)";
+                textBox.Text = null;
+                textBox.PlaceholderText = "(multiple)";
             }
         }
     }

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         public SliderWithTextBoxInput(LocalisableString labelText)
         {
-            LabelledTextBox textbox;
+            LabelledTextBox textBox;
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Edit.Timing
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        textbox = new LabelledTextBox
+                        textBox = new LabelledTextBox
                         {
                             Label = labelText,
                         },
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Edit.Timing
                 },
             };
 
-            textbox.OnCommit += (t, isNew) =>
+            textBox.OnCommit += (t, isNew) =>
             {
                 if (!isNew) return;
 
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             Current.BindValueChanged(val =>
             {
-                textbox.Text = val.NewValue.ToString();
+                textBox.Text = val.NewValue.ToString();
             }, true);
         }
 

--- a/osu.Game/Screens/Import/FileImportScreen.cs
+++ b/osu.Game/Screens/Import/FileImportScreen.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.Import
                 {
                     new Box
                     {
-                        Colour = colours.GreySeafoamDark,
+                        Colour = colours.GreySeaFoamDark,
                         RelativeSizeAxes = Axes.Both,
                     },
                     fileSelector = new OsuFileSelector(validFileExtensions: game.HandledExtensions.ToArray())
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Import
                         {
                             new Box
                             {
-                                Colour = colours.GreySeafoamDarker,
+                                Colour = colours.GreySeaFoamDarker,
                                 RelativeSizeAxes = Axes.Both
                             },
                             new Container

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// How much should each bar go down each millisecond (based on a full bar).
         /// </summary>
-        private const float decay_per_milisecond = 0.0024f;
+        private const float decay_per_millisecond = 0.0024f;
 
         /// <summary>
         /// Number of milliseconds between each amplitude update.
@@ -136,7 +136,7 @@ namespace osu.Game.Screens.Menu
         {
             base.Update();
 
-            float decayFactor = (float)Time.Elapsed * decay_per_milisecond;
+            float decayFactor = (float)Time.Elapsed * decay_per_millisecond;
 
             for (int i = 0; i < bars_per_visualiser; i++)
             {

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 this.room = room;
             }
 
-            private OsuPasswordTextBox passwordTextbox;
+            private OsuPasswordTextBox passwordTextBox;
             private TriangleButton joinButton;
             private OsuSpriteText errorText;
             private Sample sampleJoinFail;
@@ -218,7 +218,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                passwordTextbox = new OsuPasswordTextBox
+                                passwordTextBox = new OsuPasswordTextBox
                                 {
                                     Width = 200,
                                     PlaceholderText = "password",
@@ -246,21 +246,21 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             {
                 base.LoadComplete();
 
-                Schedule(() => GetContainingInputManager().ChangeFocus(passwordTextbox));
-                passwordTextbox.OnCommit += (_, __) => performJoin();
+                Schedule(() => GetContainingInputManager().ChangeFocus(passwordTextBox));
+                passwordTextBox.OnCommit += (_, __) => performJoin();
             }
 
             private void performJoin()
             {
-                lounge?.Join(room, passwordTextbox.Text, null, joinFailed);
-                GetContainingInputManager().TriggerFocusContention(passwordTextbox);
+                lounge?.Join(room, passwordTextBox.Text, null, joinFailed);
+                GetContainingInputManager().TriggerFocusContention(passwordTextBox);
             }
 
             private void joinFailed(string error) => Schedule(() =>
             {
-                passwordTextbox.Text = string.Empty;
+                passwordTextBox.Text = string.Empty;
 
-                GetContainingInputManager().ChangeFocus(passwordTextbox);
+                GetContainingInputManager().ChangeFocus(passwordTextBox);
 
                 errorText.Text = error;
                 errorText

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         public Bindable<bool> Expanded = new Bindable<bool>();
 
-        private readonly Bindable<bool> expandedFromTextboxFocus = new Bindable<bool>();
+        private readonly Bindable<bool> expandedFromTextBoxFocus = new Bindable<bool>();
 
         private const float height = 100;
 
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             Background.Alpha = 0.2f;
 
-            Textbox.FocusLost = () => expandedFromTextboxFocus.Value = false;
+            TextBox.FocusLost = () => expandedFromTextBoxFocus.Value = false;
         }
 
         protected override bool OnHover(HoverEvent e) => true; // use UI mouse cursor.
@@ -51,14 +51,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             {
                 // for now let's never hold focus. this avoid misdirected gameplay keys entering chat.
                 // note that this is done within this callback as it triggers an un-focus as well.
-                Textbox.HoldFocus = false;
+                TextBox.HoldFocus = false;
 
                 // only hold focus (after sending a message) during breaks
-                Textbox.ReleaseFocusOnCommit = playing.NewValue;
+                TextBox.ReleaseFocusOnCommit = playing.NewValue;
             }, true);
 
             Expanded.BindValueChanged(_ => updateExpandedState(), true);
-            expandedFromTextboxFocus.BindValueChanged(focus =>
+            expandedFromTextBoxFocus.BindValueChanged(focus =>
             {
                 if (focus.NewValue)
                     updateExpandedState();
@@ -76,25 +76,25 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             switch (e.Action)
             {
                 case GlobalAction.Back:
-                    if (Textbox.HasFocus)
+                    if (TextBox.HasFocus)
                     {
-                        Schedule(() => Textbox.KillFocus());
+                        Schedule(() => TextBox.KillFocus());
                         return true;
                     }
 
                     break;
 
                 case GlobalAction.ToggleChatFocus:
-                    if (Textbox.HasFocus)
+                    if (TextBox.HasFocus)
                     {
-                        Schedule(() => Textbox.KillFocus());
+                        Schedule(() => TextBox.KillFocus());
                     }
                     else
                     {
-                        expandedFromTextboxFocus.Value = true;
+                        expandedFromTextBoxFocus.Value = true;
 
                         // schedule required to ensure the textbox has become present from above bindable update.
-                        Schedule(() => Textbox.TakeFocus());
+                        Schedule(() => TextBox.TakeFocus());
                     }
 
                     return true;
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void updateExpandedState()
         {
-            if (Expanded.Value || expandedFromTextboxFocus.Value)
+            if (Expanded.Value || expandedFromTextBoxFocus.Value)
             {
                 this.FadeIn(300, Easing.OutQuint);
                 this.ResizeHeightTo(height, 500, Easing.OutQuint);

--- a/osu.Game/Screens/Play/HUD/HealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HealthDisplay.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens.Play.HUD
     /// </summary>
     public abstract class HealthDisplay : CompositeDrawable
     {
-        private readonly Bindable<bool> showHealthbar = new Bindable<bool>(true);
+        private readonly Bindable<bool> showHealthBar = new Bindable<bool>(true);
 
         [Resolved]
         protected HealthProcessor HealthProcessor { get; private set; }
@@ -43,10 +43,10 @@ namespace osu.Game.Screens.Play.HUD
             HealthProcessor.NewJudgement += onNewJudgement;
 
             if (hudOverlay != null)
-                showHealthbar.BindTo(hudOverlay.ShowHealthbar);
+                showHealthBar.BindTo(hudOverlay.ShowHealthBar);
 
             // this probably shouldn't be operating on `this.`
-            showHealthbar.BindValueChanged(healthBar => this.FadeTo(healthBar.NewValue ? 1 : 0, HUDOverlay.FADE_DURATION, HUDOverlay.FADE_EASING), true);
+            showHealthBar.BindValueChanged(healthBar => this.FadeTo(healthBar.NewValue ? 1 : 0, HUDOverlay.FADE_DURATION, HUDOverlay.FADE_EASING), true);
         }
 
         private void onNewJudgement(JudgementResult judgement)

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play
         public readonly HoldForMenuButton HoldToQuit;
         public readonly PlayerSettingsOverlay PlayerSettingsOverlay;
 
-        public Bindable<bool> ShowHealthbar = new Bindable<bool>(true);
+        public Bindable<bool> ShowHealthBar = new Bindable<bool>(true);
 
         private readonly DrawableRuleset drawableRuleset;
         private readonly IReadOnlyList<Mod> mods;
@@ -258,7 +258,7 @@ namespace osu.Game.Screens.Play
 
         protected FailingLayer CreateFailingLayer() => new FailingLayer
         {
-            ShowHealth = { BindTarget = ShowHealthbar }
+            ShowHealth = { BindTarget = ShowHealthBar }
         };
 
         protected KeyCounterDisplay CreateKeyCounter() => new KeyCounterDisplay

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -496,7 +496,7 @@ namespace osu.Game.Screens.Play
             private void load(OsuColour colours, AudioManager audioManager, NotificationOverlay notificationOverlay, VolumeOverlay volumeOverlay)
             {
                 Icon = FontAwesome.Solid.VolumeMute;
-                IconBackgound.Colour = colours.RedDark;
+                IconBackground.Colour = colours.RedDark;
 
                 Activated = delegate
                 {
@@ -548,7 +548,7 @@ namespace osu.Game.Screens.Play
             private void load(OsuColour colours, NotificationOverlay notificationOverlay)
             {
                 Icon = FontAwesome.Solid.BatteryQuarter;
-                IconBackgound.Colour = colours.RedDark;
+                IconBackground.Colour = colours.RedDark;
 
                 Activated = delegate
                 {

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSliderBar.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSliderBar.cs
@@ -15,12 +15,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
     {
         public OsuSliderBar<T> Bar => (OsuSliderBar<T>)Control;
 
-        protected override Drawable CreateControl() => new Sliderbar
+        protected override Drawable CreateControl() => new SliderBar
         {
             RelativeSizeAxes = Axes.X
         };
 
-        private class Sliderbar : OsuSliderBar<T>
+        private class SliderBar : OsuSliderBar<T>
         {
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Updater
             private void load(OsuColour colours, ChangelogOverlay changelog, NotificationOverlay notificationOverlay)
             {
                 Icon = FontAwesome.Solid.CheckSquare;
-                IconBackgound.Colour = colours.BlueDark;
+                IconBackground.Colour = colours.BlueDark;
 
                 Activated = delegate
                 {

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -920,27 +920,40 @@ private void load()
 {
 	$END$
 };</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=antiflow/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Beatmap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=beatmaps/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Beatmapset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=beatmap_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catmull/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Daycore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dimmable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Disableable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Drawables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Failable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gamefield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Geki/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hitnormal/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobject/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobjects/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hitsound/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hitsounded/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hitsounds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Judgeable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Katu/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keymods/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kiai/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kudosu/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leaderboard/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leaderboards/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migratable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nightcore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Overlined/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pausable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pippidon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playfield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=playfields/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Poolable/@EntryIndexedValue">True</s:Boolean>
@@ -956,7 +969,9 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rulesets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ruleset_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scorable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=seeya/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Snappable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Soleily/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Spinnable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Strongable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Taiko/@EntryIndexedValue">True</s:Boolean>

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -926,20 +926,44 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catmull/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dimmable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Disableable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Drawables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Failable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobject/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobjects/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Judgeable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keymods/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kiai/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leaderboard/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leaderboards/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migratable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Overlined/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pausable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playfield/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=playfields/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Poolable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Preclicked/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=purgeable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rearrangeable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=refetch/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=refetched/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Refilter/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reinstantiation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resampler/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ruleset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rulesets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ruleset_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scorable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Snappable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Spinnable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Strongable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Taiko/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=undim/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=undownloadable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unhover/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unhovered/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unplayed/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unproxy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unranked/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This was done locally using Rider w/ ReSpeller by enabling the typo inspections and manually checking most of them. I ignored some special cases and added most of them to the dictionary. Only did identifier names for now as comments/strings are another story.

The big problem was with compound words and whether they should be open (i.e. have a space) or closed (i.e. no space). I did my best in determining based on the inspections, but ignored some like `Hitsound` because that spelling is most known to the community and the wiki page has it formatted like that too: https://osu.ppy.sh/wiki/en/Beatmapping/Hitsound.