### PR TITLE
Improve safety and logging of realm migration process

### DIFF
--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Storage;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
 
@@ -147,6 +148,7 @@ namespace osu.Game.Database
 
         public void CreateBackup(string filename)
         {
+            Logger.Log($"Creating full EF database backup at {filename}", LoggingTarget.Database);
             using (var source = storage.GetStream(DATABASE_NAME))
             using (var destination = storage.GetStream(filename, FileAccess.Write, FileMode.CreateNew))
                 source.CopyTo(destination);

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -143,6 +144,13 @@ namespace osu.Game.Database
         {
             Database = { AutoTransactionsEnabled = false }
         };
+
+        public void CreateBackup(string filename)
+        {
+            using (var source = storage.GetStream(DATABASE_NAME))
+            using (var destination = storage.GetStream(filename, FileAccess.Write, FileMode.CreateNew))
+                source.CopyTo(destination);
+        }
 
         public void ResetDatabase()
         {

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Storage;
+using osu.Framework.Development;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
@@ -146,11 +147,15 @@ namespace osu.Game.Database
             Database = { AutoTransactionsEnabled = false }
         };
 
-        public void CreateBackup(string filename)
+        public void CreateBackup(string backupFilename)
         {
-            Logger.Log($"Creating full EF database backup at {filename}", LoggingTarget.Database);
+            Logger.Log($"Creating full EF database backup at {backupFilename}", LoggingTarget.Database);
+
+            if (DebugUtils.IsDebugBuild)
+                Logger.Log("Your development database has been fully migrated to realm. If you switch back to a pre-realm branch and need your previous database, rename the backup file back to \"client.db\".\n\nNote that doing this can potentially leave your file store in a bad state.", level: LogLevel.Important);
+
             using (var source = storage.GetStream(DATABASE_NAME))
-            using (var destination = storage.GetStream(filename, FileAccess.Write, FileMode.CreateNew))
+            using (var destination = storage.GetStream(backupFilename, FileAccess.Write, FileMode.CreateNew))
                 source.CopyTo(destination);
         }
 

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -148,10 +148,10 @@ namespace osu.Game.Database
                         }
 
                         transaction.Commit();
+                        Logger.Log($"Successfully migrated {existingBeatmapSets.Count} beatmaps to realm", LoggingTarget.Database);
                     }
                 }
 
-                Logger.Log($"Successfully migrated {existingBeatmapSets.Count} beatmaps to realm", LoggingTarget.Database);
                 ef.Context.RemoveRange(existingBeatmapSets);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
             }
@@ -257,10 +257,10 @@ namespace osu.Game.Database
                         }
 
                         transaction.Commit();
+                        Logger.Log($"Successfully migrated {existingScores.Count} scores to realm", LoggingTarget.Database);
                     }
                 }
 
-                Logger.Log($"Successfully migrated {existingScores.Count} scores to realm", LoggingTarget.Database);
                 db.Context.RemoveRange(existingScores);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
             }

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -34,16 +34,12 @@ namespace osu.Game.Database
         public void Run()
         {
             using (var ef = efContextFactory.GetForWrite())
+            {
                 migrateSettings(ef);
-
-            using (var ef = efContextFactory.GetForWrite())
                 migrateSkins(ef);
-
-            using (var ef = efContextFactory.GetForWrite())
                 migrateBeatmaps(ef);
-
-            using (var ef = efContextFactory.GetForWrite())
                 migrateScores(ef);
+            }
 
             // Delete the database permanently.
             // Will cause future startups to not attempt migration.

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Database
                 }
 
                 // only migrate data if the realm database is empty.
-                // note that this cannot be written as: `realm.All<BeatmapInfo>().All(s => s.Protected)`, because realm does not support `.All()`.
+                // note that this cannot be written as: `realm.All<BeatmapSetInfo>().All(s => s.Protected)`, because realm does not support `.All()`.
                 if (realm.All<BeatmapSetInfo>().Any(s => !s.Protected))
                 {
                     Logger.Log("Skipping migration as realm already has beatmaps loaded", LoggingTarget.Database);
@@ -215,7 +215,6 @@ namespace osu.Game.Database
                 }
 
                 // only migrate data if the realm database is empty.
