### PR TITLE
Fix `ButtonSystem` null reference crash due to missing null check in delayed animations

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -49,6 +50,7 @@ namespace osu.Game.Screens.Menu
         public const float BUTTON_WIDTH = 140f;
         public const float WEDGE_WIDTH = 20;
 
+        [CanBeNull]
         private OsuLogo logo;
 
         /// <summary>
@@ -328,9 +330,9 @@ namespace osu.Game.Screens.Menu
 
                         game?.Toolbar.Hide();
 
-                        logo.ClearTransforms(targetMember: nameof(Position));
-                        logo.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
-                        logo.ScaleTo(1, 800, Easing.OutExpo);
+                        logo?.ClearTransforms(targetMember: nameof(Position));
+                        logo?.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
+                        logo?.ScaleTo(1, 800, Easing.OutExpo);
                     }, buttonArea.Alpha * 150);
                     break;
 
@@ -354,7 +356,7 @@ namespace osu.Game.Screens.Menu
                             logoDelayedAction = Scheduler.AddDelayed(() =>
                             {
                                 if (impact)
-                                    logo.Impact();
+                                    logo?.Impact();
 
                                 game?.Toolbar.Show();
                             }, 200);


### PR DESCRIPTION
```csharp
[runtime] 2022-01-27 07:36:34 [error]: System.NullReferenceException: Object reference not set to an instance of an object.
[runtime] 2022-01-27 07:36:34 [error]: at osu.Game.Screens.Menu.ButtonSystem.<>c__DisplayClass56_0.<updateLogoState>b__1() in /Users/dean/Projects/osu/osu.Game/Screens/Menu/ButtonSystem.cs:line 357
[runtime] 2022-01-27 07:36:34 [error]: at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
[runtime] 2022-01-27 07:36:34 [error]: at osu.Framework.Threading.Scheduler.Update()
[runtime] 2022-01-27 07:36:34 [error]: at osu.Framework.Graphics.Drawable.UpdateSubTree()
```