### PR TITLE
Remove unnecessary detach operation

### DIFF
--- a/osu.Game/Collections/CollectionManager.cs
+++ b/osu.Game/Collections/CollectionManager.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Collections
 
                             string checksum = sr.ReadString();
 
-                            var beatmap = beatmaps.QueryBeatmap(b => b.MD5Hash == checksum)?.Detach();
+                            var beatmap = beatmaps.QueryBeatmap(b => b.MD5Hash == checksum);
                             if (beatmap != null)
                                 collection.Beatmaps.Add(beatmap);
                         }


### PR DESCRIPTION
Something I had dangling on a defunct branch. I'm trying to keep the calls to `Detach` as few and far between as possible so it's easy to track where the detach operation is happening. This one isn't required.