### PR TITLE
Clean up realm naming

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkRealmReads.cs
+++ b/osu.Game.Benchmarks/BenchmarkRealmReads.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Benchmarks
 
             realm = new RealmAccess(storage, "client");
 
-            realm.Run(realm =>
+            realm.Run(r =>
             {
                 realm.Write(c => c.Add(TestResources.CreateTestBeatmapSetInfo(rulesets: new[] { new OsuRuleset().RulesetInfo })));
             });
@@ -41,9 +41,9 @@ namespace osu.Game.Benchmarks
         [Benchmark]
         public void BenchmarkDirectPropertyRead()
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var beatmapSet = realm.All<BeatmapSetInfo>().First();
+                var beatmapSet = r.All<BeatmapSetInfo>().First();
 
                 for (int i = 0; i < ReadsPerFetch; i++)
                 {
@@ -119,9 +119,9 @@ namespace osu.Game.Benchmarks
         [Benchmark]
         public void BenchmarkDetachedPropertyRead()
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var beatmapSet = realm.All<BeatmapSetInfo>().First().Detach();
+                var beatmapSet = r.All<BeatmapSetInfo>().First().Detach();
 
                 for (int i = 0; i < ReadsPerFetch; i++)
                 {

--- a/osu.Game.Tests/Beatmaps/IO/BeatmapImportHelper.cs
+++ b/osu.Game.Tests/Beatmaps/IO/BeatmapImportHelper.cs
@@ -53,9 +53,9 @@ namespace osu.Game.Tests.Beatmaps.IO
 
         private static void ensureLoaded(OsuGameBase osu, int timeout = 60000)
         {
-            var realmContextFactory = osu.Dependencies.Get<RealmContextFactory>();
+            var realm = osu.Dependencies.Get<RealmAccess>();
 
-            realmContextFactory.Run(realm => BeatmapImporterTests.EnsureLoaded(realm, timeout));
+            realm.Run(r => BeatmapImporterTests.EnsureLoaded(r, timeout));
 
             // TODO: add back some extra checks outside of the realm ones?
             // var set = queryBeatmapSets().First();

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -38,10 +38,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestDetachBeatmapSet()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using (var importer = new BeatmapModelManager(realmFactory, storage))
-                using (new RulesetStore(realmFactory, storage))
+                using (var importer = new BeatmapModelManager(realm, storage))
+                using (new RulesetStore(realm, storage))
                 {
                     ILive<BeatmapSetInfo>? beatmapSet;
 
@@ -82,10 +82,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestUpdateDetachedBeatmapSet()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using (var importer = new BeatmapModelManager(realmFactory, storage))
-                using (new RulesetStore(realmFactory, storage))
+                using (var importer = new BeatmapModelManager(realm, storage))
+                using (new RulesetStore(realm, storage))
                 {
                     ILive<BeatmapSetInfo>? beatmapSet;
 
@@ -139,53 +139,53 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportBeatmapThenCleanup()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using (var importer = new BeatmapModelManager(realmFactory, storage))
-                using (new RulesetStore(realmFactory, storage))
+                using (var importer = new BeatmapModelManager(realm, storage))
+                using (new RulesetStore(realm, storage))
                 {
                     ILive<BeatmapSetInfo>? imported;
 
                     using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
                         imported = await importer.Import(reader);
 
-                    Assert.AreEqual(1, realmFactory.Context.All<BeatmapSetInfo>().Count());
+                    Assert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count());
 
                     Assert.NotNull(imported);
                     Debug.Assert(imported != null);
 
                     imported.PerformWrite(s => s.DeletePending = true);
 
-                    Assert.AreEqual(1, realmFactory.Context.All<BeatmapSetInfo>().Count(s => s.DeletePending));
+                    Assert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count(s => s.DeletePending));
                 }
             });
 
             Logger.Log("Running with no work to purge pending deletions");
 
-            RunTestWithRealm((realmFactory, _) => { Assert.AreEqual(0, realmFactory.Context.All<BeatmapSetInfo>().Count()); });
+            RunTestWithRealm((realm, _) => { Assert.AreEqual(0, realm.Realm.All<BeatmapSetInfo>().Count()); });
         }
 
         [Test]
         public void TestImportWhenClosed()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                await LoadOszIntoStore(importer, realmFactory.Context);
+                await LoadOszIntoStore(importer, realm.Realm);
             });
         }
 
         [Test]
         public void TestAccessFileAfterImport()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
                 var beatmap = imported.Beatmaps.First();
                 var file = beatmap.File;
@@ -198,24 +198,24 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportThenDelete()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                deleteBeatmapSet(imported, realmFactory.Context);
+                deleteBeatmapSet(imported, realm.Realm);
             });
         }
 
         [Test]
         public void TestImportThenDeleteFromStream()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? tempPath = TestResources.GetTestBeatmapForImport();
 
@@ -224,7 +224,7 @@ namespace osu.Game.Tests.Database
                 using (var stream = File.OpenRead(tempPath))
                 {
                     importedSet = await importer.Import(new ImportTask(stream, Path.GetFileName(tempPath)));
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
                 }
 
                 Assert.NotNull(importedSet);
@@ -233,39 +233,39 @@ namespace osu.Game.Tests.Database
                 Assert.IsTrue(File.Exists(tempPath), "Stream source file somehow went missing");
                 File.Delete(tempPath);
 
-                var imported = realmFactory.Context.All<BeatmapSetInfo>().First(beatmapSet => beatmapSet.ID == importedSet.ID);
+                var imported = realm.Realm.All<BeatmapSetInfo>().First(beatmapSet => beatmapSet.ID == importedSet.ID);
 
-                deleteBeatmapSet(imported, realmFactory.Context);
+                deleteBeatmapSet(imported, realm.Realm);
             });
         }
 
         [Test]
         public void TestImportThenImport()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
-                var importedSecondTime = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
+                var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
                 Assert.IsTrue(imported.ID == importedSecondTime.ID);
                 Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
 
-                checkBeatmapSetCount(realmFactory.Context, 1);
-                checkSingleReferencedFileCount(realmFactory.Context, 18);
+                checkBeatmapSetCount(realm.Realm, 1);
+                checkSingleReferencedFileCount(realm.Realm, 18);
             });
         }
 
         [Test]
         public void TestImportThenImportWithReZip()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -274,7 +274,7 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                    var imported = await LoadOszIntoStore(importer, realm.Realm);
 
                     string hashBefore = hashFile(temp);
 
@@ -292,7 +292,7 @@ namespace osu.Game.Tests.Database
 
                     var importedSecondTime = await importer.Import(new ImportTask(temp));
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
 
                     Assert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
@@ -311,10 +311,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportThenImportWithChangedHashedFile()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -323,9 +323,9 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                    var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                    await createScoreForBeatmap(realmFactory.Context, imported.Beatmaps.First());
+                    await createScoreForBeatmap(realm.Realm, imported.Beatmaps.First());
 
                     using (var zip = ZipArchive.Open(temp))
                         zip.WriteToDirectory(extractedFolder);
@@ -343,7 +343,7 @@ namespace osu.Game.Tests.Database
 
                     var importedSecondTime = await importer.Import(new ImportTask(temp));
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
 
                     // check the newly "imported" beatmap is not the original.
                     Assert.NotNull(importedSecondTime);
@@ -363,10 +363,10 @@ namespace osu.Game.Tests.Database
         [Ignore("intentionally broken by import optimisations")]
         public void TestImportThenImportWithChangedFile()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -375,7 +375,7 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                    var imported = await LoadOszIntoStore(importer, realm.Realm);
 
                     using (var zip = ZipArchive.Open(temp))
                         zip.WriteToDirectory(extractedFolder);
@@ -392,7 +392,7 @@ namespace osu.Game.Tests.Database
 
                     var importedSecondTime = await importer.Import(new ImportTask(temp));
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
 
                     Assert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
@@ -411,10 +411,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportThenImportWithDifferentFilename()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -423,7 +423,7 @@ namespace osu.Game.Tests.Database
 
                 try
                 {
-                    var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                    var imported = await LoadOszIntoStore(importer, realm.Realm);
 
                     using (var zip = ZipArchive.Open(temp))
                         zip.WriteToDirectory(extractedFolder);
@@ -440,7 +440,7 @@ namespace osu.Game.Tests.Database
 
                     var importedSecondTime = await importer.Import(new ImportTask(temp));
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
 
                     Assert.NotNull(importedSecondTime);
                     Debug.Assert(importedSecondTime != null);
@@ -460,12 +460,12 @@ namespace osu.Game.Tests.Database
         [Ignore("intentionally broken by import optimisations")]
         public void TestImportCorruptThenImport()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
                 var firstFile = imported.Files.First();
 
@@ -476,7 +476,7 @@ namespace osu.Game.Tests.Database
                 using (var stream = storage.GetStream(firstFile.File.GetStoragePath(), FileAccess.Write, FileMode.Create))
                     stream.WriteByte(0);
 
-                var importedSecondTime = await LoadOszIntoStore(importer, realmFactory.Context);
+                var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 using (var stream = storage.GetStream(firstFile.File.GetStoragePath()))
                     Assert.AreEqual(stream.Length, originalLength, "Corruption was not fixed on second import");
@@ -485,18 +485,18 @@ namespace osu.Game.Tests.Database
                 Assert.IsTrue(imported.ID == importedSecondTime.ID);
                 Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
 
-                checkBeatmapSetCount(realmFactory.Context, 1);
-                checkSingleReferencedFileCount(realmFactory.Context, 18);
+                checkBeatmapSetCount(realm.Realm, 1);
+                checkSingleReferencedFileCount(realm.Realm, 18);
             });
         }
 
         [Test]
         public void TestModelCreationFailureDoesntReturn()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 var progressNotification = new ImportProgressNotification();
 
@@ -510,8 +510,8 @@ namespace osu.Game.Tests.Database
                     new ImportTask(zipStream, string.Empty)
                 );
 
-                checkBeatmapSetCount(realmFactory.Context, 0);
-                checkBeatmapCount(realmFactory.Context, 0);
+                checkBeatmapSetCount(realm.Realm, 0);
+                checkBeatmapCount(realm.Realm, 0);
 
                 Assert.IsEmpty(imported);
                 Assert.AreEqual(ProgressNotificationState.Cancelled, progressNotification.State);
@@ -521,7 +521,7 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestRollbackOnFailure()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
                 int loggedExceptionCount = 0;
 
@@ -531,16 +531,16 @@ namespace osu.Game.Tests.Database
                         Interlocked.Increment(ref loggedExceptionCount);
                 };
 
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                realmFactory.Context.Write(() => imported.Hash += "-changed");
+                realm.Realm.Write(() => imported.Hash += "-changed");
 
-                checkBeatmapSetCount(realmFactory.Context, 1);
-                checkBeatmapCount(realmFactory.Context, 12);
-                checkSingleReferencedFileCount(realmFactory.Context, 18);
+                checkBeatmapSetCount(realm.Realm, 1);
+                checkBeatmapCount(realm.Realm, 12);
+                checkSingleReferencedFileCount(realm.Realm, 18);
 
                 string? brokenTempFilename = TestResources.GetTestBeatmapForImport();
 
@@ -565,10 +565,10 @@ namespace osu.Game.Tests.Database
                 {
                 }
 
-                checkBeatmapSetCount(realmFactory.Context, 1);
-                checkBeatmapCount(realmFactory.Context, 12);
+                checkBeatmapSetCount(realm.Realm, 1);
+                checkBeatmapCount(realm.Realm, 12);
 
-                checkSingleReferencedFileCount(realmFactory.Context, 18);
+                checkSingleReferencedFileCount(realm.Realm, 18);
 
                 Assert.AreEqual(1, loggedExceptionCount);
 
@@ -579,18 +579,18 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportThenDeleteThenImportOptimisedPath()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                deleteBeatmapSet(imported, realmFactory.Context);
+                deleteBeatmapSet(imported, realm.Realm);
 
                 Assert.IsTrue(imported.DeletePending);
 
-                var importedSecondTime = await LoadOszIntoStore(importer, realmFactory.Context);
+                var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
                 Assert.IsTrue(imported.ID == importedSecondTime.ID);
@@ -603,18 +603,18 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportThenDeleteThenImportNonOptimisedPath()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new NonOptimisedBeatmapImporter(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new NonOptimisedBeatmapImporter(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                deleteBeatmapSet(imported, realmFactory.Context);
+                deleteBeatmapSet(imported, realm.Realm);
 
                 Assert.IsTrue(imported.DeletePending);
 
-                var importedSecondTime = await LoadOszIntoStore(importer, realmFactory.Context);
+                var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
                 Assert.IsTrue(imported.ID == importedSecondTime.ID);
@@ -627,22 +627,22 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportThenDeleteThenImportWithOnlineIDsMissing()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realmFactory.Context);
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
 
-                realmFactory.Context.Write(() =>
+                realm.Realm.Write(() =>
                 {
                     foreach (var b in imported.Beatmaps)
                         b.OnlineID = -1;
                 });
 
-                deleteBeatmapSet(imported, realmFactory.Context);
+                deleteBeatmapSet(imported, realm.Realm);
 
-                var importedSecondTime = await LoadOszIntoStore(importer, realmFactory.Context);
+                var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
                 // check the newly "imported" beatmap has been reimported due to mismatch (even though hashes matched)
                 Assert.IsTrue(imported.ID != importedSecondTime.ID);
@@ -653,10 +653,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportWithDuplicateBeatmapIDs()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 var metadata = new BeatmapMetadata
                 {
@@ -667,7 +667,7 @@ namespace osu.Game.Tests.Database
                     }
                 };
 
-                var ruleset = realmFactory.Context.All<RulesetInfo>().First();
+                var ruleset = realm.Realm.All<RulesetInfo>().First();
 
                 var toImport = new BeatmapSetInfo
                 {
@@ -699,15 +699,15 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportWhenFileOpen()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
                 using (File.OpenRead(temp))
                     await importer.Import(temp);
-                EnsureLoaded(realmFactory.Context);
+                EnsureLoaded(realm.Realm);
                 File.Delete(temp);
                 Assert.IsFalse(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
             });
@@ -716,10 +716,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportWithDuplicateHashes()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -740,7 +740,7 @@ namespace osu.Game.Tests.Database
 
                     await importer.Import(temp);
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
                 }
                 finally
                 {
@@ -752,10 +752,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportNestedStructure()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -780,7 +780,7 @@ namespace osu.Game.Tests.Database
                     Assert.NotNull(imported);
                     Debug.Assert(imported != null);
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
 
                     Assert.IsFalse(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("subfolder"))), "Files contain common subfolder");
                 }
@@ -794,10 +794,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportWithIgnoredDirectoryInArchive()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 
@@ -830,7 +830,7 @@ namespace osu.Game.Tests.Database
                     Assert.NotNull(imported);
                     Debug.Assert(imported != null);
 
-                    EnsureLoaded(realmFactory.Context);
+                    EnsureLoaded(realm.Realm);
 
                     Assert.IsFalse(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("__MACOSX"))), "Files contain resource fork folder, which should be ignored");
                     Assert.IsFalse(imported.PerformRead(s => s.Files.Any(f => f.Filename.Contains("actual_data"))), "Files contain common subfolder");
