### PR TITLE
Add user state to SpectatorState, allowing multiplayer to continue to results

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 Player.ScoreProcessor.NewJudgement += b => judged = true;
             });
             AddUntilStep("swell judged", () => judged);
-            AddAssert("failed", () => Player.HasFailed);
+            AddAssert("failed", () => Player.GameplayState.HasFailed);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override void AddCheckSteps()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddUntilStep("wait for fail overlay", () => ((FailPlayer)Player).FailOverlay.State.Value == Visibility.Visible);
 
             // The pause screen and fail animation both ramp frequency.

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override void AddCheckSteps()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddUntilStep("wait for multiple judgements", () => ((FailPlayer)Player).ScoreProcessor.JudgedHits > 1);
             AddAssert("total number of results == 1", () =>
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestPauseAfterFail()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddUntilStep("fail overlay shown", () => Player.FailOverlayVisible);
 
             confirmClockRunning(false);
@@ -201,7 +201,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestExitFromFailedGameplayAfterFailAnimation()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddUntilStep("wait for fail overlay shown", () => Player.FailOverlayVisible);
 
             confirmClockRunning(false);
@@ -213,7 +213,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestExitFromFailedGameplayDuringFailAnimation()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
 
             // will finish the fail animation and show the fail/pause screen.
             AddStep("attempt exit via pause key", () => Player.ExitViaPause());
@@ -227,7 +227,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestQuickRetryFromFailedGameplay()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddStep("quick retry", () => Player.GameplayClockContainer.ChildrenOfType<HotkeyRetryOverlay>().First().Action?.Invoke());
 
             confirmExited();
@@ -236,7 +236,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestQuickExitFromFailedGameplay()
         {
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddStep("quick exit", () => Player.GameplayClockContainer.ChildrenOfType<HotkeyExitOverlay>().First().Action?.Invoke());
 
             confirmExited();
@@ -341,7 +341,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             confirmClockRunning(false);
             confirmNotExited();
-            AddAssert("player not failed", () => !Player.HasFailed);
+            AddAssert("player not failed", () => !Player.GameplayState.HasFailed);
             AddAssert("pause overlay shown", () => Player.PauseOverlayVisible);
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
 
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddStep("exit", () => Player.Exit());
 
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);
@@ -176,7 +176,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             addFakeHit();
 
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddStep("exit", () => Player.Exit());
 
             AddAssert("ensure failing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == false);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -274,7 +274,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send quit", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Quit));
+            AddStep("send quit", () => spectatorClient.EndPlay(streamingUser.Id));
             AddUntilStep("state is quit", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Quit);
 
             start();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             checkPaused(true);
             sendFrames();
 
-            finish(SpectatingUserState.Failed);
+            finish(SpectatedUserState.Failed);
 
             checkPaused(false); // Should continue playing until out of frames
             checkPaused(true); // And eventually stop after running out of frames and fail.
@@ -244,7 +244,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             start();
             sendFrames();
             waitForPlayer();
-            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+            AddUntilStep("state is playing", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Playing);
         }
 
         [Test]
@@ -256,13 +256,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send passed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Passed));
-            AddUntilStep("state is passed", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Passed);
+            AddStep("send passed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatedUserState.Passed));
+            AddUntilStep("state is passed", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Passed);
 
             start();
             sendFrames();
             waitForPlayer();
-            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+            AddUntilStep("state is playing", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Playing);
         }
 
         [Test]
@@ -275,12 +275,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             waitForPlayer();
 
             AddStep("send quit", () => spectatorClient.EndPlay(streamingUser.Id));
-            AddUntilStep("state is quit", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Quit);
+            AddUntilStep("state is quit", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Quit);
 
             start();
             sendFrames();
             waitForPlayer();
-            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+            AddUntilStep("state is playing", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Playing);
         }
 
         [Test]
@@ -292,13 +292,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send failed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Failed));
-            AddUntilStep("state is failed", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Failed);
+            AddStep("send failed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatedUserState.Failed));
+            AddUntilStep("state is failed", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Failed);
 
             start();
             sendFrames();
             waitForPlayer();
-            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+            AddUntilStep("state is playing", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Playing);
         }
 
         private OsuFramedReplayInputHandler replayHandler =>
@@ -313,7 +313,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void start(int? beatmapId = null) => AddStep("start play", () => spectatorClient.StartPlay(streamingUser.Id, beatmapId ?? importedBeatmapId));
 
-        private void finish(SpectatingUserState state = SpectatingUserState.Quit) => AddStep("end play", () => spectatorClient.EndPlay(streamingUser.Id, state));
+        private void finish(SpectatedUserState state = SpectatedUserState.Quit) => AddStep("end play", () => spectatorClient.EndPlay(streamingUser.Id, state));
 
         private void checkPaused(bool state) =>
             AddUntilStep($"game is {(state ? "paused" : "playing")}", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value == state);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -160,7 +160,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             finish(SpectatingUserState.Failed);
 
             checkPaused(false); // Should continue playing until out of frames
