### PR TITLE
Wait for `DialogOverlay` load in more tests

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddStep("choose clear all scores", () => InputManager.Key(Key.Number4));
 
+            AddUntilStep("wait for dialog display", () => Game.Dependencies.Get<DialogOverlay>().IsLoaded);
             AddUntilStep("wait for dialog", () => Game.Dependencies.Get<DialogOverlay>().CurrentDialog != null);
             AddStep("confirm deletion", () => InputManager.Key(Key.Number1));
             AddUntilStep("wait for dialog dismissed", () => Game.Dependencies.Get<DialogOverlay>().CurrentDialog == null);
@@ -172,6 +173,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 InputManager.Click(MouseButton.Left);
             });
 
+            AddUntilStep("wait for dialog display", () => Game.Dependencies.Get<DialogOverlay>().IsLoaded);
             AddUntilStep("wait for dialog", () => Game.Dependencies.Get<DialogOverlay>().CurrentDialog != null);
             AddStep("confirm deletion", () => InputManager.Key(Key.Number1));
             AddUntilStep("wait for dialog dismissed", () => Game.Dependencies.Get<DialogOverlay>().CurrentDialog == null);


### PR DESCRIPTION
Apparently the previous fix was not enough as this can still be seen failing (https://github.com/ppy/osu/runs/5046718623?check_suite_focus=true).

This change is copying from what other tests use seemingly reliably, such as `TestScenePerformFromScreen`)