### PR TITLE
Allow "disable mouse button" setting to apply to touch as well

### DIFF
--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -127,6 +127,17 @@ namespace osu.Game.Rulesets.UI
             return base.Handle(e);
         }
 
+        protected override bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
+        {
+            if (mouseDisabled.Value)
+            {
+                // Only propagate positional data when mouse buttons are disabled.
+                e = new TouchStateChangeEvent(e.State, e.Input, e.Touch, false, e.LastPosition);
+            }
+
+            return base.HandleMouseTouchStateChange(e);
+        }
+
         #endregion
 
         #region Key Counter Attachment

--- a/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
@@ -18,7 +19,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             {
                 mouseButtonsCheckbox = new PlayerCheckbox
                 {
-                    LabelText = "Disable mouse buttons"
+                    LabelText = MouseSettingsStrings.DisableMouseButtons
                 }
             };
         }


### PR DESCRIPTION
PR for proposal. Not sure if these options should be joined together like this (but at the same time, I'm not sure the original option should even exist, rather than having users unbind their mouse buttons).


If this is to stick, we may want to update the localisation text on the option to also mention touch (and tablet?).

- [x] Depends on ppy/osu-framework#4983
- Closes https://github.com/ppy/osu/issues/12019