### PR TITLE
Fix beatmap difficulties no longer being refreshed correctly when filter status changes

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -42,6 +42,68 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestExternalRulesetChange()
+        {
+            createCarousel(new List<BeatmapSetInfo>());
+
+            AddStep("filter to ruleset 0", () => carousel.Filter(new FilterCriteria
+            {
+                Ruleset = rulesets.AvailableRulesets.ElementAt(0),
+                AllowConvertedBeatmaps = true,
+            }, false));
+
+            AddStep("add mixed ruleset beatmapset", () =>
+            {
+                var testMixed = TestResources.CreateTestBeatmapSetInfo(3);
+
+                for (int i = 0; i <= 2; i++)
+                {
+                    testMixed.Beatmaps[i].Ruleset = rulesets.AvailableRulesets.ElementAt(i);
+                }
+
+                carousel.UpdateBeatmapSet(testMixed);
+            });
+
+            AddUntilStep("wait for filtered difficulties", () =>
+            {
+                var visibleBeatmapPanels = carousel.Items.OfType<DrawableCarouselBeatmap>().Where(p => p.IsPresent).ToArray();
+
+                return visibleBeatmapPanels.Length == 1
+                       && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item).BeatmapInfo.Ruleset.OnlineID == 0) == 1;
+            });
+
+            AddStep("filter to ruleset 1", () => carousel.Filter(new FilterCriteria
+            {
+                Ruleset = rulesets.AvailableRulesets.ElementAt(1),
+                AllowConvertedBeatmaps = true,
+            }, false));
+
+            AddUntilStep("wait for filtered difficulties", () =>
+            {
+                var visibleBeatmapPanels = carousel.Items.OfType<DrawableCarouselBeatmap>().Where(p => p.IsPresent).ToArray();
+
+                return visibleBeatmapPanels.Length == 2
+                       && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item).BeatmapInfo.Ruleset.OnlineID == 0) == 1
+                       && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item).BeatmapInfo.Ruleset.OnlineID == 1) == 1;
+            });
+
+            AddStep("filter to ruleset 2", () => carousel.Filter(new FilterCriteria
+            {
+                Ruleset = rulesets.AvailableRulesets.ElementAt(2),
+                AllowConvertedBeatmaps = true,
+            }, false));
+
+            AddUntilStep("wait for filtered difficulties", () =>
+            {
+                var visibleBeatmapPanels = carousel.Items.OfType<DrawableCarouselBeatmap>().Where(p => p.IsPresent).ToArray();
+
+                return visibleBeatmapPanels.Length == 2
+                       && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item).BeatmapInfo.Ruleset.OnlineID == 0) == 1
+                       && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item).BeatmapInfo.Ruleset.OnlineID == 2) == 1;
+            });
+        }
+
+        [Test]
         public void TestScrollPositionMaintainedOnAdd()
         {
             loadBeatmaps(count: 1, randomDifficulties: false);

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -126,9 +126,9 @@ namespace osu.Game.Screens.Select.Carousel
             mainFlow.DelayedLoadComplete += d => d.FadeInFromZero(500, Easing.OutQuint);
         }
 
-        protected override void ApplyStateFromChildChange()
+        protected override void ApplyStateFromChildrenChange()
         {
-            base.ApplyStateFromChildChange();
+            base.ApplyStateFromChildrenChange();
 
             if (Item.State.Value == CarouselItemState.Selected)
                 Scheduler.AddOnce(updateBeatmapDifficulties);

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -126,6 +126,14 @@ namespace osu.Game.Screens.Select.Carousel
             mainFlow.DelayedLoadComplete += d => d.FadeInFromZero(500, Easing.OutQuint);
         }
 
+        protected override void ApplyStateFromChildChange()
+        {
+            base.ApplyStateFromChildChange();
+
+            if (Item.State.Value == CarouselItemState.Selected)
+                Scheduler.AddOnce(updateBeatmapDifficulties);
+        }
+
         protected override void Deselected()
         {
             base.Deselected();
@@ -141,14 +149,12 @@ namespace osu.Game.Screens.Select.Carousel
 
             MovementContainer.MoveToX(-100, 500, Easing.OutExpo);
 
-            updateBeatmapDifficulties();
+            Scheduler.AddOnce(updateBeatmapDifficulties);
         }
 
         private void updateBeatmapDifficulties()
         {
-            var carouselBeatmapSet = (CarouselBeatmapSet)Item;
-
-            var visibleBeatmaps = carouselBeatmapSet.Children.Where(c => c.Visible).ToArray();
+            var visibleBeatmaps = ((CarouselBeatmapSet)Item).Children.Where(c => c.Visible).ToArray();
 
             // if we are already displaying all the correct beatmaps, only run animation updates.
             // note that the displayed beatmaps may change due to the applied filter.

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Select.Carousel
                     if (item is CarouselGroup group)
                     {
                         foreach (var c in group.Children)
-                            c.Filtered.ValueChanged -= onChildStateChanged;
+                            c.Filtered.ValueChanged -= onChildrenChanged;
                     }
                 }
 
