### PR TITLE
Detach beatmap set before checking hidden state

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -677,10 +677,10 @@ namespace osu.Game.Screens.Select
 
         private CarouselBeatmapSet createCarouselSet(BeatmapSetInfo beatmapSet)
         {
+            beatmapSet = beatmapSet.Detach();
+
             if (beatmapSet.Beatmaps.All(b => b.Hidden))
                 return null;
-
-            beatmapSet = beatmapSet.Detach();
 
             var set = new CarouselBeatmapSet(beatmapSet)
             {


### PR DESCRIPTION
Before vs after

![20220119 170100 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/150088607-0ebf52ab-f18e-4b59-8e01-9ce8ccaba2e7.png)

I think the savings are higher than what is seen there (just error in profile runs) - the detach operations in both cases detach the same number of sets (ie. i have no sets that are hidden completely).

I also tried using realm queries here, but in such a tight loop it is not productive. Combining in the top level query would make more sense (future effort).