### PR TITLE
Fix a couple of cases of incorrect equality checks in the case both values are null

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -107,6 +107,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         {
             set
             {
+                if (score == null && value == null)
+                    return;
+
                 if (score?.Equals(value) == true)
                     return;
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -38,6 +38,14 @@ namespace osu.Game.Screens.Select.Leaderboards
             get => beatmapInfo;
             set
             {
+                if (beatmapInfo == null && value == null)
+                {
+                    // always null scores to ensure a correct initial display.
+                    // see weird `scoresLoadedOnce` logic in base implementation.
+                    Scores = null;
+                    return;
+                }
+
                 if (beatmapInfo?.Equals(value) == true)
                     return;
 


### PR DESCRIPTION
Could be seen when importing beatmaps while on a ruleset that doesn't match any beatmaps:

https://user-images.githubusercontent.com/191335/151492520-767edeac-845f-4712-bec5-659b66dccbfa.mp4


