### PR TITLE
Refactor `SkinSection` to avoid unnecessary realm queries

### DIFF
--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -216,12 +216,6 @@ namespace osu.Game.Database
             return new RealmLiveUnmanaged<T>(realmObject);
         }
 
-        public static List<Live<T>> ToLive<T>(this IEnumerable<T> realmList, RealmAccess realm)
-            where T : RealmObject, IHasGuidPrimaryKey
-        {
-            return realmList.Select(l => new RealmLive<T>(l, realm)).Cast<Live<T>>().ToList();
-        }
-
         public static Live<T> ToLive<T>(this T realmObject, RealmAccess realm)
             where T : RealmObject, IHasGuidPrimaryKey
         {


### PR DESCRIPTION
Slight restructuring was required to remove the initial query in `LoadComplete` (which was being relied upon to avoid a feedback loop to the config stored value during initial dropdown population). The `OldValue==null` check handles this edge case. Apart from that should be pretty straightforward.

This fixes one known case of realm context blocking being unfeasible due to inner context retrieval.