### PR TITLE
Fix the game overlapping notches and punch-hole cameras on mobile devices

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSafeAreaHandling.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSafeAreaHandling.cs
@@ -29,11 +29,10 @@ namespace osu.Game.Tests.Visual.UserInterface
             // Usually this would be placed between the host and the game, but that's a bit of a pain to do with the test scene hierarchy.
 
             // Add is required for the container to get a size (and give out correct metrics to the usages in SafeAreaContainer).
-            Add(
-                safeAreaContainer = new SafeAreaDefiningContainer(safeArea = new BindableSafeArea())
-                {
-                    RelativeSizeAxes = Axes.Both
-                });
+            Add(safeAreaContainer = new SafeAreaDefiningContainer(safeArea = new BindableSafeArea())
+            {
+                RelativeSizeAxes = Axes.Both
+            });
 
             // Cache is required for the test game to see the safe area.
             Dependencies.CacheAs<ISafeArea>(safeAreaContainer);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSafeAreaHandling.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSafeAreaHandling.cs
@@ -1,0 +1,116 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays.Settings;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneSafeAreaHandling : OsuGameTestScene
+    {
+        private SafeAreaDefiningContainer safeAreaContainer;
+
+        private static BindableSafeArea safeArea;
+
+        private readonly Bindable<float> safeAreaPaddingTop = new BindableFloat { MinValue = 0, MaxValue = 200 };
+        private readonly Bindable<float> safeAreaPaddingBottom = new BindableFloat { MinValue = 0, MaxValue = 200 };
+        private readonly Bindable<float> safeAreaPaddingLeft = new BindableFloat { MinValue = 0, MaxValue = 200 };
+        private readonly Bindable<float> safeAreaPaddingRight = new BindableFloat { MinValue = 0, MaxValue = 200 };
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Usually this would be placed between the host and the game, but that's a bit of a pain to do with the test scene hierarchy.
+
+            // Add is required for the container to get a size (and give out correct metrics to the usages in SafeAreaContainer).
+            Add(
+                safeAreaContainer = new SafeAreaDefiningContainer(safeArea = new BindableSafeArea())
+                {
+                    RelativeSizeAxes = Axes.Both
+                });
+
+            // Cache is required for the test game to see the safe area.
+            Dependencies.CacheAs<ISafeArea>(safeAreaContainer);
+        }
+
+        public override void SetUpSteps()
+        {
+            AddStep("Add adjust controls", () =>
+            {
+                Add(new Container
+                {
+                    Depth = float.MinValue,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = Color4.Black,
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0.8f,
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Y,
+                            Width = 400,
+                            Children = new Drawable[]
+                            {
+                                new SettingsSlider<float>
+                                {
+                                    Current = safeAreaPaddingTop,
+                                    LabelText = "Top"
+                                },
+                                new SettingsSlider<float>
+                                {
+                                    Current = safeAreaPaddingBottom,
+                                    LabelText = "Bottom"
+                                },
+                                new SettingsSlider<float>
+                                {
+                                    Current = safeAreaPaddingLeft,
+                                    LabelText = "Left"
+                                },
+                                new SettingsSlider<float>
+                                {
+                                    Current = safeAreaPaddingRight,
+                                    LabelText = "Right"
+                                },
+                            }
+                        }
+                    }
+                });
+
+                safeAreaPaddingTop.BindValueChanged(_ => updateSafeArea());
+                safeAreaPaddingBottom.BindValueChanged(_ => updateSafeArea());
+                safeAreaPaddingLeft.BindValueChanged(_ => updateSafeArea());
+                safeAreaPaddingRight.BindValueChanged(_ => updateSafeArea());
+            });
+
+            base.SetUpSteps();
+        }
+
+        private void updateSafeArea()
+        {
+            safeArea.Value = new MarginPadding
+            {
+                Top = safeAreaPaddingTop.Value,
+                Bottom = safeAreaPaddingBottom.Value,
+                Left = safeAreaPaddingLeft.Value,
+                Right = safeAreaPaddingRight.Value,
+            };
+        }
+
+        [Test]
+        public void TestSafeArea()
+        {
+        }
+    }
+}

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Graphics.Containers
 
             var targetSize = scaling ? new Vector2(sizeX.Value, sizeY.Value) : Vector2.One;
             var targetPosition = scaling ? new Vector2(posX.Value, posY.Value) * (Vector2.One - targetSize) : Vector2.Zero;
-            bool requiresMasking = scaling && targetSize != Vector2.One
+            bool requiresMasking = (scaling && targetSize != Vector2.One)
                                    // For the top level scaling container, for now we apply masking if safe areas are in use.
                                    // In the future this can likely be removed as more of the actual UI supports overflowing into the safe areas.
                                    || (targetMode == ScalingMode.Everything && safeArea.SafeAreaPadding.Value.Total != Vector2.Zero);

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Graphics.Containers
                     return;
 
                 allowScaling = value;
-                if (IsLoaded) updateSize();
+                if (IsLoaded) Scheduler.AddOnce(updateSize);
             }
         }
 
