### PR TITLE
Fix `MultiplayerMatchSubScreen` mutating mods outside of bindable lease

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -381,7 +381,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         protected virtual void UpdateMods()
         {
-            if (SelectedItem.Value == null)
+            if (SelectedItem.Value == null || !this.IsCurrentScreen())
                 return;
 
             Mods.Value = UserMods.Value.Concat(SelectedItem.Value.RequiredMods).ToList();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override void UpdateMods()
         {
-            if (SelectedItem.Value == null || client.LocalUser == null)
+            if (SelectedItem.Value == null || client.LocalUser == null || !this.IsCurrentScreen())
                 return;
 
             // update local mods based on room's reported status for the local user (omitting the base call implementation).


### PR DESCRIPTION
As seen at https://github.com/peppy/osu/runs/4674501626?check_suite_focus=true.

`OnResuming` already handles this correctly (ensuring it's run once) so this should be fine, I think.