### PR TITLE
Fix `LegacyScoreDecoderTest` incorrectly comparing unset beatmap IDs

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(decodedAfterEncode, Is.Not.Null);
 
                 Assert.That(decodedAfterEncode.ScoreInfo.User.Username, Is.EqualTo(scoreInfo.User.Username));
-                Assert.That(decodedAfterEncode.ScoreInfo.BeatmapInfoID, Is.EqualTo(scoreInfo.BeatmapInfoID));
+                Assert.That(decodedAfterEncode.ScoreInfo.BeatmapInfo.MD5Hash, Is.EqualTo(scoreInfo.BeatmapInfo.MD5Hash));
                 Assert.That(decodedAfterEncode.ScoreInfo.Ruleset, Is.EqualTo(scoreInfo.Ruleset));
                 Assert.That(decodedAfterEncode.ScoreInfo.TotalScore, Is.EqualTo(scoreInfo.TotalScore));
                 Assert.That(decodedAfterEncode.ScoreInfo.MaxCombo, Is.EqualTo(scoreInfo.MaxCombo));

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -95,7 +95,6 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(decodedAfterEncode, Is.Not.Null);
 
                 Assert.That(decodedAfterEncode.ScoreInfo.User.Username, Is.EqualTo(scoreInfo.User.Username));
-                Assert.That(decodedAfterEncode.ScoreInfo.BeatmapInfo.MD5Hash, Is.EqualTo(scoreInfo.BeatmapInfo.MD5Hash));
                 Assert.That(decodedAfterEncode.ScoreInfo.Ruleset, Is.EqualTo(scoreInfo.Ruleset));
                 Assert.That(decodedAfterEncode.ScoreInfo.TotalScore, Is.EqualTo(scoreInfo.TotalScore));
                 Assert.That(decodedAfterEncode.ScoreInfo.MaxCombo, Is.EqualTo(scoreInfo.MaxCombo));


### PR DESCRIPTION
This has been wrong from the outside, but hidden by the fact that the default values are equal. I've changed to MD5Hash which actually asserts that the correct beatmap has likely arrived.

Found this in my realm changes, where it fails due to the beatmap ID being a differing Guid in each case.