-            checkPaused(true);
+            checkPaused(true); // And eventually stop after running out of frames and fail.
+            // Todo: Should check for + display a failed message.
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -247,7 +247,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestCompletionState()
+        public void TestPassedState()
         {
             loadSpectatingScreen();
 
@@ -255,8 +255,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send completion", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Completed));
-            AddUntilStep("state is completed", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Completed);
+            AddStep("send passed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Passed));
+            AddUntilStep("state is passed", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Passed);
 
             start();
             sendFrames();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("send frames and finish play", () =>
             {
                 spectatorClient.HandleFrame(new OsuReplayFrame(1000, Vector2.Zero));
-                spectatorClient.EndPlaying();
+                spectatorClient.EndPlaying(new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset()) { HasPassed = true });
             });
 
             // We can't access API because we're an "online" test.

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -235,6 +235,71 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("last frame has header", () => lastBundle.Frames[^1].Header != null);
         }
 
+        [Test]
+        public void TestPlayingState()
+        {
+            loadSpectatingScreen();
+
+            start();
+            sendFrames();
+            waitForPlayer();
+            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+        }
+
+        [Test]
+        public void TestCompletionState()
+        {
+            loadSpectatingScreen();
+
+            start();
+            sendFrames();
+            waitForPlayer();
+
+            AddStep("send completion", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Completed));
+            AddUntilStep("state is completed", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Completed);
+
+            start();
+            sendFrames();
+            waitForPlayer();
+            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+        }
+
+        [Test]
+        public void TestQuitState()
+        {
+            loadSpectatingScreen();
+
+            start();
+            sendFrames();
+            waitForPlayer();
+
+            AddStep("send quit", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Quit));
+            AddUntilStep("state is quit", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Quit);
+
+            start();
+            sendFrames();
+            waitForPlayer();
+            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+        }
+
+        [Test]
+        public void TestFailedState()
+        {
+            loadSpectatingScreen();
+
+            start();
+            sendFrames();
+            waitForPlayer();
+
+            AddStep("send failed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatingUserState.Failed));
+            AddUntilStep("state is failed", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Failed);
+
+            start();
+            sendFrames();
+            waitForPlayer();
+            AddUntilStep("state is playing", () => spectatorClient.WatchingUserStates[streamingUser.Id].State == SpectatingUserState.Playing);
+        }
+
         private OsuFramedReplayInputHandler replayHandler =>
             (OsuFramedReplayInputHandler)Stack.ChildrenOfType<OsuInputManager>().First().ReplayInputHandler;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -155,11 +155,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             waitForPlayer();
             checkPaused(true);
+            sendFrames();
 
-            finish();
+            finish(SpectatingUserState.Failed);
 
-            checkPaused(false);
-            // TODO: should replay until running out of frames then fail
+            checkPaused(false); // Should continue playing until out of frames
+            checkPaused(true);
         }
 
         [Test]
@@ -246,7 +247,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void start(int? beatmapId = null) => AddStep("start play", () => spectatorClient.StartPlay(streamingUser.Id, beatmapId ?? importedBeatmapId));
 
-        private void finish() => AddStep("end play", () => spectatorClient.EndPlay(streamingUser.Id));
+        private void finish(SpectatingUserState state = SpectatingUserState.Quit) => AddStep("end play", () => spectatorClient.EndPlay(streamingUser.Id, state));
 
         private void checkPaused(bool state) =>
             AddUntilStep($"game is {(state ? "paused" : "playing")}", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value == state);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorHost.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorHost.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestClientSendsCorrectRuleset()
         {
-            AddUntilStep("spectator client sending frames", () => spectatorClient.WatchingUserStates.ContainsKey(dummy_user_id));
-            AddAssert("spectator client sent correct ruleset", () => spectatorClient.WatchingUserStates[dummy_user_id].RulesetID == Ruleset.Value.OnlineID);
+            AddUntilStep("spectator client sending frames", () => spectatorClient.WatchedUserStates.ContainsKey(dummy_user_id));
+            AddAssert("spectator client sent correct ruleset", () => spectatorClient.WatchedUserStates[dummy_user_id].RulesetID == Ruleset.Value.OnlineID);
         }
 
         public override void TearDownSteps()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorHost.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorHost.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestClientSendsCorrectRuleset()
         {
-            AddUntilStep("spectator client sending frames", () => spectatorClient.PlayingUserStates.ContainsKey(dummy_user_id));
-            AddAssert("spectator client sent correct ruleset", () => spectatorClient.PlayingUserStates[dummy_user_id].RulesetID == Ruleset.Value.OnlineID);
+            AddUntilStep("spectator client sending frames", () => spectatorClient.WatchingUserStates.ContainsKey(dummy_user_id));
+            AddAssert("spectator client sent correct ruleset", () => spectatorClient.WatchingUserStates[dummy_user_id].RulesetID == Ruleset.Value.OnlineID);
         }
 
         public override void TearDownSteps()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -20,7 +17,6 @@ using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Online.API;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays;
 using osu.Game.Replays.Legacy;
@@ -47,8 +43,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private Replay replay;
 
-        private readonly IBindableList<int> users = new BindableList<int>();
-
         private TestReplayRecorder recorder;
 
         private ManualClock manualClock;
@@ -56,9 +50,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         private OsuSpriteText latencyDisplay;
 
         private TestFramedReplayInputHandler replayHandler;
-
-        [Resolved]
-        private IAPIProvider api { get; set; }
 
         [Resolved]
         private SpectatorClient spectatorClient { get; set; }
@@ -77,35 +68,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                 manualClock = new ManualClock();
 
                 spectatorClient.OnNewFrames += onNewFrames;
