### PR TITLE
Fix saved beatmap filename not including author name correctly

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -46,6 +46,7 @@ namespace osu.Game.Tests.Visual.Editing
                 editorBeatmap.BeatmapInfo.Metadata.Artist = "artist";
                 editorBeatmap.BeatmapInfo.Metadata.Title = "title";
             });
+            AddStep("Set author", () => editorBeatmap.BeatmapInfo.Metadata.Author.Username = "author");
             AddStep("Set difficulty name", () => editorBeatmap.BeatmapInfo.DifficultyName = "difficulty");
 
             AddStep("Add timing point", () => editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint()));
@@ -64,6 +65,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("Save", () => InputManager.Keys(PlatformAction.Save));
 
             checkMutations();
+            AddAssert("Beatmap has correct .osu file path", () => editorBeatmap.BeatmapInfo.Path == "artist - title (author) [difficulty].osu");
 
             AddStep("Exit", () => InputManager.Key(Key.Escape));
 
@@ -88,6 +90,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("Beatmap contains single hitcircle", () => editorBeatmap.HitObjects.Count == 1);
             AddAssert("Beatmap has correct overall difficulty", () => editorBeatmap.Difficulty.OverallDifficulty == 7);
             AddAssert("Beatmap has correct metadata", () => editorBeatmap.BeatmapInfo.Metadata.Artist == "artist" && editorBeatmap.BeatmapInfo.Metadata.Title == "title");
+            AddAssert("Beatmap has correct author", () => editorBeatmap.BeatmapInfo.Metadata.Author.Username == "author");
             AddAssert("Beatmap has correct difficulty name", () => editorBeatmap.BeatmapInfo.DifficultyName == "difficulty");
         }
     }

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Beatmaps
         private static string getFilename(BeatmapInfo beatmapInfo)
         {
             var metadata = beatmapInfo.Metadata;
-            return $"{metadata.Artist} - {metadata.Title} ({metadata.Author}) [{beatmapInfo.DifficultyName}].osu".GetValidArchiveContentFilename();
+            return $"{metadata.Artist} - {metadata.Title} ({metadata.Author.Username}) [{beatmapInfo.DifficultyName}].osu".GetValidArchiveContentFilename();
         }
 
         /// <summary>


### PR DESCRIPTION
Spotted when rewriting #14799 for realm. Yet another implicit `ToString()` failure via string interpolation.

Test coverage included for posterity.