### PR TITLE
Add volume dip to track during fail sequence

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.109.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.114.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.111.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Screens.Play
 
         private readonly DrawableRuleset drawableRuleset;
         private readonly BindableDouble trackFreq = new BindableDouble(1);
+        private readonly BindableDouble volumeAdjustment = new BindableDouble(0.5);
 
         private Container filters;
 
@@ -125,6 +126,7 @@ namespace osu.Game.Screens.Play
             failSample.Play();
 
             track.AddAdjustment(AdjustableProperty.Frequency, trackFreq);
+            track.AddAdjustment(AdjustableProperty.Volume, volumeAdjustment);
 
             applyToPlayfield(drawableRuleset.Playfield);
             drawableRuleset.Playfield.HitObjectContainer.FadeOut(duration / 2);
@@ -153,6 +155,8 @@ namespace osu.Game.Screens.Play
         {
             if (resetTrackFrequency)
                 track?.RemoveAdjustment(AdjustableProperty.Frequency, trackFreq);
+
+            track?.RemoveAdjustment(AdjustableProperty.Volume, volumeAdjustment);
 
             if (filters.Parent == null)
                 return;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.7.1" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.111.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.109.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.114.0" />
     <PackageReference Include="Sentry" Version="3.12.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.111.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.109.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.114.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
- [x] Depends on ppy/osu-resources#169
- [x] Depends on resource bump

Pairs with the new gameplay fail sample (ppy/osu-resources#169) to help it remain audible (esp. for louder songs)