### PR TITLE
Add basic "time ago" display to leaderboards on beatmap overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoreboardTime.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoreboardTime.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+using osu.Game.Overlays.BeatmapSet.Scores;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public class TestSceneScoreboardTime : OsuTestScene
+    {
+        private StopwatchClock stopwatch;
+
+        [Test]
+        public void TestVariousUnits()
+        {
+            AddStep("create various scoreboard times", () => Child = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Clock = new FramedClock(stopwatch = new StopwatchClock()), // prevent time from naturally elapsing.
+                Direction = FillDirection.Vertical,
+                ChildrenEnumerable = testCases.Select(dateTime => new ScoreboardTime(dateTime, 24).With(time => time.Anchor = time.Origin = Anchor.TopCentre))
+            });
+
+            AddStep("start stopwatch", () => stopwatch.Start());
+        }
+
+        private static IEnumerable<DateTimeOffset> testCases => new[]
+        {
+            DateTimeOffset.Now,
+            DateTimeOffset.Now.AddSeconds(-1),
+            DateTimeOffset.Now.AddSeconds(-25),
+            DateTimeOffset.Now.AddSeconds(-59),
+            DateTimeOffset.Now.AddMinutes(-1),
+            DateTimeOffset.Now.AddMinutes(-25),
+            DateTimeOffset.Now.AddMinutes(-59),
+            DateTimeOffset.Now.AddHours(-1),
+            DateTimeOffset.Now.AddHours(-13),
+            DateTimeOffset.Now.AddHours(-23),
+            DateTimeOffset.Now.AddDays(-1),
+            DateTimeOffset.Now.AddDays(-6),
+            DateTimeOffset.Now.AddDays(-16),
+            DateTimeOffset.Now.AddMonths(-1),
+            DateTimeOffset.Now.AddMonths(-11),
+            DateTimeOffset.Now.AddYears(-1),
+            DateTimeOffset.Now.AddYears(-5)
+        };
+    }
+}

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             if (showPerformancePoints)
                 columns.Add(new TableColumn(BeatmapsetsStrings.ShowScoreboardHeaderspp, Anchor.CentreLeft, new Dimension(GridSizeMode.Absolute, 30)));
 
+            columns.Add(new TableColumn(BeatmapsetsStrings.ShowScoreboardHeadersTime, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize)));
             columns.Add(new TableColumn(BeatmapsetsStrings.ShowScoreboardHeadersMods, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize)));
 
             return columns.ToArray();
@@ -201,6 +202,11 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     Font = OsuFont.GetFont(size: text_size)
                 });
             }
+
+            content.Add(new ScoreboardTime(score.Date, text_size)
+            {
+                Margin = new MarginPadding { Right = 10 }
+            });
 
             content.Add(new FillFlowContainer
             {

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreboardTime.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreboardTime.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using Humanizer;
 using osu.Game.Graphics;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -15,7 +17,40 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
 
         protected override string Format()
         {
-            return base.Format();
+            var now = DateTime.Now;
+            var difference = now - Date;
+
+            // web uses momentjs's custom locales to format the date for the purposes of the scoreboard.
+            // this is intended to be a best-effort, more legible approximation of that.
+            // compare:
+            // * https://github.com/ppy/osu-web/blob/a8f5a68fb435cb19a4faa4c7c4bce08c4f096933/resources/assets/lib/scoreboard-time.tsx
+            // * https://momentjs.com/docs/#/customization/ (reference for the customisation format)
+
+            // TODO: support localisation (probably via `CommonStrings.CountHours()` etc.)
+            // requires pluralisable string support framework-side
+
+            if (difference.TotalHours < 1)
+                return CommonStrings.TimeNow.ToString();
+            if (difference.TotalDays < 1)
+                return "hr".ToQuantity((int)difference.TotalHours);
+
+            // this is where this gets more complicated because of how the calendar works.
+            // since there's no `TotalMonths` / `TotalYears`, we have to iteratively add months/years
+            // and test against cutoff dates to determine how many months/years to show.
+
+            if (Date > now.AddMonths(-1))
+                return difference.TotalDays < 2 ? "1dy" : $"{(int)difference.TotalDays}dys";
+
+            for (int months = 1; months <= 11; ++months)
+            {
+                if (Date > now.AddMonths(-(months + 1)))
+                    return months == 1 ? "1mo" : $"{months}mos";
+            }
+
+            int years = 1;
+            while (Date <= now.AddYears(-(years + 1)))
+                years += 1;
+            return years == 1 ? "1yr" : $"{years}yrs";
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreboardTime.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreboardTime.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Graphics;
+
+namespace osu.Game.Overlays.BeatmapSet.Scores
+{
+    public class ScoreboardTime : DrawableDate
+    {
+        public ScoreboardTime(DateTimeOffset date, float textSize = OsuFont.DEFAULT_FONT_SIZE, bool italic = true)
+            : base(date, textSize, italic)
+        {
+        }
+
+        protected override string Format()
+        {
+            return base.Format();
+        }
+    }
+}


### PR DESCRIPTION
Initial implementation of #16336.

![osu_2022-01-07_19-21-45](https://user-images.githubusercontent.com/20418176/148589336-7b304886-161b-48f3-84ca-247cf749a8b6.jpg)

Caveats:

* This differs greatly from how web displays this, as [web's setup](https://github.com/ppy/osu-web/blob/a8f5a68fb435cb19a4faa4c7c4bce08c4f096933/resources/assets/lib/scoreboard-time.tsx) is very coupled to the `momentjs` javascript library, to the point where the localisation analyser didn't pick up the [relevant localisations](https://github.com/ppy/osu-resources/blob/be13ff4ace496f7826a813a9743f88fdeb799dd9/osu.Game.Resources/Localisation/Web/CommonStrings.cs#L432-L490) as formattable strings, because they use js's `%d` placeholders rather than `:arg` laravel placeholders
* Additionally for simplicity the rounding strategy is different. This implementation intends to floor the timespan to the largest possible whole unit (e.g. 34 hours -> 1 day, 2 months 13 days -> 2 months, 4 years 7 months -> 4 years). It's not entirely clear what momentjs does and I'm not super interested in reproducing that 1:1.
* The actual string formatting is different from web, to reduce confusion (web displays 3 months as `3m` which is confusing)
* Implementation does not support localisations yet (requires https://github.com/ppy/osu-framework/pull/4918)