### PR TITLE
Fix pasted sliders having sample points with time at infinity

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
@@ -85,11 +86,17 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
 
+            Slider slider = null;
+            AddStep("retrieve slider", () => slider = (Slider)EditorBeatmap.HitObjects.Single());
             AddAssert("path matches", () =>
             {
-                var path = ((Slider)EditorBeatmap.HitObjects.Single()).Path;
+                var path = slider.Path;
                 return path.ControlPoints.Count == 2 && path.ControlPoints.SequenceEqual(addedObject.Path.ControlPoints);
             });
+
+            // see `HitObject.control_point_leniency`.
+            AddAssert("sample control point has correct time", () => Precision.AlmostEquals(slider.SampleControlPoint.Time, slider.GetEndTime(), 1));
+            AddAssert("difficulty control point has correct time", () => slider.DifficultyControlPoint.Time == slider.StartTime);
         }
 
         [Test]

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -146,11 +146,8 @@ namespace osu.Game.Rulesets.Objects
                 foreach (var nested in nestedHitObjects)
                     nested.StartTime += offset;
 
-                if (DifficultyControlPoint != DifficultyControlPoint.DEFAULT)
-                    DifficultyControlPoint.Time = time.NewValue;
-
-                if (SampleControlPoint != SampleControlPoint.DEFAULT)
-                    SampleControlPoint.Time = this.GetEndTime() + control_point_leniency;
+                DifficultyControlPoint.Time = time.NewValue;
+                SampleControlPoint.Time = this.GetEndTime() + control_point_leniency;
             };
 
             DefaultsApplied?.Invoke(this);


### PR DESCRIPTION
Fixes #16417.

Going to be honest, while I'm pretty sure this makes sense, I'm a touch worried about this fix, and I haven't tested it too thoroughly (checked the failure scenario, a few obvious things in gameplay, and ran full test suite on fork CI). So this is primarily PR'd for comment.

The failure case was as follows: In the context of a paste operation, `StartTime` is changed on the pasted object(s) before they have had their `ApplyDefaults()` called:

https://github.com/ppy/osu/blob/c328b26de1ddecaa0647ce7f5840860e13059c7c/osu.Game/Screens/Edit/Compose/ComposeScreen.cs#L120-L130

`StartTime` proxies to `StartTimeBindable`, which had the following callback installed:

https://github.com/ppy/osu/blob/c328b26de1ddecaa0647ce7f5840860e13059c7c/osu.Game/Rulesets/Objects/HitObject.cs#L99-L103

And because `ApplyDefaults()` had not been called yet, `this.GetEndTime()` happily returns infinity for sliders, which then gets written into the `.osu` beatmap file, and only fails at the next decode when the parser spews due to value being out of range.

To fix, I've changed the `ApplyDefaults()` logic to always apply the sane times to both hitobject-specific control points regardless of where they came from, as well as moved the `ValueChanged` callback registration so that it can't fire if defaults have not yet been applied. I've also removed some guards against `DEFAULT` because they look unreachable after the above changes (unless somebody tries to shoot themselves in the foot *really* hard by manually setting `DEFAULT` points on the object, at which point it's probably a good thing that they get an exception for it).

I *could* have as well just fixed the usage site in editor to mutate the start time only after defaults have been applied, but this feels like a better fix, if correct, as it should eliminate that entire class of bugs.