### PR TITLE
Add mention to detach methods of only running once

### DIFF
--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Database
         /// <summary>
         /// Create a detached copy of the each item in the collection.
         /// </summary>
+        /// <remarks>
+        /// Items which are already detached (ie. not managed by realm) will not be modified.
+        /// </remarks>
         /// <param name="items">A list of managed <see cref="RealmObject"/>s to detach.</param>
         /// <typeparam name="T">The type of object.</typeparam>
         /// <returns>A list containing non-managed copies of provided items.</returns>
@@ -42,6 +45,9 @@ namespace osu.Game.Database
         /// <summary>
         /// Create a detached copy of the item.
         /// </summary>
+        /// <remarks>
+        /// If the item if already detached (ie. not managed by realm) it will not be detached again and the original instance will be returned. This allows this method to be potentially called at multiple levels while only incurring the clone overhead once.
+        /// </remarks>
         /// <param name="item">The managed <see cref="RealmObject"/> to detach.</param>
         /// <typeparam name="T">The type of object.</typeparam>
         /// <returns>A non-managed copy of provided item. Will return the provided item if already detached.</returns>


### PR DESCRIPTION
Ran into this in a realm test failure as I was using `Detach` incorrectly as a "clone" operation. Probably good to mention/document this fact.