### PR TITLE
Fade out inactive player rows on user ranking table

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
@@ -1,38 +1,27 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays.Rankings.Tables;
 using osu.Framework.Graphics;
-using osu.Game.Online.API.Requests;
-using osu.Game.Rulesets;
 using System.Threading;
-using osu.Game.Online.API;
-using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Mania;
-using osu.Game.Rulesets.Taiko;
-using osu.Game.Rulesets.Catch;
 using osu.Framework.Allocation;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Rankings;
+using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
     public class TestSceneRankingsTables : OsuTestScene
     {
-        protected override bool UseOnlineAPI => true;
-
-        [Resolved]
-        private IAPIProvider api { get; set; }
-
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
 
         private readonly BasicScrollContainer scrollFlow;
         private readonly LoadingLayer loading;
         private CancellationTokenSource cancellationToken;
-        private APIRequest request;
 
         public TestSceneRankingsTables()
         {
@@ -53,73 +42,120 @@ namespace osu.Game.Tests.Visual.Online
         {
             base.LoadComplete();
 
-            AddStep("Osu performance", () => createPerformanceTable(new OsuRuleset().RulesetInfo, null));
-            AddStep("Mania scores", () => createScoreTable(new ManiaRuleset().RulesetInfo));
-            AddStep("Taiko country scores", () => createCountryTable(new TaikoRuleset().RulesetInfo));
-            AddStep("Catch US performance page 10", () => createPerformanceTable(new CatchRuleset().RulesetInfo, "US", 10));
-            AddStep("Osu spotlight table (chart 271)", () => createSpotlightTable(new OsuRuleset().RulesetInfo, 271));
+            AddStep("User performance", createPerformanceTable);
+            AddStep("User scores", createScoreTable);
+            AddStep("Country scores", createCountryTable);
         }
 
-        private void createCountryTable(RulesetInfo ruleset, int page = 1)
+        private void createCountryTable()
         {
             onLoadStarted();
 
-            request = new GetCountryRankingsRequest(ruleset, page);
-            ((GetCountryRankingsRequest)request).Success += rankings => Schedule(() =>
+            var countries = new List<CountryStatistics>
             {
-                var table = new CountriesTable(page, rankings.Countries);
-                loadTable(table);
-            });
+                new CountryStatistics
+                {
+                    Country = new Country { FlagName = "US", FullName = "United States" },
+                    FlagName = "US",
+                    ActiveUsers = 2_972_623,
+                    PlayCount = 3_086_515_743,
+                    RankedScore = 449_407_643_332_546,
+                    Performance = 371_974_024
+                },
+                new CountryStatistics
+                {
+                    Country = new Country { FlagName = "RU", FullName = "Russian Federation" },
+                    FlagName = "RU",
+                    ActiveUsers = 1_609_989,
+                    PlayCount = 1_637_052_841,
+                    RankedScore = 221_660_827_473_004,
+                    Performance = 163_426_476
+                }
+            };
 
-            api.Queue(request);
+            var table = new CountriesTable(1, countries);
+            loadTable(table);
         }
 
-        private void createPerformanceTable(RulesetInfo ruleset, string country, int page = 1)
+        private static List<UserStatistics> createUserStatistics() => new List<UserStatistics>
+        {
+            new UserStatistics
+            {
+                User = new APIUser
+                {
+                    Username = "first active user",
+                    Country = new Country { FlagName = "JP" },
+                    Active = true,
+                },
+                Accuracy = 0.9972,
+                PlayCount = 233_215,
+                TotalScore = 983_231_234_656,
+                RankedScore = 593_231_345_897,
+                PP = 23_934,
+                GradesCount = new UserStatistics.Grades
+                {
+                    SS = 35_132,
+                    S = 23_345,
+                    A = 12_234
+                }
+            },
+            new UserStatistics
+            {
+                User = new APIUser
+                {
+                    Username = "inactive user",
+                    Country = new Country { FlagName = "AU" },
+                    Active = false,
+                },
+                Accuracy = 0.9831,
+                PlayCount = 195_342,
+                TotalScore = 683_231_234_656,
+                RankedScore = 393_231_345_897,
+                PP = 20_934,
+                GradesCount = new UserStatistics.Grades
+                {
+                    SS = 32_132,
+                    S = 20_345,
+                    A = 9_234
+                }
+            },
+            new UserStatistics
+            {
+                User = new APIUser
+                {
+                    Username = "second active user",
+                    Country = new Country { FlagName = "PL" },
+                    Active = true,
+                },
+                Accuracy = 0.9584,
+                PlayCount = 100_903,
+                TotalScore = 97_242_983_434,
+                RankedScore = 3_156_345_897,
+                PP = 9_568,
+                GradesCount = new UserStatistics.Grades
+                {
+                    SS = 13_152,
+                    S = 24_375,
+                    A = 9_960
+                }
+            },
+        };
+
+        private void createPerformanceTable()
         {
             onLoadStarted();
-
-            request = new GetUserRankingsRequest(ruleset, country: country, page: page);
-            ((GetUserRankingsRequest)request).Success += rankings => Schedule(() =>
-            {
-                var table = new PerformanceTable(page, rankings.Users);
-                loadTable(table);
-            });
-
-            api.Queue(request);
+            loadTable(new PerformanceTable(1, createUserStatistics()));
         }
 
-        private void createScoreTable(RulesetInfo ruleset, int page = 1)
+        private void createScoreTable()
         {
             onLoadStarted();
-
-            request = new GetUserRankingsRequest(ruleset, UserRankingsType.Score, page);
-            ((GetUserRankingsRequest)request).Success += rankings => Schedule(() =>
-            {
-                var table = new ScoresTable(page, rankings.Users);
-                loadTable(table);
-            });
-
-            api.Queue(request);
-        }
-
-        private void createSpotlightTable(RulesetInfo ruleset, int spotlight)
-        {
-            onLoadStarted();
-
-            request = new GetSpotlightRankingsRequest(ruleset, spotlight, RankingsSortCriteria.All);
-            ((GetSpotlightRankingsRequest)request).Success += rankings => Schedule(() =>
-            {
-                var table = new ScoresTable(1, rankings.Users);
-                loadTable(table);
-            });
-
-            api.Queue(request);
+            loadTable(new ScoresTable(1, createUserStatistics()));
         }
 
         private void onLoadStarted()
         {
             loading.Show();
-            request?.Cancel();
             cancellationToken?.Cancel();
             cancellationToken = new CancellationTokenSource();
         }

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -54,13 +54,15 @@ namespace osu.Game.Overlays.Rankings.Tables
                 Spacing = new Vector2(0, row_spacing),
             });
 
