### PR TITLE
Standardise grouping and ordering of `IRulesetInfo`/`RulesetInfo`s

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -457,11 +457,9 @@ namespace osu.Game.Tests.Visual.UserInterface
             public override ModType Type => ModType.Conversion;
         }
 
-        private class TestUnimplementedModOsuRuleset : OsuRuleset, ILegacyRuleset
+        private class TestUnimplementedModOsuRuleset : OsuRuleset
         {
             public override string ShortName => "unimplemented";
-
-            int ILegacyRuleset.LegacyID => -1;
 
             public override IEnumerable<Mod> GetModsFor(ModType type)
             {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -457,9 +457,11 @@ namespace osu.Game.Tests.Visual.UserInterface
             public override ModType Type => ModType.Conversion;
         }
 
-        private class TestUnimplementedModOsuRuleset : OsuRuleset
+        private class TestUnimplementedModOsuRuleset : OsuRuleset, ILegacyRuleset
         {
             public override string ShortName => "unimplemented";
+
+            int ILegacyRuleset.LegacyID => -1;
 
             public override IEnumerable<Mod> GetModsFor(ModType type)
             {

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardDifficultyList.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardDifficultyList.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
             bool firstGroup = true;
 
-            foreach (var group in beatmapSetInfo.Beatmaps.GroupBy(beatmap => beatmap.Ruleset.OnlineID).OrderBy(group => group.Key))
+            foreach (var group in beatmapSetInfo.Beatmaps.GroupBy(beatmap => beatmap.Ruleset).OrderBy(group => group.Key))
             {
                 if (!firstGroup)
                 {

--- a/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultySpectrumDisplay.cs
@@ -62,10 +62,8 @@ namespace osu.Game.Beatmaps.Drawables
             // matching web: https://github.com/ppy/osu-web/blob/d06d8c5e735eb1f48799b1654b528e9a7afb0a35/resources/assets/lib/beatmapset-panel.tsx#L127
             bool collapsed = beatmapSet.Beatmaps.Count() > 12;
 
-            foreach (var rulesetGrouping in beatmapSet.Beatmaps.GroupBy(beatmap => beatmap.Ruleset.OnlineID).OrderBy(group => group.Key))
-            {
-                flow.Add(new RulesetDifficultyGroup(rulesetGrouping.Key, rulesetGrouping, collapsed));
-            }
+            foreach (var rulesetGrouping in beatmapSet.Beatmaps.GroupBy(beatmap => beatmap.Ruleset).OrderBy(group => group.Key))
+                flow.Add(new RulesetDifficultyGroup(rulesetGrouping.Key.OnlineID, rulesetGrouping, collapsed));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public string MD5Hash => Checksum;
 
-        public IRulesetInfo Ruleset => new RulesetInfo { OnlineID = RulesetID };
+        public IRulesetInfo Ruleset => new APIRuleset { OnlineID = RulesetID };
 
         [JsonIgnore]
         public string Hash => throw new NotImplementedException();
@@ -106,5 +106,29 @@ namespace osu.Game.Online.API.Requests.Responses
         #endregion
 
         public bool Equals(IBeatmapInfo? other) => other is APIBeatmap b && this.MatchesOnlineID(b);
+
+        private class APIRuleset : IRulesetInfo
+        {
+            public int OnlineID { get; set; } = -1;
+
+            public string Name => $@"{nameof(APIRuleset)} (ID: {OnlineID})";
+            public string ShortName => nameof(APIRuleset);
+            public string InstantiationInfo => string.Empty;
+
+            public Ruleset CreateInstance() => throw new NotImplementedException();
+
+            public bool Equals(IRulesetInfo? other) => other is APIRuleset r && this.MatchesOnlineID(r);
+
+            public int CompareTo(IRulesetInfo other)
+            {
+                if (!(other is APIRuleset ruleset))
+                    throw new ArgumentException($@"Object is not of type {nameof(APIRuleset)}.", nameof(other));
+
+                return OnlineID.CompareTo(ruleset.OnlineID);
+            }
+
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
+            public override int GetHashCode() => OnlineID;
+        }
     }
 }

--- a/osu.Game/Rulesets/EFRulesetInfo.cs
+++ b/osu.Game/Rulesets/EFRulesetInfo.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets
 {
     [ExcludeFromDynamicCompile]
     [Table(@"RulesetInfo")]
-    public sealed class EFRulesetInfo : IEquatable<EFRulesetInfo>, IRulesetInfo
+    public sealed class EFRulesetInfo : IEquatable<EFRulesetInfo>, IComparable<EFRulesetInfo>, IRulesetInfo
     {
         public int? ID { get; set; }
 
@@ -42,7 +42,15 @@ namespace osu.Game.Rulesets
 
         public bool Equals(EFRulesetInfo other) => other != null && ID == other.ID && Available == other.Available && Name == other.Name && InstantiationInfo == other.InstantiationInfo;
 
-        public int CompareTo(RulesetInfo other) => OnlineID.CompareTo(other.OnlineID);
+        public int CompareTo(EFRulesetInfo other) => OnlineID.CompareTo(other.OnlineID);
+
+        public int CompareTo(IRulesetInfo other)
+        {
+            if (!(other is EFRulesetInfo ruleset))
+                throw new ArgumentException($@"Object is not of type {nameof(EFRulesetInfo)}.", nameof(other));
+
+            return CompareTo(ruleset);
+        }
 
         public override bool Equals(object obj) => obj is EFRulesetInfo rulesetInfo && Equals(rulesetInfo);
 

--- a/osu.Game/Rulesets/IRulesetInfo.cs
+++ b/osu.Game/Rulesets/IRulesetInfo.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets
     /// <summary>
     /// A representation of a ruleset's metadata.
     /// </summary>
-    public interface IRulesetInfo : IHasOnlineID<int>, IEquatable<IRulesetInfo>, IComparable<RulesetInfo>
+    public interface IRulesetInfo : IHasOnlineID<int>, IEquatable<IRulesetInfo>, IComparable<IRulesetInfo>
     {
         /// <summary>
         /// The user-exposed name of this ruleset.

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets
 {
     [ExcludeFromDynamicCompile]
     [MapTo("Ruleset")]
-    public class RulesetInfo : RealmObject, IEquatable<RulesetInfo>, IRulesetInfo
+    public class RulesetInfo : RealmObject, IEquatable<RulesetInfo>, IComparable<RulesetInfo>, IRulesetInfo
     {
         [PrimaryKey]
         public string ShortName { get; set; } = string.Empty;
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets
             return ShortName == other.ShortName;
         }
 
-        public bool Equals(IRulesetInfo? other) => other is RulesetInfo b && Equals(b);
+        public bool Equals(IRulesetInfo? other) => other is RulesetInfo r && Equals(r);
 
         public int CompareTo(RulesetInfo other)
         {
@@ -61,6 +61,14 @@ namespace osu.Game.Rulesets
                 return 1;
 
             return string.Compare(ShortName, other.ShortName, StringComparison.Ordinal);
+        }
+
+        public int CompareTo(IRulesetInfo other)
+        {
+            if (!(other is RulesetInfo ruleset))
+                throw new ArgumentException($@"Object is not of type {nameof(RulesetInfo)}.", nameof(other));
+
+            return CompareTo(ruleset);
         }
 
         public override int GetHashCode()

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Rulesets
             if (ReferenceEquals(this, other)) return true;
             if (other == null) return false;
 
+            if (OnlineID >= 0 && other.OnlineID >= 0)
+                return OnlineID == other.OnlineID;
+
             return ShortName == other.ShortName;
         }
 

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -44,9 +44,6 @@ namespace osu.Game.Rulesets
             if (ReferenceEquals(this, other)) return true;
             if (other == null) return false;
 
-            if (OnlineID >= 0 && other.OnlineID >= 0)
-                return OnlineID == other.OnlineID;
-
             return ShortName == other.ShortName;
         }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -851,7 +851,7 @@ namespace osu.Game.Screens.Edit
 
             var difficultyItems = new List<MenuItem>();
 
-            foreach (var rulesetBeatmaps in beatmapSet.Beatmaps.GroupBy(b => b.Ruleset.ShortName).OrderBy(group => group.Key))
+            foreach (var rulesetBeatmaps in beatmapSet.Beatmaps.GroupBy(b => b.Ruleset).OrderBy(group => group.Key))
             {
                 if (difficultyItems.Count > 0)
                     difficultyItems.Add(new EditorMenuItemSpacer());

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Select.Carousel
             var beatmaps = carouselSet.Beatmaps.ToList();
 
             return beatmaps.Count > maximum_difficulty_icons
-                ? (IEnumerable<DifficultyIcon>)beatmaps.GroupBy(b => b.BeatmapInfo.Ruleset.ShortName)
+                ? (IEnumerable<DifficultyIcon>)beatmaps.GroupBy(b => b.BeatmapInfo.Ruleset)
                                                        .Select(group => new FilterableGroupedDifficultyIcon(group.ToList(), group.Last().BeatmapInfo.Ruleset))
                 : beatmaps.Select(b => new FilterableDifficultyIcon(b));
         }


### PR DESCRIPTION
Since `RulesetInfo` provides an `IComparable<T>` implementation, all usages should always compare by it rather than arbitrarily ordering by `OnlineID`/`ShortName`.

This fixes ruleset groups in `Editor`'s difficulty switch menu not being ordered appropriately:
| Before | After |
|--------|-------|
| ![CleanShot 2022-02-11 at 03 20 14](https://user-images.githubusercontent.com/22781491/153523936-62a23342-909e-45f7-b6bd-68532b693588.png) | ![CleanShot 2022-02-11 at 04 23 17](https://user-images.githubusercontent.com/22781491/153523992-f0ec3224-c1d9-4795-aa46-252d54da0381.png) |

I have updated `EFRulesetInfo` as well and isolated it from potentially comparing with realm `RulesetInfo`s, in case that ever happens. Have tested performing an EF migration with this change and everything seem to still work.