### PR TITLE
Fix ruleset filters not working correctly on song select

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -79,6 +79,20 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        public void TestCriteriaMatchingConvertedBeatmapsForCustomRulesets()
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { OnlineID = -25 },
+                AllowConvertedBeatmaps = true
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.IsFalse(carouselItem.Filtered.Value);
+        }
+
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public void TestCriteriaMatchingRangeMin(bool inclusive)

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { OnlineID = -25 },
+                Ruleset = new RulesetInfo { OnlineID = -1 },
                 AllowConvertedBeatmaps = true
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -16,7 +16,11 @@ namespace osu.Game.Tests.NonVisual.Filtering
     {
         private BeatmapInfo getExampleBeatmap() => new BeatmapInfo
         {
-            Ruleset = new RulesetInfo { OnlineID = 0 },
+            Ruleset = new RulesetInfo
+            {
+                ShortName = "osu",
+                OnlineID = 0
+            },
             StarRating = 4.0d,
             Difficulty = new BeatmapDifficulty
             {
@@ -57,7 +61,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
-                Ruleset = new RulesetInfo { OnlineID = 6 }
+                Ruleset = new RulesetInfo { ShortName = "catch" }
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Select.Carousel
             bool match =
                 criteria.Ruleset == null ||
                 BeatmapInfo.RulesetID == criteria.Ruleset.OnlineID ||
-                (BeatmapInfo.RulesetID == 0 && criteria.Ruleset.OnlineID > 0 && criteria.AllowConvertedBeatmaps);
+                (BeatmapInfo.RulesetID == 0 && criteria.Ruleset.OnlineID != 0 && criteria.AllowConvertedBeatmaps);
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             bool match =
                 criteria.Ruleset == null ||
-                BeatmapInfo.RulesetID == criteria.Ruleset.OnlineID ||
+                BeatmapInfo.Ruleset.ShortName == criteria.Ruleset.ShortName ||
                 (BeatmapInfo.RulesetID == 0 && criteria.Ruleset.OnlineID != 0 && criteria.AllowConvertedBeatmaps);
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)


### PR DESCRIPTION
Regression caused in this commit: https://github.com/ppy/osu/commit/02d8a6359a98a3c8ed393eda5c26376079d8cd79#diff-835d640b64dafd0c349eae448749a909626b2c02c31f9978b88cc3cfbc046605

Custom rulesets always have a negative onlineID, causing std beatmaps to always be filtered, and making custom rulesets unplayable for everybody. 

This PR changes the check to consider anything that isn't 0.