### PR TITLE
Fix realm subscriptions getting lost after a context recycle

### DIFF
--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Database
             {
                 bool callbackRan = false;
 
-                realmFactory.Register(realm =>
+                realmFactory.RegisterCustomSubscription(realm =>
                 {
                     var subscription = realm.All<BeatmapInfo>().QueryAsyncWithNotifications((sender, changes, error) =>
                     {

--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Database
             {
                 bool callbackRan = false;
 
-                realmFactory.Run(realm =>
+                realmFactory.Register(realm =>
                 {
                     var subscription = realm.All<BeatmapInfo>().QueryAsyncWithNotifications((sender, changes, error) =>
                     {
@@ -60,6 +60,7 @@ namespace osu.Game.Tests.Database
                     realmFactory.Run(r => r.Refresh());
 
                     subscription?.Dispose();
+                    return null;
                 });
 
                 Assert.IsTrue(callbackRan);

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Tests.Database
             {
                 int changesTriggered = 0;
 
-                realmFactory.Run(outerRealm =>
+                realmFactory.Register(outerRealm =>
                 {
                     outerRealm.All<BeatmapInfo>().QueryAsyncWithNotifications(gotChange);
                     ILive<BeatmapInfo>? liveBeatmap = null;
@@ -277,6 +277,8 @@ namespace osu.Game.Tests.Database
                             r.Remove(resolved);
                         });
                     });
+
+                    return null;
                 });
 
                 void gotChange(IRealmCollection<BeatmapInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Tests.Database
             {
                 int changesTriggered = 0;
 
-                realmFactory.Register(outerRealm =>
+                realmFactory.RegisterCustomSubscription(outerRealm =>
                 {
                     outerRealm.All<BeatmapInfo>().QueryAsyncWithNotifications(gotChange);
                     ILive<BeatmapInfo>? liveBeatmap = null;

--- a/osu.Game.Tests/Database/RealmSubscriptionRegistrationTests.cs
+++ b/osu.Game.Tests/Database/RealmSubscriptionRegistrationTests.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tests.Database
             {
                 realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
 
-                var registration = realmFactory.Register(realm => realm.All<BeatmapSetInfo>(), onChanged);
+                var registration = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>(), onChanged);
 
                 testEventsArriving(true);
 
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Database
 
                 realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
 
-                var subscription = realmFactory.Register(realm =>
+                var subscription = realmFactory.RegisterCustomSubscription(realm =>
                 {
                     beatmapSetInfo = realm.All<BeatmapSetInfo>().First();
 

--- a/osu.Game.Tests/Database/RealmSubscriptionRegistrationTests.cs
+++ b/osu.Game.Tests/Database/RealmSubscriptionRegistrationTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Tests.Resources;
+using Realms;
+
+#nullable enable
+
+namespace osu.Game.Tests.Database
+{
+    [TestFixture]
+    public class RealmSubscriptionRegistrationTests : RealmTest
+    {
+        [Test]
+        public void TestSubscriptionWithContextLoss()
+        {
+            IEnumerable<BeatmapSetInfo>? resolvedItems = null;
+            ChangeSet? lastChanges = null;
+
+            RunTestWithRealm((realmFactory, _) =>
+            {
+                realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
+
+                var registration = realmFactory.Register(realm => realm.All<BeatmapSetInfo>(), onChanged);
+
+                testEventsArriving(true);
+
+                // All normal until here.
+                // Now let's yank the main realm context.
+                resolvedItems = null;
+                lastChanges = null;
+
+                using (realmFactory.BlockAllOperations())
+                    Assert.That(resolvedItems, Is.Empty);
+
+                realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
+
+                testEventsArriving(true);
+
+                // Now let's try unsubscribing.
+                resolvedItems = null;
+                lastChanges = null;
+
+                registration.Dispose();
+
+                realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
+
+                testEventsArriving(false);
+
+                // And make sure even after another context loss we don't get firings.
+                using (realmFactory.BlockAllOperations())
+                    Assert.That(resolvedItems, Is.Null);
+
+                realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
+
+                testEventsArriving(false);
+
+                void testEventsArriving(bool shouldArrive)
+                {
+                    realmFactory.Run(realm => realm.Refresh());
+
+                    if (shouldArrive)
+                        Assert.That(resolvedItems, Has.One.Items);
+                    else
+                        Assert.That(resolvedItems, Is.Null);
+
+                    realmFactory.Write(realm =>
+                    {
+                        realm.RemoveAll<BeatmapSetInfo>();
+                        realm.RemoveAll<RulesetInfo>();
+                    });
+
+                    realmFactory.Run(realm => realm.Refresh());
+
+                    if (shouldArrive)
+                        Assert.That(lastChanges?.DeletedIndices, Has.One.Items);
+                    else
+                        Assert.That(lastChanges, Is.Null);
+                }
+            });
+
+            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error)
+            {
+                if (changes == null)
+                    resolvedItems = sender;
+
+                lastChanges = changes;
+            }
+        }
+
+        [Test]
+        public void TestCustomRegisterWithContextLoss()
+        {
+            RunTestWithRealm((realmFactory, _) =>
+            {
+                BeatmapSetInfo? beatmapSetInfo = null;
+
+                realmFactory.Write(realm => realm.Add(TestResources.CreateTestBeatmapSetInfo()));
+
+                var subscription = realmFactory.Register(realm =>
+                {
+                    beatmapSetInfo = realm.All<BeatmapSetInfo>().First();
+
+                    return new InvokeOnDisposal(() => beatmapSetInfo = null);
+                });
+
+                Assert.That(beatmapSetInfo, Is.Not.Null);
+
+                using (realmFactory.BlockAllOperations())
+                {
+                    // custom disposal action fired when context lost.
+                    Assert.That(beatmapSetInfo, Is.Null);
+                }
+
+                // re-registration after context restore.
+                realmFactory.Run(realm => realm.Refresh());
+                Assert.That(beatmapSetInfo, Is.Not.Null);
+
+                subscription.Dispose();
+
+                Assert.That(beatmapSetInfo, Is.Null);
+
+                using (realmFactory.BlockAllOperations())
+                    Assert.That(beatmapSetInfo, Is.Null);
+
+                realmFactory.Run(realm => realm.Refresh());
+                Assert.That(beatmapSetInfo, Is.Null);
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -80,7 +80,10 @@ namespace osu.Game.Tests.Resources
         public static BeatmapSetInfo CreateTestBeatmapSetInfo(int? difficultyCount = null, RulesetInfo[] rulesets = null)
         {
             int j = 0;
-            RulesetInfo getRuleset() => rulesets?[j++ % rulesets.Length] ?? new OsuRuleset().RulesetInfo;
+
+            rulesets ??= new[] { new OsuRuleset().RulesetInfo };
+
+            RulesetInfo getRuleset() => rulesets?[j++ % rulesets.Length];
 
             int setId = Interlocked.Increment(ref importId);
 

--- a/osu.Game/Database/EmptyRealmSet.cs
+++ b/osu.Game/Database/EmptyRealmSet.cs
@@ -15,21 +15,14 @@ namespace osu.Game.Database
 {
     public class EmptyRealmSet<T> : IRealmCollection<T>
     {
-        private static List<T> emptySet => new List<T>();
+        private IList<T> emptySet => Array.Empty<T>();
 
-        public IEnumerator<T> GetEnumerator()
-        {
-            return emptySet.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable)emptySet).GetEnumerator();
-        }
-
+        public IEnumerator<T> GetEnumerator() => emptySet.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => emptySet.GetEnumerator();
         public int Count => emptySet.Count;
-
         public T this[int index] => emptySet[index];
+        public int IndexOf(object item) => emptySet.IndexOf((T)item);
+        public bool Contains(object item) => emptySet.Contains((T)item);
 
         public event NotifyCollectionChangedEventHandler? CollectionChanged
         {
@@ -43,32 +36,11 @@ namespace osu.Game.Database
             remove => throw new NotImplementedException();
         }
 
-        public int IndexOf(object item)
-        {
-            return emptySet.IndexOf((T)item);
-        }
-
-        public bool Contains(object item)
-        {
-            return emptySet.Contains((T)item);
-        }
-
-        public IRealmCollection<T> Freeze()
-        {
-            throw new NotImplementedException();
-        }
-
-        public IDisposable SubscribeForNotifications(NotificationCallbackDelegate<T> callback)
-        {
-            throw new NotImplementedException();
-        }
-
+        public IRealmCollection<T> Freeze() => throw new NotImplementedException();
+        public IDisposable SubscribeForNotifications(NotificationCallbackDelegate<T> callback) => throw new NotImplementedException();
         public bool IsValid => throw new NotImplementedException();
-
         public Realm Realm => throw new NotImplementedException();
-
         public ObjectSchema ObjectSchema => throw new NotImplementedException();
-
         public bool IsFrozen => throw new NotImplementedException();
     }
 }

--- a/osu.Game/Database/EmptyRealmSet.cs
+++ b/osu.Game/Database/EmptyRealmSet.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Realms;
+using Realms.Schema;
+
+#nullable enable
+
+namespace osu.Game.Database
+{
+    public class EmptyRealmSet<T> : IRealmCollection<T>
+    {
+        private static List<T> emptySet => new List<T>();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return emptySet.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)emptySet).GetEnumerator();
+        }
+
+        public int Count => emptySet.Count;
+
+        public T this[int index] => emptySet[index];
+
+        public event NotifyCollectionChangedEventHandler? CollectionChanged
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public int IndexOf(object item)
+        {
+            return emptySet.IndexOf((T)item);
+        }
+
+        public bool Contains(object item)
+        {
+            return emptySet.Contains((T)item);
+        }
+
+        public IRealmCollection<T> Freeze()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable SubscribeForNotifications(NotificationCallbackDelegate<T> callback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsValid => throw new NotImplementedException();
+
+        public Realm Realm => throw new NotImplementedException();
+
+        public ObjectSchema ObjectSchema => throw new NotImplementedException();
+
+        public bool IsFrozen => throw new NotImplementedException();
+    }
+}

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -243,9 +243,11 @@ namespace osu.Game.Database
             if (!ThreadSafety.IsUpdateThread)
                 throw new InvalidOperationException(@$"{nameof(Register)} must be called from the update thread.");
 
-            realmSubscriptionsResetMap.Add(action, () => onChanged(new EmptyRealmSet<T>(), null, null));
-
-            return Register(action);
+            lock (contextLock)
+            {
+                realmSubscriptionsResetMap.Add(action, () => onChanged(new EmptyRealmSet<T>(), null, null));
+                return Register(action);
+            }
 
             IDisposable? action(Realm realm) => query(realm).QueryAsyncWithNotifications(onChanged);
         }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -264,14 +264,12 @@ namespace osu.Game.Database
         /// </remarks>
         /// <param name="query">The <see cref="IQueryable{T}"/> to observe for changes.</param>
         /// <typeparam name="T">Type of the elements in the list.</typeparam>
-        /// <seealso cref="IRealmCollection{T}.SubscribeForNotifications"/>
         /// <param name="callback">The callback to be invoked with the updated <see cref="IRealmCollection{T}"/>.</param>
         /// <returns>
         /// A subscription token. It must be kept alive for as long as you want to receive change notifications.
         /// To stop receiving notifications, call <see cref="IDisposable.Dispose"/>.
-        ///
-        /// May be null in the case the provided collection is not managed.
         /// </returns>
+        /// <seealso cref="IRealmCollection{T}.SubscribeForNotifications"/>
         public IDisposable RegisterForNotifications<T>(Func<Realm, IQueryable<T>> query, NotificationCallbackDelegate<T> callback)
             where T : RealmObjectBase
         {

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -244,7 +244,6 @@ namespace osu.Game.Database
             if (!ThreadSafety.IsUpdateThread)
                 throw new InvalidOperationException(@$"{nameof(Register)} must be called from the update thread.");
 
-            subscriptionActions.Add(action, null);
             registerSubscription(action);
 
             return new InvokeOnDisposal(() =>
@@ -264,10 +263,8 @@ namespace osu.Game.Database
 
             lock (contextLock)
             {
-                Debug.Assert(context != null);
-
                 current_thread_subscriptions_allowed.Value = true;
-                subscriptionActions[action] = action(context);
+                subscriptionActions[action] = action(Context);
                 current_thread_subscriptions_allowed.Value = false;
             }
         }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -249,11 +249,13 @@ namespace osu.Game.Database
 
             return new InvokeOnDisposal(() =>
             {
-                // TODO: this likely needs to be run on the update thread.
-                if (subscriptionActions.TryGetValue(action, out var unsubscriptionAction))
+                lock (contextLock)
                 {
-                    unsubscriptionAction?.Dispose();
-                    subscriptionActions.Remove(action);
+                    if (subscriptionActions.TryGetValue(action, out var unsubscriptionAction))
+                    {
+                        unsubscriptionAction?.Dispose();
+                        subscriptionActions.Remove(action);
+                    }
                 }
             });
         }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -292,7 +292,9 @@ namespace osu.Game.Database
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
-            // Get context outside of flag update to ensure beyond doubt this can't be cyclic.
+            // Retrieve context outside of flag update to ensure that the context is constructed,
+            // as attempting to access it inside the subscription if it's not constructed would lead to
+            // cyclic invocations of the subscription callback.
             var realm = Context;
 
             lock (contextLock)

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -330,13 +330,16 @@ namespace osu.Game.Database
         /// </summary>
         private void unregisterAllSubscriptions()
         {
-            foreach (var action in realmSubscriptionsResetMap.Values)
-                action();
-
-            foreach (var action in customSubscriptionsResetMap)
+            lock (contextLock)
             {
-                action.Value?.Dispose();
-                customSubscriptionsResetMap[action.Key] = null;
+                foreach (var action in realmSubscriptionsResetMap.Values)
+                    action();
+
+                foreach (var action in customSubscriptionsResetMap)
+                {
+                    action.Value?.Dispose();
+                    customSubscriptionsResetMap[action.Key] = null;
+                }
             }
         }
 

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -88,6 +88,8 @@ namespace osu.Game.Database
                             registerSubscription(action);
                     }
 
+                    Debug.Assert(context != null);
+
                     // creating a context will ensure our schema is up-to-date and migrated.
                     return context;
                 }
@@ -261,10 +263,13 @@ namespace osu.Game.Database
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
+            // Get context outside of flag update to ensure beyond doubt this can't be cyclic.
+            var realm = Context;
+
             lock (contextLock)
             {
                 current_thread_subscriptions_allowed.Value = true;
-                subscriptionActions[action] = action(Context);
+                subscriptionActions[action] = action(realm);
                 current_thread_subscriptions_allowed.Value = false;
             }
         }

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -69,30 +69,29 @@ namespace osu.Game.Database
 
         private Realm? context;
 
-        public Realm Context
+        public Realm Context => ensureUpdateContext();
+
+        private Realm ensureUpdateContext()
         {
-            get
+            if (!ThreadSafety.IsUpdateThread)
+                throw new InvalidOperationException(@$"Use {nameof(createContext)} when performing realm operations from a non-update thread");
+
+            lock (contextLock)
             {
-                if (!ThreadSafety.IsUpdateThread)
-                    throw new InvalidOperationException(@$"Use {nameof(createContext)} when performing realm operations from a non-update thread");
-
-                lock (contextLock)
+                if (context == null)
                 {
-                    if (context == null)
-                    {
-                        context = createContext();
-                        Logger.Log(@$"Opened realm ""{context.Config.DatabasePath}"" at version {context.Config.SchemaVersion}");
+                    context = createContext();
+                    Logger.Log(@$"Opened realm ""{context.Config.DatabasePath}"" at version {context.Config.SchemaVersion}");
 
-                        // Resubscribe any subscriptions
-                        foreach (var action in subscriptionActions.Keys)
-                            registerSubscription(action);
-                    }
-
-                    Debug.Assert(context != null);
-
-                    // creating a context will ensure our schema is up-to-date and migrated.
-                    return context;
+                    // Resubscribe any subscriptions
+                    foreach (var action in subscriptionActions.Keys)
+                        registerSubscription(action);
                 }
+
+                Debug.Assert(context != null);
+
+                // creating a context will ensure our schema is up-to-date and migrated.
+                return context;
             }
         }
 
@@ -506,6 +505,8 @@ namespace osu.Game.Database
             if (isDisposed)
                 throw new ObjectDisposedException(nameof(RealmContextFactory));
 
+            SynchronizationContext syncContext;
+
             try
             {
                 contextCreationLock.Wait();
@@ -514,6 +515,8 @@ namespace osu.Game.Database
                 {
                     if (!ThreadSafety.IsUpdateThread && context != null)
                         throw new InvalidOperationException(@$"{nameof(BlockAllOperations)} must be called from the update thread.");
+
+                    syncContext = SynchronizationContext.Current;
 
                     Logger.Log(@"Blocking realm operations.", LoggingTarget.Database);
 
@@ -553,6 +556,9 @@ namespace osu.Game.Database
             {
                 factory.contextCreationLock.Release();
                 Logger.Log(@"Restoring realm operations.", LoggingTarget.Database);
+
+                // Post back to the update thread to revive any subscriptions.
+                syncContext?.Post(_ => ensureUpdateContext(), null);
             });
         }
 

--- a/osu.Game/Database/RealmContextFactory.cs
+++ b/osu.Game/Database/RealmContextFactory.cs
@@ -309,13 +309,13 @@ namespace osu.Game.Database
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
-            // Retrieve context outside of flag update to ensure that the context is constructed,
-            // as attempting to access it inside the subscription if it's not constructed would lead to
-            // cyclic invocations of the subscription callback.
-            var realm = Context;
-
             lock (contextLock)
             {
+                // Retrieve context outside of flag update to ensure that the context is constructed,
+                // as attempting to access it inside the subscription if it's not constructed would lead to
+                // cyclic invocations of the subscription callback.
+                var realm = Context;
+
                 Debug.Assert(!customSubscriptionsResetMap.TryGetValue(action, out var found) || found == null);
 
                 current_thread_subscriptions_allowed.Value = true;

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using AutoMapper;
 using AutoMapper.Internal;
-using osu.Framework.Development;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Bindings;
 using osu.Game.Models;
@@ -272,9 +271,8 @@ namespace osu.Game.Database
         public static IDisposable? QueryAsyncWithNotifications<T>(this IRealmCollection<T> collection, NotificationCallbackDelegate<T> callback)
             where T : RealmObjectBase
         {
-            // Subscriptions can only work on the main thread.
-            if (!ThreadSafety.IsUpdateThread)
-                throw new InvalidOperationException("Cannot subscribe for realm notifications from a non-update thread.");
+            if (!RealmContextFactory.CurrentThreadSubscriptionsAllowed)
+                throw new InvalidOperationException($"Make sure to call {nameof(RealmContextFactory)}.{nameof(RealmContextFactory.Register)}");
 
             return collection.SubscribeForNotifications(callback);
         }

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -272,7 +272,7 @@ namespace osu.Game.Database
             where T : RealmObjectBase
         {
             if (!RealmContextFactory.CurrentThreadSubscriptionsAllowed)
-                throw new InvalidOperationException($"Make sure to call {nameof(RealmContextFactory)}.{nameof(RealmContextFactory.Register)}");
+                throw new InvalidOperationException($"Make sure to call {nameof(RealmContextFactory)}.{nameof(RealmContextFactory.RegisterForNotifications)}");
 
             return collection.SubscribeForNotifications(callback);
         }

--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Input.Bindings
 
         protected override void LoadComplete()
         {
-            realmSubscription = realmFactory.Register(realm => queryRealmKeyBindings(), (sender, changes, error) =>
+            realmSubscription = realmFactory.RegisterForNotifications(realm => queryRealmKeyBindings(), (sender, changes, error) =>
             {
                 // The first fire of this is a bit redundant as this is being called in base.LoadComplete,
                 // but this is safest in case the subscription is restored after a context recycle.

--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -55,13 +55,12 @@ namespace osu.Game.Input.Bindings
 
         protected override void LoadComplete()
         {
-            realmSubscription = realmFactory.Register(realm => queryRealmKeyBindings()
-                .QueryAsyncWithNotifications((sender, changes, error) =>
-                {
-                    // The first fire of this is a bit redundant as this is being called in base.LoadComplete,
-                    // but this is safest in case the subscription is restored after a context recycle.
-                    ReloadMappings();
-                }));
+            realmSubscription = realmFactory.Register(realm => queryRealmKeyBindings(), (sender, changes, error) =>
+            {
+                // The first fire of this is a bit redundant as this is being called in base.LoadComplete,
+                // but this is safest in case the subscription is restored after a context recycle.
+                ReloadMappings();
+            });
 
             base.LoadComplete();
         }

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realmContextFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
+            realmSubscription = realmContextFactory.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realmContextFactory.Context.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending).QueryAsyncWithNotifications((items, changes, ___) =>
+            realmSubscription = realmContextFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending).QueryAsyncWithNotifications((items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));
@@ -54,7 +54,7 @@ namespace osu.Game.Online
                         attachDownload(Downloader.GetExistingDownload(beatmapSetInfo));
                     });
                 }
-            });
+            }));
         }
 
         private void downloadBegan(ArchiveDownloadRequest<IBeatmapSetInfo> request) => Schedule(() =>

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realmContextFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending).QueryAsyncWithNotifications((items, changes, ___) =>
+            realmSubscription = realmContextFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));
@@ -54,7 +54,7 @@ namespace osu.Game.Online
                         attachDownload(Downloader.GetExistingDownload(beatmapSetInfo));
                     });
                 }
-            }));
+            });
         }
 
         private void downloadBegan(ArchiveDownloadRequest<IBeatmapSetInfo> request) => Schedule(() =>

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -78,13 +78,13 @@ namespace osu.Game.Online.Rooms
 
                 // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
                 realmSubscription?.Dispose();
-                realmSubscription = filteredBeatmaps().QueryAsyncWithNotifications((items, changes, ___) =>
+                realmSubscription = realmContextFactory.Register(realm => filteredBeatmaps().QueryAsyncWithNotifications((items, changes, ___) =>
                 {
                     if (changes == null)
                         return;
 
                     Scheduler.AddOnce(updateAvailability);
-                });
+                }));
             }, true);
         }
 

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Online.Rooms
 
                 // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
                 realmSubscription?.Dispose();
