### PR TITLE
Fix gameplay not completing on some taiko maps

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumRollJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumRollJudgements.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneDrumRollJudgements : TestSceneTaikoPlayer
+    {
+        [Test]
+        public void TestStrongDrumRollFullyJudgedOnKilled()
+        {
+            AddUntilStep("gameplay finished", () => Player.ScoreProcessor.HasCompleted.Value);
+            AddAssert("all judgements are misses", () => Player.Results.All(r => r.Type == r.Judgement.MinResult));
+        }
+
+        protected override bool Autoplay => false;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap<TaikoHitObject>()
+        {
+            BeatmapInfo = { Ruleset = new TaikoRuleset().RulesetInfo },
+            HitObjects =
+            {
+                new DrumRoll
+                {
+                    StartTime = 1000,
+                    Duration = 1000,
+                    IsStrong = true
+                }
+            }
+        };
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumRollJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumRollJudgements.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         protected override bool Autoplay => false;
 
-        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap<TaikoHitObject>()
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap<TaikoHitObject>
         {
             BeatmapInfo = { Ruleset = new TaikoRuleset().RulesetInfo },
             HitObjects =

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -197,6 +197,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 ApplyResult(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
+            public override void OnKilled()
+            {
+                base.OnKilled();
+
+                if (Time.Current > ParentHitObject.HitObject.GetEndTime() && !Judged)
+                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+            }
+
             public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
         }
     }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -5,6 +5,7 @@ using System;
 using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
@@ -52,6 +53,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
+        public override void OnKilled()
+        {
+            base.OnKilled();
+
+            if (Time.Current > HitObject.GetEndTime() && !Judged)
+                ApplyResult(r => r.Type = r.Judgement.MinResult);
+        }
+
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             switch (state)
@@ -90,6 +99,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     return;
 
                 ApplyResult(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
+            }
+
+            public override void OnKilled()
+            {
+                base.OnKilled();
+
+                if (Time.Current > ParentHitObject.HitObject.GetEndTime() && !Judged)
+                    ApplyResult(r => r.Type = r.Judgement.MinResult);
             }
 
             public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;


### PR DESCRIPTION
Hopefully resolves https://github.com/ppy/osu/discussions/15472. PRing for comment, I'm not 100% on this solution.

There is a test scenario included, but for a manual repro scenario on `master` you could also try the following:

1. Import https://osu.ppy.sh/beatmapsets/665612#taiko/1410446
2. Start gameplay on said map with No Fail, Hidden (also recommend putting Double Time on with max speed to make faster)
3. Enter map, wait for it to complete
4. Map does not complete

The reason why this was happening was that nested objects weren't getting judged on kill.

* The last drum roll tick's hit window extended past the parent object's end time, causing it to not be judged even via the `DrawableHitObject.OnKilled()` flow:

  https://github.com/ppy/osu/blob/4ca2822d409ff8b4b17213f9ef1c2916d8fdd706/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs#L42-L47

  In the case of the last tick, the inner offset check does not pass if the tick is positioned closer than half of tick spacing away from the end time.

* If a drum roll is strong, then its ticks also have nested strong objects. Those depend on their parent objects to be judged:

  https://github.com/ppy/osu/blob/4ca2822d409ff8b4b17213f9ef1c2916d8fdd706/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs#L87-L93

  However, the `OnKilled()` flow judges the parent object *after* the nesteds:

  https://github.com/ppy/osu/blob/4ca2822d409ff8b4b17213f9ef1c2916d8fdd706/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L624-L637

  Therefore in the nested objects `CheckForResult()` did nothing, leaving the nested strong objects without a result.

  I initially wanted to invert the order of operations in `OnKilled()` (to apply result to the parent first), but then realised this is highly situational and depends on what the ruleset wants - some objects will want their children to be judged first to judge the parent. In fact osu! sliders with classic mod will do precisely that, so I refrained from touching that ordering and applied local fixes.

The `Time.Current` checks everywhere are required because sometimes `OnKilled()` will get called on objects before they have even started, causing false misses.