### PR TITLE
Fix multiplayer spectator occasionally freezing at start unexpectedly

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -347,18 +347,43 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert($"{PLAYER_1_ID} score quit still set", () => getLeaderboardScore(PLAYER_1_ID).HasQuit.Value);
         }
 
-        private void loadSpectateScreen(bool waitForPlayerLoad = true)
+        /// <summary>
+        /// Tests spectating with a gameplay start time set to a negative value.
+        /// Simulating beatmaps with high <see cref="BeatmapInfo.AudioLeadIn"/> or negative time storyboard elements.
+        /// </summary>
+        [Test]
+        public void TestNegativeGameplayStartTime()
         {
-            AddStep("load screen", () =>
+            start(PLAYER_1_ID);
+
+            loadSpectateScreen(false, -500);
+
+            // to ensure negative gameplay start time does not affect spectator, send frames exactly after StartGameplay().
+            // (similar to real spectating sessions in which the first frames get sent between StartGameplay() and player load complete)
+            AddStep("send frames at gameplay start", () => getInstance(PLAYER_1_ID).OnGameplayStarted += () => SpectatorClient.SendFrames(PLAYER_1_ID, 100));
+
+            AddUntilStep("wait for player load", () => spectatorScreen.AllPlayersLoaded);
+
+            AddWaitStep("wait for progression", 3);
+
+            assertNotCatchingUp(PLAYER_1_ID);
+            assertRunning(PLAYER_1_ID);
+        }
+
+        private void loadSpectateScreen(bool waitForPlayerLoad = true, double? gameplayStartTime = null)
+        {
+            AddStep(!gameplayStartTime.HasValue ? "load screen" : $"load screen (start = {gameplayStartTime}ms)", () =>
             {
                 Beatmap.Value = beatmapManager.GetWorkingBeatmap(importedBeatmap);
                 Ruleset.Value = importedBeatmap.Ruleset;
 
-                LoadScreen(spectatorScreen = new MultiSpectatorScreen(playingUsers.ToArray()));
+                LoadScreen(spectatorScreen = new TestMultiSpectatorScreen(playingUsers.ToArray(), gameplayStartTime));
             });
 
             AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded && (!waitForPlayerLoad || spectatorScreen.AllPlayersLoaded));
         }
