### PR TITLE
Hide the login panel when clicking the country flag

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneLoginPanel.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneLoginPanel.cs
@@ -8,6 +8,8 @@ using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Login;
+using osu.Game.Users.Drawables;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Menus
 {
@@ -15,6 +17,7 @@ namespace osu.Game.Tests.Visual.Menus
     public class TestSceneLoginPanel : OsuManualInputManagerTestScene
     {
         private LoginPanel loginPanel;
+        private int hideCount;
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -26,6 +29,7 @@ namespace osu.Game.Tests.Visual.Menus
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Width = 0.5f,
+                    RequestHide = () => hideCount++,
                 });
             });
         }
@@ -50,6 +54,23 @@ namespace osu.Game.Tests.Visual.Menus
 
             AddStep("enter password", () => loginPanel.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
             AddStep("submit", () => loginPanel.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
+        }
+
+        [Test]
+        public void TestClickingOnFlagClosesPanel()
+        {
+            AddStep("reset hide count", () => hideCount = 0);
+
+            AddStep("logout", () => API.Logout());
+            AddStep("enter password", () => loginPanel.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
+            AddStep("submit", () => loginPanel.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
+
+            AddStep("click on flag", () =>
+            {
+                InputManager.MoveMouseTo(loginPanel.ChildrenOfType<UpdateableFlag>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("hide requested", () => hideCount == 1);
         }
     }
 }

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -22,6 +23,12 @@ namespace osu.Game.Users.Drawables
         /// Whether to show a place holder on null country.
         /// </summary>
         public bool ShowPlaceholderOnNull = true;
+
+        /// <summary>
+        /// Perform an action in addition to showing the country ranking.
+        /// This should be used to perform auxiliary tasks and not as a primary action for clicking a flag (to maintain a consistent UX).
+        /// </summary>
+        public Action Action;
 
         public UpdateableFlag(Country country = null)
         {
@@ -52,6 +59,7 @@ namespace osu.Game.Users.Drawables
 
         protected override bool OnClick(ClickEvent e)
         {
+            Action?.Invoke();
             rankingsOverlay?.ShowCountry(Country);
             return true;
         }

--- a/osu.Game/Users/ExtendedUserPanel.cs
+++ b/osu.Game/Users/ExtendedUserPanel.cs
@@ -53,7 +53,8 @@ namespace osu.Game.Users
 
         protected UpdateableFlag CreateFlag() => new UpdateableFlag(User.Country)
         {
-            Size = new Vector2(39, 26)
+            Size = new Vector2(39, 26),
+            Action = Action,
         };
 
         protected SpriteIcon CreateStatusIcon() => statusIcon = new SpriteIcon


### PR DESCRIPTION
`UpdateableFlag.Action` is modeled after [`UserPanel.Action`](https://github.com/ppy/osu/blob/202d0ea1fc7195d2b7608384bf1c96b68e048a1d/osu.Game/Users/UserPanel.cs#L24-L28).

Figured this was a simple problem with a simple fix, so I didn't open a discussion.