-            rankings.ForEach(_ => backgroundFlow.Add(new TableRowBackground { Height = row_height }));
+            rankings.ForEach(s => backgroundFlow.Add(CreateRowBackground(s)));
 
             Columns = mainHeaders.Concat(CreateAdditionalHeaders()).Cast<TableColumn>().ToArray();
-            Content = rankings.Select((s, i) => createContent((page - 1) * items_per_page + i, s)).ToArray().ToRectangular();
+            Content = rankings.Select((s, i) => CreateRowContent((page - 1) * items_per_page + i, s)).ToArray().ToRectangular();
         }
 
-        private Drawable[] createContent(int index, TModel item) => new Drawable[] { createIndexDrawable(index), createMainContent(item) }.Concat(CreateAdditionalContent(item)).ToArray();
+        protected virtual Drawable CreateRowBackground(TModel item) => new TableRowBackground { Height = row_height };
+
+        protected virtual Drawable[] CreateRowContent(int index, TModel item) => new Drawable[] { createIndexDrawable(index), createMainContent(item) }.Concat(CreateAdditionalContent(item)).ToArray();
 
         private static RankingsTableColumn[] mainHeaders => new[]
         {

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
             var background = base.CreateRowBackground(item);
 
+            // see: https://github.com/ppy/osu-web/blob/9de00a0b874c56893d98261d558d78d76259d81b/resources/views/multiplayer/rooms/_rankings_table.blade.php#L23
             if (!item.User.Active)
                 background.Alpha = 0.5f;
 
@@ -38,6 +39,7 @@ namespace osu.Game.Overlays.Rankings.Tables
         {
             var content = base.CreateRowContent(index, item);
 
+            // see: https://github.com/ppy/osu-web/blob/9de00a0b874c56893d98261d558d78d76259d81b/resources/views/multiplayer/rooms/_rankings_table.blade.php#L23
             if (!item.User.Active)
             {
                 foreach (var d in content)

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -24,6 +24,29 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected virtual IEnumerable<LocalisableString> GradeColumns => new List<LocalisableString> { RankingsStrings.Statss, RankingsStrings.Stats, RankingsStrings.Stata };
 
+        protected override Drawable CreateRowBackground(UserStatistics item)
+        {
+            var background = base.CreateRowBackground(item);
+
+            if (!item.User.Active)
+                background.Alpha = 0.5f;
+
+            return background;
+        }
+
+        protected override Drawable[] CreateRowContent(int index, UserStatistics item)
+        {
+            var content = base.CreateRowContent(index, item);
+
+            if (!item.User.Active)
+            {
+                foreach (var d in content)
+                    d.Alpha = 0.5f;
+            }
+
+            return content;
+        }
+
         protected override RankingsTableColumn[] CreateAdditionalHeaders() => new[]
             {
                 new RankingsTableColumn(RankingsStrings.StatAccuracy, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),


### PR DESCRIPTION
Fixes #16380.

Compare web implementation for [property used](https://github.com/ppy/osu-web/blob/9de00a0b874c56893d98261d558d78d76259d81b/resources/views/multiplayer/rooms/_rankings_table.blade.php#L23)  and [styling applied](https://github.com/ppy/osu-web/blob/24a5dbce05ffa48f92541f0f5d760d7a868d1449/resources/assets/less/bem/ranking-page-table.less#L60-L62).

Not overly happy with the way this is implemented but it can't be done better with the current structure, lest I rewrite the entire table from scratch to have rows be... rows, rather than separate row content and row backgrounds.

Diff also includes decoupling the test scene from API for good practice (and also dev does not have inactive users).