### PR TITLE
Avoid constructor allocation/GC overhead in realm implicit constructors

### DIFF
--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -63,23 +63,9 @@ namespace osu.Game.Tests.Database
             using (var realm = realmContextFactory.CreateContext())
             using (var transaction = realm.BeginWrite())
             {
-                realm.Add(new RealmKeyBinding
-                {
-                    Action = GlobalAction.Back,
-                    KeyCombination = new KeyCombination(InputKey.A)
-                });
-
-                realm.Add(new RealmKeyBinding
-                {
-                    Action = GlobalAction.Back,
-                    KeyCombination = new KeyCombination(InputKey.S)
-                });
-
-                realm.Add(new RealmKeyBinding
-                {
-                    Action = GlobalAction.Back,
-                    KeyCombination = new KeyCombination(InputKey.D)
-                });
+                realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.A)));
+                realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.S)));
+                realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.D)));
 
                 transaction.Commit();
             }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Beatmaps
 
         public BeatmapMetadata Metadata { get; set; } = null!;
 
+        [JsonIgnore]
         [Backlink(nameof(ScoreInfo.BeatmapInfo))]
         public IQueryable<ScoreInfo> Scores { get; } = null!;
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -26,37 +26,35 @@ namespace osu.Game.Beatmaps
     public class BeatmapInfo : RealmObject, IHasGuidPrimaryKey, IBeatmapInfo, IEquatable<BeatmapInfo>
     {
         [PrimaryKey]
-        public Guid ID { get; set; } = Guid.NewGuid();
+        public Guid ID { get; set; }
 
         public string DifficultyName { get; set; } = string.Empty;
 
-        public RulesetInfo Ruleset { get; set; }
+        public RulesetInfo Ruleset { get; set; } = null!;
 
-        public BeatmapDifficulty Difficulty { get; set; }
+        public BeatmapDifficulty Difficulty { get; set; } = null!;
 
-        public BeatmapMetadata Metadata { get; set; }
+        public BeatmapMetadata Metadata { get; set; } = null!;
 
         [Backlink(nameof(ScoreInfo.BeatmapInfo))]
         public IQueryable<ScoreInfo> Scores { get; } = null!;
 
-        public BeatmapInfo(RulesetInfo ruleset, BeatmapDifficulty difficulty, BeatmapMetadata metadata)
+        public BeatmapInfo(RulesetInfo? ruleset = null, BeatmapDifficulty? difficulty = null, BeatmapMetadata? metadata = null)
         {
-            Ruleset = ruleset;
-            Difficulty = difficulty;
-            Metadata = metadata;
-        }
-
-        [UsedImplicitly]
-        public BeatmapInfo() // TODO: consider removing this and migrating all usages to ctor with parameters.
-        {
-            Ruleset = new RulesetInfo
+            ID = Guid.NewGuid();
+            Ruleset = ruleset ?? new RulesetInfo
             {
                 OnlineID = 0,
                 ShortName = @"osu",
                 Name = @"null placeholder ruleset"
             };
-            Difficulty = new BeatmapDifficulty();
-            Metadata = new BeatmapMetadata();
+            Difficulty = difficulty ?? new BeatmapDifficulty();
+            Metadata = metadata ?? new BeatmapMetadata();
+        }
+
+        [UsedImplicitly]
+        private BeatmapInfo()
+        {
         }
 
         public BeatmapSetInfo? BeatmapSet { get; set; }

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Testing;
 using osu.Game.Models;
@@ -27,7 +28,7 @@ namespace osu.Game.Beatmaps
         [JsonProperty("artist_unicode")]
         public string ArtistUnicode { get; set; } = string.Empty;
 
-        public RealmUser Author { get; set; } = new RealmUser(); // TODO: not sure we want to initialise this only to have it overwritten by retrieval.
+        public RealmUser Author { get; set; } = null!;
 
         public string Source { get; set; } = string.Empty;
 
@@ -42,6 +43,16 @@ namespace osu.Game.Beatmaps
 
         public string AudioFile { get; set; } = string.Empty;
         public string BackgroundFile { get; set; } = string.Empty;
+
+        public BeatmapMetadata(RealmUser? user = null)
+        {
+            Author = new RealmUser();
+        }
+
+        [UsedImplicitly] // Realm
+        private BeatmapMetadata()
+        {
+        }
 
         IUser IBeatmapMetadataInfo.Author => Author;
 

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Extensions;
@@ -19,7 +20,7 @@ namespace osu.Game.Beatmaps
     public class BeatmapSetInfo : RealmObject, IHasGuidPrimaryKey, IHasRealmFiles, ISoftDelete, IEquatable<BeatmapSetInfo>, IBeatmapSetInfo
     {
         [PrimaryKey]
-        public Guid ID { get; set; } = Guid.NewGuid();
+        public Guid ID { get; set; }
 
         [Indexed]
         public int OnlineID { get; set; } = -1;
@@ -56,6 +57,19 @@ namespace osu.Game.Beatmaps
         public double MaxLength => Beatmaps.Count == 0 ? 0 : Beatmaps.Max(b => b.Length);
 
         public double MaxBPM => Beatmaps.Count == 0 ? 0 : Beatmaps.Max(b => b.BPM);
+
+        public BeatmapSetInfo(IEnumerable<BeatmapInfo>? beatmaps = null)
+            : this()
+        {
+            ID = Guid.NewGuid();
+            if (beatmaps != null)
+                Beatmaps.AddRange(beatmaps);
+        }
+
+        [UsedImplicitly] // Realm
+        private BeatmapSetInfo()
+        {
+        }
 
         /// <summary>
         /// Returns the storage path for the file in this beatmapset with the given filename, if any exists, otherwise null.

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Newtonsoft.Json;
 using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Extensions;
@@ -27,6 +28,7 @@ namespace osu.Game.Beatmaps
 
         public DateTimeOffset DateAdded { get; set; }
 
+        [JsonIgnore]
         public IBeatmapMetadataInfo Metadata => Beatmaps.FirstOrDefault()?.Metadata ?? new BeatmapMetadata();
 
         public IList<BeatmapInfo> Beatmaps { get; } = null!;

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Database
                  copyChangesToRealm(s.Metadata, d.Metadata);
              });
             c.CreateMap<BeatmapSetInfo, BeatmapSetInfo>()
