### PR TITLE
Allow statistic items in results screen to display without needing to watch a replay

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -370,8 +370,7 @@ namespace osu.Game.Rulesets.Mania
             {
                 Columns = new[]
                 {
-                    new StatisticItem("Timing Distribution",
-                        true,
+                    new StatisticItem("Timing Distribution", true,
                         () => new HitEventTimingDistributionGraph(score.HitEvents)
                         {
                             RelativeSizeAxes = Axes.X,
@@ -383,8 +382,7 @@ namespace osu.Game.Rulesets.Mania
             {
                 Columns = new[]
                 {
-                    new StatisticItem(string.Empty,
-                        true,
+                    new StatisticItem(string.Empty, true,
                         () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
                         {
                             new UnstableRate(score.HitEvents)

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -370,21 +370,25 @@ namespace osu.Game.Rulesets.Mania
             {
                 Columns = new[]
                 {
-                    new StatisticItem("Timing Distribution", new HitEventTimingDistributionGraph(score.HitEvents)
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Height = 250
-                    }),
+                    new StatisticItem("Timing Distribution",
+                        true,
+                        () => new HitEventTimingDistributionGraph(score.HitEvents)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 250
+                        }),
                 }
             },
             new StatisticRow
             {
                 Columns = new[]
                 {
-                    new StatisticItem(string.Empty, new SimpleStatisticTable(3, new SimpleStatisticItem[]
-                    {
-                        new UnstableRate(score.HitEvents)
-                    }))
+                    new StatisticItem(string.Empty,
+                        true,
+                        () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                        {
+                            new UnstableRate(score.HitEvents)
+                        }))
                 }
             }
         };

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -370,23 +370,21 @@ namespace osu.Game.Rulesets.Mania
             {
                 Columns = new[]
                 {
-                    new StatisticItem("Timing Distribution", true,
-                        () => new HitEventTimingDistributionGraph(score.HitEvents)
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = 250
-                        }),
+                    new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 250
+                    }, true),
                 }
             },
             new StatisticRow
             {
                 Columns = new[]
                 {
-                    new StatisticItem(string.Empty, true,
-                        () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
-                        {
-                            new UnstableRate(score.HitEvents)
-                        }))
+                    new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                    {
+                        new UnstableRate(score.HitEvents)
+                    }), true)
                 }
             }
         };

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -277,35 +277,32 @@ namespace osu.Game.Rulesets.Osu
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Timing Distribution", true,
-                            () => new HitEventTimingDistributionGraph(timedHitEvents)
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                Height = 250
-                            }),
+                        new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 250
+                        }, true),
                     }
                 },
                 new StatisticRow
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Accuracy Heatmap", true,
-                            () => new AccuracyHeatmap(score, playableBeatmap)
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                Height = 250
-                            }),
+                        new StatisticItem("Accuracy Heatmap", () => new AccuracyHeatmap(score, playableBeatmap)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 250
+                        }, true),
                     }
                 },
                 new StatisticRow
                 {
                     Columns = new[]
                     {
-                        new StatisticItem(string.Empty, true,
-                            () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
-                            {
-                                new UnstableRate(timedHitEvents)
-                            }))
+                        new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                        {
+                            new UnstableRate(timedHitEvents)
+                        }), true)
                     }
                 }
             };

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -277,8 +277,7 @@ namespace osu.Game.Rulesets.Osu
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Timing Distribution",
-                            true,
+                        new StatisticItem("Timing Distribution", true,
                             () => new HitEventTimingDistributionGraph(timedHitEvents)
                             {
                                 RelativeSizeAxes = Axes.X,
@@ -290,8 +289,7 @@ namespace osu.Game.Rulesets.Osu
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Accuracy Heatmap",
-                            true,
+                        new StatisticItem("Accuracy Heatmap", true,
                             () => new AccuracyHeatmap(score, playableBeatmap)
                             {
                                 RelativeSizeAxes = Axes.X,
@@ -303,8 +301,7 @@ namespace osu.Game.Rulesets.Osu
                 {
                     Columns = new[]
                     {
-                        new StatisticItem(string.Empty,
-                            true,
+                        new StatisticItem(string.Empty, true,
                             () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
                             {
                                 new UnstableRate(timedHitEvents)

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -278,7 +278,8 @@ namespace osu.Game.Rulesets.Osu
                     Columns = new[]
                     {
                         new StatisticItem("Timing Distribution",
-                            new HitEventTimingDistributionGraph(timedHitEvents)
+                            true,
+                            () => new HitEventTimingDistributionGraph(timedHitEvents)
                             {
                                 RelativeSizeAxes = Axes.X,
                                 Height = 250
@@ -289,21 +290,25 @@ namespace osu.Game.Rulesets.Osu
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Accuracy Heatmap", new AccuracyHeatmap(score, playableBeatmap)
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = 250
-                        }),
+                        new StatisticItem("Accuracy Heatmap",
+                            true,
+                            () => new AccuracyHeatmap(score, playableBeatmap)
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 250
+                            }),
                     }
                 },
                 new StatisticRow
                 {
                     Columns = new[]
                     {
-                        new StatisticItem(string.Empty, new SimpleStatisticTable(3, new SimpleStatisticItem[]
-                        {
-                            new UnstableRate(timedHitEvents)
-                        }))
+                        new StatisticItem(string.Empty,
+                            true,
+                            () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                            {
+                                new UnstableRate(timedHitEvents)
+                            }))
                     }
                 }
             };

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -213,23 +213,21 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Timing Distribution", true,
-                            () => new HitEventTimingDistributionGraph(timedHitEvents)
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                Height = 250
-                            }),
+                        new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 250
+                        }, true),
                     }
                 },
                 new StatisticRow
                 {
                     Columns = new[]
                     {
-                        new StatisticItem(string.Empty, true,
-                            () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
-                            {
-                                new UnstableRate(timedHitEvents)
-                            }))
+                        new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                        {
+                            new UnstableRate(timedHitEvents)
+                        }), true)
                     }
                 }
             };

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -213,8 +213,7 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Timing Distribution",
-                            true,
+                        new StatisticItem("Timing Distribution", true,
                             () => new HitEventTimingDistributionGraph(timedHitEvents)
                             {
                                 RelativeSizeAxes = Axes.X,
@@ -226,8 +225,7 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     Columns = new[]
                     {
-                        new StatisticItem(string.Empty,
-                            true,
+                        new StatisticItem(string.Empty, true,
                             () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
                             {
                                 new UnstableRate(timedHitEvents)

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -213,21 +213,25 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     Columns = new[]
                     {
-                        new StatisticItem("Timing Distribution", new HitEventTimingDistributionGraph(timedHitEvents)
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = 250
-                        }),
+                        new StatisticItem("Timing Distribution",
+                            true,
+                            () => new HitEventTimingDistributionGraph(timedHitEvents)
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 250
+                            }),
                     }
                 },
                 new StatisticRow
                 {
                     Columns = new[]
                     {
-                        new StatisticItem(string.Empty, new SimpleStatisticTable(3, new SimpleStatisticItem[]
-                        {
-                            new UnstableRate(timedHitEvents)
-                        }))
+                        new StatisticItem(string.Empty,
+                            true,
+                            () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                            {
+                                new UnstableRate(timedHitEvents)
+                            }))
                     }
                 }
             };

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -6,10 +6,18 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
 using osu.Game.Tests.Resources;
 using osuTK;
 
@@ -39,6 +47,24 @@ namespace osu.Game.Tests.Visual.Ranking
         public void TestScoreWithoutStatistics()
         {
             loadPanel(TestResources.CreateTestScoreInfo());
+        }
+
+        [Test]
+        public void TestScoreInRulesetWhereAllStatsRequireHitEvents()
+        {
+            loadPanel(TestResources.CreateTestScoreInfo(new TestRulesetAllStatsRequireHitEvents().RulesetInfo));
+        }
+
+        [Test]
+        public void TestScoreInRulesetWhereNoStatsRequireHitEvents()
+        {
+            loadPanel(TestResources.CreateTestScoreInfo(new TestRulesetNoStatsRequireHitEvents().RulesetInfo));
+        }
+
+        [Test]
+        public void TestScoreInMixedRuleset()
+        {
+            loadPanel(TestResources.CreateTestScoreInfo(new TestRulesetMixed().RulesetInfo));
         }
 
         [Test]
@@ -74,6 +100,135 @@ namespace osu.Game.Tests.Visual.Ranking
             }
 
             return hitEvents;
