### PR TITLE
Add ability to create new difficulties from within the editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -109,6 +109,7 @@ namespace osu.Game.Tests.Visual.Editing
                        && set != null
                        && set.PerformRead(s => s.Beatmaps.Single().ID == beatmap.ID);
             });
+            AddAssert("can save again", () => Editor.Save());
 
             AddStep("create new difficulty", () => Editor.CreateNewDifficulty(new OsuRuleset().RulesetInfo));
             AddUntilStep("wait for created", () =>

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -129,6 +129,8 @@ namespace osu.Game.Beatmaps
                 newBeatmap.ControlPointInfo.Add(timingPoint.Time, timingPoint.DeepClone());
 
             var createdBeatmapInfo = beatmapModelManager.AddDifficultyToBeatmapSet(beatmapSetInfo, newBeatmap);
+
+            workingBeatmapCache.Invalidate(createdBeatmapInfo.BeatmapSet);
             return GetWorkingBeatmap(createdBeatmapInfo);
         }
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -128,10 +128,10 @@ namespace osu.Game.Beatmaps
             foreach (var timingPoint in referenceBeatmap.Beatmap.ControlPointInfo.TimingPoints)
                 newBeatmap.ControlPointInfo.Add(timingPoint.Time, timingPoint.DeepClone());
 
-            var createdBeatmapInfo = beatmapModelManager.AddDifficultyToBeatmapSet(beatmapSetInfo, newBeatmap);
+            beatmapModelManager.AddDifficultyToBeatmapSet(beatmapSetInfo, newBeatmap);
 
-            workingBeatmapCache.Invalidate(createdBeatmapInfo.BeatmapSet);
-            return GetWorkingBeatmap(createdBeatmapInfo);
+            workingBeatmapCache.Invalidate(beatmapSetInfo);
+            return GetWorkingBeatmap(newBeatmap.BeatmapInfo);
         }
 
         // TODO: add back support for making a copy of another difficulty

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Beatmaps
         /// The new difficulty will be backed by a <see cref="BeatmapInfo"/> model
         /// and represented by the returned <see cref="WorkingBeatmap"/>.
         /// </summary>
-        public WorkingBeatmap CreateNewBlankDifficulty(BeatmapSetInfo beatmapSetInfo, RulesetInfo rulesetInfo)
+        public virtual WorkingBeatmap CreateNewBlankDifficulty(BeatmapSetInfo beatmapSetInfo, RulesetInfo rulesetInfo)
         {
             // fetch one of the existing difficulties to copy timing points and metadata from,
             // so that the user doesn't have to fill all of that out again.

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using osu.Framework.Testing;
 using osu.Game.Models;
 using osu.Game.Users;
+using osu.Game.Utils;
 using Realms;
 
 #nullable enable
@@ -16,7 +17,7 @@ namespace osu.Game.Beatmaps
     [ExcludeFromDynamicCompile]
     [Serializable]
     [MapTo("BeatmapMetadata")]
-    public class BeatmapMetadata : RealmObject, IBeatmapMetadataInfo
+    public class BeatmapMetadata : RealmObject, IBeatmapMetadataInfo, IDeepCloneable<BeatmapMetadata>
     {
         public string Title { get; set; } = string.Empty;
 
@@ -57,5 +58,18 @@ namespace osu.Game.Beatmaps
         IUser IBeatmapMetadataInfo.Author => Author;
 
         public override string ToString() => this.GetDisplayTitle();
+
+        public BeatmapMetadata DeepClone() => new BeatmapMetadata(Author.DeepClone())
+        {
+            Title = Title,
+            TitleUnicode = TitleUnicode,
+            Artist = Artist,
+            ArtistUnicode = ArtistUnicode,
+            Source = Source,
+            Tags = Tags,
+            PreviewTime = PreviewTime,
+            AudioFile = AudioFile,
+            BackgroundFile = BackgroundFile
+        };
     }
 }

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Beatmaps
                 string targetFilename = getFilename(beatmapInfo);
 
                 // ensure that two difficulties from the set don't point at the same beatmap file.
