### PR TITLE
Rewrite `Leaderboard` component to bring up to current code standards

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -114,7 +114,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestPlaceholderStates()
         {
-            AddStep(@"Empty Scores", () => leaderboard.SetErrorState(LeaderboardErrorState.NoScores));
+            AddStep("ensure no scores displayed", () => leaderboard.SetScores(null));
+
             AddStep(@"Network failure", () => leaderboard.SetErrorState(LeaderboardErrorState.NetworkFailure));
             AddStep(@"No supporter", () => leaderboard.SetErrorState(LeaderboardErrorState.NotSupporter));
             AddStep(@"Not logged in", () => leaderboard.SetErrorState(LeaderboardErrorState.NotLoggedIn));

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -122,13 +122,6 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep(@"None selected", () => leaderboard.SetRetrievalState(PlaceholderState.NoneSelected));
         }
 
-        [Test]
-        public void TestBeatmapStates()
-        {
-            foreach (BeatmapOnlineStatus status in Enum.GetValues(typeof(BeatmapOnlineStatus)))
-                AddStep($"{status} beatmap", () => showBeatmapWithStatus(status));
-        }
-
         private void showPersonalBestWithNullPosition()
         {
             leaderboard.TopScore = new ScoreInfo

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -114,12 +114,12 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestPlaceholderStates()
         {
-            AddStep(@"Empty Scores", () => leaderboard.SetRetrievalState(PlaceholderState.NoScores));
-            AddStep(@"Network failure", () => leaderboard.SetRetrievalState(PlaceholderState.NetworkFailure));
-            AddStep(@"No supporter", () => leaderboard.SetRetrievalState(PlaceholderState.NotSupporter));
-            AddStep(@"Not logged in", () => leaderboard.SetRetrievalState(PlaceholderState.NotLoggedIn));
-            AddStep(@"Unavailable", () => leaderboard.SetRetrievalState(PlaceholderState.Unavailable));
-            AddStep(@"None selected", () => leaderboard.SetRetrievalState(PlaceholderState.NoneSelected));
+            AddStep(@"Empty Scores", () => leaderboard.SetErrorState(LeaderboardErrorState.NoScores));
+            AddStep(@"Network failure", () => leaderboard.SetErrorState(LeaderboardErrorState.NetworkFailure));
+            AddStep(@"No supporter", () => leaderboard.SetErrorState(LeaderboardErrorState.NotSupporter));
+            AddStep(@"Not logged in", () => leaderboard.SetErrorState(LeaderboardErrorState.NotLoggedIn));
+            AddStep(@"Unavailable", () => leaderboard.SetErrorState(LeaderboardErrorState.Unavailable));
+            AddStep(@"None selected", () => leaderboard.SetErrorState(LeaderboardErrorState.NoneSelected));
         }
 
         private void showPersonalBestWithNullPosition()
@@ -401,22 +401,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             };
         }
 
