### PR TITLE
Fix rulesets potentially being marked `Available` even when methods are missing

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -149,6 +149,10 @@ namespace osu.Game.Rulesets
                         var instanceInfo = (Activator.CreateInstance(resolvedType) as Ruleset)?.RulesetInfo
                                            ?? throw new RulesetLoadException(@"Instantiation failure");
 
+                        // If a ruleset isn't up-to-date with the API, it could cause a crash at an arbitrary point of execution.
+                        // To eagerly handle cases of missing implementations, enumerate all types here and mark as non-available on throw.
+                        resolvedType.Assembly.GetTypes();
+
                         r.Name = instanceInfo.Name;
                         r.ShortName = instanceInfo.ShortName;
                         r.InstantiationInfo = instanceInfo.InstantiationInfo;


### PR DESCRIPTION
Came up when running the game after the recent breaking changes (https://github.com/ppy/osu/pull/16722), where two template rulesets I had loaded were erroring on startup but still being marked as available, allowing them to crash the game on attempting to initiate relpay logic.

These cases are already handled for first-time ruleset loading via the `GetTypes()` enumeration in `RulesetStore.addRuleset`, but when consistency checking already present rulesets the only runtime validation being done was `ruleset.CreateInstance()`, which does not handle missing types or methods.