+        }
+
+        private class TestRuleset : Ruleset
+        {
+            public override IEnumerable<Mod> GetModsFor(ModType type)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override string Description => string.Empty;
+
+            public override string ShortName => string.Empty;
+
+            protected static Drawable CreatePlaceholderStatistic(string message) => new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Masking = true,
+                CornerRadius = 20,
+                Height = 250,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = OsuColour.Gray(0.5f),
+                        Alpha = 0.5f
+                    },
+                    new OsuSpriteText
+                    {
+                        Origin = Anchor.CentreLeft,
+                        Anchor = Anchor.CentreLeft,
+                        Text = message,
+                        Margin = new MarginPadding { Left = 20 }
+                    }
+                }
+            };
+        }
+
+        private class TestRulesetAllStatsRequireHitEvents : TestRuleset
+        {
+            public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap)
+            {
+                return new[]
+                {
+                    new StatisticRow
+                    {
+                        Columns = new[]
+                        {
+                            new StatisticItem("Statistic Requiring Hit Events 1",
+                                () => CreatePlaceholderStatistic("Placeholder statistic. Requires hit events"), true)
+                        }
+                    },
+                    new StatisticRow
+                    {
+                        Columns = new[]
+                        {
+                            new StatisticItem("Statistic Requiring Hit Events 2",
+                                () => CreatePlaceholderStatistic("Placeholder statistic. Requires hit events"), true)
+                        }
+                    }
+                };
+            }
+        }
+
+        private class TestRulesetNoStatsRequireHitEvents : TestRuleset
+        {
+            public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap)
+            {
+                return new[]
+                {
+                    new StatisticRow
+                    {
+                        Columns = new[]
+                        {
+                            new StatisticItem("Statistic Not Requiring Hit Events 1",
+                                () => CreatePlaceholderStatistic("Placeholder statistic. Does not require hit events"))
+                        }
+                    },
+                    new StatisticRow
+                    {
+                        Columns = new[]
+                        {
+                            new StatisticItem("Statistic Not Requiring Hit Events 2",
+                                () => CreatePlaceholderStatistic("Placeholder statistic. Does not require hit events"))
+                        }
+                    }
+                };
+            }
+        }
+
+        private class TestRulesetMixed : TestRuleset
+        {
+            public override StatisticRow[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap)
+            {
+                return new[]
+                {
+                    new StatisticRow
+                    {
+                        Columns = new[]
+                        {
+                            new StatisticItem("Statistic Requiring Hit Events",
+                                () => CreatePlaceholderStatistic("Placeholder statistic. Requires hit events"), true)
+                        }
+                    },
+                    new StatisticRow
+                    {
+                        Columns = new[]
+                        {
+                            new StatisticItem("Statistic Not Requiring Hit Events",
+                                () => CreatePlaceholderStatistic("Placeholder statistic. Does not require hit events"))
+                        }
+                    }
+                };
+            }
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
                             Margin = new MarginPadding { Top = 15 },
-                            Child = item.Content
+                            Child = item.Content()
                         }
                     },
                 },

