### PR TITLE
Use asynchronous loading for beatmap carousel again

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -182,9 +182,10 @@ namespace osu.Game.Screens.Select
             RightClickScrollingEnabled.ValueChanged += enabled => Scroll.RightMouseScrollbar = enabled.NewValue;
             RightClickScrollingEnabled.TriggerChange();
 
-            using (var realm = realmFactory.CreateContext())
+            if (!loadedTestBeatmaps)
             {
-                loadBeatmapSets(getBeatmapSets(realm));
+                using (var realm = realmFactory.CreateContext())
+                    loadBeatmapSets(getBeatmapSets(realm));
             }
         }
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -714,7 +714,7 @@ namespace osu.Game.Screens.Select
             beatmapSet = beatmapSet.Detach();
 
             // This can be moved to the realm query if required using:
-            // .Filter("DeletePending == false && Protected == false && ALL Beatmaps.Hidden == false")
+            // .Filter("DeletePending == false && Protected == false && ANY Beatmaps.Hidden == false")
             //
             // As long as we are detaching though, it makes more sense to do it here as adding to the realm query has an overhead
             // as seen at https://github.com/realm/realm-dotnet/discussions/2773#discussioncomment-2004275.

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -126,14 +126,8 @@ namespace osu.Game.Screens.Select
 
             applyActiveCriteria(false);
 
-            // Run on late scheduler want to ensure this runs after all pending UpdateBeatmapSet / RemoveBeatmapSet operations are run.
-            SchedulerAfterChildren.Add(() =>
-            {
-                BeatmapSetsChanged?.Invoke();
-                BeatmapSetsLoaded = true;
-
-                itemsCache.Invalidate();
-            });
+            if (loadedTestBeatmaps)
+                signalBeatmapsLoaded();
         }
 
         private readonly List<CarouselItem> visibleItems = new List<CarouselItem>();
@@ -249,6 +243,7 @@ namespace osu.Game.Screens.Select
                         RemoveBeatmapSet(realmFactory.Context.Find<BeatmapSetInfo>(s));
                 }
 
+                signalBeatmapsLoaded();
                 return;
             }
 
@@ -545,6 +540,16 @@ namespace osu.Game.Screens.Select
                 if (alwaysResetScrollPosition || !Scroll.UserScrolling)
                     ScrollToSelected(true);
             }
+        }
+
+        private void signalBeatmapsLoaded()
+        {
+            Debug.Assert(BeatmapSetsLoaded == false);
+
+            BeatmapSetsChanged?.Invoke();
+            BeatmapSetsLoaded = true;
+
+            itemsCache.Invalidate();
         }
 
         private float? scrollTarget;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -713,6 +713,11 @@ namespace osu.Game.Screens.Select
         {
             beatmapSet = beatmapSet.Detach();
 
+            // This can be moved to the realm query if required using:
+            // .Filter("DeletePending == false && Protected == false && ALL Beatmaps.Hidden == false")
+            //
+            // As long as we are detaching though, it makes more sense to do it here as adding to the realm query has an overhead
+            // as seen at https://github.com/realm/realm-dotnet/discussions/2773#discussioncomment-2004275.
             if (beatmapSet.Beatmaps.All(b => b.Hidden))
                 return null;
 


### PR DESCRIPTION
With 24k beatmap sets

Before realm (EF):

https://user-images.githubusercontent.com/191335/150095645-2ff8e98e-c79d-4da4-90af-7a365577581e.mp4

After (realm):

https://user-images.githubusercontent.com/191335/150096178-427ccf01-09fa-4f5b-9c96-6fc31c69c3e1.mp4

Surprisingly performance is almost tied. There's a slight overhead for the catch-up hashing logic (mostly from `BeatmapSetInfo` construction I believe) but this is far better than what we had, and good enough to actually release.