-
-                users.BindTo(spectatorClient.PlayingUsers);
-                users.BindCollectionChanged((obj, args) =>
-                {
-                    switch (args.Action)
-                    {
-                        case NotifyCollectionChangedAction.Add:
-                            Debug.Assert(args.NewItems != null);
-
-                            foreach (int user in args.NewItems)
-                            {
-                                if (user == api.LocalUser.Value.Id)
-                                    spectatorClient.WatchUser(user);
-                            }
-
-                            break;
-
-                        case NotifyCollectionChangedAction.Remove:
-                            Debug.Assert(args.OldItems != null);
-
-                            foreach (int user in args.OldItems)
-                            {
-                                if (user == api.LocalUser.Value.Id)
-                                    spectatorClient.StopWatchingUser(user);
-                            }
-
-                            break;
-                    }
-                }, true);
 
                 Children = new Drawable[]
                 {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 AddStep("set storyboard duration to 0.6s", () => currentStoryboardDuration = 600);
             });
 
-            AddUntilStep("wait for fail", () => Player.HasFailed);
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
             AddUntilStep("wait for fail overlay", () => Player.FailOverlay.State.Value == Visibility.Visible);
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             public void RandomlyUpdateState()
             {
-                foreach (int userId in PlayingUsers)
+                foreach ((int userId, _) in PlayingUserStates)
                 {
                     if (RNG.NextBool())
                         continue;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             public void RandomlyUpdateState()
             {
-                foreach ((int userId, _) in WatchingUserStates)
+                foreach ((int userId, _) in WatchedUserStates)
                 {
                     if (RNG.NextBool())
                         continue;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             public void RandomlyUpdateState()
             {
-                foreach ((int userId, _) in PlayingUserStates)
+                foreach ((int userId, _) in WatchingUserStates)
                 {
                     if (RNG.NextBool())
                         continue;

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 return (player = Game.ScreenStack.CurrentScreen as Player) != null;
             });
 
-            AddUntilStep("wait for fail", () => player.HasFailed);
+            AddUntilStep("wait for fail", () => player.GameplayState.HasFailed);
 
             AddUntilStep("wait for track stop", () => !Game.MusicController.IsPlaying);
             AddAssert("Ensure time before preview point", () => Game.MusicController.CurrentTrack.CurrentTime < beatmap().BeatmapInfo.Metadata.PreviewTime);

--- a/osu.Game/Online/Spectator/SpectatedUserState.cs
+++ b/osu.Game/Online/Spectator/SpectatedUserState.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Online.Spectator
 {
-    public enum SpectatingUserState
+    public enum SpectatedUserState
     {
         /// <summary>
         /// The spectated user is not yet playing.
@@ -26,7 +26,7 @@ namespace osu.Game.Online.Spectator
         Passed,
 
         /// <summary>
-        /// The spectator user has failed gameplay.
+        /// The spectated user has failed gameplay.
         /// </summary>
         Failed,
 

--- a/osu.Game/Online/Spectator/SpectatingUserState.cs
+++ b/osu.Game/Online/Spectator/SpectatingUserState.cs
@@ -16,6 +16,11 @@ namespace osu.Game.Online.Spectator
         Playing,
 
         /// <summary>
+        /// The spectated user is currently paused. Unused for the time being.
+        /// </summary>
+        Paused,
+
+        /// <summary>
         /// The spectated user has passed gameplay.
         /// </summary>
         Passed,

--- a/osu.Game/Online/Spectator/SpectatingUserState.cs
+++ b/osu.Game/Online/Spectator/SpectatingUserState.cs
@@ -6,7 +6,7 @@ namespace osu.Game.Online.Spectator
     public enum SpectatingUserState
     {
         /// <summary>
-        /// The spectated user has not yet played.
+        /// The spectated user is not yet playing.
         /// </summary>
         Idle,
 
@@ -16,17 +16,17 @@ namespace osu.Game.Online.Spectator
         Playing,
 
         /// <summary>
-        /// The spectated user has successfully completed gameplay.
+        /// The spectated user has passed gameplay.
         /// </summary>
-        Completed,
+        Passed,
 
         /// <summary>
-        /// The spectator user has failed during gameplay.
+        /// The spectator user has failed gameplay.
         /// </summary>
         Failed,
 
         /// <summary>
-        /// The spectated user has quit during gameplay.
+        /// The spectated user has quit gameplay.
         /// </summary>
         Quit
     }

--- a/osu.Game/Online/Spectator/SpectatingUserState.cs
+++ b/osu.Game/Online/Spectator/SpectatingUserState.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Online.Spectator
+{
+    public enum SpectatingUserState
+    {
+        /// <summary>
+        /// The spectated user has not yet played.
+        /// </summary>
+        Idle,
+
+        /// <summary>
+        /// The spectated user is currently playing.
+        /// </summary>
+        Playing,
+
+        /// <summary>
+        /// The spectated user has successfully completed gameplay.
+        /// </summary>
+        Completed,
+
+        /// <summary>
+        /// The spectator user has failed during gameplay.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// The spectated user has quit during gameplay.
+        /// </summary>
+        Quit
+    }
+}

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -37,9 +37,6 @@ namespace osu.Game.Online.Spectator
 
         private readonly List<int> watchingUsers = new List<int>();
 
-        public IBindableList<int> PlayingUsers => playingUsers;
-        private readonly BindableList<int> playingUsers = new BindableList<int>();
-
         public IBindableDictionary<int, SpectatorState> PlayingUserStates => playingUserStates;
         private readonly BindableDictionary<int, SpectatorState> playingUserStates = new BindableDictionary<int, SpectatorState>();
 
@@ -88,10 +85,7 @@ namespace osu.Game.Online.Spectator
                         BeginPlayingInternal(currentState);
                 }
                 else
-                {
-                    playingUsers.Clear();
                     playingUserStates.Clear();
-                }
             }), true);
         }
 
@@ -99,9 +93,6 @@ namespace osu.Game.Online.Spectator
         {
             Schedule(() =>
             {
-                if (!playingUsers.Contains(userId))
-                    playingUsers.Add(userId);
-
                 // UserBeganPlaying() is called by the server regardless of whether the local user is watching the remote user, and is called a further time when the remote user is watched.
                 // This may be a temporary thing (see: https://github.com/ppy/osu-server-spectator/blob/2273778e02cfdb4a9c6a934f2a46a8459cb5d29c/osu.Server.Spectator/Hubs/SpectatorHub.cs#L28-L29).
                 // We don't want the user states to update unless the player is being watched, otherwise calling BindUserBeganPlaying() can lead to double invocations.
@@ -118,7 +109,6 @@ namespace osu.Game.Online.Spectator
         {
             Schedule(() =>
             {
-                playingUsers.Remove(userId);
                 playingUserStates.Remove(userId);
 
                 OnUserFinishedPlaying?.Invoke(userId, state);

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -93,12 +93,8 @@ namespace osu.Game.Online.Spectator
         {
             Schedule(() =>
             {
-                // UserBeganPlaying() is called by the server regardless of whether the local user is watching the remote user, and is called a further time when the remote user is watched.
-                // This may be a temporary thing (see: https://github.com/ppy/osu-server-spectator/blob/2273778e02cfdb4a9c6a934f2a46a8459cb5d29c/osu.Server.Spectator/Hubs/SpectatorHub.cs#L28-L29).
-                // We don't want the user states to update unless the player is being watched, otherwise calling BindUserBeganPlaying() can lead to double invocations.
                 if (watchingUsers.Contains(userId))
                     playingUserStates[userId] = state;
-
                 OnUserBeganPlaying?.Invoke(userId, state);
             });
 
@@ -109,8 +105,8 @@ namespace osu.Game.Online.Spectator
         {
             Schedule(() =>
             {
-                playingUserStates.Remove(userId);
-
+                if (watchingUsers.Contains(userId))
+                    playingUserStates[userId] = state;
                 OnUserFinishedPlaying?.Invoke(userId, state);
             });
 

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -138,6 +138,7 @@ namespace osu.Game.Online.Spectator
                 currentState.BeatmapID = score.ScoreInfo.BeatmapInfo.OnlineID;
                 currentState.RulesetID = score.ScoreInfo.RulesetID;
                 currentState.Mods = score.ScoreInfo.Mods.Select(m => new APIMod(m)).ToArray();
+                currentState.State = SpectatingUserState.Playing;
 
                 currentBeatmap = state.Beatmap;
                 currentScore = score;
@@ -148,7 +149,7 @@ namespace osu.Game.Online.Spectator
 
         public void SendFrames(FrameDataBundle data) => lastSend = SendFramesInternal(data);
 
-        public void EndPlaying()
+        public void EndPlaying(GameplayState state)
         {
             // This method is most commonly called via Dispose(), which is can be asynchronous (via the AsyncDisposalQueue).
             // We probably need to find a better way to handle this...
@@ -162,6 +163,13 @@ namespace osu.Game.Online.Spectator
 
                 IsPlaying = false;
                 currentBeatmap = null;
+
+                if (state.HasPassed)
+                    currentState.State = SpectatingUserState.Completed;
+                else if (state.HasFailed)
+                    currentState.State = SpectatingUserState.Failed;
+                else
+                    currentState.State = SpectatingUserState.Quit;
 
                 EndPlayingInternal(currentState);
             });

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Online.Spectator
 
         private readonly List<int> watchingUsers = new List<int>();
 
-        public IBindableDictionary<int, SpectatorState> PlayingUserStates => playingUserStates;
-        private readonly BindableDictionary<int, SpectatorState> playingUserStates = new BindableDictionary<int, SpectatorState>();
+        public IBindableDictionary<int, SpectatorState> WatchingUserStates => watchingUserStates;
+        private readonly BindableDictionary<int, SpectatorState> watchingUserStates = new BindableDictionary<int, SpectatorState>();
 
         private IBeatmap? currentBeatmap;
         private Score? currentScore;
@@ -85,7 +85,7 @@ namespace osu.Game.Online.Spectator
                         BeginPlayingInternal(currentState);
                 }
                 else
-                    playingUserStates.Clear();
+                    watchingUserStates.Clear();
             }), true);
         }
 
@@ -94,7 +94,7 @@ namespace osu.Game.Online.Spectator
             Schedule(() =>
             {
                 if (watchingUsers.Contains(userId))
-                    playingUserStates[userId] = state;
+                    watchingUserStates[userId] = state;
                 OnUserBeganPlaying?.Invoke(userId, state);
             });
 
@@ -106,7 +106,7 @@ namespace osu.Game.Online.Spectator
             Schedule(() =>
             {
                 if (watchingUsers.Contains(userId))
-                    playingUserStates[userId] = state;
+                    watchingUserStates[userId] = state;
                 OnUserFinishedPlaying?.Invoke(userId, state);
             });
 
@@ -193,7 +193,7 @@ namespace osu.Game.Online.Spectator
             Schedule(() =>
             {
                 watchingUsers.Remove(userId);
-                playingUserStates.Remove(userId);
+                watchingUserStates.Remove(userId);
                 StopWatchingUserInternal(userId);
             });
         }

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Online.Spectator
                 currentBeatmap = null;
 
                 if (state.HasPassed)
-                    currentState.State = SpectatingUserState.Completed;
+                    currentState.State = SpectatingUserState.Passed;
                 else if (state.HasFailed)
                     currentState.State = SpectatingUserState.Failed;
                 else

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -98,8 +98,8 @@ namespace osu.Game.Online.Spectator
                 }
                 else
                 {
-                    watchingUserStates.Clear();
                     playingUsers.Clear();
+                    watchingUserStates.Clear();
                 }
             }), true);
         }

