### PR TITLE
Add padding to the bottom of the beatmap listing overlay to avoid hovered panels exceeding visible bounds

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
@@ -153,6 +153,5 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 Hollow = true,
             }, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
-
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
@@ -3,16 +3,13 @@
 
 #nullable enable
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input.Events;
 using osu.Framework.Threading;
-using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osuTK;
@@ -157,53 +154,5 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             }, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
 
-        private class ExpandedContentScrollContainer : OsuScrollContainer
-        {
-            public ExpandedContentScrollContainer()
-            {
-                ScrollbarVisible = false;
-            }
-
-            protected override void Update()
-            {
-                base.Update();
-
-                Height = Math.Min(Content.DrawHeight, 400);
-            }
-
-            private bool allowScroll => !Precision.AlmostEquals(DrawSize, Content.DrawSize);
-
-            protected override bool OnDragStart(DragStartEvent e)
-            {
-                if (!allowScroll)
-                    return false;
-
-                return base.OnDragStart(e);
-            }
-
-            protected override void OnDrag(DragEvent e)
-            {
-                if (!allowScroll)
-                    return;
-
-                base.OnDrag(e);
-            }
-
-            protected override void OnDragEnd(DragEndEvent e)
-            {
-                if (!allowScroll)
-                    return;
-
-                base.OnDragEnd(e);
-            }
-
-            protected override bool OnScroll(ScrollEvent e)
-            {
-                if (!allowScroll)
-                    return false;
-
-                return base.OnScroll(e);
-            }
-        }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 {
     public class ExpandedContentScrollContainer : OsuScrollContainer
     {
-        public const float HEIGHT = 400;
+        public const float HEIGHT = 200;
 
         public ExpandedContentScrollContainer()
         {

--- a/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Beatmaps.Drawables.Cards
+{
+    public class ExpandedContentScrollContainer : OsuScrollContainer
+    {
+        public const float HEIGHT = 400;
+
+        public ExpandedContentScrollContainer()
+        {
+            ScrollbarVisible = false;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            Height = Math.Min(Content.DrawHeight, HEIGHT);
+        }
+
+        private bool allowScroll => !Precision.AlmostEquals(DrawSize, Content.DrawSize);
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            if (!allowScroll)
+                return false;
+
+            return base.OnDragStart(e);
+        }
+
+        protected override void OnDrag(DragEvent e)
+        {
+            if (!allowScroll)
+                return;
+
+            base.OnDrag(e);
+        }
+
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+            if (!allowScroll)
+                return;
+
+            base.OnDragEnd(e);
+        }
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            if (!allowScroll)
+                return false;
+
+            return base.OnScroll(e);
+        }
+    }
+}

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -186,7 +186,11 @@ namespace osu.Game.Overlays
                 AutoSizeAxes = Axes.Y,
                 Spacing = new Vector2(10),
                 Alpha = 0,
-                Margin = new MarginPadding { Vertical = 15 },
+                Margin = new MarginPadding
+                {
+                    Vertical = 15,
+                    Bottom = ExpandedContentScrollContainer.HEIGHT
+                },
                 ChildrenEnumerable = newCards
             };
             return content;

--- a/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Overlays.Rankings
                 {
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
+                    Margin = new MarginPadding { Bottom = ExpandedContentScrollContainer.HEIGHT },
                     Spacing = new Vector2(10),
                     Children = response.BeatmapSets.Select(b => new BeatmapCardNormal(b)
                     {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/16120.

Not sure about the `400` height specification here, seems too tall for the dropdown? I get that this probably follows what osu-web is doing, but still unsure it needs to ever be that tall.. would propose we reduce to around 200 as part of this PR?