### PR TITLE
Add test coverage of aggregate scores displaying correctly at multiplayer/playlists screens

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.OnlinePlay.Components;
+using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Beatmaps;
@@ -70,6 +71,8 @@ namespace osu.Game.Tests.Visual.Playlists
             });
 
             AddUntilStep("Progress details are hidden", () => match.ChildrenOfType<RoomLocalUserInfo>().FirstOrDefault()?.Parent.Alpha == 0);
+
+            AddUntilStep("Leaderboard shows two aggregate scores", () => match.ChildrenOfType<MatchLeaderboardScore>().Count(s => s.ScoreText.Text != "0") == 2);
 
             AddStep("start match", () => match.ChildrenOfType<PlaylistsReadyButton>().First().TriggerClick());
             AddUntilStep("player loader loaded", () => Stack.CurrentScreen is PlayerLoader);

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -53,7 +53,9 @@ namespace osu.Game.Online.Leaderboards
         private Drawable avatar;
         private Drawable scoreRank;
         private OsuSpriteText nameLabel;
-        private GlowingSpriteText scoreLabel;
+
+        public GlowingSpriteText ScoreText { get; private set; }
+
         private Container flagBadgeContainer;
         private FillFlowContainer<ModIcon> modsContainer;
 
@@ -198,7 +200,7 @@ namespace osu.Game.Online.Leaderboards
                                     Spacing = new Vector2(5f, 0f),
                                     Children = new Drawable[]
                                     {
-                                        scoreLabel = new GlowingSpriteText
+                                        ScoreText = new GlowingSpriteText
                                         {
                                             TextColour = Color4.White,
                                             GlowColour = Color4Extensions.FromHex(@"83ccfa"),
@@ -240,7 +242,7 @@ namespace osu.Game.Online.Leaderboards
 
         public override void Show()
         {
-            foreach (var d in new[] { avatar, nameLabel, scoreLabel, scoreRank, flagBadgeContainer, modsContainer }.Concat(statisticsLabels))
+            foreach (var d in new[] { avatar, nameLabel, ScoreText, scoreRank, flagBadgeContainer, modsContainer }.Concat(statisticsLabels))
                 d.FadeOut();
 
             Alpha = 0;
@@ -262,7 +264,7 @@ namespace osu.Game.Online.Leaderboards
 
                 using (BeginDelayedSequence(250))
                 {
-                    scoreLabel.FadeIn(200);
+                    ScoreText.FadeIn(200);
                     scoreRank.FadeIn(200);
 
                     using (BeginDelayedSequence(50))

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -70,6 +70,29 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                     return true;
                 }
 
+                case GetRoomLeaderboardRequest roomLeaderboardRequest:
+                    roomLeaderboardRequest.TriggerSuccess(new APILeaderboard
+                    {
+                        Leaderboard = new List<APIUserScoreAggregate>
+                        {
+                            new APIUserScoreAggregate
+                            {
+                                TotalScore = 1000000,
+                                TotalAttempts = 5,
+                                CompletedBeatmaps = 2,
+                                User = new APIUser { Username = "best user" }
+                            },
+                            new APIUserScoreAggregate
+                            {
+                                TotalScore = 50,
+                                TotalAttempts = 1,
+                                CompletedBeatmaps = 1,
+                                User = new APIUser { Username = "worst user" }
+                            }
+                        }
+                    });
+                    return true;
+
                 case PartRoomRequest partRoomRequest:
                     partRoomRequest.TriggerSuccess();
                     return true;


### PR DESCRIPTION
Covers the regression that surfaced twice in the realm PR. Have tested to correctly fail there.

Bit unfortunate about having to expose `ScoreText` but I can't see a better way apart from subclassing it for `ChildrenOfType` usage.