--- a/osu.Game/Online/Spectator/SpectatorState.cs
+++ b/osu.Game/Online/Spectator/SpectatorState.cs
@@ -24,14 +24,17 @@ namespace osu.Game.Online.Spectator
         [Key(2)]
         public IEnumerable<APIMod> Mods { get; set; } = Enumerable.Empty<APIMod>();
 
+        [Key(3)]
+        public SpectatingUserState State { get; set; }
+
         public bool Equals(SpectatorState other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return BeatmapID == other.BeatmapID && Mods.SequenceEqual(other.Mods) && RulesetID == other.RulesetID;
+            return BeatmapID == other.BeatmapID && Mods.SequenceEqual(other.Mods) && RulesetID == other.RulesetID && State == other.State;
         }
 
-        public override string ToString() => $"Beatmap:{BeatmapID} Mods:{string.Join(',', Mods)} Ruleset:{RulesetID}";
+        public override string ToString() => $"Beatmap:{BeatmapID} Mods:{string.Join(',', Mods)} Ruleset:{RulesetID} State:{State}";
     }
 }

--- a/osu.Game/Online/Spectator/SpectatorState.cs
+++ b/osu.Game/Online/Spectator/SpectatorState.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Online.Spectator
         public IEnumerable<APIMod> Mods { get; set; } = Enumerable.Empty<APIMod>();
 
         [Key(3)]