-                realmSubscription = realmContextFactory.Register(realm => filteredBeatmaps(), (items, changes, ___) =>
+                realmSubscription = realmContextFactory.RegisterForNotifications(realm => filteredBeatmaps(), (items, changes, ___) =>
                 {
                     if (changes == null)
                         return;

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -78,13 +78,13 @@ namespace osu.Game.Online.Rooms
 
                 // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
                 realmSubscription?.Dispose();
-                realmSubscription = realmContextFactory.Register(realm => filteredBeatmaps().QueryAsyncWithNotifications((items, changes, ___) =>
+                realmSubscription = realmContextFactory.Register(realm => filteredBeatmaps(), (items, changes, ___) =>
                 {
                     if (changes == null)
                         return;
 
                     Scheduler.AddOnce(updateAvailability);
-                }));
+                });
             }, true);
         }
 

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
-            realmSubscription = realmContextFactory.Context.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending).QueryAsyncWithNotifications((items, changes, ___) =>
+            realmSubscription = realmContextFactory.Register(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending).QueryAsyncWithNotifications((items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));
@@ -59,7 +59,7 @@ namespace osu.Game.Online
                         attachDownload(Downloader.GetExistingDownload(scoreInfo));
                     });
                 }
-            });
+            }));
         }
 
         private void downloadBegan(ArchiveDownloadRequest<IScoreInfo> request) => Schedule(() =>

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
-            realmSubscription = realmContextFactory.Register(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending).QueryAsyncWithNotifications((items, changes, ___) =>
+            realmSubscription = realmContextFactory.Register(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));
@@ -59,7 +59,7 @@ namespace osu.Game.Online
                         attachDownload(Downloader.GetExistingDownload(scoreInfo));
                     });
                 }
