### PR TITLE
Don't include nested hit objects' `DifficultyControlPoints` in legacy encoder logic

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
@@ -1,0 +1,98 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osu.Game.Screens.Edit.Timing;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public class TestSceneSliderVelocityAdjust : OsuGameTestScene
+    {
+        private Screens.Edit.Editor editor => Game.ScreenStack.CurrentScreen as Screens.Edit.Editor;
+
+        private EditorBeatmap editorBeatmap => editor.ChildrenOfType<EditorBeatmap>().FirstOrDefault();
+
+        private EditorClock editorClock => editor.ChildrenOfType<EditorClock>().FirstOrDefault();
+
+        private Slider slider => editorBeatmap.HitObjects.OfType<Slider>().FirstOrDefault();
+
+        private TimelineHitObjectBlueprint blueprint => editor.ChildrenOfType<TimelineHitObjectBlueprint>().FirstOrDefault();
+
+        private DifficultyPointPiece difficultyPointPiece => blueprint.ChildrenOfType<DifficultyPointPiece>().First();
+
+        private IndeterminateSliderWithTextBoxInput<double> velocityTextBox => Game.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().First().ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().First();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        private bool editorComponentsReady => editor.ChildrenOfType<HitObjectComposer>().FirstOrDefault()?.IsLoaded == true
+                                              && editor.ChildrenOfType<TimelineArea>().FirstOrDefault()?.IsLoaded == true
+                                              && editor?.ChildrenOfType<Playfield>().FirstOrDefault()?.IsLoaded == true;
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestVelocityChangeSavesCorrectly(bool adjustVelocity)
+        {
+            double? velocity = null;
+
+            AddStep("enter editor", () => Game.ScreenStack.Push(new EditorLoader()));
+            AddUntilStep("wait for editor load", () => editorComponentsReady);
+
+            AddStep("seek to first control point", () => editorClock.Seek(editorBeatmap.ControlPointInfo.TimingPoints.First().Time));
+            AddStep("enter slider placement mode", () => InputManager.Key(Key.Number3));
+
+            AddStep("move mouse to centre", () => InputManager.MoveMouseTo(editor.ChildrenOfType<Playfield>().First().ScreenSpaceDrawQuad.Centre));
+            AddStep("start placement", () => InputManager.Click(MouseButton.Left));
+
+            AddStep("move mouse to bottom right", () => InputManager.MoveMouseTo(editor.ChildrenOfType<Playfield>().First().ScreenSpaceDrawQuad.BottomRight - new Vector2(10)));
+            AddStep("end placement", () => InputManager.Click(MouseButton.Right));
+
+            AddStep("exit placement mode", () => InputManager.Key(Key.Number1));
+
+            AddAssert("slider placed", () => slider != null);
+
+            AddStep("select slider", () => editorBeatmap.SelectedHitObjects.Add(slider));
+
+            AddAssert("ensure one slider placed", () => slider != null);
+
+            AddStep("store velocity", () => velocity = slider.Velocity);
+
+            if (adjustVelocity)
+            {
+                AddStep("open velocity adjust panel", () => difficultyPointPiece.TriggerClick());
+                AddStep("change velocity", () => velocityTextBox.Current.Value = 2);
+
+                AddAssert("velocity adjusted", () =>
+                {
+                    Debug.Assert(velocity != null);
+                    return Precision.AlmostEquals(velocity.Value * 2, slider.Velocity);
+                });
+
+                AddStep("store velocity", () => velocity = slider.Velocity);
+            }
+
+            AddStep("save", () => InputManager.Keys(PlatformAction.Save));
+            AddStep("exit", () => InputManager.Key(Key.Escape));
+
+            AddStep("enter editor (again)", () => Game.ScreenStack.Push(new EditorLoader()));
+            AddUntilStep("wait for editor load", () => editorComponentsReady);
+
+            AddStep("seek to slider", () => editorClock.Seek(slider.StartTime));
+            AddAssert("slider has correct velocity", () => slider.Velocity == velocity);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -242,12 +242,7 @@ namespace osu.Game.Beatmaps.Formats
                     yield break;
 
                 foreach (var hitObject in hitObjects)
-                {
                     yield return hitObject.DifficultyControlPoint;
-
-                    foreach (var nested in collectDifficultyControlPoints(hitObject.NestedHitObjects))
-                        yield return nested;
-                }
             }
 
             void extractDifficultyControlPoints(IEnumerable<HitObject> hitObjects)


### PR DESCRIPTION
The editor doesn't currently propagate velocity to nested objects. We're not yet sure whether it should or not. For now, let's just ignore nested objects' `DifficultyControlPoints` for simplicity.

Note that this only affects osu! ruleset due to the pre-check on `isOsuRuleset`. Therefore I only added test coverage for osu!.

Closes #16540.