### PR TITLE
Recreate working beatmap per-test in `EditorTestScene`

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit;
+using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps.IO;
 
 namespace osu.Game.Tests.Visual.Editing
@@ -37,11 +38,8 @@ namespace osu.Game.Tests.Visual.Editing
             base.SetUpSteps();
         }
 
-        protected override void LoadEditor()
-        {
-            Beatmap.Value = beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First());
-            base.LoadEditor();
-        }
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+            => beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First());
 
         [Test]
         public void TestBasicSwitch()

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
+using osu.Game.Storyboards;
 using osu.Game.Tests.Resources;
 using SharpCompress.Archives;
 using SharpCompress.Archives.Zip;
@@ -39,11 +40,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("make new beatmap unique", () => EditorBeatmap.Metadata.Title = Guid.NewGuid().ToString());
         }
 
-        protected override void LoadEditor()
-        {
-            Beatmap.Value = new DummyWorkingBeatmap(Audio, null);
-            base.LoadEditor();
-        }
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null) => new DummyWorkingBeatmap(Audio, null);
 
         [Test]
         public void TestCreateNewBeatmap()

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -17,6 +17,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Screens.Play;
+using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps.IO;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -43,9 +44,11 @@ namespace osu.Game.Tests.Visual.Editing
             base.SetUpSteps();
         }
 
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+            => beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First(b => b.RulesetID == 0));
+
         protected override void LoadEditor()
         {
-            Beatmap.Value = beatmaps.GetWorkingBeatmap(importedBeatmapSet.Beatmaps.First(b => b.RulesetID == 0));
             SelectedMods.Value = new[] { new ModCinema() };
             base.LoadEditor();
         }

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -43,26 +43,14 @@ namespace osu.Game.Tests.Visual
         };
 
         private TestBeatmapManager testBeatmapManager;
-        private WorkingBeatmap working;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio, RulesetStore rulesets)
         {
             Add(logo);
 
-            working = CreateWorkingBeatmap(Ruleset.Value);
-
             if (IsolateSavingFromDatabase)
                 Dependencies.CacheAs<BeatmapManager>(testBeatmapManager = new TestBeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            Beatmap.Value = working;
-            if (testBeatmapManager != null)
-                testBeatmapManager.TestBeatmap = working;
         }
 
         protected virtual bool EditorComponentsReady => Editor.ChildrenOfType<HitObjectComposer>().FirstOrDefault()?.IsLoaded == true
@@ -78,6 +66,11 @@ namespace osu.Game.Tests.Visual
 
         protected virtual void LoadEditor()
         {
+            Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
+
+            if (testBeatmapManager != null)
+                testBeatmapManager.TestBeatmap = Beatmap.Value;
+
             LoadScreen(editorLoader = new TestEditorLoader());
         }
 


### PR DESCRIPTION
Resolves [test failures](https://github.com/ppy/osu/runs/4934634311?check_suite_focus=true) indirectly caused by #16610.

This was happening due to `EditorTestScene` not refreshing the working beatmap on `SetUp`, which caused pollution in other test cases (the test mentioned above did not fail prior to #16610 due to `BindableBeatDivisor` updating `EditorBeatmap.PlayableBeatmap`, which is an isolated copy per `Editor` instance, unlike `EditorBeatmap.BeatmapInfo` which is a direct reference to `Beatmap.Value.BeatmapInfo`).