@@ -107,29 +107,29 @@ namespace osu.Game.Graphics.Containers
         private void load(OsuConfigManager config, ISafeArea safeArea)
         {
             scalingMode = config.GetBindable<ScalingMode>(OsuSetting.Scaling);
-            scalingMode.ValueChanged += _ => updateSize();
+            scalingMode.ValueChanged += _ => Scheduler.AddOnce(updateSize);
 
             sizeX = config.GetBindable<float>(OsuSetting.ScalingSizeX);
-            sizeX.ValueChanged += _ => updateSize();
+            sizeX.ValueChanged += _ => Scheduler.AddOnce(updateSize);
 
             sizeY = config.GetBindable<float>(OsuSetting.ScalingSizeY);
-            sizeY.ValueChanged += _ => updateSize();
+            sizeY.ValueChanged += _ => Scheduler.AddOnce(updateSize);
 
             posX = config.GetBindable<float>(OsuSetting.ScalingPositionX);
-            posX.ValueChanged += _ => updateSize();
+            posX.ValueChanged += _ => Scheduler.AddOnce(updateSize);
 
             posY = config.GetBindable<float>(OsuSetting.ScalingPositionY);
-            posY.ValueChanged += _ => updateSize();
+            posY.ValueChanged += _ => Scheduler.AddOnce(updateSize);
 
             safeAreaPadding = safeArea.SafeAreaPadding.GetBoundCopy();
-            safeAreaPadding.BindValueChanged(_ => updateSize());
+            safeAreaPadding.BindValueChanged(_ => Scheduler.AddOnce(updateSize));
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            updateSize();
+            Scheduler.AddOnce(updateSize);
             sizableContainer.FinishTransforms();
         }
 

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Graphics.Containers
         private Bindable<float> posX;
         private Bindable<float> posY;
 
+        private Bindable<MarginPadding> safeAreaPadding;
+
         private readonly ScalingMode? targetMode;
 
         private Bindable<ScalingMode> scalingMode;
@@ -101,11 +103,8 @@ namespace osu.Game.Graphics.Containers
             }
         }
 
-        [Resolved]
-        private ISafeArea safeArea { get; set; }
-
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, ISafeArea safeArea)
         {
             scalingMode = config.GetBindable<ScalingMode>(OsuSetting.Scaling);
             scalingMode.ValueChanged += _ => updateSize();
@@ -122,7 +121,8 @@ namespace osu.Game.Graphics.Containers
             posY = config.GetBindable<float>(OsuSetting.ScalingPositionY);
             posY.ValueChanged += _ => updateSize();
 
-            safeArea.SafeAreaPadding.BindValueChanged(_ => updateSize());
+            safeAreaPadding = safeArea.SafeAreaPadding.GetBoundCopy();
+            safeAreaPadding.BindValueChanged(_ => updateSize());
         }
 
         protected override void LoadComplete()
@@ -169,7 +169,7 @@ namespace osu.Game.Graphics.Containers
             bool requiresMasking = (scaling && targetSize != Vector2.One)
                                    // For the top level scaling container, for now we apply masking if safe areas are in use.
                                    // In the future this can likely be removed as more of the actual UI supports overflowing into the safe areas.
-                                   || (targetMode == ScalingMode.Everything && safeArea.SafeAreaPadding.Value.Total != Vector2.Zero);
+                                   || (targetMode == ScalingMode.Everything && safeAreaPadding.Value.Total != Vector2.Zero);
 
             if (requiresMasking)
                 sizableContainer.Masking = true;

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -101,6 +101,9 @@ namespace osu.Game.Graphics.Containers
             }
         }
 
+        [Resolved]
+        private ISafeArea safeArea { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
@@ -118,6 +121,8 @@ namespace osu.Game.Graphics.Containers
 
             posY = config.GetBindable<float>(OsuSetting.ScalingPositionY);
             posY.ValueChanged += _ => updateSize();
+
+            safeArea.SafeAreaPadding.BindValueChanged(_ => updateSize());
         }
 
         protected override void LoadComplete()
@@ -161,7 +166,10 @@ namespace osu.Game.Graphics.Containers
 
             var targetSize = scaling ? new Vector2(sizeX.Value, sizeY.Value) : Vector2.One;
             var targetPosition = scaling ? new Vector2(posX.Value, posY.Value) * (Vector2.One - targetSize) : Vector2.Zero;
