### PR TITLE
Update `FilterMatchingTest` and filter code to use ruleset's `OnlineID`

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -16,7 +16,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
     {
         private BeatmapInfo getExampleBeatmap() => new BeatmapInfo
         {
-            Ruleset = new RulesetInfo { OnlineID = 5 },
+            Ruleset = new RulesetInfo { OnlineID = 0 },
+            RulesetID = 0,
             StarRating = 4.0d,
             BaseDifficulty = new BeatmapDifficulty
             {

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Screens.Select.Carousel
 
             bool match =
                 criteria.Ruleset == null ||
-                BeatmapInfo.RulesetID == criteria.Ruleset.ID ||
-                (BeatmapInfo.RulesetID == 0 && criteria.Ruleset.ID > 0 && criteria.AllowConvertedBeatmaps);
+                BeatmapInfo.RulesetID == criteria.Ruleset.OnlineID ||
+                (BeatmapInfo.RulesetID == 0 && criteria.Ruleset.OnlineID > 0 && criteria.AllowConvertedBeatmaps);
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {


### PR DESCRIPTION
The tests were relying on the `RulesetID` being set to 0 in the example beatmap, even though the ruleset *instance* was set to ID 5.

This explicitly adds that 0 value to show intent, and also removes the incorrect specification of 5 (which would cause the convert filter tests to fail).

Also updates the filter code to use `OnlineID`, which is required in realm changes.