-        private void showBeatmapWithStatus(BeatmapOnlineStatus status)
-        {
-            leaderboard.BeatmapInfo = new BeatmapInfo
-            {
-                OnlineID = 1113057,
-                Status = status,
-            };
-        }
-
         private class FailableLeaderboard : BeatmapLeaderboard
         {
-            public void SetRetrievalState(PlaceholderState state)
-            {
-                Scores = null;
-                PlaceholderState = state;
-            }
+            public new void SetErrorState(LeaderboardErrorState errorState) => base.SetErrorState(errorState);
 
             public new ICollection<ScoreInfo> Scores
             {

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -414,6 +414,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             public void SetRetrievalState(PlaceholderState state)
             {
+                Scores = null;
                 PlaceholderState = state;
             }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -100,7 +101,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestGlobalScoresDisplay()
         {
             AddStep(@"Set scope", () => leaderboard.Scope = BeatmapLeaderboardScope.Global);
-            AddStep(@"New Scores", () => leaderboard.Scores = generateSampleScores(null));
+            AddStep(@"New Scores", () => leaderboard.SetScores(generateSampleScores(null)));
         }
 
         [Test]
@@ -422,6 +423,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 PlaceholderState = state;
             }
+
+            public void SetScores(ICollection<ScoreInfo> scores) => Scores = scores;
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -116,11 +116,11 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep("ensure no scores displayed", () => leaderboard.SetScores(null));
 
-            AddStep(@"Network failure", () => leaderboard.SetErrorState(LeaderboardErrorState.NetworkFailure));
-            AddStep(@"No supporter", () => leaderboard.SetErrorState(LeaderboardErrorState.NotSupporter));
-            AddStep(@"Not logged in", () => leaderboard.SetErrorState(LeaderboardErrorState.NotLoggedIn));
-            AddStep(@"Unavailable", () => leaderboard.SetErrorState(LeaderboardErrorState.Unavailable));
-            AddStep(@"None selected", () => leaderboard.SetErrorState(LeaderboardErrorState.NoneSelected));
+            AddStep(@"Network failure", () => leaderboard.SetErrorState(LeaderboardState.NetworkFailure));
+            AddStep(@"No supporter", () => leaderboard.SetErrorState(LeaderboardState.NotSupporter));
+            AddStep(@"Not logged in", () => leaderboard.SetErrorState(LeaderboardState.NotLoggedIn));
+            AddStep(@"Unavailable", () => leaderboard.SetErrorState(LeaderboardState.Unavailable));
+            AddStep(@"None selected", () => leaderboard.SetErrorState(LeaderboardState.NoneSelected));
         }
 
         private void showPersonalBestWithNullPosition()
@@ -404,7 +404,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private class FailableLeaderboard : BeatmapLeaderboard
         {
-            public new void SetErrorState(LeaderboardErrorState errorState) => base.SetErrorState(errorState);
+            public new void SetErrorState(LeaderboardState state) => base.SetErrorState(state);
             public new void SetScores(IEnumerable<ScoreInfo> scores, ScoreInfo userScore = default) => base.SetScores(scores, userScore);
         }
     }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestGlobalScoresDisplay()
         {
             AddStep(@"Set scope", () => leaderboard.Scope = BeatmapLeaderboardScope.Global);
-            AddStep(@"New Scores", () => leaderboard.Scores = generateSampleScores(null));
+            AddStep(@"New Scores", () => leaderboard.Scores = generateSampleScores(new BeatmapInfo()));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestGlobalScoresDisplay()
         {
             AddStep(@"Set scope", () => leaderboard.Scope = BeatmapLeaderboardScope.Global);
-            AddStep(@"New Scores", () => leaderboard.Scores = generateSampleScores(new BeatmapInfo()));
+            AddStep(@"New Scores", () => leaderboard.SetScores(generateSampleScores(new BeatmapInfo())));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void showPersonalBestWithNullPosition()
         {
-            leaderboard.TopScore = new ScoreInfo
+            leaderboard.SetScores(leaderboard.Scores, new ScoreInfo
             {
                 Rank = ScoreRank.XH,
                 Accuracy = 1,
@@ -142,12 +142,12 @@ namespace osu.Game.Tests.Visual.SongSelect
                         FlagName = @"ES",
                     },
                 },
-            };
+            });
         }
 
         private void showPersonalBest()
         {
-            leaderboard.TopScore = new ScoreInfo
+            leaderboard.SetScores(leaderboard.Scores, new ScoreInfo
             {
                 Position = 999,
                 Rank = ScoreRank.XH,
@@ -166,7 +166,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                         FlagName = @"ES",
                     },
                 },
-            };
+            });
         }
 
         private void loadMoreScores(Func<BeatmapInfo> beatmapInfo)
@@ -404,12 +404,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private class FailableLeaderboard : BeatmapLeaderboard
         {
             public new void SetErrorState(LeaderboardErrorState errorState) => base.SetErrorState(errorState);
-
-            public new ICollection<ScoreInfo> Scores
-            {
-                get => base.Scores;
-                set => base.Scores = value;
-            }
+            public new void SetScores(IEnumerable<ScoreInfo> scores, ScoreInfo userScore = default) => base.SetScores(scores, userScore);
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestGlobalScoresDisplay()
         {
             AddStep(@"Set scope", () => leaderboard.Scope = BeatmapLeaderboardScope.Global);
-            AddStep(@"New Scores", () => leaderboard.SetScores(generateSampleScores(null)));
+            AddStep(@"New Scores", () => leaderboard.Scores = generateSampleScores(null));
         }
 
         [Test]
@@ -417,7 +417,11 @@ namespace osu.Game.Tests.Visual.SongSelect
                 PlaceholderState = state;
             }
 
