### PR TITLE
Fix a failed `BlockAllOperations` leaving update realm in unretrieved state

### DIFF
--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -95,6 +95,11 @@ namespace osu.Game.Tests.Database
                 });
 
                 stopThreadedUsage.Set();
+
+                // Ensure we can block a second time after the usage has ended.
+                using (realm.BlockAllOperations())
+                {
+                }
             });
         }
     }

--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -87,6 +87,11 @@ namespace osu.Game.Tests.Database
 
                 hasThreadedUsage.Wait();
 
+                // Usually the host would run the synchronization context work per frame.
+                // For the sake of keeping this test simple (there's only one update invocation),
+                // let's replace it so we can ensure work is run immediately.
+                SynchronizationContext.SetSynchronizationContext(new ImmediateExecuteSynchronizationContext());
+
                 Assert.Throws<TimeoutException>(() =>
                 {
                     using (realm.BlockAllOperations())
@@ -101,6 +106,11 @@ namespace osu.Game.Tests.Database
                 {
                 }
             });
+        }
+
+        private class ImmediateExecuteSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object? state) => d(state);
         }
     }
 }


### PR DESCRIPTION
If the operation timed out on..

```csharp
throw new TimeoutException(@"Took too long to acquire lock");
```

..from an update thread, it would not restore the update context.

The next call would then fail on the assert that ensures a non-null context
in such cases.

Can add test coverage if required.

- [x] Depends on #16593 for conflict avoidance.