-            }));
+            });
         }
 
         private void downloadBegan(ArchiveDownloadRequest<IScoreInfo> request) => Schedule(() =>

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
-            realmSubscription = realmContextFactory.Register(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
+            realmSubscription = realmContextFactory.RegisterForNotifications(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Overlays
             foreach (var s in queryRealmBeatmapSets())
                 beatmapSets.Add(s.Detach());
 
-            beatmapSubscription = realmFactory.Register(realm => queryRealmBeatmapSets(), beatmapsChanged);
+            beatmapSubscription = realmFactory.RegisterForNotifications(realm => queryRealmBeatmapSets(), beatmapsChanged);
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -80,9 +80,10 @@ namespace osu.Game.Overlays
             mods.BindValueChanged(_ => ResetTrackAdjustments(), true);
         }
 
-        private IQueryable<BeatmapSetInfo> availableBeatmaps => realmFactory.Context
-                                                                            .All<BeatmapSetInfo>()
-                                                                            .Where(s => !s.DeletePending);
+        private IQueryable<BeatmapSetInfo> queryRealmBeatmapSets() =>
+            realmFactory.Context
+                        .All<BeatmapSetInfo>()
+                        .Where(s => !s.DeletePending);
 
         protected override void LoadComplete()
         {
@@ -90,10 +91,10 @@ namespace osu.Game.Overlays
 
             // ensure we're ready before completing async load.
             // probably not a good way of handling this (as there is a period we aren't watching for changes until the realm subscription finishes up.
-            foreach (var s in availableBeatmaps)
+            foreach (var s in queryRealmBeatmapSets())
                 beatmapSets.Add(s.Detach());
 
-            beatmapSubscription = realmFactory.Register(realm => availableBeatmaps, beatmapsChanged);
+            beatmapSubscription = realmFactory.Register(realm => queryRealmBeatmapSets(), beatmapsChanged);
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Overlays
             foreach (var s in availableBeatmaps)
                 beatmapSets.Add(s.Detach());
 
-            beatmapSubscription = realmFactory.Register(realm => availableBeatmaps.QueryAsyncWithNotifications(beatmapsChanged));
+            beatmapSubscription = realmFactory.Register(realm => availableBeatmaps, beatmapsChanged);
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -33,10 +33,6 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                         using (realmFactory.BlockAllOperations())
                         {
                         }
-
-                        // retrieve context to revive realm subscriptions.
-                        // TODO: should we do this from OsuGame or RealmContextFactory or something? Answer: yes.
-                        var _ = realmFactory.Context;
                     }
                 },
             };

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -33,6 +33,10 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                         using (realmFactory.BlockAllOperations())
                         {
                         }