-            public void SetScores(ICollection<ScoreInfo> scores) => Scores = scores;
+            public new ICollection<ScoreInfo> Scores
+            {
+                get => base.Scores;
+                set => base.Scores = value;
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             leaderboard.FinishTransforms(true); // After setting scores, we may be waiting for transforms to expire drawables
 
             leaderboard.BeatmapInfo = beatmapInfo;
-            leaderboard.RefreshScores(); // Required in the case that the beatmap hasn't changed
+            leaderboard.RefetchScores(); // Required in the case that the beatmap hasn't changed
         });
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -135,11 +135,9 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUpSteps]
         public void SetupSteps()
         {
-            // Ensure the leaderboard has finished async-loading drawables
-            AddUntilStep("wait for drawables", () => leaderboard.ChildrenOfType<LeaderboardScore>().Any());
-
             // Ensure the leaderboard items have finished showing up
             AddStep("finish transforms", () => leaderboard.FinishTransforms(true));
+            AddUntilStep("wait for drawables", () => leaderboard.ChildrenOfType<LeaderboardScore>().Any());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -128,9 +128,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                 scoreManager.Undelete(r.All<ScoreInfo>().Where(s => s.DeletePending).ToList());
             });
 
-            leaderboard.Scores = null;
-            leaderboard.FinishTransforms(true); // After setting scores, we may be waiting for transforms to expire drawables
-
             leaderboard.BeatmapInfo = beatmapInfo;
             leaderboard.RefetchScores(); // Required in the case that the beatmap hasn't changed
         });

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Online.Leaderboards
     /// <typeparam name="TScoreInfo">The score model class.</typeparam>
     public abstract class Leaderboard<TScope, TScoreInfo> : CompositeDrawable
     {
+        /// <summary>
+        /// Whether the current scope should refetch in response to changes in API connectivity state.
+        /// </summary>
         protected abstract bool IsOnlineScope { get; }
 
         private const double fade_duration = 300;

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Online.Leaderboards
                     return;
 
                 scope = value;
-                RefreshScores();
+                RefetchScores();
             }
         }
 
@@ -160,7 +160,7 @@ namespace osu.Game.Online.Leaderboards
                     case PlaceholderState.NetworkFailure:
                         replacePlaceholder(new ClickablePlaceholder(@"Couldn't fetch scores!", FontAwesome.Solid.Sync)
                         {
-                            Action = RefreshScores
+                            Action = RefetchScores
                         });
                         break;
 
@@ -272,15 +272,15 @@ namespace osu.Game.Online.Leaderboards
                 case APIState.Online:
                 case APIState.Offline:
                     if (IsOnlineScope)
-                        RefreshScores();
+                        RefetchScores();
 
                     break;
             }
         });
 
-        public void RefreshScores() => Scheduler.AddOnce(UpdateScores);
+        public void RefetchScores() => Scheduler.AddOnce(refetchScores);
 
-        protected void UpdateScores()
+        private void refetchScores()
         {
             // don't display any scores or placeholder until the first Scores_Set has been called.
             // this avoids scope changes flickering a "no scores" placeholder before initialisation of song select is finished.

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -278,10 +278,18 @@ namespace osu.Game.Online.Leaderboards
                         replacePlaceholder(new MessagePlaceholder(@"Please invest in an osu!supporter tag to view this leaderboard!"));
                         break;
 
-                    default:
+                    case PlaceholderState.Retrieving:
+                        Debug.Assert(scores?.Any() != true);
+                        replacePlaceholder(null);
+                        break;
+
+                    case PlaceholderState.Successful:
                         Debug.Assert(scores?.Any() == true);
                         replacePlaceholder(null);
                         break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
                 }
             }
         }

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -303,10 +303,9 @@ namespace osu.Game.Online.Leaderboards
                 .Expire();
             scoreFlowContainer = null;
 