-                if (setInfo.Beatmaps.Any(b => string.Equals(b.Path, targetFilename, StringComparison.OrdinalIgnoreCase)))
+                if (setInfo.Beatmaps.Any(b => b.ID != beatmapInfo.ID && string.Equals(b.Path, targetFilename, StringComparison.OrdinalIgnoreCase)))
                     throw new InvalidOperationException($"{setInfo.GetDisplayString()} already has a difficulty with the name of '{beatmapInfo.DifficultyName}'.");
 
                 if (existingFileInfo != null)

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -90,19 +90,6 @@ namespace osu.Game.Beatmaps
             WorkingBeatmapCache?.Invalidate(beatmapInfo);
         }
 
-        /// <summary>
-        /// Add a new difficulty to the beatmap set represented by the provided <see cref="BeatmapSetInfo"/>.
-        /// </summary>
-        public void AddDifficultyToBeatmapSet(BeatmapSetInfo beatmapSetInfo, Beatmap beatmap)
-        {
-            var beatmapInfo = beatmap.BeatmapInfo;
-
-            beatmapSetInfo.Beatmaps.Add(beatmapInfo);
-            beatmapInfo.BeatmapSet = beatmapSetInfo;
-
-            Save(beatmapInfo, beatmap);
-        }
-
         private static string getFilename(BeatmapInfo beatmapInfo)
         {
             var metadata = beatmapInfo.Metadata;

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> to save the content against. The file referenced by <see cref="BeatmapInfo.Path"/> will be replaced.</param>
         /// <param name="beatmapContent">The <see cref="IBeatmap"/> content to write.</param>
         /// <param name="beatmapSkin">The beatmap <see cref="ISkin"/> content to write, null if to be omitted.</param>
-        public virtual void Save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin? beatmapSkin = null)
+        public void Save(BeatmapInfo beatmapInfo, IBeatmap beatmapContent, ISkin? beatmapSkin = null)
         {
             var setInfo = beatmapInfo.BeatmapSet;
             Debug.Assert(setInfo != null);

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -93,19 +93,14 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Add a new difficulty to the beatmap set represented by the provided <see cref="BeatmapSetInfo"/>.
         /// </summary>
-        public BeatmapInfo AddDifficultyToBeatmapSet(BeatmapSetInfo beatmapSetInfo, Beatmap beatmap)
+        public void AddDifficultyToBeatmapSet(BeatmapSetInfo beatmapSetInfo, Beatmap beatmap)
         {
-            return Realm.Run(realm =>
-            {
-                var beatmapInfo = beatmap.BeatmapInfo;
+            var beatmapInfo = beatmap.BeatmapInfo;
 
-                beatmapSetInfo.Beatmaps.Add(beatmapInfo);
-                beatmapInfo.BeatmapSet = beatmapSetInfo;
+            beatmapSetInfo.Beatmaps.Add(beatmapInfo);
+            beatmapInfo.BeatmapSet = beatmapSetInfo;
 
-                Save(beatmapInfo, beatmap);
-
-                return beatmapInfo.Detach();
-            });
+            Save(beatmapInfo, beatmap);
         }
 
         private static string getFilename(BeatmapInfo beatmapInfo)

--- a/osu.Game/Beatmaps/BeatmapModelManager.cs
+++ b/osu.Game/Beatmaps/BeatmapModelManager.cs
@@ -71,6 +71,12 @@ namespace osu.Game.Beatmaps
 
                 // AddFile generally handles updating/replacing files, but this is a case where the filename may have also changed so let's delete for simplicity.
                 var existingFileInfo = setInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, beatmapInfo.Path, StringComparison.OrdinalIgnoreCase));
