### PR TITLE
Remove all calls to `Realm.Refresh` to fix blocking overhead from subscriptions

### DIFF
--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -46,9 +46,6 @@ namespace osu.Game.Database
                 migrateScores(ef);
             }
 
-            Logger.Log("Refreshing realm...", LoggingTarget.Database);
-            realmContextFactory.Refresh();
-
             // Delete the database permanently.
             // Will cause future startups to not attempt migration.
             Logger.Log("Migration successful, deleting EF database", LoggingTarget.Database);

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -61,10 +61,10 @@ namespace osu.Game.Database
 
         private readonly ThreadLocal<bool> currentThreadCanCreateContexts = new ThreadLocal<bool>();
 
-        private static readonly GlobalStatistic<int> refreshes = GlobalStatistics.Get<int>(@"Realm", @"Dirty Refreshes");
         private static readonly GlobalStatistic<int> contexts_created = GlobalStatistics.Get<int>(@"Realm", @"Contexts (Created)");
 
         private readonly object contextLock = new object();
+
         private Realm? context;
 
         public Realm Context
@@ -168,18 +168,6 @@ namespace osu.Game.Database
         /// </summary>
         /// <returns></returns>
         public bool Compact() => Realm.Compact(getConfiguration());
-
-        /// <summary>
-        /// Perform a blocking refresh on the main realm context.
-        /// </summary>
-        public void Refresh()
-        {
-            lock (contextLock)
-            {
-                if (context?.Refresh() == true)
-                    refreshes.Value++;
-            }
-        }
 
         public Realm CreateContext()
         {

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -351,13 +351,6 @@ namespace osu.Game
             FrameStatistics.ValueChanged += e => fpsDisplayVisible.Value = e.NewValue != FrameStatisticsMode.None;
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            realmFactory.Refresh();
-        }
-
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 


### PR DESCRIPTION
Turns out this is not required if realm is aware of a `SynchronizationContext`. See https://github.com/realm/realm-dotnet/discussions/2775#discussioncomment-2005412 for further reading.

This reduces the rate at which realm subscription callbacks occur in some cases, but also means they will never block the update thread.

*wipes sweat* somewhat relieving.