### PR TITLE
Rewrite `HardwareCorrectionOffsetClock` to handle seeking on different gameplay rates

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -2,7 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual;
@@ -12,6 +18,14 @@ namespace osu.Game.Tests.Gameplay
     [HeadlessTest]
     public class TestSceneMasterGameplayClockContainer : OsuTestScene
     {
+        private OsuConfigManager localConfig;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Dependencies.Cache(localConfig = new OsuConfigManager(LocalStorage));
+        }
+
         [Test]
         public void TestStartThenElapsedTime()
         {
@@ -53,6 +67,44 @@ namespace osu.Game.Tests.Gameplay
             });
 
             AddAssert("current time < time at reset", () => gcc.GameplayClock.CurrentTime < timeAtReset);
+        }
+
+        [Test]
+        public void TestSeekPerformsInGameplayTime(
+            [Values(1.0, 0.5, 2.0)] double clockRate,
+            [Values(0.0, 200.0, -200.0)] double userOffset,
+            [Values(false, true)] bool whileStopped)
+        {
+            ClockBackedTestWorkingBeatmap working = null;
+            GameplayClockContainer gcc = null;
+
+            AddStep("create container", () =>
+            {
+                working = new ClockBackedTestWorkingBeatmap(new OsuRuleset().RulesetInfo, new FramedClock(new ManualClock()), Audio);
+                working.LoadTrack();
+
+                Add(gcc = new MasterGameplayClockContainer(working, 0));
+
+                if (whileStopped)
+                    gcc.Stop();
+
+                gcc.Reset();
+            });
+
+            AddStep($"set clock rate to {clockRate}", () => working.Track.AddAdjustment(AdjustableProperty.Frequency, new BindableDouble(clockRate)));
+            AddStep($"set audio offset to {userOffset}", () => localConfig.SetValue(OsuSetting.AudioOffset, userOffset));
+
+            AddStep("seek to 2500", () => gcc.Seek(2500));
+            AddAssert("gameplay clock time = 2500", () => Precision.AlmostEquals(gcc.CurrentTime, 2500, 10f));
+
+            AddStep("seek to 10000", () => gcc.Seek(10000));
+            AddAssert("gameplay clock time = 10000", () => Precision.AlmostEquals(gcc.CurrentTime, 10000, 10f));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            localConfig?.Dispose();
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -29,44 +29,44 @@ namespace osu.Game.Tests.Gameplay
         [Test]
         public void TestStartThenElapsedTime()
         {
-            GameplayClockContainer gcc = null;
+            GameplayClockContainer gameplayClockContainer = null;
 
             AddStep("create container", () =>
             {
                 var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
                 working.LoadTrack();
 
-                Add(gcc = new MasterGameplayClockContainer(working, 0));
+                Add(gameplayClockContainer = new MasterGameplayClockContainer(working, 0));
             });
 
-            AddStep("start clock", () => gcc.Start());
-            AddUntilStep("elapsed greater than zero", () => gcc.GameplayClock.ElapsedFrameTime > 0);
+            AddStep("start clock", () => gameplayClockContainer.Start());
+            AddUntilStep("elapsed greater than zero", () => gameplayClockContainer.GameplayClock.ElapsedFrameTime > 0);
         }
 
         [Test]
         public void TestElapseThenReset()
         {
-            GameplayClockContainer gcc = null;
+            GameplayClockContainer gameplayClockContainer = null;
 
             AddStep("create container", () =>
             {
                 var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
                 working.LoadTrack();
 
-                Add(gcc = new MasterGameplayClockContainer(working, 0));
+                Add(gameplayClockContainer = new MasterGameplayClockContainer(working, 0));
             });
 
-            AddStep("start clock", () => gcc.Start());
-            AddUntilStep("current time greater 2000", () => gcc.GameplayClock.CurrentTime > 2000);
+            AddStep("start clock", () => gameplayClockContainer.Start());
+            AddUntilStep("current time greater 2000", () => gameplayClockContainer.GameplayClock.CurrentTime > 2000);
 
             double timeAtReset = 0;
             AddStep("reset clock", () =>
             {
-                timeAtReset = gcc.GameplayClock.CurrentTime;
-                gcc.Reset();
+                timeAtReset = gameplayClockContainer.GameplayClock.CurrentTime;
+                gameplayClockContainer.Reset();
             });
 
-            AddAssert("current time < time at reset", () => gcc.GameplayClock.CurrentTime < timeAtReset);
+            AddAssert("current time < time at reset", () => gameplayClockContainer.GameplayClock.CurrentTime < timeAtReset);
         }
 
         [Test]
@@ -76,29 +76,29 @@ namespace osu.Game.Tests.Gameplay
             [Values(false, true)] bool whileStopped)
         {
             ClockBackedTestWorkingBeatmap working = null;
-            GameplayClockContainer gcc = null;
+            GameplayClockContainer gameplayClockContainer = null;
 
             AddStep("create container", () =>
             {
                 working = new ClockBackedTestWorkingBeatmap(new OsuRuleset().RulesetInfo, new FramedClock(new ManualClock()), Audio);
                 working.LoadTrack();
 
-                Add(gcc = new MasterGameplayClockContainer(working, 0));
+                Add(gameplayClockContainer = new MasterGameplayClockContainer(working, 0));
 
                 if (whileStopped)
-                    gcc.Stop();
+                    gameplayClockContainer.Stop();
 
-                gcc.Reset();
+                gameplayClockContainer.Reset();
             });
 
             AddStep($"set clock rate to {clockRate}", () => working.Track.AddAdjustment(AdjustableProperty.Frequency, new BindableDouble(clockRate)));
             AddStep($"set audio offset to {userOffset}", () => localConfig.SetValue(OsuSetting.AudioOffset, userOffset));
 
-            AddStep("seek to 2500", () => gcc.Seek(2500));
-            AddAssert("gameplay clock time = 2500", () => Precision.AlmostEquals(gcc.CurrentTime, 2500, 10f));
+            AddStep("seek to 2500", () => gameplayClockContainer.Seek(2500));
+            AddAssert("gameplay clock time = 2500", () => Precision.AlmostEquals(gameplayClockContainer.CurrentTime, 2500, 10f));
 
-            AddStep("seek to 10000", () => gcc.Seek(10000));
-            AddAssert("gameplay clock time = 10000", () => Precision.AlmostEquals(gcc.CurrentTime, 10000, 10f));
+            AddStep("seek to 10000", () => gameplayClockContainer.Seek(10000));
+            AddAssert("gameplay clock time = 10000", () => Precision.AlmostEquals(gameplayClockContainer.CurrentTime, 10000, 10f));
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Resolves the remaining edge case I mentioned at https://github.com/ppy/osu/pull/14361#issuecomment-939876602. Doesn't seem to be any relevant to the multi-spectator freezing issues, but may be worth fixing anyways.

Initially I was only going to expose an `Offset * Rate` property and use that to perform the seeks, but as I was going through it, I noticed that `HardwareCorrecitonOffsetClock` could be rewritten to not do the `CurrentTime` override and calculate the rate-adjusted offset and set it to `Offset` directly instead, now that the offset adjustment is updated per frame.

I find the rewritten version better than how it was previously, but I can revert if one is against it.

| Test results on master | Test results on PR |
|--------|----|
| ![CleanShot 2022-01-31 at 01 42 07](https://user-images.githubusercontent.com/22781491/151721037-31ab2766-7c93-43ab-ab4e-667d3a20ad8c.png) |  ![CleanShot 2022-01-31 at 01 42 28](https://user-images.githubusercontent.com/22781491/151721073-8a99732c-f756-40e7-a616-2bd2759c32cb.png) |