### PR TITLE
Assign position to spinner ticks for correct positional sound playback

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -65,8 +65,8 @@ namespace osu.Game.Rulesets.Osu.Objects
                 double startTime = StartTime + (float)(i + 1) / totalSpins * Duration;
 
                 AddNested(i < SpinsRequired
-                    ? new SpinnerTick { StartTime = startTime }
-                    : new SpinnerBonusTick { StartTime = startTime });
+                    ? new SpinnerTick { StartTime = startTime, Position = Position }
+                    : new SpinnerBonusTick { StartTime = startTime, Position = Position });
             }
         }
 


### PR DESCRIPTION
Closes #16462

Since the off-centered sound plays from spinner ticks, resolving this was as simple as copying the position from the main spinner hitobject (which is also a friendly way for "non-centered spinners" in the future).

Not sure how this one could sensibly be tested (asserting position is equal sounds like it's missing the point).