### PR TITLE
Avoid file retrieval overhead when detaching `BeatmapSetInfo`

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -57,8 +57,9 @@ namespace osu.Game.Tests.Database
                     {
                         detachedBeatmapSet = live.Detach();
 
-                        Assert.AreEqual(live.Files.Count, detachedBeatmapSet.Files.Count);
-                        Assert.AreEqual(live.Files.Select(f => f.File).Count(), detachedBeatmapSet.Files.Select(f => f.File).Count());
+                        // files are omitted
+                        Assert.AreEqual(0, detachedBeatmapSet.Files.Count);
+
                         Assert.AreEqual(live.Beatmaps.Count, detachedBeatmapSet.Beatmaps.Count);
                         Assert.AreEqual(live.Beatmaps.Select(f => f.Difficulty).Count(), detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
                         Assert.AreEqual(live.Metadata, detachedBeatmapSet.Metadata);
@@ -67,11 +68,9 @@ namespace osu.Game.Tests.Database
                     Debug.Assert(detachedBeatmapSet != null);
 
                     // Check detached instances can all be accessed without throwing.
-                    Assert.NotNull(detachedBeatmapSet.Files.Count);
-                    Assert.NotZero(detachedBeatmapSet.Files.Select(f => f.File).Count());
+                    Assert.AreEqual(0, detachedBeatmapSet.Files.Count);
                     Assert.NotNull(detachedBeatmapSet.Beatmaps.Count);
                     Assert.NotZero(detachedBeatmapSet.Beatmaps.Select(f => f.Difficulty).Count());
-                    Assert.NotNull(detachedBeatmapSet.Beatmaps.First().Path);
                     Assert.NotNull(detachedBeatmapSet.Metadata);
 
                     // Check cyclic reference to beatmap set
@@ -96,9 +95,12 @@ namespace osu.Game.Tests.Database
                     Assert.NotNull(beatmapSet);
                     Debug.Assert(beatmapSet != null);
 
-                    BeatmapSetInfo? detachedBeatmapSet = null;
+                    // Detach at the BeatmapInfo point, similar to what GetWorkingBeatmap does.
+                    BeatmapInfo? detachedBeatmap = null;
 
-                    beatmapSet.PerformRead(s => detachedBeatmapSet = s.Detach());
+                    beatmapSet.PerformRead(s => detachedBeatmap = s.Beatmaps.First().Detach());
+
+                    BeatmapSetInfo? detachedBeatmapSet = detachedBeatmap?.BeatmapSet;
 
                     Debug.Assert(detachedBeatmapSet != null);
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -299,7 +299,23 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IWorkingBeatmapCache
 
-        public WorkingBeatmap GetWorkingBeatmap(BeatmapInfo? importedBeatmap) => workingBeatmapCache.GetWorkingBeatmap(importedBeatmap);
+        public WorkingBeatmap GetWorkingBeatmap(BeatmapInfo? importedBeatmap)
+        {
+            // Detached sets don't come with files.
+            // If we seem to be missing files, now is a good time to re-fetch.
+            if (importedBeatmap?.BeatmapSet?.Files.Count == 0)
+            {
+                using (var realm = contextFactory.CreateContext())
+                {
+                    var refetch = realm.Find<BeatmapInfo>(importedBeatmap.ID)?.Detach();
+
+                    if (refetch != null)
+                        importedBeatmap = refetch;
+                }
+            }
+
+            return workingBeatmapCache.GetWorkingBeatmap(importedBeatmap);
+        }
 
         public WorkingBeatmap GetWorkingBeatmap(ILive<BeatmapInfo>? importedBeatmap)
         {

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -76,6 +76,14 @@ namespace osu.Game.Database
         {
             applyCommonConfiguration(c);
 
+            c.CreateMap<BeatmapSetInfo, BeatmapSetInfo>()
+             .MaxDepth(2)
+             .AfterMap((s, d) =>
+             {
+                 foreach (var beatmap in d.Beatmaps)
+                     beatmap.BeatmapSet = d;
+             });
+
             // This can be further optimised to reduce cyclic retrievals, similar to the optimised set mapper below.
             // Only hasn't been done yet as we detach at the point of BeatmapInfo less often.
             c.CreateMap<BeatmapInfo, BeatmapInfo>()
@@ -99,6 +107,15 @@ namespace osu.Game.Database
         private static readonly IMapper beatmap_set_mapper = new MapperConfiguration(c =>
         {
             applyCommonConfiguration(c);
+
+            c.CreateMap<BeatmapSetInfo, BeatmapSetInfo>()
+             .MaxDepth(2)
+             .ForMember(b => b.Files, cc => cc.Ignore())
+             .AfterMap((s, d) =>
+             {
+                 foreach (var beatmap in d.Beatmaps)
+                     beatmap.BeatmapSet = d;
+             });
 
             c.CreateMap<BeatmapInfo, BeatmapInfo>()
              .MaxDepth(1)
@@ -131,13 +148,6 @@ namespace osu.Game.Database
             c.CreateMap<RealmUser, RealmUser>();
             c.CreateMap<RealmFile, RealmFile>();
             c.CreateMap<RealmNamedFileUsage, RealmNamedFileUsage>();
-            c.CreateMap<BeatmapSetInfo, BeatmapSetInfo>()
-             .MaxDepth(2)
-             .AfterMap((s, d) =>
-             {
-                 foreach (var beatmap in d.Beatmaps)
-                     beatmap.BeatmapSet = d;
-             });
         }
 
         /// <summary>


### PR DESCRIPTION
It seems that no usages of `BeatmapSetInfo` detaches require files - a `WorkingBeatmap` is always obtained before doing further lookups.

Therefore we can omit this include unless the detaching object is a `BeatmapInfo`. A refetch is performed when retrieving a `WorkingBeatmap` to complete the equation.

PR for discussion. We did similar with EF, so there is precedent for this. My current thinking is that we should try and get detach working on-par with EF performance, and then move away from it where it makes sense. Detach is surprisingly easier to optimise at song select due to the intensive use of property retrieval in the filtering engine.

- [x] Depends on #16508.

For one beatmap carousel load with 24,000 sets:

Left: state as of #16508 
Right: this PR

![E119DCC4-381C-4812-8E50-21D07691EE1D](https://user-images.githubusercontent.com/191335/149974622-97710f93-6bf8-41e4-ba0c-5b36076f64d2.jpeg)

Performance is now roughly on par with EF. Note that EF still feels better due to the detach being bound to the update thread (an unfortunate issue of using realm subscriptions...), will need to try and figure a fix for this as a follow-up.