-                // note that this cannot be written as: `realm.All<ScoreInfo>().All(s => s.Protected)`, because realm does not support `.All()`.
                 if (realm.All<ScoreInfo>().Any())
                 {
                     Logger.Log("Skipping migration as realm already has scores loaded", LoggingTarget.Database);

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -75,6 +75,9 @@ namespace osu.Game.Database
                 if (!realm.All<BeatmapSetInfo>().Any(s => !s.Protected))
                 {
                     Logger.Log($"Migrating {existingBeatmapSets.Count} beatmaps", LoggingTarget.Database);
+                    string migration = $"before_beatmap_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
+                    realmContextFactory.CreateBackup($"client.{migration}.realm");
+                    efContextFactory.CreateBackup($"client.{migration}.db");
 
                     foreach (var beatmapSet in existingBeatmapSets)
                     {
@@ -131,7 +134,6 @@ namespace osu.Game.Database
                     }
                 }
 
-                efContextFactory.CreateBackup($"client.before_beatmap_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.db");
                 ef.Context.RemoveRange(existingBeatmapSets);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
 
@@ -187,6 +189,9 @@ namespace osu.Game.Database
                 if (!realm.All<ScoreInfo>().Any())
                 {
                     Logger.Log($"Migrating {existingScores.Count} scores", LoggingTarget.Database);
+                    string migration = $"before_score_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
+                    realmContextFactory.CreateBackup($"client.{migration}.realm");
+                    efContextFactory.CreateBackup($"client.{migration}.db");
 
                     foreach (var score in existingScores)
                     {
@@ -222,7 +227,6 @@ namespace osu.Game.Database
                     }
                 }
 
-                efContextFactory.CreateBackup($"client.before_scores_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.db");
                 db.Context.RemoveRange(existingScores);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
 

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -38,6 +38,10 @@ namespace osu.Game.Database
                 migrateBeatmaps(ef);
                 migrateScores(ef);
             }
+
+            // Delete the database permanently.
+            // Will cause future startups to not attempt migration.
+            efContextFactory.ResetDatabase();
         }
 
         private void migrateBeatmaps(DatabaseWriteUsage ef)

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -30,20 +30,20 @@ namespace osu.Game.Database
 
         public void Run()
         {
-            using (var db = efContextFactory.GetForWrite())
+            using (var ef = efContextFactory.GetForWrite())
             {
-                migrateSettings(db);
-                migrateSkins(db);
+                migrateSettings(ef);
+                migrateSkins(ef);
 
-                migrateBeatmaps(db);
-                migrateScores(db);
+                migrateBeatmaps(ef);
+                migrateScores(ef);
             }
         }
 
-        private void migrateBeatmaps(DatabaseWriteUsage db)
+        private void migrateBeatmaps(DatabaseWriteUsage ef)
         {
             // can be removed 20220730.
-            var existingBeatmapSets = db.Context.EFBeatmapSetInfo
+            var existingBeatmapSets = ef.Context.EFBeatmapSetInfo
                                         .Include(s => s.Beatmaps).ThenInclude(b => b.RulesetInfo)
                                         .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
                                         .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
@@ -117,7 +117,7 @@ namespace osu.Game.Database
                     }
                 }
 
