### PR TITLE
Fix test failures due to double `BeginPlaying` calls

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -36,7 +36,7 @@ using osuTK.Graphics;
 namespace osu.Game.Tests.Visual.Background
 {
     [TestFixture]
-    public class TestSceneUserDimBackgrounds : OsuManualInputManagerTestScene
+    public class TestSceneUserDimBackgrounds : ScreenTestScene
     {
         private DummySongSelect songSelect;
         private TestPlayerLoader playerLoader;
@@ -56,14 +56,12 @@ namespace osu.Game.Tests.Visual.Background
             Beatmap.SetDefault();
         }
 
-        [SetUp]
-        public virtual void SetUp() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            var stack = new OsuScreenStack { RelativeSizeAxes = Axes.Both };
-            Child = stack;
+            base.SetUpSteps();
 
-            stack.Push(songSelect = new DummySongSelect());
-        });
+            AddStep("push song select", () => Stack.Push(songSelect = new DummySongSelect()));
+        }
 
         /// <summary>
         /// User settings should always be ignored on song select screen.


### PR DESCRIPTION
Should fix the remaining common test failures as [seen](https://github.com/ppy/osu/runs/4770716980?check_suite_focus=true) [here](https://github.com/ppy/osu/runs/4791375041?check_suite_focus=true).

Issue was that this test scene was not cleaning up the previous player instance properly due to having very custom screen stack logic.