+
+                        // retrieve context to revive realm subscriptions.
+                        // TODO: should we do this from OsuGame or RealmContextFactory or something? Answer: yes.
+                        var _ = realmFactory.Context;
                     }
                 },
             };

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
             skinDropdown.Current = dropdownBindable;
 
-            realmSubscription = realmFactory.Register(realm => queryRealmSkins(), (sender, changes, error) =>
+            realmSubscription = realmFactory.RegisterForNotifications(realm => queryRealmSkins(), (sender, changes, error) =>
             {
                 // The first fire of this is a bit redundant due to the call below,
                 // but this is safest in case the subscription is restored after a context recycle.

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private IDisposable realmSubscription;
 
-        private IQueryable<SkinInfo> realmSkins =>
+        private IQueryable<SkinInfo> queryRealmSkins() =>
             realmFactory.Context.All<SkinInfo>()
                         .Where(s => !s.DeletePending)
                         .OrderByDescending(s => s.Protected) // protected skins should be at the top.
@@ -83,13 +83,12 @@ namespace osu.Game.Overlays.Settings.Sections
 
             skinDropdown.Current = dropdownBindable;
 
-            realmSubscription = realmFactory.Register(realm => realmSkins
-                .QueryAsyncWithNotifications((sender, changes, error) =>
-                {
-                    // The first fire of this is a bit redundant due to the call below,
-                    // but this is safest in case the subscription is restored after a context recycle.
-                    updateItems();
-                }));
+            realmSubscription = realmFactory.Register(realm => queryRealmSkins(), (sender, changes, error) =>
+            {
+                // The first fire of this is a bit redundant due to the call below,
+                // but this is safest in case the subscription is restored after a context recycle.
+                updateItems();
+            });
 
             updateItems();
 
@@ -129,9 +128,9 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private void updateItems()
         {
-            int protectedCount = realmSkins.Count(s => s.Protected);
+            int protectedCount = queryRealmSkins().Count(s => s.Protected);
 
-            skinItems = realmSkins.ToLive(realmFactory);
+            skinItems = queryRealmSkins().ToLive(realmFactory);
 
             skinItems.Insert(protectedCount, random_skin_info);
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -190,13 +190,13 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
 
-            subscriptionSets = realmFactory.Register(getBeatmapSets, beatmapSetsChanged);
-            subscriptionBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
+            subscriptionSets = realmFactory.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
+            subscriptionBeatmaps = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
 
             // Can't use main subscriptions because we can't lookup deleted indices.
             // https://github.com/realm/realm-dotnet/discussions/2634#discussioncomment-1605595.
-            subscriptionDeletedSets = realmFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
-            subscriptionHiddenBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
+            subscriptionDeletedSets = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
+            subscriptionHiddenBeatmaps = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
         }
 
         private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -190,13 +190,13 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
 
-            subscriptionSets = getBeatmapSets(realmFactory.Context).QueryAsyncWithNotifications(beatmapSetsChanged);
-            subscriptionBeatmaps = realmFactory.Context.All<BeatmapInfo>().Where(b => !b.Hidden).QueryAsyncWithNotifications(beatmapsChanged);
+            subscriptionSets = realmFactory.Register(realm => getBeatmapSets(realm).QueryAsyncWithNotifications(beatmapSetsChanged));
+            subscriptionBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden).QueryAsyncWithNotifications(beatmapsChanged));
 
             // Can't use main subscriptions because we can't lookup deleted indices.
             // https://github.com/realm/realm-dotnet/discussions/2634#discussioncomment-1605595.
-            subscriptionDeletedSets = realmFactory.Context.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected).QueryAsyncWithNotifications(deletedBeatmapSetsChanged);
-            subscriptionHiddenBeatmaps = realmFactory.Context.All<BeatmapInfo>().Where(b => b.Hidden).QueryAsyncWithNotifications(beatmapsChanged);
+            subscriptionDeletedSets = realmFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected).QueryAsyncWithNotifications(deletedBeatmapSetsChanged));
+            subscriptionHiddenBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden).QueryAsyncWithNotifications(beatmapsChanged));
         }
 
         private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)
