### PR TITLE
Make `Ruleset.RulesetInfo` get only

### DIFF
--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets
     [ExcludeFromDynamicCompile]
     public abstract class Ruleset
     {
-        public RulesetInfo RulesetInfo { get; internal set; }
+        public RulesetInfo RulesetInfo { get; }
 
         private static readonly ConcurrentDictionary<string, IMod[]> mod_reference_cache = new ConcurrentDictionary<string, IMod[]>();
 


### PR DESCRIPTION
Doesn't look like we need the ability to set any more. This feels more safe.