### PR TITLE
Fix beat divisor no longer saving in editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.ControlPoints;
@@ -40,6 +41,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("Enter compose mode", () => InputManager.Key(Key.F1));
             AddUntilStep("Wait for compose mode load", () => editor.ChildrenOfType<HitObjectComposer>().FirstOrDefault()?.IsLoaded == true);
 
+            AddStep("Set beat divisor", () => editor.Dependencies.Get<BindableBeatDivisor>().Value = 16);
             AddStep("Set overall difficulty", () => editorBeatmap.Difficulty.OverallDifficulty = 7);
             AddStep("Set artist and title", () =>
             {
@@ -88,6 +90,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void checkMutations()
         {
             AddAssert("Beatmap contains single hitcircle", () => editorBeatmap.HitObjects.Count == 1);
+            AddAssert("Beatmap has correct beat divisor", () => editorBeatmap.BeatmapInfo.BeatDivisor == 16);
             AddAssert("Beatmap has correct overall difficulty", () => editorBeatmap.Difficulty.OverallDifficulty == 7);
             AddAssert("Beatmap has correct metadata", () => editorBeatmap.BeatmapInfo.Metadata.Artist == "artist" && editorBeatmap.BeatmapInfo.Metadata.Title == "title");
             AddAssert("Beatmap has correct author", () => editorBeatmap.BeatmapInfo.Metadata.Author.Username == "author");

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -158,9 +158,6 @@ namespace osu.Game.Screens.Edit
                 return;
             }
 
-            beatDivisor.Value = playableBeatmap.BeatmapInfo.BeatDivisor;
-            beatDivisor.BindValueChanged(divisor => playableBeatmap.BeatmapInfo.BeatDivisor = divisor.NewValue);
-
             // Todo: should probably be done at a DrawableRuleset level to share logic with Player.
             clock = new EditorClock(playableBeatmap, beatDivisor) { IsCoupled = false };
             clock.ChangeSource(loadableBeatmap.Track);
@@ -177,6 +174,9 @@ namespace osu.Game.Screens.Edit
             dependencies.CacheAs(editorBeatmap);
             changeHandler = new EditorChangeHandler(editorBeatmap);
             dependencies.CacheAs<IEditorChangeHandler>(changeHandler);
+
+            beatDivisor.Value = editorBeatmap.BeatmapInfo.BeatDivisor;
+            beatDivisor.BindValueChanged(divisor => editorBeatmap.BeatmapInfo.BeatDivisor = divisor.NewValue);
 
             updateLastSavedHash();
 


### PR DESCRIPTION
- [x] Depends on #16611 (for test fixes)

Turns out the way beat divisor bindable updates the beatmap is completely wrong, as it updates `EditorBeatmap.PlayableBeatmap.BeatmapInfo`, which is not what the editor uses on save:

https://github.com/ppy/osu/blob/939381d83f9d90c7325a356c98eb0ec013096a0f/osu.Game/Screens/Edit/Editor.cs#L354-L363

In fact, `BeatmapManager` already sets `PlayableBeatmap.BeatmapInfo` to `EditorBeatmap.BeatmapInfo` prior to encoding, so changes to `EditorBeatmap.BeatmapInfo` will also be encoded properly:

https://github.com/ppy/osu/blob/3e5c9e843606647561eb35541459386ecf54da20/osu.Game/Beatmaps/BeatmapModelManager.cs#L63-L64