### PR TITLE
Update framework

### DIFF
--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/VisualTestRunner.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/VisualTestRunner.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.EmptyFreeform.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/VisualTestRunner.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/VisualTestRunner.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Pippidon.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/VisualTestRunner.cs
+++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/VisualTestRunner.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.EmptyScrolling.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/VisualTestRunner.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/VisualTestRunner.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Pippidon.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.115.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.118.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.125.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -55,7 +55,7 @@ namespace osu.Desktop
                 }
             }
 
-            using (DesktopGameHost host = Host.GetSuitableHost(gameName, true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(gameName, new HostOptions { PortableInstallation = true }))
             {
                 host.ExceptionThrown += handleException;
 

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -55,7 +55,7 @@ namespace osu.Desktop
                 }
             }
 
-            using (DesktopGameHost host = Host.GetSuitableDesktopHost(gameName, new HostOptions { PortableInstallation = true }))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(gameName, new HostOptions { BindIPC = true }))
             {
                 host.ExceptionThrown += handleException;
 

--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -155,7 +156,7 @@ namespace osu.Game.Tests.Collections.IO
             }
 
             // Name matches the automatically chosen name from `CleanRunHeadlessGameHost` above, so we end up using the same storage location.
-            using (HeadlessGameHost host = new TestRunHeadlessGameHost(firstRunName))
+            using (HeadlessGameHost host = new TestRunHeadlessGameHost(firstRunName, null))
             {
                 try
                 {

--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;

--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -4,7 +4,6 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;

--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -37,7 +38,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
         [Test]
         public void TestCustomDirectory()
         {
-            using (HeadlessGameHost host = new TestRunHeadlessGameHost(nameof(TestCustomDirectory))) // don't use clean run as we are writing a config file.
+            using (HeadlessGameHost host = new TestRunHeadlessGameHost(nameof(TestCustomDirectory), null)) // don't use clean run as we are writing a config file.
             {
                 string osuDesktopStorage = Path.Combine(host.UserStoragePaths.First(), nameof(TestCustomDirectory));
                 const string custom_tournament = "custom";
@@ -68,7 +69,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
         [Test]
         public void TestMigration()
         {
-            using (HeadlessGameHost host = new TestRunHeadlessGameHost(nameof(TestMigration))) // don't use clean run as we are writing test files for migration.
+            using (HeadlessGameHost host = new TestRunHeadlessGameHost(nameof(TestMigration), null)) // don't use clean run as we are writing test files for migration.
             {
                 string osuRoot = Path.Combine(host.UserStoragePaths.First(), nameof(TestMigration));
                 string configFile = Path.Combine(osuRoot, "tournament.ini");

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -4,7 +4,6 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -19,7 +20,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
         public void CheckIPCLocation()
         {
             // don't use clean run because files are being written before osu! launches.
-            using (var host = new TestRunHeadlessGameHost(nameof(CheckIPCLocation)))
+            using (var host = new TestRunHeadlessGameHost(nameof(CheckIPCLocation), null))
             {
                 string basePath = Path.Combine(host.UserStoragePaths.First(), nameof(CheckIPCLocation));
 

--- a/osu.Game.Tournament.Tests/TournamentTestRunner.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestRunner.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tournament.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { PortableInstallation = true }))
             {
                 host.Run(new TournamentTestBrowser());
                 return 0;

--- a/osu.Game.Tournament.Tests/TournamentTestRunner.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestRunner.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tournament.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { PortableInstallation = true }))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
             {
                 host.Run(new TournamentTestBrowser());
                 return 0;

--- a/osu.Game/Tests/CleanRunHeadlessGameHost.cs
+++ b/osu.Game/Tests/CleanRunHeadlessGameHost.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using osu.Framework;
 using osu.Framework.Testing;
 
 namespace osu.Game.Tests
@@ -20,7 +21,10 @@ namespace osu.Game.Tests
         /// <param name="bypassCleanup">Whether to bypass directory cleanup on host disposal. Should be used only if a subsequent test relies on the files still existing.</param>
         /// <param name="callingMethodName">The name of the calling method, used for test file isolation and clean-up.</param>
         public CleanRunHeadlessGameHost(bool bindIPC = false, bool realtime = true, bool bypassCleanup = false, [CallerMemberName] string callingMethodName = @"")
-            : base($"{callingMethodName}-{Guid.NewGuid()}", bindIPC, realtime, bypassCleanup: bypassCleanup)
+            : base($"{callingMethodName}-{Guid.NewGuid()}", new HostOptions
+            {
+                BindIPC = bindIPC,
+            }, bypassCleanup: bypassCleanup, realtime: realtime)
         {
         }
 

--- a/osu.Game/Tests/VisualTestRunner.cs
+++ b/osu.Game/Tests/VisualTestRunner.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { PortableInstallation = true, }))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true, }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/osu.Game/Tests/VisualTestRunner.cs
+++ b/osu.Game/Tests/VisualTestRunner.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { PortableInstallation = true, }))
             {
                 host.Run(new OsuTestBrowser());
                 return 0;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.8.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.118.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.125.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.115.0" />
     <PackageReference Include="Sentry" Version="3.13.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -60,7 +60,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.118.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.125.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.115.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -83,7 +83,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.118.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.125.0" />
     <PackageReference Include="SharpCompress" Version="0.30.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Note that I've intentionally used `null` for `HostOptions` when there's no non-default options, as this will show the parameter as redundant once the obsoleted version is removed. Currently it's required to disambiguify.