### PR TITLE
Change editor flip hotkeys to perform flips around origin

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -54,7 +54,11 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public override bool HandleFlip(Direction direction, bool flipOverOrigin)
         {
-            if (SelectedItems.Count == 0 && !flipOverOrigin)
+            if (SelectedItems.Count == 0)
+                return false;
+
+            // This could be implemented in the future if there's a requirement for it.
+            if (direction == Direction.Vertical)
                 return false;
 
             var selectionRange = CatchHitObjectUtils.GetPositionRange(SelectedItems);

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             return true;
         }
 
-        public override bool HandleFlip(Direction direction)
+        public override bool HandleFlip(Direction direction, bool flipOverOrigin)
         {
             var selectionRange = CatchHitObjectUtils.GetPositionRange(SelectedItems);
 
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             EditorBeatmap.PerformOnSelection(h =>
             {
                 if (h is CatchHitObject catchObject)
-                    changed |= handleFlip(selectionRange, catchObject);
+                    changed |= handleFlip(selectionRange, catchObject, flipOverOrigin);
             });
             return changed;
         }
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Catch.Edit
             return Math.Clamp(deltaX, lowerBound, upperBound);
         }
 
-        private bool handleFlip(PositionRange selectionRange, CatchHitObject hitObject)
+        private bool handleFlip(PositionRange selectionRange, CatchHitObject hitObject, bool flipOverOrigin)
         {
             switch (hitObject)
             {
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                     return false;
 
                 case JuiceStream juiceStream:
-                    juiceStream.OriginalX = selectionRange.GetFlippedPosition(juiceStream.OriginalX);
+                    juiceStream.OriginalX = getFlippedPosition(juiceStream.OriginalX);
 
                     foreach (var point in juiceStream.Path.ControlPoints)
                         point.Position *= new Vector2(-1, 1);
@@ -133,9 +133,11 @@ namespace osu.Game.Rulesets.Catch.Edit
                     return true;
 
                 default:
-                    hitObject.OriginalX = selectionRange.GetFlippedPosition(hitObject.OriginalX);
+                    hitObject.OriginalX = getFlippedPosition(hitObject.OriginalX);
                     return true;
             }
+
+            float getFlippedPosition(float original) => flipOverOrigin ? CatchPlayfield.WIDTH - original : selectionRange.GetFlippedPosition(original);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -54,14 +54,19 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public override bool HandleFlip(Direction direction, bool flipOverOrigin)
         {
+            if (SelectedItems.Count == 0 && !flipOverOrigin)
+                return false;
+
             var selectionRange = CatchHitObjectUtils.GetPositionRange(SelectedItems);
 
             bool changed = false;
+
             EditorBeatmap.PerformOnSelection(h =>
             {
                 if (h is CatchHitObject catchObject)
                     changed |= handleFlip(selectionRange, catchObject, flipOverOrigin);
             });
+
             return changed;
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -89,17 +89,24 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             var hitObjects = selectedMovableObjects;
 
-            if (hitObjects.Length == 1 && !flipOverOrigin)
-                return false;
-
             var flipQuad = flipOverOrigin ? new Quad(0, 0, OsuPlayfield.BASE_SIZE.X, OsuPlayfield.BASE_SIZE.Y) : getSurroundingQuad(hitObjects);
+
+            bool didFlip = false;
 
             foreach (var h in hitObjects)
             {
-                h.Position = GetFlippedPosition(direction, flipQuad, h.Position);
+                var flippedPosition = GetFlippedPosition(direction, flipQuad, h.Position);
+
+                if (!Precision.AlmostEquals(flippedPosition, h.Position))
+                {
+                    h.Position = flippedPosition;
+                    didFlip = true;
+                }
 
                 if (h is Slider slider)
                 {
+                    didFlip = true;
+
                     foreach (var point in slider.Path.ControlPoints)
                     {
                         point.Position = new Vector2(
@@ -110,7 +117,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 }
             }
 
-            return true;
+            return didFlip;
         }
 
         public override bool HandleScale(Vector2 scale, Anchor reference)

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -89,6 +89,9 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             var hitObjects = selectedMovableObjects;
 
+            if (hitObjects.Length == 1 && !flipOverOrigin)
+                return false;
+
             var flipQuad = flipOverOrigin ? new Quad(0, 0, OsuPlayfield.BASE_SIZE.X, OsuPlayfield.BASE_SIZE.Y) : getSurroundingQuad(hitObjects);
 
             foreach (var h in hitObjects)

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -10,6 +10,7 @@ using osu.Game.Extensions;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -84,15 +85,15 @@ namespace osu.Game.Rulesets.Osu.Edit
             return true;
         }
 
-        public override bool HandleFlip(Direction direction)
+        public override bool HandleFlip(Direction direction, bool flipOverOrigin)
         {
             var hitObjects = selectedMovableObjects;
 
-            var selectedObjectsQuad = getSurroundingQuad(hitObjects);
+            var flipQuad = flipOverOrigin ? new Quad(0, 0, OsuPlayfield.BASE_SIZE.X, OsuPlayfield.BASE_SIZE.Y) : getSurroundingQuad(hitObjects);
 
             foreach (var h in hitObjects)
             {
-                h.Position = GetFlippedPosition(direction, selectedObjectsQuad, h.Position);
+                h.Position = GetFlippedPosition(direction, flipQuad, h.Position);
 
                 if (h is Slider slider)
                 {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
+            new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.EditorFlipHorizontally),
+            new KeyBinding(new[] { InputKey.Control, InputKey.J }, GlobalAction.EditorFlipVertically),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -292,6 +294,12 @@ namespace osu.Game.Input.Bindings
         EditorCycleGridDisplayMode,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTestGameplay))]
-        EditorTestGameplay
+        EditorTestGameplay,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorFlipHorizontally))]
+        EditorFlipHorizontally,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorFlipVertically))]
+        EditorFlipVertically,
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -230,6 +230,16 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorNudgeRight => new TranslatableString(getKey(@"editor_nudge_right"), @"Nudge selection right");
 
         /// <summary>
