### PR TITLE
Remove `ILive<>` interface (and use `abstract Live<>` instead)

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Database
                 using (var importer = new BeatmapModelManager(realm, storage))
                 using (new RulesetStore(realm, storage))
                 {
-                    ILive<BeatmapSetInfo>? beatmapSet;
+                    Live<BeatmapSetInfo>? beatmapSet;
 
                     using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
                         beatmapSet = await importer.Import(reader);
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Database
                 using (var importer = new BeatmapModelManager(realm, storage))
                 using (new RulesetStore(realm, storage))
                 {
-                    ILive<BeatmapSetInfo>? beatmapSet;
+                    Live<BeatmapSetInfo>? beatmapSet;
 
                     using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
                         beatmapSet = await importer.Import(reader);
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Database
                 using (var importer = new BeatmapModelManager(realm, storage))
                 using (new RulesetStore(realm, storage))
                 {
-                    ILive<BeatmapSetInfo>? imported;
+                    Live<BeatmapSetInfo>? imported;
 
                     using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
                         imported = await importer.Import(reader);
@@ -219,7 +219,7 @@ namespace osu.Game.Tests.Database
 
                 string? tempPath = TestResources.GetTestBeatmapForImport();
 
-                ILive<BeatmapSetInfo>? importedSet;
+                Live<BeatmapSetInfo>? importedSet;
 
                 using (var stream = File.OpenRead(tempPath))
                 {

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realm, _) =>
             {
-                ILive<BeatmapInfo> beatmap = realm.Run(r => r.Write(_ => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata()))).ToLive(realm));
+                Live<BeatmapInfo> beatmap = realm.Run(r => r.Write(_ => r.Add(new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata()))).ToLive(realm));
 
-                ILive<BeatmapInfo> beatmap2 = realm.Run(r => r.All<BeatmapInfo>().First().ToLive(realm));
+                Live<BeatmapInfo> beatmap2 = realm.Run(r => r.All<BeatmapInfo>().First().ToLive(realm));
 
                 Assert.AreEqual(beatmap, beatmap2);
             });
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Database
             {
                 var beatmap = new BeatmapInfo(CreateRuleset(), new BeatmapDifficulty(), new BeatmapMetadata());
 
-                ILive<BeatmapInfo>? liveBeatmap = null;
+                Live<BeatmapInfo>? liveBeatmap = null;
 
                 realm.Run(r =>
                 {
@@ -100,7 +100,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realm, _) =>
             {
-                ILive<BeatmapInfo>? liveBeatmap = null;
+                Live<BeatmapInfo>? liveBeatmap = null;
                 Task.Factory.StartNew(() =>
                 {
                     realm.Run(threadContext =>
@@ -129,7 +129,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realm, _) =>
             {
-                ILive<BeatmapInfo>? liveBeatmap = null;
+                Live<BeatmapInfo>? liveBeatmap = null;
                 Task.Factory.StartNew(() =>
                 {
                     realm.Run(threadContext =>
@@ -170,7 +170,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realm, _) =>
             {
-                ILive<BeatmapInfo>? liveBeatmap = null;
+                Live<BeatmapInfo>? liveBeatmap = null;
 
                 Task.Factory.StartNew(() =>
                 {
@@ -209,7 +209,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealm((realm, _) =>
             {
-                ILive<BeatmapInfo>? liveBeatmap = null;
+                Live<BeatmapInfo>? liveBeatmap = null;
                 Task.Factory.StartNew(() =>
                 {
                     realm.Run(threadContext =>
@@ -242,7 +242,7 @@ namespace osu.Game.Tests.Database
                 realm.RegisterCustomSubscription(outerRealm =>
                 {
                     outerRealm.All<BeatmapInfo>().QueryAsyncWithNotifications(gotChange);
-                    ILive<BeatmapInfo>? liveBeatmap = null;
+                    Live<BeatmapInfo>? liveBeatmap = null;
 
                     Task.Factory.StartNew(() =>
                     {

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Tests.Online
         {
             public TaskCompletionSource<bool> AllowImport = new TaskCompletionSource<bool>();
 
-            public ILive<BeatmapSetInfo> CurrentImport { get; private set; }
+            public Live<BeatmapSetInfo> CurrentImport { get; private set; }
 
             public TestBeatmapManager(Storage storage, RealmAccess realm, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host = null, WorkingBeatmap defaultBeatmap = null)
                 : base(storage, realm, rulesets, api, audioManager, resources, host, defaultBeatmap)
@@ -186,7 +186,7 @@ namespace osu.Game.Tests.Online
                     this.testBeatmapManager = testBeatmapManager;
                 }
 
-                public override ILive<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
+                public override Live<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
                 {
                     testBeatmapManager.AllowImport.Task.WaitSafely();
                     return (testBeatmapManager.CurrentImport = base.Import(item, archive, lowPriority, cancellationToken));

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -235,7 +235,7 @@ namespace osu.Game.Tests.Skins.IO
 
         #endregion
 
-        private void assertCorrectMetadata(ILive<SkinInfo> import1, string name, string creator, OsuGameBase osu)
+        private void assertCorrectMetadata(Live<SkinInfo> import1, string name, string creator, OsuGameBase osu)
         {
             import1.PerformRead(i =>
             {
@@ -250,7 +250,7 @@ namespace osu.Game.Tests.Skins.IO
             });
         }
 
-        private void assertImportedBoth(ILive<SkinInfo> import1, ILive<SkinInfo> import2)
+        private void assertImportedBoth(Live<SkinInfo> import1, Live<SkinInfo> import2)
         {
             import1.PerformRead(i1 => import2.PerformRead(i2 =>
             {
@@ -260,7 +260,7 @@ namespace osu.Game.Tests.Skins.IO
             }));
         }
 
-        private void assertImportedOnce(ILive<SkinInfo> import1, ILive<SkinInfo> import2)
+        private void assertImportedOnce(Live<SkinInfo> import1, Live<SkinInfo> import2)
         {
             import1.PerformRead(i1 => import2.PerformRead(i2 =>
             {
@@ -334,7 +334,7 @@ namespace osu.Game.Tests.Skins.IO
             }
         }
 
-        private async Task<ILive<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ArchiveReader archive = null)
+        private async Task<Live<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ArchiveReader archive = null)
         {
             var skinManager = osu.Dependencies.Get<SkinManager>();
             return await skinManager.Import(archive);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestScoreImportThenDelete()
         {
-            ILive<ScoreInfo> imported = null;
+            Live<ScoreInfo> imported = null;
 
             AddStep("create button without replay", () =>
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestDownloadButtonHiddenWhenBeatmapExists()
         {
             var beatmap = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo;
-            ILive<BeatmapSetInfo> imported = null;
+            Live<BeatmapSetInfo> imported = null;
 
             Debug.Assert(beatmap.BeatmapSet != null);
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
-        public ILive<BeatmapSetInfo>? QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query)
+        public Live<BeatmapSetInfo>? QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query)
         {
             return realm.Run(r => r.All<BeatmapSetInfo>().FirstOrDefault(query)?.ToLive(realm));
         }
@@ -279,22 +279,22 @@ namespace osu.Game.Beatmaps
             return beatmapModelManager.Import(tasks);
         }
 
-        public Task<IEnumerable<ILive<BeatmapSetInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks)
+        public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks)
         {
             return beatmapModelManager.Import(notification, tasks);
         }
 
-        public Task<ILive<BeatmapSetInfo>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return beatmapModelManager.Import(task, lowPriority, cancellationToken);
         }
 
-        public Task<ILive<BeatmapSetInfo>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Task<Live<BeatmapSetInfo>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return beatmapModelManager.Import(archive, lowPriority, cancellationToken);
         }
 
-        public ILive<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return beatmapModelManager.Import(item, archive, lowPriority, cancellationToken);
         }
@@ -323,7 +323,7 @@ namespace osu.Game.Beatmaps
             return workingBeatmapCache.GetWorkingBeatmap(importedBeatmap);
         }
 
-        public WorkingBeatmap GetWorkingBeatmap(ILive<BeatmapInfo>? importedBeatmap)
+        public WorkingBeatmap GetWorkingBeatmap(Live<BeatmapInfo>? importedBeatmap)
         {
             WorkingBeatmap working = workingBeatmapCache.GetWorkingBeatmap(null);
 
@@ -367,7 +367,7 @@ namespace osu.Game.Beatmaps
 
         #region Implementation of IPostImports<out BeatmapSetInfo>
 
-        public Action<IEnumerable<ILive<BeatmapSetInfo>>>? PostImport
+        public Action<IEnumerable<Live<BeatmapSetInfo>>>? PostImport
         {
             set => beatmapModelManager.PostImport = value;
         }

--- a/osu.Game/Database/IModelImporter.cs
+++ b/osu.Game/Database/IModelImporter.cs
@@ -16,9 +16,9 @@ namespace osu.Game.Database
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
     public interface IModelImporter<TModel> : IPostNotifications, IPostImports<TModel>, ICanAcceptFiles
-        where TModel : class
+        where TModel : class, IHasGuidPrimaryKey
     {
-        Task<IEnumerable<ILive<TModel>>> Import(ProgressNotification notification, params ImportTask[] tasks);
+        Task<IEnumerable<Live<TModel>>> Import(ProgressNotification notification, params ImportTask[] tasks);
 
         /// <summary>
         /// Import one <typeparamref name="TModel"/> from the filesystem and delete the file on success.
@@ -28,7 +28,7 @@ namespace osu.Game.Database
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The imported model, if successful.</returns>
-        Task<ILive<TModel>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default);
+        Task<Live<TModel>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Silently import an item from an <see cref="ArchiveReader"/>.
@@ -36,7 +36,7 @@ namespace osu.Game.Database
         /// <param name="archive">The archive to be imported.</param>
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        Task<ILive<TModel>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default);
+        Task<Live<TModel>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Silently import an item from a <typeparamref name="TModel"/>.
@@ -45,7 +45,7 @@ namespace osu.Game.Database
         /// <param name="archive">An optional archive to use for model population.</param>
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        ILive<TModel>? Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
+        Live<TModel>? Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// A user displayable name for the model type associated with this manager.

--- a/osu.Game/Database/IPostImports.cs
+++ b/osu.Game/Database/IPostImports.cs
@@ -9,11 +9,11 @@ using System.Collections.Generic;
 namespace osu.Game.Database
 {
     public interface IPostImports<TModel>
-        where TModel : class
+        where TModel : class, IHasGuidPrimaryKey
     {
         /// <summary>
         /// Fired when the user requests to view the resulting import.
         /// </summary>
-        public Action<IEnumerable<ILive<TModel>>>? PostImport { set; }
+        public Action<IEnumerable<Live<TModel>>>? PostImport { set; }
     }
 }

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Database
     /// A class which handles importing legacy user data of a single type from osu-stable.
     /// </summary>
     public abstract class LegacyModelImporter<TModel>
-        where TModel : class
+        where TModel : class, IHasGuidPrimaryKey
     {
         /// <summary>
         /// The relative path from osu-stable's data directory to import items from.

--- a/osu.Game/Database/Live.cs
+++ b/osu.Game/Database/Live.cs
@@ -3,39 +3,41 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Game.Database
 {
     /// <summary>
     /// A wrapper to provide access to database backed classes in a thread-safe manner.
     /// </summary>
     /// <typeparam name="T">The databased type.</typeparam>
-    public interface ILive<T> : IEquatable<ILive<T>>
-        where T : class // TODO: Add IHasGuidPrimaryKey once we don't need EF support any more.
+    public abstract class Live<T> : IEquatable<Live<T>>
+        where T : class, IHasGuidPrimaryKey
     {
-        Guid ID { get; }
+        public Guid ID { get; }
 
         /// <summary>
         /// Perform a read operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        void PerformRead(Action<T> perform);
+        public abstract void PerformRead(Action<T> perform);
 
         /// <summary>
         /// Perform a read operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        TReturn PerformRead<TReturn>(Func<T, TReturn> perform);
+        public abstract TReturn PerformRead<TReturn>(Func<T, TReturn> perform);
 
         /// <summary>
         /// Perform a write operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        void PerformWrite(Action<T> perform);
+        public abstract void PerformWrite(Action<T> perform);
 
         /// <summary>
         /// Whether this instance is tracking data which is managed by the database backing.
         /// </summary>
-        bool IsManaged { get; }
+        public abstract bool IsManaged { get; }
 
         /// <summary>
         /// Resolve the value of this instance on the update thread.
@@ -43,6 +45,15 @@ namespace osu.Game.Database
         /// <remarks>
         /// After resolving, the data should not be passed between threads.
         /// </remarks>
-        T Value { get; }
+        public abstract T Value { get; }
+
+        protected Live(Guid id)
+        {
+            ID = id;
+        }
+
+        public bool Equals(Live<T>? other) => ID == other?.ID;
+
+        public override string ToString() => PerformRead(i => i.ToString());
     }
 }

--- a/osu.Game/Database/RealmLiveUnmanaged.cs
+++ b/osu.Game/Database/RealmLiveUnmanaged.cs
@@ -13,13 +13,19 @@ namespace osu.Game.Database
     /// Usually used for testing purposes where the instance is never required to be managed.
     /// </summary>
     /// <typeparam name="T">The underlying object type.</typeparam>
-    public class RealmLiveUnmanaged<T> : ILive<T> where T : RealmObjectBase, IHasGuidPrimaryKey
+    public class RealmLiveUnmanaged<T> : Live<T> where T : RealmObjectBase, IHasGuidPrimaryKey
     {
+        /// <summary>
+        /// The original live data used to create this instance.
+        /// </summary>
+        public override T Value { get; }
+
         /// <summary>
         /// Construct a new instance of live realm data.
         /// </summary>
         /// <param name="data">The realm data.</param>
         public RealmLiveUnmanaged(T data)
+            : base(data.ID)
         {
             if (data.IsManaged)
                 throw new InvalidOperationException($"Cannot use {nameof(RealmLiveUnmanaged<T>)} with managed instances");
@@ -27,23 +33,12 @@ namespace osu.Game.Database
             Value = data;
         }
 
-        public bool Equals(ILive<T>? other) => ID == other?.ID;
+        public override void PerformRead(Action<T> perform) => perform(Value);
 
-        public override string ToString() => Value.ToString();
+        public override TReturn PerformRead<TReturn>(Func<T, TReturn> perform) => perform(Value);
 
-        public Guid ID => Value.ID;
+        public override void PerformWrite(Action<T> perform) => throw new InvalidOperationException(@"Can't perform writes on a non-managed underlying value");
 
-        public void PerformRead(Action<T> perform) => perform(Value);
-
-        public TReturn PerformRead<TReturn>(Func<T, TReturn> perform) => perform(Value);
-
-        public void PerformWrite(Action<T> perform) => throw new InvalidOperationException(@"Can't perform writes on a non-managed underlying value");
-
-        public bool IsManaged => false;
-
-        /// <summary>
-        /// The original live data used to create this instance.
-        /// </summary>
-        public T Value { get; }
+        public override bool IsManaged => false;
     }
 }

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -204,25 +204,25 @@ namespace osu.Game.Database
         private static void copyChangesToRealm<T>(T source, T destination) where T : RealmObjectBase
             => write_mapper.Map(source, destination);
 
-        public static List<ILive<T>> ToLiveUnmanaged<T>(this IEnumerable<T> realmList)
+        public static List<Live<T>> ToLiveUnmanaged<T>(this IEnumerable<T> realmList)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return realmList.Select(l => new RealmLiveUnmanaged<T>(l)).Cast<ILive<T>>().ToList();
+            return realmList.Select(l => new RealmLiveUnmanaged<T>(l)).Cast<Live<T>>().ToList();
         }
 
-        public static ILive<T> ToLiveUnmanaged<T>(this T realmObject)
+        public static Live<T> ToLiveUnmanaged<T>(this T realmObject)
             where T : RealmObject, IHasGuidPrimaryKey
         {
             return new RealmLiveUnmanaged<T>(realmObject);
         }
 
-        public static List<ILive<T>> ToLive<T>(this IEnumerable<T> realmList, RealmAccess realm)
+        public static List<Live<T>> ToLive<T>(this IEnumerable<T> realmList, RealmAccess realm)
             where T : RealmObject, IHasGuidPrimaryKey
         {
-            return realmList.Select(l => new RealmLive<T>(l, realm)).Cast<ILive<T>>().ToList();
+            return realmList.Select(l => new RealmLive<T>(l, realm)).Cast<Live<T>>().ToList();
         }
 
-        public static ILive<T> ToLive<T>(this T realmObject, RealmAccess realm)
+        public static Live<T> ToLive<T>(this T realmObject, RealmAccess realm)
             where T : RealmObject, IHasGuidPrimaryKey
         {
             return new RealmLive<T>(realmObject, realm);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -249,7 +249,7 @@ namespace osu.Game
             SkinManager.CurrentSkinInfo.ValueChanged += skin => configSkin.Value = skin.NewValue.ID.ToString();
             configSkin.ValueChanged += skinId =>
             {
-                ILive<SkinInfo> skinInfo = null;
+                Live<SkinInfo> skinInfo = null;
 
                 if (Guid.TryParse(skinId.NewValue, out var guid))
                     skinInfo = SkinManager.Query(s => s.ID == guid);
@@ -439,7 +439,7 @@ namespace osu.Game
         /// </remarks>
         public void PresentBeatmap(IBeatmapSetInfo beatmap, Predicate<BeatmapInfo> difficultyCriteria = null)
         {
-            ILive<BeatmapSetInfo> databasedSet = null;
+            Live<BeatmapSetInfo> databasedSet = null;
 
             if (beatmap.OnlineID > 0)
                 databasedSet = BeatmapManager.QueryBeatmapSet(s => s.OnlineID == beatmap.OnlineID);

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -32,16 +32,16 @@ namespace osu.Game.Overlays.Settings.Sections
             Icon = FontAwesome.Solid.PaintBrush
         };
 
-        private readonly Bindable<ILive<SkinInfo>> dropdownBindable = new Bindable<ILive<SkinInfo>> { Default = DefaultSkin.CreateInfo().ToLiveUnmanaged() };
+        private readonly Bindable<Live<SkinInfo>> dropdownBindable = new Bindable<Live<SkinInfo>> { Default = DefaultSkin.CreateInfo().ToLiveUnmanaged() };
         private readonly Bindable<string> configBindable = new Bindable<string>();
 
-        private static readonly ILive<SkinInfo> random_skin_info = new SkinInfo
+        private static readonly Live<SkinInfo> random_skin_info = new SkinInfo
         {
             ID = SkinInfo.RANDOM_SKIN,
             Name = "<Random Skin>",
         }.ToLiveUnmanaged();
 
-        private List<ILive<SkinInfo>> skinItems;
+        private List<Live<SkinInfo>> skinItems;
 
         [Resolved]
         private SkinManager skins { get; set; }
@@ -118,7 +118,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private void updateSelectedSkinFromConfig()
         {
-            ILive<SkinInfo> skin = null;
+            Live<SkinInfo> skin = null;
 
             if (Guid.TryParse(configBindable.Value, out var configId))
                 skin = skinDropdown.Items.FirstOrDefault(s => s.ID == configId);
@@ -144,13 +144,13 @@ namespace osu.Game.Overlays.Settings.Sections
             realmSubscription?.Dispose();
         }
 
-        private class SkinSettingsDropdown : SettingsDropdown<ILive<SkinInfo>>
+        private class SkinSettingsDropdown : SettingsDropdown<Live<SkinInfo>>
         {
-            protected override OsuDropdown<ILive<SkinInfo>> CreateDropdown() => new SkinDropdownControl();
+            protected override OsuDropdown<Live<SkinInfo>> CreateDropdown() => new SkinDropdownControl();
 
             private class SkinDropdownControl : DropdownControl
             {
-                protected override LocalisableString GenerateItemText(ILive<SkinInfo> item) => item.ToString();
+                protected override LocalisableString GenerateItemText(Live<SkinInfo> item) => item.ToString();
             }
         }
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -293,22 +293,22 @@ namespace osu.Game.Scoring
 
         public IEnumerable<string> HandledExtensions => scoreModelManager.HandledExtensions;
 
-        public Task<IEnumerable<ILive<ScoreInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks)
+        public Task<IEnumerable<Live<ScoreInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks)
         {
             return scoreModelManager.Import(notification, tasks);
         }
 
-        public Task<ILive<ScoreInfo>> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Task<Live<ScoreInfo>> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return scoreModelManager.Import(task, lowPriority, cancellationToken);
         }
 
-        public Task<ILive<ScoreInfo>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Task<Live<ScoreInfo>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return scoreModelManager.Import(archive, lowPriority, cancellationToken);
         }
 
-        public ILive<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return scoreModelManager.Import(item, archive, lowPriority, cancellationToken);
         }
@@ -322,7 +322,7 @@ namespace osu.Game.Scoring
 
         #region Implementation of IPresentImports<ScoreInfo>
 
-        public Action<IEnumerable<ILive<ScoreInfo>>> PostImport
+        public Action<IEnumerable<Live<ScoreInfo>>> PostImport
         {
             set => scoreModelManager.PostImport = value;
         }

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Skinning
 {
     public abstract class Skin : IDisposable, ISkin
     {
-        public readonly ILive<SkinInfo> SkinInfo;
+        public readonly Live<SkinInfo> SkinInfo;
         private readonly IStorageResourceProvider resources;
 
         public SkinConfiguration Configuration { get; set; }

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Skinning
 
         public readonly Bindable<Skin> CurrentSkin = new Bindable<Skin>();
 
-        public readonly Bindable<ILive<SkinInfo>> CurrentSkinInfo = new Bindable<ILive<SkinInfo>>(Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged())
+        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged())
         {
             Default = Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged()
         };
@@ -176,7 +176,7 @@ namespace osu.Game.Skinning
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
-        public ILive<SkinInfo> Query(Expression<Func<SkinInfo, bool>> query)
+        public Live<SkinInfo> Query(Expression<Func<SkinInfo, bool>> query)
         {
             return realm.Run(r => r.All<SkinInfo>().FirstOrDefault(query)?.ToLive(realm));
         }
@@ -245,7 +245,7 @@ namespace osu.Game.Skinning
             set => skinModelManager.PostNotification = value;
         }
 
-        public Action<IEnumerable<ILive<SkinInfo>>> PostImport
+        public Action<IEnumerable<Live<SkinInfo>>> PostImport
         {
             set => skinModelManager.PostImport = value;
         }
@@ -262,22 +262,22 @@ namespace osu.Game.Skinning
 
         public IEnumerable<string> HandledExtensions => skinModelManager.HandledExtensions;
 
-        public Task<IEnumerable<ILive<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks)
+        public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks)
         {
             return skinModelManager.Import(notification, tasks);
         }
 
-        public Task<ILive<SkinInfo>> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Task<Live<SkinInfo>> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return skinModelManager.Import(task, lowPriority, cancellationToken);
         }
 
-        public Task<ILive<SkinInfo>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Task<Live<SkinInfo>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return skinModelManager.Import(archive, lowPriority, cancellationToken);
         }
 
-        public ILive<SkinInfo> Import(SkinInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public Live<SkinInfo> Import(SkinInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return skinModelManager.Import(item, archive, lowPriority, cancellationToken);
         }

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Stores
         /// <summary>
         /// Fired when the user requests to view the resulting import.
         /// </summary>
-        public Action<IEnumerable<ILive<TModel>>>? PostImport { get; set; }
+        public Action<IEnumerable<Live<TModel>>>? PostImport { get; set; }
 
         /// <summary>
         /// Set an endpoint for notifications to be posted to.
@@ -104,7 +104,7 @@ namespace osu.Game.Stores
             return Import(notification, tasks);
         }
 
-        public async Task<IEnumerable<ILive<TModel>>> Import(ProgressNotification notification, params ImportTask[] tasks)
+        public async Task<IEnumerable<Live<TModel>>> Import(ProgressNotification notification, params ImportTask[] tasks)
         {
             if (tasks.Length == 0)
             {
@@ -118,7 +118,7 @@ namespace osu.Game.Stores
 
             int current = 0;
 
-            var imported = new List<ILive<TModel>>();
+            var imported = new List<Live<TModel>>();
 
             bool isLowPriorityImport = tasks.Length > low_priority_import_batch_size;
 
@@ -196,11 +196,11 @@ namespace osu.Game.Stores
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The imported model, if successful.</returns>
-        public async Task<ILive<TModel>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public async Task<Live<TModel>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            ILive<TModel>? import;
+            Live<TModel>? import;
             using (ArchiveReader reader = task.GetReader())
                 import = await Import(reader, lowPriority, cancellationToken).ConfigureAwait(false);
 
@@ -227,7 +227,7 @@ namespace osu.Game.Stores
         /// <param name="archive">The archive to be imported.</param>
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        public async Task<ILive<TModel>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public async Task<Live<TModel>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -320,7 +320,7 @@ namespace osu.Game.Stores
         /// <param name="archive">An optional archive to use for model population.</param>
         /// <param name="lowPriority">Whether this is a low priority import.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        public virtual ILive<TModel>? Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
+        public virtual Live<TModel>? Import(TModel item, ArchiveReader? archive = null, bool lowPriority = false, CancellationToken cancellationToken = default)
         {
             return Realm.Run(realm =>
             {
@@ -416,7 +416,7 @@ namespace osu.Game.Stores
                     throw;
                 }
 
-                return (ILive<TModel>?)item.ToLive(Realm);
+                return (Live<TModel>?)item.ToLive(Realm);
             });
         }
 


### PR DESCRIPTION
My main goal was to drop the "I" from the naming just to reduce mental burden of deeply generic type specifications (ie. `OsuRearrangeableListContainer<Bindable<ILive<BeatmapSetInfo>>>`).

- [x] Depends on https://github.com/ppy/osu/pull/16618 to avoid conflicts