### PR TITLE
Decrease default timeline zoom and add saving support

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -47,25 +47,25 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects = new[]
             {
-                new HitCircle { StartTime = 100 },
-                new HitCircle { StartTime = 200, Position = new Vector2(100) },
-                new HitCircle { StartTime = 300, Position = new Vector2(200) },
-                new HitCircle { StartTime = 400, Position = new Vector2(300) },
+                new HitCircle { StartTime = 500 },
+                new HitCircle { StartTime = 1000, Position = new Vector2(100) },
+                new HitCircle { StartTime = 1500, Position = new Vector2(200) },
+                new HitCircle { StartTime = 2000, Position = new Vector2(300) },
             }));
 
             AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.AddRange(addedObjects));
 
             AddStep("nudge forwards", () => InputManager.Key(Key.K));
-            AddAssert("objects moved forwards in time", () => addedObjects[0].StartTime > 100);
+            AddAssert("objects moved forwards in time", () => addedObjects[0].StartTime > 500);
 
             AddStep("nudge backwards", () => InputManager.Key(Key.J));
-            AddAssert("objects reverted to original position", () => addedObjects[0].StartTime == 100);
+            AddAssert("objects reverted to original position", () => addedObjects[0].StartTime == 500);
         }
 
         [Test]
         public void TestBasicSelect()
         {
-            var addedObject = new HitCircle { StartTime = 100 };
+            var addedObject = new HitCircle { StartTime = 500 };
             AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
 
             moveMouseToObject(() => addedObject);
@@ -75,7 +75,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             var addedObject2 = new HitCircle
             {
-                StartTime = 200,
+                StartTime = 1000,
                 Position = new Vector2(100),
             };
 
@@ -92,10 +92,10 @@ namespace osu.Game.Tests.Visual.Editing
         {
             var addedObjects = new[]
             {
-                new HitCircle { StartTime = 100 },
-                new HitCircle { StartTime = 200, Position = new Vector2(100) },
-                new HitCircle { StartTime = 300, Position = new Vector2(200) },
-                new HitCircle { StartTime = 400, Position = new Vector2(300) },
+                new HitCircle { StartTime = 500 },
+                new HitCircle { StartTime = 1000, Position = new Vector2(100) },
+                new HitCircle { StartTime = 1500, Position = new Vector2(200) },
+                new HitCircle { StartTime = 2000, Position = new Vector2(300) },
             };
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
@@ -125,7 +125,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestBasicDeselect()
         {
-            var addedObject = new HitCircle { StartTime = 100 };
+            var addedObject = new HitCircle { StartTime = 500 };
             AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
 
             moveMouseToObject(() => addedObject);
@@ -166,11 +166,11 @@ namespace osu.Game.Tests.Visual.Editing
         {
             var addedObjects = new[]
             {
-                new HitCircle { StartTime = 100 },
-                new HitCircle { StartTime = 200, Position = new Vector2(100) },
-                new HitCircle { StartTime = 300, Position = new Vector2(200) },
-                new HitCircle { StartTime = 400, Position = new Vector2(300) },
-                new HitCircle { StartTime = 500, Position = new Vector2(400) },
+                new HitCircle { StartTime = 500 },
+                new HitCircle { StartTime = 1000, Position = new Vector2(100) },
+                new HitCircle { StartTime = 1500, Position = new Vector2(200) },
+                new HitCircle { StartTime = 2000, Position = new Vector2(300) },
+                new HitCircle { StartTime = 2500, Position = new Vector2(400) },
             };
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
@@ -236,10 +236,10 @@ namespace osu.Game.Tests.Visual.Editing
         {
             var addedObjects = new[]
             {
-                new HitCircle { StartTime = 100 },
-                new HitCircle { StartTime = 200, Position = new Vector2(100) },
-                new HitCircle { StartTime = 300, Position = new Vector2(200) },
-                new HitCircle { StartTime = 400, Position = new Vector2(300) },
+                new HitCircle { StartTime = 500 },
+                new HitCircle { StartTime = 1000, Position = new Vector2(100) },
+                new HitCircle { StartTime = 1500, Position = new Vector2(200) },
+                new HitCircle { StartTime = 2000, Position = new Vector2(300) },
             };
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -216,9 +216,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             return base.OnScroll(e);
         }
 
-        protected override void OnZoomChange()
+        protected override void OnZoomChanged()
         {
-            base.OnZoomChange();
+            base.OnZoomChanged();
             timelineZoomScale.Value = Zoom / defaultTimelineZoom;
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -24,7 +24,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     [Cached]
     public class Timeline : ZoomableScrollContainer, IPositionSnapProvider
     {
+        private const float timeline_height = 72;
+        private const float timeline_expanded_height = 94;
+
         private readonly Drawable userContent;
+
         public readonly Bindable<bool> WaveformVisible = new Bindable<bool>();
 
         public readonly Bindable<bool> ControlPointsVisible = new Bindable<bool>();
@@ -58,8 +62,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private Track track;
 
-        private const float timeline_height = 72;
-        private const float timeline_expanded_height = 94;
+        /// <summary>
+        /// The timeline zoom level at a 1x zoom scale.
+        /// </summary>
+        private float defaultTimelineZoom;
+
+        private readonly Bindable<double> timelineZoomScale = new BindableDouble(1.0);
 
         public Timeline(Drawable userContent)
         {
@@ -84,7 +92,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Bindable<float> waveformOpacity;
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours, OsuConfigManager config)
+        private void load(IBindable<WorkingBeatmap> beatmap, EditorBeatmap editorBeatmap, OsuColour colours, OsuConfigManager config)
         {
             CentreMarker centreMarker;
 
@@ -141,8 +149,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     MaxZoom = getZoomLevelForVisibleMilliseconds(500);
                     MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-                    Zoom = getZoomLevelForVisibleMilliseconds(6000);
+                    defaultTimelineZoom = getZoomLevelForVisibleMilliseconds(6000);
                 }
+            }, true);
+
+            timelineZoomScale.Value = editorBeatmap.BeatmapInfo.TimelineZoom;
+            timelineZoomScale.BindValueChanged(scale =>
+            {
+                Zoom = (float)(defaultTimelineZoom * scale.NewValue);
+                editorBeatmap.BeatmapInfo.TimelineZoom = scale.NewValue;
             }, true);
         }
 
@@ -199,6 +214,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 return false;
 
             return base.OnScroll(e);
+        }
+
+        protected override void OnZoomChange()
+        {
+            base.OnZoomChange();
+            timelineZoomScale.Value = Zoom / defaultTimelineZoom;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     MaxZoom = getZoomLevelForVisibleMilliseconds(500);
                     MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-                    Zoom = getZoomLevelForVisibleMilliseconds(2000);
+                    Zoom = getZoomLevelForVisibleMilliseconds(6000);
                 }
             }, true);
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -137,16 +137,16 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             zoomTarget = Math.Clamp(newZoom, MinZoom, MaxZoom);
             transformZoomTo(zoomTarget, focusPoint, ZoomDuration, ZoomEasing);
 