-            bool requiresMasking = scaling && targetSize != Vector2.One;
+            bool requiresMasking = scaling && targetSize != Vector2.One
+                                   // For the top level scaling container, for now we apply masking if safe areas are in use.
+                                   // In the future this can likely be removed as more of the actual UI supports overflowing into the safe areas.
+                                   || (targetMode == ScalingMode.Everything && safeArea.SafeAreaPadding.Value.Total != Vector2.Zero);
 
             if (requiresMasking)
                 sizableContainer.Masking = true;

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Graphics.Containers
         {
             base.LoadComplete();
 
-            Scheduler.AddOnce(updateSize);
+            updateSize();
             sizableContainer.FinishTransforms();
         }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -301,6 +301,7 @@ namespace osu.Game
 
             base.Content.Add(new SafeAreaContainer
             {
+                SafeAreaOverrideEdges = Edges.Bottom,
                 RelativeSizeAxes = Axes.Both,
                 Child = CreateScalingContainer().WithChildren(new Drawable[]
                 {

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -93,7 +93,7 @@ namespace osu.Game
         /// The <see cref="Edges"/> that the game should be drawn over at a top level.
         /// Defaults to <see cref="Edges.None"/>.
         /// </summary>
-        public virtual Edges SafeAreaOverrideEdges { get; set; }
+        protected virtual Edges SafeAreaOverrideEdges => Edges.None;
 
         protected OsuConfigManager LocalConfig { get; private set; }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -299,16 +299,22 @@ namespace osu.Game
 
             GlobalActionContainer globalBindings;
 
-            var mainContent = new Drawable[]
+            base.Content.Add(new SafeAreaContainer
             {
-                MenuCursorContainer = new MenuCursorContainer { RelativeSizeAxes = Axes.Both },
-                // to avoid positional input being blocked by children, ensure the GlobalActionContainer is above everything.
-                globalBindings = new GlobalActionContainer(this)
-            };
-
-            MenuCursorContainer.Child = content = new OsuTooltipContainer(MenuCursorContainer.Cursor) { RelativeSizeAxes = Axes.Both };
-
-            base.Content.Add(CreateScalingContainer().WithChildren(mainContent));
+                RelativeSizeAxes = Axes.Both,
+                Child = CreateScalingContainer().WithChildren(new Drawable[]
+                {
+                    (MenuCursorContainer = new MenuCursorContainer
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    }).WithChild(content = new OsuTooltipContainer(MenuCursorContainer.Cursor)
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    }),
+                    // to avoid positional input being blocked by children, ensure the GlobalActionContainer is above everything.
+                    globalBindings = new GlobalActionContainer(this)
+                })
+            });
 
             KeyBindingStore = new RealmKeyBindingStore(realm, keyCombinationProvider);
             KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -89,6 +89,12 @@ namespace osu.Game
             }
         }
 
+        /// <summary>
+        /// The <see cref="Edges"/> that the game should be drawn over at a top level.
+        /// Defaults to <see cref="Edges.None"/>.
+        /// </summary>
+        public virtual Edges SafeAreaOverrideEdges { get; set; }
+
         protected OsuConfigManager LocalConfig { get; private set; }
 
         protected SessionStatics SessionStatics { get; private set; }
@@ -301,7 +307,7 @@ namespace osu.Game
 
             base.Content.Add(new SafeAreaContainer
             {
-                SafeAreaOverrideEdges = Edges.Bottom,
+                SafeAreaOverrideEdges = SafeAreaOverrideEdges,
                 RelativeSizeAxes = Axes.Both,
                 Child = CreateScalingContainer().WithChildren(new Drawable[]
                 {

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -19,7 +19,7 @@ namespace osu.iOS
 
         protected override BatteryInfo CreateBatteryInfo() => new IOSBatteryInfo();
 
-        public override Edges SafeAreaOverrideEdges =>
+        protected override Edges SafeAreaOverrideEdges =>
             // iOS shows a home indicator at the bottom, and adds a safe area to account for this.
             // Because we have the home indicator (mostly) hidden we don't really care about drawing in this region.
             Edges.Bottom;

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Foundation;
+using osu.Framework.Graphics;
 using osu.Game;
 using osu.Game.Updater;
 using osu.Game.Utils;
@@ -17,6 +18,11 @@ namespace osu.iOS
         protected override UpdateManager CreateUpdateManager() => new SimpleUpdateManager();
 
         protected override BatteryInfo CreateBatteryInfo() => new IOSBatteryInfo();
+
+        public override Edges SafeAreaOverrideEdges =>
+            // iOS shows a home indicator at the bottom, and adds a safe area to account for this.
+            // Because we have the home indicator (mostly) hidden we don't really care about drawing in this region.
+            Edges.Bottom;
 
         private class IOSBatteryInfo : BatteryInfo
         {


### PR DESCRIPTION
This is a MVP implementation of safe areas.

Supersedes https://github.com/ppy/osu/pull/4856.

Tested on iPhone 12 mini and iPad 11" to work (mostly?) as expected. I think we can potentially add some better rules to the framework side with further investigation (ie. we don't need the bottom safe area if we are able to hide the home bar, which I think we are/were doing?).

It's better than what we had at least.

iPhone 12 (note that even though the notch is only on one side, the provided safe areas are provided symmetrically):

![image](https://user-images.githubusercontent.com/191335/152493522-eedd1692-e1ef-4f51-a40e-9e7ecbb4e6cd.png)

iPad Pro 11" (safe area comes from home button OSD):

![image](https://user-images.githubusercontent.com/191335/152493660-e4d25ebe-ca57-49a8-bc60-bf6b2cd1eb09.png)