### PR TITLE
Improve carousel performance during imports and deletions

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Select
         {
             CarouselRoot newRoot = new CarouselRoot(this);
 
-            newRoot.AddChildren(beatmapSets.Select(createCarouselSet).Where(g => g != null));
+            newRoot.AddChildren(beatmapSets.Select(s => createCarouselSet(s.Detach())).Where(g => g != null));
 
             root = newRoot;
             if (selectedBeatmapSet != null && !beatmapSets.Contains(selectedBeatmapSet.BeatmapSet))
@@ -209,7 +209,7 @@ namespace osu.Game.Screens.Select
                 return;
 
             foreach (int i in changes.InsertedIndices)
-                RemoveBeatmapSet(sender[i]);
+                RemoveBeatmapSet(sender[i].Detach());
         }
 
         private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)
@@ -248,10 +248,10 @@ namespace osu.Game.Screens.Select
             }
 
             foreach (int i in changes.NewModifiedIndices)
-                UpdateBeatmapSet(sender[i]);
+                UpdateBeatmapSet(sender[i].Detach());
 
             foreach (int i in changes.InsertedIndices)
-                UpdateBeatmapSet(sender[i]);
+                UpdateBeatmapSet(sender[i].Detach());
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapInfo> sender, ChangeSet changes, Exception error)
@@ -261,7 +261,7 @@ namespace osu.Game.Screens.Select
                 return;
 
             foreach (int i in changes.InsertedIndices)
-                UpdateBeatmapSet(sender[i].BeatmapSet);
+                UpdateBeatmapSet(sender[i].BeatmapSet?.Detach());
         }
 
         private IRealmCollection<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected).AsRealmCollection();
@@ -711,8 +711,6 @@ namespace osu.Game.Screens.Select
 
         private CarouselBeatmapSet createCarouselSet(BeatmapSetInfo beatmapSet)
         {
-            beatmapSet = beatmapSet.Detach();
-
             // This can be moved to the realm query if required using:
             // .Filter("DeletePending == false && Protected == false && ANY Beatmaps.Hidden == false")
             //

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Select
 
         protected readonly CarouselScrollContainer Scroll;
 
-        private IEnumerable<CarouselBeatmapSet> beatmapSets => root.Children.OfType<CarouselBeatmapSet>();
+        private IEnumerable<CarouselBeatmapSet> beatmapSets => root.BeatmapSetsByID.Values;
 
         // todo: only used for testing, maybe remove.
         private bool loadedTestBeatmaps;
@@ -117,6 +117,7 @@ namespace osu.Game.Screens.Select
             newRoot.AddChildren(beatmapSets.Select(s => createCarouselSet(s.Detach())).Where(g => g != null));
 
             root = newRoot;
+
             if (selectedBeatmapSet != null && !beatmapSets.Contains(selectedBeatmapSet.BeatmapSet))
                 selectedBeatmapSet = null;
 
@@ -209,7 +210,7 @@ namespace osu.Game.Screens.Select
                 return;
 
             foreach (int i in changes.InsertedIndices)
-                RemoveBeatmapSet(sender[i].Detach());
+                removeBeatmapSet(sender[i].ID);
         }
 
         private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)
@@ -223,24 +224,20 @@ namespace osu.Game.Screens.Select
                 // During initial population, we must manually account for the fact that our original query was done on an async thread.
                 // Since then, there may have been imports or deletions.
                 // Here we manually catch up on any changes.
-                var populatedSets = new HashSet<Guid>();
-                foreach (var s in beatmapSets)
-                    populatedSets.Add(s.BeatmapSet.ID);
-
                 var realmSets = new HashSet<Guid>();
                 foreach (var s in sender)
                     realmSets.Add(s.ID);
 
-                foreach (var s in realmSets)
+                foreach (var id in realmSets)
                 {
-                    if (!populatedSets.Contains(s))
-                        UpdateBeatmapSet(realmFactory.Context.Find<BeatmapSetInfo>(s));
+                    if (!root.BeatmapSetsByID.ContainsKey(id))
+                        UpdateBeatmapSet(realmFactory.Context.Find<BeatmapSetInfo>(id).Detach());
                 }
 
