### PR TITLE
Fix `IntroScreen` retrieving and iterating all realm beatmap sets

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Menu
 
                     int setCount = sets.Count;
 
-                    if (sets.Any())
+                    if (setCount > 0)
                     {
                         var found = sets[RNG.Next(0, setCount - 1)].Beatmaps.FirstOrDefault();
 


### PR DESCRIPTION
Really want to remove the method completely, but it's used in a lot of tests and can't easily be made into a test-only extension method (unless `ContextFactory` is exposed in `BeatmapManager` as `public`).

This was the last usage of the method outside of tests.

- [x] Depends on https://github.com/ppy/osu/pull/16535.