### PR TITLE
Use `0.1` keyboard step for "Difficulty Adjust" sliders

### DIFF
--- a/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Rulesets.Mods
                     {
                         ShowsDefaultIndicator = false,
                         Current = currentNumber,
+                        KeyboardStep = 0.1f,
                     }
                 };
 


### PR DESCRIPTION
Closes #16746 

Regressed during the migration to the new `DifficultyAdjustSettingsControl` class – should've been using 0.1 keyboard step as originally specified in the `SettingSourceAttribute` logic:
https://github.com/ppy/osu/blob/41a2e6eeeba92bfd9e0b1d8e896f6c283d3d6e1c/osu.Game/Configuration/SettingSourceAttribute.cs#L101-L121