### PR TITLE
Don't auto-unblock realm when user has manually pressed unblock button

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -73,6 +73,9 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 
                     void unblock()
                     {
+                        if (token == null)
+                            return;
+
                         token?.Dispose();
                         token = null;
 


### PR DESCRIPTION
The delayed callback would fire regardless of the user interacting with the unblock button, which meant that a second block action could be undone earlier than expected.