@@ -845,22 +845,22 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestUpdateBeatmapInfo()
         {
-            RunTestWithRealmAsync(async (realmFactory, storage) =>
+            RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new BeatmapModelManager(realmFactory, storage);
-                using var store = new RulesetStore(realmFactory, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
+                using var store = new RulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
                 await importer.Import(temp);
 
                 // Update via the beatmap, not the beatmap info, to ensure correct linking
-                BeatmapSetInfo setToUpdate = realmFactory.Context.All<BeatmapSetInfo>().First();
+                BeatmapSetInfo setToUpdate = realm.Realm.All<BeatmapSetInfo>().First();
 
                 var beatmapToUpdate = setToUpdate.Beatmaps.First();
 
-                realmFactory.Context.Write(() => beatmapToUpdate.DifficultyName = "updated");
+                realm.Realm.Write(() => beatmapToUpdate.DifficultyName = "updated");
 
-                BeatmapInfo updatedInfo = realmFactory.Context.All<BeatmapInfo>().First(b => b.ID == beatmapToUpdate.ID);
+                BeatmapInfo updatedInfo = realm.Realm.All<BeatmapInfo>().First(b => b.ID == beatmapToUpdate.ID);
                 Assert.That(updatedInfo.DifficultyName, Is.EqualTo("updated"));
             });
         }
@@ -1004,8 +1004,8 @@ namespace osu.Game.Tests.Database
 
         public class NonOptimisedBeatmapImporter : BeatmapImporter
         {
-            public NonOptimisedBeatmapImporter(RealmContextFactory realmFactory, Storage storage)
-                : base(realmFactory, storage)
+            public NonOptimisedBeatmapImporter(RealmAccess realm, Storage storage)
+                : base(realm, storage)
             {
             }
 

--- a/osu.Game.Tests/Database/FileStoreTests.cs
+++ b/osu.Game.Tests/Database/FileStoreTests.cs
@@ -19,10 +19,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportFile()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmFactory.Context;
-                var files = new RealmFileStore(realmFactory, storage);
+                var realm = realmAccess.Context;
+                var files = new RealmFileStore(realmAccess, storage);
 
                 var testData = new MemoryStream(new byte[] { 0, 1, 2, 3 });
 
@@ -36,10 +36,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestImportSameFileTwice()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmFactory.Context;
-                var files = new RealmFileStore(realmFactory, storage);
+                var realm = realmAccess.Context;
+                var files = new RealmFileStore(realmAccess, storage);
 
                 var testData = new MemoryStream(new byte[] { 0, 1, 2, 3 });
 
@@ -53,10 +53,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestDontPurgeReferenced()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmFactory.Context;
-                var files = new RealmFileStore(realmFactory, storage);
+                var realm = realmAccess.Context;
+                var files = new RealmFileStore(realmAccess, storage);
 
                 var file = realm.Write(() => files.Add(new MemoryStream(new byte[] { 0, 1, 2, 3 }), realm));
 
@@ -92,10 +92,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestPurgeUnreferenced()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmFactory.Context;
-                var files = new RealmFileStore(realmFactory, storage);
+                var realm = realmAccess.Context;
+                var files = new RealmFileStore(realmAccess, storage);
 
                 var file = realm.Write(() => files.Add(new MemoryStream(new byte[] { 0, 1, 2, 3 }), realm));
 

--- a/osu.Game.Tests/Database/FileStoreTests.cs
+++ b/osu.Game.Tests/Database/FileStoreTests.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmAccess.Context;
+                var realm = realmAccess.Realm;
                 var files = new RealmFileStore(realmAccess, storage);
 
                 var testData = new MemoryStream(new byte[] { 0, 1, 2, 3 });
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmAccess.Context;
+                var realm = realmAccess.Realm;
                 var files = new RealmFileStore(realmAccess, storage);
 
                 var testData = new MemoryStream(new byte[] { 0, 1, 2, 3 });
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmAccess.Context;
+                var realm = realmAccess.Realm;
                 var files = new RealmFileStore(realmAccess, storage);
 
                 var file = realm.Write(() => files.Add(new MemoryStream(new byte[] { 0, 1, 2, 3 }), realm));
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realmAccess, storage) =>
             {
-                var realm = realmAccess.Context;
+                var realm = realmAccess.Realm;
                 var files = new RealmFileStore(realmAccess, storage);
 
                 var file = realm.Write(() => files.Add(new MemoryStream(new byte[] { 0, 1, 2, 3 }), realm));

--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -21,15 +21,15 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestConstructRealm()
         {
-            RunTestWithRealm((realmFactory, _) => { realmFactory.Run(realm => realm.Refresh()); });
+            RunTestWithRealm((realm, _) => { realm.Run(r => r.Refresh()); });
         }
 
         [Test]
         public void TestBlockOperations()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
-                using (realmFactory.BlockAllOperations())
+                using (realm.BlockAllOperations())
                 {
                 }
             });
@@ -42,22 +42,22 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestNestedContextCreationWithSubscription()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 bool callbackRan = false;
 
