### PR TITLE
Add support for starting with a fresh realm database if the existing one is not usable

### DIFF
--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -21,6 +21,7 @@ using osu.Game.Stores;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using Realms;
+using Realms.Exceptions;
 
 #nullable enable
 
@@ -427,7 +428,7 @@ namespace osu.Game.Database
                             throw new TimeoutException(@"Took too long to acquire lock");
                     }
                 }
-                catch (Exception e)
+                catch (RealmException e)
                 {
                     // Compact may fail if the realm is in a bad state.
                     // We still want to continue with the blocking operation, though.


### PR DESCRIPTION
The most common scenario is switching between schema versions when testing.  This should alleviate the manual overhead of that for the majority of cases.

For users, this will show a notification on startup if their database was purged, similar to what we had with EF.

- [x] Depends on https://github.com/ppy/osu/pull/16491.