### PR TITLE
Fix skin hash repopulation not working since realm migration

### DIFF
--- a/osu.Game/Skinning/SkinModelManager.cs
+++ b/osu.Game/Skinning/SkinModelManager.cs
@@ -210,13 +210,13 @@ namespace osu.Game.Skinning
         {
             using (var realm = ContextFactory.CreateContext())
             {
-                var skinsWithoutHashes = realm.All<SkinInfo>().Where(i => string.IsNullOrEmpty(i.Hash)).ToArray();
+                var skinsWithoutHashes = realm.All<SkinInfo>().Where(i => !i.Protected && string.IsNullOrEmpty(i.Hash)).ToArray();
 
                 foreach (SkinInfo skin in skinsWithoutHashes)
                 {
                     try
                     {
-                        Update(skin);
+                        realm.Write(r => skin.Hash = ComputeHash(skin));
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
Pretty huge oversight I found while refactoring everything.

Not adding test coverage as this is code which will be removed in a few months (and the current tests don't easily allow re-running the `ctor` code in `SkinModelManager` to test this out). Here's a video showing this working correctly:

https://user-images.githubusercontent.com/191335/149108398-d9c816be-9045-4a29-9aad-c20f390a5a7d.mp4


