### PR TITLE
Strip `@2x` scale specifications from legacy texture lookups if present

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Resources/special-skin/skin.ini
+++ b/osu.Game.Rulesets.Mania.Tests/Resources/special-skin/skin.ini
@@ -4,11 +4,14 @@ Version: 2.5
 [Mania]
 Keys: 4
 ColumnLineWidth: 3,1,3,1,1
-Hit0: mania/hit0
-Hit50: mania/hit50
-Hit100: mania/hit100
-Hit200: mania/hit200
-Hit300: mania/hit300
-Hit300g: mania/hit300g
+// some skins found in the wild had configuration keys where the @2x suffix was included in the values.
+// the expected compatibility behaviour is that the presence of the @2x suffix shouldn't change anything
+// if @2x assets are present.
+Hit0: mania/hit0@2x
+Hit50: mania/hit50@2x
+Hit100: mania/hit100@2x
+Hit200: mania/hit200@2x
+Hit300: mania/hit300@2x
+Hit300g: mania/hit300g@2x
 StageLeft: mania/stage-left
 StageRight: mania/stage-right

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
@@ -5,8 +5,10 @@ using System;
 using System.Linq;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Mania.Skinning.Legacy;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -23,15 +25,24 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
             {
                 if (hitWindows.IsHitResultAllowed(result))
                 {
-                    AddStep("Show " + result.GetDescription(), () => SetContents(_ =>
-                        new DrawableManiaJudgement(new JudgementResult(new HitObject { StartTime = Time.Current }, new Judgement())
-                        {
-                            Type = result
-                        }, null)
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                        }));
+                    AddStep("Show " + result.GetDescription(), () =>
+                    {
+                        SetContents(_ =>
+                            new DrawableManiaJudgement(new JudgementResult(new HitObject { StartTime = Time.Current }, new Judgement())
+                            {
+                                Type = result
+                            }, null)
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            });
+
+                        // for test purposes, undo the Y adjustment related to the `ScorePosition` legacy positioning config value
+                        // (see `LegacyManiaJudgementPiece.load()`).
+                        // this prevents the judgements showing somewhere below or above the bounding box of the judgement.
+                        foreach (var legacyPiece in this.ChildrenOfType<LegacyManiaJudgementPiece>())
+                            legacyPiece.Y = 0;
+                    });
                 }
             }
         }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -474,13 +474,18 @@ namespace osu.Game.Skinning
         {
             foreach (string name in getFallbackNames(componentName))
             {
+                // some component names (especially user-controlled ones, like `HitX` in mania)
+                // may contain `@2x` scale specifications.
+                // stable happens to check for that and strip them, so do the same to match stable behaviour.
+                string lookupName = name.Replace(@"@2x", string.Empty);
+
                 float ratio = 2;
-                var texture = Textures?.Get($"{name}@2x", wrapModeS, wrapModeT);
+                var texture = Textures?.Get(@$"{lookupName}@2x", wrapModeS, wrapModeT);
 
                 if (texture == null)
                 {
                     ratio = 1;
-                    texture = Textures?.Get(name, wrapModeS, wrapModeT);
+                    texture = Textures?.Get(lookupName, wrapModeS, wrapModeT);
                 }
 
                 if (texture == null)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/discussions/16403

Also contains some changes to `TestSceneDrawableJudgement` which looks broken on `master` due to score position logic destroying that scene.