### PR TITLE
Increase lenience of alpha check in `TestSceneOsuModNoScope`

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -145,6 +145,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
 
         private bool isBreak() => Player.IsBreakTime.Value;
 
-        private bool cursorAlphaAlmostEquals(float alpha) => Precision.AlmostEquals(Player.DrawableRuleset.Cursor.Alpha, alpha);
+        private bool cursorAlphaAlmostEquals(float alpha) => Precision.AlmostEquals(Player.DrawableRuleset.Cursor.Alpha, alpha, 0.1f);
     }
 }


### PR DESCRIPTION
I believe the [test failures](https://github.com/ppy/osu/runs/4977283066?check_suite_focus=true) we're seeing here are due to the implementation of interpolation of the alpha being frame dependent (in a way that doesn't interact well with tests). The reason for never hitting the expected value is that the beatmap ends, causing the cursor to become fully visible again.

It's probably already good-enough for most cases, so let's attempt to silence these test failures by not checking so precisely for the alpha value.

We're checking for either 1 or 0 so it's not too important how close it is to either.