### PR TITLE
Allow game folder migration to fail gracefully when cleanup cannot completely succeed

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneMigrationScreens.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneMigrationScreens.cs
@@ -3,32 +3,69 @@
 
 using System.IO;
 using System.Threading;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Screens;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Settings.Sections.Maintenance;
 
 namespace osu.Game.Tests.Visual.Settings
 {
     public class TestSceneMigrationScreens : ScreenTestScene
     {
+        [Cached]
+        private readonly NotificationOverlay notifications;
+
         public TestSceneMigrationScreens()
         {
-            AddStep("Push screen", () => Stack.Push(new TestMigrationSelectScreen()));
+            Children = new Drawable[]
+            {
+                notifications = new NotificationOverlay
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                }
+            };
+        }
+
+        [Test]
+        public void TestDeleteSuccess()
+        {
+            AddStep("Push screen", () => Stack.Push(new TestMigrationSelectScreen(true)));
+        }
+
+        [Test]
+        public void TestDeleteFails()
+        {
+            AddStep("Push screen", () => Stack.Push(new TestMigrationSelectScreen(false)));
         }
 
         private class TestMigrationSelectScreen : MigrationSelectScreen
         {
-            protected override void BeginMigration(DirectoryInfo target) => this.Push(new TestMigrationRunScreen());
+            private readonly bool deleteSuccess;
+
+            public TestMigrationSelectScreen(bool deleteSuccess)
+            {
+                this.deleteSuccess = deleteSuccess;
+            }
+
+            protected override void BeginMigration(DirectoryInfo target) => this.Push(new TestMigrationRunScreen(deleteSuccess));
 
             private class TestMigrationRunScreen : MigrationRunScreen
             {
-                protected override void PerformMigration()
-                {
-                    Thread.Sleep(3000);
-                }
+                private readonly bool success;
 
-                public TestMigrationRunScreen()
+                public TestMigrationRunScreen(bool success)
                     : base(null)
                 {
+                    this.success = success;
+                }
+
+                protected override bool PerformMigration()
+                {
+                    Thread.Sleep(3000);
+                    return success;
                 }
             }
         }

--- a/osu.Game.Tournament/IO/TournamentStorage.cs
+++ b/osu.Game.Tournament/IO/TournamentStorage.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tournament.IO
 
         public IEnumerable<string> ListTournaments() => AllTournaments.GetDirectories(string.Empty);
 
-        public override void Migrate(Storage newStorage)
+        public override bool Migrate(Storage newStorage)
         {
             // this migration only happens once on moving to the per-tournament storage system.
             // listed files are those known at that point in time.
@@ -94,6 +94,8 @@ namespace osu.Game.Tournament.IO
             ChangeTargetStorage(newStorage);
             storageConfig.SetValue(StorageConfig.CurrentTournament, default_tournament);
             storageConfig.Save();
+
+            return true;
         }
 
         private void moveFileIfExists(string file, DirectoryInfo destination)

--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -113,11 +113,14 @@ namespace osu.Game.IO
             }
         }
 
-        public override void Migrate(Storage newStorage)
+        public override bool Migrate(Storage newStorage)
         {
-            base.Migrate(newStorage);
+            bool cleanupSucceeded = base.Migrate(newStorage);
+
             storageConfig.SetValue(StorageConfig.FullPath, newStorage.GetFullPath("."));
             storageConfig.Save();
+
+            return cleanupSucceeded;
         }
     }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -413,7 +413,7 @@ namespace osu.Game
                 Scheduler.AddDelayed(GracefullyExit, 2000);
         }
 
-        public void Migrate(string path)
+        public bool Migrate(string path)
         {
             Logger.Log($@"Migrating osu! data from ""{Storage.GetFullPath(string.Empty)}"" to ""{path}""...");
 
@@ -432,14 +432,15 @@ namespace osu.Game
 
                 readyToRun.Wait();
 
-                (Storage as OsuStorage)?.Migrate(Host.GetStorage(path));
+                bool? cleanupSucceded = (Storage as OsuStorage)?.Migrate(Host.GetStorage(path));
+
+                Logger.Log(@"Migration complete!");
+                return cleanupSucceded != false;
             }
             finally
             {
                 realmBlocker?.Dispose();
             }
-
-            Logger.Log(@"Migration complete!");
         }
 
         protected override UserInputManager CreateUserInputManager() => new OsuUserInputManager();

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -4,13 +4,16 @@
 using System.IO;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
+using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Screens;
 using osuTK;
 
@@ -22,6 +25,15 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
         [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
+
+        [Resolved]
+        private NotificationOverlay notifications { get; set; }
+
+        [Resolved]
+        private Storage storage { get; set; }
+
+        [Resolved]
+        private GameHost host { get; set; }
 
         public override bool AllowBackButton => false;
 
@@ -84,17 +96,33 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
             Beatmap.Value = Beatmap.Default;
 
+            var originalStorage = new NativeStorage(storage.GetFullPath(string.Empty), host);
+
             migrationTask = Task.Run(PerformMigration)
-                                .ContinueWith(t =>
+                                .ContinueWith(task =>
                                 {
-                                    if (t.IsFaulted)
-                                        Logger.Error(t.Exception, $"Error during migration: {t.Exception?.Message}");
+                                    if (task.IsFaulted)
+                                    {
+                                        Logger.Error(task.Exception, $"Error during migration: {task.Exception?.Message}");
+                                    }
+                                    else if (!task.GetResultSafely())
+                                    {
+                                        notifications.Post(new SimpleNotification
+                                        {
+                                            Text = "Some files couldn't be cleaned up during migration. Clicking this notification will open the folder so you can manually clean things up.",
+                                            Activated = () =>
+                                            {
+                                                originalStorage.PresentExternally();
+                                                return true;
+                                            }
+                                        });
+                                    }
 
                                     Schedule(this.Exit);
                                 });
         }
 
-        protected virtual void PerformMigration() => game?.Migrate(destination.FullName);
+        protected virtual bool PerformMigration() => game?.Migrate(destination.FullName) != false;
 
         public override void OnEntering(IScreen last)
         {


### PR DESCRIPTION
Closes #16841.

The only thing I'm unsure about is the open folder action, as if the user goes to the folder and deletes `storage.ini` it will break the redirect to their new storage location. Open to suggestions.

https://user-images.githubusercontent.com/191335/153389675-d1b25ee4-5fb1-4428-be05-3300c0bc9f37.mp4