-        public SpectatingUserState State { get; set; }
+        public SpectatedUserState State { get; set; }
 
         public bool Equals(SpectatorState other)
         {

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -69,17 +69,17 @@ namespace osu.Game.Overlays.Dashboard
                         {
                             var user = task.GetResultSafely();
 
-                            if (user != null)
-                            {
-                                Schedule(() =>
-                                {
-                                    // user may no longer be playing.
-                                    if (!playingUsers.Contains(user.Id))
-                                        return;
+                            if (user == null)
+                                return;
 
-                                    userFlow.Add(createUserPanel(user));
-                                });
-                            }
+                            Schedule(() =>
+                            {
+                                // user may no longer be playing.
+                                if (!playingUsers.Contains(user.Id))
+                                    return;
+
+                                userFlow.Add(createUserPanel(user));
+                            });
                         });
                     }
 

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Overlays.Dashboard
         {
             base.LoadComplete();
 
-            userStates.BindTo(spectatorClient.PlayingUserStates);
+            userStates.BindTo(spectatorClient.WatchingUserStates);
             userStates.BindCollectionChanged(onUserStatesChanged, true);
         }
 

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -55,7 +55,9 @@ namespace osu.Game.Rulesets.UI
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            spectatorClient?.EndPlaying();
+
+            if (spectatorClient != null && gameplayState != null)
+                spectatorClient.EndPlaying(gameplayState);
         }
 
         protected override void Update()

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -54,9 +55,7 @@ namespace osu.Game.Rulesets.UI
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-
-            if (spectatorClient != null && gameplayState != null)
-                spectatorClient.EndPlaying(gameplayState);
+            spectatorClient?.EndPlaying(gameplayState);
         }
 
         protected override void Update()

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.UI
 
         public int RecordFrameRate = 60;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private SpectatorClient spectatorClient { get; set; }
 
         [Resolved]
@@ -48,8 +48,7 @@ namespace osu.Game.Rulesets.UI
             base.LoadComplete();
 
             inputManager = GetContainingInputManager();
-
-            spectatorClient?.BeginPlaying(gameplayState, target);
+            spectatorClient.BeginPlaying(gameplayState, target);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     public class MultiplayerPlayerLoader : PlayerLoader
     {
-        public bool GameplayPassed => player?.GameplayPassed == true;
+        public bool GameplayPassed => player?.GameplayState.HasPassed == true;
 
         private Player player;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -215,8 +215,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         protected override void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState)
             => instances.Single(i => i.UserId == userId).LoadScore(spectatorGameplayState.Score);
 
