### PR TITLE
More implementations for Relax (pp and star rating)

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -41,7 +41,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 
             if (mods.Any(h => h is OsuModRelax))
-                speedRating = 0.0;
+            {
+                // These are probably less than ideal, but can be worked on in the future.
+                // Value "weighting":
+                // 0.95 - Less affected by relax, minimum nerf applied.
+                // 0.9 - More affected by relax, harsher nerf applied.
+                // 0.85 - Largely affected by relax, harshest nerf applied.
+                aimRating *= 0.95;
+                speedRating *= 0.9;
+                flashlightRating *= 0.9;
+            }
 
             double baseAimPerformance = Math.Pow(5 * Math.Max(1, aimRating / 0.0675) - 4, 3) / 100000;
             double baseSpeedPerformance = Math.Pow(5 * Math.Max(1, speedRating / 0.0675) - 4, 3) / 100000;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 
-
             double baseAimPerformance = Math.Pow(5 * Math.Max(1, aimRating / 0.0675) - 4, 3) / 100000;
             double baseSpeedPerformance = Math.Pow(5 * Math.Max(1, speedRating / 0.0675) - 4, 3) / 100000;
             double baseFlashlightPerformance = 0.0;
@@ -50,7 +49,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(h => h is OsuModRelax))
             {
-
                 // Similar idea to the PP system speed crosscheck, but for star rating.
                 double speedCrosscheck = baseAimPerformance / baseSpeedPerformance;
                 if (speedCrosscheck < 1.0) // From testing, higher values tend to be entirely unrelated or ridiculously difficult.

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -50,10 +50,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (mods.Any(h => h is OsuModRelax))
             {
-                // These are probably less than ideal, but can be worked on in the future.
-                // Value "weighting":
-                // 0.6 - Less affected by relax, minimum nerf applied.
-                // 0.4 - More affected by relax, harsher nerf applied.
 
                 // Similar idea to the PP system speed crosscheck, but for star rating.
                 double speedCrosscheck = baseAimPerformance / baseSpeedPerformance;
@@ -64,9 +60,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                     baseSpeedPerformance *= Math.Max(0.1, crosscheckMultiplier);
                 }
 
-                // Base nerfs
-                baseAimPerformance *= 0.6;
-                baseSpeedPerformance *= 0.4;
+                // These are probably less than ideal, but can be worked on in the future.
+                baseAimPerformance *= 0.4;
+                baseSpeedPerformance *= 0.5;
                 baseFlashlightPerformance *= 0.6;
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 accuracyValue *= 0.95;
 
                 // Account for any relax gains which are non-specific
-                multiplier = 0.6;
+                multiplier *= 0.54;
             }
 
             double totalValue =

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Description => @"You don't need to click. Give your clicking/tapping fingers a break from the heat of things.";
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModAutopilot)).ToArray();
+        public override double ScoreMultiplier => 0.8;
 
         /// <summary>
         /// How early before a hitobject's start time to trigger a hit.

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Description => @"You don't need to click. Give your clicking/tapping fingers a break from the heat of things.";
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModAutopilot)).ToArray();
-        public override double ScoreMultiplier => 0.8;
 
         /// <summary>
         /// How early before a hitobject's start time to trigger a hit.


### PR DESCRIPTION
The point of this PR is to aid relax towards a more implementable state in a future scenario. Currently there is very basic implementation for Relax, but it is not factored for what relax means for difficulty. There are a multitude of changes I have made which this PR will explain. Some of these changes will likely to be tweaked in the future, but they are way better than the current implementation and help relax be closer to implementable.

# Changes

## Speed cross-check

The idea of the speed cross-check is to get a ratio of aim:speed pp. When using relax, streams are rather easy in comparison to vanilla as there is a lack of tapping aspect. However, speed can still be difficult for some patterns in relax too. By checking this ratio, we can gather if a play is speed focused without any difficult aim (streams) or not. This crosscheck is apparent in both the star rating and pp system calculations and can be seen in both:

https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L61-L70
https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs#L54-L61

This cross check scales by how little aim difficulty there is, and gets applied to both aim and speed pp.

## Miss penalty

Since Relax is entirely aim focused, the miss penalty has been made more harsh in order to factor for the easier overall play experience. It is only slight and can be found here: 

https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L115-L118

## Accuracy scaling

For the same reason stated above, accuracy is also considerably easier to retain on Relax. For this reason, accuracy formulas across all skills have been nerfed for relax. They can be found here:

https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L151-L159
https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L248-L250
https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L281-L282

## Speed AR multiplier

The AR multiplier has only been adjusted for speed, as speed as a skillset in Relax is entirely halfed as there is no aspect of rhythm. This means reading plays little factor into speed for relax, so the multiplier has been nerfed. This can be found here: 

https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L179-L184

## Speed multiplier

For the same reasons stated above, the overall speed value is nerfed: 

https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L203-L206

## Static changes

These are likely to be the ones which need tweaking now. In the future, these may need to get removed, but I don't think it's essential. These static changes are base changes to some multipliers or values with some testing across a plethora of maps and skillsets. They can be found here:

https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs#L72-L77
https://github.com/tsunyoku/osu/blob/66494844321e298110f47f6b7547a234b0270036/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs#L63-L66

## Score multiplier

An actual score multiplier has been implemented for Relax at 0.8. Through testing, I saw this is a good balance between vanilla scores being prioritised, but high mod combo Relax scores still being shown off.

I am open to any suggestions, tweaks etc. to the codebase as I am looking to balance Relax as much as possible. Thanks!