### PR TITLE
Fix custom rulesets being displayed before official ones

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -163,7 +163,10 @@ namespace osu.Game.Rulesets
                     }
                 }
 
-                availableRulesets.AddRange(detachedRulesets);
+                // add known official rulesets first..
+                availableRulesets.AddRange(detachedRulesets.Where(r => r.OnlineID >= 0).OrderBy(r => r.OnlineID));
+                // .. then add any customs
+                availableRulesets.AddRange(detachedRulesets.Where(r => r.OnlineID < 0).OrderBy(r => r.ShortName));
             });
         }
 

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Select.Carousel
             var beatmaps = carouselSet.Beatmaps.ToList();
 
             return beatmaps.Count > maximum_difficulty_icons
-                ? (IEnumerable<DifficultyIcon>)beatmaps.GroupBy(b => b.BeatmapInfo.RulesetID)
+                ? (IEnumerable<DifficultyIcon>)beatmaps.GroupBy(b => b.BeatmapInfo.Ruleset.ShortName)
                                                        .Select(group => new FilterableGroupedDifficultyIcon(group.ToList(), group.Last().BeatmapInfo.Ruleset))
                 : beatmaps.Select(b => new FilterableDifficultyIcon(b));
         }


### PR DESCRIPTION
Regressed with realm, it would seem.

Before:
![20220126 184846 (osu!)](https://user-images.githubusercontent.com/191335/151140768-4a0887c6-0ae0-4c9f-8ec9-d31db1c6ca24.png)

After:
![20220126 184731 (osu!)](https://user-images.githubusercontent.com/191335/151140683-c652f510-8133-4e22-ab4d-97cf38a35c7e.png)