--- a/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
                             Margin = new MarginPadding { Top = 15 },
-                            Child = item.Content()
+                            Child = item.CreateContent()
                         }
                     },
                 },

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,7 +21,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <summary>
         /// The <see cref="Drawable"/> content to be displayed.
         /// </summary>
-        public readonly Drawable Content;
+        public readonly Func<Drawable> Content;
 
         /// <summary>
         /// The <see cref="Dimension"/> of this row. This can be thought of as the column dimension of an encompassing <see cref="GridContainer"/>.
@@ -28,14 +29,21 @@ namespace osu.Game.Screens.Ranking.Statistics
         public readonly Dimension Dimension;
 
         /// <summary>
+        /// Whether this item requires hit events. If true, the <see cref="Content"/> will not be created if no hit events are available.
+        /// </summary>
+        public readonly bool RequiresHitEvents;
+
+        /// <summary>
         /// Creates a new <see cref="StatisticItem"/>, to be displayed inside a <see cref="StatisticRow"/> in the results screen.
         /// </summary>
         /// <param name="name">The name of the item. Can be <see cref="string.Empty"/> to hide the item header.</param>
+        /// <param name="requiresHitEvents">Whether this item requires hit events. If true, the <see cref="Content"/> will not be created if no hit events are available.</param>
         /// <param name="content">The <see cref="Drawable"/> content to be displayed.</param>
         /// <param name="dimension">The <see cref="Dimension"/> of this item. This can be thought of as the column dimension of an encompassing <see cref="GridContainer"/>.</param>
