### PR TITLE
Avoid adding "exit all screens" step when running tests interactively

### DIFF
--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -72,8 +73,11 @@ namespace osu.Game.Tests.Visual
         [TearDownSteps]
         public void TearDownSteps()
         {
-            AddStep("exit game", () => Game.Exit());
-            AddUntilStep("wait for game exit", () => Game.Parent == null);
+            if (DebugUtils.IsNUnitRunning)
+            {
+                AddStep("exit game", () => Game.Exit());
+                AddUntilStep("wait for game exit", () => Game.Parent == null);
+            }
         }
 
         protected void CreateGame()

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
@@ -48,7 +49,11 @@ namespace osu.Game.Tests.Visual
         public virtual void SetUpSteps() => addExitAllScreensStep();
 
         [TearDownSteps]
-        public virtual void TearDownSteps() => addExitAllScreensStep();
+        public virtual void TearDownSteps()
+        {
+            if (DebugUtils.IsNUnitRunning)
+                addExitAllScreensStep();
+        }
 
         private void addExitAllScreensStep()
         {


### PR DESCRIPTION
Sick of commenting this out every time i work on a `ScreenTestScene`.