### PR TITLE
Add test to check full flow of rebinding gameplay key bindings

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -14,7 +14,6 @@ using osu.Game.Overlays.Settings.Sections.Input;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osu.Game.Tests.Beatmaps.IO;
-using osu.Game.Tests.Database;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Navigation

--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Testing;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
+using osu.Game.Overlays.Settings.Sections.Input;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Select;
+using osu.Game.Tests.Beatmaps.IO;
+using osu.Game.Tests.Database;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public class TestSceneChangeAndUseGameplayBindings : OsuGameTestScene
+    {
+        [Test]
+        public void TestGameplayKeyBindings()
+        {
+            AddAssert("databased key is default", () => firstOsuRulesetKeyBindings.KeyCombination.Keys.SequenceEqual(new[] { InputKey.Z }));
+
+            AddStep("open settings", () => { Game.Settings.Show(); });
+
+            // Until step requires as settings has a delayed load.
+            AddUntilStep("wait for button", () => configureBindingsButton?.Enabled.Value == true);
+            AddStep("scroll to section", () => Game.Settings.SectionsContainer.ScrollTo(configureBindingsButton));
+            AddStep("press button", () => configureBindingsButton.TriggerClick());
+            AddUntilStep("wait for panel", () => keyBindingPanel?.IsLoaded == true);
+            AddUntilStep("wait for osu subsection", () => osuBindingSubsection?.IsLoaded == true);
+            AddStep("scroll to section", () => keyBindingPanel.SectionsContainer.ScrollTo(osuBindingSubsection));
+            AddWaitStep("wait for scroll to end", 3);
+            AddStep("start rebinding first osu! key", () =>
+            {
+                var button = osuBindingSubsection.ChildrenOfType<KeyBindingRow>().First();
+
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("Press 's'", () => InputManager.Key(Key.S));
+
+            AddUntilStep("wait for database updated", () => firstOsuRulesetKeyBindings.KeyCombination.Keys.SequenceEqual(new[] { InputKey.S }));
+
+            AddStep("close settings", () => Game.Settings.Hide());
+
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).WaitSafely());
+            PushAndConfirm(() => new PlaySongSelect());
+
+            AddStep("enter gameplay", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for gameplay", () => player?.IsBreakTime.Value == false);
+
+            AddStep("press 'z'", () => InputManager.Key(Key.Z));
+            AddAssert("key counter didn't increase", () => keyCounter.CountPresses == 0);
+
+            AddStep("press 's'", () => InputManager.Key(Key.S));
+            AddAssert("key counter did increase", () => keyCounter.CountPresses == 1);
+        }
+
+        private KeyBindingsSubsection osuBindingSubsection => keyBindingPanel
+                                                              .ChildrenOfType<VariantBindingsSubsection>()
+                                                              .FirstOrDefault(s => s.Ruleset.ShortName == "osu");
+
+        private OsuButton configureBindingsButton => Game.Settings
+                                                         .ChildrenOfType<BindingSettings>().SingleOrDefault()?
+                                                         .ChildrenOfType<OsuButton>()?
+                                                         .First(b => b.Text.ToString() == "Configure");
+
+        private KeyBindingPanel keyBindingPanel => Game.Settings
+                                                       .ChildrenOfType<KeyBindingPanel>().SingleOrDefault();
+
+        private RealmKeyBinding firstOsuRulesetKeyBindings => Game.Dependencies
+                                                                  .Get<RealmContextFactory>().Context
+                                                                  .All<RealmKeyBinding>()
+                                                                  .AsEnumerable()
+                                                                  .First(k => k.RulesetName == "osu" && k.ActionInt == 0);
+
+        private Player player => Game.ScreenStack.CurrentScreen as Player;
+
+        private KeyCounter keyCounter => player.ChildrenOfType<KeyCounter>().First();
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
     {
         protected IEnumerable<Framework.Input.Bindings.KeyBinding> Defaults;
 
-        protected RulesetInfo Ruleset;
+        public RulesetInfo Ruleset { get; protected set; }
 
         private readonly int? variant;
 


### PR DESCRIPTION
Addresses a regression found in realm PR that was not covered by tests. Have tested that it fails against the non-fixed code.