### PR TITLE
Fix crash at results screen when viewing another score panel after playing

### DIFF
--- a/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
@@ -26,12 +26,16 @@ namespace osu.Game.Tests.NonVisual
 
             score.Statistics[HitResult.Good]++;
             score.Rank = ScoreRank.X;
+            score.RealmUser.Username = "test";
 
             Assert.That(scoreCopy.Statistics[HitResult.Good], Is.EqualTo(10));
             Assert.That(score.Statistics[HitResult.Good], Is.EqualTo(11));
 
             Assert.That(scoreCopy.Rank, Is.EqualTo(ScoreRank.B));
             Assert.That(score.Rank, Is.EqualTo(ScoreRank.X));
+
+            Assert.That(scoreCopy.RealmUser.Username, Is.EqualTo("test"));
+            Assert.That(score.Rank, Is.Empty);
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ScoreInfoTest.cs
@@ -34,8 +34,8 @@ namespace osu.Game.Tests.NonVisual
             Assert.That(scoreCopy.Rank, Is.EqualTo(ScoreRank.B));
             Assert.That(score.Rank, Is.EqualTo(ScoreRank.X));
 
-            Assert.That(scoreCopy.RealmUser.Username, Is.EqualTo("test"));
-            Assert.That(score.Rank, Is.Empty);
+            Assert.That(scoreCopy.RealmUser.Username, Is.Empty);
+            Assert.That(score.RealmUser.Username, Is.EqualTo("test"));
         }
 
         [Test]

--- a/osu.Game/Models/RealmUser.cs
+++ b/osu.Game/Models/RealmUser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Models
     {
         public int OnlineID { get; set; } = 1;
 
-        public string Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
         public bool IsBot => false;
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -133,6 +133,11 @@ namespace osu.Game.Scoring
             var clone = (ScoreInfo)this.Detach().MemberwiseClone();
 
             clone.Statistics = new Dictionary<HitResult, int>(clone.Statistics);
+            clone.RealmUser = new RealmUser
+            {
+                OnlineID = RealmUser.OnlineID,
+                Username = RealmUser.Username,
+            };
 
             return clone;
         }


### PR DESCRIPTION
I'm still not at all happy with the play-to-results flow (with multiple clones of the `ScoreInfo` along the way), but this will have to do for now.

Hard to add an actual test for this due to the requirement of a local play and also online scores being fetched. Can do if it's deemed required, but probably multi-hour.

Closes https://github.com/ppy/osu/issues/16621.