### PR TITLE
Ensure first control point starts at 0 in most common beat length calculation

### DIFF
--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -93,8 +93,10 @@ namespace osu.Game.Beatmaps
                                     if (t.Time > lastTime)
                                         return (beatLength: t.BeatLength, 0);
 
+                                    double currentTime = i == 0 ? 0 : t.Time;
                                     double nextTime = i == ControlPointInfo.TimingPoints.Count - 1 ? lastTime : ControlPointInfo.TimingPoints[i + 1].Time;
-                                    return (beatLength: t.BeatLength, duration: nextTime - t.Time);
+
+                                    return (beatLength: t.BeatLength, duration: nextTime - currentTime);
                                 })
                                 // Aggregate durations into a set of (beatLength, duration) tuples for each beat length
                                 .GroupBy(t => Math.Round(t.beatLength * 1000) / 1000)

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -93,6 +93,8 @@ namespace osu.Game.Beatmaps
                                     if (t.Time > lastTime)
                                         return (beatLength: t.BeatLength, 0);
 
+                                    // osu-stable forced the first control point to start at 0.
+                                    // This is reproduced here to maintain compatibility around osu!mania scroll speed and song select display.
                                     double currentTime = i == 0 ? 0 : t.Time;
                                     double nextTime = i == ControlPointInfo.TimingPoints.Count - 1 ? lastTime : ControlPointInfo.TimingPoints[i + 1].Time;
 


### PR DESCRIPTION
This function was made to replicate the functionality of osu-stable's `Beatmap.BeatsPerMinuteRange.Z`. osu-stable forces the first control point to start at 0 for this calculation.

Note that this change also affects osu-difficulty-calculator, so the values currently displayed on osu-web sometimes differ from those displayed in osu-stable.

For example: https://osu.ppy.sh/beatmapsets/1592995#mania/3253520
In this beatmap the first control point has t=274, so the control point is extended by +274ms which makes it the most common value.
```
Current osu-lazer: 279.8 BPM
osu-web          : 279.8 BPM (via osu-difficulty-calculator)
osu-stable       : 215 BPM
This PR          : 215 BPM
```