### PR TITLE
Add failsafe to `IntroScreen` to stop users with incorrect audio configuration getting stuck

### DIFF
--- a/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
+++ b/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Threading;
+using osu.Game.Overlays;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osuTK;
@@ -22,6 +24,11 @@ namespace osu.Game.Tests.Visual.Menus
 
         private IntroScreen intro;
 
+        [Cached]
+        private NotificationOverlay notifications;
+
+        private ScheduledDelegate trackResetDelegate;
+
         protected IntroTestScene()
         {
             Children = new Drawable[]
@@ -38,6 +45,11 @@ namespace osu.Game.Tests.Visual.Menus
                     RelativePositionAxes = Axes.Both,
                     Depth = float.MinValue,
                     Position = new Vector2(0.5f),
+                },
+                notifications = new NotificationOverlay
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
                 }
             };
         }
@@ -61,6 +73,39 @@ namespace osu.Game.Tests.Visual.Menus
             });
 
             AddUntilStep("wait for menu", () => intro.DidLoadMenu);
+        }
+
+        [Test]
+        public virtual void TestPlayIntroWithFailingAudioDevice()
+        {
+            AddStep("hide notifications", () => notifications.Hide());
+            AddStep("restart sequence", () =>
+            {
+                logo.FinishTransforms();
+                logo.IsTracking = false;
+
+                IntroStack?.Expire();
+
+                Add(IntroStack = new OsuScreenStack
+                {
+                    RelativeSizeAxes = Axes.Both,
+                });
+
+                IntroStack.Push(intro = CreateScreen());
+            });
+
+            AddStep("trigger failure", () =>
+            {
+                trackResetDelegate = Scheduler.AddDelayed(() =>
+                {
+                    intro.Beatmap.Value.Track.Seek(0);
+                }, 0, true);
+            });
+
+            AddUntilStep("wait for menu", () => intro.DidLoadMenu);
+            AddUntilStep("wait for notification", () => notifications.UnreadCount.Value == 1);
+
+            AddStep("uninstall delegate", () => trackResetDelegate?.Cancel());
         }
 
         protected abstract IntroScreen CreateScreen();

--- a/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
+++ b/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Tests.Visual.Menus
         [Cached]
         private OsuLogo logo;
 
+        protected abstract bool IntroReliesOnTrack { get; }
+
         protected OsuScreenStack IntroStack;
 
         private IntroScreen intro;
@@ -103,7 +105,9 @@ namespace osu.Game.Tests.Visual.Menus
             });
 
             AddUntilStep("wait for menu", () => intro.DidLoadMenu);
-            AddUntilStep("wait for notification", () => notifications.UnreadCount.Value == 1);
+
+            if (IntroReliesOnTrack)
+                AddUntilStep("wait for notification", () => notifications.UnreadCount.Value == 1);
 
             AddStep("uninstall delegate", () => trackResetDelegate?.Cancel());
         }

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroCircles.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroCircles.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneIntroCircles : IntroTestScene
     {
+        protected override bool IntroReliesOnTrack => false;
         protected override IntroScreen CreateScreen() => new IntroCircles();
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroTriangles.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroTriangles.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneIntroTriangles : IntroTestScene
     {
+        protected override bool IntroReliesOnTrack => true;
         protected override IntroScreen CreateScreen() => new IntroTriangles();
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroWelcome.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroWelcome.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneIntroWelcome : IntroTestScene
     {
+        protected override bool IntroReliesOnTrack => false;
         protected override IntroScreen CreateScreen() => new IntroWelcome();
 
         public override void TestPlayIntro()

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -93,6 +93,9 @@ namespace osu.Game.Screens.Menu
         {
             base.OnSuspending(next);
 
+            // ensure the background is shown, even if the TriangleIntroSequence failed to do so.
+            background.ApplyToBackground(b => b.Show());
+
             // important as there is a clock attached to a track which will likely be disposed before returning to this screen.
             intro.Expire();
         }


### PR DESCRIPTION
The most common case of this seems to be linux users with incorrect or unsupported audio driver configurations. It continues to be [brought](https://github.com/ppy/osu/issues/11777) [up](https://github.com/ppy/osu/issues/11927) [in](https://github.com/ppy/osu/discussions/14633) [discussions](https://github.com/ppy/osu/discussions/16685#discussioncomment-2068540) as people are unsure of why their game freezes on startup, and unable to easily recover.

Note that I have not confirmed this worked with the specific case that many linux users run into, but I expect it will do fine.

See https://github.com/ppy/osu-framework/issues/3297 for relevant framework side issue. I propose we add this as a failsafe for not just that said issue, but as a catch-all to allow users to get to the main menu at very least. The same issue will (from my experience with osu-stable) also happen in some cases where no devices are available on the system.