### PR TITLE
Fix beatmap listing overlay not expiring content from previous searches

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -108,18 +108,30 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestCorrectOldContentExpiration()
+        {
+            AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
+
+            AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 100).ToArray()));
+            assertAllCardsOfType<BeatmapCardNormal>(100);
+
+            AddStep("show more results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 30).ToArray()));
+            assertAllCardsOfType<BeatmapCardNormal>(30);
+        }
+
+        [Test]
         public void TestCardSizeSwitching()
         {
             AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
 
             AddStep("show many results", () => fetchFor(Enumerable.Repeat(CreateAPIBeatmapSet(Ruleset.Value), 100).ToArray()));
-            assertAllCardsOfType<BeatmapCardNormal>();
+            assertAllCardsOfType<BeatmapCardNormal>(100);
 
             setCardSize(BeatmapCardSize.Extra);
-            assertAllCardsOfType<BeatmapCardExtra>();
+            assertAllCardsOfType<BeatmapCardExtra>(100);
 
             setCardSize(BeatmapCardSize.Normal);
-            assertAllCardsOfType<BeatmapCardNormal>();
+            assertAllCardsOfType<BeatmapCardNormal>(100);
 
             AddStep("fetch for 0 beatmaps", () => fetchFor());
             AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
@@ -323,13 +335,12 @@ namespace osu.Game.Tests.Visual.Online
 
         private void setCardSize(BeatmapCardSize cardSize) => AddStep($"set card size to {cardSize}", () => overlay.ChildrenOfType<BeatmapListingCardSizeTabControl>().Single().Current.Value = cardSize);
 
-        private void assertAllCardsOfType<T>()
+        private void assertAllCardsOfType<T>(int expectedCount)
             where T : BeatmapCard =>
             AddUntilStep($"all loaded beatmap cards are {typeof(T)}", () =>
             {
                 int loadedCorrectCount = this.ChildrenOfType<BeatmapCard>().Count(card => card.IsLoaded && card.GetType() == typeof(T));
-                int totalCount = this.ChildrenOfType<BeatmapCard>().Count();
-                return loadedCorrectCount > 0 && loadedCorrectCount == totalCount;
+                return loadedCorrectCount > 0 && loadedCorrectCount == expectedCount;
             });
     }
 }

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -79,7 +79,6 @@ namespace osu.Game.Overlays
                                 Padding = new MarginPadding { Horizontal = 20 },
                                 Children = new Drawable[]
                                 {
-                                    foundContent = new FillFlowContainer<BeatmapCard>(),
                                     notFoundContent = new NotFoundDrawable(),
                                     supporterRequiredContent = new SupporterRequiredDrawable(),
                                 }

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -212,7 +212,7 @@ namespace osu.Game.Overlays
                 // To resolve both of these issues, the bypass is delayed until a point when the content transitions (fade-in and fade-out) overlap and it looks good to do so.
                 var sequence = lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y);
 
