### PR TITLE
Improve realm migration UX to give users a recovery path on error

### DIFF
--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Database
                         Text = "IMPORTANT: During data migration, some of your data could not be successfully migrated. The previous version has been backed up.\n\nFor further assistance, please open a discussion on github and attach your backup files (click to get started).",
                         Activated = () =>
                         {
-                            game.OpenUrlExternally(@"https://github.com/ppy/osu/discussions/new?title=Realm%20migration%20issue&body=Please%20drag%20the%20""attach_me.zip""%20file%20here!&category=q-a", true);
+                            game.OpenUrlExternally($@"https://github.com/ppy/osu/discussions/new?title=Realm%20migration%20issue ({t.Exception.Message})&body=Please%20drag%20the%20""attach_me.zip""%20file%20here!&category=q-a", true);
 
                             const string attachment_filename = "attach_me.zip";
                             const string backup_folder = "backups";

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Database
                         Text = "IMPORTANT: During data migration, some of your data could not be successfully migrated. The previous version has been backed up.\n\nFor further assistance, please open a discussion on github and attach your backup files (click to get started).",
                         Activated = () =>
                         {
-                            game.OpenUrlExternally(@"https://github.com/ppy/osu/discussions/new?title=Realm%20migration%20issue&body=Please%20drag%20the%20""attach_me.zip""%20file%20here!&category=q-a");
+                            game.OpenUrlExternally(@"https://github.com/ppy/osu/discussions/new?title=Realm%20migration%20issue&body=Please%20drag%20the%20""attach_me.zip""%20file%20here!&category=q-a", true);
 
                             const string attachment_filename = "attach_me.zip";
                             const string backup_folder = "backups";

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -166,11 +166,15 @@ namespace osu.Game.Database
 
                             backupStorage.Delete(attachment_filename);
 
-                            using (var zip = ZipArchive.Create())
+                            try
                             {
-                                zip.AddAllFromDirectory(backupStorage.GetFullPath(string.Empty));
-                                zip.SaveTo(Path.Combine(backupStorage.GetFullPath(string.Empty), attachment_filename), new ZipWriterOptions(CompressionType.Deflate));
+                                using (var zip = ZipArchive.Create())
+                                {
+                                    zip.AddAllFromDirectory(backupStorage.GetFullPath(string.Empty));
+                                    zip.SaveTo(Path.Combine(backupStorage.GetFullPath(string.Empty), attachment_filename), new ZipWriterOptions(CompressionType.Deflate));
+                                }
                             }
+                            catch { }
 
                             backupStorage.PresentFileExternally(attachment_filename);
 

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -142,6 +142,16 @@ namespace osu.Game.Database
                 {
                     log("Migration failed!");
                     Logger.Log(t.Exception.ToString(), LoggingTarget.Database);
+
+                    notificationOverlay.Post(new SimpleErrorNotification
+                    {
+                        Text = "IMPORTANT: During data migration, some of your data could not be successfully migrated. It has been backed up in your osu! folder.\n\nFor further assistance, please open a discussion on github and attach your backup files (click to get started).",
+                        Activated = () =>
+                        {
+                            game.OpenUrlExternally(@"https://github.com/ppy/osu/discussions/new?title=Realm%20migration%20issue&body=Please%20attach%20your%20database%20backups%20by%20zipping%20them%20and%20dragging%20in%20here!&category=q-a");
+                            return true;
+                        }
+                    });
                 }
 
                 // Regardless of success, since the game is going to continue with startup let's move the ef database out of the way.

--- a/osu.Game/Online/Chat/ExternalLinkOpener.cs
+++ b/osu.Game/Online/Chat/ExternalLinkOpener.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Online.Chat
             externalLinkWarning = config.GetBindable<bool>(OsuSetting.ExternalLinkWarning);
         }
 
-        public void OpenUrlExternally(string url)
+        public void OpenUrlExternally(string url, bool bypassWarning = false)
         {
-            if (externalLinkWarning.Value)
+            if (!bypassWarning && externalLinkWarning.Value)
                 dialogOverlay.Push(new ExternalLinkDialog(url, () => host.OpenUrlExternally(url)));
             else
                 host.OpenUrlExternally(url);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -357,12 +357,12 @@ namespace osu.Game
             }
         });
 
-        public void OpenUrlExternally(string url) => waitForReady(() => externalLinkOpener, _ =>
+        public void OpenUrlExternally(string url, bool bypassExternalUrlWarning = false) => waitForReady(() => externalLinkOpener, _ =>
         {
             if (url.StartsWith('/'))
                 url = $"{API.APIEndpointUrl}{url}";
 
-            externalLinkOpener.OpenUrlExternally(url);
+            externalLinkOpener.OpenUrlExternally(url, bypassExternalUrlWarning);
         });
 
         /// <summary>

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -202,16 +202,18 @@ namespace osu.Game
             // See https://github.com/ppy/osu/pull/16547 for more discussion.
             if (EFContextFactory != null)
             {
+                const string backup_folder = "backups";
+
                 string migration = $"before_final_migration_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
 
-                EFContextFactory.CreateBackup($"client.{migration}.db");
-                realm.CreateBackup($"client.{migration}.realm");
+                EFContextFactory.CreateBackup(Path.Combine(backup_folder, $"client.{migration}.db"));
+                realm.CreateBackup(Path.Combine(backup_folder, $"client.{migration}.realm"));
 
                 using (var source = Storage.GetStream("collection.db"))
                 {
                     if (source != null)
                     {
-                        using (var destination = Storage.GetStream($"collection.{migration}.db", FileAccess.Write, FileMode.CreateNew))
+                        using (var destination = Storage.GetStream(Path.Combine(backup_folder, $"collection.{migration}.db"), FileAccess.Write, FileMode.CreateNew))
                             source.CopyTo(destination);
                     }
                 }


### PR DESCRIPTION
Mainly, this no longer retries to migrate each startup (nuking any new beatmaps/scores).


https://user-images.githubusercontent.com/191335/151300595-ed5787a3-cc6e-4877-8dec-e0e1bf54d254.mp4


