### PR TITLE
Revert rename of implicitly-used newtonsoft method

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -70,8 +70,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             SliderFactor = values[ATTRIB_ID_SLIDER_FACTOR];
         }
 
-        // Used implicitly by Newtonsoft.Json to not serialize flashlight property in some cases.
+        #region Newtonsoft.Json implicit ShouldSerialize() methods
+
+        // The properties in this region are used implicitly by Newtonsoft.Json to not serialise certain fields in some cases.
+        // They rely on being named exactly the same as the corresponding fields (casing included) and as such should NOT be renamed
+        // unless the fields are also renamed.
+
         [UsedImplicitly]
         public bool ShouldSerializeFlashlightRating() => Mods.Any(m => m is ModFlashlight);
+
+        #endregion
     }
 }

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
@@ -112,8 +113,20 @@ namespace osu.Game.Online.Rooms
             }
         }
 
+        #region Newtonsoft.Json implicit ShouldSerialize() methods
+
+        // The properties in this region are used implicitly by Newtonsoft.Json to not serialise certain fields in some cases.
+        // They rely on being named exactly the same as the corresponding fields (casing included) and as such should NOT be renamed
+        // unless the fields are also renamed.
+
+        [UsedImplicitly]
         public bool ShouldSerializeID() => false;
+
+        // ReSharper disable once IdentifierTypo
+        [UsedImplicitly]
         public bool ShouldSerializeapiBeatmap() => false;
+
+        #endregion
 
         public bool Equals(PlaylistItem other)
             => ID == other?.ID

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Online.Rooms
         }
 
         public bool ShouldSerializeID() => false;
-        public bool ShouldSerializeAPIBeatmap() => false;
+        public bool ShouldSerializeapiBeatmap() => false;
 
         public bool Equals(PlaylistItem other)
             => ID == other?.ID

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -211,8 +212,21 @@ namespace osu.Game.Online.Rooms
                 Playlist.RemoveAll(i => i.Expired);
         }
 
+        #region Newtonsoft.Json implicit ShouldSerialize() methods
+
+        // The properties in this region are used implicitly by Newtonsoft.Json to not serialise certain fields in some cases.
+        // They rely on being named exactly the same as the corresponding fields (casing included) and as such should NOT be renamed
+        // unless the fields are also renamed.
+
+        [UsedImplicitly]
         public bool ShouldSerializeRoomID() => false;
+
+        [UsedImplicitly]
         public bool ShouldSerializeHost() => false;
+
+        [UsedImplicitly]
         public bool ShouldSerializeEndDate() => false;
+
+        #endregion
     }
 }


### PR DESCRIPTION
As per https://github.com/ppy/osu/pull/16266#discussion_r775758350.

Additionally all methods implciitly used by newtonsoft are marked with a region and an inline comment explaining their purpose and the correct procedure for renaming them.