-                realmFactory.RegisterCustomSubscription(realm =>
+                realm.RegisterCustomSubscription(r =>
                 {
-                    var subscription = realm.All<BeatmapInfo>().QueryAsyncWithNotifications((sender, changes, error) =>
+                    var subscription = r.All<BeatmapInfo>().QueryAsyncWithNotifications((sender, changes, error) =>
                     {
-                        realmFactory.Run(_ =>
+                        realm.Run(_ =>
                         {
                             callbackRan = true;
                         });
                     });
 
                     // Force the callback above to run.
-                    realmFactory.Run(r => r.Refresh());
+                    realm.Run(rr => rr.Refresh());
 
                     subscription?.Dispose();
                     return null;
@@ -70,14 +70,14 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestBlockOperationsWithContention()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 ManualResetEventSlim stopThreadedUsage = new ManualResetEventSlim();
                 ManualResetEventSlim hasThreadedUsage = new ManualResetEventSlim();
 
                 Task.Factory.StartNew(() =>
                 {
-                    realmFactory.Run(_ =>
+                    realm.Run(_ =>
                     {
                         hasThreadedUsage.Set();
 
@@ -89,7 +89,7 @@ namespace osu.Game.Tests.Database
 
                 Assert.Throws<TimeoutException>(() =>
                 {
-                    using (realmFactory.BlockAllOperations())
+                    using (realm.BlockAllOperations())
                     {
                     }
                 });

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -21,11 +21,11 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestLiveEquality()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
-                ILive<BeatmapInfo> beatmap = realmFactory.Run(realm => realm.Write(r => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata()))).ToLive(realmFactory));
+                ILive<BeatmapInfo> beatmap = realm.Run(r => r.Write(_ => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata()))).ToLive(realm));
 
-                ILive<BeatmapInfo> beatmap2 = realmFactory.Run(realm => realm.All<BeatmapInfo>().First().ToLive(realmFactory));
+                ILive<BeatmapInfo> beatmap2 = realm.Run(r => r.All<BeatmapInfo>().First().ToLive(realm));
 
                 Assert.AreEqual(beatmap, beatmap2);
             });
@@ -34,20 +34,20 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestAccessAfterStorageMigrate()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realm, storage) =>
             {
                 var beatmap = new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata());
 
                 ILive<BeatmapInfo>? liveBeatmap = null;
 
-                realmFactory.Run(realm =>
+                realm.Run(r =>
                 {
-                    realm.Write(r => r.Add(beatmap));
+                    r.Write(_ => r.Add(beatmap));
 
-                    liveBeatmap = beatmap.ToLive(realmFactory);
+                    liveBeatmap = beatmap.ToLive(realm);
                 });
 
-                using (realmFactory.BlockAllOperations())
+                using (realm.BlockAllOperations())
                 {
                     // recycle realm before migrating
                 }
@@ -66,13 +66,13 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestAccessAfterAttach()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 var beatmap = new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata());
 
-                var liveBeatmap = beatmap.ToLive(realmFactory);
+                var liveBeatmap = beatmap.ToLive(realm);
 
-                realmFactory.Run(realm => realm.Write(r => r.Add(beatmap)));
+                realm.Run(r => r.Write(_ => r.Add(beatmap)));
 
                 Assert.IsFalse(liveBeatmap.PerformRead(l => l.Hidden));
             });
@@ -98,16 +98,16 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestScopedReadWithoutContext()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 ILive<BeatmapInfo>? liveBeatmap = null;
                 Task.Factory.StartNew(() =>
                 {
-                    realmFactory.Run(threadContext =>
+                    realm.Run(threadContext =>
                     {
                         var beatmap = threadContext.Write(r => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive(realmFactory);
+                        liveBeatmap = beatmap.ToLive(realm);
                     });
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
 
@@ -127,16 +127,16 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestScopedWriteWithoutContext()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 ILive<BeatmapInfo>? liveBeatmap = null;
                 Task.Factory.StartNew(() =>
                 {
-                    realmFactory.Run(threadContext =>
+                    realm.Run(threadContext =>
                     {
                         var beatmap = threadContext.Write(r => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive(realmFactory);
+                        liveBeatmap = beatmap.ToLive(realm);
                     });
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
 
@@ -153,10 +153,10 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestValueAccessNonManaged()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 var beatmap = new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata());
-                var liveBeatmap = beatmap.ToLive(realmFactory);
+                var liveBeatmap = beatmap.ToLive(realm);
 
                 Assert.DoesNotThrow(() =>
                 {
@@ -168,17 +168,17 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestValueAccessWithOpenContextFails()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 ILive<BeatmapInfo>? liveBeatmap = null;
 
                 Task.Factory.StartNew(() =>
                 {
-                    realmFactory.Run(threadContext =>
+                    realm.Run(threadContext =>
                     {
                         var beatmap = threadContext.Write(r => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive(realmFactory);
+                        liveBeatmap = beatmap.ToLive(realm);
                     });
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
 
@@ -193,7 +193,7 @@ namespace osu.Game.Tests.Database
                     });
 
                     // Can't be used, even from within a valid context.
-                    realmFactory.Run(threadContext =>
+                    realm.Run(threadContext =>
                     {
                         Assert.Throws<InvalidOperationException>(() =>
                         {
@@ -207,16 +207,16 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestValueAccessWithoutOpenContextFails()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 ILive<BeatmapInfo>? liveBeatmap = null;
                 Task.Factory.StartNew(() =>
                 {
-                    realmFactory.Run(threadContext =>
+                    realm.Run(threadContext =>
                     {
                         var beatmap = threadContext.Write(r => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata())));
 
-                        liveBeatmap = beatmap.ToLive(realmFactory);
+                        liveBeatmap = beatmap.ToLive(realm);
                     });
                 }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
 
@@ -235,18 +235,18 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestLiveAssumptions()
         {
-            RunTestWithRealm((realmFactory, _) =>
+            RunTestWithRealm((realm, _) =>
             {
                 int changesTriggered = 0;
 
-                realmFactory.RegisterCustomSubscription(outerRealm =>
+                realm.RegisterCustomSubscription(outerRealm =>
                 {
                     outerRealm.All<BeatmapInfo>().QueryAsyncWithNotifications(gotChange);
                     ILive<BeatmapInfo>? liveBeatmap = null;
 
                     Task.Factory.StartNew(() =>
                     {
-                        realmFactory.Run(innerRealm =>
+                        realm.Run(innerRealm =>
                         {
                             var ruleset = CreateRuleset();
                             var beatmap = innerRealm.Write(r => r.Add(new BeatmapInfo(ruleset, new BeatmapDifficulty(), new BeatmapMetadata())));
@@ -255,7 +255,7 @@ namespace osu.Game.Tests.Database
                             // not just a refresh from the resolved Live.
                             innerRealm.Write(r => r.Add(new BeatmapInfo(ruleset, new BeatmapDifficulty(), new BeatmapMetadata())));
 
-                            liveBeatmap = beatmap.ToLive(realmFactory);
+                            liveBeatmap = beatmap.ToLive(realm);
                         });
                     }, TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
 

--- a/osu.Game.Tests/Database/RealmTest.cs
+++ b/osu.Game.Tests/Database/RealmTest.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Database
             storage.DeleteDirectory(string.Empty);
         }
 
-        protected void RunTestWithRealm(Action<RealmContextFactory, OsuStorage> testAction, [CallerMemberName] string caller = "")
+        protected void RunTestWithRealm(Action<RealmAccess, OsuStorage> testAction, [CallerMemberName] string caller = "")
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost(callingMethodName: caller))
             {
@@ -39,22 +39,22 @@ namespace osu.Game.Tests.Database
                     // ReSharper disable once AccessToDisposedClosure
                     var testStorage = new OsuStorage(host, storage.GetStorageForDirectory(caller));
 
-                    using (var realmFactory = new RealmContextFactory(testStorage, "client"))
+                    using (var realm = new RealmAccess(testStorage, "client"))
                     {
-                        Logger.Log($"Running test using realm file {testStorage.GetFullPath(realmFactory.Filename)}");
-                        testAction(realmFactory, testStorage);
+                        Logger.Log($"Running test using realm file {testStorage.GetFullPath(realm.Filename)}");
+                        testAction(realm, testStorage);
 
-                        realmFactory.Dispose();
+                        realm.Dispose();
 
-                        Logger.Log($"Final database size: {getFileSize(testStorage, realmFactory)}");
-                        realmFactory.Compact();
-                        Logger.Log($"Final database size after compact: {getFileSize(testStorage, realmFactory)}");
+                        Logger.Log($"Final database size: {getFileSize(testStorage, realm)}");
+                        realm.Compact();
+                        Logger.Log($"Final database size after compact: {getFileSize(testStorage, realm)}");
                     }
                 }));
             }
         }
 
-        protected void RunTestWithRealmAsync(Func<RealmContextFactory, Storage, Task> testAction, [CallerMemberName] string caller = "")
+        protected void RunTestWithRealmAsync(Func<RealmAccess, Storage, Task> testAction, [CallerMemberName] string caller = "")
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost(callingMethodName: caller))
             {
@@ -62,15 +62,15 @@ namespace osu.Game.Tests.Database
                 {
                     var testStorage = storage.GetStorageForDirectory(caller);
 
-                    using (var realmFactory = new RealmContextFactory(testStorage, "client"))
+                    using (var realm = new RealmAccess(testStorage, "client"))
                     {
-                        Logger.Log($"Running test using realm file {testStorage.GetFullPath(realmFactory.Filename)}");
-                        await testAction(realmFactory, testStorage);
+                        Logger.Log($"Running test using realm file {testStorage.GetFullPath(realm.Filename)}");
+                        await testAction(realm, testStorage);
 
-                        realmFactory.Dispose();
+                        realm.Dispose();
 
-                        Logger.Log($"Final database size: {getFileSize(testStorage, realmFactory)}");
-                        realmFactory.Compact();
+                        Logger.Log($"Final database size: {getFileSize(testStorage, realm)}");
+                        realm.Compact();
                     }
                 }));
             }
@@ -138,11 +138,11 @@ namespace osu.Game.Tests.Database
             }
         }
 
-        private static long getFileSize(Storage testStorage, RealmContextFactory realmFactory)
+        private static long getFileSize(Storage testStorage, RealmAccess realm)
         {
             try
             {
-                using (var stream = testStorage.GetStream(realmFactory.Filename))
+                using (var stream = testStorage.GetStream(realm.Filename))
                     return stream?.Length ?? 0;
             }
             catch

--- a/osu.Game.Tests/Database/RulesetStoreTests.cs
+++ b/osu.Game.Tests/Database/RulesetStoreTests.cs
@@ -12,37 +12,37 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestCreateStore()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realm, storage) =>
             {
-                var rulesets = new RulesetStore(realmFactory, storage);
+                var rulesets = new RulesetStore(realm, storage);
 
                 Assert.AreEqual(4, rulesets.AvailableRulesets.Count());
-                Assert.AreEqual(4, realmFactory.Context.All<RulesetInfo>().Count());
+                Assert.AreEqual(4, realm.Realm.All<RulesetInfo>().Count());
             });
         }
 
         [Test]
         public void TestCreateStoreTwiceDoesntAddRulesetsAgain()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realm, storage) =>
             {
-                var rulesets = new RulesetStore(realmFactory, storage);
-                var rulesets2 = new RulesetStore(realmFactory, storage);
+                var rulesets = new RulesetStore(realm, storage);
+                var rulesets2 = new RulesetStore(realm, storage);
 
                 Assert.AreEqual(4, rulesets.AvailableRulesets.Count());
                 Assert.AreEqual(4, rulesets2.AvailableRulesets.Count());
 
                 Assert.AreEqual(rulesets.AvailableRulesets.First(), rulesets2.AvailableRulesets.First());
-                Assert.AreEqual(4, realmFactory.Context.All<RulesetInfo>().Count());
+                Assert.AreEqual(4, realm.Realm.All<RulesetInfo>().Count());
             });
         }
 
         [Test]
         public void TestRetrievedRulesetsAreDetached()
         {
-            RunTestWithRealm((realmFactory, storage) =>
+            RunTestWithRealm((realm, storage) =>
             {
-                var rulesets = new RulesetStore(realmFactory, storage);
+                var rulesets = new RulesetStore(realm, storage);
 
                 Assert.IsFalse(rulesets.AvailableRulesets.First().IsManaged);
                 Assert.IsFalse(rulesets.GetRuleset(0)?.IsManaged);

--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -76,9 +76,9 @@ namespace osu.Game.Tests.Database
 
         private int queryCount(GlobalAction? match = null)
         {
-            return realm.Run(realm =>
+            return realm.Run(r =>
             {
-                var results = realm.All<RealmKeyBinding>();
+                var results = r.All<RealmKeyBinding>();
                 if (match.HasValue)
                     results = results.Where(k => k.ActionInt == (int)match.Value);
                 return results.Count();

--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Database
 
         private RealmKeyBindingStore keyBindingStore;
 
-        private RealmContextFactory realmContextFactory;
+        private RealmAccess realm;
 
         [SetUp]
         public void SetUp()
@@ -33,8 +33,8 @@ namespace osu.Game.Tests.Database
 
             storage = new NativeStorage(directory.FullName);
 
-            realmContextFactory = new RealmContextFactory(storage, "test");
-            keyBindingStore = new RealmKeyBindingStore(realmContextFactory, new ReadableKeyCombinationProvider());
+            realm = new RealmAccess(storage, "test");
+            keyBindingStore = new RealmKeyBindingStore(realm, new ReadableKeyCombinationProvider());
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Database
             KeyBindingContainer testContainer = new TestKeyBindingContainer();
 
             // Add some excess bindings for an action which only supports 1.
-            realmContextFactory.Write(realm =>
+            realm.Write(realm =>
             {
                 realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.A)));
                 realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.S)));
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Database
 
         private int queryCount(GlobalAction? match = null)
         {
-            return realmContextFactory.Run(realm =>
+            return realm.Run(realm =>
             {
                 var results = realm.All<RealmKeyBinding>();
                 if (match.HasValue)
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Database
 
             keyBindingStore.Register(testContainer, Enumerable.Empty<RulesetInfo>());
 
-            realmContextFactory.Run(outerRealm =>
+            realm.Run(outerRealm =>
             {
                 var backBinding = outerRealm.All<RealmKeyBinding>().Single(k => k.ActionInt == (int)GlobalAction.Back);
 
@@ -100,7 +100,7 @@ namespace osu.Game.Tests.Database
 
                 var tsr = ThreadSafeReference.Create(backBinding);
 
-                realmContextFactory.Run(innerRealm =>
+                realm.Run(innerRealm =>
                 {
                     var binding = innerRealm.ResolveReference(tsr);
                     innerRealm.Write(() => binding.KeyCombination = new KeyCombination(InputKey.BackSpace));
@@ -117,7 +117,7 @@ namespace osu.Game.Tests.Database
         [TearDown]
         public void TearDown()
         {
-            realmContextFactory.Dispose();
+            realm.Dispose();
             storage.DeleteDirectory(string.Empty);
         }
 

--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -60,11 +60,11 @@ namespace osu.Game.Tests.Database
             KeyBindingContainer testContainer = new TestKeyBindingContainer();
 
             // Add some excess bindings for an action which only supports 1.
-            realm.Write(realm =>
+            realm.Write(r =>
             {
-                realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.A)));
-                realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.S)));
-                realm.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.D)));
+                r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.A)));
+                r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.S)));
+                r.Add(new RealmKeyBinding(GlobalAction.Back, new KeyCombination(InputKey.D)));
             });
 
             Assert.That(queryCount(GlobalAction.Back), Is.EqualTo(3));

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Tests.Gameplay
         public AudioManager AudioManager => Audio;
         public IResourceStore<byte[]> Files => null;
         public new IResourceStore<byte[]> Resources => base.Resources;
-        public RealmContextFactory RealmContextFactory => null;
+        public RealmAccess RealmAccess => null;
         public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => null;
 
         #endregion

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Tests.Online
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, GameHost host)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.CacheAs<BeatmapManager>(beatmaps = new TestBeatmapManager(LocalStorage, ContextFactory, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.CacheAs<BeatmapManager>(beatmaps = new TestBeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
             Dependencies.CacheAs<BeatmapModelDownloader>(beatmapDownloader = new TestBeatmapModelDownloader(beatmaps, API, host));
         }
 
@@ -60,8 +60,8 @@ namespace osu.Game.Tests.Online
             testBeatmapInfo = getTestBeatmapInfo(testBeatmapFile);
             testBeatmapSet = testBeatmapInfo.BeatmapSet;
 
-            ContextFactory.Write(r => r.RemoveAll<BeatmapSetInfo>());
-            ContextFactory.Write(r => r.RemoveAll<BeatmapInfo>());
+            Access.Write(r => r.RemoveAll<BeatmapSetInfo>());
+            Access.Write(r => r.RemoveAll<BeatmapInfo>());
 
             selectedItem.Value = new PlaylistItem
             {
@@ -166,22 +166,22 @@ namespace osu.Game.Tests.Online
 
             public Task<ILive<BeatmapSetInfo>> CurrentImportTask { get; private set; }
 
-            public TestBeatmapManager(Storage storage, RealmContextFactory contextFactory, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host = null, WorkingBeatmap defaultBeatmap = null)
-                : base(storage, contextFactory, rulesets, api, audioManager, resources, host, defaultBeatmap)
+            public TestBeatmapManager(Storage storage, RealmAccess realm, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host = null, WorkingBeatmap defaultBeatmap = null)
+                : base(storage, realm, rulesets, api, audioManager, resources, host, defaultBeatmap)
             {
             }
 
-            protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmContextFactory contextFactory, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
+            protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
             {
-                return new TestBeatmapModelManager(this, storage, contextFactory, rulesets, onlineLookupQueue);
+                return new TestBeatmapModelManager(this, storage, realm, rulesets, onlineLookupQueue);
             }
 
             internal class TestBeatmapModelManager : BeatmapModelManager
             {
                 private readonly TestBeatmapManager testBeatmapManager;
 
-                public TestBeatmapModelManager(TestBeatmapManager testBeatmapManager, Storage storage, RealmContextFactory databaseContextFactory, RulesetStore rulesetStore, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
-                    : base(databaseContextFactory, storage, beatmapOnlineLookupQueue)
+                public TestBeatmapModelManager(TestBeatmapManager testBeatmapManager, Storage storage, RealmAccess databaseAccess, RulesetStore rulesetStore, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
+                    : base(databaseAccess, storage, beatmapOnlineLookupQueue)
                 {
                     this.testBeatmapManager = testBeatmapManager;
                 }

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Tests.Online
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, GameHost host)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.CacheAs<BeatmapManager>(beatmaps = new TestBeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.CacheAs<BeatmapManager>(beatmaps = new TestBeatmapManager(LocalStorage, Realm, rulesets, API, audio, Resources, host, Beatmap.Default));
             Dependencies.CacheAs<BeatmapModelDownloader>(beatmapDownloader = new TestBeatmapModelDownloader(beatmaps, API, host));
         }
 
@@ -60,8 +60,8 @@ namespace osu.Game.Tests.Online
             testBeatmapInfo = getTestBeatmapInfo(testBeatmapFile);
             testBeatmapSet = testBeatmapInfo.BeatmapSet;
 
-            Access.Write(r => r.RemoveAll<BeatmapSetInfo>());
-            Access.Write(r => r.RemoveAll<BeatmapInfo>());
+            Realm.Write(r => r.RemoveAll<BeatmapSetInfo>());
+            Realm.Write(r => r.RemoveAll<BeatmapInfo>());
 
             selectedItem.Value = new PlaylistItem
             {

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -47,10 +47,10 @@ namespace osu.Game.Tests.Visual.Background
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(new OsuConfigManager(LocalStorage));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(Realm);
 
             manager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -47,10 +47,10 @@ namespace osu.Game.Tests.Visual.Background
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(new OsuConfigManager(LocalStorage));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(Access);
 
             manager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Tests.Visual.Collections
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesets, null, Audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, rulesets, null, Audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Tests.Visual.Collections
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, Audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesets, null, Audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -47,9 +47,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -47,9 +47,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -43,9 +43,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -43,9 +43,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -61,9 +61,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -61,9 +61,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             beatmaps = new List<BeatmapInfo>();
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             beatmaps = new List<BeatmapInfo>();
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -38,9 +38,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -38,9 +38,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
@@ -33,9 +33,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         [SetUp]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
@@ -33,9 +33,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         [SetUp]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -38,9 +38,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -38,9 +38,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -40,9 +40,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -40,9 +40,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -41,9 +41,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -41,9 +41,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             var beatmapSet = TestResources.CreateTestBeatmapSetInfo();
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             var beatmapSet = TestResources.CreateTestBeatmapSetInfo();
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.Navigation
                                                        .ChildrenOfType<KeyBindingPanel>().SingleOrDefault();
 
         private RealmKeyBinding firstOsuRulesetKeyBindings => Game.Dependencies
-                                                                  .Get<RealmAccess>().Context
+                                                                  .Get<RealmAccess>().Realm
                                                                   .All<RealmKeyBinding>()
                                                                   .AsEnumerable()
                                                                   .First(k => k.RulesetName == "osu" && k.ActionInt == 0);

--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.Navigation
                                                        .ChildrenOfType<KeyBindingPanel>().SingleOrDefault();
 
         private RealmKeyBinding firstOsuRulesetKeyBindings => Game.Dependencies
-                                                                  .Get<RealmContextFactory>().Context
+                                                                  .Get<RealmAccess>().Context
                                                                   .All<RealmKeyBinding>()
                                                                   .AsEnumerable()
                                                                   .First(k => k.RulesetName == "osu" && k.ActionInt == 0);

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -40,9 +40,9 @@ namespace osu.Game.Tests.Visual.Playlists
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
         }
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -40,9 +40,9 @@ namespace osu.Game.Tests.Visual.Playlists
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
         }
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -42,11 +42,11 @@ namespace osu.Game.Tests.Visual.Ranking
         {
             base.LoadComplete();
 
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var beatmapInfo = realm.All<BeatmapInfo>()
-                                       .Filter($"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} = $0", 0)
-                                       .FirstOrDefault();
+                var beatmapInfo = r.All<BeatmapInfo>()
+                                   .Filter($"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} = $0", 0)
+                                   .FirstOrDefault();
 
                 if (beatmapInfo != null)
                     Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo);

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -36,13 +36,13 @@ namespace osu.Game.Tests.Visual.Ranking
         private BeatmapManager beatmaps { get; set; }
 
         [Resolved]
-        private RealmContextFactory realmContextFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            realmContextFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 var beatmapInfo = realm.All<BeatmapInfo>()
                                        .Filter($"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} = $0", 0)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -42,10 +42,10 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.Cache(rulesetStore = new RulesetStore(Access));
-            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
-            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, Access, Scheduler));
-            Dependencies.Cache(Access);
+            dependencies.Cache(rulesetStore = new RulesetStore(Realm));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, Realm, Scheduler));
+            Dependencies.Cache(Realm);
 
             return dependencies;
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -42,10 +42,10 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.Cache(rulesetStore = new RulesetStore(ContextFactory));
-            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
-            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, ContextFactory, Scheduler));
-            Dependencies.Cache(ContextFactory);
+            dependencies.Cache(rulesetStore = new RulesetStore(Access));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(rulesetStore, () => beatmapManager, LocalStorage, Access, Scheduler));
+            Dependencies.Cache(Access);
 
             return dependencies;
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, Audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesets, null, Audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Access);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesets, null, Audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, rulesets, null, Audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(Realm);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -47,9 +47,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             // These DI caches are required to ensure for interactive runs this test scene doesn't nuke all user beatmaps in the local install.
             // At a point we have isolated interactive test runs enough, this can likely be removed.
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(Access);
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(Realm);
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
 
             Dependencies.Cache(music = new MusicController());
 

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -47,9 +47,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             // These DI caches are required to ensure for interactive runs this test scene doesn't nuke all user beatmaps in the local install.
             // At a point we have isolated interactive test runs enough, this can likely be removed.
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(ContextFactory);
-            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(Access);
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
 
             Dependencies.Cache(music = new MusicController());
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneTopLocalRank.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneTopLocalRank.cs
@@ -28,10 +28,10 @@ namespace osu.Game.Tests.Visual.SongSelect
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
-            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(scoreManager = new ScoreManager(rulesets, () => beatmapManager, LocalStorage, ContextFactory, Scheduler));
-            Dependencies.Cache(ContextFactory);
+            Dependencies.Cache(rulesets = new RulesetStore(Access));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(scoreManager = new ScoreManager(rulesets, () => beatmapManager, LocalStorage, Access, Scheduler));
+            Dependencies.Cache(Access);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneTopLocalRank.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneTopLocalRank.cs
@@ -28,10 +28,10 @@ namespace osu.Game.Tests.Visual.SongSelect
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            Dependencies.Cache(rulesets = new RulesetStore(Access));
-            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(scoreManager = new ScoreManager(rulesets, () => beatmapManager, LocalStorage, Access, Scheduler));
-            Dependencies.Cache(Access);
+            Dependencies.Cache(rulesets = new RulesetStore(Realm));
+            Dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(scoreManager = new ScoreManager(rulesets, () => beatmapManager, LocalStorage, Realm, Scheduler));
+            Dependencies.Cache(Realm);
 
             beatmapManager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -122,10 +122,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
                 // Due to soft deletions, we can re-use deleted scores between test runs
-                scoreManager.Undelete(realm.All<ScoreInfo>().Where(s => s.DeletePending).ToList());
+                scoreManager.Undelete(r.All<ScoreInfo>().Where(s => s.DeletePending).ToList());
             });
 
             leaderboard.Scores = null;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -87,10 +87,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.Cache(rulesetStore = new RulesetStore(Access));
-            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
-            dependencies.Cache(scoreManager = new ScoreManager(dependencies.Get<RulesetStore>(), () => beatmapManager, LocalStorage, Access, Scheduler));
-            Dependencies.Cache(Access);
+            dependencies.Cache(rulesetStore = new RulesetStore(Realm));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Realm, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(dependencies.Get<RulesetStore>(), () => beatmapManager, LocalStorage, Realm, Scheduler));
+            Dependencies.Cache(Realm);
 
             var imported = beatmapManager.Import(new ImportTask(TestResources.GetQuickTestBeatmapForImport())).GetResultSafely();
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private BeatmapInfo beatmapInfo;
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         [Cached]
         private readonly DialogOverlay dialogOverlay;
@@ -87,10 +87,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.Cache(rulesetStore = new RulesetStore(ContextFactory));
-            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, ContextFactory, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
-            dependencies.Cache(scoreManager = new ScoreManager(dependencies.Get<RulesetStore>(), () => beatmapManager, LocalStorage, ContextFactory, Scheduler));
-            Dependencies.Cache(ContextFactory);
+            dependencies.Cache(rulesetStore = new RulesetStore(Access));
+            dependencies.Cache(beatmapManager = new BeatmapManager(LocalStorage, Access, rulesetStore, null, dependencies.Get<AudioManager>(), Resources, dependencies.Get<GameHost>(), Beatmap.Default));
+            dependencies.Cache(scoreManager = new ScoreManager(dependencies.Get<RulesetStore>(), () => beatmapManager, LocalStorage, Access, Scheduler));
+            Dependencies.Cache(Access);
 
             var imported = beatmapManager.Import(new ImportTask(TestResources.GetQuickTestBeatmapForImport())).GetResultSafely();
 
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            realmFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 // Due to soft deletions, we can re-use deleted scores between test runs
                 scoreManager.Undelete(realm.All<ScoreInfo>().Where(s => s.DeletePending).ToList());

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -119,12 +119,12 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapInfo">The beatmap difficulty to hide.</param>
         public void Hide(BeatmapInfo beatmapInfo)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                using (var transaction = realm.BeginWrite())
+                using (var transaction = r.BeginWrite())
                 {
                     if (!beatmapInfo.IsManaged)
-                        beatmapInfo = realm.Find<BeatmapInfo>(beatmapInfo.ID);
+                        beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID);
 
                     beatmapInfo.Hidden = true;
                     transaction.Commit();
@@ -138,12 +138,12 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapInfo">The beatmap difficulty to restore.</param>
         public void Restore(BeatmapInfo beatmapInfo)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                using (var transaction = realm.BeginWrite())
+                using (var transaction = r.BeginWrite())
                 {
                     if (!beatmapInfo.IsManaged)
-                        beatmapInfo = realm.Find<BeatmapInfo>(beatmapInfo.ID);
+                        beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID);
 
                     beatmapInfo.Hidden = false;
                     transaction.Commit();
@@ -153,11 +153,11 @@ namespace osu.Game.Beatmaps
 
         public void RestoreAll()
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                using (var transaction = realm.BeginWrite())
+                using (var transaction = r.BeginWrite())
                 {
-                    foreach (var beatmap in realm.All<BeatmapInfo>().Where(b => b.Hidden))
+                    foreach (var beatmap in r.All<BeatmapInfo>().Where(b => b.Hidden))
                         beatmap.Hidden = false;
 
                     transaction.Commit();
@@ -171,10 +171,10 @@ namespace osu.Game.Beatmaps
         /// <returns>A list of available <see cref="BeatmapSetInfo"/>.</returns>
         public List<BeatmapSetInfo> GetAllUsableBeatmapSets()
         {
-            return realm.Run(realm =>
+            return realm.Run(r =>
             {
-                realm.Refresh();
-                return realm.All<BeatmapSetInfo>().Where(b => !b.DeletePending).Detach();
+                r.Refresh();
+                return r.All<BeatmapSetInfo>().Where(b => !b.DeletePending).Detach();
             });
         }
 
@@ -240,9 +240,9 @@ namespace osu.Game.Beatmaps
 
         public void Delete(Expression<Func<BeatmapSetInfo, bool>>? filter = null, bool silent = false)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var items = realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected);
+                var items = r.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected);
 
                 if (filter != null)
                     items = items.Where(filter);
@@ -253,7 +253,7 @@ namespace osu.Game.Beatmaps
 
         public void UndeleteAll()
         {
-            realm.Run(realm => beatmapModelManager.Undelete(realm.All<BeatmapSetInfo>().Where(s => s.DeletePending).ToList()));
+            realm.Run(r => beatmapModelManager.Undelete(r.All<BeatmapSetInfo>().Where(s => s.DeletePending).ToList()));
         }
 
         public void Undelete(List<BeatmapSetInfo> items, bool silent = false)
@@ -312,9 +312,9 @@ namespace osu.Game.Beatmaps
             // If we seem to be missing files, now is a good time to re-fetch.
             if (importedBeatmap?.BeatmapSet?.Files.Count == 0)
             {
-                realm.Run(realm =>
+                realm.Run(r =>
                 {
-                    var refetch = realm.Find<BeatmapInfo>(importedBeatmap.ID)?.Detach();
+                    var refetch = r.Find<BeatmapInfo>(importedBeatmap.ID)?.Detach();
 
                     if (refetch != null)
                         importedBeatmap = refetch;

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -33,8 +33,8 @@ namespace osu.Game.Beatmaps
 
         protected override string[] HashableFileTypes => new[] { ".osu" };
 
-        public BeatmapModelManager(RealmContextFactory contextFactory, Storage storage, BeatmapOnlineLookupQueue? onlineLookupQueue = null)
-            : base(contextFactory, storage, onlineLookupQueue)
+        public BeatmapModelManager(RealmAccess realm, Storage storage, BeatmapOnlineLookupQueue? onlineLookupQueue = null)
+            : base(realm, storage, onlineLookupQueue)
         {
         }
 
@@ -98,12 +98,12 @@ namespace osu.Game.Beatmaps
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public BeatmapInfo? QueryBeatmap(Expression<Func<BeatmapInfo, bool>> query)
         {
-            return ContextFactory.Run(realm => realm.All<BeatmapInfo>().FirstOrDefault(query)?.Detach());
+            return Access.Run(realm => realm.All<BeatmapInfo>().FirstOrDefault(query)?.Detach());
         }
 
         public void Update(BeatmapSetInfo item)
         {
-            ContextFactory.Write(realm =>
+            Access.Write(realm =>
             {
                 var existing = realm.Find<BeatmapSetInfo>(item.ID);
                 item.CopyChangesToRealm(existing);

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -98,12 +98,12 @@ namespace osu.Game.Beatmaps
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public BeatmapInfo? QueryBeatmap(Expression<Func<BeatmapInfo, bool>> query)
         {
-            return Access.Run(realm => realm.All<BeatmapInfo>().FirstOrDefault(query)?.Detach());
+            return Realm.Run(realm => realm.All<BeatmapInfo>().FirstOrDefault(query)?.Detach());
         }
 
         public void Update(BeatmapSetInfo item)
         {
-            Access.Write(realm =>
+            Realm.Write(realm =>
             {
                 var existing = realm.Find<BeatmapSetInfo>(item.ID);
                 item.CopyChangesToRealm(existing);

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Beatmaps
         TextureStore IBeatmapResourceProvider.LargeTextureStore => largeTextureStore;
         ITrackStore IBeatmapResourceProvider.Tracks => trackStore;
         AudioManager IStorageResourceProvider.AudioManager => audioManager;
-        RealmContextFactory IStorageResourceProvider.RealmContextFactory => null;
+        RealmAccess IStorageResourceProvider.RealmAccess => null;
         IResourceStore<byte[]> IStorageResourceProvider.Files => files;
         IResourceStore<byte[]> IStorageResourceProvider.Resources => resources;
         IResourceStore<TextureUpload> IStorageResourceProvider.CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => host?.CreateTextureLoaderStore(underlyingStore);

--- a/osu.Game/Configuration/SettingsStore.cs
+++ b/osu.Game/Configuration/SettingsStore.cs
@@ -10,11 +10,11 @@ namespace osu.Game.Configuration
         // this class mostly exists as a wrapper to avoid breaking the ruleset API (see usage in RulesetConfigManager).
         // it may cease to exist going forward, depending on how the structure of the config data layer changes.
 
-        public readonly RealmContextFactory Realm;
+        public readonly RealmAccess Realm;
 
-        public SettingsStore(RealmContextFactory realmFactory)
+        public SettingsStore(RealmAccess realm)
         {
-            Realm = realmFactory;
+            Realm = realm;
         }
     }
 }

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -101,15 +101,15 @@ namespace osu.Game.Database
             {
                 using (var ef = efContextFactory.Get())
                 {
-                    realm.Write(realm =>
+                    realm.Write(r =>
                     {
                         // Before beginning, ensure realm is in an empty state.
                         // Migrations which are half-completed could lead to issues if the user tries a second time.
                         // Note that we only do this for beatmaps and scores since the other migrations are yonks old.
-                        realm.RemoveAll<BeatmapSetInfo>();
-                        realm.RemoveAll<BeatmapInfo>();
-                        realm.RemoveAll<BeatmapMetadata>();
-                        realm.RemoveAll<ScoreInfo>();
+                        r.RemoveAll<BeatmapSetInfo>();
+                        r.RemoveAll<BeatmapInfo>();
+                        r.RemoveAll<BeatmapMetadata>();
+                        r.RemoveAll<ScoreInfo>();
                     });
 
                     migrateSettings(ef);

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Database
         private DatabaseContextFactory efContextFactory { get; set; } = null!;
 
         [Resolved]
-        private RealmContextFactory realmContextFactory { get; set; } = null!;
+        private RealmAccess realm { get; set; } = null!;
 
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
@@ -101,7 +101,7 @@ namespace osu.Game.Database
             {
                 using (var ef = efContextFactory.Get())
                 {
-                    realmContextFactory.Write(realm =>
+                    realm.Write(realm =>
                     {
                         // Before beginning, ensure realm is in an empty state.
                         // Migrations which are half-completed could lead to issues if the user tries a second time.
@@ -158,7 +158,7 @@ namespace osu.Game.Database
 
             int count = existingBeatmapSets.Count();
 
-            realmContextFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 log($"Found {count} beatmaps in EF");
 
@@ -280,7 +280,7 @@ namespace osu.Game.Database
 
             int count = existingScores.Count();
 
-            realmContextFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 log($"Found {count} scores in EF");
 
@@ -369,7 +369,7 @@ namespace osu.Game.Database
                     break;
             }
 
-            realmContextFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 using (var transaction = realm.BeginWrite())
                 {
@@ -428,7 +428,7 @@ namespace osu.Game.Database
 
             log("Beginning settings migration to realm");
 
-            realmContextFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 using (var transaction = realm.BeginWrite())
                 {

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -30,7 +30,7 @@ using Realms.Exceptions;
 namespace osu.Game.Database
 {
     /// <summary>
-    /// A factory which provides both the main (update thread bound) realm context and creates contexts for async usage.
+    /// A factory which provides safe access to the realm storage backend.
     /// </summary>
     public class RealmAccess : IDisposable
     {
@@ -57,9 +57,9 @@ namespace osu.Game.Database
         private const int schema_version = 13;
 
         /// <summary>
-        /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking context creation during blocking periods.
+        /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
         /// </summary>
-        private readonly SemaphoreSlim realmCreationLock = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim realmRetrievalLock = new SemaphoreSlim(1);
 
         private readonly ThreadLocal<bool> currentThreadCanCreateRealmInstances = new ThreadLocal<bool>();
 
@@ -76,7 +76,7 @@ namespace osu.Game.Database
 
         /// <summary>
         /// Holds a map of functions registered via <see cref="RegisterForNotifications{T}"/> and a coinciding action which when triggered,
-        /// fires a change set event with an empty collection. This is used to inform subscribers when a realm context goes away, and ensure they don't use invalidated
+        /// fires a change set event with an empty collection. This is used to inform subscribers when the main realm instance gets recycled, and ensure they don't use invalidated
         /// managed realm objects from a previous firing.
         /// </summary>
         private readonly Dictionary<Func<Realm, IDisposable?>, Action> notificationsResetMap = new Dictionary<Func<Realm, IDisposable?>, Action>();
@@ -364,7 +364,7 @@ namespace osu.Game.Database
             {
                 if (!currentThreadCanCreateRealmInstances.Value)
                 {
-                    realmCreationLock.Wait();
+                    realmRetrievalLock.Wait();
                     currentThreadCanCreateRealmInstances.Value = true;
                     tookSemaphoreLock = true;
                 }
@@ -383,7 +383,7 @@ namespace osu.Game.Database
             {
                 if (tookSemaphoreLock)
                 {
-                    realmCreationLock.Release();
+                    realmRetrievalLock.Release();
                     currentThreadCanCreateRealmInstances.Value = false;
                 }
             }
@@ -589,7 +589,7 @@ namespace osu.Game.Database
 
             try
             {
-                realmCreationLock.Wait();
+                realmRetrievalLock.Wait();
 
                 lock (realmLock)
                 {
@@ -639,13 +639,13 @@ namespace osu.Game.Database
             }
             catch
             {
-                realmCreationLock.Release();
+                realmRetrievalLock.Release();
                 throw;
             }
 
             return new InvokeOnDisposal<RealmAccess>(this, factory =>
             {
-                factory.realmCreationLock.Release();
+                factory.realmRetrievalLock.Release();
                 Logger.Log(@"Restoring realm operations.", LoggingTarget.Database);
 
                 // Post back to the update thread to revive any subscriptions.
@@ -667,9 +667,9 @@ namespace osu.Game.Database
 
             if (!isDisposed)
             {
-                // intentionally block context creation indefinitely. this ensures that nothing can start consuming a new context after disposal.
-                realmCreationLock.Wait();
-                realmCreationLock.Dispose();
+                // intentionally block realm retrieval indefinitely. this ensures that nothing can start consuming a new instance after disposal.
+                realmRetrievalLock.Wait();
+                realmRetrievalLock.Dispose();
 
                 isDisposed = true;
             }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Database
     /// <summary>
     /// A factory which provides both the main (update thread bound) realm context and creates contexts for async usage.
     /// </summary>
-    public class RealmContextFactory : IDisposable
+    public class RealmAccess : IDisposable
     {
         private readonly Storage storage;
 
@@ -123,7 +123,7 @@ namespace osu.Game.Database
         /// <param name="storage">The game storage which will be used to create the realm backing file.</param>
         /// <param name="filename">The filename to use for the realm backing file. A ".realm" extension will be added automatically if not specified.</param>
         /// <param name="efContextFactory">An EF factory used only for migration purposes.</param>
-        public RealmContextFactory(Storage storage, string filename, IDatabaseContextFactory? efContextFactory = null)
+        public RealmAccess(Storage storage, string filename, IDatabaseContextFactory? efContextFactory = null)
         {
             this.storage = storage;
             this.efContextFactory = efContextFactory;
@@ -365,7 +365,7 @@ namespace osu.Game.Database
         private Realm createContext()
         {
             if (isDisposed)
-                throw new ObjectDisposedException(nameof(RealmContextFactory));
+                throw new ObjectDisposedException(nameof(RealmAccess));
 
             bool tookSemaphoreLock = false;
 
@@ -592,7 +592,7 @@ namespace osu.Game.Database
         public IDisposable BlockAllOperations()
         {
             if (isDisposed)
-                throw new ObjectDisposedException(nameof(RealmContextFactory));
+                throw new ObjectDisposedException(nameof(RealmAccess));
 
             SynchronizationContext? syncContext = null;
 
@@ -652,7 +652,7 @@ namespace osu.Game.Database
                 throw;
             }
 
-            return new InvokeOnDisposal<RealmContextFactory>(this, factory =>
+            return new InvokeOnDisposal<RealmAccess>(this, factory =>
             {
                 factory.contextCreationLock.Release();
                 Logger.Log(@"Restoring realm operations.", LoggingTarget.Database);

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -51,10 +51,7 @@ namespace osu.Game.Database
                 return;
             }
 
-            realm.Run(realm =>
-            {
-                perform(retrieveFromID(realm, ID));
-            });
+            realm.Run(r => perform(retrieveFromID(r, ID)));
         }
 
         /// <summary>
@@ -66,9 +63,9 @@ namespace osu.Game.Database
             if (!IsManaged)
                 return perform(data);
 
-            return realm.Run(realm =>
+            return realm.Run(r =>
             {
-                var returnData = perform(retrieveFromID(realm, ID));
+                var returnData = perform(retrieveFromID(r, ID));
 
                 if (returnData is RealmObjectBase realmObject && realmObject.IsManaged)
                     throw new InvalidOperationException(@$"Managed realm objects should not exit the scope of {nameof(PerformRead)}.");

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -24,17 +24,17 @@ namespace osu.Game.Database
         /// </summary>
         private readonly T data;
 
-        private readonly RealmContextFactory realmFactory;
+        private readonly RealmAccess realm;
 
         /// <summary>
         /// Construct a new instance of live realm data.
         /// </summary>
         /// <param name="data">The realm data.</param>
-        /// <param name="realmFactory">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
-        public RealmLive(T data, RealmContextFactory realmFactory)
+        /// <param name="realm">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
+        public RealmLive(T data, RealmAccess realm)
         {
             this.data = data;
-            this.realmFactory = realmFactory;
+            this.realm = realm;
 
             ID = data.ID;
         }
@@ -51,7 +51,7 @@ namespace osu.Game.Database
                 return;
             }
 
-            realmFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 perform(retrieveFromID(realm, ID));
             });
@@ -66,7 +66,7 @@ namespace osu.Game.Database
             if (!IsManaged)
                 return perform(data);
 
-            return realmFactory.Run(realm =>
+            return realm.Run(realm =>
             {
                 var returnData = perform(retrieveFromID(realm, ID));
 
@@ -104,7 +104,7 @@ namespace osu.Game.Database
                 if (!ThreadSafety.IsUpdateThread)
                     throw new InvalidOperationException($"Can't use {nameof(Value)} on managed objects from non-update threads");
 
-                return realmFactory.Context.Find<T>(ID);
+                return realm.Realm.Find<T>(ID);
             }
         }
 

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -216,16 +216,16 @@ namespace osu.Game.Database
             return new RealmLiveUnmanaged<T>(realmObject);
         }
 
-        public static List<ILive<T>> ToLive<T>(this IEnumerable<T> realmList, RealmContextFactory realmContextFactory)
+        public static List<ILive<T>> ToLive<T>(this IEnumerable<T> realmList, RealmAccess realm)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return realmList.Select(l => new RealmLive<T>(l, realmContextFactory)).Cast<ILive<T>>().ToList();
+            return realmList.Select(l => new RealmLive<T>(l, realm)).Cast<ILive<T>>().ToList();
         }
 
-        public static ILive<T> ToLive<T>(this T realmObject, RealmContextFactory realmContextFactory)
+        public static ILive<T> ToLive<T>(this T realmObject, RealmAccess realm)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return new RealmLive<T>(realmObject, realmContextFactory);
+            return new RealmLive<T>(realmObject, realm);
         }
 
         /// <summary>
@@ -271,8 +271,8 @@ namespace osu.Game.Database
         public static IDisposable? QueryAsyncWithNotifications<T>(this IRealmCollection<T> collection, NotificationCallbackDelegate<T> callback)
             where T : RealmObjectBase
         {
-            if (!RealmContextFactory.CurrentThreadSubscriptionsAllowed)
-                throw new InvalidOperationException($"Make sure to call {nameof(RealmContextFactory)}.{nameof(RealmContextFactory.RegisterForNotifications)}");
+            if (!RealmAccess.CurrentThreadSubscriptionsAllowed)
+                throw new InvalidOperationException($"Make sure to call {nameof(RealmAccess)}.{nameof(RealmAccess.RegisterForNotifications)}");
 
             return collection.SubscribeForNotifications(callback);
         }

--- a/osu.Game/IO/IStorageResourceProvider.cs
+++ b/osu.Game/IO/IStorageResourceProvider.cs
@@ -28,7 +28,7 @@ namespace osu.Game.IO
         /// <summary>
         /// Access realm.
         /// </summary>
-        RealmContextFactory RealmContextFactory { get; }
+        RealmAccess RealmAccess { get; }
 
         /// <summary>
         /// Create a texture loader store based on an underlying data store.

--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Input.Bindings
 
         protected override void LoadComplete()
         {
-            realmSubscription = realm.RegisterForNotifications(realm => queryRealmKeyBindings(), (sender, changes, error) =>
+            realmSubscription = realm.RegisterForNotifications(r => queryRealmKeyBindings(), (sender, changes, error) =>
             {
                 // The first fire of this is a bit redundant as this is being called in base.LoadComplete,
                 // but this is safest in case the subscription is restored after a context recycle.

--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Input.Bindings
         private IDisposable realmSubscription;
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => ruleset.CreateInstance().GetDefaultKeyBindings(variant ?? 0);
 
@@ -49,13 +49,13 @@ namespace osu.Game.Input.Bindings
         private IQueryable<RealmKeyBinding> queryRealmKeyBindings()
         {
             string rulesetName = ruleset?.ShortName;
-            return realmFactory.Context.All<RealmKeyBinding>()
-                               .Where(b => b.RulesetName == rulesetName && b.Variant == variant);
+            return realm.Realm.All<RealmKeyBinding>()
+                        .Where(b => b.RulesetName == rulesetName && b.Variant == variant);
         }
 
         protected override void LoadComplete()
         {
-            realmSubscription = realmFactory.RegisterForNotifications(realm => queryRealmKeyBindings(), (sender, changes, error) =>
+            realmSubscription = realm.RegisterForNotifications(realm => queryRealmKeyBindings(), (sender, changes, error) =>
             {
                 // The first fire of this is a bit redundant as this is being called in base.LoadComplete,
                 // but this is safest in case the subscription is restored after a context recycle.

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -56,21 +56,21 @@ namespace osu.Game.Input
         /// <param name="rulesets">The rulesets to populate defaults from.</param>
         public void Register(KeyBindingContainer container, IEnumerable<RulesetInfo> rulesets)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                using (var transaction = realm.BeginWrite())
+                using (var transaction = r.BeginWrite())
                 {
                     // intentionally flattened to a list rather than querying against the IQueryable, as nullable fields being queried against aren't indexed.
                     // this is much faster as a result.
-                    var existingBindings = realm.All<RealmKeyBinding>().ToList();
+                    var existingBindings = r.All<RealmKeyBinding>().ToList();
 
-                    insertDefaults(realm, existingBindings, container.DefaultKeyBindings);
+                    insertDefaults(r, existingBindings, container.DefaultKeyBindings);
 
                     foreach (var ruleset in rulesets)
                     {
                         var instance = ruleset.CreateInstance();
                         foreach (int variant in instance.AvailableVariants)
-                            insertDefaults(realm, existingBindings, instance.GetDefaultKeyBindings(variant), ruleset.ShortName, variant);
+                            insertDefaults(r, existingBindings, instance.GetDefaultKeyBindings(variant), ruleset.ShortName, variant);
                     }
 
                     transaction.Commit();

--- a/osu.Game/Input/RealmKeyBindingStore.cs
+++ b/osu.Game/Input/RealmKeyBindingStore.cs
@@ -16,12 +16,12 @@ namespace osu.Game.Input
 {
     public class RealmKeyBindingStore
     {
-        private readonly RealmContextFactory realmFactory;
+        private readonly RealmAccess realm;
         private readonly ReadableKeyCombinationProvider keyCombinationProvider;
 
-        public RealmKeyBindingStore(RealmContextFactory realmFactory, ReadableKeyCombinationProvider keyCombinationProvider)
+        public RealmKeyBindingStore(RealmAccess realm, ReadableKeyCombinationProvider keyCombinationProvider)
         {
-            this.realmFactory = realmFactory;
+            this.realm = realm;
             this.keyCombinationProvider = keyCombinationProvider;
         }
 
@@ -34,7 +34,7 @@ namespace osu.Game.Input
         {
             List<string> combinations = new List<string>();
 
-            realmFactory.Run(context =>
+            realm.Run(context =>
             {
                 foreach (var action in context.All<RealmKeyBinding>().Where(b => string.IsNullOrEmpty(b.RulesetName) && (GlobalAction)b.ActionInt == globalAction))
                 {
@@ -56,7 +56,7 @@ namespace osu.Game.Input
         /// <param name="rulesets">The rulesets to populate defaults from.</param>
         public void Register(KeyBindingContainer container, IEnumerable<RulesetInfo> rulesets)
         {
-            realmFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 using (var transaction = realm.BeginWrite())
                 {

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Online
         private IDisposable? realmSubscription;
 
         [Resolved]
-        private RealmContextFactory realmContextFactory { get; set; } = null!;
+        private RealmAccess realm { get; set; } = null!;
 
         public BeatmapDownloadTracker(IBeatmapSetInfo trackedItem)
             : base(trackedItem)
@@ -42,7 +42,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realmContextFactory.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
+            realmSubscription = realm.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realm.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Online.Rooms
 
                 // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
                 realmSubscription?.Dispose();
-                realmSubscription = realm.RegisterForNotifications(realm => filteredBeatmaps(), (items, changes, ___) =>
+                realmSubscription = realm.RegisterForNotifications(r => filteredBeatmaps(), (items, changes, ___) =>
                 {
                     if (changes == null)
                         return;

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Online.Rooms
         protected override bool RequiresChildrenUpdate => true;
 
         [Resolved]
-        private RealmContextFactory realmContextFactory { get; set; } = null!;
+        private RealmAccess realm { get; set; } = null!;
 
         /// <summary>
         /// The availability state of the currently selected playlist item.
@@ -78,7 +78,7 @@ namespace osu.Game.Online.Rooms
 
                 // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
                 realmSubscription?.Dispose();
-                realmSubscription = realmContextFactory.RegisterForNotifications(realm => filteredBeatmaps(), (items, changes, ___) =>
+                realmSubscription = realm.RegisterForNotifications(realm => filteredBeatmaps(), (items, changes, ___) =>
                 {
                     if (changes == null)
                         return;
@@ -128,9 +128,9 @@ namespace osu.Game.Online.Rooms
             int onlineId = SelectedItem.Value.Beatmap.Value.OnlineID;
             string checksum = SelectedItem.Value.Beatmap.Value.MD5Hash;
 
-            return realmContextFactory.Context
-                                      .All<BeatmapInfo>()
-                                      .Filter("OnlineID == $0 && MD5Hash == $1 && BeatmapSet.DeletePending == false", onlineId, checksum);
+            return realm.Realm
+                        .All<BeatmapInfo>()
+                        .Filter("OnlineID == $0 && MD5Hash == $1 && BeatmapSet.DeletePending == false", onlineId, checksum);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online
         private IDisposable? realmSubscription;
 
         [Resolved]
-        private RealmContextFactory realmContextFactory { get; set; } = null!;
+        private RealmAccess realm { get; set; } = null!;
 
         public ScoreDownloadTracker(ScoreInfo trackedItem)
             : base(trackedItem)
@@ -47,7 +47,7 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
-            realmSubscription = realmContextFactory.RegisterForNotifications(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
+            realmSubscription = realm.RegisterForNotifications(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
-            realmSubscription = realm.RegisterForNotifications(realm => realm.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
+            realmSubscription = realm.RegisterForNotifications(r => r.All<ScoreInfo>().Where(s => ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID) || s.Hash == TrackedItem.Hash) && !s.DeletePending), (items, changes, ___) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -149,7 +149,7 @@ namespace osu.Game
 
         private MultiplayerClient multiplayerClient;
 
-        private RealmContextFactory realmFactory;
+        private RealmAccess realm;
 
         protected override Container<Drawable> Content => content;
 
@@ -192,9 +192,9 @@ namespace osu.Game
             if (Storage.Exists(DatabaseContextFactory.DATABASE_NAME))
                 dependencies.Cache(EFContextFactory = new DatabaseContextFactory(Storage));
 
-            dependencies.Cache(realmFactory = new RealmContextFactory(Storage, "client", EFContextFactory));
+            dependencies.Cache(realm = new RealmAccess(Storage, "client", EFContextFactory));
 
-            dependencies.Cache(RulesetStore = new RulesetStore(realmFactory, Storage));
+            dependencies.Cache(RulesetStore = new RulesetStore(realm, Storage));
             dependencies.CacheAs<IRulesetStore>(RulesetStore);
 
             // Backup is taken here rather than in EFToRealmMigrator to avoid recycling realm contexts
@@ -205,7 +205,7 @@ namespace osu.Game
                 string migration = $"before_final_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
 
                 EFContextFactory.CreateBackup($"client.{migration}.db");
-                realmFactory.CreateBackup($"client.{migration}.realm");
+                realm.CreateBackup($"client.{migration}.realm");
 
                 using (var source = Storage.GetStream("collection.db"))
                 using (var destination = Storage.GetStream($"collection.{migration}.db", FileAccess.Write, FileMode.CreateNew))
@@ -225,7 +225,7 @@ namespace osu.Game
 
             Audio.Samples.PlaybackConcurrency = SAMPLE_CONCURRENCY;
 
-            dependencies.Cache(SkinManager = new SkinManager(Storage, realmFactory, Host, Resources, Audio, Scheduler));
+            dependencies.Cache(SkinManager = new SkinManager(Storage, realm, Host, Resources, Audio, Scheduler));
             dependencies.CacheAs<ISkinSource>(SkinManager);
 
             EndpointConfiguration endpoints = UseDevelopmentServer ? (EndpointConfiguration)new DevelopmentEndpointConfiguration() : new ProductionEndpointConfiguration();
@@ -240,8 +240,8 @@ namespace osu.Game
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
-            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realmFactory, Scheduler, Host, () => difficultyCache, LocalConfig));
-            dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, realmFactory, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
+            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, Scheduler, Host, () => difficultyCache, LocalConfig));
+            dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, realm, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
             dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API));
             dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API));
@@ -259,7 +259,7 @@ namespace osu.Game
             dependencies.Cache(scorePerformanceManager);
             AddInternal(scorePerformanceManager);
 
-            dependencies.CacheAs<IRulesetConfigCache>(rulesetConfigCache = new RulesetConfigCache(realmFactory, RulesetStore));
+            dependencies.CacheAs<IRulesetConfigCache>(rulesetConfigCache = new RulesetConfigCache(realm, RulesetStore));
 
             var powerStatus = CreateBatteryInfo();
             if (powerStatus != null)
@@ -303,7 +303,7 @@ namespace osu.Game
 
             base.Content.Add(CreateScalingContainer().WithChildren(mainContent));
 
-            KeyBindingStore = new RealmKeyBindingStore(realmFactory, keyCombinationProvider);
+            KeyBindingStore = new RealmKeyBindingStore(realm, keyCombinationProvider);
             KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);
 
             dependencies.Cache(globalBindings);
@@ -405,7 +405,7 @@ namespace osu.Game
 
                 Scheduler.Add(() =>
                 {
-                    realmBlocker = realmFactory.BlockAllOperations();
+                    realmBlocker = realm.BlockAllOperations();
 
                     readyToRun.Set();
                 }, false);
@@ -483,7 +483,7 @@ namespace osu.Game
             BeatmapManager?.Dispose();
             LocalConfig?.Dispose();
 
-            realmFactory?.Dispose();
+            realm?.Dispose();
         }
     }
 }

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays
         public DrawableTrack CurrentTrack { get; private set; } = new DrawableTrack(new TrackVirtual(1000));
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -81,9 +81,9 @@ namespace osu.Game.Overlays
         }
 
         private IQueryable<BeatmapSetInfo> queryRealmBeatmapSets() =>
-            realmFactory.Context
-                        .All<BeatmapSetInfo>()
-                        .Where(s => !s.DeletePending);
+            realm.Realm
+                 .All<BeatmapSetInfo>()
+                 .Where(s => !s.DeletePending);
 
         protected override void LoadComplete()
         {
@@ -94,7 +94,7 @@ namespace osu.Game.Overlays
             foreach (var s in queryRealmBeatmapSets())
                 beatmapSets.Add(s.Detach());
 
-            beatmapSubscription = realmFactory.RegisterForNotifications(realm => queryRealmBeatmapSets(), beatmapsChanged);
+            beatmapSubscription = realm.RegisterForNotifications(realm => queryRealmBeatmapSets(), beatmapsChanged);
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            beatmapSubscription = realm.RegisterForNotifications(realm => queryRealmBeatmapSets(), beatmapsChanged);
+            beatmapSubscription = realm.RegisterForNotifications(r => queryRealmBeatmapSets(), beatmapsChanged);
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
         protected override LocalisableString Header => DebugSettingsStrings.MemoryHeader;
 
         [BackgroundDependencyLoader]
-        private void load(GameHost host, RealmContextFactory realmFactory)
+        private void load(GameHost host, RealmAccess realm)
         {
             SettingsButton blockAction;
             SettingsButton unblockAction;
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                     Action = () =>
                     {
                         // Blocking operations implicitly causes a Compact().
-                        using (realmFactory.BlockAllOperations())
+                        using (realm.BlockAllOperations())
                         {
                         }
                     }
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             {
                 try
                 {
-                    var token = realmFactory.BlockAllOperations();
+                    var token = realm.BlockAllOperations();
 
                     blockAction.Enabled.Value = false;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -386,10 +386,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private void updateStoreFromButton(KeyButton button)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var binding = realm.Find<RealmKeyBinding>(((IHasGuidPrimaryKey)button.KeyBinding).ID);
-                realm.Write(() => binding.KeyCombinationString = button.KeyBinding.KeyCombinationString);
+                var binding = r.Find<RealmKeyBinding>(((IHasGuidPrimaryKey)button.KeyBinding).ID);
+                r.Write(() => binding.KeyCombinationString = button.KeyBinding.KeyCombinationString);
             });
         }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         }
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -386,7 +386,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private void updateStoreFromButton(KeyButton button)
         {
-            realmFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 var binding = realm.Find<RealmKeyBinding>(((IHasGuidPrimaryKey)button.KeyBinding).ID);
                 realm.Write(() => binding.KeyCombinationString = button.KeyBinding.KeyCombinationString);

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         }
 
         [BackgroundDependencyLoader]
-        private void load(RealmContextFactory realmFactory)
+        private void load(RealmAccess realm)
         {
             string rulesetName = Ruleset?.ShortName;
 
-            var bindings = realmFactory.Run(realm => realm.All<RealmKeyBinding>()
-                                                          .Where(b => b.RulesetName == rulesetName && b.Variant == variant)
-                                                          .Detach());
+            var bindings = realm.Run(r => r.All<RealmKeyBinding>()
+                                           .Where(b => b.RulesetName == rulesetName && b.Variant == variant)
+                                           .Detach());
 
             foreach (var defaultGroup in Defaults.GroupBy(d => d.Action))
             {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -47,15 +47,15 @@ namespace osu.Game.Overlays.Settings.Sections
         private SkinManager skins { get; set; }
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         private IDisposable realmSubscription;
 
         private IQueryable<SkinInfo> queryRealmSkins() =>
-            realmFactory.Context.All<SkinInfo>()
-                        .Where(s => !s.DeletePending)
-                        .OrderByDescending(s => s.Protected) // protected skins should be at the top.
-                        .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase);
+            realm.Realm.All<SkinInfo>()
+                 .Where(s => !s.DeletePending)
+                 .OrderByDescending(s => s.Protected) // protected skins should be at the top.
+                 .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase);
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(OsuConfigManager config, [CanBeNull] SkinEditorOverlay skinEditor)
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
             skinDropdown.Current = dropdownBindable;
 
-            realmSubscription = realmFactory.RegisterForNotifications(realm => queryRealmSkins(), (sender, changes, error) =>
+            realmSubscription = realm.RegisterForNotifications(realm => queryRealmSkins(), (sender, changes, error) =>
             {
                 // The first fire of this is a bit redundant due to the call below,
                 // but this is safest in case the subscription is restored after a context recycle.
@@ -130,7 +130,7 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             int protectedCount = queryRealmSkins().Count(s => s.Protected);
 
-            skinItems = queryRealmSkins().ToLive(realmFactory);
+            skinItems = queryRealmSkins().ToLive(realm);
 
             skinItems.Insert(protectedCount, random_skin_info);
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
             skinDropdown.Current = dropdownBindable;
 
-            realmSubscription = realm.RegisterForNotifications(realm => queryRealmSkins(), (sender, changes, error) =>
+            realmSubscription = realm.RegisterForNotifications(r => queryRealmSkins(), (sender, changes, error) =>
             {
                 // The first fire of this is a bit redundant due to the call below,
                 // but this is safest in case the subscription is restored after a context recycle.

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Toolbar
         protected FillFlowContainer Flow;
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         protected ToolbarButton()
             : base(HoverSampleSet.Toolbar)
@@ -207,7 +207,7 @@ namespace osu.Game.Overlays.Toolbar
         {
             if (Hotkey == null) return;
 
-            var realmKeyBinding = realmFactory.Context.All<RealmKeyBinding>().FirstOrDefault(rkb => rkb.RulesetName == null && rkb.ActionInt == (int)Hotkey.Value);
+            var realmKeyBinding = realm.Realm.All<RealmKeyBinding>().FirstOrDefault(rkb => rkb.RulesetName == null && rkb.ActionInt == (int)Hotkey.Value);
 
             if (realmKeyBinding != null)
             {

--- a/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
+++ b/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
@@ -56,11 +56,11 @@ namespace osu.Game.Rulesets.Configuration
                 pendingWrites.Clear();
             }
 
-            realm?.Write(realm =>
+            realm?.Write(r =>
             {
                 foreach (var c in changed)
                 {
-                    var setting = realm.All<RealmRulesetSetting>().First(s => s.RulesetName == rulesetName && s.Variant == variant && s.Key == c.ToString());
+                    var setting = r.All<RealmRulesetSetting>().First(s => s.RulesetName == rulesetName && s.Variant == variant && s.Key == c.ToString());
 
                     setting.Value = ConfigStore[c].ToString();
                 }

--- a/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
+++ b/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Configuration
     public abstract class RulesetConfigManager<TLookup> : ConfigManager<TLookup>, IRulesetConfigManager
         where TLookup : struct, Enum
     {
-        private readonly RealmContextFactory realmFactory;
+        private readonly RealmAccess realm;
 
         private readonly int variant;
 
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Configuration
 
         protected RulesetConfigManager(SettingsStore store, RulesetInfo ruleset, int? variant = null)
         {
-            realmFactory = store?.Realm;
+            realm = store?.Realm;
 
             rulesetName = ruleset.ShortName;
 
@@ -37,10 +37,10 @@ namespace osu.Game.Rulesets.Configuration
 
         protected override void PerformLoad()
         {
-            if (realmFactory != null)
+            if (realm != null)
             {
                 // As long as RulesetConfigCache exists, there is no need to subscribe to realm events.
-                databasedSettings = realmFactory.Context.All<RealmRulesetSetting>().Where(b => b.RulesetName == rulesetName && b.Variant == variant).ToList();
+                databasedSettings = realm.Realm.All<RealmRulesetSetting>().Where(b => b.RulesetName == rulesetName && b.Variant == variant).ToList();
             }
         }
 
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Configuration
                 pendingWrites.Clear();
             }
 
-            realmFactory?.Write(realm =>
+            realm?.Write(realm =>
             {
                 foreach (var c in changed)
                 {
@@ -89,7 +89,7 @@ namespace osu.Game.Rulesets.Configuration
                     Variant = variant,
                 };
 
-                realmFactory?.Context.Write(() => realmFactory.Context.Add(setting));
+                realm?.Realm.Write(() => realm.Realm.Add(setting));
 
                 databasedSettings.Add(setting);
             }

--- a/osu.Game/Rulesets/RulesetConfigCache.cs
+++ b/osu.Game/Rulesets/RulesetConfigCache.cs
@@ -13,14 +13,14 @@ namespace osu.Game.Rulesets
 {
     public class RulesetConfigCache : Component, IRulesetConfigCache
     {
-        private readonly RealmContextFactory realmFactory;
+        private readonly RealmAccess realm;
         private readonly RulesetStore rulesets;
 
         private readonly Dictionary<string, IRulesetConfigManager> configCache = new Dictionary<string, IRulesetConfigManager>();
 
-        public RulesetConfigCache(RealmContextFactory realmFactory, RulesetStore rulesets)
+        public RulesetConfigCache(RealmAccess realm, RulesetStore rulesets)
         {
-            this.realmFactory = realmFactory;
+            this.realm = realm;
             this.rulesets = rulesets;
         }
 
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets
         {
             base.LoadComplete();
 
-            var settingsStore = new SettingsStore(realmFactory);
+            var settingsStore = new SettingsStore(realm);
 
             // let's keep things simple for now and just retrieve all the required configs at startup..
             foreach (var ruleset in rulesets.AvailableRulesets)

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets
 {
     public class RulesetStore : IDisposable, IRulesetStore
     {
-        private readonly RealmAccess realm;
+        private readonly RealmAccess realmAccess;
 
         private const string ruleset_library_prefix = @"osu.Game.Rulesets";
 
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets
 
         public RulesetStore(RealmAccess realm, Storage? storage = null)
         {
-            this.realm = realm;
+            realmAccess = realm;
 
             // On android in release configuration assemblies are loaded from the apk directly into memory.
             // We cannot read assemblies from cwd, so should check loaded assemblies instead.
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets
 
         private void addMissingRulesets()
         {
-            realm.Write(realm =>
+            realmAccess.Write(realm =>
             {
                 var rulesets = realm.All<RulesetInfo>();
 

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets
 {
     public class RulesetStore : IDisposable, IRulesetStore
     {
-        private readonly RealmContextFactory realmFactory;
+        private readonly RealmAccess realm;
 
         private const string ruleset_library_prefix = @"osu.Game.Rulesets";
 
@@ -31,9 +31,9 @@ namespace osu.Game.Rulesets
 
         private readonly List<RulesetInfo> availableRulesets = new List<RulesetInfo>();
 
-        public RulesetStore(RealmContextFactory realmFactory, Storage? storage = null)
+        public RulesetStore(RealmAccess realm, Storage? storage = null)
         {
-            this.realmFactory = realmFactory;
+            this.realm = realm;
 
             // On android in release configuration assemblies are loaded from the apk directly into memory.
             // We cannot read assemblies from cwd, so should check loaded assemblies instead.
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets
 
         private void addMissingRulesets()
         {
-            realmFactory.Write(realm =>
+            realm.Write(realm =>
             {
                 var rulesets = realm.All<RulesetInfo>();
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -25,21 +25,21 @@ namespace osu.Game.Scoring
 {
     public class ScoreManager : IModelManager<ScoreInfo>, IModelImporter<ScoreInfo>
     {
-        private readonly RealmContextFactory contextFactory;
+        private readonly RealmAccess realm;
         private readonly Scheduler scheduler;
         private readonly Func<BeatmapDifficultyCache> difficulties;
         private readonly OsuConfigManager configManager;
         private readonly ScoreModelManager scoreModelManager;
 
-        public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmContextFactory contextFactory, Scheduler scheduler,
+        public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmAccess realm, Scheduler scheduler,
                             IIpcHost importHost = null, Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
         {
-            this.contextFactory = contextFactory;
+            this.realm = realm;
             this.scheduler = scheduler;
             this.difficulties = difficulties;
             this.configManager = configManager;
 
-            scoreModelManager = new ScoreModelManager(rulesets, beatmaps, storage, contextFactory);
+            scoreModelManager = new ScoreModelManager(rulesets, beatmaps, storage, realm);
         }
 
         public Score GetScore(ScoreInfo score) => scoreModelManager.GetScore(score);
@@ -51,7 +51,7 @@ namespace osu.Game.Scoring
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public ScoreInfo Query(Expression<Func<ScoreInfo, bool>> query)
         {
-            return contextFactory.Run(realm => realm.All<ScoreInfo>().FirstOrDefault(query)?.Detach());
+            return realm.Run(realm => realm.All<ScoreInfo>().FirstOrDefault(query)?.Detach());
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace osu.Game.Scoring
 
         public void Delete([CanBeNull] Expression<Func<ScoreInfo, bool>> filter = null, bool silent = false)
         {
-            contextFactory.Run(realm =>
+            realm.Run(realm =>
             {
                 var items = realm.All<ScoreInfo>()
                                  .Where(s => !s.DeletePending);

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Scoring
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public ScoreInfo Query(Expression<Func<ScoreInfo, bool>> query)
         {
-            return realm.Run(realm => realm.All<ScoreInfo>().FirstOrDefault(query)?.Detach());
+            return realm.Run(r => r.All<ScoreInfo>().FirstOrDefault(query)?.Detach());
         }
 
         /// <summary>
@@ -254,10 +254,10 @@ namespace osu.Game.Scoring
 
         public void Delete([CanBeNull] Expression<Func<ScoreInfo, bool>> filter = null, bool silent = false)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var items = realm.All<ScoreInfo>()
-                                 .Where(s => !s.DeletePending);
+                var items = r.All<ScoreInfo>()
+                             .Where(s => !s.DeletePending);
 
                 if (filter != null)
                     items = items.Where(filter);

--- a/osu.Game/Scoring/ScoreModelManager.cs
+++ b/osu.Game/Scoring/ScoreModelManager.cs
@@ -29,8 +29,8 @@ namespace osu.Game.Scoring
         private readonly RulesetStore rulesets;
         private readonly Func<BeatmapManager> beatmaps;
 
-        public ScoreModelManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmContextFactory contextFactory)
-            : base(storage, contextFactory)
+        public ScoreModelManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmAccess realm)
+            : base(storage, realm)
         {
             this.rulesets = rulesets;
             this.beatmaps = beatmaps;
@@ -74,7 +74,7 @@ namespace osu.Game.Scoring
 
         public override bool IsAvailableLocally(ScoreInfo model)
         {
-            return ContextFactory.Run(realm => realm.All<ScoreInfo>().Any(s => s.OnlineID == model.OnlineID));
+            return Access.Run(realm => realm.All<ScoreInfo>().Any(s => s.OnlineID == model.OnlineID));
         }
     }
 }

--- a/osu.Game/Scoring/ScoreModelManager.cs
+++ b/osu.Game/Scoring/ScoreModelManager.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Scoring
 
         public override bool IsAvailableLocally(ScoreInfo model)
         {
-            return Access.Run(realm => realm.All<ScoreInfo>().Any(s => s.OnlineID == model.OnlineID));
+            return Realm.Run(realm => realm.All<ScoreInfo>().Any(s => s.OnlineID == model.OnlineID));
         }
     }
 }

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Menu
         private BeatmapManager beatmaps { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, Framework.Game game, RealmContextFactory realmContextFactory)
+        private void load(OsuConfigManager config, Framework.Game game, RealmAccess realm)
         {
             // prevent user from changing beatmap while the intro is still running.
             beatmap = Beatmap.BeginLease(false);
@@ -97,9 +97,9 @@ namespace osu.Game.Screens.Menu
             // if the user has requested not to play theme music, we should attempt to find a random beatmap from their collection.
             if (!MenuMusic.Value)
             {
-                realmContextFactory.Run(realm =>
+                realm.Run(r =>
                 {
-                    var usableBeatmapSets = realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected).AsRealmCollection();
+                    var usableBeatmapSets = r.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected).AsRealmCollection();
 
                     int setCount = usableBeatmapSets.Count;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -179,24 +179,24 @@ namespace osu.Game.Screens.Select
 
             if (!loadedTestBeatmaps)
             {
-                realmFactory.Run(realm => loadBeatmapSets(getBeatmapSets(realm)));
+                realm.Run(realm => loadBeatmapSets(getBeatmapSets(realm)));
             }
         }
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            subscriptionSets = realmFactory.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
-            subscriptionBeatmaps = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
+            subscriptionSets = realm.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
+            subscriptionBeatmaps = realm.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
 
             // Can't use main subscriptions because we can't lookup deleted indices.
             // https://github.com/realm/realm-dotnet/discussions/2634#discussioncomment-1605595.
-            subscriptionDeletedSets = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
-            subscriptionHiddenBeatmaps = realmFactory.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
+            subscriptionDeletedSets = realm.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
+            subscriptionHiddenBeatmaps = realm.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
         }
 
         private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)
@@ -231,7 +231,7 @@ namespace osu.Game.Screens.Select
                 foreach (var id in realmSets)
                 {
                     if (!root.BeatmapSetsByID.ContainsKey(id))
-                        UpdateBeatmapSet(realmFactory.Context.Find<BeatmapSetInfo>(id).Detach());
+                        UpdateBeatmapSet(realm.Realm.Find<BeatmapSetInfo>(id).Detach());
                 }
 
                 foreach (var id in root.BeatmapSetsByID.Keys)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -191,12 +191,12 @@ namespace osu.Game.Screens.Select
             base.LoadComplete();
 
             subscriptionSets = realm.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
-            subscriptionBeatmaps = realm.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
+            subscriptionBeatmaps = realm.RegisterForNotifications(r => r.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
 
             // Can't use main subscriptions because we can't lookup deleted indices.
             // https://github.com/realm/realm-dotnet/discussions/2634#discussioncomment-1605595.
-            subscriptionDeletedSets = realm.RegisterForNotifications(realm => realm.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
-            subscriptionHiddenBeatmaps = realm.RegisterForNotifications(realm => realm.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
+            subscriptionDeletedSets = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.DeletePending && !s.Protected), deletedBeatmapSetsChanged);
+            subscriptionHiddenBeatmaps = realm.RegisterForNotifications(r => r.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
         }
 
         private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Screens.Select
 
             if (!loadedTestBeatmaps)
             {
-                realm.Run(realm => loadBeatmapSets(getBeatmapSets(realm)));
+                realm.Run(r => loadBeatmapSets(getBeatmapSets(r)));
             }
         }
 

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Select.Carousel
         private IBindable<RulesetInfo> ruleset { get; set; }
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         [Resolved]
         private IAPIProvider api { get; set; }
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Select.Carousel
             ruleset.BindValueChanged(_ =>
             {
                 scoreSubscription?.Dispose();
-                scoreSubscription = realmFactory.RegisterForNotifications(realm =>
+                scoreSubscription = realm.RegisterForNotifications(realm =>
                         realm.All<ScoreInfo>()
                              .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
                                      + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -48,13 +48,13 @@ namespace osu.Game.Screens.Select.Carousel
             ruleset.BindValueChanged(_ =>
             {
                 scoreSubscription?.Dispose();
-                scoreSubscription = realm.RegisterForNotifications(realm =>
-                        realm.All<ScoreInfo>()
-                             .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
-                                     + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"
-                                     + $" && {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $2"
-                                     + $" && {nameof(ScoreInfo.DeletePending)} == false", api.LocalUser.Value.Id, beatmapInfo.ID, ruleset.Value.ShortName)
-                             .OrderByDescending(s => s.TotalScore),
+                scoreSubscription = realm.RegisterForNotifications(r =>
+                        r.All<ScoreInfo>()
+                         .Filter($"{nameof(ScoreInfo.User)}.{nameof(RealmUser.OnlineID)} == $0"
+                                 + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} == $1"
+                                 + $" && {nameof(ScoreInfo.Ruleset)}.{nameof(RulesetInfo.ShortName)} == $2"
+                                 + $" && {nameof(ScoreInfo.DeletePending)} == false", api.LocalUser.Value.Id, beatmapInfo.ID, ruleset.Value.ShortName)
+                         .OrderByDescending(s => s.TotalScore),
                     (items, changes, ___) =>
                     {
                         Rank = items.FirstOrDefault()?.Rank;

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -150,12 +150,12 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (Scope == BeatmapLeaderboardScope.Local)
             {
-                realm.Run(realm =>
+                realm.Run(r =>
                 {
-                    var scores = realm.All<ScoreInfo>()
-                                      .AsEnumerable()
-                                      // TODO: update to use a realm filter directly (or at least figure out the beatmap part to reduce scope).
-                                      .Where(s => !s.DeletePending && s.BeatmapInfo.ID == fetchBeatmapInfo.ID && s.Ruleset.OnlineID == ruleset.Value.ID);
+                    var scores = r.All<ScoreInfo>()
+                                  .AsEnumerable()
+                                  // TODO: update to use a realm filter directly (or at least figure out the beatmap part to reduce scope).
+                                  .Where(s => !s.DeletePending && s.BeatmapInfo.ID == fetchBeatmapInfo.ID && s.Ruleset.OnlineID == ruleset.Value.ID);
 
                     if (filterMods && !mods.Value.Any())
                     {

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Select.Leaderboards
         private RulesetStore rulesets { get; set; }
 
         [Resolved]
-        private RealmContextFactory realmFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         private BeatmapInfo beatmapInfo;
 
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (beatmapInfo == null)
                 return;
 
-            scoreSubscription = realmFactory.RegisterForNotifications(realm =>
+            scoreSubscription = realm.RegisterForNotifications(realm =>
                     realm.All<ScoreInfo>()
                          .Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} = $0", beatmapInfo.ID),
                 (_, changes, ___) =>
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (Scope == BeatmapLeaderboardScope.Local)
             {
-                realmFactory.Run(realm =>
+                realm.Run(realm =>
                 {
                     var scores = realm.All<ScoreInfo>()
                                       .AsEnumerable()

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -113,9 +113,9 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (beatmapInfo == null)
                 return;
 
-            scoreSubscription = realm.RegisterForNotifications(realm =>
-                    realm.All<ScoreInfo>()
-                         .Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} = $0", beatmapInfo.ID),
+            scoreSubscription = realm.RegisterForNotifications(r =>
+                    r.All<ScoreInfo>()
+                     .Filter($"{nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.ID)} = $0", beatmapInfo.ID),
                 (_, changes, ___) =>
                 {
                     if (!IsOnlineScope)

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.Spectate
         }
 
         [Resolved]
-        private RealmContextFactory realmContextFactory { get; set; }
+        private RealmAccess realm { get; set; }
 
         private IDisposable realmSubscription;
 
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Spectate
                 playingUserStates.BindTo(spectatorClient.PlayingUserStates);
                 playingUserStates.BindCollectionChanged(onPlayingUserStatesChanged, true);
 
-                realmSubscription = realmContextFactory.RegisterForNotifications(
+                realmSubscription = realm.RegisterForNotifications(
                     realm => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending), beatmapsChanged);
 
                 foreach ((int id, var _) in userMap)

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -43,8 +43,8 @@ namespace osu.Game.Skinning
 
         protected Skin(SkinInfo skin, IStorageResourceProvider resources, [CanBeNull] Stream configurationStream = null)
         {
-            SkinInfo = resources?.RealmContextFactory != null
-                ? skin.ToLive(resources.RealmContextFactory)
+            SkinInfo = resources?.RealmAccess != null
+                ? skin.ToLive(resources.RealmAccess)
                 // This path should only be used in some tests.
                 : skin.ToLiveUnmanaged();
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -289,10 +289,10 @@ namespace osu.Game.Skinning
 
         public void Delete([CanBeNull] Expression<Func<SkinInfo, bool>> filter = null, bool silent = false)
         {
-            realm.Run(realm =>
+            realm.Run(r =>
             {
-                var items = realm.All<SkinInfo>()
-                                 .Where(s => !s.Protected && !s.DeletePending);
+                var items = r.All<SkinInfo>()
+                             .Where(s => !s.Protected && !s.DeletePending);
                 if (filter != null)
                     items = items.Where(filter);
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -87,12 +87,12 @@ namespace osu.Game.Skinning
             };
 
             // Ensure the default entries are present.
-            realm.Write(realm =>
+            realm.Write(r =>
             {
                 foreach (var skin in defaultSkins)
                 {
-                    if (realm.Find<SkinInfo>(skin.SkinInfo.ID) == null)
-                        realm.Add(skin.SkinInfo.Value);
+                    if (r.Find<SkinInfo>(skin.SkinInfo.ID) == null)
+                        r.Add(skin.SkinInfo.Value);
                 }
             });
 

--- a/osu.Game/Skinning/SkinModelManager.cs
+++ b/osu.Game/Skinning/SkinModelManager.cs
@@ -27,8 +27,8 @@ namespace osu.Game.Skinning
 
         private readonly IStorageResourceProvider skinResources;
 
-        public SkinModelManager(Storage storage, RealmContextFactory contextFactory, GameHost host, IStorageResourceProvider skinResources)
-            : base(storage, contextFactory)
+        public SkinModelManager(Storage storage, RealmAccess realm, GameHost host, IStorageResourceProvider skinResources)
+            : base(storage, realm)
         {
             this.skinResources = skinResources;
 
@@ -205,7 +205,7 @@ namespace osu.Game.Skinning
 
         private void populateMissingHashes()
         {
-            ContextFactory.Run(realm =>
+            Access.Run(realm =>
             {
                 var skinsWithoutHashes = realm.All<SkinInfo>().Where(i => !i.Protected && string.IsNullOrEmpty(i.Hash)).ToArray();
 

--- a/osu.Game/Skinning/SkinModelManager.cs
+++ b/osu.Game/Skinning/SkinModelManager.cs
@@ -205,7 +205,7 @@ namespace osu.Game.Skinning
 
         private void populateMissingHashes()
         {
-            Access.Run(realm =>
+            Realm.Run(realm =>
             {
                 var skinsWithoutHashes = realm.All<SkinInfo>().Where(i => !i.Protected && string.IsNullOrEmpty(i.Hash)).ToArray();
 

--- a/osu.Game/Stores/BeatmapImporter.cs
+++ b/osu.Game/Stores/BeatmapImporter.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Stores
 
         public override bool IsAvailableLocally(BeatmapSetInfo model)
         {
-            return Access.Run(realm => realm.All<BeatmapInfo>().Any(b => b.OnlineID == model.OnlineID));
+            return Realm.Run(realm => realm.All<BeatmapInfo>().Any(b => b.OnlineID == model.OnlineID));
         }
 
         public override string HumanisedModelName => "beatmap";

--- a/osu.Game/Stores/BeatmapImporter.cs
+++ b/osu.Game/Stores/BeatmapImporter.cs
@@ -44,8 +44,8 @@ namespace osu.Game.Stores
 
         private readonly BeatmapOnlineLookupQueue? onlineLookupQueue;
 
-        protected BeatmapImporter(RealmContextFactory contextFactory, Storage storage, BeatmapOnlineLookupQueue? onlineLookupQueue = null)
-            : base(storage, contextFactory)
+        protected BeatmapImporter(RealmAccess realm, Storage storage, BeatmapOnlineLookupQueue? onlineLookupQueue = null)
+            : base(storage, realm)
         {
             this.onlineLookupQueue = onlineLookupQueue;
         }
@@ -165,7 +165,7 @@ namespace osu.Game.Stores
 
         public override bool IsAvailableLocally(BeatmapSetInfo model)
         {
-            return ContextFactory.Run(realm => realm.All<BeatmapInfo>().Any(b => b.OnlineID == model.OnlineID));
+            return Access.Run(realm => realm.All<BeatmapInfo>().Any(b => b.OnlineID == model.OnlineID));
         }
 
         public override string HumanisedModelName => "beatmap";

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Stores
 
         protected readonly RealmFileStore Files;
 
-        protected readonly RealmContextFactory ContextFactory;
+        protected readonly RealmAccess Access;
 
         /// <summary>
         /// Fired when the user requests to view the resulting import.
@@ -71,11 +71,11 @@ namespace osu.Game.Stores
         /// </summary>
         public Action<Notification>? PostNotification { protected get; set; }
 
-        protected RealmArchiveModelImporter(Storage storage, RealmContextFactory contextFactory)
+        protected RealmArchiveModelImporter(Storage storage, RealmAccess realm)
         {
-            ContextFactory = contextFactory;
+            Access = realm;
 
-            Files = new RealmFileStore(contextFactory, storage);
+            Files = new RealmFileStore(realm, storage);
         }
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace osu.Game.Stores
         /// <param name="cancellationToken">An optional cancellation token.</param>
         public virtual Task<ILive<TModel>?> Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
-            return ContextFactory.Run(realm =>
+            return Access.Run(realm =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -352,7 +352,7 @@ namespace osu.Game.Stores
                                 transaction.Commit();
                             }
 
-                            return Task.FromResult((ILive<TModel>?)existing.ToLive(ContextFactory));
+                            return Task.FromResult((ILive<TModel>?)existing.ToLive(Access));
                         }
 
                         LogForModel(item, @"Found existing (optimised) but failed pre-check.");
@@ -387,7 +387,7 @@ namespace osu.Game.Stores
                                 existing.DeletePending = false;
                                 transaction.Commit();
 
-                                return Task.FromResult((ILive<TModel>?)existing.ToLive(ContextFactory));
+                                return Task.FromResult((ILive<TModel>?)existing.ToLive(Access));
                             }
 
                             LogForModel(item, @"Found existing but failed re-use check.");
@@ -413,7 +413,7 @@ namespace osu.Game.Stores
                     throw;
                 }
 
-                return Task.FromResult((ILive<TModel>?)item.ToLive(ContextFactory));
+                return Task.FromResult((ILive<TModel>?)item.ToLive(Access));
             });
         }
 

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Stores
 
         protected readonly RealmFileStore Files;
 
-        protected readonly RealmAccess Access;
+        protected readonly RealmAccess Realm;
 
         /// <summary>
         /// Fired when the user requests to view the resulting import.
@@ -73,7 +73,7 @@ namespace osu.Game.Stores
 
         protected RealmArchiveModelImporter(Storage storage, RealmAccess realm)
         {
-            Access = realm;
+            Realm = realm;
 
             Files = new RealmFileStore(realm, storage);
         }
@@ -320,7 +320,7 @@ namespace osu.Game.Stores
         /// <param name="cancellationToken">An optional cancellation token.</param>
         public virtual Task<ILive<TModel>?> Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
-            return Access.Run(realm =>
+            return Realm.Run(realm =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -352,7 +352,7 @@ namespace osu.Game.Stores
                                 transaction.Commit();
                             }
 
-                            return Task.FromResult((ILive<TModel>?)existing.ToLive(Access));
+                            return Task.FromResult((ILive<TModel>?)existing.ToLive(Realm));
                         }
 
                         LogForModel(item, @"Found existing (optimised) but failed pre-check.");
@@ -387,7 +387,7 @@ namespace osu.Game.Stores
                                 existing.DeletePending = false;
                                 transaction.Commit();
 
-                                return Task.FromResult((ILive<TModel>?)existing.ToLive(Access));
+                                return Task.FromResult((ILive<TModel>?)existing.ToLive(Realm));
                             }
 
                             LogForModel(item, @"Found existing but failed re-use check.");
@@ -413,7 +413,7 @@ namespace osu.Game.Stores
                     throw;
                 }
 
-                return Task.FromResult((ILive<TModel>?)item.ToLive(Access));
+                return Task.FromResult((ILive<TModel>?)item.ToLive(Realm));
             });
         }
 

--- a/osu.Game/Stores/RealmArchiveModelManager.cs
+++ b/osu.Game/Stores/RealmArchiveModelManager.cs
@@ -24,10 +24,10 @@ namespace osu.Game.Stores
     {
         private readonly RealmFileStore realmFileStore;
 
-        protected RealmArchiveModelManager(Storage storage, RealmContextFactory contextFactory)
-            : base(storage, contextFactory)
+        protected RealmArchiveModelManager(Storage storage, RealmAccess realm)
+            : base(storage, realm)
         {
-            realmFileStore = new RealmFileStore(contextFactory, storage);
+            realmFileStore = new RealmFileStore(realm, storage);
         }
 
         public void DeleteFile(TModel item, RealmNamedFileUsage file) =>
@@ -45,7 +45,7 @@ namespace osu.Game.Stores
             // This method should be removed as soon as all the surrounding pieces support non-detached operations.
             if (!item.IsManaged)
             {
-                var managed = ContextFactory.Context.Find<TModel>(item.ID);
+                var managed = Access.Context.Find<TModel>(item.ID);
                 managed.Realm.Write(() => operation(managed));
 
                 item.Files.Clear();
@@ -165,7 +165,7 @@ namespace osu.Game.Stores
 
         public bool Delete(TModel item)
         {
-            return ContextFactory.Run(realm =>
+            return Access.Run(realm =>
             {
                 if (!item.IsManaged)
                     item = realm.Find<TModel>(item.ID);
@@ -180,7 +180,7 @@ namespace osu.Game.Stores
 
         public void Undelete(TModel item)
         {
-            ContextFactory.Run(realm =>
+            Access.Run(realm =>
             {
                 if (!item.IsManaged)
                     item = realm.Find<TModel>(item.ID);

--- a/osu.Game/Stores/RealmArchiveModelManager.cs
+++ b/osu.Game/Stores/RealmArchiveModelManager.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Stores
             // This method should be removed as soon as all the surrounding pieces support non-detached operations.
             if (!item.IsManaged)
             {
-                var managed = Access.Realm.Find<TModel>(item.ID);
+                var managed = Realm.Realm.Find<TModel>(item.ID);
                 managed.Realm.Write(() => operation(managed));
 
                 item.Files.Clear();
@@ -165,7 +165,7 @@ namespace osu.Game.Stores
 
         public bool Delete(TModel item)
         {
-            return Access.Run(realm =>
+            return Realm.Run(realm =>
             {
                 if (!item.IsManaged)
                     item = realm.Find<TModel>(item.ID);
@@ -180,7 +180,7 @@ namespace osu.Game.Stores
 
         public void Undelete(TModel item)
         {
-            Access.Run(realm =>
+            Realm.Run(realm =>
             {
                 if (!item.IsManaged)
                     item = realm.Find<TModel>(item.ID);

--- a/osu.Game/Stores/RealmArchiveModelManager.cs
+++ b/osu.Game/Stores/RealmArchiveModelManager.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Stores
             // This method should be removed as soon as all the surrounding pieces support non-detached operations.
             if (!item.IsManaged)
             {
-                var managed = Access.Context.Find<TModel>(item.ID);
+                var managed = Access.Realm.Find<TModel>(item.ID);
                 managed.Realm.Write(() => operation(managed));
 
                 item.Files.Clear();

--- a/osu.Game/Stores/RealmFileStore.cs
+++ b/osu.Game/Stores/RealmFileStore.cs
@@ -92,10 +92,10 @@ namespace osu.Game.Stores
             int removedFiles = 0;
 
             // can potentially be run asynchronously, although we will need to consider operation order for disk deletion vs realm removal.
-            realm.Write(realm =>
+            realm.Write(r =>
             {
                 // TODO: consider using a realm native query to avoid iterating all files (https://github.com/realm/realm-dotnet/issues/2659#issuecomment-927823707)
-                var files = realm.All<RealmFile>().ToList();
+                var files = r.All<RealmFile>().ToList();
 
                 foreach (var file in files)
                 {
@@ -108,7 +108,7 @@ namespace osu.Game.Stores
                     {
                         removedFiles++;
                         Storage.Delete(file.GetStoragePath());
-                        realm.Remove(file);
+                        r.Remove(file);
                     }
                     catch (Exception e)
                     {

--- a/osu.Game/Stores/RealmFileStore.cs
+++ b/osu.Game/Stores/RealmFileStore.cs
@@ -24,15 +24,15 @@ namespace osu.Game.Stores
     [ExcludeFromDynamicCompile]
     public class RealmFileStore
     {
-        private readonly RealmContextFactory realmFactory;
+        private readonly RealmAccess realm;
 
         public readonly IResourceStore<byte[]> Store;
 
         public readonly Storage Storage;
 
-        public RealmFileStore(RealmContextFactory realmFactory, Storage storage)
+        public RealmFileStore(RealmAccess realm, Storage storage)
         {
-            this.realmFactory = realmFactory;
+            this.realm = realm;
 
             Storage = storage.GetStorageForDirectory(@"files");
             Store = new StorageBackedResourceStore(Storage);
@@ -92,7 +92,7 @@ namespace osu.Game.Stores
             int removedFiles = 0;
 
             // can potentially be run asynchronously, although we will need to consider operation order for disk deletion vs realm removal.
-            realmFactory.Write(realm =>
+            realm.Write(realm =>
             {
                 // TODO: consider using a realm native query to avoid iterating all files (https://github.com/realm/realm-dotnet/issues/2659#issuecomment-927823707)
                 var files = realm.All<RealmFile>().ToList();

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -77,12 +77,12 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(GameplayClock clock, CancellationToken? cancellationToken, GameHost host, RealmContextFactory realmContextFactory)
+        private void load(GameplayClock clock, CancellationToken? cancellationToken, GameHost host, RealmAccess realm)
         {
             if (clock != null)
                 Clock = clock;
 
-            dependencies.Cache(new TextureStore(host.CreateTextureLoaderStore(new RealmFileStore(realmContextFactory, host.Storage).Store), false, scaleAdjust: 1));
+            dependencies.Cache(new TextureStore(host.CreateTextureLoaderStore(new RealmFileStore(realm, host.Storage).Store), false, scaleAdjust: 1));
 
             foreach (var layer in Storyboard.Layers)
             {

--- a/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
+++ b/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Beatmaps
         public IResourceStore<byte[]> Files => userSkinResourceStore;
         public new IResourceStore<byte[]> Resources => base.Resources;
         public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => null;
-        RealmContextFactory IStorageResourceProvider.RealmContextFactory => null;
+        RealmAccess IStorageResourceProvider.RealmAccess => null;
 
         #endregion
 

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual
             working = CreateWorkingBeatmap(Ruleset.Value);
 
             if (IsolateSavingFromDatabase)
-                Dependencies.CacheAs<BeatmapManager>(testBeatmapManager = new TestBeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, Resources, host, Beatmap.Default));
+                Dependencies.CacheAs<BeatmapManager>(testBeatmapManager = new TestBeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
         }
 
         protected override void LoadComplete()
@@ -126,14 +126,14 @@ namespace osu.Game.Tests.Visual
         {
             public WorkingBeatmap TestBeatmap;
 
-            public TestBeatmapManager(Storage storage, RealmContextFactory contextFactory, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host, WorkingBeatmap defaultBeatmap)
-                : base(storage, contextFactory, rulesets, api, audioManager, resources, host, defaultBeatmap)
+            public TestBeatmapManager(Storage storage, RealmAccess realm, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host, WorkingBeatmap defaultBeatmap)
+                : base(storage, realm, rulesets, api, audioManager, resources, host, defaultBeatmap)
             {
             }
 
-            protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmContextFactory contextFactory, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
+            protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
             {
-                return new TestBeatmapModelManager(storage, contextFactory, rulesets, onlineLookupQueue);
+                return new TestBeatmapModelManager(storage, realm, rulesets, onlineLookupQueue);
             }
 
             protected override WorkingBeatmapCache CreateWorkingBeatmapCache(AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> storage, WorkingBeatmap defaultBeatmap, GameHost host)
@@ -157,8 +157,8 @@ namespace osu.Game.Tests.Visual
 
             internal class TestBeatmapModelManager : BeatmapModelManager
             {
-                public TestBeatmapModelManager(Storage storage, RealmContextFactory databaseContextFactory, RulesetStore rulesetStore, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
-                    : base(databaseContextFactory, storage, beatmapOnlineLookupQueue)
+                public TestBeatmapModelManager(Storage storage, RealmAccess databaseAccess, RulesetStore rulesetStore, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
+                    : base(databaseAccess, storage, beatmapOnlineLookupQueue)
                 {
                 }
 

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual
             working = CreateWorkingBeatmap(Ruleset.Value);
 
             if (IsolateSavingFromDatabase)
-                Dependencies.CacheAs<BeatmapManager>(testBeatmapManager = new TestBeatmapManager(LocalStorage, Access, rulesets, null, audio, Resources, host, Beatmap.Default));
+                Dependencies.CacheAs<BeatmapManager>(testBeatmapManager = new TestBeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -75,9 +75,9 @@ namespace osu.Game.Tests.Visual
         /// <remarks>
         /// In interactive runs (ie. VisualTests) this will use the user's database if <see cref="UseFreshStoragePerRun"/> is not set to <c>true</c>.
         /// </remarks>
-        protected RealmAccess Access => contextFactory.Value;
+        protected RealmAccess Realm => realm.Value;
 
-        private Lazy<RealmAccess> contextFactory;
+        private Lazy<RealmAccess> realm;
 
         /// <summary>
         /// Whether a fresh storage should be initialised per test (method) run.
@@ -119,7 +119,7 @@ namespace osu.Game.Tests.Visual
 
             Resources = parent.Get<OsuGameBase>().Resources;
 
-            contextFactory = new Lazy<RealmAccess>(() => new RealmAccess(LocalStorage, "client"));
+            realm = new Lazy<RealmAccess>(() => new RealmAccess(LocalStorage, "client"));
 
             RecycleLocalStorage(false);
 

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -75,9 +75,9 @@ namespace osu.Game.Tests.Visual
         /// <remarks>
         /// In interactive runs (ie. VisualTests) this will use the user's database if <see cref="UseFreshStoragePerRun"/> is not set to <c>true</c>.
         /// </remarks>
-        protected RealmContextFactory ContextFactory => contextFactory.Value;
+        protected RealmAccess Access => contextFactory.Value;
 
-        private Lazy<RealmContextFactory> contextFactory;
+        private Lazy<RealmAccess> contextFactory;
 
         /// <summary>
         /// Whether a fresh storage should be initialised per test (method) run.
@@ -119,7 +119,7 @@ namespace osu.Game.Tests.Visual
 
             Resources = parent.Get<OsuGameBase>().Resources;
 
-            contextFactory = new Lazy<RealmContextFactory>(() => new RealmContextFactory(LocalStorage, "client"));
+            contextFactory = new Lazy<RealmAccess>(() => new RealmAccess(LocalStorage, "client"));
 
             RecycleLocalStorage(false);
 

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Tests.Visual
         public IResourceStore<byte[]> Files => null;
         public new IResourceStore<byte[]> Resources => base.Resources;
         public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => host.CreateTextureLoaderStore(underlyingStore);
-        RealmContextFactory IStorageResourceProvider.RealmContextFactory => null;
+        RealmAccess IStorageResourceProvider.RealmAccess => null;
 
         #endregion
 


### PR DESCRIPTION
`RealmContextFactory` -> `RealmAccess`
`realmFactory` -> `realm`
`realmContextFactory` -> `realm`

Also most usage of `context` is replaced with `instance`.