### PR TITLE
Fix settings toolbox toggle button starting in incorrect state

### DIFF
--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -158,7 +158,9 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             this.Delay(600).FadeTo(inactive_alpha, fade_duration, Easing.OutQuint);
+            updateExpanded();
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -177,8 +179,6 @@ namespace osu.Game.Overlays
         private void load(OsuColour colours)
         {
             expandedColour = colours.Yellow;
-
-            updateExpanded();
         }
 
         private void updateExpanded() => button.FadeColour(expanded ? expandedColour : Color4.White, 200, Easing.InOutQuint);


### PR DESCRIPTION
Closes #16344.

While displaying replays, the colour of the toolbox toggle button would not match the actual state of the rest of the toolbox, i.e. both buttons would be white, even though the "playback settings" section was expanded and as such should have a yellow toggle button.

In the case of the replay player, the failure scenario was as follows:

1. `SettingsToolboxGroup` calls `updateExpanded()` in its BDL to update the initial state of the toolbox, including the toggle button colour, by adding a colour fade transform:

  https://github.com/ppy/osu/blob/32b6bf64d08fe85fa48bceecfa707ed58e15b2c3/osu.Game/Overlays/SettingsToolboxGroup.cs#L176-L182

2. An ancestor of both the toolbox groups - `PlayerSettingsOverlay`, which is a `VisibilityContainer` - [calls `FinishTransforms(true)` in its `LoadCompleteAsync()`](https://github.com/ppy/osu-framework/blob/cba8095b566ec4815866a608b4d77fd0af9f5472/osu.Framework/Graphics/Containers/VisibilityContainer.cs#L35), therefore instantly applying the colour from point (1) to the toggle button instantly.

3. However, `IconButton` inherits from `OsuAnimatedButton`. And `OsuAnimatedButton` changes its colour in `LoadComplete()`, therefore undoing the instant application from point (2):

  https://github.com/ppy/osu/blob/32b6bf64d08fe85fa48bceecfa707ed58e15b2c3/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs#L92

This conjunction of circumstances is instrumental to reproducing the bug, because if the `FinishTransforms(true)` call wasn't there, point (3) wouldn't matter - the transform would get applied to its end at a point in the future relative to it, ignoring the write from `OsuAnimatedButton`. (As such this scenario is not easily testable.)

As for the fix, move the `updateExpanded()` call in `SettingsToolboxGroup` to `LoadComplete()` to avoid the above unfortunate order. Applying initial visual state in `LoadComplete()` is the idiomatic style of doing things these days anyhow.