### PR TITLE
Fix `TestSceneMultiSpectatorLeaderboard` not waiting for user population

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for load", () => leaderboard.IsLoaded);
+            AddUntilStep("wait for user population", () => leaderboard.ChildrenOfType<GameplayLeaderboardScore>().Count() == 2);
 
             AddStep("add clock sources", () =>
             {


### PR DESCRIPTION
As seen at https://github.com/peppy/osu/runs/4666507713?check_suite_focus=true.

Same fix as applied to `TestSceneMultiGameplayLeaderboard` previously.