-                foreach (var s in populatedSets)
+                foreach (var id in root.BeatmapSetsByID.Keys)
                 {
-                    if (!realmSets.Contains(s))
-                        RemoveBeatmapSet(realmFactory.Context.Find<BeatmapSetInfo>(s));
+                    if (!realmSets.Contains(id))
+                        removeBeatmapSet(id);
                 }
 
                 signalBeatmapsLoaded();
@@ -261,16 +258,30 @@ namespace osu.Game.Screens.Select
                 return;
 
             foreach (int i in changes.InsertedIndices)
-                UpdateBeatmapSet(sender[i].BeatmapSet?.Detach());
+            {
+                var beatmapInfo = sender[i];
+                var beatmapSet = beatmapInfo.BeatmapSet;
+
+                Debug.Assert(beatmapSet != null);
+
+                // Only require to action here if the beatmap is missing.
+                // This avoids processing these events unnecessarily when new beatmaps are imported, for example.
+                if (root.BeatmapSetsByID.TryGetValue(beatmapSet.ID, out var existingSet)
+                    && existingSet.BeatmapSet.Beatmaps.All(b => b.ID != beatmapInfo.ID))
+                {
+                    UpdateBeatmapSet(beatmapSet.Detach());
+                }
+            }
         }
 
         private IRealmCollection<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected).AsRealmCollection();
 
-        public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
-        {
-            var existingSet = beatmapSets.FirstOrDefault(b => b.BeatmapSet.Equals(beatmapSet));
+        public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) =>
+            removeBeatmapSet(beatmapSet.ID);
 
