### PR TITLE
Fix multiplayer starting gameplay using last picked item ruleset rather than actual current item ruleset

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -1,13 +1,21 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+using osu.Game.Screens.Play;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -83,7 +91,24 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
         }
 
-        private void addItem(Func<BeatmapInfo> beatmap)
+        [Test]
+        public void TestCorrectRulesetSelectedAfterNewItemAdded()
+        {
+            addItem(() => OtherBeatmap, new CatchRuleset().RulesetInfo);
+            AddUntilStep("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
+
+            AddUntilStep("wait for idle", () => Client.LocalUser?.State == MultiplayerUserState.Idle);
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
+
+            AddUntilStep("wait for ready", () => Client.LocalUser?.State == MultiplayerUserState.Ready);
+            ClickButtonWhenEnabled<MultiplayerReadyButton>();
+
+            AddUntilStep("wait for player", () => CurrentScreen is Player player && player.IsLoaded);
+            AddAssert("ruleset is correct", () => ((Player)CurrentScreen).Ruleset.Value.Equals(new OsuRuleset().RulesetInfo));
+            AddStep("exit player", () => CurrentScreen.Exit());
+        }
+
+        private void addItem(Func<BeatmapInfo> beatmap, RulesetInfo? ruleset = null)
         {
             AddStep("click add button", () =>
             {
@@ -92,6 +117,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for song select", () => CurrentSubScreen is Screens.Select.SongSelect select && select.BeatmapSetsLoaded);
+
+            if (ruleset != null)
+            {
+                AddStep($"set {ruleset.Name} ruleset", () => ((Screens.Select.SongSelect)CurrentSubScreen).Ruleset.Value = ruleset);
+            }
+
             AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(beatmap()));
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
@@ -23,6 +24,7 @@ using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay.Components;
@@ -476,6 +478,45 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("play started", () => multiplayerComponents.CurrentScreen is Player);
 
             AddAssert("Ruleset matches current item", () => Ruleset.Value.OnlineID == client.Room?.Playlist.First().RulesetID);
+        }
+
+        [Test]
+        public void TestPlayStartsWithCorrectModsWhileAtSongSelect()
+        {
+            createRoom(() => new Room
+            {
+                Name = { Value = "Test Room" },
+                Playlist =
+                {
+                    new PlaylistItem
+                    {
+                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.RulesetID == 0)).BeatmapInfo },
+                        Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                    }
+                }
+            });
+
+            pressReadyButton();
+
+            AddStep("Enter song select", () =>
+            {
+                var currentSubScreen = ((Screens.OnlinePlay.Multiplayer.Multiplayer)multiplayerComponents.CurrentScreen).CurrentSubScreen;
+                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.Room?.Settings.PlaylistItemId);
+            });
+
+            AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);
+
+            AddAssert("Mods match current item", () => SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(client.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
+
+            AddStep("Switch required mods", () => ((MultiplayerMatchSongSelect)multiplayerComponents.MultiplayerScreen.CurrentSubScreen).Mods.Value = new Mod[] { new OsuModDoubleTime() });
+
+            AddAssert("Mods don't match current item", () => !SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(client.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
+
+            AddStep("start match externally", () => client.StartMatch());
+
+            AddUntilStep("play started", () => multiplayerComponents.CurrentScreen is Player);
+
+            AddAssert("Mods match current item", () => SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(client.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -300,6 +300,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             updateWorkingBeatmap();
             beginHandlingTrack();
             Scheduler.AddOnce(UpdateMods);
+            Scheduler.AddOnce(updateRuleset);
         }
 
         public override bool OnExiting(IScreen next)
@@ -353,8 +354,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
                                      .ToList();
 
             UpdateMods();
-
-            Ruleset.Value = rulesets.GetRuleset(selected.RulesetID);
+            updateRuleset();
 
             if (!selected.AllowedMods.Any())
             {
@@ -385,6 +385,14 @@ namespace osu.Game.Screens.OnlinePlay.Match
                 return;
 
             Mods.Value = UserMods.Value.Concat(SelectedItem.Value.RequiredMods).ToList();
+        }
+
+        private void updateRuleset()
+        {
+            if (SelectedItem.Value == null || !this.IsCurrentScreen())
+                return;
+
+            Ruleset.Value = rulesets.GetRuleset(SelectedItem.Value.RulesetID);
         }
 
         private void beginHandlingTrack()


### PR DESCRIPTION
Closes #16351, by applying pretty much the same fix as #15784.

Test coverage for ruleset and mod bindables (mostly adapted from #15784 and #15950) also included for posterity, so that this sort of bug hopefully never occurs again.