### PR TITLE
Fix tournament client not loading

### DIFF
--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -61,18 +61,15 @@ namespace osu.Game.Tournament
 
             loadingSpinner.Show();
 
-            BracketLoadTask.ContinueWith(t =>
+            BracketLoadTask.ContinueWith(t => Schedule(() =>
             {
                 if (t.IsFaulted)
                 {
-                    Schedule(() =>
-                    {
-                        loadingSpinner.Hide();
-                        loadingSpinner.Expire();
+                    loadingSpinner.Hide();
+                    loadingSpinner.Expire();
 
-                        Logger.Error(t.Exception, "Couldn't load bracket with error");
-                        Add(new WarningBox($"Your {BRACKET_FILENAME} file could not be parsed. Please check runtime.log for more details."));
-                    });
+                    Logger.Error(t.Exception, "Couldn't load bracket with error");
+                    Add(new WarningBox($"Your {BRACKET_FILENAME} file could not be parsed. Please check runtime.log for more details."));
 
                     return;
                 }
@@ -143,7 +140,7 @@ namespace osu.Game.Tournament
                         windowMode.Value = WindowMode.Windowed;
                     }), true);
                 });
-            });
+            }));
         }
     }
 }


### PR DESCRIPTION
[As reported on twitter.](https://twitter.com/omkelderman/status/1486719308851920900)

Caused by a `LoadComponentsAsync()` call being fired from a worker thread, which will throw exceptions since the recent addition of safety checks around that method. Fixed by hoisting the inner schedule already used for the fail branch outside so that it encompasses the entire continuation callback.

Quite unfortunate as this same failure mode was fixed in the test browser at 13aaf766f93eadf358ea9d6b0d0bac2e71358a46.

I've _very_ quickly skimmed all other usages of `LoadComponent(s?)Async()` and they appear to be safe as far as I can tell.