### PR TITLE
Fix crash when gameplay is started while inside multiplayer spectator screen

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -871,6 +871,52 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("queue is empty", () => this.ChildrenOfType<MultiplayerQueueList>().Single().Items.Count == 0);
         }
 
+        [Test]
+        public void TestGameplayStartsWhileInSpectatorScreen()
+        {
+            createRoom(() => new Room
+            {
+                Name = { Value = "Test Room" },
+                Playlist =
+                {
+                    new PlaylistItem
+                    {
+                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
+                        Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                    }
+                }
+            });
+
+            AddStep("join other user and make host", () =>
+            {
+                client.AddUser(new APIUser { Id = 1234 });
+                client.TransferHost(1234);
+            });
+
+            AddStep("set local user spectating", () => client.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
+            AddUntilStep("wait for spectating state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+
+            runGameplay();
+
+            AddStep("exit gameplay for other user", () => client.ChangeUserState(1234, MultiplayerUserState.Idle));
+            AddUntilStep("wait for room to be idle", () => client.Room?.State == MultiplayerRoomState.Open);
+
+            runGameplay();
+
+            void runGameplay()
+            {
+                AddStep("start match by other user", () =>
+                {
+                    client.ChangeUserState(1234, MultiplayerUserState.Ready);
+                    client.StartMatch();
+                });
+
+                AddUntilStep("wait for loading", () => client.Room?.State == MultiplayerRoomState.WaitingForLoad);
+                AddStep("set player loaded", () => client.ChangeUserState(1234, MultiplayerUserState.Loaded));
+                AddUntilStep("wait for gameplay to start", () => client.Room?.State == MultiplayerRoomState.Playing);
+            }
+        }
+
         private void enterGameplay()
         {
             pressReadyButton();

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -914,6 +914,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 AddUntilStep("wait for loading", () => client.Room?.State == MultiplayerRoomState.WaitingForLoad);
                 AddStep("set player loaded", () => client.ChangeUserState(1234, MultiplayerUserState.Loaded));
                 AddUntilStep("wait for gameplay to start", () => client.Room?.State == MultiplayerRoomState.Playing);
+                AddUntilStep("wait for local user to enter spectator", () => multiplayerComponents.CurrentScreen is MultiSpectatorScreen);
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -461,7 +461,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             // This is an issue with MultiSpectatorScreen which is effectively in an always "ready" state and receives LoadRequested() callbacks
             // even when it is not truly ready (i.e. the beatmap hasn't been selected by the client yet). For the time being, a simple fix to this is to ignore the callback.
             // Note that spectator will be entered automatically when the client is capable of doing so via beatmap availability callbacks (see: updateBeatmapAvailability()).
-            if (client.LocalUser?.State == MultiplayerUserState.Spectating && Beatmap.IsDefault)
+            if (client.LocalUser?.State == MultiplayerUserState.Spectating && (SelectedItem.Value == null || Beatmap.IsDefault))
                 return;
 
             StartPlay();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -457,6 +457,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
+            // The beatmap is queried asynchronously when the selected item changes.
+            // This is an issue with MultiSpectatorScreen which is effectively in an always "ready" state and receives LoadRequested() callbacks
+            // even when it is not truly ready (i.e. the beatmap hasn't been selected by the client yet). For the time being, a simple fix to this is to ignore the callback.
+            // Note that spectator will be entered automatically when the client is capable of doing so via beatmap availability callbacks (see: updateBeatmapAvailability()).
+            if (client.LocalUser?.State == MultiplayerUserState.Spectating && Beatmap.IsDefault)
+                return;
+
             StartPlay();
 
             readyClickOperation?.Dispose();


### PR DESCRIPTION
The problem here is as follows. Suppose we are in `MultiSpectatorScreen`. Gameplay ends and the playlist gets updated, with the room now having a new current item. The code which updates this client side is the following:
https://github.com/ppy/osu/blob/dbf2a1149c5858f8d01267cfc66c3b611cac2d9f/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L398-L433
Of importance:
- `SelectedItem.Value` is nulled,
- An async task is invoked to query the beatmap.
- The continuation from that task schedules back onto the screen.
This means that as we return to the screen, potentially the task hasn't run but also the scheduled continuation hasn't run either, which will then actually schedule the beatmap update _again_ when `SelectedItem.Value` is set non-null:
https://github.com/ppy/osu/blob/dbf2a1149c5858f8d01267cfc66c3b611cac2d9f/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs#L246

So the result is that when returning to the match subscreen (for the purpose of going back into another `MultiSpectatorScreen`), we have at least one frame where `SelectedItem.Value` is null and the beatmap has been returned to the dummy working beatmap, causing the crash.

This PR takes the easy path, by handling the crash site and not the underlying issue. I understand how dodgy this is/looks, but I believe it's the simplest solution until my further work on multiplayer - as I mentioned I want to remove this nulling of `SelectedItem.Value` completely as a first step, and additional work will be required on top of that to fix the underlying cause here.

Note that, in the case of spectating, there is additional code which runs when the beatmap is updated in order to push the user into the spectator screen, so `MultiSpectatorScreen` will still eventually enter automatically a second time when it's able to:
https://github.com/ppy/osu/blob/dbf2a1149c5858f8d01267cfc66c3b611cac2d9f/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L316-L334

This is not an issue with normal gameplay as users are automatically unreadied upon gameplay starting.