### PR TITLE
Improve performance of migration to realm

### DIFF
--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -148,8 +148,6 @@ namespace osu.Game.Database
                 }
 
                 Logger.Log($"Successfully migrated {count} beatmaps to realm", LoggingTarget.Database);
-                ef.Context.RemoveRange(existingBeatmapSets);
-                // Intentionally don't clean up the files, so they don't get purged by EF.
             }
         }
 
@@ -253,8 +251,6 @@ namespace osu.Game.Database
                 }
 
                 Logger.Log($"Successfully migrated {count} scores to realm", LoggingTarget.Database);
-                db.Context.RemoveRange(existingScores);
-                // Intentionally don't clean up the files, so they don't get purged by EF.
             }
         }
 
@@ -313,9 +309,6 @@ namespace osu.Game.Database
                     }
                 }
 
-                db.Context.RemoveRange(existingSkins);
-                // Intentionally don't clean up the files, so they don't get purged by EF.
-
                 transaction.Commit();
             }
         }
@@ -371,8 +364,6 @@ namespace osu.Game.Database
                         });
                     }
                 }
-
-                db.Context.RemoveRange(existingSettings);
 
                 transaction.Commit();
             }

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using osu.Framework.Logging;
@@ -54,13 +53,12 @@ namespace osu.Game.Database
         private void migrateBeatmaps(DatabaseWriteUsage ef)
         {
             // can be removed 20220730.
-            List<EFBeatmapSetInfo> existingBeatmapSets = ef.Context.EFBeatmapSetInfo
-                                                           .Include(s => s.Beatmaps).ThenInclude(b => b.RulesetInfo)
-                                                           .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
-                                                           .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
-                                                           .Include(s => s.Files).ThenInclude(f => f.FileInfo)
-                                                           .Include(s => s.Metadata)
-                                                           .ToList();
+            var existingBeatmapSets = ef.Context.EFBeatmapSetInfo
+                                        .Include(s => s.Beatmaps).ThenInclude(b => b.RulesetInfo)
+                                        .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
+                                        .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
+                                        .Include(s => s.Files).ThenInclude(f => f.FileInfo)
+                                        .Include(s => s.Metadata);
 
             Logger.Log("Beginning beatmaps migration to realm", LoggingTarget.Database);
 
@@ -71,9 +69,11 @@ namespace osu.Game.Database
                 return;
             }
 
+            int count = existingBeatmapSets.Count();
+
             using (var realm = realmContextFactory.CreateContext())
             {
-                Logger.Log($"Found {existingBeatmapSets.Count} beatmaps in EF", LoggingTarget.Database);
+                Logger.Log($"Found {count} beatmaps in EF", LoggingTarget.Database);
                 string migration = $"before_beatmap_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
                 efContextFactory.CreateBackup($"client.{migration}.db");
 
@@ -147,7 +147,7 @@ namespace osu.Game.Database
                     }
                 }
 
-                Logger.Log($"Successfully migrated {existingBeatmapSets.Count} beatmaps to realm", LoggingTarget.Database);
+                Logger.Log($"Successfully migrated {count} beatmaps to realm", LoggingTarget.Database);
                 ef.Context.RemoveRange(existingBeatmapSets);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
             }
@@ -180,12 +180,11 @@ namespace osu.Game.Database
         private void migrateScores(DatabaseWriteUsage db)
         {
             // can be removed 20220730.
-            List<EFScoreInfo> existingScores = db.Context.ScoreInfo
-                                                 .Include(s => s.Ruleset)
-                                                 .Include(s => s.BeatmapInfo)
-                                                 .Include(s => s.Files)
-                                                 .ThenInclude(f => f.FileInfo)
-                                                 .ToList();
+            var existingScores = db.Context.ScoreInfo
+                                   .Include(s => s.Ruleset)
+                                   .Include(s => s.BeatmapInfo)
+                                   .Include(s => s.Files)
+                                   .ThenInclude(f => f.FileInfo);
 
             Logger.Log("Beginning scores migration to realm", LoggingTarget.Database);
 
@@ -196,9 +195,11 @@ namespace osu.Game.Database
                 return;
             }
 
