### PR TITLE
Add tooltip with relative rotation in degrees to rotation handles

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -15,6 +15,7 @@ using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
+    [Cached]
     public class SelectionBox : CompositeDrawable
     {
         public const float BORDER_RADIUS = 3;
@@ -306,7 +307,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             var handle = new SelectionBoxScaleHandle
             {
                 Anchor = anchor,
-                HandleDrag = e => OnScale?.Invoke(e.Delta, anchor)
+                HandleScale = (delta, a) => OnScale?.Invoke(delta, a)
             };
 
             handle.OperationStarted += operationStarted;
@@ -319,7 +320,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             var handle = new SelectionBoxRotationHandle
             {
                 Anchor = anchor,
-                HandleDrag = e => OnRotation?.Invoke(convertDragEventToAngleOfRotation(e))
+                HandleRotate = angle => OnRotation?.Invoke(angle)
             };
 
             handle.OperationStarted += operationStarted;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxDragHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxDragHandle.cs
@@ -8,18 +8,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
 {
     public abstract class SelectionBoxDragHandle : SelectionBoxControl
     {
-        public Action<DragEvent> HandleDrag { get; set; }
-
         protected override bool OnDragStart(DragStartEvent e)
         {
             TriggerOperationStarted();
             return true;
-        }
-
-        protected override void OnDrag(DragEvent e)
-        {
-            HandleDrag?.Invoke(e);
-            base.OnDrag(e);
         }
 
         protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -3,20 +3,28 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    public class SelectionBoxRotationHandle : SelectionBoxDragHandle
+    public class SelectionBoxRotationHandle : SelectionBoxDragHandle, IHasTooltip
     {
         public Action<float> HandleRotate { get; set; }
 
+        public LocalisableString TooltipText { get; private set; }
+
         private SpriteIcon icon;
+
+        private readonly Bindable<float?> cumulativeRotation = new Bindable<float?>();
 
         [Resolved]
         private SelectionBox selectionBox { get; set; }
@@ -40,16 +48,45 @@ namespace osu.Game.Screens.Edit.Compose.Components
             });
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            cumulativeRotation.BindValueChanged(_ => updateTooltipText(), true);
+        }
+
         protected override void UpdateHoverState()
         {
             base.UpdateHoverState();
             icon.FadeColour(!IsHeld && IsHovered ? Color4.White : Color4.Black, TRANSFORM_DURATION, Easing.OutQuint);
         }
 
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            bool handle = base.OnDragStart(e);
+            if (handle)
+                cumulativeRotation.Value = 0;
+            return handle;
+        }
+
         protected override void OnDrag(DragEvent e)
         {
             base.OnDrag(e);
-            HandleRotate?.Invoke(convertDragEventToAngleOfRotation(e));
+
+            float instantaneousAngle = convertDragEventToAngleOfRotation(e);
+            cumulativeRotation.Value += instantaneousAngle;
+
+            if (cumulativeRotation.Value < -180)
+                cumulativeRotation.Value += 360;
+            else if (cumulativeRotation.Value > 180)
+                cumulativeRotation.Value -= 360;
+
+            HandleRotate?.Invoke(instantaneousAngle);
+        }
+
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+            base.OnDragEnd(e);
+            cumulativeRotation.Value = null;
         }
 
         private float convertDragEventToAngleOfRotation(DragEvent e)
@@ -59,6 +96,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float endAngle = MathF.Atan2(e.MousePosition.Y - selectionBox.DrawHeight / 2, e.MousePosition.X - selectionBox.DrawWidth / 2);
 
             return (endAngle - startAngle) * 180 / MathF.PI;
+        }
+
+        private void updateTooltipText()
+        {
+            TooltipText = cumulativeRotation.Value?.ToLocalisableString("0.0°") ?? default(LocalisableString);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
 using osuTK;
 using osuTK.Graphics;
 
@@ -12,7 +14,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 {
     public class SelectionBoxRotationHandle : SelectionBoxDragHandle
     {
+        public Action<float> HandleRotate { get; set; }
+
         private SpriteIcon icon;
+
+        [Resolved]
+        private SelectionBox selectionBox { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -37,6 +44,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             base.UpdateHoverState();
             icon.FadeColour(!IsHeld && IsHovered ? Color4.White : Color4.Black, TRANSFORM_DURATION, Easing.OutQuint);
+        }
+
+        protected override void OnDrag(DragEvent e)
+        {
+            base.OnDrag(e);
+            HandleRotate?.Invoke(convertDragEventToAngleOfRotation(e));
+        }
+
+        private float convertDragEventToAngleOfRotation(DragEvent e)
+        {
+            // Adjust coordinate system to the center of SelectionBox
+            float startAngle = MathF.Atan2(e.LastMousePosition.Y - selectionBox.DrawHeight / 2, e.LastMousePosition.X - selectionBox.DrawWidth / 2);
+            float endAngle = MathF.Atan2(e.MousePosition.Y - selectionBox.DrawHeight / 2, e.MousePosition.X - selectionBox.DrawWidth / 2);
+
+            return (endAngle - startAngle) * 180 / MathF.PI;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
@@ -1,17 +1,28 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
     public class SelectionBoxScaleHandle : SelectionBoxDragHandle
     {
+        public Action<Vector2, Anchor> HandleScale { get; set; }
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Size = new Vector2(10);
+        }
+
+        protected override void OnDrag(DragEvent e)
+        {
+            HandleScale?.Invoke(e.Delta, Anchor);
+            base.OnDrag(e);
         }
     }
 }


### PR DESCRIPTION
Mostly resolves #10396.

https://user-images.githubusercontent.com/20418176/148656735-4aea6573-9f06-443d-b86b-185939b615fa.mp4

Displayed range is [-180deg, 180deg], which was taken from a few graphics apps with transform controls. Implemented at the base level of the drag handles themselves, so works in both beatmap and skin editor.

Snapping to ortho angles (0, 45, 90, ...) is the natural next step, but not easy to achieve right off the bat as all selection handlers would need to be migrated to operate on the cumulative angle rather than instantaneous angles on each mouse movements as done currently, so leaving that as a follow-up item.

Another follow up item would be to make displayed rotations in skin editor not reset every time as done currently. For editor sliders the current mode is fine since the selection box is always axis-aligned, but in skin editor it's not. But this seems usable enough for a start.