-            loading.Hide();
-
             if (scores?.Any() != true)
             {
+                loading.Hide();
                 PlaceholderState = PlaceholderState.NoScores;
                 return;
             }

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -110,12 +110,7 @@ namespace osu.Game.Online.Leaderboards
                             },
                             new Drawable[]
                             {
-                                new Container
-                                {
-                                    AutoSizeAxes = Axes.Y,
-                                    RelativeSizeAxes = Axes.X,
-                                    Child = userScoreContainer = new UserTopScoreContainer<TScoreInfo>(CreateDrawableTopScore)
-                                },
+                                userScoreContainer = new UserTopScoreContainer<TScoreInfo>(CreateDrawableTopScore)
                             },
                         },
                     },

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -165,6 +165,7 @@ namespace osu.Game.Online.Leaderboards
         {
             switch (errorState)
             {
+                case LeaderboardErrorState.NoScores:
                 case LeaderboardErrorState.NoError:
                     throw new InvalidOperationException($"State {errorState} cannot be set by a leaderboard implementation.");
             }
@@ -250,7 +251,7 @@ namespace osu.Game.Online.Leaderboards
 
             if (scores?.Any() != true)
             {
-                SetErrorState(LeaderboardErrorState.NoScores);
+                setErrorState(LeaderboardErrorState.NoScores);
                 loading.Hide();
                 return;
             }

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -82,7 +82,13 @@ namespace osu.Game.Online.Leaderboards
                 // ensure placeholder is hidden when displaying scores
                 PlaceholderState = PlaceholderState.Successful;
 
-                var scoreFlow = CreateScoreFlow();
+                var scoreFlow = new FillFlowContainer<LeaderboardScore>
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(0f, 5f),
+                    Padding = new MarginPadding { Top = 10, Bottom = 5 },
+                };
                 scoreFlow.ChildrenEnumerable = scores.Select((s, index) => CreateDrawableScore(s, index + 1));
 
                 // schedule because we may not be loaded yet (LoadComponentAsync complains).
@@ -117,15 +123,6 @@ namespace osu.Game.Online.Leaderboards
                     topScoreContainer.Show();
             }
         }
-
-        protected virtual FillFlowContainer<LeaderboardScore> CreateScoreFlow()
-            => new FillFlowContainer<LeaderboardScore>
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Spacing = new Vector2(0f, 5f),
-                Padding = new MarginPadding { Top = 10, Bottom = 5 },
-            };
 
         private TScope scope;
 
@@ -345,9 +342,6 @@ namespace osu.Game.Online.Leaderboards
             currentPlaceholder = placeholder;
         }
 
-        protected virtual bool FadeBottom => true;
-        protected virtual bool FadeTop => false;
-
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
@@ -366,22 +360,21 @@ namespace osu.Game.Online.Leaderboards
                 float topY = c.ToSpaceOfOtherDrawable(Vector2.Zero, scrollFlow).Y;
                 float bottomY = topY + LeaderboardScore.HEIGHT;
 
-                bool requireTopFade = FadeTop && topY <= fadeTop;
-                bool requireBottomFade = FadeBottom && bottomY >= fadeBottom;
+                bool requireBottomFade = bottomY >= fadeBottom;
 