+                string targetFilename = getFilename(beatmapInfo);
+
+                // ensure that two difficulties from the set don't point at the same beatmap file.
+                if (setInfo.Beatmaps.Any(b => string.Equals(b.Path, targetFilename, StringComparison.OrdinalIgnoreCase)))
+                    throw new InvalidOperationException($"{setInfo.GetDisplayString()} already has a difficulty with the name of '{beatmapInfo.DifficultyName}'.");
+
                 if (existingFileInfo != null)
                     DeleteFile(setInfo, existingFileInfo);
 

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -58,7 +58,16 @@ namespace osu.Game.Database
                      if (existing != null)
                          copyChangesToRealm(beatmap, existing);
                      else
-                         d.Beatmaps.Add(beatmap);
+                     {
+                         var newBeatmap = new BeatmapInfo
+                         {
+                             ID = beatmap.ID,
+                             BeatmapSet = d,
+                             Ruleset = d.Realm.Find<RulesetInfo>(beatmap.Ruleset.ShortName)
+                         };
+                         d.Beatmaps.Add(newBeatmap);
+                         copyChangesToRealm(beatmap, newBeatmap);
+                     }
                  }
              });
 

--- a/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
@@ -117,6 +117,7 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     NormalText = new OsuSpriteText
                     {
+                        AlwaysPresent = true, // ensures that the menu item does not change width when switching between normal and bold text.
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         Font = OsuFont.GetFont(size: text_size),
@@ -124,7 +125,7 @@ namespace osu.Game.Graphics.UserInterface
                     },
                     BoldText = new OsuSpriteText
                     {
-                        AlwaysPresent = true,
+                        AlwaysPresent = true, // ensures that the menu item does not change width when switching between normal and bold text.
                         Alpha = 0,
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,

--- a/osu.Game/Models/RealmUser.cs
+++ b/osu.Game/Models/RealmUser.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Database;
 using osu.Game.Users;
+using osu.Game.Utils;
 using Realms;
 
 namespace osu.Game.Models
 {
-    public class RealmUser : EmbeddedObject, IUser, IEquatable<RealmUser>
+    public class RealmUser : EmbeddedObject, IUser, IEquatable<RealmUser>, IDeepCloneable<RealmUser>
     {
         public int OnlineID { get; set; } = 1;
 
@@ -22,5 +24,7 @@ namespace osu.Game.Models
 
             return OnlineID == other.OnlineID && Username == other.Username;
         }
+
+        public RealmUser DeepClone() => (RealmUser)this.Detach().MemberwiseClone();
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -378,12 +378,16 @@ namespace osu.Game.Screens.Edit
             Clipboard.Content.Value = state.ClipboardContent;
         });
 
-        protected void Save()
+        /// <summary>
+        /// Saves the currently edited beatmap.
+        /// </summary>
+        /// <returns>Whether the save was successful.</returns>
+        protected bool Save()
         {
             if (!canSave)
             {
                 notifications?.Post(new SimpleErrorNotification { Text = "Saving is not supported for this ruleset yet, sorry!" });
-                return;
+                return false;
             }
 
             try
@@ -395,12 +399,13 @@ namespace osu.Game.Screens.Edit
             {
                 // can fail e.g. due to duplicated difficulty names.
                 Logger.Error(ex, ex.Message);
-                return;
+                return false;
             }
 
             // no longer new after first user-triggered save.
             isNewBeatmap = false;
             updateLastSavedHash();
+            return true;
         }
 
         protected override void Update()
@@ -809,7 +814,7 @@ namespace osu.Game.Screens.Edit
         {
             var fileMenuItems = new List<MenuItem>
             {
-                new EditorMenuItem("Save", MenuItemType.Standard, Save)
+                new EditorMenuItem("Save", MenuItemType.Standard, () => Save())
             };
 
             if (RuntimeInfo.IsDesktop)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -386,12 +386,20 @@ namespace osu.Game.Screens.Edit
                 return;
             }
 
