### PR TITLE
Fix several cases of unused constructor and method parameters

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 
                     case CatchSkinComponents.CatchComboCounter:
                         if (providesComboCounter)
-                            return new LegacyCatchComboCounter(Skin);
+                            return new LegacyCatchComboCounter();
 
                         return null;
 

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyCatchComboCounter.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyCatchComboCounter.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 
         private readonly LegacyRollingCounter explosion;
 
-        public LegacyCatchComboCounter(ISkin skin)
+        public LegacyCatchComboCounter()
         {
             AutoSizeAxes = Axes.Both;
 

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneColumnHitObjectArea.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneColumnHitObjectArea.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                     {
                         RelativeSizeAxes = Axes.Both,
                         Width = 0.5f,
-                        Child = new ColumnHitObjectArea(0, new HitObjectContainer())
+                        Child = new ColumnHitObjectArea(new HitObjectContainer())
                         {
                             RelativeSizeAxes = Axes.Both
                         }
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                     {
                         RelativeSizeAxes = Axes.Both,
                         Width = 0.5f,
-                        Child = new ColumnHitObjectArea(1, new HitObjectContainer())
+                        Child = new ColumnHitObjectArea(new HitObjectContainer())
                         {
                             RelativeSizeAxes = Axes.Both
                         }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 sampleTriggerSource = new GameplaySampleTriggerSource(HitObjectContainer),
                 // For input purposes, the background is added at the highest depth, but is then proxied back below all other elements
                 background.CreateProxy(),
-                HitObjectArea = new ColumnHitObjectArea(Index, HitObjectContainer) { RelativeSizeAxes = Axes.Both },
+                HitObjectArea = new ColumnHitObjectArea(HitObjectContainer) { RelativeSizeAxes = Axes.Both },
                 new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.KeyArea), _ => new DefaultKeyArea())
                 {
                     RelativeSizeAxes = Axes.Both

--- a/osu.Game.Rulesets.Mania/UI/Components/ColumnHitObjectArea.cs
+++ b/osu.Game.Rulesets.Mania/UI/Components/ColumnHitObjectArea.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Mania.UI.Components
 
         private readonly Drawable hitTarget;
 
-        public ColumnHitObjectArea(int columnIndex, HitObjectContainer hitObjectContainer)
+        public ColumnHitObjectArea(HitObjectContainer hitObjectContainer)
             : base(hitObjectContainer)
         {
             AddRangeInternal(new[]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -118,7 +118,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             public Drawable GetDrawableComponent(ISkinComponent component) => null;
             public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => null;
             public ISample GetSample(ISampleInfo sampleInfo) => null;
-            public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => null;
 
             public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
             {

--- a/osu.Game.Tests/Editing/Checks/CheckTooShortAudioFilesTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckTooShortAudioFilesTest.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Editing.Checks
             beatmap.BeatmapInfo.BeatmapSet.Files.Add(CheckTestHelpers.CreateMockFile("jpg"));
 
             // Should fail to load, but not produce an error due to the extension not being expected to load.
-            Assert.IsEmpty(check.Run(getContext(null, allowMissing: true)));
+            Assert.IsEmpty(check.Run(getContext(null)));
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             using (var resourceStream = TestResources.OpenResource("Samples/missing.mp3"))
             {
-                Assert.IsEmpty(check.Run(getContext(resourceStream, allowMissing: true)));
+                Assert.IsEmpty(check.Run(getContext(resourceStream)));
             }
         }
 
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Editing.Checks
             }
         }
 
-        private BeatmapVerifierContext getContext(Stream resourceStream, bool allowMissing = false)
+        private BeatmapVerifierContext getContext(Stream resourceStream)
         {
             var mockWorkingBeatmap = new Mock<TestWorkingBeatmap>(beatmap, null, null);
             mockWorkingBeatmap.Setup(w => w.GetStream(It.IsAny<string>())).Returns(resourceStream);

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectAccentColour.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectAccentColour.cs
@@ -131,8 +131,6 @@ namespace osu.Game.Tests.Gameplay
 
             public ISample GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 
-            public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => null;
-
             public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
             {
                 switch (lookup)

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
@@ -61,7 +61,6 @@ namespace osu.Game.Tests.NonVisual.Skinning
             public Drawable GetDrawableComponent(ISkinComponent component) => throw new NotSupportedException();
             public ISample GetSample(ISampleInfo sampleInfo) => throw new NotSupportedException();
             public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new NotSupportedException();
-            public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => null;
         }
 
         private class TestAnimationTimeReference : IAnimationTimeReference

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Online
         {
             Dependencies.Cache(rulesets = new RulesetStore(Realm));
             Dependencies.CacheAs<BeatmapManager>(beatmaps = new TestBeatmapManager(LocalStorage, Realm, rulesets, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.CacheAs<BeatmapModelDownloader>(beatmapDownloader = new TestBeatmapModelDownloader(beatmaps, API, host));
+            Dependencies.CacheAs<BeatmapModelDownloader>(beatmapDownloader = new TestBeatmapModelDownloader(beatmaps, API));
         }
 
         [SetUp]
@@ -196,7 +196,7 @@ namespace osu.Game.Tests.Online
 
         internal class TestBeatmapModelDownloader : BeatmapModelDownloader
         {
-            public TestBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> importer, IAPIProvider apiProvider, GameHost gameHost)
+            public TestBeatmapModelDownloader(IModelImporter<BeatmapSetInfo> importer, IAPIProvider apiProvider)
                 : base(importer, apiProvider)
             {
             }

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -173,14 +173,14 @@ namespace osu.Game.Tests.Online
 
             protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
             {
-                return new TestBeatmapModelManager(this, storage, realm, rulesets, onlineLookupQueue);
+                return new TestBeatmapModelManager(this, storage, realm, onlineLookupQueue);
             }
 
             internal class TestBeatmapModelManager : BeatmapModelManager
             {
                 private readonly TestBeatmapManager testBeatmapManager;
 
-                public TestBeatmapModelManager(TestBeatmapManager testBeatmapManager, Storage storage, RealmAccess databaseAccess, RulesetStore rulesetStore, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
+                public TestBeatmapModelManager(TestBeatmapManager testBeatmapManager, Storage storage, RealmAccess databaseAccess, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
                     : base(databaseAccess, storage, beatmapOnlineLookupQueue)
                 {
                     this.testBeatmapManager = testBeatmapManager;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableDrawable.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableDrawable.cs
@@ -301,8 +301,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             public ISample GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 
             public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new NotImplementedException();
-
-            public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => throw new NotImplementedException();
         }
 
         private class SecondarySource : ISkin
@@ -314,8 +312,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             public ISample GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 
             public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new NotImplementedException();
-
-            public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => throw new NotImplementedException();
         }
 
         [Cached(typeof(ISkinSource))]

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Beatmaps
 
         public BeatmapMetadata(RealmUser? user = null)
         {
-            Author = new RealmUser();
+            Author = user ?? new RealmUser();
         }
 
         [UsedImplicitly] // Realm

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Database
                     return;
                 }
 
-                perform(retrieveFromID(r, ID));
+                perform(retrieveFromID(r));
                 RealmLiveStatistics.USAGE_ASYNC.Value++;
             });
         }
@@ -85,7 +85,7 @@ namespace osu.Game.Database
 
             return realm.Run(r =>
             {
-                var returnData = perform(retrieveFromID(r, ID));
+                var returnData = perform(retrieveFromID(r));
                 RealmLiveStatistics.USAGE_ASYNC.Value++;
 
                 if (returnData is RealmObjectBase realmObject && realmObject.IsManaged)
@@ -139,11 +139,11 @@ namespace osu.Game.Database
             }
 
             dataIsFromUpdateThread = true;
-            data = retrieveFromID(realm.Realm, ID);
+            data = retrieveFromID(realm.Realm);
             RealmLiveStatistics.USAGE_UPDATE_REFETCH.Value++;
         }
 
-        private T retrieveFromID(Realm realm, Guid id)
+        private T retrieveFromID(Realm realm)
         {
             var found = realm.Find<T>(ID);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -247,7 +247,7 @@ namespace osu.Game
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
-            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, Scheduler, Host, () => difficultyCache, LocalConfig));
+            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, Scheduler, () => difficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, realm, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
             dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API));

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Scoring
         private readonly ScoreModelManager scoreModelManager;
 
         public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmAccess realm, Scheduler scheduler,
