### PR TITLE
Allow realm `.Write()` extension methods to be called in a nested manner

### DIFF
--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Rulesets;
 
 #nullable enable
 
@@ -101,6 +104,46 @@ namespace osu.Game.Tests.Database
                 {
                 }
             });
+        }
+
+        /// <summary>
+        /// This test ensures that the <see cref="RealmExtensions.Write"/> and <see cref="RealmExtensions.Write{T}"/> methods
+        /// can be used in a nested fashion.
+        /// </summary>
+        [Test]
+        public void TestNestedWrites()
+        {
+            RunTestWithRealm((realm, __) =>
+            {
+                realm.Write(r =>
+                {
+                    r.Add(new RulesetInfo { ShortName = "ruleset1" });
+                    checkCountOffThread(0, realm);
+
+                    // check the non-generic variant. note that the braces are required to exercise this.
+                    r.Write(r2 =>
+                    {
+                        r2.Add(new RulesetInfo { ShortName = "ruleset2" });
+                    });
+                    checkCountOffThread(0, realm);
+
+                    // check the generic variant.
+                    _ = r.Write(r3 => r3.Add(new RulesetInfo { ShortName = "ruleset3" }));
+                    checkCountOffThread(0, realm);
+                });
+
+                int finalCount = realm.Run(r => r.All<RulesetInfo>().Count());
+                Assert.AreEqual(3, finalCount);
+                checkCountOffThread(3, realm);
+            });
+
+            void checkCountOffThread(int expectedCount, RealmAccess realmAccess)
+            {
+                int actualCount = -1;
+                // run a refetch from another thread to check what is the actual count which will be seen by other threads.
+                Task.Factory.StartNew(() => actualCount = realmAccess.Run(r1 => r1.All<RulesetInfo>().Count()), TaskCreationOptions.LongRunning | TaskCreationOptions.HideScheduler).WaitSafely();
+                Assert.AreEqual(expectedCount, actualCount);
+            }
         }
     }
 }

--- a/osu.Game/Database/RealmExtensions.cs
+++ b/osu.Game/Database/RealmExtensions.cs
@@ -10,6 +10,14 @@ namespace osu.Game.Database
     {
         public static void Write(this Realm realm, Action<Realm> function)
         {
+            // if a higher-level transaction is already taking place, simply proceed with the write.
+            // the assumption is that the write will be committed by the aforementioned higher-level transaction.
+            if (realm.IsInTransaction)
+            {
+                function(realm);
+                return;
+            }
+
             using var transaction = realm.BeginWrite();
             function(realm);
             transaction.Commit();
@@ -17,6 +25,11 @@ namespace osu.Game.Database
 
         public static T Write<T>(this Realm realm, Func<Realm, T> function)
         {
+            // if a higher-level transaction is already taking place, simply proceed with the write.
+            // the assumption is that the write will be committed by the aforementioned higher-level transaction.
+            if (realm.IsInTransaction)
+                return function(realm);
+
             using var transaction = realm.BeginWrite();
             var result = function(realm);
             transaction.Commit();


### PR DESCRIPTION
I'm PRing this change as a proposal / request for comments first and foremost, not necessarily something to be merged. I'll begin this by explaining my use case for adding this capability.

When reimplementing new difficulty creation with realm, I ran into an issue when writing the actual creation operation - namely, that when [trying to use the existing `BeatmapModelManager.Save()` method from within the difficulty creation operation](https://github.com/bdach/osu/blob/d5171ad8e19fe4c33f0063dad9d0d8c5ec53420e/osu.Game/Beatmaps/BeatmapManager.cs#L146-L151) it would crash, because it is not possible to begin a write on a context if one already has begun - and `BeatmapModelManager.Update()`, which `Save()` calls, [also attempts to start a write](https://github.com/bdach/osu/blob/d5171ad8e19fe4c33f0063dad9d0d8c5ec53420e/osu.Game/Beatmaps/BeatmapModelManager.cs#L110-L117).

Now, at this point I'll explain my assumptions / thought process:

* Generally I want to reuse `Save()`. There is nothing I need to do differently for the new difficulty creation case than what that method already does.
* Ideally, I really _do_ want to run that `Save()` method alongside the other write operations in that block, and the most obvious reason for this is atomicity. I want this entire write operation to either succeed or fail as a whole.
* Moreover, in its [only existing usage in editor](https://github.com/ppy/osu/blob/d1158acb828e0e0b5c4fe97621f0c5f3b7010bf6/osu.Game/Screens/Edit/Editor.cs#L360), `BeatmapModelManager.Save()` receives a detached `BeatmapInfo` model. So without the change present in this PR, to implement new difficulty creation I would not only have to pull the `Save()` call out of the top-level write call, but I would also have to detach the `BeatmapInfo` to be saved - because `BeatmapModelManager.Save()` [casually writes to properties of the model](https://github.com/bdach/osu/blob/d5171ad8e19fe4c33f0063dad9d0d8c5ec53420e/osu.Game/Beatmaps/BeatmapModelManager.cs#L61), which causes a crash if the model instance is managed (because that implies a live write without a write usage taken).

Thus this change, which allows nested `.Write()` calls, was born. It helps with both issues, as with it I could both have the operation be atomic, as well as not have to detach the model.

---

An alternative to this would be to enforce a soft rule that "composable" methods that utilise realms should never take contexts on their own, and that the top-level operation should always take the context to be used further down. But I'm not sure how feasible that is in the long run, and to me having nested writes seems like quite a natural idea from other DBs.

Another alternative would be to ignore this problem for now as possibly-irrelevant in the long run, and run `Save()` separately outside of the top-level write and take the detach hit for the time being. The thought process there would be that when (if?) editor is going to fully run on managed instances, then this will no longer be required, because there will be no more detaching/copying out anymore, and all composable methods could assume that they have received managed instances and there is an active write going.