### PR TITLE
Improve quality of beatmap background blurs

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -14,6 +14,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -323,7 +324,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public bool IsBackgroundUndimmed() => background.CurrentColour == Color4.White;
 
-            public bool IsUserBlurApplied() => background.CurrentBlur == new Vector2((float)BlurLevel.Value * BackgroundScreenBeatmap.USER_BLUR_FACTOR);
+            public bool IsUserBlurApplied() => Precision.AlmostEquals(background.CurrentBlur, new Vector2((float)BlurLevel.Value * BackgroundScreenBeatmap.USER_BLUR_FACTOR), 0.1f);
 
             public bool IsUserBlurDisabled() => background.CurrentBlur == new Vector2(0);
 
@@ -331,9 +332,9 @@ namespace osu.Game.Tests.Visual.Background
 
             public bool IsBackgroundVisible() => background.CurrentAlpha == 1;
 
-            public bool IsBackgroundBlur() => background.CurrentBlur == new Vector2(BACKGROUND_BLUR);
+            public bool IsBackgroundBlur() => Precision.AlmostEquals(background.CurrentBlur, new Vector2(BACKGROUND_BLUR), 0.1f);
 
-            public bool CheckBackgroundBlur(Vector2 expected) => background.CurrentBlur == expected;
+            public bool CheckBackgroundBlur(Vector2 expected) => Precision.AlmostEquals(background.CurrentBlur, expected, 0.1f);
 
             /// <summary>
             /// Make sure every time a screen gets pushed, the background doesn't get replaced

--- a/osu.Game/Graphics/Backgrounds/Background.cs
+++ b/osu.Game/Graphics/Backgrounds/Background.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -17,8 +18,6 @@ namespace osu.Game.Graphics.Backgrounds
     /// </summary>
     public class Background : CompositeDrawable, IEquatable<Background>
     {
-        private const float blur_scale = 0.5f;
-
         public readonly Sprite Sprite;
 
         private readonly string textureName;
@@ -46,7 +45,7 @@ namespace osu.Game.Graphics.Backgrounds
                 Sprite.Texture = textures.Get(textureName);
         }
 
-        public Vector2 BlurSigma => bufferedContainer?.BlurSigma / blur_scale ?? Vector2.Zero;
+        public Vector2 BlurSigma => Vector2.Divide(bufferedContainer?.BlurSigma ?? Vector2.Zero, blurScale);
 
         /// <summary>
         /// Smoothly adjusts <see cref="IBufferedContainer.BlurSigma"/> over time.
@@ -67,9 +66,48 @@ namespace osu.Game.Graphics.Backgrounds
             }
 
             if (bufferedContainer != null)
-                bufferedContainer.FrameBufferScale = newBlurSigma == Vector2.Zero ? Vector2.One : new Vector2(blur_scale);
+                transformBlurSigma(newBlurSigma, duration, easing);
+        }
 
-            bufferedContainer?.BlurTo(newBlurSigma * blur_scale, duration, easing);
+        private void transformBlurSigma(Vector2 newBlurSigma, double duration, Easing easing)
+            => this.TransformTo(nameof(blurSigma), newBlurSigma, duration, easing);
+
+        private Vector2 blurSigmaBacking = Vector2.Zero;
+        private Vector2 blurScale = Vector2.One;
+
+        private Vector2 blurSigma
+        {
+            get => blurSigmaBacking;
+            set
+            {
+                Debug.Assert(bufferedContainer != null);
+
+                blurSigmaBacking = value;
+                blurScale = new Vector2(calculateBlurDownscale(value.X), calculateBlurDownscale(value.Y));
+
+                bufferedContainer.FrameBufferScale = blurScale;
+                bufferedContainer.BlurSigma = value * blurScale; // If the image is scaled down, the blur radius also needs to be reduced to cover the same pixel block.
+            }
+        }
+
+        /// <summary>
+        /// Determines a factor to downscale the background based on a given blur sigma, in order to reduce the computational complexity of blurs.
+        /// </summary>
+        /// <param name="sigma">The blur sigma.</param>
+        /// <returns>The scale-down factor.</returns>
+        private float calculateBlurDownscale(float sigma)
+        {
+            // If we're blurring within one pixel, scaling down will always result in an undesirable loss of quality.
+            // The algorithm below would also cause this value to go above 1, which is likewise undesirable.
+            if (sigma <= 1)
+                return 1;
+
+            // A good value is one where the loss in quality as a result of downscaling the image is not easily perceivable.
+            // The constants here have been experimentally chosen to yield nice transitions by approximating a log curve through the points {{ 1, 1 }, { 4, 0.75 }, { 16, 0.5 }, { 32, 0.25 }}.
+            float scale = -0.18f * MathF.Log(0.004f * sigma);
+
+            // To reduce shimmering, the scaling transitions are limited to happen only in increments of 0.2.
+            return MathF.Round(scale / 0.2f, MidpointRounding.AwayFromZero) * 0.2f;
         }
 
         public virtual bool Equals(Background other)


