### PR TITLE
Add read-only pinned scores view in user profile overlay

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.210.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.211.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.204.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Online.API.Requests
     {
         Best,
         Firsts,
-        Recent
+        Recent,
+        Pinned
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -151,6 +151,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"scores_recent_count")]
         public int ScoresRecentCount;
 
+        [JsonProperty(@"scores_pinned_count")]
+        public int ScoresPinnedCount;
+
         [JsonProperty(@"beatmap_playcounts_count")]
         public int BeatmapPlayCountsCount;
 

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                 case ScoreType.Recent:
                     return user.ScoresRecentCount;
 
+                case ScoreType.Pinned:
+                    return user.ScoresPinnedCount;
+
                 default:
                     return 0;
             }

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -18,8 +18,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             Children = new[]
             {
-                // todo: update to use UsersStrings.ShowExtraTopRanksPinnedTitle once that exists.
-                new PaginatedScoreContainer(ScoreType.Pinned, User, "Pinned Scores"),
+                new PaginatedScoreContainer(ScoreType.Pinned, User, UsersStrings.ShowExtraTopRanksPinnedTitle),
                 new PaginatedScoreContainer(ScoreType.Best, User, UsersStrings.ShowExtraTopRanksBestTitle),
                 new PaginatedScoreContainer(ScoreType.Firsts, User, UsersStrings.ShowExtraTopRanksFirstTitle)
             };

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             Children = new[]
             {
+                // todo: update to use UsersStrings.ShowExtraTopRanksPinnedTitle once that exists.
+                new PaginatedScoreContainer(ScoreType.Pinned, User, "Pinned Scores"),
                 new PaginatedScoreContainer(ScoreType.Best, User, UsersStrings.ShowExtraTopRanksBestTitle),
                 new PaginatedScoreContainer(ScoreType.Firsts, User, UsersStrings.ShowExtraTopRanksFirstTitle)
             };

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.8.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.204.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.210.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.211.0" />
     <PackageReference Include="Sentry" Version="3.13.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.204.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.210.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.211.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Closes #16848 

![CleanShot 2022-02-10 at 21 34 23](https://user-images.githubusercontent.com/22781491/153473909-294b0291-7626-44f7-a124-d30fefb86c4f.png)

The "Pinned Scores" title is not localised as the web localisations `osu-resources`-side don't look to have been updated to include that yet (cc @peppy), left a TODO for now.