### PR TITLE
Avoid performing keyword filtering at song select unless keywords are specified

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarRating);
 
-            if (match)
+            if (match && criteria.SearchTerms.Length > 0)
             {
                 string[] terms = BeatmapInfo.GetSearchableTerms();
 


### PR DESCRIPTION
This is a pre-realm issue.

Improves initial load of song select and simple operations like changing sort or ruleset. Not worth showing profiling because video is enough to show the difference.

Before:

https://user-images.githubusercontent.com/191335/150463582-4b895ed7-d6c5-4776-a86b-3e04250ce918.mp4

After:

https://user-images.githubusercontent.com/191335/150463436-fc02c618-e4dd-4880-9b1a-66dbc97c9b77.mp4

Removes overheads associated with building and filtering the keyword array, even when it's empty (before this change seen below):

![20220121 130404 (Parallels Desktop)](https://user-images.githubusercontent.com/191335/150463760-dc129925-539a-4520-8ab7-a4503cdb884c.png)
