### PR TITLE
Change some beatmap info/metadata defaults in a backwards compatible manner

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -794,5 +794,32 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(path.Distance, Is.EqualTo(1));
             }
         }
+
+        [Test]
+        public void TestLegacyDefaultsPreserved()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var memoryStream = new MemoryStream())
+            using (var stream = new LineBufferedReader(memoryStream))
+            {
+                var decoded = decoder.Decode(stream);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(decoded.BeatmapInfo.AudioLeadIn, Is.EqualTo(0));
+                    Assert.That(decoded.BeatmapInfo.StackLeniency, Is.EqualTo(0.7f));
+                    Assert.That(decoded.BeatmapInfo.SpecialStyle, Is.False);
+                    Assert.That(decoded.BeatmapInfo.LetterboxInBreaks, Is.False);
+                    Assert.That(decoded.BeatmapInfo.WidescreenStoryboard, Is.False);
+                    Assert.That(decoded.BeatmapInfo.EpilepsyWarning, Is.False);
+                    Assert.That(decoded.BeatmapInfo.SamplesMatchPlaybackRate, Is.False);
+                    Assert.That(decoded.BeatmapInfo.Countdown, Is.EqualTo(CountdownType.Normal));
+                    Assert.That(decoded.BeatmapInfo.CountdownOffset, Is.EqualTo(0));
+                    Assert.That(decoded.BeatmapInfo.Metadata.PreviewTime, Is.EqualTo(-1));
+                    Assert.That(decoded.BeatmapInfo.Ruleset.OnlineID, Is.EqualTo(0));
+                });
+            }
+        }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -99,11 +99,11 @@ namespace osu.Game.Beatmaps
 
         public bool LetterboxInBreaks { get; set; }
 
-        public bool WidescreenStoryboard { get; set; }
+        public bool WidescreenStoryboard { get; set; } = true;
 
         public bool EpilepsyWarning { get; set; }
 
-        public bool SamplesMatchPlaybackRate { get; set; }
+        public bool SamplesMatchPlaybackRate { get; set; } = true;
 
         public double DistanceSpacing { get; set; }
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -90,14 +90,7 @@ namespace osu.Game.Beatmaps
             {
                 Beatmaps =
                 {
-                    new BeatmapInfo
-                    {
-                        Difficulty = new BeatmapDifficulty(),
-                        Ruleset = ruleset,
-                        Metadata = metadata,
-                        WidescreenStoryboard = true,
-                        SamplesMatchPlaybackRate = true,
-                    }
+                    new BeatmapInfo(ruleset, new BeatmapDifficulty(), metadata)
                 }
             };
 

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Beatmaps
         /// The time in milliseconds to begin playing the track for preview purposes.
         /// If -1, the track should begin playing at 40% of its length.
         /// </summary>
-        public int PreviewTime { get; set; }
+        public int PreviewTime { get; set; } = -1;
 
         public string AudioFile { get; set; } = string.Empty;
         public string BackgroundFile { get; set; } = string.Empty;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Beatmaps.Formats
             this.beatmap = beatmap;
             this.beatmap.BeatmapInfo.BeatmapVersion = FormatVersion;
 
+            applyLegacyDefaults(this.beatmap.BeatmapInfo);
+
             base.ParseStreamInto(stream, beatmap);
 
             flushPendingPoints();
@@ -68,6 +70,19 @@ namespace osu.Game.Beatmaps.Formats
 
             foreach (var hitObject in this.beatmap.HitObjects)
                 hitObject.ApplyDefaults(this.beatmap.ControlPointInfo, this.beatmap.Difficulty);
+        }
+
+        /// <summary>
+        /// Some `BeatmapInfo` members have default values that differ from the default values used by stable.
+        /// In addition, legacy beatmaps will sometimes not contain some configuration keys, in which case
+        /// the legacy default values should be used.
+        /// This method's intention is to restore those legacy defaults.
+        /// See also: https://osu.ppy.sh/wiki/en/Client/File_formats/Osu_%28file_format%29
+        /// </summary>
+        private void applyLegacyDefaults(BeatmapInfo beatmapInfo)
+        {
+            beatmapInfo.WidescreenStoryboard = false;
+            beatmapInfo.SamplesMatchPlaybackRate = false;
         }
 
         protected override bool ShouldSkipLine(string line) => base.ShouldSkipLine(line) || line.StartsWith(' ') || line.StartsWith('_');


### PR DESCRIPTION
In my [original attempt](https://github.com/ppy/osu/pull/14799/files) to implement new difficulty creation for editor, I added a [static `BeatmapInfo.CreateDefault()` method](https://github.com/bdach/osu/blob/a84a93a0709b4483b1eddbb8596b324bb5d0760e/osu.Game/Beatmaps/BeatmapInfo.cs#L155-L172) that just created a `BeatmapInfo`, but with some properties changed, with the rationale that they were better and more modern defaults than what the legacy format specifies. For instance, as the days of 4:3 are long gone, so it makes sense to have storyboards be widescreen by default in new beatmaps going forward; a similar argument could be also made for the "samples follow playback rate" setting.

This was [met with a review comment](https://github.com/ppy/osu/pull/14799/files#r711944299) that a better idea would be to apply those modern defaults directly to `BeatmapInfo` fields, but to keep the legacy format defaults in `LegacyBeatmapDecoder` to preserve backward compatibility. This PR achieves this by moving the application of selected legacy defaults to an `applyLegacyDefaults()` method in the decoder.

In the process I've also added test coverage for this, unconditionally applied a default of `-1` to `BeatmapMetadata.PreviewTime` (as it is both the legacy default and looks like the sanest default to apply in general), and also removed a usage of the `BeatmapInfo` parameterless ctor.