### PR TITLE
Fix tournament match chats not polling fast enough

### DIFF
--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tournament.Components
 
                     if (manager == null)
                     {
-                        AddInternal(manager = new ChannelManager());
+                        AddInternal(manager = new ChannelManager { HighPollRate = { Value = true } });
                         Channel.BindTo(manager.CurrentChannel);
                     }
 


### PR DESCRIPTION
Closes #16563 

Since the entirety of chat polling is to be replaced with websocket, I've went with the simplest way of enabling `HighPollRate` in `TournamentMatchChatDisplay`. This doesn't need to be disabled on hide as the chat display would stop updating the embedded `ChannelManager`, which would stop polling until the chat is shown back again.