+            try
+            {
+                // save the loaded beatmap's data stream.
+                beatmapManager.Save(editorBeatmap.BeatmapInfo, editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin);
+            }
+            catch (Exception ex)
+            {
+                // can fail e.g. due to duplicated difficulty names.
+                Logger.Error(ex, ex.Message);
+                return;
+            }
+
             // no longer new after first user-triggered save.
             isNewBeatmap = false;
-
-            // save the loaded beatmap's data stream.
-            beatmapManager.Save(editorBeatmap.BeatmapInfo, editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin);
-
             updateLastSavedHash();
         }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -822,12 +822,12 @@ namespace osu.Game.Screens.Edit
             var rulesetItems = new List<MenuItem>();
 
             foreach (var ruleset in rulesets.AvailableRulesets.OrderBy(ruleset => ruleset.OnlineID))
-                rulesetItems.Add(new EditorMenuItem(ruleset.Name, MenuItemType.Standard, () => createNewDifficulty(ruleset)));
+                rulesetItems.Add(new EditorMenuItem(ruleset.Name, MenuItemType.Standard, () => CreateNewDifficulty(ruleset)));
 
             return new EditorMenuItem("Create new difficulty") { Items = rulesetItems };
         }
 
-        private void createNewDifficulty(RulesetInfo rulesetInfo)
+        protected void CreateNewDifficulty(RulesetInfo rulesetInfo)
             => loader?.ScheduleSwitchToNewDifficulty(editorBeatmap.BeatmapInfo.BeatmapSet, rulesetInfo, GetState());
 
         private EditorMenuItem createDifficultySwitchMenu()

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -806,6 +806,15 @@ namespace osu.Game.Screens.Edit
 
             fileMenuItems.Add(new EditorMenuItemSpacer());
 
+            fileMenuItems.Add(createDifficultySwitchMenu());
+
+            fileMenuItems.Add(new EditorMenuItemSpacer());
+            fileMenuItems.Add(new EditorMenuItem("Exit", MenuItemType.Standard, this.Exit));
+            return fileMenuItems;
+        }
+
+        private EditorMenuItem createDifficultySwitchMenu()
+        {
             var beatmapSet = playableBeatmap.BeatmapInfo.BeatmapSet;
 
             Debug.Assert(beatmapSet != null);
@@ -818,20 +827,13 @@ namespace osu.Game.Screens.Edit
                     difficultyItems.Add(new EditorMenuItemSpacer());
 
                 foreach (var beatmap in rulesetBeatmaps.OrderBy(b => b.StarRating))
-                    difficultyItems.Add(createDifficultyMenuItem(beatmap));
+                {
+                    bool isCurrentDifficulty = playableBeatmap.BeatmapInfo.Equals(beatmap);
+                    difficultyItems.Add(new DifficultyMenuItem(beatmap, isCurrentDifficulty, SwitchToDifficulty));
+                }
             }
 
