### PR TITLE
Fix cursors sent to osu-web being potentially string formatted in incorrect culture

### DIFF
--- a/osu.Game/Extensions/WebRequestExtensions.cs
+++ b/osu.Game/Extensions/WebRequestExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
+using Newtonsoft.Json.Linq;
 using osu.Framework.IO.Network;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Online.API.Requests;
@@ -16,7 +18,7 @@ namespace osu.Game.Extensions
         {
             cursor?.Properties.ForEach(x =>
             {
-                webRequest.AddParameter("cursor[" + x.Key + "]", x.Value.ToString());
+                webRequest.AddParameter("cursor[" + x.Key + "]", (x.Value as JValue)?.ToString(CultureInfo.InvariantCulture) ?? x.Value.ToString());
             });
         }
     }


### PR DESCRIPTION
Fixed as per solution at https://github.com/JamesNK/Newtonsoft.Json/issues/874.

Note that due to the use of `JsonExtensionDataAttribute` it's not feasible to change the actual specification to `JValue` in the `Dictionary`.

In discussion with the osu-web team, it may be worthwhile to change the cursor to a string format where parsing is not required at our end. We could already do this in fact, but there are tests that rely on it being a `JToken` so the switch to `JValue` seems like the easier path right now.