-            OnZoomChange();
+            OnZoomChanged();
         }
 
         private void transformZoomTo(float newZoom, float focusPoint, double duration = 0, Easing easing = Easing.None)
             => this.TransformTo(this.PopulateTransform(new TransformZoom(focusPoint, zoomedContent.DrawWidth, Current), newZoom, duration, easing));
 
         /// <summary>
-        /// Invoked when the zoom target has changed.
+        /// Invoked when <see cref="Zoom"/> has changed.
         /// </summary>
-        protected virtual void OnZoomChange()
+        protected virtual void OnZoomChanged()
         {
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -136,10 +136,19 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             zoomTarget = Math.Clamp(newZoom, MinZoom, MaxZoom);
             transformZoomTo(zoomTarget, focusPoint, ZoomDuration, ZoomEasing);
+
+            OnZoomChange();
         }
 
         private void transformZoomTo(float newZoom, float focusPoint, double duration = 0, Easing easing = Easing.None)
             => this.TransformTo(this.PopulateTransform(new TransformZoom(focusPoint, zoomedContent.DrawWidth, Current), newZoom, duration, easing));
+
+        /// <summary>
+        /// Invoked when the zoom target has changed.
+        /// </summary>
+        protected virtual void OnZoomChange()
+        {
+        }
 
         private class TransformZoom : Transform<float, ZoomableScrollContainer>
         {


### PR DESCRIPTION
Closes #16581 

Roughly matches osu!(stable) without being too precise on the value. Could even lower down to `5000` if it feels better.

| timeline zoom 1x | timeline zoom 1.7x |
|-----------------|---------------------|
| ![CleanShot 2022-01-25 at 10 00 34](https://user-images.githubusercontent.com/22781491/150958758-6baf3a78-0017-418d-8468-90dc0c666ec9.png) | ![CleanShot 2022-01-25 at 09 54 01](https://user-images.githubusercontent.com/22781491/150958740-43995e20-d4be-40ec-b63f-2b99aacb5243.png) |
