### PR TITLE
Fix occasional non-fatal errors from polling API requests incorrectly getting queued twice

### DIFF
--- a/osu.Game/Online/PollingComponent.cs
+++ b/osu.Game/Online/PollingComponent.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Threading;
 
@@ -66,6 +68,8 @@ namespace osu.Game.Online
 
         private void doPoll()
         {
+            Debug.Assert(ThreadSafety.IsUpdateThread);
+
             scheduledPoll = null;
             pollingActive = true;
             Poll().ContinueWith(_ => pollComplete());
@@ -96,13 +100,13 @@ namespace osu.Game.Online
 
             if (!lastTimePolled.HasValue)
             {
-                doPoll();
+                Scheduler.AddOnce(doPoll);
                 return;
             }
 
             if (Time.Current - lastTimePolled.Value > TimeBetweenPolls.Value)
             {
-                doPoll();
+                Scheduler.AddOnce(doPoll);
                 return;
             }
 

--- a/osu.Game/Screens/OnlinePlay/Components/ListingPollingComponent.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/ListingPollingComponent.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             });
         }
 
-        private GetRoomsRequest pollReq;
+        private GetRoomsRequest lastPollRequest;
 
         protected override Task Poll()
         {
@@ -45,10 +45,11 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             var tcs = new TaskCompletionSource<bool>();
 
-            pollReq?.Cancel();
-            pollReq = new GetRoomsRequest(Filter.Value.Status, Filter.Value.Category);
+            lastPollRequest?.Cancel();
 
-            pollReq.Success += result =>
+            var req = new GetRoomsRequest(Filter.Value.Status, Filter.Value.Category);
+
+            req.Success += result =>
             {
                 foreach (var existing in RoomManager.Rooms.ToArray())
                 {
@@ -66,10 +67,11 @@ namespace osu.Game.Screens.OnlinePlay.Components
                 tcs.SetResult(true);
             };
 
-            pollReq.Failure += _ => tcs.SetResult(false);
+            req.Failure += _ => tcs.SetResult(false);
 
-            API.Queue(pollReq);
+            API.Queue(req);
 
+            lastPollRequest = req;
             return tcs.Task;
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Components/SelectionPollingComponent.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/SelectionPollingComponent.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             this.room = room;
         }
 
-        private GetRoomRequest pollReq;
+        private GetRoomRequest lastPollRequest;
 
         protected override Task Poll()
         {
@@ -30,19 +30,22 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             var tcs = new TaskCompletionSource<bool>();
 
-            pollReq?.Cancel();
-            pollReq = new GetRoomRequest(room.RoomID.Value.Value);
+            lastPollRequest?.Cancel();
 
-            pollReq.Success += result =>
+            var req = new GetRoomRequest(room.RoomID.Value.Value);
+
+            req.Success += result =>
             {
                 result.RemoveExpiredPlaylistItems();
                 RoomManager.AddOrUpdateRoom(result);
                 tcs.SetResult(true);
             };
 
-            pollReq.Failure += _ => tcs.SetResult(false);
+            req.Failure += _ => tcs.SetResult(false);
 
-            API.Queue(pollReq);
+            API.Queue(req);
+
+            lastPollRequest = req;
 
             return tcs.Task;
         }


### PR DESCRIPTION
The cause was `Poll` getting called twice from two threads, in such a way that the same request was incorrectly queued twice to `APIAccess`.

I've fixed this at two levels. Rationale being that ensuring it runs on the update thread will potentially save future mistakes.

Closes #16672.