+
+        private void start(int userId, int? beatmapId = null) => start(new[] { userId }, beatmapId);
 
         private void start(int[] userIds, int? beatmapId = null)
         {
@@ -419,6 +444,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private void assertMuted(int userId, bool muted)
             => AddAssert($"{userId} {(muted ? "is" : "is not")} muted", () => getInstance(userId).Mute == muted);
 
+        private void assertRunning(int userId)
+            => AddAssert($"{userId} clock running", () => getInstance(userId).GameplayClock.IsRunning);
+
+        private void assertNotCatchingUp(int userId)
+            => AddAssert($"{userId} in sync", () => !getInstance(userId).GameplayClock.IsCatchingUp);
+
         private void waitForCatchup(int userId)
             => AddUntilStep($"{userId} not catching up", () => !getInstance(userId).GameplayClock.IsCatchingUp);
 
@@ -429,5 +460,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private GameplayLeaderboardScore getLeaderboardScore(int userId) => spectatorScreen.ChildrenOfType<GameplayLeaderboardScore>().Single(s => s.User?.Id == userId);
 
         private int[] getPlayerIds(int count) => Enumerable.Range(PLAYER_1_ID, count).ToArray();
+
+        private class TestMultiSpectatorScreen : MultiSpectatorScreen
+        {
+            private readonly double? gameplayStartTime;
+
+            public TestMultiSpectatorScreen(MultiplayerRoomUser[] users, double? gameplayStartTime = null)
+                : base(users)
+            {
+                this.gameplayStartTime = gameplayStartTime;
+            }
+
+            protected override MasterGameplayClockContainer CreateMasterGameplayClockContainer(WorkingBeatmap beatmap)
+                => new MasterGameplayClockContainer(beatmap, gameplayStartTime ?? 0, gameplayStartTime.HasValue);
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             public SpectatorGameplayClockContainer([NotNull] IClock sourceClock)
                 : base(sourceClock)
             {
+                // the container should initially be in a stopped state until the catch-up clock is started by the sync manager.
+                Stop();
             }
 
             protected override void Update()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Spectator;
@@ -68,7 +69,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             Container leaderboardContainer;
             Container scoreDisplayContainer;
 
-            masterClockContainer = new MasterGameplayClockContainer(Beatmap.Value, 0);
+            masterClockContainer = CreateMasterGameplayClockContainer(Beatmap.Value);
 
             InternalChildren = new[]
             {
@@ -235,5 +236,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             return base.OnBackButton();
         }
+
+        protected virtual MasterGameplayClockContainer CreateMasterGameplayClockContainer(WorkingBeatmap beatmap) => new MasterGameplayClockContainer(beatmap, 0);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             stack.Push(new MultiSpectatorPlayerLoader(Score, () =>
             {
                 var player = new MultiSpectatorPlayer(Score, GameplayClock);
-                player.OnGameplayStarted += OnGameplayStarted;
+                player.OnGameplayStarted += () => OnGameplayStarted?.Invoke();
                 return player;
             }));
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
     public class PlayerArea : CompositeDrawable
     {
         /// <summary>
+        /// Raised after <see cref="Player.StartGameplay"/> is called on <see cref="Player"/>.
+        /// </summary>
+        public event Action OnGameplayStarted;
+
+        /// <summary>
         /// Whether a <see cref="Player"/> is loaded in the area.
         /// </summary>
         public bool PlayerLoaded => (stack?.CurrentScreen as Player)?.IsLoaded == true;
@@ -93,7 +98,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 }
             };
 
-            stack.Push(new MultiSpectatorPlayerLoader(Score, () => new MultiSpectatorPlayer(Score, GameplayClock)));
+            stack.Push(new MultiSpectatorPlayerLoader(Score, () =>
+            {
+                var player = new MultiSpectatorPlayer(Score, GameplayClock);
+                player.OnGameplayStarted += OnGameplayStarted;
+                return player;
+            }));
+
             loadingLayer.Hide();
         }
 

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Stops gameplay.
         /// </summary>
-        public virtual void Stop() => IsPaused.Value = true;
+        public void Stop() => IsPaused.Value = true;
 
         /// <summary>
         /// Resets this <see cref="GameplayClockContainer"/> and the source to an initial state ready for gameplay.

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public const double RESULTS_DISPLAY_DELAY = 1000.0;
 
+        /// <summary>
+        /// Raised after <see cref="StartGameplay"/> is called.
+        /// </summary>
+        public event Action OnGameplayStarted;
+
         public override bool AllowBackButton => false; // handled by HoldForMenuButton
 
         protected override UserActivity InitialActivity => new UserActivity.InSoloGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
@@ -958,7 +963,9 @@ namespace osu.Game.Screens.Play
             updateGameplayState();
 
             GameplayClockContainer.FadeInFromZero(750, Easing.OutQuint);
+
             StartGameplay();
+            OnGameplayStarted?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu/issues/14162.

The catch-up clock should normally never be started unless by the `CatchUpSyncManager`, but since it is used as a source clock for the `MultiSpectatorPlayer`'s spectator GCC, it gets incorrectly started when `StartGameplay()` is called, as that performs a `Reset()` which in turn perform `Start()` and start up the underlying catch-up clock.

