### PR TITLE
Fix editor playfield not being centered correctly

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -105,7 +105,6 @@ namespace osu.Game.Rulesets.Edit
                 new Container
                 {
                     Name = "Content",
-                    Padding = new MarginPadding { Left = toolbar_width },
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {


### PR DESCRIPTION
This has come up multiple times, with mappers citing that they have muscle memory for mapping based on the centre of the playfield being in the centre of the window.

The original plan was to have a second toolbar on the right hand side of the screen to balance the padding, but we're not at that point yet.  Easiest solution is to do what stable does and allow the left-hand toolbar items to overlap the playfield underneath it.

In edge cases where the user is running at an aspect ratio that causes overlaps, they can choose to collapse the toolbars down. We can probably work on this UI/UX a bit more as we update designs to be more friendly to such cases.

|             | 16:10  | 4:5 |
| ------  | ------------- | ------------- |
| Before | ![20220105 160926 (osu!)](https://user-images.githubusercontent.com/191335/148175128-ff6eaee5-24d4-42b0-a066-e5ecad3755cc.png) |  ![20220105 160918 (Safari)](https://user-images.githubusercontent.com/191335/148175107-82dfe247-0703-4fdb-8103-514008baded2.png) |
| After    | ![20220105 160833 (osu!)](https://user-images.githubusercontent.com/191335/148175005-75101ddb-1d64-4ebc-bfc0-4a1048a9f33e.png) | ![20220105 160807 (osu!)](https://user-images.githubusercontent.com/191335/148174958-b97ff4f4-16d4-4df8-a546-58476225c101.png) |