### PR TITLE
Fix playlist overlay crash when pressing enter with no selection

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Overlays.Music
 
             filter.Search.OnCommit += (sender, newText) =>
             {
-                list.FirstVisibleSet.PerformRead(set =>
+                list.FirstVisibleSet?.PerformRead(set =>
                 {
                     BeatmapInfo toSelect = set.Beatmaps.FirstOrDefault();
 


### PR DESCRIPTION
As reported at https://github.com/ppy/osu/discussions/16829.