### PR TITLE
Fix some score imports failing due to null string attempted to be parsed as json

### DIFF
--- a/osu.Game/Scoring/EFScoreInfo.cs
+++ b/osu.Game/Scoring/EFScoreInfo.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Scoring
         public string ModsJson
         {
             get => JsonConvert.SerializeObject(APIMods);
-            set => APIMods = JsonConvert.DeserializeObject<APIMod[]>(value);
+            set => APIMods = !string.IsNullOrEmpty(value) ? JsonConvert.DeserializeObject<APIMod[]>(value) : Array.Empty<APIMod>();
         }
 
         [NotMapped]


### PR DESCRIPTION
Reported during private testing:

```csharp
2022-01-26 13:19:47 [error]: An exception occurred while iterating over the results of a query for context type 'osu.Game.Database.OsuDbContext'.
2022-01-26 13:19:47 [error]: System.ArgumentNullException: Value cannot be null. (Parameter 'value')
2022-01-26 13:19:47 [error]: at Newtonsoft.Json.Utilities.ValidationUtils.ArgumentNotNull(Object value, String parameterName)
2022-01-26 13:19:47 [error]: at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
2022-01-26 13:19:47 [error]: at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
2022-01-26 13:19:47 [error]: at lambda_method532(Closure , MaterializationContext )
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.Internal.QueryBuffer.GetEntity(IKey key, EntityLoadInfo entityLoadInfo, Boolean queryStateManager, Boolean throwOnNullKey)
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.BufferedEntityShaper`1.Shape(QueryContext queryContext, ValueBuffer& valueBuffer)
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.BufferedOffsetEntityShaper`1.Shape(QueryContext queryContext, ValueBuffer& valueBuffer)
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.CompositeShaper.TypedCompositeShaper`5.Shape(QueryContext queryContext, ValueBuffer& valueBuffer)
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.CompositeShaper.TypedCompositeShaper`5.Shape(QueryContext queryContext, ValueBuffer& valueBuffer)
2022-01-26 13:19:47 [error]: at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.Internal.LinqOperatorProvider._TrackEntities[TOut,TIn](IEnumerable`1 results, QueryContext queryContext, IList`1 entityTrackingInfos, IList`1 entityAccessors)+MoveNext()
2022-01-26 13:19:47 [error]: at Microsoft.EntityFrameworkCore.Query.Internal.LinqOperatorProvider.ExceptionInterceptor`1.EnumeratorExceptionInterceptor.MoveNext()
```