-            fileMenuItems.Add(new EditorMenuItem("Change difficulty") { Items = difficultyItems });
-
-            fileMenuItems.Add(new EditorMenuItemSpacer());
-            fileMenuItems.Add(new EditorMenuItem("Exit", MenuItemType.Standard, this.Exit));
-            return fileMenuItems;
-        }
-
-        private DifficultyMenuItem createDifficultyMenuItem(BeatmapInfo beatmapInfo)
-        {
-            bool isCurrentDifficulty = playableBeatmap.BeatmapInfo.Equals(beatmapInfo);
-            return new DifficultyMenuItem(beatmapInfo, isCurrentDifficulty, SwitchToDifficulty);
+            return new EditorMenuItem("Change difficulty") { Items = difficultyItems };
         }
 
         protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, GetState(nextBeatmap));

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -834,7 +834,7 @@ namespace osu.Game.Screens.Edit
         {
             var rulesetItems = new List<MenuItem>();
 
-            foreach (var ruleset in rulesets.AvailableRulesets.OrderBy(ruleset => ruleset.OnlineID))
+            foreach (var ruleset in rulesets.AvailableRulesets)
                 rulesetItems.Add(new EditorMenuItem(ruleset.Name, MenuItemType.Standard, () => CreateNewDifficulty(ruleset)));
 
             return new EditorMenuItem("Create new difficulty") { Items = rulesetItems };

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -822,10 +822,13 @@ namespace osu.Game.Screens.Edit
             var rulesetItems = new List<MenuItem>();
 
             foreach (var ruleset in rulesets.AvailableRulesets.OrderBy(ruleset => ruleset.OnlineID))
-                rulesetItems.Add(new EditorMenuItem(ruleset.Name));
+                rulesetItems.Add(new EditorMenuItem(ruleset.Name, MenuItemType.Standard, () => createNewDifficulty(ruleset)));
 
             return new EditorMenuItem("Create new difficulty") { Items = rulesetItems };
         }
+
+        private void createNewDifficulty(RulesetInfo rulesetInfo)
+            => loader?.ScheduleSwitchToNewDifficulty(editorBeatmap.BeatmapInfo.BeatmapSet, rulesetInfo, GetState());
 
         private EditorMenuItem createDifficultySwitchMenu()
         {
@@ -850,7 +853,7 @@ namespace osu.Game.Screens.Edit
             return new EditorMenuItem("Change difficulty") { Items = difficultyItems };
         }
 
-        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleDifficultySwitch(nextBeatmap, GetState(nextBeatmap));
+        protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleSwitchToExistingDifficulty(nextBeatmap, GetState(nextBeatmap));
 
         private void cancelExit()
         {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -78,6 +78,9 @@ namespace osu.Game.Screens.Edit
         private BeatmapManager beatmapManager { get; set; }
 
         [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [Resolved]
         private Storage storage { get; set; }
 
         [Resolved(canBeNull: true)]
@@ -806,11 +809,22 @@ namespace osu.Game.Screens.Edit
 
             fileMenuItems.Add(new EditorMenuItemSpacer());
 
+            fileMenuItems.Add(createDifficultyCreationMenu());
             fileMenuItems.Add(createDifficultySwitchMenu());
 
             fileMenuItems.Add(new EditorMenuItemSpacer());
             fileMenuItems.Add(new EditorMenuItem("Exit", MenuItemType.Standard, this.Exit));
             return fileMenuItems;
+        }
+
+        private EditorMenuItem createDifficultyCreationMenu()
+        {
+            var rulesetItems = new List<MenuItem>();
+
+            foreach (var ruleset in rulesets.AvailableRulesets.OrderBy(ruleset => ruleset.OnlineID))
+                rulesetItems.Add(new EditorMenuItem(ruleset.Name));
+
+            return new EditorMenuItem("Create new difficulty") { Items = rulesetItems };
         }
 
         private EditorMenuItem createDifficultySwitchMenu()

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -10,6 +10,7 @@ using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
@@ -78,7 +79,13 @@ namespace osu.Game.Screens.Edit
             }
         }
 
