### PR TITLE
Fix song select tests not waiting for beatmap imports to arrive

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -69,20 +69,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 Ruleset.Value = new OsuRuleset().RulesetInfo;
                 Beatmap.SetDefault();
+
+                songSelect = null;
             });
 
             AddStep("delete all beatmaps", () => manager?.Delete());
-        }
-
-        public override void TearDownSteps()
-        {
-            base.TearDownSteps();
-
-            AddStep("remove song select", () =>
-            {
-                songSelect?.Expire();
-                songSelect = null;
-            });
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -13,6 +13,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
@@ -71,6 +72,17 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
 
             AddStep("delete all beatmaps", () => manager?.Delete());
+        }
+
+        public override void TearDownSteps()
+        {
+            base.TearDownSteps();
+
+            AddStep("remove song select", () =>
+            {
+                songSelect?.Expire();
+                songSelect = null;
+            });
         }
 
         [Test]
@@ -870,9 +882,16 @@ namespace osu.Game.Tests.Visual.SongSelect
             return set.ChildrenOfType<FilterableDifficultyIcon>().ToList().FindIndex(i => i == icon);
         }
 
-        private void addRulesetImportStep(int id) => AddStep($"import test map for ruleset {id}", () => importForRuleset(id));
+        private void addRulesetImportStep(int id)
+        {
+            Live<BeatmapSetInfo> imported = null;
+            AddStep($"import test map for ruleset {id}", () => imported = importForRuleset(id));
+            // This is specifically for cases where the add is happening post song select load.
+            // For cases where song select is null, the assertions are provided by the load checks.
+            AddUntilStep("wait for imported to arrive in carousel", () => songSelect == null || songSelect.Carousel.BeatmapSets.Any(s => s.ID == imported?.ID));
+        }
 
-        private void importForRuleset(int id) => manager.Import(TestResources.CreateTestBeatmapSetInfo(3, rulesets.AvailableRulesets.Where(r => r.OnlineID == id).ToArray()));
+        private Live<BeatmapSetInfo> importForRuleset(int id) => manager.Import(TestResources.CreateTestBeatmapSetInfo(3, rulesets.AvailableRulesets.Where(r => r.OnlineID == id).ToArray()));
 
         private void checkMusicPlaying(bool playing) =>
             AddUntilStep($"music {(playing ? "" : "not ")}playing", () => music.IsPlaying == playing);


### PR DESCRIPTION
After the change to realm, notification fires could take a frame or two.
We aren't accounting for this.

Fixes test failures like https://github.com/ppy/osu/runs/4963255990?check_suite_focus=true