-        protected override void EndGameplay(int userId)
+        protected override void EndGameplay(int userId, SpectatorState state)
         {
+            if (state.State == SpectatingUserState.Completed || state.State == SpectatingUserState.Failed)
+                return;
+
             RemoveUser(userId);
 
             var instance = instances.Single(i => i.UserId == userId);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -216,6 +216,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         protected override void EndGameplay(int userId, SpectatorState state)
         {
+            // Allowed passed/failed users to complete their remaining replay frames.
+            // The failed state isn't really possible in multiplayer (yet?) but is added here just for safety in case it starts being used.
             if (state.State == SpectatingUserState.Passed || state.State == SpectatingUserState.Failed)
                 return;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -216,7 +216,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         protected override void EndGameplay(int userId, SpectatorState state)
         {
-            if (state.State == SpectatingUserState.Completed || state.State == SpectatingUserState.Failed)
+            if (state.State == SpectatingUserState.Passed || state.State == SpectatingUserState.Failed)
                 return;
 
             RemoveUser(userId);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -218,7 +218,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
             // Allowed passed/failed users to complete their remaining replay frames.
             // The failed state isn't really possible in multiplayer (yet?) but is added here just for safety in case it starts being used.
-            if (state.State == SpectatingUserState.Passed || state.State == SpectatingUserState.Failed)
+            if (state.State == SpectatedUserState.Passed || state.State == SpectatedUserState.Failed)
                 return;
 
             RemoveUser(userId);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -207,7 +207,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             }
         }
 
-        protected override void OnUserStateChanged(int userId, SpectatorState spectatorState)
+        protected override void OnNewPlayingUserState(int userId, SpectatorState spectatorState)
         {
         }
 

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -50,6 +50,11 @@ namespace osu.Game.Screens.Play
         public bool HasFailed { get; set; }
 
         /// <summary>
+        /// Whether the user quit gameplay without either having either passed or failed.
+        /// </summary>
+        public bool HasQuit { get; set; }
+
+        /// <summary>
         /// A bindable tracking the last judgement result applied to any hit object.
         /// </summary>
         public IBindable<JudgementResult> LastJudgementResult => lastJudgementResult;

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -40,6 +40,16 @@ namespace osu.Game.Screens.Play
         public readonly Score Score;
 
         /// <summary>
+        /// Whether gameplay completed without the user failing.
+        /// </summary>
+        public bool HasPassed { get; set; }
+
+        /// <summary>
+        /// Whether the user failed during gameplay.
+        /// </summary>
+        public bool HasFailed { get; set; }
+
+        /// <summary>
         /// A bindable tracking the last judgement result applied to any hit object.
         /// </summary>
         public IBindable<JudgementResult> LastJudgementResult => lastJudgementResult;

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play
         public bool HasFailed { get; set; }
 
         /// <summary>
-        /// Whether the user quit gameplay without either having either passed or failed.
+        /// Whether the user quit gameplay without having either passed or failed.
         /// </summary>
         public bool HasQuit { get; set; }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -72,14 +72,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual bool PauseOnFocusLost => true;
 
-        /// <summary>
-        /// Whether gameplay has completed without the user having failed.
-        /// </summary>
-        public bool GameplayPassed { get; private set; }
-
         public Action RestartRequested;
-
-        public bool HasFailed { get; private set; }
 
         private Bindable<bool> mouseWheelDisabled;
 
@@ -559,7 +552,7 @@ namespace osu.Game.Screens.Play
             if (showDialogFirst && !pauseOrFailDialogVisible)
             {
                 // if the fail animation is currently in progress, accelerate it (it will show the pause dialog on completion).
-                if (ValidForResume && HasFailed)
+                if (ValidForResume && GameplayState.HasFailed)
                 {
                     failAnimationLayer.FinishTransforms(true);
                     return;
@@ -678,7 +671,7 @@ namespace osu.Game.Screens.Play
                 resultsDisplayDelegate?.Cancel();
                 resultsDisplayDelegate = null;
 
-                GameplayPassed = false;
+                GameplayState.HasPassed = false;
                 ValidForResume = true;
                 skipOutroOverlay.Hide();
                 return;
@@ -688,7 +681,7 @@ namespace osu.Game.Screens.Play
             if (HealthProcessor.HasFailed)
                 return;
 
-            GameplayPassed = true;
+            GameplayState.HasPassed = true;
 
             // Setting this early in the process means that even if something were to go wrong in the order of events following, there
             // is no chance that a user could return to the (already completed) Player instance from a child screen.
@@ -804,7 +797,7 @@ namespace osu.Game.Screens.Play
             if (!CheckModsAllowFailure())
                 return false;
 
-            HasFailed = true;
+            GameplayState.HasFailed = true;
             Score.ScoreInfo.Passed = false;
 
             // There is a chance that we could be in a paused state as the ruleset's internal clock (see FrameStabilityContainer)
@@ -859,13 +852,13 @@ namespace osu.Game.Screens.Play
             // replays cannot be paused and exit immediately
             && !DrawableRuleset.HasReplayLoaded.Value
             // cannot pause if we are already in a fail state
-            && !HasFailed;
+            && !GameplayState.HasFailed;
 
         private bool canResume =>
             // cannot resume from a non-paused state
             GameplayClockContainer.IsPaused.Value
             // cannot resume if we are already in a fail state
-            && !HasFailed
+            && !GameplayState.HasFailed
             // already resuming
             && !IsResuming;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1000,7 +1000,7 @@ namespace osu.Game.Screens.Play
             // EndPlaying() is typically called from ReplayRecorder.Dispose(). Disposal is currently asynchronous.
             // To resolve test failures, forcefully end playing synchronously when this screen exits.
             // Todo: Replace this with a more permanent solution once osu-framework has a synchronous cleanup method.
-            spectatorClient.EndPlaying();
+            spectatorClient.EndPlaying(GameplayState);
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.
             // as we are no longer the current screen, we cannot guarantee the track is still usable.

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -983,6 +983,9 @@ namespace osu.Game.Screens.Play
 
         public override bool OnExiting(IScreen next)
         {
+            if (!GameplayState.HasPassed && !GameplayState.HasFailed)
+                GameplayState.HasQuit = true;
+
             screenSuspension?.RemoveAndDisposeImmediately();
             failAnimationLayer?.RemoveFilters();
 

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Screens.Play
             automaticDownload.Current.BindValueChanged(_ => checkForAutomaticDownload());
         }
 
-        protected override void OnUserStateChanged(int userId, SpectatorState spectatorState)
+        protected override void OnNewPlayingUserState(int userId, SpectatorState spectatorState)
         {
             clearDisplay();
             showBeatmapPanel(spectatorState);

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Screens.Play
             scheduleStart(spectatorGameplayState);
         }
 
-        protected override void EndGameplay(int userId)
+        protected override void EndGameplay(int userId, SpectatorState state)
         {
             scheduledStart?.Cancel();
             immediateSpectatorGameplayState = null;

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Spectate
                     userMap[u.Id] = u;
                 }
 
-                userStates.BindTo(spectatorClient.WatchingUserStates);
+                userStates.BindTo(spectatorClient.WatchedUserStates);
                 userStates.BindCollectionChanged(onUserStatesChanged, true);
 
                 realmSubscription = realm.RegisterForNotifications(
@@ -134,13 +134,13 @@ namespace osu.Game.Screens.Spectate
 
             switch (newState.State)
             {
-                case SpectatingUserState.Passed:
+                case SpectatedUserState.Passed:
                     // Make sure that gameplay completes to the end.
                     if (gameplayStates.TryGetValue(userId, out var gameplayState))
                         gameplayState.Score.Replay.HasReceivedAllFrames = true;
                     break;
 
-                case SpectatingUserState.Playing:
+                case SpectatedUserState.Playing:
                     Schedule(() => OnUserStateChanged(userId, newState));
                     updateGameplayState(userId);
                     break;

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Spectate
                     userMap[u.Id] = u;
                 }
 
-                userStates.BindTo(spectatorClient.PlayingUserStates);
+                userStates.BindTo(spectatorClient.WatchingUserStates);
                 userStates.BindCollectionChanged(onUserStatesChanged, true);
 
                 realmSubscription = realm.RegisterForNotifications(

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Screens.Spectate
 
             switch (newState.State)
             {
-                case SpectatingUserState.Completed:
+                case SpectatingUserState.Passed:
                     // Make sure that gameplay completes to the end.
                     if (gameplayStates.TryGetValue(userId, out var gameplayState))
                         gameplayState.Score.Replay.HasReceivedAllFrames = true;

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Spectate
                     continue;
 
                 if (beatmapSet.Beatmaps.Any(b => b.OnlineID == userState.BeatmapID))
-                    updateGameplayState(userId);
+                    startGameplay(userId);
             }
         }
 
@@ -141,8 +141,8 @@ namespace osu.Game.Screens.Spectate
                     break;
 
                 case SpectatedUserState.Playing:
-                    Schedule(() => OnUserStateChanged(userId, newState));
-                    updateGameplayState(userId);
+                    Schedule(() => OnNewPlayingUserState(userId, newState));
+                    startGameplay(userId);
                     break;
             }
         }
@@ -161,7 +161,7 @@ namespace osu.Game.Screens.Spectate
             Schedule(() => EndGameplay(userId, state));
         }
 
-        private void updateGameplayState(int userId)
+        private void startGameplay(int userId)
         {
             Debug.Assert(userMap.ContainsKey(userId));
 
@@ -195,11 +195,11 @@ namespace osu.Game.Screens.Spectate
         }
 
         /// <summary>
-        /// Invoked when a spectated user's state has changed.
+        /// Invoked when a spectated user's state has changed to a new state indicating the player is currently playing.
         /// </summary>
         /// <param name="userId">The user whose state has changed.</param>
         /// <param name="spectatorState">The new state.</param>
-        protected abstract void OnUserStateChanged(int userId, [NotNull] SpectatorState spectatorState);
+        protected abstract void OnNewPlayingUserState(int userId, [NotNull] SpectatorState spectatorState);
 
         /// <summary>
         /// Starts gameplay for a user.

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -118,8 +118,8 @@ namespace osu.Game.Screens.Spectate
                     break;
 
                 case NotifyDictionaryChangedAction.Remove:
-                    foreach ((int userId, _) in e.OldItems.AsNonNull())
-                        onUserStateRemoved(userId);
+                    foreach ((int userId, SpectatorState state) in e.OldItems.AsNonNull())
+                        onUserStateRemoved(userId, state);
                     break;
             }
         }
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.Spectate
             }
         }
 