@@ -552,10 +552,11 @@ namespace osu.Game.Screens.Select
 
         private void signalBeatmapsLoaded()
         {
-            Debug.Assert(BeatmapSetsLoaded == false);
-
-            BeatmapSetsChanged?.Invoke();
-            BeatmapSetsLoaded = true;
+            if (!BeatmapSetsLoaded)
+            {
+                BeatmapSetsChanged?.Invoke();
+                BeatmapSetsLoaded = true;
+            }
 
             itemsCache.Invalidate();
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
 
-            subscriptionSets = realmFactory.Register(realm => getBeatmapSets(realm).QueryAsyncWithNotifications(beatmapSetsChanged));
+            subscriptionSets = realmFactory.Register(getBeatmapSets, beatmapSetsChanged);
             subscriptionBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden).QueryAsyncWithNotifications(beatmapsChanged));
 
             // Can't use main subscriptions because we can't lookup deleted indices.
@@ -274,7 +274,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private IRealmCollection<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected).AsRealmCollection();
+        private IQueryable<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected);
 
         public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) =>
             removeBeatmapSet(beatmapSet.ID);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -191,12 +191,12 @@ namespace osu.Game.Screens.Select
             base.LoadComplete();
 
             subscriptionSets = realmFactory.Register(getBeatmapSets, beatmapSetsChanged);
