### PR TITLE
Improve usability of expanded card content on beatmap listing

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
@@ -12,16 +12,12 @@ namespace osu.Game.Beatmaps.Drawables.Cards
     {
         public const float HEIGHT = 200;
 
-        public ExpandedContentScrollContainer()
-        {
-            ScrollbarVisible = false;
-        }
-
         protected override void Update()
         {
             base.Update();
 
             Height = Math.Min(Content.DrawHeight, HEIGHT);
+            ScrollbarVisible = allowScroll;
         }
 
         private bool allowScroll => !Precision.AlmostEquals(DrawSize, Content.DrawSize);

--- a/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
@@ -11,6 +12,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
     public class ExpandedContentScrollContainer : OsuScrollContainer
     {
         public const float HEIGHT = 200;
+
+        protected override ScrollbarContainer CreateScrollbar(Direction direction) => new ExpandedContentScrollbar(direction);
 
         protected override void Update()
         {
@@ -52,6 +55,23 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 return false;
 
             return base.OnScroll(e);
+        }
+
+        private class ExpandedContentScrollbar : OsuScrollbar
+        {
+            public ExpandedContentScrollbar(Direction scrollDir)
+                : base(scrollDir)
+            {
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                base.OnHover(e);
+                // do not handle hover, as handling hover would make the beatmap card's expanded content not-hovered
+                // and therefore cause it to hide when trying to drag the scroll bar.
+                // see: `BeatmapCardContent.dropdownContent` and its `Unhovered` handler.
+                return false;
+            }
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -187,8 +187,10 @@ namespace osu.Game.Overlays
                 Alpha = 0,
                 Margin = new MarginPadding
                 {
-                    Vertical = 15,
-                    Bottom = ExpandedContentScrollContainer.HEIGHT
+                    Top = 15,
+                    // the + 20 adjustment is roughly eyeballed in order to fit all of the expanded content height after it's scaled
+                    // as well as provide visual balance to the top margin.
+                    Bottom = ExpandedContentScrollContainer.HEIGHT + 20
                 },
                 ChildrenEnumerable = newCards
             };


### PR DESCRIPTION
Addresses both issues in https://github.com/ppy/osu/discussions/16514. Bundling these together to reduce general noise, didn't seem like there was much point to splitting.

* Roughly adjusts the bottom padding on the beatmap overlay to ensure that the full height of the expanded content fits (with some more slack to match the top padding).
* Adds a scrollbar to the expanded content whenever it is scrollable. I've unfortunately had to pile on a bit of a hack there due to how hover handling works in framework and how it's used in the context of the dropdown.

Test coverage (for the first part) included.

https://user-images.githubusercontent.com/20418176/150219039-39b8a4f4-7028-4f81-a5e0-e8425bdbad6f.mp4
