### PR TITLE
Improve reliability of `TestStoryboardSkipOutro`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -53,8 +53,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest(null);
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("skip outro", () => InputManager.Key(osuTK.Input.Key.Space));
+            AddAssert("player is no longer current screen", () => !Player.IsCurrentScreen());
             AddUntilStep("wait for score shown", () => Player.IsScoreShown);
-            AddUntilStep("time less than storyboard duration", () => Player.GameplayClockContainer.GameplayClock.CurrentTime < currentStoryboardDuration);
         }
 
         [Test]


### PR DESCRIPTION
Aims to resolve failures as seen at https://github.com/peppy/osu/runs/4677353822?check_suite_focus=true.

Have run quite a lot locally with no failures (while removing the skip step 100% fails). Time will tell how it holds up on CI.