### PR TITLE
Refactor carousel drawables to reduce invalidations

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -894,10 +894,8 @@ namespace osu.Game.Screens.Select
             // child items (difficulties) are still visible.
             item.Header.X = offsetX(dist, visibleHalfHeight) - (parent?.X ?? 0);
 
-            // We are applying a multiplicative alpha (which is internally done by nesting an
-            // additional container and setting that container's alpha) such that we can
-            // layer alpha transformations on top.
-            item.SetMultiplicativeAlpha(Math.Clamp(1.75f - 1.5f * dist, 0, 1));
+            // We are applying alpha to the header here such that we can layer alpha transformations on top.
+            item.Header.Alpha = Math.Clamp(1.75f - 1.5f * dist, 0, 1);
         }
 
         private enum PendingScrollOperation

--- a/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Screens.Select.Carousel
 {
     public class CarouselHeader : Container
     {
-        public Container BorderContainer;
-
         public readonly Bindable<CarouselItemState> State = new Bindable<CarouselItemState>(CarouselItemState.NotSelected);
 
         private readonly HoverLayer hoverLayer;
@@ -37,17 +35,14 @@ namespace osu.Game.Screens.Select.Carousel
             RelativeSizeAxes = Axes.X;
             Height = DrawableCarouselItem.MAX_HEIGHT;
 
-            InternalChild = BorderContainer = new Container
+            Masking = true;
+            CornerRadius = corner_radius;
+            BorderColour = new Color4(221, 255, 255, 255);
+
+            InternalChildren = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Masking = true,
-                CornerRadius = corner_radius,
-                BorderColour = new Color4(221, 255, 255, 255),
-                Children = new Drawable[]
-                {
-                    Content,
-                    hoverLayer = new HoverLayer()
-                }
+                Content,
+                hoverLayer = new HoverLayer()
             };
         }
 
@@ -66,21 +61,21 @@ namespace osu.Game.Screens.Select.Carousel
                 case CarouselItemState.NotSelected:
                     hoverLayer.InsetForBorder = false;
 
-                    BorderContainer.BorderThickness = 0;
-                    BorderContainer.EdgeEffect = new EdgeEffectParameters
+                    BorderThickness = 0;
+                    EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Shadow,
                         Offset = new Vector2(1),
                         Radius = 10,
-                        Colour = Color4.Black.Opacity(100),
+                        Colour = Color4.Black.Opacity(0.5f),
                     };
                     break;
 
                 case CarouselItemState.Selected:
                     hoverLayer.InsetForBorder = true;
 
-                    BorderContainer.BorderThickness = border_thickness;
-                    BorderContainer.EdgeEffect = new EdgeEffectParameters
+                    BorderThickness = border_thickness;
+                    EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
                         Colour = new Color4(130, 204, 255, 150),

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -71,6 +71,9 @@ namespace osu.Game.Screens.Select.Carousel
         {
             beatmapInfo = panel.BeatmapInfo;
             Item = panel;
+
+            // Difficulty panels should start hidden for a better initial effect.
+            Hide();
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Screens.Select.Carousel
         /// <summary>
         /// The height of a carousel beatmap, including vertical spacing.
         /// </summary>
-        public const float HEIGHT = height + CAROUSEL_BEATMAP_SPACING;
+        public const float HEIGHT = header_height + CAROUSEL_BEATMAP_SPACING;
 
-        private const float height = MAX_HEIGHT * 0.6f;
+        private const float header_height = MAX_HEIGHT * 0.6f;
 
         private readonly BeatmapInfo beatmapInfo;
 
@@ -67,6 +67,7 @@ namespace osu.Game.Screens.Select.Carousel
         private CancellationTokenSource starDifficultyCancellationSource;
 
         public DrawableCarouselBeatmap(CarouselBeatmap panel)
+            : base(header_height)
         {
             beatmapInfo = panel.BeatmapInfo;
             Item = panel;
@@ -75,8 +76,6 @@ namespace osu.Game.Screens.Select.Carousel
         [BackgroundDependencyLoader(true)]
         private void load(BeatmapManager manager, SongSelect songSelect)
         {
-            Header.Height = height;
-
             if (songSelect != null)
             {
                 startRequested = b => songSelect.FinaliseSelection(b);

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -124,9 +124,9 @@ namespace osu.Game.Screens.Select.Carousel
 
             background.DelayedLoadComplete += fadeContentIn;
             mainFlow.DelayedLoadComplete += fadeContentIn;
-        }
 
-        private void fadeContentIn(Drawable d) => d.FadeInFromZero(750, Easing.OutQuint);
+            static void fadeContentIn(Drawable d) => d.FadeInFromZero(750, Easing.OutQuint);
+        }
 
         protected override void Deselected()
         {

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -122,10 +122,8 @@ namespace osu.Game.Screens.Select.Carousel
                 },
             };
 
-            background.DelayedLoadComplete += fadeContentIn;
-            mainFlow.DelayedLoadComplete += fadeContentIn;
-
-            static void fadeContentIn(Drawable d) => d.FadeInFromZero(750, Easing.OutQuint);
+            background.DelayedLoadComplete += d => d.FadeInFromZero(750, Easing.OutQuint);
+            mainFlow.DelayedLoadComplete += d => d.FadeInFromZero(500, Easing.OutQuint);
         }
 
         protected override void Deselected()

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
         }
 
