### PR TITLE
Fix realm migration failures with presence of databased EF rulesets that don't exist on disk

### DIFF
--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -286,6 +286,7 @@ namespace osu.Game.Database
 
                 var transaction = r.BeginWrite();
                 int written = 0;
+                int missing = 0;
 
                 try
                 {
@@ -300,6 +301,13 @@ namespace osu.Game.Database
 
                         var beatmap = r.All<BeatmapInfo>().First(b => b.Hash == score.BeatmapInfo.Hash);
                         var ruleset = r.Find<RulesetInfo>(score.Ruleset.ShortName);
+
+                        if (ruleset == null)
+                        {
+                            log($"Skipping {++missing} scores with missing ruleset");
+                            continue;
+                        }
+
                         var user = new RealmUser
                         {
                             OnlineID = score.User.OnlineID,

--- a/osu.Game/Rulesets/EFRulesetInfo.cs
+++ b/osu.Game/Rulesets/EFRulesetInfo.cs
@@ -28,20 +28,14 @@ namespace osu.Game.Rulesets
         public Ruleset CreateInstance()
         {
             if (!Available)
-                throw new RulesetLoadException(@"Ruleset not available");
+                return null;
 
             var type = Type.GetType(InstantiationInfo);
 
             if (type == null)
-                throw new RulesetLoadException(@"Type lookup failure");
+                return null;
 
             var ruleset = Activator.CreateInstance(type) as Ruleset;
-
-            if (ruleset == null)
-                throw new RulesetLoadException(@"Instantiation failure");
-
-            // overwrite the pre-populated RulesetInfo with a potentially database attached copy.
-            // ruleset.RulesetInfo = this;
 
             return ruleset;
         }


### PR DESCRIPTION
Simplest method possible

- Closes https://github.com/ppy/osu/issues/16625.