-        public StatisticItem([NotNull] string name, [NotNull] Drawable content, [CanBeNull] Dimension dimension = null)
+        public StatisticItem([NotNull] string name, bool requiresHitEvents, [NotNull] Func<Drawable> content, [CanBeNull] Dimension dimension = null)
         {
             Name = name;
+            RequiresHitEvents = requiresHitEvents;
             Content = content;
             Dimension = dimension;
         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -37,10 +37,10 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// Creates a new <see cref="StatisticItem"/>, to be displayed inside a <see cref="StatisticRow"/> in the results screen.
         /// </summary>
         /// <param name="name">The name of the item. Can be <see cref="string.Empty"/> to hide the item header.</param>
-        /// <param name="requiresHitEvents">Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.</param>
         /// <param name="createContent">A function returning the <see cref="Drawable"/> content to be displayed.</param>
+        /// <param name="requiresHitEvents">Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.</param>
         /// <param name="dimension">The <see cref="Dimension"/> of this item. This can be thought of as the column dimension of an encompassing <see cref="GridContainer"/>.</param>
-        public StatisticItem([NotNull] string name, bool requiresHitEvents, [NotNull] Func<Drawable> createContent, [CanBeNull] Dimension dimension = null)
+        public StatisticItem([NotNull] string name, [NotNull] Func<Drawable> createContent, bool requiresHitEvents = false, [CanBeNull] Dimension dimension = null)
         {
             Name = name;
             RequiresHitEvents = requiresHitEvents;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -33,6 +33,12 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// </summary>
         public readonly bool RequiresHitEvents;
 
+        [Obsolete("Use constructor which takes creation function instead.")] // Can be removed 20220803.
+        public StatisticItem([NotNull] string name, [NotNull] Drawable content, [CanBeNull] Dimension dimension = null)
+            : this(name, () => content, true, dimension)
+        {
+        }
+
         /// <summary>
         /// Creates a new <see cref="StatisticItem"/>, to be displayed inside a <see cref="StatisticRow"/> in the results screen.
         /// </summary>

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -19,9 +19,9 @@ namespace osu.Game.Screens.Ranking.Statistics
         public readonly string Name;
 
         /// <summary>
-        /// The <see cref="Drawable"/> content to be displayed.
+        /// A function returning the <see cref="Drawable"/> content to be displayed.
         /// </summary>
-        public readonly Func<Drawable> Content;
+        public readonly Func<Drawable> CreateContent;
 
         /// <summary>
         /// The <see cref="Dimension"/> of this row. This can be thought of as the column dimension of an encompassing <see cref="GridContainer"/>.
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         public readonly Dimension Dimension;
 
         /// <summary>
-        /// Whether this item requires hit events. If true, the <see cref="Content"/> will not be created if no hit events are available.
+        /// Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.
         /// </summary>
         public readonly bool RequiresHitEvents;
 
@@ -37,14 +37,14 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// Creates a new <see cref="StatisticItem"/>, to be displayed inside a <see cref="StatisticRow"/> in the results screen.
         /// </summary>
         /// <param name="name">The name of the item. Can be <see cref="string.Empty"/> to hide the item header.</param>
-        /// <param name="requiresHitEvents">Whether this item requires hit events. If true, the <see cref="Content"/> will not be created if no hit events are available.</param>
-        /// <param name="content">The <see cref="Drawable"/> content to be displayed.</param>
+        /// <param name="requiresHitEvents">Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.</param>
+        /// <param name="createContent">A function returning the <see cref="Drawable"/> content to be displayed.</param>
         /// <param name="dimension">The <see cref="Dimension"/> of this item. This can be thought of as the column dimension of an encompassing <see cref="GridContainer"/>.</param>
-        public StatisticItem([NotNull] string name, bool requiresHitEvents, [NotNull] Func<Drawable> content, [CanBeNull] Dimension dimension = null)
+        public StatisticItem([NotNull] string name, bool requiresHitEvents, [NotNull] Func<Drawable> createContent, [CanBeNull] Dimension dimension = null)
         {
             Name = name;
             RequiresHitEvents = requiresHitEvents;
-            Content = content;
+            CreateContent = createContent;
             Dimension = dimension;
         }
     }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -110,9 +110,9 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     var columnsToDisplay = hitEventsAvailable
                         ? row.Columns
-                        : row.Columns?.Where(c => !c.RequiresHitEvents).ToArray();
+                        : row.Columns.Where(c => !c.RequiresHitEvents).ToArray();
 
-                    if (columnsToDisplay?.Any() ?? false)
+                    if (columnsToDisplay.Any())
                         panelIsEmpty = false;
                     else
                         continue;
@@ -132,8 +132,8 @@ namespace osu.Game.Screens.Ranking.Statistics
                                 Origin = Anchor.Centre,
                             }).Cast<Drawable>().ToArray()
                         },
