### PR TITLE
Play both 'random beatmap' and 'beatmap selection changed' samples when hitting random

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.202.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.204.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.204.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -154,6 +154,7 @@ namespace osu.Game.Screens.Select
         private readonly DrawablePool<DrawableCarouselBeatmapSet> setPool = new DrawablePool<DrawableCarouselBeatmapSet>(100);
 
         private Sample spinSample;
+        private Sample randomSelectSample;
 
         private int visibleSetsCount;
 
@@ -178,6 +179,7 @@ namespace osu.Game.Screens.Select
         private void load(OsuConfigManager config, AudioManager audio)
         {
             spinSample = audio.Samples.Get("SongSelect/random-spin");
+            randomSelectSample = audio.Samples.Get(@"SongSelect/select-random");
 
             config.BindWith(OsuSetting.RandomSelectAlgorithm, RandomAlgorithm);
             config.BindWith(OsuSetting.SongSelectRightMouseScroll, RightClickScrollingEnabled);
@@ -495,6 +497,8 @@ namespace osu.Game.Screens.Select
             var chan = spinSample.GetChannel();
             chan.Frequency.Value = 1f + Math.Min(1f, distance / visibleSetsCount);
             chan.Play();
+
+            randomSelectSample?.Play();
         }
 
         private void select(CarouselItem item)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -100,7 +100,6 @@ namespace osu.Game.Screens.Select
 
         private Sample sampleChangeDifficulty;
         private Sample sampleChangeBeatmap;
-        private Sample sampleRandomBeatmap;
 
         private Container carouselContainer;
 
@@ -109,8 +108,6 @@ namespace osu.Game.Screens.Select
         private readonly Bindable<RulesetInfo> decoupledRuleset = new Bindable<RulesetInfo>();
 
         private double audioFeedbackLastPlaybackTime;
-
-        private bool randomSelectionPending;
 
         [Resolved]
         private MusicController music { get; set; }
@@ -291,7 +288,6 @@ namespace osu.Game.Screens.Select
 
             sampleChangeDifficulty = audio.Samples.Get(@"SongSelect/select-difficulty");
             sampleChangeBeatmap = audio.Samples.Get(@"SongSelect/select-expand");
-            sampleRandomBeatmap = audio.Samples.Get(@"SongSelect/select-random");
             SampleConfirm = audio.Samples.Get(@"SongSelect/confirm-selection");
 
             if (dialogOverlay != null)
@@ -319,16 +315,8 @@ namespace osu.Game.Screens.Select
             (new FooterButtonMods { Current = Mods }, ModSelect),
             (new FooterButtonRandom
             {
-                NextRandom = () =>
-                {
-                    randomSelectionPending = true;
-                    Carousel.SelectNextRandom();
-                },
-                PreviousRandom = () =>
-                {
-                    randomSelectionPending = true;
-                    Carousel.SelectPreviousRandom();
-                }
+                NextRandom = () => Carousel.SelectNextRandom(),
+                PreviousRandom = Carousel.SelectPreviousRandom
             }, null),
             (new FooterButtonOptions(), BeatmapOptions)
         };
@@ -498,9 +486,7 @@ namespace osu.Game.Screens.Select
             {
                 if (beatmap != null && beatmapInfoPrevious != null && Time.Current - audioFeedbackLastPlaybackTime >= 50)
                 {
-                    if (randomSelectionPending)
-                        sampleRandomBeatmap.Play();
-                    else if (beatmap.BeatmapSet?.ID == beatmapInfoPrevious.BeatmapSet?.ID)
+                    if (beatmap.BeatmapSet?.ID == beatmapInfoPrevious.BeatmapSet?.ID)
                         sampleChangeDifficulty.Play();
                     else
                         sampleChangeBeatmap.Play();
@@ -508,7 +494,6 @@ namespace osu.Game.Screens.Select
                     audioFeedbackLastPlaybackTime = Time.Current;
                 }
 
-                randomSelectionPending = false;
                 beatmapInfoPrevious = beatmap;
             }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.8.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.204.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.202.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.204.0" />
     <PackageReference Include="Sentry" Version="3.13.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.204.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.202.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.204.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Partially reverts #16675 to layer playback of the 'random beatmap' and 'beatmap selection changed' samples.

Layering originally sounded bad, but works with the updated song-select samples in ppy/osu-resources#176

- [x] depends on ppy/osu-resources#176