-                            IIpcHost importHost = null, Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
+                            Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
         {
             this.realm = realm;
             this.scheduler = scheduler;

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Edit.Timing
                 }
 
                 Columns = createHeaders();
-                Content = value.Select((g, i) => createContent(i, g)).ToArray().ToRectangular();
+                Content = value.Select(createContent).ToArray().ToRectangular();
             }
         }
 
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.Edit.Timing
             return columns.ToArray();
         }
 
-        private Drawable[] createContent(int index, ControlPointGroup group)
+        private Drawable[] createContent(ControlPointGroup group)
         {
             return new Drawable[]
             {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -49,7 +48,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load()
         {
             InternalChild = new FillFlowContainer
             {
@@ -127,7 +126,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 }
             };
 
-            createColourBars(colours);
+            createColourBars();
         }
 
         protected override void LoadComplete()
@@ -150,7 +149,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             iconLate.Rotation = -Rotation;
         }
 
-        private void createColourBars(OsuColour colours)
+        private void createColourBars()
         {
             var windows = HitWindows.GetAllAvailableWindows().ToArray();
 

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.Play.HUD
                     return;
 
                 if (isRolling)
-                    onDisplayedCountRolling(displayedCount, value);
+                    onDisplayedCountRolling(value);
                 else if (displayedCount + 1 == value)
                     onDisplayedCountIncrement(value);
                 else
@@ -151,7 +151,7 @@ namespace osu.Game.Screens.Play.HUD
                 if (prev + 1 == Current.Value)
                     onCountIncrement(prev, Current.Value);
                 else
-                    onCountChange(prev, Current.Value);
+                    onCountChange(Current.Value);
             }
             else
             {
@@ -226,7 +226,7 @@ namespace osu.Game.Screens.Play.HUD
             transformRoll(currentValue, newValue);
         }
 
