### PR TITLE
Fix some realm-related test failures

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -50,7 +50,10 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("close settings", () => Game.Settings.Hide());
 
             AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+
             PushAndConfirm(() => new PlaySongSelect());
+
+            AddUntilStep("wait for selection", () => !Game.Beatmap.IsDefault);
 
             AddStep("enter gameplay", () => InputManager.Key(Key.Enter));
 

--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -57,6 +57,13 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddStep("enter gameplay", () => InputManager.Key(Key.Enter));
 
+            AddUntilStep("wait for player", () =>
+            {
+                // dismiss any notifications that may appear (ie. muted notification).
+                clickMouseInCentre();
+                return player != null;
+            });
+
             AddUntilStep("wait for gameplay", () => player?.IsBreakTime.Value == false);
 
             AddStep("press 'z'", () => InputManager.Key(Key.Z));
@@ -64,6 +71,12 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddStep("press 's'", () => InputManager.Key(Key.S));
             AddAssert("key counter did increase", () => keyCounter.CountPresses == 1);
+        }
+
+        private void clickMouseInCentre()
+        {
+            InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre);
+            InputManager.Click(MouseButton.Left);
         }
 
         private KeyBindingsSubsection osuBindingSubsection => keyBindingPanel

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -64,13 +64,13 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             base.SetUpSteps();
 
-            AddStep("delete all beatmaps", () =>
+            AddStep("reset defaults", () =>
             {
                 Ruleset.Value = new OsuRuleset().RulesetInfo;
-                manager?.Delete(manager.GetAllUsableBeatmapSets());
-
                 Beatmap.SetDefault();
             });
+
+            AddStep("delete all beatmaps", () => manager?.Delete());
         }
 
         [Test]


### PR DESCRIPTION
I think there are still some which we'll come across, but I want to watch over some more CI runs before committing to any fixes. I'd also like to get https://github.com/ppy/osu-framework/pull/5002 in, because there's a chance that will restore "expected" behaviour in tests which were doing update-bound imports and expecting events to fire on the same frame.