-                db.Context.RemoveRange(existingBeatmapSets);
+                ef.Context.RemoveRange(existingBeatmapSets);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
 
                 transaction.Commit();

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -358,6 +358,7 @@ namespace osu.Game.Database
         {
             using (BlockAllOperations())
             {
+                Logger.Log($"Creating full realm database backup at {filename}", LoggingTarget.Database);
                 using (var source = storage.GetStream(Filename))
                 using (var destination = storage.GetStream(filename, FileAccess.Write, FileMode.CreateNew))
                     source.CopyTo(destination);

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -361,13 +361,13 @@ namespace osu.Game.Database
         private string? getRulesetShortNameFromLegacyID(long rulesetId) =>
             efContextFactory?.Get().RulesetInfo.FirstOrDefault(r => r.ID == rulesetId)?.ShortName;
 
-        public void CreateBackup(string filename)
+        public void CreateBackup(string backupFilename)
         {
             using (BlockAllOperations())
             {
-                Logger.Log($"Creating full realm database backup at {filename}", LoggingTarget.Database);
+                Logger.Log($"Creating full realm database backup at {backupFilename}", LoggingTarget.Database);
                 using (var source = storage.GetStream(Filename))
-                using (var destination = storage.GetStream(filename, FileAccess.Write, FileMode.CreateNew))
+                using (var destination = storage.GetStream(backupFilename, FileAccess.Write, FileMode.CreateNew))
                     source.CopyTo(destination);
             }
         }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -366,17 +366,17 @@ namespace osu.Game.Database
             if (isDisposed)
                 throw new ObjectDisposedException(nameof(RealmContextFactory));
 
-            if (!ThreadSafety.IsUpdateThread)
-                throw new InvalidOperationException(@$"{nameof(BlockAllOperations)} must be called from the update thread.");
-
-            Logger.Log(@"Blocking realm operations.", LoggingTarget.Database);
-
             try
             {
                 contextCreationLock.Wait();
 
                 lock (contextLock)
                 {
+                    if (!ThreadSafety.IsUpdateThread && context != null)
+                        throw new InvalidOperationException(@$"{nameof(BlockAllOperations)} must be called from the update thread.");
+
+                    Logger.Log(@"Blocking realm operations.", LoggingTarget.Database);
+
                     context?.Dispose();
                     context = null;
                 }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -352,6 +353,16 @@ namespace osu.Game.Database
 
         private string? getRulesetShortNameFromLegacyID(long rulesetId) =>
             efContextFactory?.Get().RulesetInfo.FirstOrDefault(r => r.ID == rulesetId)?.ShortName;
+
+        public void CreateBackup(string filename)
+        {
+            using (BlockAllOperations())
+            {
+                using (var source = storage.GetStream(Filename))
+                using (var destination = storage.GetStream(filename, FileAccess.Write, FileMode.CreateNew))
+                    source.CopyTo(destination);
+            }
+        }
 
         /// <summary>
         /// Flush any active contexts and block any further writes.

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -193,6 +193,7 @@ namespace osu.Game
             dependencies.Cache(RulesetStore = new RulesetStore(realmFactory, Storage));
             dependencies.CacheAs<IRulesetStore>(RulesetStore);
 
+            // A non-null context factory means there's still content to migrate.
             if (efContextFactory != null)
                 new EFToRealmMigrator(efContextFactory, realmFactory, LocalConfig).Run();
 


### PR DESCRIPTION
This PR creates point-in-time backups of both EF and realm databases before both beatmap and score migration operations. To recover / retry the migration, the user just needs to remove the filename suffix on both.

Also adds more logging to the migration process, and adds back the final `client.db` deletion after the migration completes.

- [x] Depends on #16428

I probably wouldn't recommend reviewing this until the dependency is merged.

![20220118 145128 (iTerm)](https://user-images.githubusercontent.com/191335/149878670-fd165076-f813-46f3-b0e8-ab671ad6fa7c.png)

```csharp

[database] 2022-01-18 05:50:54 [verbose]: Beginning beatmaps migration to realm
[database] 2022-01-18 05:50:54 [verbose]: Found 99 beatmaps in EF
[database] 2022-01-18 05:50:54 [verbose]: Creating full EF database backup at client.before_beatmap_migration_1642485054.db
[database] 2022-01-18 05:50:54 [verbose]: Blocking realm operations.
[database] 2022-01-18 05:50:54 [verbose]: Creating full realm database backup at client.before_beatmap_migration_1642485054.realm
[database] 2022-01-18 05:50:54 [verbose]: Restoring realm operations.
[database] 2022-01-18 05:50:54 [verbose]: Successfully migrated 99 beatmaps to realm
[database] 2022-01-18 05:50:55 [verbose]: Beginning scores migration to realm
[database] 2022-01-18 05:50:55 [verbose]: No scores found to migrate
[database] 2022-01-18 05:50:55 [verbose]: Migration successful, deleting EF database

```

I did look at the potential of making a UI for this operation to give feedback, but it's not going to be a simple task (a lot of game-level components immediately start consuming realm on startup before we can show a UI). Going to wait to test against some large user databases before deciding if that's worth the effort of fixing.

Closes https://github.com/ppy/osu/issues/16441.