-        private void onUserStateRemoved(int userId)
+        private void onUserStateRemoved(int userId, SpectatorState state)
         {
             if (!userMap.ContainsKey(userId))
                 return;
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.Spectate
             gameplayState.Score.Replay.HasReceivedAllFrames = true;
 
             gameplayStates.Remove(userId);
-            Schedule(() => EndGameplay(userId));
+            Schedule(() => EndGameplay(userId, state));
         }
 
         private void updateGameplayState(int userId)
@@ -212,7 +212,8 @@ namespace osu.Game.Screens.Spectate
         /// Ends gameplay for a user.
         /// </summary>
         /// <param name="userId">The user to end gameplay for.</param>
-        protected abstract void EndGameplay(int userId);
+        /// <param name="state">The final user state.</param>
+        protected abstract void EndGameplay(int userId, SpectatorState state);
 
         /// <summary>
         /// Stops spectating a user.
@@ -220,7 +221,10 @@ namespace osu.Game.Screens.Spectate
         /// <param name="userId">The user to stop spectating.</param>
         protected void RemoveUser(int userId)
         {
-            onUserStateRemoved(userId);
+            if (!userStates.TryGetValue(userId, out var state))
+                return;
+
+            onUserStateRemoved(userId, state);
 
             users.Remove(userId);
             userMap.Remove(userId);

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -42,7 +41,7 @@ namespace osu.Game.Tests.Visual.Spectator
         {
             OnNewFrames += (i, bundle) =>
             {
-                if (PlayingUsers.Contains(i))
+                if (PlayingUserStates.ContainsKey(i))
                     lastReceivedUserFrames[i] = bundle.Frames[^1];
             };
         }
@@ -65,7 +64,7 @@ namespace osu.Game.Tests.Visual.Spectator
         /// <param name="userId">The user to end play for.</param>
         public void EndPlay(int userId)
         {
-            if (!PlayingUsers.Contains(userId))
+            if (!PlayingUserStates.ContainsKey(userId))
                 return;
 
             ((ISpectatorClient)this).UserFinishedPlaying(userId, new SpectatorState
@@ -131,7 +130,7 @@ namespace osu.Game.Tests.Visual.Spectator
         protected override Task WatchUserInternal(int userId)
         {
             // When newly watching a user, the server sends the playing state immediately.
-            if (PlayingUsers.Contains(userId))
+            if (PlayingUserStates.ContainsKey(userId))
                 sendPlayingState(userId);
 
             return Task.CompletedTask;

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -39,11 +39,7 @@ namespace osu.Game.Tests.Visual.Spectator
 
         public TestSpectatorClient()
         {
-            OnNewFrames += (i, bundle) =>
-            {
-                if (PlayingUserStates.ContainsKey(i))
-                    lastReceivedUserFrames[i] = bundle.Frames[^1];
-            };
+            OnNewFrames += (i, bundle) => lastReceivedUserFrames[i] = bundle.Frames[^1];
         }
 
         /// <summary>
@@ -62,16 +58,20 @@ namespace osu.Game.Tests.Visual.Spectator
         /// Ends play for an arbitrary user.
         /// </summary>
         /// <param name="userId">The user to end play for.</param>
-        public void EndPlay(int userId)
+        /// <param name="state">The spectator state to end play with.</param>
+        public void EndPlay(int userId, SpectatingUserState state = SpectatingUserState.Quit)
         {
-            if (!PlayingUserStates.ContainsKey(userId))
+            if (!userBeatmapDictionary.ContainsKey(userId))
                 return;
 
             ((ISpectatorClient)this).UserFinishedPlaying(userId, new SpectatorState
             {
                 BeatmapID = userBeatmapDictionary[userId],
                 RulesetID = 0,
+                State = state
             });
+
+            userBeatmapDictionary.Remove(userId);
         }
 
         public new void Schedule(Action action) => base.Schedule(action);
@@ -130,7 +130,7 @@ namespace osu.Game.Tests.Visual.Spectator
         protected override Task WatchUserInternal(int userId)
         {
             // When newly watching a user, the server sends the playing state immediately.
-            if (PlayingUserStates.ContainsKey(userId))
+            if (userBeatmapDictionary.ContainsKey(userId))
                 sendPlayingState(userId);
 
             return Task.CompletedTask;
@@ -144,6 +144,7 @@ namespace osu.Game.Tests.Visual.Spectator
             {
                 BeatmapID = userBeatmapDictionary[userId],
                 RulesetID = 0,
+                State = SpectatingUserState.Playing
             });
         }
     }

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Spectator
         /// </summary>
         /// <param name="userId">The user to end play for.</param>
         /// <param name="state">The spectator state to end play with.</param>
-        public void EndPlay(int userId, SpectatingUserState state = SpectatingUserState.Quit)
+        public void EndPlay(int userId, SpectatedUserState state = SpectatedUserState.Quit)
         {
             if (!userBeatmapDictionary.ContainsKey(userId))
                 return;
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Spectator
             {
                 BeatmapID = userBeatmapDictionary[userId],
                 RulesetID = 0,
-                State = SpectatingUserState.Playing
+                State = SpectatedUserState.Playing
             });
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/14768

**Important: This requires an osu-server-spectator deploy with these changes present (won't crash without, just spectating won't work).**

I've tested this thoroughly using both multiplayer spectator and solo spectator, using more than one spectated client.

The commits are a little bit of a mess here but they're mostly compartmentalized  - some have already been extracted into other PRs (e.g. https://github.com/ppy/osu/pull/16774), which makes the diff easy to read in a top-down fashion. Let me know if this is unacceptable and I'll rebase + re-PR.

- Moves passed/failed booleans into `GameplayState`, which is used to populate the new `SpectatorState.State` value. Also adds a new quit state to `GameplayState` for the same purpose.
- `SpectatingUserState` has a bunch of reasonable states, including two unused: `Idle` and `Paused`.
  - Not sure if we'll ever use `Idle` but it's a sane default imo.
  - `Paused` is completely unused/unimplemented but I hope that we can eventually, along with the `Failed` and `Quit` states, display some sort of message at the spectator's side for this state. I've added it in for now to prevent breaking changes down the line (from serialisation or enum ordering or otherwise).
- The `PlayingUsers` list has been removed and replaced by a new dictionary storing the states of every user currently being watched. Unlike the previously-exposed bindables, states don't get removed from this dictionary unless the user stops spectating. Instead, the states get updated with the new `SpectatingUserState` value upon `UserBeganPlaying`/`UserFinishedPlaying`.
- One particular change of importance otherwise is `MultiSpectatorScreen`, which ignores stopping gameplay in `Passed`/`Failed` user states.