-                        ColumnDimensions = Enumerable.Range(0, columnsToDisplay?.Length ?? 0)
-                                                     .Select(i => columnsToDisplay?[i].Dimension ?? new Dimension()).ToArray(),
+                        ColumnDimensions = Enumerable.Range(0, columnsToDisplay.Length)
+                                                     .Select(i => columnsToDisplay[i].Dimension ?? new Dimension()).ToArray(),
                         RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
                     });
                 }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 };
 
                 bool panelIsEmpty = true;
+                bool panelIsComplete = true;
                 bool hitEventsAvailable = newScore.HitEvents.Count != 0;
 
                 foreach (var row in newScore.Ruleset.CreateInstance().CreateStatisticsForScore(newScore, playableBeatmap))
@@ -112,6 +113,9 @@ namespace osu.Game.Screens.Ranking.Statistics
                     var columnsToDisplay = hitEventsAvailable
                         ? row.Columns
                         : row.Columns.Where(c => !c.RequiresHitEvents).ToArray();
+
+                    if (columnsToDisplay.Length < row.Columns.Length)
+                        panelIsComplete = false;
 
                     if (columnsToDisplay.Any())
                         panelIsEmpty = false;
@@ -163,7 +167,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             }
                         };
                     }
-                    else
+                    else if (!panelIsComplete)
                     {
                         rows.Add(new FillFlowContainer
                         {

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                     if (panelIsEmpty)
                     {
                         // Replace the scroll container with fill flow container to get the message centered.
+                        container.Dispose();
                         container = new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                     if (panelIsEmpty)
                     {
                         // Replace the scroll container with fill flow container to get the message centered.
+                        rows.Dispose();
                         container.Dispose();
                         container = new FillFlowContainer
                         {

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -98,7 +98,8 @@ namespace osu.Game.Screens.Ranking.Statistics
                         rows = new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
+                            AutoSizeAxes = Axes.Y,
+                            Spacing = new Vector2(30, 15)
                         }
                     }
                 };
@@ -123,7 +124,6 @@ namespace osu.Game.Screens.Ranking.Statistics
                         Origin = Anchor.TopCentre,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Margin = new MarginPadding { Bottom = 15 },
                         Content = new[]
                         {
                             columnsToDisplay?.Select(c => new StatisticContainer(c)

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -118,6 +118,10 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                     foreach (var row in newScore.Ruleset.CreateInstance().CreateStatisticsForScore(newScore, playableBeatmap))
                     {
+                        var columnsToDisplay = newScore.HitEvents.Count == 0
+                            ? row.Columns?.Where(c => !c.RequiresHitEvents).ToArray()
+                            : row.Columns;
+
                         rows.Add(new GridContainer
                         {
                             Anchor = Anchor.TopCentre,
@@ -126,14 +130,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                             AutoSizeAxes = Axes.Y,
                             Content = new[]
                             {
-                                row.Columns?.Select(c => new StatisticContainer(c)
+                                columnsToDisplay?.Select(c => new StatisticContainer(c)
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
                                 }).Cast<Drawable>().ToArray()
                             },
-                            ColumnDimensions = Enumerable.Range(0, row.Columns?.Length ?? 0)
-                                                         .Select(i => row.Columns[i].Dimension ?? new Dimension()).ToArray(),
+                            ColumnDimensions = Enumerable.Range(0, columnsToDisplay?.Length ?? 0)
+                                                         .Select(i => columnsToDisplay?[i].Dimension ?? new Dimension()).ToArray(),
                             RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
                         });
                     }


### PR DESCRIPTION
Re: https://github.com/ppy/osu/pull/16483#issuecomment-1027533601

Refactor `StatisticPanel` so that each `StatisticItem` can specify whether a replay is needed (whether hit events are required) to display that item. When a replay hasn't been watched yet, only items that do not require a replay would be displayed, with a message below hinting that more statistics are available after watching a replay.

<details>
<summary>Screenshots</summary>

In the current state where all statistic items require hit events:
![image](https://user-images.githubusercontent.com/25472513/152130997-fa94db26-f76f-4488-9321-5dea7b6c3d51.png)

Adding a placeholder `StatisticItem` for illustration:
![image](https://user-images.githubusercontent.com/25472513/152130724-88574a3c-04b9-4438-b3f5-f7f271026bf0.png)

![image](https://user-images.githubusercontent.com/25472513/152130842-3b8ceab4-4a79-46e3-b9e8-e76f05559361.png)

</details>

Note: I added scrolling to the statistics panel because it is definitely going to overflow when stuff like #16483 is added to the panel. There is already a `VerticalScrollContainer` in `ResultsScreen` that seems to be doing a similar job, but I have no idea what the point of its existence is, since it is basically non-functional even if the statistics panel overflows.