### PR TITLE
Fix migration errors not outputting the call stack to logs

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                                 .ContinueWith(t =>
                                 {
                                     if (t.IsFaulted)
-                                        Logger.Log($"Error during migration: {t.Exception?.Message}", level: LogLevel.Error);
+                                        Logger.Error(t.Exception, $"Error during migration: {t.Exception?.Message}");
 
                                     Schedule(this.Exit);
                                 });


### PR DESCRIPTION
Was not great:

![Parallels Desktop 2022-02-10 at 06 50 20](https://user-images.githubusercontent.com/191335/153352992-97428076-0cab-46c2-b76e-34caa8ac9afb.png)