+        /// "Flip selection horizontally"
+        /// </summary>
+        public static LocalisableString EditorFlipHorizontally => new TranslatableString(getKey(@"editor_flip_horizontally"), @"Flip selection horizontally");
+
+        /// <summary>
+        /// "Flip selection vertically"
+        /// </summary>
+        public static LocalisableString EditorFlipVertically => new TranslatableString(getKey(@"editor_flip_vertically"), @"Flip selection vertically");
+
+        /// <summary>
         /// "Toggle skin editor"
         /// </summary>
         public static LocalisableString ToggleSkinEditor => new TranslatableString(getKey(@"toggle_skin_editor"), @"Toggle skin editor");

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public Func<float, bool> OnRotation;
         public Func<Vector2, Anchor, bool> OnScale;
-        public Func<Direction, bool> OnFlip;
+        public Func<Direction, bool, bool> OnFlip;
         public Func<bool> OnReverse;
 
         public Action OperationStarted;
@@ -281,12 +281,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void addXFlipComponents()
         {
-            addButton(FontAwesome.Solid.ArrowsAltH, "Flip horizontally", () => OnFlip?.Invoke(Direction.Horizontal));
+            addButton(FontAwesome.Solid.ArrowsAltH, "Flip horizontally", () => OnFlip?.Invoke(Direction.Horizontal, false));
         }
 
         private void addYFlipComponents()
         {
-            addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically", () => OnFlip?.Invoke(Direction.Vertical));
+            addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically", () => OnFlip?.Invoke(Direction.Vertical, false));
         }
 
         private void addButton(IconUsage icon, string tooltip, Action action)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -174,12 +174,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 case Key.G:
                     return CanReverse && runOperationFromHotkey(OnReverse);
-
-                case Key.H:
-                    return CanFlipX && runOperationFromHotkey(() => OnFlip?.Invoke(Direction.Horizontal) ?? false);
-
-                case Key.J:
-                    return CanFlipY && runOperationFromHotkey(() => OnFlip?.Invoke(Direction.Vertical) ?? false);
             }
 
             return base.OnKeyDown(e);
@@ -287,12 +281,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void addXFlipComponents()
         {
-            addButton(FontAwesome.Solid.ArrowsAltH, "Flip horizontally (Ctrl-H)", () => OnFlip?.Invoke(Direction.Horizontal));
+            addButton(FontAwesome.Solid.ArrowsAltH, "Flip horizontally", () => OnFlip?.Invoke(Direction.Horizontal));
         }
 
         private void addYFlipComponents()
         {
-            addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically (Ctrl-J)", () => OnFlip?.Invoke(Direction.Vertical));
+            addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically", () => OnFlip?.Invoke(Direction.Vertical));
         }
 
         private void addButton(IconUsage icon, string tooltip, Action action)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -17,6 +17,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
 using osuTK;
 using osuTK.Input;
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// <summary>
     /// A component which outlines items and handles movement of selections.
     /// </summary>