-                if (!requireTopFade && !requireBottomFade)
+                if (!requireBottomFade)
                     c.Colour = Color4.White;
                 else if (topY > fadeBottom + LeaderboardScore.HEIGHT || bottomY < fadeTop - LeaderboardScore.HEIGHT)
                     c.Colour = Color4.Transparent;
                 else
                 {
-                    if (bottomY - fadeBottom > 0 && FadeBottom)
+                    if (bottomY - fadeBottom > 0)
                     {
                         c.Colour = ColourInfo.GradientVertical(
                             Color4.White.Opacity(Math.Min(1 - (topY - fadeBottom) / LeaderboardScore.HEIGHT, 1)),
                             Color4.White.Opacity(Math.Min(1 - (bottomY - fadeBottom) / LeaderboardScore.HEIGHT, 1)));
                     }
-                    else if (FadeTop)
+                    else
                     {
                         c.Colour = ColourInfo.GradientVertical(
                             Color4.White.Opacity(Math.Min(1 - (fadeTop - topY) / LeaderboardScore.HEIGHT, 1)),

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -23,6 +23,12 @@ using osuTK.Graphics;
 
 namespace osu.Game.Online.Leaderboards
 {
+    /// <summary>
+    /// A leaderboard which displays a scrolling list of top scores, along with a single "user best"
+    /// for the local user.
+    /// </summary>
+    /// <typeparam name="TScope">The scope of the leaderboard (ie. global or local).</typeparam>
+    /// <typeparam name="TScoreInfo">The score model class.</typeparam>
     public abstract class Leaderboard<TScope, TScoreInfo> : Container
     {
         private const double fade_duration = 300;

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.Leaderboards
         public ICollection<TScoreInfo> Scores
         {
             get => scores;
-            set
+            protected set
             {
                 scores = value;
 

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Online.Leaderboards
     /// </summary>
     /// <typeparam name="TScope">The scope of the leaderboard (ie. global or local).</typeparam>
     /// <typeparam name="TScoreInfo">The score model class.</typeparam>
-    public abstract class Leaderboard<TScope, TScoreInfo> : Container
+    public abstract class Leaderboard<TScope, TScoreInfo> : CompositeDrawable
     {
         private const double fade_duration = 300;
 
@@ -57,10 +57,6 @@ namespace osu.Game.Online.Leaderboards
         private ScheduledDelegate pendingUpdateScores;
 
         private readonly IBindable<APIState> apiState = new Bindable<APIState>();
-
-        private readonly Container content;
-
-        protected override Container<Drawable> Content => content;
 
         private ICollection<TScoreInfo> scores;
 
@@ -231,7 +227,7 @@ namespace osu.Game.Online.Leaderboards
                             },
                             new Drawable[]
                             {
-                                content = new Container
+                                new Container
                                 {
                                     AutoSizeAxes = Axes.Y,
                                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Online.Leaderboards
         }
 
         /// <summary>
-        /// Call when score retrieval is ready to be displayed.
+        /// Call when retrieved scores are ready to be displayed.
         /// </summary>
         /// <param name="scores">The scores to display.</param>
         /// <param name="userScore">The user top score, if any.</param>

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -44,8 +44,6 @@ namespace osu.Game.Online.Leaderboards
         private ScheduledDelegate showScoresDelegate;
         private CancellationTokenSource showScoresCancellationSource;
 
-        private bool scoresLoadedOnce;
-
         private APIRequest getScoresRequest;
         private ScheduledDelegate getScoresRequestCallback;
 
@@ -64,8 +62,6 @@ namespace osu.Game.Online.Leaderboards
             protected set
             {
                 scores = value;
-
-                scoresLoadedOnce = true;
 
                 scrollFlow?.FadeOut(fade_duration, Easing.OutQuint).Expire();
                 scrollFlow = null;
@@ -230,10 +226,6 @@ namespace osu.Game.Online.Leaderboards
 
         private void refetchScores()
         {
-            // don't display any scores or placeholder until the first Scores_Set has been called.
-            // this avoids scope changes flickering a "no scores" placeholder before initialisation of song select is finished.
-            if (!scoresLoadedOnce) return;
-
             cancelPendingWork();
 
             PlaceholderState = PlaceholderState.Retrieving;

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -243,11 +243,10 @@ namespace osu.Game.Online.Leaderboards
 
                 placeholderState = value;
 
-                Debug.Assert(placeholderState != PlaceholderState.Successful || scores?.Any() == true);
-
                 switch (placeholderState)
                 {
                     case PlaceholderState.NetworkFailure:
+                        Debug.Assert(scores?.Any() != true);
                         replacePlaceholder(new ClickablePlaceholder(@"Couldn't fetch scores!", FontAwesome.Solid.Sync)
                         {
                             Action = RefetchScores
@@ -255,26 +254,32 @@ namespace osu.Game.Online.Leaderboards
                         break;
 
                     case PlaceholderState.NoneSelected:
+                        Debug.Assert(scores?.Any() != true);
                         replacePlaceholder(new MessagePlaceholder(@"Please select a beatmap!"));
                         break;
 
                     case PlaceholderState.Unavailable:
+                        Debug.Assert(scores?.Any() != true);
                         replacePlaceholder(new MessagePlaceholder(@"Leaderboards are not available for this beatmap!"));
                         break;
 
                     case PlaceholderState.NoScores:
+                        Debug.Assert(scores?.Any() != true);
                         replacePlaceholder(new MessagePlaceholder(@"No records yet!"));
                         break;
 
                     case PlaceholderState.NotLoggedIn:
+                        Debug.Assert(scores?.Any() != true);
                         replacePlaceholder(new LoginPlaceholder(@"Please sign in to view online leaderboards!"));
                         break;
 
                     case PlaceholderState.NotSupporter:
+                        Debug.Assert(scores?.Any() != true);
                         replacePlaceholder(new MessagePlaceholder(@"Please invest in an osu!supporter tag to view this leaderboard!"));
                         break;
 
                     default:
+                        Debug.Assert(scores?.Any() == true);
                         replacePlaceholder(null);
                         break;
                 }

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -241,9 +241,11 @@ namespace osu.Game.Online.Leaderboards
                 if (value == placeholderState)
                     return;
 
-                loading.Hide();
+                placeholderState = value;
 
-                switch (placeholderState = value)
+                Debug.Assert(placeholderState != PlaceholderState.Successful || scores?.Any() == true);
+
+                switch (placeholderState)
                 {
                     case PlaceholderState.NetworkFailure:
                         replacePlaceholder(new ClickablePlaceholder(@"Couldn't fetch scores!", FontAwesome.Solid.Sync)

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -312,12 +312,14 @@ namespace osu.Game.Online.Leaderboards
             {
                 scrollContainer.Add(scoreFlowContainer = newFlow);
 
-                int i = 0;
+                double delay = 0;
 
                 foreach (var s in scoreFlowContainer.Children)
                 {
-                    using (s.BeginDelayedSequence(i++ * 50))
+                    using (s.BeginDelayedSequence(delay))
                         s.Show();
+
+                    delay += 50;
                 }
 
                 scrollContainer.ScrollToStart(false);

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Online.Leaderboards
             protected set
             {
                 scores = value;
-                Scheduler.AddOnce(updateScoresDrawables);
+                Scheduler.Add(updateScoresDrawables, false);
             }
         }
 

--- a/osu.Game/Online/Leaderboards/LeaderboardErrorState.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardErrorState.cs
@@ -3,10 +3,9 @@
 
 namespace osu.Game.Online.Leaderboards
 {
-    public enum PlaceholderState
+    public enum LeaderboardErrorState
     {
-        Successful,
-        Retrieving,
+        NoError,
         NetworkFailure,
         Unavailable,
         NoneSelected,

--- a/osu.Game/Online/Leaderboards/LeaderboardState.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardState.cs
@@ -3,9 +3,10 @@
 
 namespace osu.Game.Online.Leaderboards
 {
-    public enum LeaderboardErrorState
+    public enum LeaderboardState
     {
-        NoError,
+        Success,
+        Retrieving,
         NetworkFailure,
         Unavailable,
         NoneSelected,

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Online.API;
@@ -30,7 +31,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
         protected override bool IsOnlineScope => true;
 
-        protected override APIRequest FetchScores()
+        protected override APIRequest FetchScores(CancellationToken cancellationToken)
         {
             if (roomId.Value == null)
                 return null;
@@ -39,6 +40,9 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
             req.Success += r =>
             {
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
                 Scores = r.Leaderboard;
                 TopScore = r.UserScore;
             };

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Online.API;
@@ -32,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
         protected override bool IsOnlineScope => true;
 
-        protected override APIRequest FetchScores(Action<IEnumerable<APIUserScoreAggregate>> scoresCallback)
+        protected override APIRequest FetchScores()
         {
             if (roomId.Value == null)
                 return null;
@@ -41,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
             req.Success += r =>
             {
-                scoresCallback?.Invoke(r.Leaderboard);
+                Scores = r.Leaderboard;
                 TopScore = r.UserScore;
             };
 

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
                     return;
 
                 Scores = null;
-                UpdateScores();
+                RefetchScores();
             }, true);
         }
 

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
                 if (id.NewValue == null)
                     return;
 
-                Scores = null;
+                SetScores(null);
                 RefetchScores();
             }, true);
         }
@@ -43,8 +43,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
                 if (cancellationToken.IsCancellationRequested)
                     return;
 
-                Scores = r.Leaderboard;
-                TopScore = r.UserScore;
+                SetScores(r.Leaderboard, r.UserScore);
             };
 
             return req;

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -220,7 +220,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected override Screen CreateGameplayScreen() => new PlayerLoader(() => new PlaylistsPlayer(Room, SelectedItem.Value)
         {
-            Exited = () => leaderboard.RefreshScores()
+            Exited = () => leaderboard.RefetchScores()
         });
     }
 }

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -201,10 +201,13 @@ namespace osu.Game.Screens.Select.Leaderboards
                 scores = scores.Detach();
 
                 scoreManager.OrderByTotalScoreAsync(scores.ToArray(), cancellationToken)
-                            .ContinueWith(ordered =>
+                            .ContinueWith(ordered => Schedule(() =>
                             {
+                                if (cancellationToken.IsCancellationRequested)
+                                    return;
+
                                 SetScores(ordered.GetResultSafely());
-                            }, TaskContinuationOptions.OnlyOnRanToCompletion);
+                            }), TaskContinuationOptions.OnlyOnRanToCompletion);
             }
         }
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet changes, Exception exception)
             {
-                if (IsOnlineScope || cancellationToken.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested)
                     return;
 
                 var scores = sender.AsEnumerable();

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (fetchBeatmapInfo == null)
             {
-                SetErrorState(LeaderboardErrorState.NoneSelected);
+                SetErrorState(LeaderboardState.NoneSelected);
                 return null;
             }
 
@@ -113,19 +113,19 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (api?.IsLoggedIn != true)
             {
-                SetErrorState(LeaderboardErrorState.NotLoggedIn);
+                SetErrorState(LeaderboardState.NotLoggedIn);
                 return null;
             }
 
             if (fetchBeatmapInfo.OnlineID <= 0 || fetchBeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
             {
-                SetErrorState(LeaderboardErrorState.Unavailable);
+                SetErrorState(LeaderboardState.Unavailable);
                 return null;
             }
 
             if (!api.LocalUser.Value.IsSupporter && (Scope != BeatmapLeaderboardScope.Global || filterMods))
             {
-                SetErrorState(LeaderboardErrorState.NotSupporter);
+                SetErrorState(LeaderboardState.NotSupporter);
                 return null;
             }
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -93,12 +93,6 @@ namespace osu.Game.Screens.Select.Leaderboards
             };
         }
 
-        protected override void Reset()
-        {
-            base.Reset();
-            TopScore = null;
-        }
-
         protected override bool IsOnlineScope => Scope != BeatmapLeaderboardScope.Local;
 
         protected override APIRequest FetchScores(CancellationToken cancellationToken)
@@ -153,8 +147,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                                 if (cancellationToken.IsCancellationRequested)
                                     return;
 
-                                Scores = task.GetResultSafely();
-                                TopScore = r.UserScore?.CreateScoreInfo(rulesets, fetchBeatmapInfo);
+                                SetScores(task.GetResultSafely(), r.UserScore?.CreateScoreInfo(rulesets, fetchBeatmapInfo));
                             }), TaskContinuationOptions.OnlyOnRanToCompletion);
             };
 
@@ -210,7 +203,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                 scoreManager.OrderByTotalScoreAsync(scores.ToArray(), cancellationToken)
                             .ContinueWith(ordered =>
                             {
-                                Scores = ordered.GetResultSafely();
+                                SetScores(ordered.GetResultSafely());
                             }, TaskContinuationOptions.OnlyOnRanToCompletion);
             }
         }

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -121,7 +121,6 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (Scope == BeatmapLeaderboardScope.Local)
             {
                 subscribeToLocalScores(cancellationToken);
-
                 return null;
             }
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -33,19 +33,12 @@ namespace osu.Game.Screens.Select.Leaderboards
             set
             {
                 if (beatmapInfo == null && value == null)
-                {
-                    // always null scores to ensure a correct initial display.
-                    // see weird `scoresLoadedOnce` logic in base implementation.
-                    Scores = null;
                     return;
-                }
 
                 if (beatmapInfo?.Equals(value) == true)
                     return;
 
                 beatmapInfo = value;
-                Scores = null;
-
                 RefetchScores();
             }
         }