+            int count = existingScores.Count();
+
             using (var realm = realmContextFactory.CreateContext())
             {
-                Logger.Log($"Found {existingScores.Count} scores in EF", LoggingTarget.Database);
+                Logger.Log($"Found {count} scores in EF", LoggingTarget.Database);
                 string migration = $"before_score_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
                 efContextFactory.CreateBackup($"client.{migration}.db");
 
@@ -251,7 +252,7 @@ namespace osu.Game.Database
                     }
                 }
 
-                Logger.Log($"Successfully migrated {existingScores.Count} scores to realm", LoggingTarget.Database);
+                Logger.Log($"Successfully migrated {count} scores to realm", LoggingTarget.Database);
                 db.Context.RemoveRange(existingScores);
                 // Intentionally don't clean up the files, so they don't get purged by EF.
             }


### PR DESCRIPTION
Before:

```csharp
[runtime] 2022-01-18 10:15:46 [verbose]: Finished realm file store cleanup (0 of 0 deleted)
[database] 2022-01-18 10:16:15 [verbose]: Beginning beatmaps migration to realm
[database] 2022-01-18 10:16:15 [verbose]: Found 24183 beatmaps in EF
[database] 2022-01-18 10:16:15 [verbose]: Creating full EF database backup at client.before_beatmap_migration_1642500975.db
[database] 2022-01-18 10:16:15 [verbose]: Blocking realm operations.
[database] 2022-01-18 10:16:15 [verbose]: Creating full realm database backup at client.before_beatmap_migration_1642500975.realm
[database] 2022-01-18 10:16:15 [verbose]: Restoring realm operations.
[database] 2022-01-18 10:16:35 [verbose]: Successfully migrated 24183 beatmaps to realm
[database] 2022-01-18 10:17:20 [verbose]: Beginning scores migration to realm
[database] 2022-01-18 10:17:20 [verbose]: No scores found to migrate
[database] 2022-01-18 10:17:20 [verbose]: Migration successful, deleting EF database
```

Total: 1 minute 34 seconds

After:

```csharp
[runtime] 2022-01-18 10:19:38 [verbose]: Finished realm file store cleanup (0 of 0 deleted)
[database] 2022-01-18 10:19:39 [verbose]: Beginning beatmaps migration to realm
[database] 2022-01-18 10:19:39 [verbose]: Found 24183 beatmaps in EF
[database] 2022-01-18 10:19:39 [verbose]: Creating full EF database backup at client.before_beatmap_migration_1642501179.db
[database] 2022-01-18 10:19:39 [verbose]: Blocking realm operations.
[database] 2022-01-18 10:19:39 [verbose]: Creating full realm database backup at client.before_beatmap_migration_1642501179.realm
[database] 2022-01-18 10:19:39 [verbose]: Restoring realm operations.
[database] 2022-01-18 10:20:26 [verbose]: Successfully migrated 24183 beatmaps to realm
[database] 2022-01-18 10:20:33 [verbose]: Beginning scores migration to realm
[database] 2022-01-18 10:20:33 [verbose]: Found 967 scores in EF
[database] 2022-01-18 10:20:33 [verbose]: Creating full EF database backup at client.before_score_migration_1642501233.db
[database] 2022-01-18 10:20:33 [verbose]: Blocking realm operations.
[database] 2022-01-18 10:20:33 [verbose]: Creating full realm database backup at client.before_score_migration_1642501233.realm
[database] 2022-01-18 10:20:33 [verbose]: Restoring realm operations.
[database] 2022-01-18 10:20:35 [verbose]: Successfully migrated 967 scores to realm
[database] 2022-01-18 10:20:35 [verbose]: Migration successful, deleting EF database
```

Total: 57 seconds

Also reduced memory overhead as we're no long shoving the whole of EF in memory at once.

- [x] Depends on #16491 mostly to avoid merge conflicts