-            subscriptionBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden).QueryAsyncWithNotifications(beatmapsChanged));
+            subscriptionBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
 
             // Can't use main subscriptions because we can't lookup deleted indices.
             // https://github.com/realm/realm-dotnet/discussions/2634#discussioncomment-1605595.
-            subscriptionDeletedSets = realmFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected).QueryAsyncWithNotifications(deletedBeatmapSetsChanged));
-            subscriptionHiddenBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden).QueryAsyncWithNotifications(beatmapsChanged));
+            subscriptionDeletedSets = realmFactory.Register(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
+            subscriptionHiddenBeatmaps = realmFactory.Register(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
         }
 
         private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -48,18 +48,19 @@ namespace osu.Game.Screens.Select.Carousel
             ruleset.BindValueChanged(_ =>
             {
                 scoreSubscription?.Dispose();
-                scoreSubscription = realmFactory.Context.All<ScoreInfo>()
-                                                .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
-                                                        + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"
-                                                        + $" && {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $2"
-                                                        + $" && {nameof(ScoreInfo.DeletePending)} == false", api.LocalUser.Value.Id, beatmapInfo.ID, ruleset.Value.ShortName)
-                                                .OrderByDescending(s => s.TotalScore)
-                                                .QueryAsyncWithNotifications((items, changes, ___) =>
-                                                {
-                                                    Rank = items.FirstOrDefault()?.Rank;
-                                                    // Required since presence is changed via IsPresent override
-                                                    Invalidate(Invalidation.Presence);
-                                                });
+                scoreSubscription = realmFactory.Register(realm =>
+                    realm.All<ScoreInfo>()
+                         .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
+                                 + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"
+                                 + $" && {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $2"
+                                 + $" && {nameof(ScoreInfo.DeletePending)} == false", api.LocalUser.Value.Id, beatmapInfo.ID, ruleset.Value.ShortName)
+                         .OrderByDescending(s => s.TotalScore)
+                         .QueryAsyncWithNotifications((items, changes, ___) =>
+                         {
+                             Rank = items.FirstOrDefault()?.Rank;
+                             // Required since presence is changed via IsPresent override
+                             Invalidate(Invalidation.Presence);
+                         }));
             }, true);
         }
 

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -49,18 +49,18 @@ namespace osu.Game.Screens.Select.Carousel
             {
                 scoreSubscription?.Dispose();
                 scoreSubscription = realmFactory.Register(realm =>
-                    realm.All<ScoreInfo>()
-                         .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
-                                 + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"
-                                 + $" && {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $2"
-                                 + $" && {nameof(ScoreInfo.DeletePending)} == false", api.LocalUser.Value.Id, beatmapInfo.ID, ruleset.Value.ShortName)
-                         .OrderByDescending(s => s.TotalScore)
-                         .QueryAsyncWithNotifications((items, changes, ___) =>
-                         {
-                             Rank = items.FirstOrDefault()?.Rank;
-                             // Required since presence is changed via IsPresent override
-                             Invalidate(Invalidation.Presence);
-                         }));
+                        realm.All<ScoreInfo>()
+                             .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
+                                     + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"
+                                     + $" && {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $2"
+                                     + $" && {nameof(ScoreInfo.DeletePending)} == false", api.LocalUser.Value.Id, beatmapInfo.ID, ruleset.Value.ShortName)
+                             .OrderByDescending(s => s.TotalScore),
+                    (items, changes, ___) =>
+                    {
+                        Rank = items.FirstOrDefault()?.Rank;
+                        // Required since presence is changed via IsPresent override
+                        Invalidate(Invalidation.Presence);
+                    });
             }, true);
         }
 

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Select.Carousel
             ruleset.BindValueChanged(_ =>
             {
                 scoreSubscription?.Dispose();
-                scoreSubscription = realmFactory.Register(realm =>
+                scoreSubscription = realmFactory.RegisterForNotifications(realm =>
                         realm.All<ScoreInfo>()
                              .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
                                      + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -114,13 +114,13 @@ namespace osu.Game.Screens.Select.Leaderboards
                 return;
 
             scoreSubscription = realmFactory.Register(realm =>
-                realm.All<ScoreInfo>()
-                     .Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} = $0", beatmapInfo.ID)
-                     .QueryAsyncWithNotifications((_, changes, ___) =>
-                     {
-                         if (!IsOnlineScope)
-                             RefreshScores();
-                     }));
+                    realm.All<ScoreInfo>()
+                         .Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} = $0", beatmapInfo.ID),
+                (_, changes, ___) =>
+                {
+                    if (!IsOnlineScope)
+                        RefreshScores();
+                });
         }
 
         protected override void Reset()

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (beatmapInfo == null)
                 return;
 