-                if (lastContent == foundContent)
+                if (!isPlaceholderContent(lastContent))
                 {
                     sequence.Then().Schedule(() =>
                     {
@@ -231,6 +231,12 @@ namespace osu.Game.Overlays
             // restore to the initial state.
             currentContent.BypassAutoSizeAxes = Axes.None;
         }
+
+        /// <summary>
+        /// Whether <paramref name="drawable"/> is a static placeholder reused multiple times by this overlay.
+        /// </summary>
+        private bool isPlaceholderContent(Drawable drawable)
+            => drawable == notFoundContent || drawable == supporterRequiredContent;
 
         private void onCardSizeChanged()
         {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Overlays
             if (searchResult.Type == BeatmapListingFilterControl.SearchResultType.SupporterOnlyFilters)
             {
                 supporterRequiredContent.UpdateText(searchResult.SupporterOnlyFiltersUsed);
-                addContentToPlaceholder(supporterRequiredContent);
+                addContentToResultsArea(supporterRequiredContent);
                 return;
             }
 
@@ -151,13 +151,13 @@ namespace osu.Game.Overlays
                 //No matches case
                 if (!newCards.Any())
                 {
-                    addContentToPlaceholder(notFoundContent);
+                    addContentToResultsArea(notFoundContent);
                     return;
                 }
 
                 var content = createCardContainerFor(newCards);
 
-                panelLoadTask = LoadComponentAsync(foundContent = content, addContentToPlaceholder, (cancellationToken = new CancellationTokenSource()).Token);
+                panelLoadTask = LoadComponentAsync(foundContent = content, addContentToResultsArea, (cancellationToken = new CancellationTokenSource()).Token);
             }
             else
             {
@@ -192,7 +192,7 @@ namespace osu.Game.Overlays
             return content;
         }
 
-        private void addContentToPlaceholder(Drawable content)
+        private void addContentToResultsArea(Drawable content)
         {
             Loading.Hide();
             lastFetchDisplayedTime = Time.Current;

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Overlays
 
         private void onCardSizeChanged()
         {
-            if (foundContent == null || !foundContent.Any())
+            if (foundContent?.IsAlive != true || !foundContent.Any())
                 return;
 
             Loading.Show();

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -204,32 +204,16 @@ namespace osu.Game.Overlays
 
             if (lastContent != null)
             {
-                lastContent.FadeOut(100, Easing.OutQuint);
-
-                // Consider the case when the new content is smaller than the last content.
-                // If the auto-size computation is delayed until fade out completes, the background remain high for too long making the resulting transition to the smaller height look weird.
-                // At the same time, if the last content's height is bypassed immediately, there is a period where the new content is at Alpha = 0 when the auto-sized height will be 0.
-                // To resolve both of these issues, the bypass is delayed until a point when the content transitions (fade-in and fade-out) overlap and it looks good to do so.
-                var sequence = lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y);
-
+                lastContent.FadeOut();
                 if (!isPlaceholderContent(lastContent))
-                {
-                    sequence.Then().Schedule(() =>
-                    {
-                        foundContent.Expire();
-                        foundContent = null;
-                    });
-                }
+                    lastContent.Expire();
             }
 
             if (!content.IsAlive)
                 panelTarget.Add(content);
 
-            content.FadeInFromZero(200, Easing.OutQuint);
+            content.FadeInFromZero();
             currentContent = content;
-            // currentContent may be one of the placeholders, and still have BypassAutoSizeAxes set to Y from the last fade-out.
-            // restore to the initial state.
-            currentContent.BypassAutoSizeAxes = Axes.None;
         }
 
         /// <summary>
@@ -265,10 +249,6 @@ namespace osu.Game.Overlays
 
         public class NotFoundDrawable : CompositeDrawable
         {
-            // required for scheduled tasks to complete correctly
-            // (see `addContentToPlaceholder()` and the scheduled `BypassAutoSizeAxes` set during fade-out in outer class above)
-            public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
-
             public NotFoundDrawable()
             {
                 RelativeSizeAxes = Axes.X;
@@ -313,10 +293,6 @@ namespace osu.Game.Overlays
         // (https://github.com/ppy/osu-framework/issues/4530)
         public class SupporterRequiredDrawable : CompositeDrawable
         {
-            // required for scheduled tasks to complete correctly
-            // (see `addContentToPlaceholder()` and the scheduled `BypassAutoSizeAxes` set during fade-out in outer class above)
-            public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
-
             private LinkFlowContainer supporterRequiredText;
 
             public SupporterRequiredDrawable()


### PR DESCRIPTION
So while I was reviewing #16307, I noticed that something is very wrong with the beatmap listing overlay and that it is most likely my fault:

![2022-01-03-213759_519x292_scrot](https://user-images.githubusercontent.com/20418176/147977924-94c8d2de-9dbd-4b43-adc6-4d668b04a944.png)

There should not have been any way wherein multiple reverse fill flows (with cards still remaining in them!) should still remain attached to the overlay. The reason why that was the case was the smorgasbord of multiple issues, namely:

* The `lastContent == foundContent` check, last touched in a49a432, despite looking sensible in a diff is terminally broken, as it would always be false. `foundContent` is mutated to point at the _new_, to-be-loaded content when a new card load task is started in `onSearchFinished()`, which is *before* the aforementioned check.

  The code prior to a49a432 was checking against the two static reused placeholder drawables which was the correct check to apply, and this commit reverts to using a variant of that check.

* The transform sequence juggling the `BypassAutoSizeAxes` manipulations was enqueued on the content which is being in the process of fading out. That was partially fixed in 25e3856, but as it turns out, that only works if `lastContent` is one of the two placeholder drawables (results not found / supporter required to use filter).

  It would not work if `lastContent` is a `ReverseChildIDFillFlowContainer` with cards from a previous search in it, for the same reason the above fix was targeting (the container could become not-present before the scheduled operation was executed). Fixing would require inheriting `ReverseChildIDFillFlowContainer`, or...

* In general `BypassAutoSizeAxes` juggling was finicky and ugly, has been touched several times already to fix various breakage, and didn't really look much different than an instant fade. Therefore, as I am sick of trying to get some sense into it, all fade durations and manipulations of `BypassAutoSizeAxes` are removed. The content is now instantly swapped out, nuking most of the bug-incurring complexity.

Also includes some other minor cleanups (removing a redundant initialisation of `foundContent` and some renames of weirdly-named methods).