### PR TITLE
Remove pointless constructor in `RulesetInfo`

### DIFF
--- a/osu.Game.Tests/Database/RealmTest.cs
+++ b/osu.Game.Tests/Database/RealmTest.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Tests.Database
         }
 
         protected static RulesetInfo CreateRuleset() =>
-            new RulesetInfo(0, "osu!", "osu", true);
+            new RulesetInfo("osu", "osu!", string.Empty, 0) { Available = true };
 
         private class RealmTestGame : Framework.Game
         {

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -37,14 +37,6 @@ namespace osu.Game.Rulesets
         {
         }
 
-        public RulesetInfo(int? onlineID, string name, string shortName, bool available)
-        {
-            OnlineID = onlineID ?? -1;
-            Name = name;
-            ShortName = shortName;
-            Available = available;
-        }
-
         public bool Available { get; set; }
 
         public bool Equals(RulesetInfo? other)


### PR DESCRIPTION
I think this was an accident during conversion to using ctor in more places. Only had one usage, which can easily be switched across.