-            scoreSubscription = realmFactory.Register(realm =>
+            scoreSubscription = realmFactory.RegisterForNotifications(realm =>
                     realm.All<ScoreInfo>()
                          .Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} = $0", beatmapInfo.ID),
                 (_, changes, ___) =>

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Spectate
                 playingUserStates.BindTo(spectatorClient.PlayingUserStates);
                 playingUserStates.BindCollectionChanged(onPlayingUserStatesChanged, true);
 
-                realmSubscription = realmContextFactory.Register(
+                realmSubscription = realmContextFactory.RegisterForNotifications(
                     realm => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending), beatmapsChanged);
 
                 foreach ((int id, var _) in userMap)

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -79,17 +79,17 @@ namespace osu.Game.Screens.Spectate
                 playingUserStates.BindTo(spectatorClient.PlayingUserStates);
                 playingUserStates.BindCollectionChanged(onPlayingUserStatesChanged, true);
 
-                realmSubscription = realmContextFactory.Context
-                                                       .All<BeatmapSetInfo>()
-                                                       .Where(s => !s.DeletePending)
-                                                       .QueryAsyncWithNotifications((items, changes, ___) =>
-                                                       {
-                                                           if (changes?.InsertedIndices == null)
-                                                               return;
+                realmSubscription = realmContextFactory.Register(realm =>
+                    realm.All<BeatmapSetInfo>()
+                         .Where(s => !s.DeletePending)
+                         .QueryAsyncWithNotifications((items, changes, ___) =>
+                         {
+                             if (changes?.InsertedIndices == null)
+                                 return;
 
-                                                           foreach (int c in changes.InsertedIndices)
-                                                               beatmapUpdated(items[c]);
-                                                       });
+                             foreach (int c in changes.InsertedIndices)
+                                 beatmapUpdated(items[c]);
+                         }));
 
                 foreach ((int id, var _) in userMap)
                     spectatorClient.WatchUser(id);

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -17,6 +17,7 @@ using osu.Game.Online.Spectator;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
+using Realms;
 
 namespace osu.Game.Screens.Spectate
 {
@@ -79,21 +80,19 @@ namespace osu.Game.Screens.Spectate
                 playingUserStates.BindTo(spectatorClient.PlayingUserStates);
                 playingUserStates.BindCollectionChanged(onPlayingUserStatesChanged, true);
 
-                realmSubscription = realmContextFactory.Register(realm =>
-                    realm.All<BeatmapSetInfo>()
-                         .Where(s => !s.DeletePending)
-                         .QueryAsyncWithNotifications((items, changes, ___) =>
-                         {
-                             if (changes?.InsertedIndices == null)
-                                 return;
-
-                             foreach (int c in changes.InsertedIndices)
-                                 beatmapUpdated(items[c]);
-                         }));
+                realmSubscription = realmContextFactory.Register(
+                    realm => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending), beatmapsChanged);
 
                 foreach ((int id, var _) in userMap)
                     spectatorClient.WatchUser(id);
             }));
+        }
+
+        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> items, ChangeSet changes, Exception ___)
+        {
+            if (changes?.InsertedIndices == null) return;
+
+            foreach (int c in changes.InsertedIndices) beatmapUpdated(items[c]);
         }
 
         private void beatmapUpdated(BeatmapSetInfo beatmapSet)


### PR DESCRIPTION
I still need to add test coverage for this, but PRing for discussion. Feels pretty good to me.

Manual testing can be performed by starting a large import or delete at anywhere you want to test, then mashing the "Compact realm" button.

We could further simplify things by removing the `QueryAsyncWithNotifications`, integrating that with the method exposed by `RealmContextFactory`. Could come as a follow-up change (interested to hearing opinions on this).

- [x] Depends on https://github.com/ppy/osu/pull/16535
