### PR TITLE
Remove pointless initial `MusicController` beatmap set population

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -30,16 +30,7 @@ namespace osu.Game.Overlays
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 
-        public IBindableList<BeatmapSetInfo> BeatmapSets
-        {
-            get
-            {
-                if (LoadState < LoadState.Ready)
-                    throw new InvalidOperationException($"{nameof(BeatmapSets)} should not be accessed before the music controller is loaded.");
-
-                return beatmapSets;
-            }
-        }
+        public IBindableList<BeatmapSetInfo> BeatmapSets => beatmapSets;
 
         /// <summary>
         /// Point in time after which the current track will be restarted on triggering a "previous track" action.

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -87,12 +87,6 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            // ensure we're ready before completing async load.
-            // probably not a good way of handling this (as there is a period we aren't watching for changes until the realm subscription finishes up.
-            foreach (var s in availableBeatmaps)
-                beatmapSets.Add(s.Detach());
-
             beatmapSubscription = realmFactory.Register(realm => availableBeatmaps.QueryAsyncWithNotifications(beatmapsChanged));
         }
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/16547

Looks pretty safe on initial testing.

The remaining detaches can be removed by splitting out `PlaylistOverlay` to its own subscription. Is on my todo list.