-        public void ScheduleDifficultySwitch(BeatmapInfo nextBeatmap, EditorState editorState)
+        public void ScheduleSwitchToNewDifficulty(BeatmapSetInfo beatmapSetInfo, RulesetInfo rulesetInfo, EditorState editorState)
+            => scheduleDifficultySwitch(() => beatmapManager.CreateNewBlankDifficulty(beatmapSetInfo, rulesetInfo), editorState);
+
+        public void ScheduleSwitchToExistingDifficulty(BeatmapInfo beatmapInfo, EditorState editorState)
+            => scheduleDifficultySwitch(() => beatmapManager.GetWorkingBeatmap(beatmapInfo), editorState);
+
+        private void scheduleDifficultySwitch(Func<WorkingBeatmap> nextBeatmap, EditorState editorState)
         {
             scheduledDifficultySwitch?.Cancel();
             ValidForResume = true;
@@ -87,7 +94,7 @@ namespace osu.Game.Screens.Edit
 
             scheduledDifficultySwitch = Schedule(() =>
             {
-                Beatmap.Value = beatmapManager.GetWorkingBeatmap(nextBeatmap);
+                Beatmap.Value = nextBeatmap.Invoke();
                 state = editorState;
 
                 // This screen is a weird exception to the rule that nothing after song select changes the global beatmap.

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -107,6 +107,8 @@ namespace osu.Game.Tests.Visual
 
             public new void SwitchToDifficulty(BeatmapInfo beatmapInfo) => base.SwitchToDifficulty(beatmapInfo);
 
+            public new void CreateNewDifficulty(RulesetInfo rulesetInfo) => base.CreateNewDifficulty(rulesetInfo);
+
             public new bool HasUnsavedChanges => base.HasUnsavedChanges;
 
             public TestEditor(EditorLoader loader = null)

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -136,6 +136,12 @@ namespace osu.Game.Tests.Visual
                 return new TestWorkingBeatmapCache(this, audioManager, resources, storage, defaultBeatmap, host);
             }
 
+            public override WorkingBeatmap CreateNewBlankDifficulty(BeatmapSetInfo beatmapSetInfo, RulesetInfo rulesetInfo)
+            {
+                // don't actually care about properly creating a difficulty for this context.
+                return TestBeatmap;
+            }
+
             private class TestWorkingBeatmapCache : WorkingBeatmapCache
             {
                 private readonly TestBeatmapManager testBeatmapManager;

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Tests.Visual
 
             public new void Redo() => base.Redo();
 
-            public new void Save() => base.Save();
+            public new bool Save() => base.Save();
 
             public new void Cut() => base.Cut();
 


### PR DESCRIPTION
Attempt no. 2 at #12035. Now with infinity% more realm. The general UI/UX hasn't changed since https://github.com/ppy/osu/pull/14799 so I'm not going to bother including a video again.

I'll preface this by saying that while this *works* - as far as I've tested, at least - I'm not tremendously sure that this diff will hold up to scrutiny. I've had a weirdly difficult time arriving at this version and it was only after some [substantial](https://discord.com/channels/188630481301012481/188630652340404224/937383500003282975) [nudging](https://discord.com/channels/188630481301012481/188630652340404224/937425239506301058) in the current direction via discord. I'm mostly getting this out today for the sake of my sanity, because I've been tweaking with this for days and still feel no more confident with the state of these changes any way I try.

The main issue is that the editor flow is a little particular about what should be detached and what shouldn't. In this diff things appear to just-work, but that's guaranteed by one silent assumption - namely, that the objects incoming to `BeatmapModelManager.AddDifficultyToBeatmapSet()` are detached (as writes to any properties of either model instance would fail if they were managed, not to mention potential attempts to take out nested write usages which will not succeed if there is an outer transaction open). This may be considered dodgy but I'll note that as things stand, the existing `Save()` method [also silently assumes its arguments are detached](https://github.com/ppy/osu/blob/3a5099cf0614ea304224e169f99250581c34ac29/osu.Game/Beatmaps/BeatmapModelManager.cs#L58-L64).

Due to the above I've considered delaying this and trying to figure out how editor could work in fully-managed mode, but there are a lot of unknowns there; I can't just hold a transaction open for the entire duration of the editing session, so where should changes go? how to do reverts? etc. etc. - so even if I were working on that day-to-day (which I 99% won't be), the timescale of that would likely be weeks-to-months. And as this is a pretty large missing piece for the editor, I figure I may as well PR what I have and see if it's passable enough. If not then I'll try the long way around I guess.

Note that you can't create a copy of a difficulty yet. My plan was to address that separately as a follow-up.