### PR TITLE
Skip beatmap imports where ruleset is not present in realm

### DIFF
--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -232,6 +232,7 @@ namespace osu.Game.Database
 
                 var transaction = r.BeginWrite();
                 int written = 0;
+                int missing = 0;
 
                 try
                 {
@@ -260,6 +261,12 @@ namespace osu.Game.Database
                         {
                             var ruleset = r.Find<RulesetInfo>(beatmap.RulesetInfo.ShortName);
                             var metadata = getBestMetadata(beatmap.Metadata, beatmapSet.Metadata);
+
+                            if (ruleset == null)
+                            {
+                                log($"Skipping {++missing} beatmaps with missing ruleset");
+                                continue;
+                            }
 
                             var realmBeatmap = new BeatmapInfo(ruleset, new BeatmapDifficulty(beatmap.BaseDifficulty), metadata)
                             {


### PR DESCRIPTION
Closes #16651.

When a ruleset is not available, the `Find` call would return null. When a null is passed to the constructor, `BeatmapInfo` would create an "osu" ruleset, which tries to get stored to realm and fails on duplicate primary key.

Probably need to add better safeties against this (or change that constructor...) but this will fix the migration process.

Probably not serious enough to pull the build. This only affects rulesets like karaoke which have custom beatmaps.