### PR TITLE
Fix news sidebar assuming returned posts are always from given year

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneNewsSidebar.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsSidebar.cs
@@ -39,6 +39,14 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestMetadataWithMultipleYears()
+        {
+            AddStep("Add data spanning multiple years", () => sidebar.Metadata.Value = metadata_with_multiple_years);
+            AddUntilStep("2022 month sections exist", () => sidebar.ChildrenOfType<MonthSection>().Any(s => s.Year == 2022));
+            AddUntilStep("2021 month sections exist", () => sidebar.ChildrenOfType<MonthSection>().Any(s => s.Year == 2021));
+        }
+
+        [Test]
         public void TestYearsPanelVisibility()
         {
             AddUntilStep("Years panel is hidden", () => yearsPanel?.Alpha == 0);
@@ -131,6 +139,74 @@ namespace osu.Game.Tests.Visual.Online
                 2013
             },
             NewsPosts = Array.Empty<APINewsPost>()
+        };
+
+        // see https://osu.ppy.sh/docs/index.html#get-news-listing:
+        // "NewsPost collections queried by year will also include posts published in November and December of the previous year if the current date is the same year and before April."
+        private static readonly APINewsSidebar metadata_with_multiple_years = new APINewsSidebar
+        {
+            CurrentYear = 2022,
+            Years = new[]
+            {
+                2022,
+                2021,
+                2020,
+                2019,
+                2018,
+                2017,
+                2016,
+                2015,
+                2014,
+                2013
+            },
+            NewsPosts = new List<APINewsPost>
+            {
+                new APINewsPost
+                {
+                    Title = "(Mar 2022) Short title",
+                    PublishedAt = new DateTime(2022, 3, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Mar 2022) Oh boy that's a long post title I wonder if it will break anything",
+                    PublishedAt = new DateTime(2022, 3, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Feb 2022) Medium title, nothing to see here",
+                    PublishedAt = new DateTime(2022, 2, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Feb 2022) Short title",
+                    PublishedAt = new DateTime(2022, 2, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Jan 2022) Oh boy that's a long post title I wonder if it will break anything",
+                    PublishedAt = new DateTime(2022, 1, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Jan 2022) Medium title, nothing to see here",
+                    PublishedAt = new DateTime(2022, 1, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Jan 2022) Short title",
+                    PublishedAt = new DateTime(2022, 1, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Dec 2021) Surprise, the last year's not gone yet",
+                    PublishedAt = new DateTime(2021, 12, 1)
+                },
+                new APINewsPost
+                {
+                    Title = "(Nov 2021) Same goes for November",
+                    PublishedAt = new DateTime(2021, 11, 1)
+                }
+            }
         };
 
         private class TestNewsSidebar : NewsSidebar

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -24,15 +24,20 @@ namespace osu.Game.Overlays.News.Sidebar
 {
     public class MonthSection : CompositeDrawable
     {
+        public int Year { get; private set; }
+        public int Month { get; private set; }
+        public readonly BindableBool Expanded = new BindableBool();
+
         private const int animation_duration = 250;
         private Sample sampleOpen;
         private Sample sampleClose;
 
-        public readonly BindableBool Expanded = new BindableBool();
-
         public MonthSection(int month, int year, IEnumerable<APINewsPost> posts)
         {
             Debug.Assert(posts.All(p => p.PublishedAt.Month == month && p.PublishedAt.Year == year));
+
+            Year = year;
+            Month = month;
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;

--- a/osu.Game/Overlays/News/Sidebar/NewsSidebar.cs
+++ b/osu.Game/Overlays/News/Sidebar/NewsSidebar.cs
@@ -56,19 +56,17 @@ namespace osu.Game.Overlays.News.Sidebar
             if (allPosts?.Any() != true)
                 return;
 
-            var lookup = metadata.NewValue.NewsPosts.ToLookup(post => post.PublishedAt.Month);
+            var lookup = metadata.NewValue.NewsPosts.ToLookup(post => (post.PublishedAt.Month, post.PublishedAt.Year));
 
             var keys = lookup.Select(kvp => kvp.Key);
-            var sortedKeys = keys.OrderByDescending(k => k).ToList();
-
-            int year = metadata.NewValue.CurrentYear;
+            var sortedKeys = keys.OrderByDescending(k => k.Year).ThenByDescending(k => k.Month).ToList();
 
             for (int i = 0; i < sortedKeys.Count; i++)
             {
-                int month = sortedKeys[i];
-                var posts = lookup[month];
+                var key = sortedKeys[i];
+                var posts = lookup[key];
 
-                monthsFlow.Add(new MonthSection(month, year, posts)
+                monthsFlow.Add(new MonthSection(key.Month, key.Year, posts)
                 {
                     Expanded = { Value = i == 0 }
                 });


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/discussions/16504

As it turns out, web docs even [state that this is intended behaviour](https://osu.ppy.sh/docs/index.html#get-news-listing):

> NewsPost collections queried by year will also include posts published in November and December of the previous year if the current date is the same year and before April.

Test coverage included.