-    public abstract class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IHasContextMenu
+    public abstract class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IKeyBindingHandler<GlobalAction>, IHasContextMenu
     {
         /// <summary>
         /// The currently selected blueprints.
@@ -127,15 +128,39 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Handles the selected items being flipped.
         /// </summary>
-        /// <param name="direction">The direction to flip</param>
+        /// <param name="direction">The direction to flip.</param>
+        /// <param name="flipOverOrigin">Whether the flip operation should be global to the playfield's origin or local to the selected pattern.</param>
         /// <returns>Whether any items could be flipped.</returns>
-        public virtual bool HandleFlip(Direction direction) => false;
+        public virtual bool HandleFlip(Direction direction, bool flipOverOrigin) => false;
 
         /// <summary>
         /// Handles the selected items being reversed pattern-wise.
         /// </summary>
         /// <returns>Whether any items could be reversed.</returns>
         public virtual bool HandleReverse() => false;
+
+        public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat)
+                return false;
+
+            switch (e.Action)
+            {
+                case GlobalAction.EditorFlipHorizontally:
+                    HandleFlip(Direction.Horizontal, true);
+                    return true;
+
+                case GlobalAction.EditorFlipVertically:
+                    HandleFlip(Direction.Vertical, true);
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
 
         public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -147,12 +147,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (e.Action)
             {
                 case GlobalAction.EditorFlipHorizontally:
-                    HandleFlip(Direction.Horizontal, true);
-                    return true;
+                    return HandleFlip(Direction.Horizontal, true);
 
                 case GlobalAction.EditorFlipVertically:
-                    HandleFlip(Direction.Vertical, true);
-                    return true;
+                    return HandleFlip(Direction.Vertical, true);
             }
 
             return false;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
@@ -28,9 +28,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            // Importantly, we block the base call here.
-            // Other key operations will be handled by the composer view's SelectionHandler instead.
-
             switch (e.Action)
             {
                 case GlobalAction.EditorNudgeLeft:
@@ -42,7 +39,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     return true;
             }
 
-            return false;
+            return base.OnPressed(e);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineSelectionHandler.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
@@ -17,7 +16,7 @@ using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
-    internal class TimelineSelectionHandler : EditorSelectionHandler, IKeyBindingHandler<GlobalAction>
+    internal class TimelineSelectionHandler : EditorSelectionHandler
     {
         [Resolved]
         private Timeline timeline { get; set; }
@@ -27,8 +26,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
         public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;
 
-        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
+            // Importantly, we block the base call here.
+            // Other key operations will be handled by the composer view's SelectionHandler instead.
+
             switch (e.Action)
             {
                 case GlobalAction.EditorNudgeLeft:
@@ -41,10 +43,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
 
             return false;
-        }
-
-        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
-        {
         }
 
         /// <summary>

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -128,14 +128,14 @@ namespace osu.Game.Skinning.Editor
 
         public override bool HandleFlip(Direction direction, bool flipOverOrigin)
         {
-            var selectionQuad = flipOverOrigin ? ScreenSpaceDrawQuad : getSelectionQuad();
+            var selectionQuad = getSelectionQuad();
             Vector2 scaleFactor = direction == Direction.Horizontal ? new Vector2(-1, 1) : new Vector2(1, -1);
 
             foreach (var b in SelectedBlueprints)
             {
                 var drawableItem = (Drawable)b.Item;
 
-                var flippedPosition = GetFlippedPosition(direction, selectionQuad, b.ScreenSpaceSelectionPoint);
+                var flippedPosition = GetFlippedPosition(direction, flipOverOrigin ? drawableItem.Parent.ScreenSpaceDrawQuad : selectionQuad, b.ScreenSpaceSelectionPoint);
 
                 updateDrawablePosition(drawableItem, flippedPosition);
 

--- a/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
+++ b/osu.Game/Skinning/Editor/SkinSelectionHandler.cs
@@ -126,9 +126,9 @@ namespace osu.Game.Skinning.Editor
             return true;
         }
 
-        public override bool HandleFlip(Direction direction)
+        public override bool HandleFlip(Direction direction, bool flipOverOrigin)
         {
-            var selectionQuad = getSelectionQuad();
+            var selectionQuad = flipOverOrigin ? ScreenSpaceDrawQuad : getSelectionQuad();
             Vector2 scaleFactor = direction == Direction.Horizontal ? new Vector2(-1, 1) : new Vector2(1, -1);
 
             foreach (var b in SelectedBlueprints)


### PR DESCRIPTION
Still need to figure out the UX for the on-screen control versions of these. For now I'm changing the hotkeys to trigger the behaviour people are used to, while leaving the buttons performing the more localised flip.

This also adds customisation of the hotkeys assigned to these actions.

Closes https://github.com/ppy/osu/issues/15071