@@ -107,22 +107,24 @@ namespace osu.Game.Screens.Select.Carousel
             if (Item is CarouselGroup group)
             {
                 foreach (var c in group.Children)
-                    c.Filtered.ValueChanged += onChildStateChanged;
+                    c.Filtered.ValueChanged += onChildrenChanged;
             }
+
+            Scheduler.AddOnce(ApplyStateFromChildrenChange);
         }
 
         private void onStateChange(ValueChangedEvent<CarouselItemState> obj) => Scheduler.AddOnce(ApplyState);
 
         private void onStateChange(ValueChangedEvent<bool> _) => Scheduler.AddOnce(ApplyState);
 
-        private void onChildStateChanged(ValueChangedEvent<bool> _) => Scheduler.AddOnce(ApplyStateFromChildChange);
+        private void onChildrenChanged(ValueChangedEvent<bool> _) => Scheduler.AddOnce(ApplyStateFromChildrenChange);
 
         private CarouselItemState? lastAppliedState;
 
         /// <summary>
         /// If <see cref="Item"/> is a <see cref="CarouselGroup"/>, will fire whenever a child's <see cref="CarouselItem.Filtered"/> state changes.
         /// </summary>
-        protected virtual void ApplyStateFromChildChange()
+        protected virtual void ApplyStateFromChildrenChange()
         {
         }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -126,9 +126,7 @@ namespace osu.Game.Screens.Select.Carousel
         /// </summary>
         protected virtual void ApplyStateFromChildrenChange()
         {
-            // Use the fact that we know the precise height of the item from the model to avoid the need for AutoSize overhead.
-            // Additionally, AutoSize doesn't work well due to content starting off-screen and being masked away.
-            Height = Item.TotalHeight;
+            updateHeight();
         }
 
         /// <summary>
@@ -158,6 +156,15 @@ namespace osu.Game.Screens.Select.Carousel
                 Hide();
             else
                 Show();
+
+            updateHeight();
+        }
+
+        private void updateHeight()
+        {
+            // Use the fact that we know the precise height of the item from the model to avoid the need for AutoSize overhead.
+            // Additionally, AutoSize doesn't work well due to content starting off-screen and being masked away.
+            Height = Item.TotalHeight;
         }
 
         private bool isVisible = true;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Select.Carousel
                     if (item is CarouselGroup group)
                     {
                         foreach (var c in group.Children)
-                            c.Filtered.ValueChanged -= onStateChange;
+                            c.Filtered.ValueChanged -= onChildStateChanged;
                     }
                 }
 
@@ -107,7 +107,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (Item is CarouselGroup group)
             {
                 foreach (var c in group.Children)
-                    c.Filtered.ValueChanged += onStateChange;
+                    c.Filtered.ValueChanged += onChildStateChanged;
             }
         }
 
@@ -115,8 +115,20 @@ namespace osu.Game.Screens.Select.Carousel
 
         private void onStateChange(ValueChangedEvent<bool> _) => Scheduler.AddOnce(ApplyState);
 
+        private void onChildStateChanged(ValueChangedEvent<bool> _) => Scheduler.AddOnce(ApplyStateFromChildChange);
+
         private CarouselItemState? lastAppliedState;
 
+        /// <summary>
+        /// If <see cref="Item"/> is a <see cref="CarouselGroup"/>, will fire whenever a child's <see cref="CarouselItem.Filtered"/> state changes.
+        /// </summary>
+        protected virtual void ApplyStateFromChildChange()
+        {
+        }
+
+        /// <summary>
+        /// Fired whenever the <see cref="Item"/>'s <see cref="CarouselItem.Filtered"/> or <see cref="CarouselItem.State"/> changes.
+        /// </summary>
         protected virtual void ApplyState()
         {
             Debug.Assert(Item != null);

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -126,6 +126,9 @@ namespace osu.Game.Screens.Select.Carousel
         /// </summary>
         protected virtual void ApplyStateFromChildrenChange()
         {
+            // Use the fact that we know the precise height of the item from the model to avoid the need for AutoSize overhead.
+            // Additionally, AutoSize doesn't work well due to content starting off-screen and being masked away.
+            Height = Item.TotalHeight;
         }
 
         /// <summary>
@@ -138,10 +141,6 @@ namespace osu.Game.Screens.Select.Carousel
             if (lastAppliedState != Item.State.Value)
             {
                 lastAppliedState = Item.State.Value;
-
-                // Use the fact that we know the precise height of the item from the model to avoid the need for AutoSize overhead.
-                // Additionally, AutoSize doesn't work well due to content starting off-screen and being masked away.
-                Height = Item.TotalHeight;
 
                 switch (lastAppliedState)
                 {


### PR DESCRIPTION
This regressed with https://github.com/ppy/osu/pull/16716/files#diff-5c1acf993805bef85672afa52a88567a5b009fb98b346db743d8ebc2a501a4f7R124 as `DrawableCarouselBeatmapSet` was relying on `Select` being called more than once.

This felt very incorrect, so I've created a new flow specifically to handle the filter changes which should trigger beatmap panel recreation.

The new test coverage focuses on the `Drawable` panels unlike all existing ones, so should give us a bit of new overall coverage as a result.

Closes https://github.com/ppy/osu/issues/16752.