@@ -114,7 +107,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (fetchBeatmapInfo == null)
             {
-                PlaceholderState = PlaceholderState.NoneSelected;
+                SetErrorState(LeaderboardErrorState.NoneSelected);
                 return null;
             }
 
@@ -126,19 +119,19 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (api?.IsLoggedIn != true)
             {
-                PlaceholderState = PlaceholderState.NotLoggedIn;
+                SetErrorState(LeaderboardErrorState.NotLoggedIn);
                 return null;
             }
 
             if (fetchBeatmapInfo.OnlineID <= 0 || fetchBeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
             {
-                PlaceholderState = PlaceholderState.Unavailable;
+                SetErrorState(LeaderboardErrorState.Unavailable);
                 return null;
             }
 
             if (!api.LocalUser.Value.IsSupporter && (Scope != BeatmapLeaderboardScope.Global || filterMods))
             {
-                PlaceholderState = PlaceholderState.NotSupporter;
+                SetErrorState(LeaderboardErrorState.NotSupporter);
                 return null;
             }
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                 Scores = null;
 
                 if (IsOnlineScope)
-                    UpdateScores();
+                    RefetchScores();
                 else
                 {
                     if (IsLoaded)
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
                 filterMods = value;
 
-                UpdateScores();
+                RefetchScores();
             }
         }
 