-        private void onCountChange(int currentValue, int newValue)
+        private void onCountChange(int newValue)
         {
             scheduledPopOutCurrentId++;
 
@@ -236,7 +236,7 @@ namespace osu.Game.Screens.Play.HUD
             DisplayedCount = newValue;
         }
 
-        private void onDisplayedCountRolling(int currentValue, int newValue)
+        private void onDisplayedCountRolling(int newValue)
         {
             if (newValue == 0)
                 displayedCountSpriteText.FadeOut(fade_out_duration);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Screens.Play
                     {
                         // underlay and gameplay should have access to the skinning sources.
                         createUnderlayComponents(),
-                        createGameplayComponents(Beatmap.Value, playableBeatmap)
+                        createGameplayComponents(Beatmap.Value)
                     }
                 },
                 FailOverlay = new FailOverlay
@@ -364,7 +364,7 @@ namespace osu.Game.Screens.Play
         private Drawable createUnderlayComponents() =>
             DimmableStoryboard = new DimmableStoryboard(Beatmap.Value.Storyboard) { RelativeSizeAxes = Axes.Both };
 
-        private Drawable createGameplayComponents(IWorkingBeatmap working, IBeatmap playableBeatmap) => new ScalingContainer(ScalingMode.Gameplay)
+        private Drawable createGameplayComponents(IWorkingBeatmap working) => new ScalingContainer(ScalingMode.Gameplay)
         {
             Children = new Drawable[]
             {

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Skinning
 
             userFiles = new StorageBackedResourceStore(storage.GetStorageForDirectory("files"));
 
-            skinModelManager = new SkinModelManager(storage, realm, host, this);
+            skinModelManager = new SkinModelManager(storage, realm, this);
 
             var defaultSkins = new[]
             {

--- a/osu.Game/Skinning/SkinModelManager.cs
+++ b/osu.Game/Skinning/SkinModelManager.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Skinning
 
         private readonly IStorageResourceProvider skinResources;
 
-        public SkinModelManager(Storage storage, RealmAccess realm, GameHost host, IStorageResourceProvider skinResources)
+        public SkinModelManager(Storage storage, RealmAccess realm, IStorageResourceProvider skinResources)
             : base(storage, realm)
         {
             this.skinResources = skinResources;

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Tests.Visual
 
             protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
             {
-                return new TestBeatmapModelManager(storage, realm, rulesets, onlineLookupQueue);
+                return new TestBeatmapModelManager(storage, realm, onlineLookupQueue);
             }
 
             protected override WorkingBeatmapCache CreateWorkingBeatmapCache(AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> storage, WorkingBeatmap defaultBeatmap, GameHost host)
@@ -150,7 +150,7 @@ namespace osu.Game.Tests.Visual
 
             internal class TestBeatmapModelManager : BeatmapModelManager
             {
-                public TestBeatmapModelManager(Storage storage, RealmAccess databaseAccess, RulesetStore rulesetStore, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
+                public TestBeatmapModelManager(Storage storage, RealmAccess databaseAccess, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
                     : base(databaseAccess, storage, beatmapOnlineLookupQueue)
                 {
                 }


### PR DESCRIPTION
This series began with me working on new difficulty creation, again, and stepping onto this rake in `BeatmapMetadata`:

https://github.com/ppy/osu/blob/2c0c44a9504c831686d49f52b574051ec03cc092/osu.Game/Beatmaps/BeatmapMetadata.cs#L47-L50

Note how the `user` param is used. Which is to say, not at all.

The above spurred me on to hunt down whatever else I could to check if there's any other breakage of this sort. Fortunately, there doesn't seem to be - besides from 3d7af805a3cd0905fef3bfc15544330d3bdcd912 which is actually fixing something, everything else is just cleanups of parameters that are just not used anymore.

Reading this commit by commit is slightly nicer than in bulk, as you can delineate each removal as some span multiple levels of passing around. All of the cleanup commits contain the SHA of the original commit that made the parameter redundant in the commit message. I didn't really want to duplicate them in this post because that just doesn't really work...?

Unfortunately I don't think it is feasible to turn on the appropriate inspection for this, as there are several disputable cases (wherein a param is technically unused, but it seems good form to pass them anyway - like [this mod usage](https://github.com/ppy/osu/blob/2c0c44a9504c831686d49f52b574051ec03cc092/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs#L35), for instance), and several cases where stuff just hasn't been implemented (like [this one](https://github.com/ppy/osu/blob/2c0c44a9504c831686d49f52b574051ec03cc092/osu.Game.Tests/Database/BeatmapImporterTests.cs#L941-L952), or [this one](https://github.com/ppy/osu/blob/2c0c44a9504c831686d49f52b574051ec03cc092/osu.Game/Graphics/OsuFont.cs#L40-L45)).