+             .ConstructUsing(_ => new BeatmapSetInfo(null))
              .ForMember(s => s.Beatmaps, cc => cc.Ignore())
              .AfterMap((s, d) =>
              {
@@ -77,6 +78,7 @@ namespace osu.Game.Database
             applyCommonConfiguration(c);
 
             c.CreateMap<BeatmapSetInfo, BeatmapSetInfo>()
+             .ConstructUsing(_ => new BeatmapSetInfo(null))
              .MaxDepth(2)
              .AfterMap((s, d) =>
              {
@@ -109,6 +111,7 @@ namespace osu.Game.Database
             applyCommonConfiguration(c);
 
             c.CreateMap<BeatmapSetInfo, BeatmapSetInfo>()
+             .ConstructUsing(_ => new BeatmapSetInfo(null))
              .MaxDepth(2)
              .ForMember(b => b.Files, cc => cc.Ignore())
              .AfterMap((s, d) =>

--- a/osu.Game/Input/Bindings/RealmKeyBinding.cs
+++ b/osu.Game/Input/Bindings/RealmKeyBinding.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Input.Bindings;
 using osu.Game.Database;
 using Realms;
@@ -14,7 +15,7 @@ namespace osu.Game.Input.Bindings
     public class RealmKeyBinding : RealmObject, IHasGuidPrimaryKey, IKeyBinding
     {
         [PrimaryKey]
-        public Guid ID { get; set; } = Guid.NewGuid();
+        public Guid ID { get; set; }
 
         public string? RulesetName { get; set; }
 
@@ -38,6 +39,21 @@ namespace osu.Game.Input.Bindings
         public int ActionInt { get; set; }
 
         [MapTo(nameof(KeyCombination))]
-        public string KeyCombinationString { get; set; } = string.Empty;
+        public string KeyCombinationString { get; set; } = null!;
+
+        public RealmKeyBinding(object action, KeyCombination keyCombination, string? rulesetName = null, int? variant = null)
+        {
+            Action = action;
+            KeyCombination = keyCombination;
+
+            RulesetName = rulesetName;
+            Variant = variant;
+            ID = Guid.NewGuid();
+        }
+
+        [UsedImplicitly] // Realm
+        private RealmKeyBinding()
+        {
+        }
     }
 }

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -92,13 +92,7 @@ namespace osu.Game.Input
                 if (defaultsCount > existingCount)
                 {
                     // insert any defaults which are missing.
-                    realm.Add(defaultsForAction.Skip(existingCount).Select(k => new RealmKeyBinding
-                    {
-                        KeyCombinationString = k.KeyCombination.ToString(),
-                        ActionInt = (int)k.Action,
-                        RulesetName = rulesetName,
-                        Variant = variant
-                    }));
+                    realm.Add(defaultsForAction.Skip(existingCount).Select(k => new RealmKeyBinding(k.Action, k.KeyCombination, rulesetName, variant)));
                 }
                 else if (defaultsCount < existingCount)
                 {

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -29,11 +29,11 @@ namespace osu.Game.Scoring
     public class ScoreInfo : RealmObject, IHasGuidPrimaryKey, IHasRealmFiles, ISoftDelete, IEquatable<ScoreInfo>, IScoreInfo
     {
         [PrimaryKey]
-        public Guid ID { get; set; } = Guid.NewGuid();
+        public Guid ID { get; set; }
 
-        public BeatmapInfo BeatmapInfo { get; set; }
+        public BeatmapInfo BeatmapInfo { get; set; } = null!;
 
-        public RulesetInfo Ruleset { get; set; }
+        public RulesetInfo Ruleset { get; set; } = null!;
 
         public IList<RealmNamedFileUsage> Files { get; } = null!;
 
@@ -57,7 +57,7 @@ namespace osu.Game.Scoring
         public long OnlineID { get; set; } = -1;
 
         [MapTo("User")]
-        public RealmUser RealmUser { get; set; }
+        public RealmUser RealmUser { get; set; } = null!;
 
         [MapTo("Mods")]
         public string ModsJson { get; set; } = string.Empty;
@@ -65,19 +65,17 @@ namespace osu.Game.Scoring
         [MapTo("Statistics")]
         public string StatisticsJson { get; set; } = string.Empty;
 
-        public ScoreInfo(BeatmapInfo beatmap, RulesetInfo ruleset, RealmUser realmUser)
+        public ScoreInfo(BeatmapInfo? beatmap = null, RulesetInfo? ruleset = null, RealmUser? realmUser = null)
         {
-            Ruleset = ruleset;
-            BeatmapInfo = beatmap;
-            RealmUser = realmUser;
+            Ruleset = ruleset ?? new RulesetInfo();
+            BeatmapInfo = beatmap ?? new BeatmapInfo();
+            RealmUser = realmUser ?? new RealmUser();
+            ID = Guid.NewGuid();
         }
 
-        [UsedImplicitly]
-        public ScoreInfo() // TODO: consider removing this and migrating all usages to ctor with parameters.
+        [UsedImplicitly] // Realm
+        private ScoreInfo()
         {
-            Ruleset = new RulesetInfo();
-            RealmUser = new RealmUser();
-            BeatmapInfo = new BeatmapInfo();
         }
 
         // TODO: this is a bit temporary to account for the fact that this class is used to ferry API user data to certain UI components.

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
@@ -26,16 +27,16 @@ namespace osu.Game.Skinning
 
         [PrimaryKey]
         [JsonProperty]
-        public Guid ID { get; set; } = Guid.NewGuid();
+        public Guid ID { get; set; }
 
         [JsonProperty]
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; set; } = null!;
 
         [JsonProperty]
-        public string Creator { get; set; } = string.Empty;
+        public string Creator { get; set; } = null!;
 
         [JsonProperty]
-        public string InstantiationInfo { get; set; } = string.Empty;
+        public string InstantiationInfo { get; set; } = null!;
 
         public string Hash { get; set; } = string.Empty;
 
@@ -54,6 +55,19 @@ namespace osu.Game.Skinning
         public IList<RealmNamedFileUsage> Files { get; } = null!;
 
         public bool DeletePending { get; set; }
+
+        public SkinInfo(string? name = null, string? creator = null, string? instantiationInfo = null)
+        {
+            Name = name ?? string.Empty;
+            Creator = creator ?? string.Empty;
+            InstantiationInfo = instantiationInfo ?? string.Empty;
+            ID = Guid.NewGuid();
+        }
+
+        [UsedImplicitly] // Realm
+        private SkinInfo()
+        {
+        }
 
         public bool Equals(SkinInfo? other)
         {


### PR DESCRIPTION
[Finding out](https://github.com/realm/realm-dotnet/discussions/2773#discussioncomment-2003763) we can make the realm implicit constructors `private` made this effort suddenly a *hell of a lot* easier.

The goal here is to remove all overhead from the parameterless constructors. This is because realm will fill in the non-nullable fields with actual data during object initialisation, making the allocations of placeholder classes redundant. They were causing considerable overhead due to allocations, which is resolved by this PR.

Note that the new constructors allow for nulls, which means code changes are not (immediately) required to make this compile/work.