### PR TITLE
Fix flashlight size multiplier printing with too many decimal digits

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override double ScoreMultiplier => 1.12;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableNumber<float> SizeMultiplier { get; } = new BindableNumber<float>
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
         {
             MinValue = 0.5f,
             MaxValue = 1.5f,

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override Type[] IncompatibleMods => new[] { typeof(ModHidden) };
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableNumber<float> SizeMultiplier { get; } = new BindableNumber<float>
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
         {
             MinValue = 0.5f,
             MaxValue = 3f,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         };
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableNumber<float> SizeMultiplier { get; } = new BindableNumber<float>
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
         {
             MinValue = 0.5f,
             MaxValue = 2f,

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override double ScoreMultiplier => 1.12;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableNumber<float> SizeMultiplier { get; } = new BindableNumber<float>
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
         {
             MinValue = 0.5f,
             MaxValue = 1.5f,

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "Restricted view area.";
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public abstract BindableNumber<float> SizeMultiplier { get; }
+        public abstract BindableFloat SizeMultiplier { get; }
 
         [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
         public abstract BindableBool ComboBasedSize { get; }


### PR DESCRIPTION
Fixes #16750

For understanding why this fixes, see [implementation of `BindableFloat`](https://github.com/ppy/osu-framework/blob/b1848ac0c2803d82b3461b63ade8d3a2a2749803/osu.Framework/Bindables/BindableFloat.cs#L15).

See also, from a distant past:

* https://github.com/ppy/osu/pull/7709
* https://github.com/ppy/osu-framework/issues/3229

(above cases are not exactly the same, but as long as `BindableFloat` exists it should probably be always the instantiated class - there may be value to exposing outwardly as `BindableNumber<float>` still).