### PR TITLE
Fix legacy score imports not correctly getting classic mod assigned

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -12,6 +12,7 @@ using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.UI;
@@ -51,6 +52,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 Assert.AreEqual(829_931, score.ScoreInfo.TotalScore);
                 Assert.AreEqual(3, score.ScoreInfo.MaxCombo);
+
+                Assert.IsTrue(score.ScoreInfo.Mods.Any(m => m is ManiaModClassic));
+                Assert.IsTrue(score.ScoreInfo.APIMods.Any(m => m.Acronym == "CL"));
+                Assert.IsTrue(score.ScoreInfo.ModsJson.Contains("CL"));
+
                 Assert.IsTrue(Precision.AlmostEquals(0.8889, score.ScoreInfo.Accuracy, 0.0001));
                 Assert.AreEqual(ScoreRank.B, score.ScoreInfo.Rank);
 

--- a/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
@@ -6,7 +6,6 @@ using osu.Game.Online.API;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 

--- a/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
@@ -2,6 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.Online.API;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -28,6 +33,42 @@ namespace osu.Game.Tests.NonVisual
 
             Assert.That(scoreCopy.Rank, Is.EqualTo(ScoreRank.B));
             Assert.That(score.Rank, Is.EqualTo(ScoreRank.X));
+        }
+
+        [Test]
+        public void TestModsInitiallyEmpty()
+        {
+            var score = new ScoreInfo();
+
+            Assert.That(score.Mods, Is.Empty);
+            Assert.That(score.APIMods, Is.Empty);
+            Assert.That(score.ModsJson, Is.Empty);
+        }
+
+        [Test]
+        public void TestModsUpdatedCorrectly()
+        {
+            var score = new ScoreInfo
+            {
+                Mods = new Mod[] { new ManiaModClassic() },
+                Ruleset = new ManiaRuleset().RulesetInfo,
+            };
+
+            Assert.That(score.Mods, Contains.Item(new ManiaModClassic()));
+            Assert.That(score.APIMods, Contains.Item(new APIMod(new ManiaModClassic())));
+            Assert.That(score.ModsJson, Contains.Substring("CL"));
+
+            score.APIMods = new[] { new APIMod(new ManiaModDoubleTime()) };
+
+            Assert.That(score.Mods, Contains.Item(new ManiaModDoubleTime()));
+            Assert.That(score.APIMods, Contains.Item(new APIMod(new ManiaModDoubleTime())));
+            Assert.That(score.ModsJson, Contains.Substring("DT"));
+
+            score.Mods = new Mod[] { new ManiaModClassic() };
+
+            Assert.That(score.Mods, Contains.Item(new ManiaModClassic()));
+            Assert.That(score.APIMods, Contains.Item(new APIMod(new ManiaModClassic())));
+            Assert.That(score.ModsJson, Contains.Substring("CL"));
         }
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -234,7 +234,9 @@ namespace osu.Game.Scoring
 
         private void updateModsJson()
         {
-            ModsJson = JsonConvert.SerializeObject(APIMods);
+            ModsJson = APIMods.Length > 0
+                ? JsonConvert.SerializeObject(APIMods)
+                : string.Empty;
         }
 
         public IEnumerable<HitResultDisplayStatistic> GetStatisticsForDisplay()

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -191,9 +191,8 @@ namespace osu.Game.Scoring
             }
             set
             {
-                apiMods = null;
+                clearAllMods();
                 mods = value;
-
                 updateModsJson();
             }
         }
@@ -220,12 +219,17 @@ namespace osu.Game.Scoring
             }
             set
             {
+                clearAllMods();
                 apiMods = value;
-                mods = null;
-
-                // We potentially can't update this yet due to Ruleset being late-bound, so instead update on read as necessary.
                 updateModsJson();
             }
+        }
+
+        private void clearAllMods()
+        {
+            ModsJson = string.Empty;
+            mods = null;
+            apiMods = null;
         }
 
         private void updateModsJson()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/16513.

I've kept this simple for now rather than overthinking, but also added test coverage.