### PR TITLE
Standardise and combine base implementation of score submission requests

### DIFF
--- a/osu.Game/Online/Rooms/SubmitRoomScoreRequest.cs
+++ b/osu.Game/Online/Rooms/SubmitRoomScoreRequest.cs
@@ -1,46 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Net.Http;
-using Newtonsoft.Json;
-using osu.Framework.IO.Network;
-using osu.Game.Online.API;
-using osu.Game.Online.Solo;
 using osu.Game.Scoring;
 
 namespace osu.Game.Online.Rooms
 {
-    public class SubmitRoomScoreRequest : APIRequest<MultiplayerScore>
+    public class SubmitRoomScoreRequest : SubmitScoreRequest
     {
-        private readonly long scoreId;
         private readonly long roomId;
         private readonly long playlistItemId;
-        private readonly SubmittableScore score;
 
-        public SubmitRoomScoreRequest(long scoreId, long roomId, long playlistItemId, ScoreInfo scoreInfo)
+        public SubmitRoomScoreRequest(ScoreInfo scoreInfo, long scoreId, long roomId, long playlistItemId)
+            : base(scoreInfo, scoreId)
         {
-            this.scoreId = scoreId;
             this.roomId = roomId;
             this.playlistItemId = playlistItemId;
-            score = new SubmittableScore(scoreInfo);
         }
 
-        protected override WebRequest CreateWebRequest()
-        {
-            var req = base.CreateWebRequest();
-
-            req.ContentType = "application/json";
-            req.Method = HttpMethod.Put;
-            req.Timeout = 30000;
-
-            req.AddRaw(JsonConvert.SerializeObject(score, new JsonSerializerSettings
-            {
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-            }));
-
-            return req;
-        }
-
-        protected override string Target => $@"rooms/{roomId}/playlist/{playlistItemId}/scores/{scoreId}";
+        protected override string Target => $@"rooms/{roomId}/playlist/{playlistItemId}/scores/{ScoreId}";
     }
 }

--- a/osu.Game/Online/Rooms/SubmitScoreRequest.cs
+++ b/osu.Game/Online/Rooms/SubmitScoreRequest.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.Http;
+using Newtonsoft.Json;
+using osu.Framework.IO.Network;
+using osu.Game.Online.API;
+using osu.Game.Online.Solo;
+using osu.Game.Scoring;
+
+namespace osu.Game.Online.Rooms
+{
+    public abstract class SubmitScoreRequest : APIRequest<MultiplayerScore>
+    {
+        public readonly SubmittableScore Score;
+
+        protected readonly long ScoreId;
+
+        protected SubmitScoreRequest(ScoreInfo scoreInfo, long scoreId)
+        {
+            Score = new SubmittableScore(scoreInfo);
+            this.ScoreId = scoreId;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+
+            req.ContentType = "application/json";
+            req.Method = HttpMethod.Put;
+            req.Timeout = 30000;
+
+            req.AddRaw(JsonConvert.SerializeObject(Score, new JsonSerializerSettings
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            }));
+
+            return req;
+        }
+    }
+}

--- a/osu.Game/Online/Rooms/SubmitScoreRequest.cs
+++ b/osu.Game/Online/Rooms/SubmitScoreRequest.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Online.Rooms
         protected SubmitScoreRequest(ScoreInfo scoreInfo, long scoreId)
         {
             Score = new SubmittableScore(scoreInfo);
-            this.ScoreId = scoreId;
+            ScoreId = scoreId;
         }
 
         protected override WebRequest CreateWebRequest()

--- a/osu.Game/Online/Solo/SubmitSoloScoreRequest.cs
+++ b/osu.Game/Online/Solo/SubmitSoloScoreRequest.cs
@@ -1,46 +1,21 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Net.Http;
-using Newtonsoft.Json;
-using osu.Framework.IO.Network;
-using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
 
 namespace osu.Game.Online.Solo
 {
-    public class SubmitSoloScoreRequest : APIRequest<MultiplayerScore>
+    public class SubmitSoloScoreRequest : SubmitScoreRequest
     {
-        public readonly SubmittableScore Score;
-
-        private readonly long scoreId;
-
         private readonly int beatmapId;
 
-        public SubmitSoloScoreRequest(int beatmapId, long scoreId, ScoreInfo scoreInfo)
+        public SubmitSoloScoreRequest(ScoreInfo scoreInfo, long scoreId, int beatmapId)
+            : base(scoreInfo, scoreId)
         {
             this.beatmapId = beatmapId;
-            this.scoreId = scoreId;
-            Score = new SubmittableScore(scoreInfo);
         }
 
-        protected override WebRequest CreateWebRequest()
-        {
-            var req = base.CreateWebRequest();
-
-            req.ContentType = "application/json";
-            req.Method = HttpMethod.Put;
-            req.Timeout = 30000;
-
-            req.AddRaw(JsonConvert.SerializeObject(Score, new JsonSerializerSettings
-            {
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-            }));
-
-            return req;
-        }
-
-        protected override string Target => $@"beatmaps/{beatmapId}/solo/scores/{scoreId}";
+        protected override string Target => $@"beatmaps/{beatmapId}/solo/scores/{ScoreId}";
     }
 }

--- a/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Play
         protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token)
         {
             Debug.Assert(Room.RoomID.Value != null);
-            return new SubmitRoomScoreRequest(token, Room.RoomID.Value.Value, PlaylistItem.ID, score.ScoreInfo);
+            return new SubmitRoomScoreRequest(score.ScoreInfo, token, Room.RoomID.Value.Value, PlaylistItem.ID);
         }
     }
 }

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play
 
             Debug.Assert(beatmap.OnlineID > 0);
 
-            return new SubmitSoloScoreRequest(beatmap.OnlineID, token, score.ScoreInfo);
+            return new SubmitSoloScoreRequest(score.ScoreInfo, token, beatmap.OnlineID);
         }
     }
 }


### PR DESCRIPTION
These share too much yet have very different constructor signatures and property exposure. Just a clean-up pass as I begin to look at replay submission.