### PR TITLE
Add button to compact realm on demand

### DIFF
--- a/osu.Game/Localisation/DebugSettingsStrings.cs
+++ b/osu.Game/Localisation/DebugSettingsStrings.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ClearAllCaches => new TranslatableString(getKey(@"clear_all_caches"), @"Clear all caches");
 
+        /// <summary>
+        /// "Compact realm"
+        /// </summary>
+        public static LocalisableString CompactRealm => new TranslatableString(getKey(@"compact_realm"), @"Compact realm");
+
         private static string getKey(string key) => $"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -6,6 +6,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
+using osu.Game.Database;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.DebugSettings
@@ -15,7 +16,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
         protected override LocalisableString Header => DebugSettingsStrings.MemoryHeader;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkDebugConfigManager config, GameHost host)
+        private void load(FrameworkDebugConfigManager config, GameHost host, RealmContextFactory realmFactory)
         {
             Children = new Drawable[]
             {
@@ -23,6 +24,17 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                 {
                     Text = DebugSettingsStrings.ClearAllCaches,
                     Action = host.Collect
+                },
+                new SettingsButton
+                {
+                    Text = DebugSettingsStrings.CompactRealm,
+                    Action = () =>
+                    {
+                        // Blocking operations implicitly causes a Compact().
+                        using (realmFactory.BlockAllOperations())
+                        {
+                        }
+                    }
                 },
             };
         }


### PR DESCRIPTION
In general we're doing things correctly so the realm file shouldn't expand (unless mass deletions are made from it), but this is a nice way to manually confirm the behaviour.

Sometimes if using realm studio with osu! running, for instance, the realm file size can blow out of proportion. This will recover from such cases.

Note that calling `RealmFactory.Compact` itself is not enough, as it will fail unless all instances of the realm have been closed.