### PR TITLE
Fix editor crashing on custom rulesets due to `ChangeHandler` not being supported

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -82,6 +82,11 @@ namespace osu.Game.Screens.Edit.Compose
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            // May be null in the case of a ruleset that doesn't have editor support, see CreateMainContent().
+            if (composer == null)
+                return;
+
             EditorBeatmap.SelectedHitObjects.BindCollectionChanged((_, __) => updateClipboardActionAvailability());
             clipboard.BindValueChanged(_ => updateClipboardActionAvailability());
             composer.OnLoadComplete += _ => updateClipboardActionAvailability();


### PR DESCRIPTION
As per https://github.com/ppy/osu/discussions/16668, even without proper saving support some ruleset developers do want to work on the editor. This brings things back into a workable state.

Also improves the UX a bit for users that attempt to save beatmaps in unsupported rulesets.

Closes #16668.