This unintended behaviour of starting up the catch-up clock prematurely has lead to the freezing in spectator on certain beatmaps (and previously rewinding, but that has since been hidden via #14776), and that can be explained pretty much via the following logs:
```
[runtime] 2022-01-30 19:45:15 [verbose]: TestMultiSpectatorScreen.LoadComplete(): Resetting MasterGameplayClockContainer.
[runtime] 2022-01-30 19:45:15 [verbose]: TestMultiSpectatorScreen.LoadComplete(): Stopping MasterGameplayClockContainer.
[runtime] 2022-01-30 19:45:15 [verbose]: TestMultiSpectatorScreen.LoadComplete(): Current master elapsed = -999.994669.
[runtime] 2022-01-30 19:45:15 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:1) loading MultiSpectatorPlayerLoader#191
[runtime] 2022-01-30 19:45:15 [verbose]: ✔️ 2 repetitions
[runtime] 2022-01-30 19:45:15 [verbose]: 🔸 Step #239 send frames at gameplay start
[runtime] 2022-01-30 19:45:15 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:1) entered MultiSpectatorPlayerLoader#191
[runtime] 2022-01-30 19:45:15 [verbose]: 📺 BackgroundScreenStack#455(depth:1) loading BackgroundScreenBeatmap#400
[runtime] 2022-01-30 19:45:15 [verbose]: 📺 BackgroundScreenStack#455(depth:1) entered BackgroundScreenBeatmap#400
[runtime] 2022-01-30 19:45:15 [verbose]: 🔸 Step #240 wait for player load
[runtime] 2022-01-30 19:45:18 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:1) suspended MultiSpectatorPlayerLoader#191 (waiting on MultiSpectatorPlayer#533)
[runtime] 2022-01-30 19:45:18 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:2) entered MultiSpectatorPlayer#533
[runtime] 2022-01-30 19:45:18 [verbose]: MultiSpectatorPlayer.StartGameplay(): Resetting SpectatorGameplayClockContainer.
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.Start(): Starting catch-up clock.
[runtime] 2022-01-30 19:45:18 [verbose]: MultiSpectatorPlayer.userSentFrames(): Received first frame bundle, seeking to 0ms
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by -999.994669ms (running at 1x).
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by -999.994669ms (running at 1x).
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSyncManager.Update(): Found running clock while sync manager is stopped, stopping clock.
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.Stop(): Stopping catch-up clock.
[runtime] 2022-01-30 19:45:18 [verbose]: ✔️ 14 repetitions
[runtime] 2022-01-30 19:45:18 [verbose]: 🔸 Step #241 wait for progression 0/3
[runtime] 2022-01-30 19:45:18 [verbose]: TestMultiSpectatorScreen.onReadyToStart(): Seeking MasterGameplayClockContainer to 0ms.
[runtime] 2022-01-30 19:45:18 [verbose]: TestMultiSpectatorScreen.onReadyToStart(): Starting MasterGameplayClockContainer.
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.Start(): Starting catch-up clock.
[runtime] 2022-01-30 19:45:18 [verbose]: TestMultiSpectatorScreen.onMasterStateChanged(): Master clock too far ahead, stopping master.
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
[runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
...
```
([log patch](https://www.github.com/ppy/osu/commit/ea7af44ace79f11da2438c9276a6a345ed6050c8), can also be tested in any real spectating session by forcing `MasterGameplayClockContainer` to have `startOffset` set to a negative time at least beyond -28ms)

I'll go through each relevant piece in the logs to explain this: 
 1. First off, the `MasterGameplayClockContainer` of the multi-spectator screen is reset and stopped on `LoadComplete`, leaving it with a stale `ElapsedFrameTime` value until it's started again (which becomes an issue later on):
    ```
    [runtime] 2022-01-30 19:45:15 [verbose]: TestMultiSpectatorScreen.LoadComplete(): Resetting MasterGameplayClockContainer.
    [runtime] 2022-01-30 19:45:15 [verbose]: TestMultiSpectatorScreen.LoadComplete(): Stopping MasterGameplayClockContainer.
    [runtime] 2022-01-30 19:45:15 [verbose]: TestMultiSpectatorScreen.LoadComplete(): Current master elapsed = -999.994669.
    ```
 2. Then, after all the multi-spectator player gets pushed to the screen, `StartGameplay()` is invoked, which in turn incorrectly start up the catch-up clock:
    ```
    [runtime] 2022-01-30 19:45:15 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:1) entered MultiSpectatorPlayerLoader#191
    [runtime] 2022-01-30 19:45:15 [verbose]: 📺 BackgroundScreenStack#455(depth:1) loading BackgroundScreenBeatmap#400
    [runtime] 2022-01-30 19:45:15 [verbose]: 📺 BackgroundScreenStack#455(depth:1) entered BackgroundScreenBeatmap#400
    [runtime] 2022-01-30 19:45:15 [verbose]: 🔸 Step #240 wait for player load
    [runtime] 2022-01-30 19:45:18 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:1) suspended MultiSpectatorPlayerLoader#191 (waiting on MultiSpectatorPlayer#533)
    [runtime] 2022-01-30 19:45:18 [verbose]: 📺 PlayerArea(OsuScreenStack)#646(depth:2) entered MultiSpectatorPlayer#533
    [runtime] 2022-01-30 19:45:18 [verbose]: MultiSpectatorPlayer.StartGameplay(): Resetting SpectatorGameplayClockContainer.
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.Start(): Starting catch-up clock.
    ```
 3. Following that, the first frame bundle is received before the catch-up clock is stopped, and the catch-up clock starts to receive `ProcessFrame()` calls from seeking, which causes it to end up in an invalid time:
    ```
    [runtime] 2022-01-30 19:45:18 [verbose]: MultiSpectatorPlayer.userSentFrames(): Received first frame bundle, seeking to 0ms
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by -999.994669ms (running at 1x).
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by -999.994669ms (running at 1x).
    ```
    (note that `MasterGameplayClockContainer` is still stopped, which makes the previously reported `ElapsedFrameTime` from stopping the master clock take its effects here)
 4. Afterwards, the `CatchUpSyncManager` will find that the catch-up clock has somehow started while the sync manager isn't ready to start yet, therefore it'll stop it:
    ```
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSyncManager.Update(): Found running clock while sync manager is stopped, stopping clock.
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.Stop(): Stopping catch-up clock.
 5. Finally, the `MultiSpectatorScreen` will get the signal to start master, but since the catch-up clock is too far behind, master is stopped again and the catch-up clock never catches up because master hasn't moved to begin with:
    ```
    [runtime] 2022-01-30 19:45:18 [verbose]: ✔️ 14 repetitions
    [runtime] 2022-01-30 19:45:18 [verbose]: 🔸 Step #241 wait for progression 0/3
    [runtime] 2022-01-30 19:45:18 [verbose]: TestMultiSpectatorScreen.onReadyToStart(): Seeking MasterGameplayClockContainer to 0ms.
    [runtime] 2022-01-30 19:45:18 [verbose]: TestMultiSpectatorScreen.onReadyToStart(): Starting MasterGameplayClockContainer.
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.Start(): Starting catch-up clock.
    [runtime] 2022-01-30 19:45:18 [verbose]: TestMultiSpectatorScreen.onMasterStateChanged(): Master clock too far ahead, stopping master.
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
    [runtime] 2022-01-30 19:45:18 [verbose]: CatchUpSpectatorPlayerClock.ProcessFrame(): Advancing time by 0ms (running at 2x).
    ...
    ```

Other things to consider:
 - It might make sense to make all `GameplayClockContainer`s have `IsPaused` set to true by default, similar to how when any clock is initialised it's always in a stopped state.
 - The `Start()` and `Stop()` methods in `SpectatorGameplayClockContainer` might better be overriden to not actually attempt at starting/stopping the catch-up clock, and leave that to the `Update()`.
 - `CatchUpSpectatorPlayerClock` may need better logic to handle scenarios where master might have an invalid or zero `ElapsedFrameTime`, but fixing the root issue should suffice for now.