### PR TITLE
Avoid refetch in `RealmLive` when operating strictly on the update thread

### DIFF
--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Database
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
-            if (dataIsFromUpdateThread)
+            if (dataIsFromUpdateThread && !data.Realm.IsClosed)
                 return;
 
             dataIsFromUpdateThread = true;


### PR DESCRIPTION
Second attempt at this (see https://github.com/ppy/osu/pull/16498). Now with better safeties and statistics.

Previous benchmarks still apply.