### PR TITLE
Add some missing `IgnoredAttributes` to reduce automapper overhead

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                     {
                         Artist = @"Unknown",
                         Title = @"You're breathtaking",
-                        AuthorString = @"Everyone",
+                        Author = { Username = @"Everyone" },
                     },
                     Ruleset = new CatchRuleset().RulesetInfo
                 },

--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTaikoRulesetTestScene.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTaikoRulesetTestScene.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                     {
                         Artist = @"Unknown",
                         Title = @"Sample Beatmap",
-                        AuthorString = @"peppy",
+                        Author = { Username = @"peppy" },
                     },
                     Ruleset = new TaikoRuleset().RulesetInfo
                 },

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
                     {
                         Artist = "Unknown",
                         Title = "Sample Beatmap",
-                        AuthorString = "Craftplacer",
+                        Author = { Username = "Craftplacer" },
                     },
                     Ruleset = new TaikoRuleset().RulesetInfo
                 },

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
                 ArtistUnicode = "check unicode too",
                 Title = "Title goes here",
                 TitleUnicode = "Title goes here",
-                AuthorString = "The Author",
+                Author = { Username = "The Author" },
                 Source = "unit tests",
                 Tags = "look for tags too",
             },

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Tests.Resources
                 // Create random metadata, then we can check if sorting works based on these
                 Artist = "Some Artist " + RNG.Next(0, 9),
                 Title = $"Some Song (set id {setId}) {Guid.NewGuid()}",
-                AuthorString = "Some Guy " + RNG.Next(0, 9),
+                Author = { Username = "Some Guy " + RNG.Next(0, 9) },
             };
 
             var beatmapSet = new BeatmapSetInfo

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 Artist = "Some Artist",
                 Title = "Some Beatmap",
-                AuthorString = "Some Author"
+                Author = { Username = "Some Author" },
             };
 
             var beatmapSetInfo = new BeatmapSetInfo

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 var metadata = new BeatmapMetadata
                 {
                     Artist = "SomeArtist",
-                    AuthorString = "SomeAuthor",
+                    Author = { Username = "SomeAuthor" },
                     Title = $"import {i}"
                 };
 

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Tests.Visual.Navigation
                             Metadata = new BeatmapMetadata
                             {
                                 Artist = "SomeArtist",
-                                AuthorString = "SomeAuthor",
+                                Author = { Username = "SomeAuthor" },
                                 Title = "import"
                             },
                             BaseDifficulty = new BeatmapDifficulty(),
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Navigation
                             Metadata = new BeatmapMetadata
                             {
                                 Artist = "SomeArtist",
-                                AuthorString = "SomeAuthor",
+                                Author = { Username = "SomeAuthor" },
                                 Title = "import"
                             },
                             BaseDifficulty = new BeatmapDifficulty(),

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -409,7 +409,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     set.Beatmaps.ForEach(b => b.Metadata.Artist = zzz_string);
 
                 if (i == 16)
-                    set.Beatmaps.ForEach(b => b.Metadata.AuthorString = zzz_string);
+                    set.Beatmaps.ForEach(b => b.Metadata.Author.Username = zzz_string);
 
                 sets.Add(set);
             }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Metadata = new BeatmapMetadata
                     {
-                        AuthorString = $"{ruleset.ShortName}Author",
+                        Author = { Username = $"{ruleset.ShortName}Author" },
                         Artist = $"{ruleset.ShortName}Artist",
                         Source = $"{ruleset.ShortName}Source",
                         Title = $"{ruleset.ShortName}Title"
@@ -230,7 +230,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Metadata = new BeatmapMetadata
                     {
-                        AuthorString = "WWWWWWWWWWWWWWW",
+                        Author = { Username = "WWWWWWWWWWWWWWW" },
                         Artist = "Verrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrry long Artist",
                         Source = "Verrrrry long Source",
                         Title = "Verrrrry long Title"

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps
                 {
                     Artist = @"Unknown",
                     Title = @"Unknown",
-                    AuthorString = @"Unknown Creator",
+                    Author = { Username = @"Unknown Creator" },
                 },
                 DifficultyName = @"Normal",
                 BaseDifficulty = Difficulty,

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Beatmaps
         [Ignored]
         public RealmNamedFileUsage? File => BeatmapSet?.Files.FirstOrDefault(f => f.File.Hash == Hash);
 
+        [Ignored]
         public BeatmapOnlineStatus Status
         {
             get => (BeatmapOnlineStatus)StatusInt;

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -45,17 +45,6 @@ namespace osu.Game.Beatmaps
 
         IUser IBeatmapMetadataInfo.Author => Author;
 
-        #region Compatibility properties
-
-        [Ignored]
-        public string AuthorString
-        {
-            get => Author.Username;
-            set => Author.Username = value;
-        }
-
-        #endregion
-
         public override string ToString() => this.GetDisplayTitle();
     }
 }

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Beatmaps
 
         #region Compatibility properties
 
+        [Ignored]
         public string AuthorString
         {
             get => Author.Username;

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Beatmaps
 
         public IList<RealmNamedFileUsage> Files { get; } = null!;
 
+        [Ignored]
         public BeatmapOnlineStatus Status
         {
             get => (BeatmapOnlineStatus)StatusInt;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Beatmaps.Formats
                     break;
 
                 case @"Creator":
-                    metadata.AuthorString = pair.Value;
+                    metadata.Author.Username = pair.Value;
                     break;
 
                 case @"Version":

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -144,7 +144,6 @@ namespace osu.Game.Database
                 PreviewTime = metadata.PreviewTime,
                 AudioFile = metadata.AudioFile,
                 BackgroundFile = metadata.BackgroundFile,
-                AuthorString = metadata.AuthorString,
             };
         }
 

--- a/osu.Game/Input/Bindings/RealmKeyBinding.cs
+++ b/osu.Game/Input/Bindings/RealmKeyBinding.cs
@@ -20,12 +20,14 @@ namespace osu.Game.Input.Bindings
 
         public int? Variant { get; set; }
 
+        [Ignored]
         public KeyCombination KeyCombination
         {
             get => KeyCombinationString;
             set => KeyCombinationString = value.ToString();
         }
 
+        [Ignored]
         public object Action
         {
             get => ActionInt;

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Scoring
             }
         }
 
+        [Ignored]
         public ScoreRank Rank
         {
             get => (ScoreRank)RankInt;

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.Metadata.TitleUnicode = TitleTextBox.Current.Value;
             Beatmap.Metadata.Title = RomanisedTitleTextBox.Current.Value;
 
-            Beatmap.Metadata.AuthorString = creatorTextBox.Current.Value;
+            Beatmap.Metadata.Author.Username = creatorTextBox.Current.Value;
             Beatmap.BeatmapInfo.DifficultyName = difficultyTextBox.Current.Value;
             Beatmap.Metadata.Source = sourceTextBox.Current.Value;
             Beatmap.Metadata.Tags = tagsTextBox.Current.Value;


### PR DESCRIPTION
Also removes all usage of `AuthorString` compatibility property while we're here.

Reduces automapper overhead by around 8%. Not much but I'm just trying to get things in sane order before attempting larger optimisations.