### PR TITLE
Fix intermittent failure in score submission test

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("exit", () => Player.Exit());
             AddStep("allow import to proceed", () => Player.AllowImportCompletion.Release(1));
-            AddAssert("ensure submission", () => Player.SubmittedScore != null && Player.ImportedScore != null);
+            AddUntilStep("ensure submission", () => Player.SubmittedScore != null && Player.ImportedScore != null);
         }
 
         [Test]

--- a/osu.Game/Online/Solo/SubmitSoloScoreRequest.cs
+++ b/osu.Game/Online/Solo/SubmitSoloScoreRequest.cs
@@ -12,17 +12,17 @@ namespace osu.Game.Online.Solo
 {
     public class SubmitSoloScoreRequest : APIRequest<MultiplayerScore>
     {
+        public readonly SubmittableScore Score;
+
         private readonly long scoreId;
 
         private readonly int beatmapId;
-
-        private readonly SubmittableScore score;
 
         public SubmitSoloScoreRequest(int beatmapId, long scoreId, ScoreInfo scoreInfo)
         {
             this.beatmapId = beatmapId;
             this.scoreId = scoreId;
-            score = new SubmittableScore(scoreInfo);
+            Score = new SubmittableScore(scoreInfo);
         }
 
         protected override WebRequest CreateWebRequest()
@@ -33,7 +33,7 @@ namespace osu.Game.Online.Solo
             req.Method = HttpMethod.Put;
             req.Timeout = 30000;
 
-            req.AddRaw(JsonConvert.SerializeObject(score, new JsonSerializerSettings
+            req.AddRaw(JsonConvert.SerializeObject(Score, new JsonSerializerSettings
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore
             }));


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/4711538224?check_suite_focus=true.

This PR does two things, one of which is not the fix and one of which is:

* Adds explicit handling of `SubmitSoloScoreRequest`, which was previously not handled at all, therefore displaying request failures in the test log output. While that was mostly a red herring and shouldn't have caused any actual *test* failures, it is still better to handle this explicitly in a realistic manner.
* The assert step failing in the test run above was optimistically assuming that the async
continuation that writes the value of `FakeImportingPlayer.ImportedScore` always completes before it, but
that's not necessarily true even if the continuation is instant (it is still subject to things like task scheduling and TPL thread pool limits). While it's a bit weird that something this quick could race, I can't really see any other reason this could happen.
  
  To ensure no spurious failures due to the above, swap out the assert step for an until step instead.