### PR DESCRIPTION
Fixes the issue brought up in https://github.com/ppy/osu/discussions/16270

First off I want to apologise for spending time on this. Blur is one of those things which I have a personal pet peeve over, and I can't let osu! have the same issues as iOS which I can't unsee and trigger me on a daily basis.

Rather than simply going down to 0.5x scale as soon as any blur is applied, this method is more of a continuous curve aiming to provide the best quality at all times.  
It does mean that at very low blur radii we're blurring a higher resolution (or even the entire original image) compared to previously, however I don't know if/think this will have much of an impact on performance in practice simply due to the smaller blur radii (<5).
Edit: Tested on a much weaker PC (Intel HD Graphics 4400) and if there's any performance impact I can't notice it.

- Before 7% blur it blurs the original resolution.
- Beyond 20% blur it blurs at a very similar resolution to previously.
- Beyond 62% blur it blurs at a lower resolution to previously.
- In song select, the blurred resolution is smaller than previously.

Comparisons ("blur size" indicates size of blurred framebuffer):
| % blur | before | after | before blur size | after blur size |
| --- | --- | --- | --- | --- |
| 1% | ![before-1%](https://user-images.githubusercontent.com/1329837/148942484-21340cbd-be6e-457d-aecc-f44ec79ea955.png) | ![after-1%](https://user-images.githubusercontent.com/1329837/148942506-cd356706-76cd-4f44-8cd6-369bcba4bf2f.png) | 1029x545 | 2057x1089 |
| 6% | ![before-6%](https://user-images.githubusercontent.com/1329837/148942537-b46df8ed-a6e1-45a6-b2ba-aa10a2da5266.png) | ![after-6%](https://user-images.githubusercontent.com/1329837/148942545-1c997c09-cff3-4c3a-9c17-e3e9dbed9f81.png) | 1029x545 | 2057x1089 | 2057x1089 |
| 7% | ![before-7%](https://user-images.githubusercontent.com/1329837/148942570-5c6554df-3776-4d29-9201-48892d5c9b21.png) | ![after-7%](https://user-images.githubusercontent.com/1329837/148942581-a34bc213-e87e-4c57-93b7-d492c7fde31a.png) | 1029x545 | 1646x871 |
| 20% | ![before-20%](https://user-images.githubusercontent.com/1329837/148942607-96a1e8a8-9868-4f10-b78b-403c792ff0d8.png) | ![after-20%](https://user-images.githubusercontent.com/1329837/148942615-e6d2563a-eead-428a-b1ba-1fe6e36df89a.png) | 1029x545 | 1646x871 |
| 21% | ![before-21%](https://user-images.githubusercontent.com/1329837/148942633-f6fb1aec-a0c8-4be5-a007-d18603765ce4.png) | ![after-21%](https://user-images.githubusercontent.com/1329837/148942645-fb96bf54-41d3-4b04-9423-2f627807ad36.png) | 1029x545 | 1234x653 |
| 50% | ![before-50%](https://user-images.githubusercontent.com/1329837/148942678-3b536e00-aa2f-43b4-a79a-bd71a0f9edc8.png) | ![after-50%](https://user-images.githubusercontent.com/1329837/148942686-71b5c72c-6fe5-4c65-8af7-37a9dc64e3cc.png) | 1029x545 | 1234x653 |
| 62% | ![before-62%](https://user-images.githubusercontent.com/1329837/148942716-60b2009b-7ed6-495e-9dd0-ec3618c38ed1.png) | ![after-62%](https://user-images.githubusercontent.com/1329837/148942733-5a2cd984-32b5-49f4-ab6c-fa4c5bdc259d.png) | 1029x545 | 1234x653 |
| 63% | ![before-63%](https://user-images.githubusercontent.com/1329837/148942747-acfd466e-20c7-44d2-9c82-1417714acc38.png) | ![after-63%](https://user-images.githubusercontent.com/1329837/148942751-e92f5d41-5754-4d3a-aedc-b538fbac80b0.png) | 1029x545 | 823x436 |
| 85% | ![before-85%](https://user-images.githubusercontent.com/1329837/148942782-7d809603-775c-4234-b98a-b9f664ac04c2.png) | ![after-85%](https://user-images.githubusercontent.com/1329837/148942792-b1bc16a8-4a03-4565-ac79-c066ede9dbdb.png) | 1029x545 | 823x436 |
| 100% | ![before-100%](https://user-images.githubusercontent.com/1329837/148942811-92354ef5-7af4-46cf-84c8-85c0d928846d.png) | ![after-100%](https://user-images.githubusercontent.com/1329837/148942823-894dc711-67ba-434e-ac0b-c8a0dd5dd03c.png) | 1029x545 | 823x436 |