-            if (existingSet == null)
+        private void removeBeatmapSet(Guid beatmapSetID) => Schedule(() =>
+        {
+            if (!root.BeatmapSetsByID.TryGetValue(beatmapSetID, out var existingSet))
                 return;
 
             root.RemoveChild(existingSet);
@@ -281,32 +292,26 @@ namespace osu.Game.Screens.Select
         {
             Guid? previouslySelectedID = null;
 
-            CarouselBeatmapSet existingSet = beatmapSets.FirstOrDefault(b => b.BeatmapSet.Equals(beatmapSet));
-
             // If the selected beatmap is about to be removed, store its ID so it can be re-selected if required
-            if (existingSet?.State?.Value == CarouselItemState.Selected)
+            if (selectedBeatmapSet?.BeatmapSet.ID == beatmapSet.ID)
                 previouslySelectedID = selectedBeatmap?.BeatmapInfo.ID;
 
             var newSet = createCarouselSet(beatmapSet);
 
-            if (existingSet != null)
-                root.RemoveChild(existingSet);
+            root.RemoveChild(beatmapSet.ID);
 
-            if (newSet == null)
+            if (newSet != null)
             {
-                itemsCache.Invalidate();
-                return;
+                root.AddChild(newSet);
+
+                // only reset scroll position if already near the scroll target.
+                // without this, during a large beatmap import it is impossible to navigate the carousel.
+                applyActiveCriteria(false, alwaysResetScrollPosition: false);
+
+                // check if we can/need to maintain our current selection.
+                if (previouslySelectedID != null)
+                    select((CarouselItem)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
             }
-
-            root.AddChild(newSet);
-
-            // only reset scroll position if already near the scroll target.
-            // without this, during a large beatmap import it is impossible to navigate the carousel.
-            applyActiveCriteria(false, alwaysResetScrollPosition: false);
-
-            // check if we can/need to maintain our current selection.
-            if (previouslySelectedID != null)
-                select((CarouselItem)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
 
             itemsCache.Invalidate();
             Schedule(() => BeatmapSetsChanged?.Invoke());
@@ -911,6 +916,8 @@ namespace osu.Game.Screens.Select
         {
             private readonly BeatmapCarousel carousel;
 
+            public readonly Dictionary<Guid, CarouselBeatmapSet> BeatmapSetsByID = new Dictionary<Guid, CarouselBeatmapSet>();
+
             public CarouselRoot(BeatmapCarousel carousel)
             {
                 // root should always remain selected. if not, PerformSelection will not be called.
@@ -918,6 +925,28 @@ namespace osu.Game.Screens.Select
                 State.ValueChanged += state => State.Value = CarouselItemState.Selected;
 
                 this.carousel = carousel;
+            }
+
+            public override void AddChild(CarouselItem i)
+            {
+                CarouselBeatmapSet set = (CarouselBeatmapSet)i;
+                BeatmapSetsByID[set.BeatmapSet.ID] = set;
+
+                base.AddChild(i);
+            }
+
+            public void RemoveChild(Guid beatmapSetID)
+            {
+                if (BeatmapSetsByID.TryGetValue(beatmapSetID, out var carouselBeatmapSet))
+                    RemoveChild(carouselBeatmapSet);
+            }
+
+            public override void RemoveChild(CarouselItem i)
+            {
+                CarouselBeatmapSet set = (CarouselBeatmapSet)i;
+                BeatmapSetsByID.Remove(set.BeatmapSet.ID);
+
+                base.RemoveChild(i);
             }
 
             protected override void PerformSelection()

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Select
 
         protected readonly CarouselScrollContainer Scroll;
 
-        private IEnumerable<CarouselBeatmapSet> beatmapSets => root.BeatmapSetsByID.Values;
+        private IEnumerable<CarouselBeatmapSet> beatmapSets => root.Children.OfType<CarouselBeatmapSet>();
 
         // todo: only used for testing, maybe remove.
         private bool loadedTestBeatmaps;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -225,8 +225,9 @@ namespace osu.Game.Screens.Select
                 // Since then, there may have been imports or deletions.
                 // Here we manually catch up on any changes.
                 var realmSets = new HashSet<Guid>();
-                foreach (var s in sender)
-                    realmSets.Add(s.ID);
+
+                for (int i = 0; i < sender.Count; i++)
+                    realmSets.Add(sender[i].ID);
 
                 foreach (var id in realmSets)
                 {

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -934,7 +934,7 @@ namespace osu.Game.Screens.Select
             public override void AddChild(CarouselItem i)
             {
                 CarouselBeatmapSet set = (CarouselBeatmapSet)i;
-                BeatmapSetsByID[set.BeatmapSet.ID] = set;
+                BeatmapSetsByID.Add(set.BeatmapSet.ID, set);
 
                 base.AddChild(i);
             }

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -55,10 +55,16 @@ namespace osu.Game.Screens.Select.Carousel
                 updateSelectedIndex();
         }
 
+        private bool addingChildren;
+
         public void AddChildren(IEnumerable<CarouselItem> items)
         {
+            addingChildren = true;
+
             foreach (var i in items)
-                base.AddChild(i);
+                AddChild(i);
+
+            addingChildren = false;
 
             attemptSelection();
         }
@@ -66,7 +72,8 @@ namespace osu.Game.Screens.Select.Carousel
         public override void AddChild(CarouselItem i)
         {
             base.AddChild(i);
-            attemptSelection();
+            if (!addingChildren)
+                attemptSelection();
         }
 
         protected override void ChildItemStateChanged(CarouselItem item, CarouselItemState value)


### PR DESCRIPTION
A lot of the preivous overhead (present even pre-realm) was from the equality comparison against existing panels to check existence. This reduces that overhead to negligible amounts.

Specifically targeting the work shown in this profiling session:
![unknown-3](https://user-images.githubusercontent.com/191335/150347605-756c53ba-7e13-401a-80d7-7157e3f41219.png)


Note that
- Imports are still slow on massive beatmap libraries due to the implicit filter operation per import
- Deletions will hitch due to a realm-resync if the current game beatmap changes (due to realm context fetch in `GetWorkingBeatmap`). Discussion [here](https://github.com/realm/realm-dotnet/discussions/2775#discussioncomment-2006353)

With a hack to fix `GetWorkingBeatmap` deletions are now super smooth, at least:

https://user-images.githubusercontent.com/191335/150348325-381f97c6-6ab3-478b-80ff-e3abc4a35bc7.mp4


