### PR TITLE
Fix changes to beatmap info made in editor persisting after exit without save

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -4,11 +4,13 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osu.Game.Screens.Select;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
@@ -115,6 +117,25 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("Placed object still has non-default control points", () =>
                 EditorBeatmap.HitObjects[0].SampleControlPoint != SampleControlPoint.DEFAULT &&
                 EditorBeatmap.HitObjects[0].DifficultyControlPoint != DifficultyControlPoint.DEFAULT);
+        }
+
+        [Test]
+        public void TestExitWithoutSaveFromExistingBeatmap()
+        {
+            const string tags_to_save = "these tags will be saved";
+            const string tags_to_discard = "these tags should be discarded";
+
+            AddStep("Set tags", () => EditorBeatmap.BeatmapInfo.Metadata.Tags = tags_to_save);
+            SaveEditor();
+            AddAssert("Tags saved correctly", () => EditorBeatmap.BeatmapInfo.Metadata.Tags == tags_to_save);
+
+            ReloadEditorToSameBeatmap();
+            AddAssert("Tags saved correctly", () => EditorBeatmap.BeatmapInfo.Metadata.Tags == tags_to_save);
+            AddStep("Set tags again", () => EditorBeatmap.BeatmapInfo.Metadata.Tags = tags_to_discard);
+
+            AddStep("Exit editor", () => Editor.Exit());
+            AddUntilStep("Wait for song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
+            AddAssert("Tags reverted correctly", () => Game.Beatmap.Value.BeatmapInfo.Metadata.Tags == tags_to_save);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -70,7 +70,11 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("current screen is editor", () => Stack.CurrentScreen is Editor);
             AddUntilStep("background has correct params", () =>
             {
-                var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single();
+                // the test gameplay player's beatmap may be the "same" beatmap as the one being edited, *but* the `BeatmapInfo` references may differ
+                // due to the beatmap refetch logic ran on editor suspend.
+                // this test cares about checking the background belonging to the editor specifically, so check that using reference equality
+                // (as `.Equals()` cannot discern between the two, as they technically share the same database GUID).
+                var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single(b => ReferenceEquals(b.Beatmap.BeatmapInfo, EditorBeatmap.BeatmapInfo));
                 return background.Colour == Color4.DarkGray && background.BlurAmount.Value == 0;
             });
             AddAssert("no mods selected", () => SelectedMods.Value.Count == 0);
@@ -99,7 +103,11 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("current screen is editor", () => Stack.CurrentScreen is Editor);
             AddUntilStep("background has correct params", () =>
             {
-                var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single();
+                // the test gameplay player's beatmap may be the "same" beatmap as the one being edited, *but* the `BeatmapInfo` references may differ
+                // due to the beatmap refetch logic ran on editor suspend.
+                // this test cares about checking the background belonging to the editor specifically, so check that using reference equality
+                // (as `.Equals()` cannot discern between the two, as they technically share the same database GUID).
+                var background = this.ChildrenOfType<BackgroundScreenBeatmap>().Single(b => ReferenceEquals(b.Beatmap.BeatmapInfo, EditorBeatmap.BeatmapInfo));
                 return background.Colour == Color4.DarkGray && background.BlurAmount.Value == 0;
             });
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -574,7 +574,9 @@ namespace osu.Game.Screens.Edit
             // To update the game-wide beatmap with any changes, perform a re-fetch on exit/suspend.
             // This is required as the editor makes its local changes via EditorBeatmap
             // (which are not propagated outwards to a potentially cached WorkingBeatmap).
-            var refetchedBeatmap = beatmapManager.GetWorkingBeatmap(Beatmap.Value.BeatmapInfo);
+            ((IWorkingBeatmapCache)beatmapManager).Invalidate(Beatmap.Value.BeatmapInfo);
+            var refetchedBeatmapInfo = beatmapManager.QueryBeatmap(b => b.ID == Beatmap.Value.BeatmapInfo.ID);
+            var refetchedBeatmap = beatmapManager.GetWorkingBeatmap(refetchedBeatmapInfo);
 
             if (!(refetchedBeatmap is DummyWorkingBeatmap))
             {


### PR DESCRIPTION
Closes #16616.

Diff is mostly the same as what was proposed in the issue thread, with the reproduction test case at 4382adad8240fee9c85f1b5cb21efea70c011184 slightly rewritten out of necessity after #16623.

There was also another slightly unfortunate resulting test failure in the coverage of the gameplay test functionality, which I've resolved with e0616476e2a0a772c5998b0194d8a0dab0ad0eb4. Essentially what ended up happening is there was more than one `BackgroundScreenBeatmap` instantiated, because the `WorkingBeatmap` is being invalidated and created anew on suspend as well, so `Player` ended up instantiating its own background. Not sure how to handle that better, I think fixing the test to pass is better than adding special suspend-only cases in the refetch logic.