### PR TITLE
Fix mania requiring PERFECTs to maintain HP

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Mania
 
         public override ScoreProcessor CreateScoreProcessor() => new ManiaScoreProcessor();
 
-        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new DrainingHealthProcessor(drainStartTime, 0.5);
+        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new ManiaHealthProcessor(drainStartTime, 0.5);
 
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new ManiaBeatmapConverter(beatmap, this);
 

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHealthProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHealthProcessor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Scoring
+{
+    public class ManiaHealthProcessor : DrainingHealthProcessor
+    {
+        /// <inheritdoc/>
+        public ManiaHealthProcessor(double drainStartTime, double drainLenience = 0)
+            : base(drainStartTime, drainLenience)
+        {
+        }
+
+        protected override HitResult GetSimulatedHitResult(Judgement judgement)
+        {
+            // Users are not expected to attain perfect judgements for all notes due to the tighter hit window.
+            return judgement.MaxResult == HitResult.Perfect ? HitResult.Great : judgement.MaxResult;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Rulesets.Scoring
                 if (result == null)
                     throw new InvalidOperationException($"{GetType().ReadableName()} must provide a {nameof(JudgementResult)} through {nameof(CreateResult)}.");
 
-                result.Type = judgement.MaxResult;
+                result.Type = GetSimulatedHitResult(judgement);
                 ApplyResult(result);
             }
         }
@@ -145,5 +145,12 @@ namespace osu.Game.Rulesets.Scoring
             base.Update();
             hasCompleted.Value = JudgedHits == MaxHits && (JudgedHits == 0 || lastAppliedResult.TimeAbsolute < Clock.CurrentTime);
         }
+
+        /// <summary>
+        /// Gets a simulated <see cref="HitResult"/> for a judgement. Used during <see cref="SimulateAutoplay"/> to simulate a "perfect" play.
+        /// </summary>
+        /// <param name="judgement">The judgement to simulate a <see cref="HitResult"/> for.</param>
+        /// <returns>The simulated <see cref="HitResult"/> for the judgement.</returns>
+        protected virtual HitResult GetSimulatedHitResult(Judgement judgement) => judgement.MaxResult;
     }
 }


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu/issues/16429

The following code makes autoplay get around 90% accuracy on this map, and passes.
```diff
diff --git a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
index efe144ac03..1658b85a59 100644
--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -3,10 +3,12 @@

 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;

 namespace osu.Game.Rulesets.Mania.Replays
 {
@@ -77,7 +79,30 @@ private IEnumerable<IActionPoint> generateActionPoints()
                 var nextObjectInColumn = GetNextObject(i); // Get the next object that requires pressing the same button
                 double releaseTime = calculateReleaseTime(currentObject, nextObjectInColumn);

-                yield return new HitPoint { Time = currentObject.StartTime, Column = currentObject.Column };
+                int rng = RNG.Next(10);
+                double offset;
+
+                switch (rng)
+                {
+                    // PERFECT (20%)
+                    case 0:
+                    case 1:
+                        offset = 0;
+                        break;
+
+                    // GOOD (20%)
+                    case 2:
+                    case 3:
+                        offset = currentObject.HitWindows.WindowFor(HitResult.Great) + 5;
+                        break;
+
+                    // GREAT (60%)
+                    default:
+                        offset = currentObject.HitWindows.WindowFor(HitResult.Perfect) + 5;
+                        break;
+                }
+
+                yield return new HitPoint { Time = currentObject.StartTime - offset, Column = currentObject.Column };

                 yield return new ReleasePoint { Time = releaseTime, Column = currentObject.Column };
```

It's probably still a bit too harsh than it should be, but I think this logic is more what's expected. Further changes could be done by adjusting the leniency (currently 0.5) or adjusting for simultaneous hitobjects.