-        protected DrawableCarouselItem()
+        protected DrawableCarouselItem(float headerHeight = MAX_HEIGHT)
         {
             RelativeSizeAxes = Axes.X;
 
@@ -73,10 +73,14 @@ namespace osu.Game.Screens.Select.Carousel
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        Header = new CarouselHeader(),
+                        Header = new CarouselHeader
+                        {
+                            Height = headerHeight,
+                        },
                         Content = new Container
                         {
                             RelativeSizeAxes = Axes.Both,
+                            Y = headerHeight,
                         }
                     }
                 },
@@ -90,12 +94,6 @@ namespace osu.Game.Screens.Select.Carousel
             base.LoadComplete();
 
             UpdateItem();
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-            Content.Y = Header.Height;
         }
 
         protected virtual void UpdateItem()

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -64,8 +64,6 @@ namespace osu.Game.Screens.Select.Carousel
         {
             RelativeSizeAxes = Axes.X;
 
-            Alpha = 0;
-
             InternalChildren = new Drawable[]
             {
                 MovementContainer = new Container
@@ -119,29 +117,56 @@ namespace osu.Game.Screens.Select.Carousel
 
         private void onStateChange(ValueChangedEvent<bool> _) => Scheduler.AddOnce(ApplyState);
 
+        private CarouselItemState? lastAppliedState;
+
         protected virtual void ApplyState()
         {
-            // Use the fact that we know the precise height of the item from the model to avoid the need for AutoSize overhead.
-            // Additionally, AutoSize doesn't work well due to content starting off-screen and being masked away.
-            Height = Item.TotalHeight;
-
             Debug.Assert(Item != null);
 
-            switch (Item.State.Value)
+            if (lastAppliedState != Item.State.Value)
             {
-                case CarouselItemState.NotSelected:
-                    Deselected();
-                    break;
+                lastAppliedState = Item.State.Value;
 
-                case CarouselItemState.Selected:
-                    Selected();
-                    break;
+                // Use the fact that we know the precise height of the item from the model to avoid the need for AutoSize overhead.
+                // Additionally, AutoSize doesn't work well due to content starting off-screen and being masked away.
+                Height = Item.TotalHeight;
+
+                switch (lastAppliedState)
+                {
+                    case CarouselItemState.NotSelected:
+                        Deselected();
+                        break;
+
+                    case CarouselItemState.Selected:
+                        Selected();
+                        break;
+                }
             }
 
             if (!Item.Visible)
-                this.FadeOut(300, Easing.OutQuint);
+                Hide();
             else
-                this.FadeIn(250);
+                Show();
+        }
+
+        private bool isVisible = true;
+
+        public override void Show()
+        {
+            if (isVisible)
+                return;
+
+            isVisible = true;
+            this.FadeIn(250);
+        }
+
+        public override void Hide()
+        {
+            if (!isVisible)
+                return;
+
+            isVisible = false;
+            this.FadeOut(300, Easing.OutQuint);
         }
 
         protected virtual void Selected()

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -85,8 +85,6 @@ namespace osu.Game.Screens.Select.Carousel
             };
         }
 
-        public void SetMultiplicativeAlpha(float alpha) => Header.BorderContainer.Alpha = alpha;
-
         protected override void LoadComplete()
         {
             base.LoadComplete();


### PR DESCRIPTION
Was hoping to get more returns from this from a performance angle - hard to measure the improvement here as it's mostly focused on the case where a user is scrolling through the carousel quickly. This comes with kind of random results when profiling (due to potential DLW triggers or different beatmaps loading / diffcalcing / whatever) so while I tried to create a before/after comparison it didn't really show much improvement.

Not going to do any further work until we get to look into new designs, as they may change the animations and load style we go for.

Contains a few individual changes:

6bc6675fa1: Adjust fade in times slightly

I was experimenting with combining the `DelayedLoadWrappers` to reduce the overhead they incur, but this both felt worse (perceptively slower load) and didn't help as much as I expected.

8917ab78f4: Reduce unnecessary container nesting and adjust empty state opacity slightly

Opacity change is intended to reduce the visual constrast when new panels fade their backgrounds in. Still not 100% happy with this, but it's an improvement, especially when a bright background is displaying in song select.

c3e3b2019d: Reduce overhead of `ApplyState` by tracking previous values

Even with pooling applied, there are overheads involved with transforms when quickly cycling through the carousel.

The main goal here is to reduce the transforms in cases the reuse is still in the same state. Avoiding firing `FadeIn` and `FadeOut` are the main areas of saving.

a06287e76a: Remove `DrawableCarouselItem.Update` updating of height

Marginal from a performance aspect, but reads better and reduces an every-update height set that didn't need to exist.