@@ -96,11 +96,11 @@ namespace osu.Game.Screens.Select.Leaderboards
         [BackgroundDependencyLoader]
         private void load()
         {
-            ruleset.ValueChanged += _ => UpdateScores();
+            ruleset.ValueChanged += _ => RefetchScores();
             mods.ValueChanged += _ =>
             {
                 if (filterMods)
-                    UpdateScores();
+                    RefetchScores();
             };
         }
 
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                 (_, changes, ___) =>
                 {
                     if (!IsOnlineScope)
-                        RefreshScores();
+                        RefetchScores();
                 });
         }
 

--- a/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Select
         {
             base.Refresh();
 
-            Leaderboard.RefreshScores();
+            Leaderboard.RefetchScores();
         }
 
         protected override void OnTabChanged(BeatmapDetailAreaTabItem tab, bool selectedMods)


### PR DESCRIPTION
This started off as a fix for a bug I came across during manual testing, where the realm subscription wasn't actually subscribing via a certain flow. It turned in to a pretty heavy refactor/rewrite to remove unnecessary complexities. Seems valid effort though, given how central this component is to the game (and given that it will likely see new features and usages going forward).

To reproduce the failure I was witnessing, these steps should work:

- Set global leaderboard
- Switch to a beatmap with local scores
- Set local leaderboard
- Delete a local score
- Note that the leaderboard doesn't update

Looking at the original code, it should be quite clear how this can happen.

To fix this, I've moved the realm flow to use a single point of query. Unfortunately I'm not able to use the `ChangeSet` logic as it stands, due to the mod filtering that we apply to the realm result set (meaning that the indices of realm removals won't match up with our local scores list, see https://github.com/realm/realm-dotnet/issues/2752). This could potentially be worked around with a solution similar to `BeatmapCarousel` with two subscriptions, but as this is going to add some complexity I've not done that in this PR.

There's likely going to be a lot of areas pointed out that this can still be improved. I've got some future work I still want to do on this but I feel like I could spend many more hours on this before I would run out of improvements. Still, open to any suggestions that are seen as required.

Also note that the tests I added somewhat duplicate those in `TestSceneBeatmapLeaderboard`, but I intentionally wanted to cover the full flow, including affirming that the local play is recorded to the database, shows up at song select on returning, and can be interacted with. Nice high level coverage to have.