### PR TITLE
Avoid performing full filter when updating carousel beatmap sets

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -300,16 +300,18 @@ namespace osu.Game.Screens.Select
 
             root.AddChild(newSet);
 
-            // only reset scroll position if already near the scroll target.
-            // without this, during a large beatmap import it is impossible to navigate the carousel.
-            applyActiveCriteria(false, alwaysResetScrollPosition: false);
-
             // check if we can/need to maintain our current selection.
             if (previouslySelectedID != null)
                 select((CarouselItem)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
 
             itemsCache.Invalidate();
-            Schedule(() => BeatmapSetsChanged?.Invoke());
+            Schedule(() =>
+            {
+                if (!Scroll.UserScrolling)
+                    ScrollToSelected(true);
+
+                BeatmapSetsChanged?.Invoke();
+            });
         });
 
         /// <summary>

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -3,7 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
+
+#nullable enable
 
 namespace osu.Game.Screens.Select.Carousel
 {
@@ -12,7 +13,7 @@ namespace osu.Game.Screens.Select.Carousel
     /// </summary>
     public class CarouselGroup : CarouselItem
     {
-        public override DrawableCarouselItem CreateDrawableRepresentation() => null;
+        public override DrawableCarouselItem? CreateDrawableRepresentation() => null;
 
         public IReadOnlyList<CarouselItem> Children => InternalChildren;
 
@@ -23,6 +24,10 @@ namespace osu.Game.Screens.Select.Carousel
         /// incremented whenever a child is added.
         /// </summary>
         private ulong currentChildID;
+
+        private Comparer<CarouselItem>? criteriaComparer;
+
+        private FilterCriteria? lastCriteria;
 
         public virtual void RemoveChild(CarouselItem i)
         {
@@ -54,7 +59,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
         }
 
-        public CarouselGroup(List<CarouselItem> items = null)
+        public CarouselGroup(List<CarouselItem>? items = null)
         {
             if (items != null) InternalChildren = items;
 
@@ -76,11 +81,6 @@ namespace osu.Game.Screens.Select.Carousel
                 }
             };
         }
-
-        private Comparer<CarouselItem> criteriaComparer;
-
-        [CanBeNull]
-        private FilterCriteria lastCriteria;
 
         public override void Filter(FilterCriteria criteria)
         {


### PR DESCRIPTION
This is a pre-realm issue.

Before (yes that's the game freezing not the video stopping):

https://user-images.githubusercontent.com/191335/150463905-f2a785b4-f151-48e9-a49b-cc37abed34f6.mp4

After (still not perfect, but better):

https://user-images.githubusercontent.com/191335/150464028-0e1c9e9b-7166-4b74-9a9b-01fe395e30d1.mp4

Originally I also had this bypassing a sort when the sort type didn't change, but it turns out this cannot be done due to the case best explained by https://github.com/ppy/osu/blob/67bf95bc91d8cda84cd53b1f521ebc8b1e78c7e1/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs#L455-L476

With this and the other optimisation branches I think the carousel is in a good enough state. Any further optimisations would be pointless considering the unknown of how much of this will remain after future refactors to

- support realm filtering maybe
- support splitting up sets to sort by individual beatmap difficulty as per stable
