### PR TITLE
Fix incorrectly cached lookup components in tests

### DIFF
--- a/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
+++ b/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
@@ -21,8 +21,8 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
         {
             var user = new APIUser { Id = 33 };
 
-            AddRepeatStep("add user multiple times", () => Client.AddUser(user), 3);
-            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
+            AddRepeatStep("add user multiple times", () => MultiplayerClient.AddUser(user), 3);
+            AddAssert("room has 2 users", () => MultiplayerClient.Room?.Users.Count == 2);
         }
 
         [Test]
@@ -30,11 +30,11 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
         {
             var user = new APIUser { Id = 44 };
 
-            AddStep("add user", () => Client.AddUser(user));
-            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
+            AddStep("add user", () => MultiplayerClient.AddUser(user));
+            AddAssert("room has 2 users", () => MultiplayerClient.Room?.Users.Count == 2);
 
-            AddRepeatStep("remove user multiple times", () => Client.RemoveUser(user), 3);
-            AddAssert("room has 1 user", () => Client.Room?.Users.Count == 1);
+            AddRepeatStep("remove user multiple times", () => MultiplayerClient.RemoveUser(user), 3);
+            AddAssert("room has 1 user", () => MultiplayerClient.Room?.Users.Count == 1);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
         {
             int id = 2000;
 
-            AddRepeatStep("add some users", () => Client.AddUser(new APIUser { Id = id++ }), 5);
+            AddRepeatStep("add some users", () => MultiplayerClient.AddUser(new APIUser { Id = id++ }), 5);
             checkPlayingUserCount(0);
 
             changeState(3, MultiplayerUserState.WaitingForLoad);
@@ -57,17 +57,17 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
             changeState(6, MultiplayerUserState.WaitingForLoad);
             checkPlayingUserCount(6);
 
-            AddStep("another user left", () => Client.RemoveUser((Client.Room?.Users.Last().User).AsNonNull()));
+            AddStep("another user left", () => MultiplayerClient.RemoveUser((MultiplayerClient.Room?.Users.Last().User).AsNonNull()));
             checkPlayingUserCount(5);
 
-            AddStep("leave room", () => Client.LeaveRoom());
+            AddStep("leave room", () => MultiplayerClient.LeaveRoom());
             checkPlayingUserCount(0);
         }
 
         [Test]
         public void TestPlayingUsersUpdatedOnJoin()
         {
-            AddStep("leave room", () => Client.LeaveRoom());
+            AddStep("leave room", () => MultiplayerClient.LeaveRoom());
             AddUntilStep("wait for room part", () => !RoomJoined);
 
             AddStep("create room initially in gameplay", () =>
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
                 newRoom.CopyFrom(SelectedRoom.Value);
 
                 newRoom.RoomID.Value = null;
-                Client.RoomSetupAction = room =>
+                MultiplayerClient.RoomSetupAction = room =>
                 {
                     room.State = MultiplayerRoomState.Playing;
                     room.Users.Add(new MultiplayerRoomUser(PLAYER_1_ID)
@@ -94,15 +94,15 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
         }
 
         private void checkPlayingUserCount(int expectedCount)
-            => AddAssert($"{"user".ToQuantity(expectedCount)} playing", () => Client.CurrentMatchPlayingUserIds.Count == expectedCount);
+            => AddAssert($"{"user".ToQuantity(expectedCount)} playing", () => MultiplayerClient.CurrentMatchPlayingUserIds.Count == expectedCount);
 
         private void changeState(int userCount, MultiplayerUserState state)
             => AddStep($"{"user".ToQuantity(userCount)} in {state}", () =>
             {
                 for (int i = 0; i < userCount; ++i)
                 {
-                    int userId = Client.Room?.Users[i].UserID ?? throw new AssertionException("Room cannot be null!");
-                    Client.ChangeUserState(userId, state);
+                    int userId = MultiplayerClient.Room?.Users[i].UserID ?? throw new AssertionException("Room cannot be null!");
+                    MultiplayerClient.ChangeUserState(userId, state);
                 }
             });
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -39,7 +39,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Resolved]
         private OsuGameBase game { get; set; }
 
-        private TestSpectatorClient spectatorClient;
+        private TestSpectatorClient spectatorClient => dependenciesScreen.Client;
+        private DependenciesScreen dependenciesScreen;
         private SoloSpectator spectatorScreen;
 
         private BeatmapSetInfo importedBeatmap;
@@ -48,16 +49,16 @@ namespace osu.Game.Tests.Visual.Gameplay
         [SetUpSteps]
         public void SetupSteps()
         {
-            DependenciesScreen dependenciesScreen = null;
-
             AddStep("load dependencies", () =>
             {
-                spectatorClient = new TestSpectatorClient();
+                LoadScreen(dependenciesScreen = new DependenciesScreen());
 
-                // The screen gets suspended so it stops receiving updates.
-                Child = spectatorClient;
-
-                LoadScreen(dependenciesScreen = new DependenciesScreen(spectatorClient));
+                // The dependencies screen gets suspended so it stops receiving updates. So its children are manually added to the test scene instead.
+                Children = new Drawable[]
+                {
+                    dependenciesScreen.UserLookupCache,
+                    dependenciesScreen.Client,
+                };
             });
 
             AddUntilStep("wait for dependencies to load", () => dependenciesScreen.IsLoaded);
@@ -335,12 +336,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         private class DependenciesScreen : OsuScreen
         {
             [Cached(typeof(SpectatorClient))]
-            public readonly TestSpectatorClient Client;
+            public readonly TestSpectatorClient Client = new TestSpectatorClient();
 
-            public DependenciesScreen(TestSpectatorClient client)
-            {
-                Client = client;
-            }
+            [Cached(typeof(UserLookupCache))]
+            public readonly TestUserLookupCache UserLookupCache = new TestUserLookupCache();
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Resolved]
         private OsuGameBase game { get; set; }
 
-        private TestSpectatorClient spectatorClient => dependenciesScreen.Client;
+        private TestSpectatorClient spectatorClient => dependenciesScreen.SpectatorClient;
         private DependenciesScreen dependenciesScreen;
         private SoloSpectator spectatorScreen;
 
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Children = new Drawable[]
                 {
                     dependenciesScreen.UserLookupCache,
-                    dependenciesScreen.Client,
+                    dependenciesScreen.SpectatorClient,
                 };
             });
 
@@ -336,7 +336,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private class DependenciesScreen : OsuScreen
         {
             [Cached(typeof(SpectatorClient))]
-            public readonly TestSpectatorClient Client = new TestSpectatorClient();
+            public readonly TestSpectatorClient SpectatorClient = new TestSpectatorClient();
 
             [Cached(typeof(UserLookupCache))]
             public readonly TestUserLookupCache UserLookupCache = new TestUserLookupCache();

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -10,7 +10,6 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
@@ -40,9 +39,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private TestMultiplayerComponents multiplayerComponents;
 
         protected TestMultiplayerClient Client => multiplayerComponents.Client;
-
-        [Cached(typeof(UserLookupCache))]
-        private UserLookupCache lookupCache = new TestUserLookupCache();
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private TestMultiplayerComponents multiplayerComponents;
 
-        protected TestMultiplayerClient Client => multiplayerComponents.Client;
+        protected TestMultiplayerClient MultiplayerClient => multiplayerComponents.MultiplayerClient;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -84,21 +84,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
-            AddUntilStep("wait for join", () => Client.RoomJoined);
+            AddUntilStep("wait for join", () => MultiplayerClient.RoomJoined);
         }
 
         [Test]
         public void TestCreatedWithCorrectMode()
         {
-            AddAssert("room created with correct mode", () => Client.APIRoom?.QueueMode.Value == Mode);
+            AddAssert("room created with correct mode", () => MultiplayerClient.APIRoom?.QueueMode.Value == Mode);
         }
 
         protected void RunGameplay()
         {
-            AddUntilStep("wait for idle", () => Client.LocalUser?.State == MultiplayerUserState.Idle);
+            AddUntilStep("wait for idle", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Idle);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
-            AddUntilStep("wait for ready", () => Client.LocalUser?.State == MultiplayerUserState.Ready);
+            AddUntilStep("wait for ready", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddUntilStep("wait for player", () => multiplayerComponents.CurrentScreen is Player player && player.IsLoaded);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -31,19 +31,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestFirstItemSelectedByDefault()
         {
-            AddAssert("first item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("first item selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
         public void TestItemAddedToTheEndOfQueue()
         {
             addItem(() => OtherBeatmap);
-            AddAssert("playlist has 2 items", () => Client.APIRoom?.Playlist.Count == 2);
+            AddAssert("playlist has 2 items", () => MultiplayerClient.APIRoom?.Playlist.Count == 2);
 
             addItem(() => InitialBeatmap);
-            AddAssert("playlist has 3 items", () => Client.APIRoom?.Playlist.Count == 3);
+            AddAssert("playlist has 3 items", () => MultiplayerClient.APIRoom?.Playlist.Count == 3);
 
-            AddAssert("first item still selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("first item still selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -51,9 +51,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             RunGameplay();
 
-            AddAssert("playlist has only one item", () => Client.APIRoom?.Playlist.Count == 1);
-            AddAssert("playlist item is expired", () => Client.APIRoom?.Playlist[0].Expired == true);
-            AddAssert("last item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("playlist has only one item", () => MultiplayerClient.APIRoom?.Playlist.Count == 1);
+            AddAssert("playlist item is expired", () => MultiplayerClient.APIRoom?.Playlist[0].Expired == true);
+            AddAssert("last item selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -64,13 +64,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             RunGameplay();
 
-            AddAssert("first item expired", () => Client.APIRoom?.Playlist[0].Expired == true);
-            AddAssert("next item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[1].ID);
+            AddAssert("first item expired", () => MultiplayerClient.APIRoom?.Playlist[0].Expired == true);
+            AddAssert("next item selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[1].ID);
 
             RunGameplay();
 
-            AddAssert("second item expired", () => Client.APIRoom?.Playlist[1].Expired == true);
-            AddAssert("next item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[2].ID);
+            AddAssert("second item expired", () => MultiplayerClient.APIRoom?.Playlist[1].Expired == true);
+            AddAssert("next item selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[2].ID);
         }
 
         [Test]
@@ -82,10 +82,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             // Move to the "other" beatmap.
             RunGameplay();
 
-            AddStep("change queue mode", () => Client.ChangeSettings(queueMode: QueueMode.HostOnly));
-            AddAssert("playlist has 3 items", () => Client.APIRoom?.Playlist.Count == 3);
-            AddAssert("item 2 is not expired", () => Client.APIRoom?.Playlist[1].Expired == false);
-            AddAssert("current item is the other beatmap", () => Client.Room?.Settings.PlaylistItemId == 2);
+            AddStep("change queue mode", () => MultiplayerClient.ChangeSettings(queueMode: QueueMode.HostOnly));
+            AddAssert("playlist has 3 items", () => MultiplayerClient.APIRoom?.Playlist.Count == 3);
+            AddAssert("item 2 is not expired", () => MultiplayerClient.APIRoom?.Playlist[1].Expired == false);
+            AddAssert("current item is the other beatmap", () => MultiplayerClient.Room?.Settings.PlaylistItemId == 2);
         }
 
         [Test]
@@ -101,10 +101,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             addItem(() => OtherBeatmap, new CatchRuleset().RulesetInfo);
             AddUntilStep("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
 
-            AddUntilStep("wait for idle", () => Client.LocalUser?.State == MultiplayerUserState.Idle);
+            AddUntilStep("wait for idle", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Idle);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
-            AddUntilStep("wait for ready", () => Client.LocalUser?.State == MultiplayerUserState.Ready);
+            AddUntilStep("wait for ready", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddUntilStep("wait for player", () => CurrentScreen is Player player && player.IsLoaded);
@@ -118,10 +118,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             addItem(() => OtherBeatmap, mods: new Mod[] { new OsuModDoubleTime() });
             AddUntilStep("selected beatmap is initial beatmap", () => Beatmap.Value.BeatmapInfo.OnlineID == InitialBeatmap.OnlineID);
 
-            AddUntilStep("wait for idle", () => Client.LocalUser?.State == MultiplayerUserState.Idle);
+            AddUntilStep("wait for idle", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Idle);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
-            AddUntilStep("wait for ready", () => Client.LocalUser?.State == MultiplayerUserState.Ready);
+            AddUntilStep("wait for ready", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddUntilStep("wait for player", () => CurrentScreen is Player player && player.IsLoaded);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneCreateMultiplayerMatchButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneCreateMultiplayerMatchButton.cs
@@ -37,10 +37,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("end joining room", () => joiningRoomOperation.Dispose());
             assertButtonEnableState(true);
 
-            AddStep("disconnect client", () => Client.Disconnect());
+            AddStep("disconnect client", () => MultiplayerClient.Disconnect());
             assertButtonEnableState(false);
 
-            AddStep("re-connect client", () => Client.Connect());
+            AddStep("re-connect client", () => MultiplayerClient.Connect());
             assertButtonEnableState(true);
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -30,15 +30,12 @@ using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    public class TestSceneDrawableRoomPlaylist : OsuManualInputManagerTestScene
+    public class TestSceneDrawableRoomPlaylist : MultiplayerTestScene
     {
         private TestPlaylist playlist;
 
         private BeatmapManager manager;
         private RulesetStore rulesets;
-
-        [Cached(typeof(UserLookupCache))]
-        private readonly TestUserLookupCache userLookupCache = new TestUserLookupCache();
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestFirstItemSelectedByDefault()
         {
-            AddAssert("first item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("first item selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             selectNewItem(() => InitialBeatmap);
 
-            AddAssert("playlist item still selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("playlist item still selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             selectNewItem(() => OtherBeatmap);
 
-            AddAssert("playlist item still selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[0].ID);
+            AddAssert("playlist item still selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[0].ID);
         }
 
         [Test]
@@ -46,10 +46,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             RunGameplay();
 
-            AddAssert("playlist contains two items", () => Client.APIRoom?.Playlist.Count == 2);
-            AddAssert("first playlist item expired", () => Client.APIRoom?.Playlist[0].Expired == true);
-            AddAssert("second playlist item not expired", () => Client.APIRoom?.Playlist[1].Expired == false);
-            AddAssert("second playlist item selected", () => Client.Room?.Settings.PlaylistItemId == Client.APIRoom?.Playlist[1].ID);
+            AddAssert("playlist contains two items", () => MultiplayerClient.APIRoom?.Playlist.Count == 2);
+            AddAssert("first playlist item expired", () => MultiplayerClient.APIRoom?.Playlist[0].Expired == true);
+            AddAssert("second playlist item not expired", () => MultiplayerClient.APIRoom?.Playlist[1].Expired == false);
+            AddAssert("second playlist item selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == MultiplayerClient.APIRoom?.Playlist[1].ID);
         }
 
         [Test]
@@ -58,23 +58,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
             RunGameplay();
 
             IBeatmapInfo firstBeatmap = null;
-            AddStep("get first playlist item beatmap", () => firstBeatmap = Client.APIRoom?.Playlist[0].Beatmap.Value);
+            AddStep("get first playlist item beatmap", () => firstBeatmap = MultiplayerClient.APIRoom?.Playlist[0].Beatmap.Value);
 
             selectNewItem(() => OtherBeatmap);
 
-            AddAssert("first playlist item hasn't changed", () => Client.APIRoom?.Playlist[0].Beatmap.Value == firstBeatmap);
-            AddAssert("second playlist item changed", () => Client.APIRoom?.Playlist[1].Beatmap.Value != firstBeatmap);
+            AddAssert("first playlist item hasn't changed", () => MultiplayerClient.APIRoom?.Playlist[0].Beatmap.Value == firstBeatmap);
+            AddAssert("second playlist item changed", () => MultiplayerClient.APIRoom?.Playlist[1].Beatmap.Value != firstBeatmap);
         }
 
         [Test]
         public void TestSettingsUpdatedWhenChangingQueueMode()
         {
-            AddStep("change queue mode", () => Client.ChangeSettings(new MultiplayerRoomSettings
+            AddStep("change queue mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings
             {
                 QueueMode = QueueMode.AllPlayers
             }).WaitSafely());
 
-            AddUntilStep("api room updated", () => Client.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
+            AddUntilStep("api room updated", () => MultiplayerClient.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             addItem(() => OtherBeatmap);
 
-            AddAssert("playlist contains two items", () => Client.APIRoom?.Playlist.Count == 2);
+            AddAssert("playlist contains two items", () => MultiplayerClient.APIRoom?.Playlist.Count == 2);
         }
 
         private void selectNewItem(Func<BeatmapInfo> beatmap)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 foreach ((int userId, var _) in clocks)
                 {
                     SpectatorClient.StartPlay(userId, 0);
-                    OnlinePlayDependencies.Client.AddUser(new APIUser { Id = userId });
+                    OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = userId });
                 }
             });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -60,8 +60,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("start players silently", () =>
             {
-                OnlinePlayDependencies.Client.AddUser(new APIUser { Id = PLAYER_1_ID }, true);
-                OnlinePlayDependencies.Client.AddUser(new APIUser { Id = PLAYER_2_ID }, true);
+                OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = PLAYER_1_ID }, true);
+                OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = PLAYER_2_ID }, true);
 
                 playingUsers.Add(new MultiplayerRoomUser(PLAYER_1_ID));
                 playingUsers.Add(new MultiplayerRoomUser(PLAYER_2_ID));
@@ -121,13 +121,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("start players", () =>
             {
-                var player1 = OnlinePlayDependencies.Client.AddUser(new APIUser { Id = PLAYER_1_ID }, true);
+                var player1 = OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = PLAYER_1_ID }, true);
                 player1.MatchState = new TeamVersusUserState
                 {
                     TeamID = 0,
                 };
 
-                var player2 = OnlinePlayDependencies.Client.AddUser(new APIUser { Id = PLAYER_2_ID }, true);
+                var player2 = OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = PLAYER_2_ID }, true);
                 player2.MatchState = new TeamVersusUserState
                 {
                     TeamID = 1,
@@ -396,7 +396,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         User = new APIUser { Id = id },
                     };
 
-                    OnlinePlayDependencies.Client.AddUser(user.User, true);
+                    OnlinePlayDependencies.MultiplayerClient.AddUser(user.User, true);
                     SpectatorClient.StartPlay(id, beatmapId ?? importedBeatmapId);
 
                     playingUsers.Add(user);
@@ -410,7 +410,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 var user = playingUsers.Single(u => u.UserID == userId);
 
-                OnlinePlayDependencies.Client.RemoveUser(user.User.AsNonNull());
+                OnlinePlayDependencies.MultiplayerClient.RemoveUser(user.User.AsNonNull());
                 SpectatorClient.EndPlay(userId);
 
                 playingUsers.Remove(user);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -17,7 +17,6 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -55,9 +54,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private TestMultiplayerClient client => multiplayerComponents.Client;
         private TestMultiplayerRoomManager roomManager => multiplayerComponents.RoomManager;
-
-        [Cached(typeof(UserLookupCache))]
-        private UserLookupCache lookupCache = new TestUserLookupCache();
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private TestMultiplayerComponents multiplayerComponents;
 
-        private TestMultiplayerClient client => multiplayerComponents.Client;
+        private TestMultiplayerClient multiplayerClient => multiplayerComponents.MultiplayerClient;
         private TestMultiplayerRoomManager roomManager => multiplayerComponents.RoomManager;
 
         [BackgroundDependencyLoader]
@@ -109,66 +109,66 @@ namespace osu.Game.Tests.Visual.Multiplayer
             // all ready
             AddUntilStep("all players ready", () =>
             {
-                var nextUnready = client.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Idle);
+                var nextUnready = multiplayerClient.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Idle);
                 if (nextUnready != null)
-                    client.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Ready);
+                    multiplayerClient.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Ready);
 
-                return client.Room?.Users.All(u => u.State == MultiplayerUserState.Ready) == true;
+                return multiplayerClient.Room?.Users.All(u => u.State == MultiplayerUserState.Ready) == true;
             });
 
             AddStep("unready all players at once", () =>
             {
-                Debug.Assert(client.Room != null);
+                Debug.Assert(multiplayerClient.Room != null);
 
-                foreach (var u in client.Room.Users) client.ChangeUserState(u.UserID, MultiplayerUserState.Idle);
+                foreach (var u in multiplayerClient.Room.Users) multiplayerClient.ChangeUserState(u.UserID, MultiplayerUserState.Idle);
             });
 
             AddStep("ready all players at once", () =>
             {
-                Debug.Assert(client.Room != null);
+                Debug.Assert(multiplayerClient.Room != null);
 
-                foreach (var u in client.Room.Users) client.ChangeUserState(u.UserID, MultiplayerUserState.Ready);
+                foreach (var u in multiplayerClient.Room.Users) multiplayerClient.ChangeUserState(u.UserID, MultiplayerUserState.Ready);
             });
         }
 
         private void addRandomPlayer()
         {
             int randomUser = RNG.Next(200000, 500000);
-            client.AddUser(new APIUser { Id = randomUser, Username = $"user {randomUser}" });
+            multiplayerClient.AddUser(new APIUser { Id = randomUser, Username = $"user {randomUser}" });
         }
 
         private void removeLastUser()
         {
-            APIUser lastUser = client.Room?.Users.Last().User;
+            APIUser lastUser = multiplayerClient.Room?.Users.Last().User;
 
-            if (lastUser == null || lastUser == client.LocalUser?.User)
+            if (lastUser == null || lastUser == multiplayerClient.LocalUser?.User)
                 return;
 
-            client.RemoveUser(lastUser);
+            multiplayerClient.RemoveUser(lastUser);
         }
 
         private void kickLastUser()
         {
-            APIUser lastUser = client.Room?.Users.Last().User;
+            APIUser lastUser = multiplayerClient.Room?.Users.Last().User;
 
-            if (lastUser == null || lastUser == client.LocalUser?.User)
+            if (lastUser == null || lastUser == multiplayerClient.LocalUser?.User)
                 return;
 
-            client.KickUser(lastUser.Id);
+            multiplayerClient.KickUser(lastUser.Id);
         }
 
         private void markNextPlayerReady()
         {
-            var nextUnready = client.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Idle);
+            var nextUnready = multiplayerClient.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Idle);
             if (nextUnready != null)
-                client.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Ready);
+                multiplayerClient.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Ready);
         }
 
         private void markNextPlayerIdle()
         {
-            var nextUnready = client.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Ready);
+            var nextUnready = multiplayerClient.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Ready);
             if (nextUnready != null)
-                client.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Idle);
+                multiplayerClient.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Idle);
         }
 
         private void performRandomAction()
@@ -218,7 +218,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Press select", () => InputManager.Key(Key.Enter));
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => client.RoomJoined);
+            AddUntilStep("wait for join", () => multiplayerClient.RoomJoined);
         }
 
         [Test]
@@ -237,8 +237,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddAssert("Check participant count correct", () => client.APIRoom?.ParticipantCount.Value == 1);
-            AddAssert("Check participant list contains user", () => client.APIRoom?.RecentParticipants.Count(u => u.Id == API.LocalUser.Value.Id) == 1);
+            AddAssert("Check participant count correct", () => multiplayerClient.APIRoom?.ParticipantCount.Value == 1);
+            AddAssert("Check participant list contains user", () => multiplayerClient.APIRoom?.RecentParticipants.Count(u => u.Id == API.LocalUser.Value.Id) == 1);
         }
 
         [Test]
@@ -297,10 +297,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("join room", () => InputManager.Key(Key.Enter));
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => client.RoomJoined);
+            AddUntilStep("wait for join", () => multiplayerClient.RoomJoined);
 
-            AddAssert("Check participant count correct", () => client.APIRoom?.ParticipantCount.Value == 1);
-            AddAssert("Check participant list contains user", () => client.APIRoom?.RecentParticipants.Count(u => u.Id == API.LocalUser.Value.Id) == 1);
+            AddAssert("Check participant count correct", () => multiplayerClient.APIRoom?.ParticipantCount.Value == 1);
+            AddAssert("Check participant list contains user", () => multiplayerClient.APIRoom?.RecentParticipants.Count(u => u.Id == API.LocalUser.Value.Id) == 1);
         }
 
         [Test]
@@ -320,7 +320,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddAssert("room has password", () => client.APIRoom?.Password.Value == "password");
+            AddAssert("room has password", () => multiplayerClient.APIRoom?.Password.Value == "password");
         }
 
         [Test]
@@ -355,7 +355,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("press join room button", () => passwordEntryPopover.ChildrenOfType<OsuButton>().First().TriggerClick());
 
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => client.RoomJoined);
+            AddUntilStep("wait for join", () => multiplayerClient.RoomJoined);
         }
 
         [Test]
@@ -375,8 +375,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddStep("change password", () => client.ChangeSettings(password: "password2"));
-            AddUntilStep("local password changed", () => client.APIRoom?.Password.Value == "password2");
+            AddStep("change password", () => multiplayerClient.ChangeSettings(password: "password2"));
+            AddUntilStep("local password changed", () => multiplayerClient.APIRoom?.Password.Value == "password2");
         }
 
         [Test]
@@ -398,7 +398,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             pressReadyButton();
 
             AddStep("delete beatmap", () => beatmaps.Delete(importedSet));
-            AddUntilStep("user state is idle", () => client.LocalUser?.State == MultiplayerUserState.Idle);
+            AddUntilStep("user state is idle", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Idle);
         }
 
         [Test]
@@ -422,22 +422,22 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Enter song select", () =>
             {
                 var currentSubScreen = ((Screens.OnlinePlay.Multiplayer.Multiplayer)multiplayerComponents.CurrentScreen).CurrentSubScreen;
-                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.Room?.Settings.PlaylistItemId);
+                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(multiplayerClient.Room?.Settings.PlaylistItemId);
             });
 
             AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);
 
-            AddAssert("Beatmap matches current item", () => Beatmap.Value.BeatmapInfo.OnlineID == client.Room?.Playlist.First().BeatmapID);
+            AddAssert("Beatmap matches current item", () => Beatmap.Value.BeatmapInfo.OnlineID == multiplayerClient.Room?.Playlist.First().BeatmapID);
 
             AddStep("Select next beatmap", () => InputManager.Key(Key.Down));
 
-            AddUntilStep("Beatmap doesn't match current item", () => Beatmap.Value.BeatmapInfo.OnlineID != client.Room?.Playlist.First().BeatmapID);
+            AddUntilStep("Beatmap doesn't match current item", () => Beatmap.Value.BeatmapInfo.OnlineID != multiplayerClient.Room?.Playlist.First().BeatmapID);
 
-            AddStep("start match externally", () => client.StartMatch());
+            AddStep("start match externally", () => multiplayerClient.StartMatch());
 
             AddUntilStep("play started", () => multiplayerComponents.CurrentScreen is Player);
 
-            AddAssert("Beatmap matches current item", () => Beatmap.Value.BeatmapInfo.OnlineID == client.Room?.Playlist.First().BeatmapID);
+            AddAssert("Beatmap matches current item", () => Beatmap.Value.BeatmapInfo.OnlineID == multiplayerClient.Room?.Playlist.First().BeatmapID);
         }
 
         [Test]
@@ -461,22 +461,22 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Enter song select", () =>
             {
                 var currentSubScreen = ((Screens.OnlinePlay.Multiplayer.Multiplayer)multiplayerComponents.CurrentScreen).CurrentSubScreen;
-                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.Room?.Settings.PlaylistItemId);
+                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(multiplayerClient.Room?.Settings.PlaylistItemId);
             });
 
             AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);
 
-            AddAssert("Ruleset matches current item", () => Ruleset.Value.OnlineID == client.Room?.Playlist.First().RulesetID);
+            AddAssert("Ruleset matches current item", () => Ruleset.Value.OnlineID == multiplayerClient.Room?.Playlist.First().RulesetID);
 
             AddStep("Switch ruleset", () => ((MultiplayerMatchSongSelect)multiplayerComponents.MultiplayerScreen.CurrentSubScreen).Ruleset.Value = new CatchRuleset().RulesetInfo);
 
-            AddUntilStep("Ruleset doesn't match current item", () => Ruleset.Value.OnlineID != client.Room?.Playlist.First().RulesetID);
+            AddUntilStep("Ruleset doesn't match current item", () => Ruleset.Value.OnlineID != multiplayerClient.Room?.Playlist.First().RulesetID);
 
-            AddStep("start match externally", () => client.StartMatch());
+            AddStep("start match externally", () => multiplayerClient.StartMatch());
 
             AddUntilStep("play started", () => multiplayerComponents.CurrentScreen is Player);
 
-            AddAssert("Ruleset matches current item", () => Ruleset.Value.OnlineID == client.Room?.Playlist.First().RulesetID);
+            AddAssert("Ruleset matches current item", () => Ruleset.Value.OnlineID == multiplayerClient.Room?.Playlist.First().RulesetID);
         }
 
         [Test]
@@ -500,22 +500,22 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("Enter song select", () =>
             {
                 var currentSubScreen = ((Screens.OnlinePlay.Multiplayer.Multiplayer)multiplayerComponents.CurrentScreen).CurrentSubScreen;
-                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(client.Room?.Settings.PlaylistItemId);
+                ((MultiplayerMatchSubScreen)currentSubScreen).OpenSongSelection(multiplayerClient.Room?.Settings.PlaylistItemId);
             });
 
             AddUntilStep("wait for song select", () => this.ChildrenOfType<MultiplayerMatchSongSelect>().FirstOrDefault()?.BeatmapSetsLoaded == true);
 
-            AddAssert("Mods match current item", () => SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(client.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
+            AddAssert("Mods match current item", () => SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(multiplayerClient.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
 
             AddStep("Switch required mods", () => ((MultiplayerMatchSongSelect)multiplayerComponents.MultiplayerScreen.CurrentSubScreen).Mods.Value = new Mod[] { new OsuModDoubleTime() });
 
-            AddAssert("Mods don't match current item", () => !SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(client.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
+            AddAssert("Mods don't match current item", () => !SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(multiplayerClient.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
 
-            AddStep("start match externally", () => client.StartMatch());
+            AddStep("start match externally", () => multiplayerClient.StartMatch());
 
             AddUntilStep("play started", () => multiplayerComponents.CurrentScreen is Player);
 
-            AddAssert("Mods match current item", () => SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(client.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
+            AddAssert("Mods match current item", () => SelectedMods.Value.Select(m => m.Acronym).SequenceEqual(multiplayerClient.Room.AsNonNull().Playlist.First().RequiredMods.Select(m => m.Acronym)));
         }
 
         [Test]
@@ -536,18 +536,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("join other user (ready, host)", () =>
             {
-                client.AddUser(new APIUser { Id = MultiplayerTestScene.PLAYER_1_ID, Username = "Other" });
-                client.TransferHost(MultiplayerTestScene.PLAYER_1_ID);
-                client.ChangeUserState(MultiplayerTestScene.PLAYER_1_ID, MultiplayerUserState.Ready);
+                multiplayerClient.AddUser(new APIUser { Id = MultiplayerTestScene.PLAYER_1_ID, Username = "Other" });
+                multiplayerClient.TransferHost(MultiplayerTestScene.PLAYER_1_ID);
+                multiplayerClient.ChangeUserState(MultiplayerTestScene.PLAYER_1_ID, MultiplayerUserState.Ready);
             });
 
             AddStep("delete beatmap", () => beatmaps.Delete(importedSet));
 
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
 
-            AddUntilStep("wait for spectating user state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddUntilStep("wait for spectating user state", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
 
-            AddStep("start match externally", () => client.StartMatch());
+            AddStep("start match externally", () => multiplayerClient.StartMatch());
 
             AddAssert("play not started", () => multiplayerComponents.IsCurrentScreen());
         }
@@ -572,16 +572,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("join other user (ready, host)", () =>
             {
-                client.AddUser(new APIUser { Id = MultiplayerTestScene.PLAYER_1_ID, Username = "Other" });
-                client.TransferHost(MultiplayerTestScene.PLAYER_1_ID);
-                client.ChangeUserState(MultiplayerTestScene.PLAYER_1_ID, MultiplayerUserState.Ready);
+                multiplayerClient.AddUser(new APIUser { Id = MultiplayerTestScene.PLAYER_1_ID, Username = "Other" });
+                multiplayerClient.TransferHost(MultiplayerTestScene.PLAYER_1_ID);
+                multiplayerClient.ChangeUserState(MultiplayerTestScene.PLAYER_1_ID, MultiplayerUserState.Ready);
             });
 
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
 
-            AddUntilStep("wait for spectating user state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddUntilStep("wait for spectating user state", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
 
-            AddStep("start match externally", () => client.StartMatch());
+            AddStep("start match externally", () => multiplayerClient.StartMatch());
 
             AddStep("restore beatmap", () =>
             {
@@ -608,7 +608,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddStep("disconnect", () => client.Disconnect());
+            AddStep("disconnect", () => multiplayerClient.Disconnect());
             AddUntilStep("back in lounge", () => this.ChildrenOfType<LoungeSubScreen>().FirstOrDefault()?.IsCurrentScreen() == true);
         }
 
@@ -718,7 +718,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("join room", () => InputManager.Key(Key.Enter));
             AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
-            AddUntilStep("wait for join", () => client.RoomJoined);
+            AddUntilStep("wait for join", () => multiplayerClient.RoomJoined);
 
             AddAssert("local room has correct settings", () =>
             {
@@ -745,11 +745,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddStep("set spectating state", () => client.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
-            AddUntilStep("state set to spectating", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddStep("set spectating state", () => multiplayerClient.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
+            AddUntilStep("state set to spectating", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
 
-            AddStep("join other user", () => client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("set other user ready", () => client.ChangeUserState(1234, MultiplayerUserState.Ready));
+            AddStep("join other user", () => multiplayerClient.AddUser(new APIUser { Id = 1234 }));
+            AddStep("set other user ready", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Ready));
 
             pressReadyButton(1234);
             AddUntilStep("wait for gameplay", () => (multiplayerComponents.CurrentScreen as MultiSpectatorScreen)?.IsLoaded == true);
@@ -761,7 +761,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for return to match subscreen", () => multiplayerComponents.MultiplayerScreen.IsCurrentScreen());
-            AddUntilStep("user state is idle", () => client.LocalUser?.State == MultiplayerUserState.Idle);
+            AddUntilStep("user state is idle", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Idle);
         }
 
         [Test]
@@ -781,16 +781,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddStep("set spectating state", () => client.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
-            AddUntilStep("state set to spectating", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddStep("set spectating state", () => multiplayerClient.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
+            AddUntilStep("state set to spectating", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
 
-            AddStep("join other user", () => client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("set other user ready", () => client.ChangeUserState(1234, MultiplayerUserState.Ready));
+            AddStep("join other user", () => multiplayerClient.AddUser(new APIUser { Id = 1234 }));
+            AddStep("set other user ready", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Ready));
 
             pressReadyButton(1234);
             AddUntilStep("wait for gameplay", () => (multiplayerComponents.CurrentScreen as MultiSpectatorScreen)?.IsLoaded == true);
-            AddStep("set other user loaded", () => client.ChangeUserState(1234, MultiplayerUserState.Loaded));
-            AddStep("set other user finished play", () => client.ChangeUserState(1234, MultiplayerUserState.FinishedPlay));
+            AddStep("set other user loaded", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Loaded));
+            AddStep("set other user finished play", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.FinishedPlay));
 
             AddStep("press back button and exit", () =>
             {
@@ -800,7 +800,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for return to match subscreen", () => multiplayerComponents.MultiplayerScreen.IsCurrentScreen());
             AddWaitStep("wait for possible state change", 5);
-            AddUntilStep("user state is spectating", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddUntilStep("user state is spectating", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
         }
 
         [Test]
@@ -822,13 +822,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             enterGameplay();
 
-            AddStep("join other user", () => client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("add item as other user", () => client.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(new PlaylistItem
+            AddStep("join other user", () => multiplayerClient.AddUser(new APIUser { Id = 1234 }));
+            AddStep("add item as other user", () => multiplayerClient.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(new PlaylistItem
             {
                 BeatmapID = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo.OnlineID
             })).WaitSafely());
 
-            AddUntilStep("item arrived in playlist", () => client.Room?.Playlist.Count == 2);
+            AddUntilStep("item arrived in playlist", () => multiplayerClient.Room?.Playlist.Count == 2);
 
             AddStep("exit gameplay as initial user", () => multiplayerComponents.MultiplayerScreen.MakeCurrent());
             AddUntilStep("queue contains item", () => this.ChildrenOfType<MultiplayerQueueList>().Single().Items.Single().ID == 2);
@@ -853,16 +853,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             enterGameplay();
 
-            AddStep("join other user", () => client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("add item as other user", () => client.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(new PlaylistItem
+            AddStep("join other user", () => multiplayerClient.AddUser(new APIUser { Id = 1234 }));
+            AddStep("add item as other user", () => multiplayerClient.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(new PlaylistItem
             {
                 BeatmapID = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo.OnlineID
             })).WaitSafely());
 
-            AddUntilStep("item arrived in playlist", () => client.Room?.Playlist.Count == 2);
+            AddUntilStep("item arrived in playlist", () => multiplayerClient.Room?.Playlist.Count == 2);
 
-            AddStep("delete item as other user", () => client.RemoveUserPlaylistItem(1234, 2).WaitSafely());
-            AddUntilStep("item removed from playlist", () => client.Room?.Playlist.Count == 1);
+            AddStep("delete item as other user", () => multiplayerClient.RemoveUserPlaylistItem(1234, 2).WaitSafely());
+            AddUntilStep("item removed from playlist", () => multiplayerClient.Room?.Playlist.Count == 1);
 
             AddStep("exit gameplay as initial user", () => multiplayerComponents.MultiplayerScreen.MakeCurrent());
             AddUntilStep("queue is empty", () => this.ChildrenOfType<MultiplayerQueueList>().Single().Items.Count == 0);
@@ -886,17 +886,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("join other user and make host", () =>
             {
-                client.AddUser(new APIUser { Id = 1234 });
-                client.TransferHost(1234);
+                multiplayerClient.AddUser(new APIUser { Id = 1234 });
+                multiplayerClient.TransferHost(1234);
             });
 
-            AddStep("set local user spectating", () => client.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
-            AddUntilStep("wait for spectating state", () => client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddStep("set local user spectating", () => multiplayerClient.ChangeUserState(API.LocalUser.Value.OnlineID, MultiplayerUserState.Spectating));
+            AddUntilStep("wait for spectating state", () => multiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
 
             runGameplay();
 
-            AddStep("exit gameplay for other user", () => client.ChangeUserState(1234, MultiplayerUserState.Idle));
-            AddUntilStep("wait for room to be idle", () => client.Room?.State == MultiplayerRoomState.Open);
+            AddStep("exit gameplay for other user", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Idle));
+            AddUntilStep("wait for room to be idle", () => multiplayerClient.Room?.State == MultiplayerRoomState.Open);
 
             runGameplay();
 
@@ -904,13 +904,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 AddStep("start match by other user", () =>
                 {
-                    client.ChangeUserState(1234, MultiplayerUserState.Ready);
-                    client.StartMatch();
+                    multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Ready);
+                    multiplayerClient.StartMatch();
                 });
 
-                AddUntilStep("wait for loading", () => client.Room?.State == MultiplayerRoomState.WaitingForLoad);
-                AddStep("set player loaded", () => client.ChangeUserState(1234, MultiplayerUserState.Loaded));
-                AddUntilStep("wait for gameplay to start", () => client.Room?.State == MultiplayerRoomState.Playing);
+                AddUntilStep("wait for loading", () => multiplayerClient.Room?.State == MultiplayerRoomState.WaitingForLoad);
+                AddStep("set player loaded", () => multiplayerClient.ChangeUserState(1234, MultiplayerUserState.Loaded));
+                AddUntilStep("wait for gameplay to start", () => multiplayerClient.Room?.State == MultiplayerRoomState.Playing);
                 AddUntilStep("wait for local user to enter spectator", () => multiplayerComponents.CurrentScreen is MultiSpectatorScreen);
             }
         }
@@ -935,7 +935,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("click ready button", () =>
             {
-                user = playingUserId == null ? client.LocalUser : client.Room?.Users.Single(u => u.UserID == playingUserId);
+                user = playingUserId == null ? multiplayerClient.LocalUser : multiplayerClient.Room?.Users.Single(u => u.UserID == playingUserId);
                 lastState = user?.State ?? MultiplayerUserState.Idle;
 
                 InputManager.MoveMouseTo(readyButton);
@@ -955,7 +955,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
-            AddUntilStep("wait for join", () => client.RoomJoined);
+            AddUntilStep("wait for join", () => multiplayerClient.RoomJoined);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             base.SetUpSteps();
 
-            AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = LookupCache.GetUserAsync(1).GetResultSafely());
+            AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = UserLookupCache.GetUserAsync(1).GetResultSafely());
 
             AddStep("create leaderboard", () =>
             {
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestUserQuit()
         {
             foreach (int user in users)
-                AddStep($"mark user {user} quit", () => Client.RemoveUser(LookupCache.GetUserAsync(user).GetResultSafely().AsNonNull()));
+                AddStep($"mark user {user} quit", () => Client.RemoveUser(UserLookupCache.GetUserAsync(user).GetResultSafely().AsNonNull()));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 foreach (int user in users)
                 {
                     SpectatorClient.StartPlay(user, Beatmap.Value.BeatmapInfo.OnlineID);
-                    multiplayerUsers.Add(OnlinePlayDependencies.Client.AddUser(new APIUser { Id = user }, true));
+                    multiplayerUsers.Add(OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = user }, true));
                 }
 
                 Children = new Drawable[]
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for load", () => leaderboard.IsLoaded);
-            AddUntilStep("wait for user population", () => Client.CurrentMatchPlayingUserIds.Count > 0);
+            AddUntilStep("wait for user population", () => MultiplayerClient.CurrentMatchPlayingUserIds.Count > 0);
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestUserQuit()
         {
             foreach (int user in users)
-                AddStep($"mark user {user} quit", () => Client.RemoveUser(UserLookupCache.GetUserAsync(user).GetResultSafely().AsNonNull()));
+                AddStep($"mark user {user} quit", () => MultiplayerClient.RemoveUser(UserLookupCache.GetUserAsync(user).GetResultSafely().AsNonNull()));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             base.SetUpSteps();
 
-            AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = LookupCache.GetUserAsync(1).GetResultSafely());
+            AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = UserLookupCache.GetUserAsync(1).GetResultSafely());
 
             AddStep("create leaderboard", () =>
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 foreach (int user in users)
                 {
                     SpectatorClient.StartPlay(user, Beatmap.Value.BeatmapInfo.OnlineID);
-                    var roomUser = OnlinePlayDependencies.Client.AddUser(new APIUser { Id = user }, true);
+                    var roomUser = OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = user }, true);
 
                     roomUser.MatchState = new TeamVersusUserState
                     {
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for load", () => leaderboard.IsLoaded);
-            AddUntilStep("wait for user population", () => Client.CurrentMatchPlayingUserIds.Count > 0);
+            AddUntilStep("wait for user population", () => MultiplayerClient.CurrentMatchPlayingUserIds.Count > 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for join", () => RoomJoined);
 
-            AddStep("select swap mod", () => Client.ChangeUserMods(API.LocalUser.Value.OnlineID, new[] { new TaikoModSwap() }));
+            AddStep("select swap mod", () => MultiplayerClient.ChangeUserMods(API.LocalUser.Value.OnlineID, new[] { new TaikoModSwap() }));
             AddUntilStep("participant panel has mod", () => this.ChildrenOfType<ParticipantPanel>().Any(p => p.ChildrenOfType<ModIcon>().Any(m => m.Mod is TaikoModSwap)));
         }
 
@@ -141,17 +141,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("join other user (ready)", () =>
             {
-                Client.AddUser(new APIUser { Id = PLAYER_1_ID });
-                Client.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready);
+                MultiplayerClient.AddUser(new APIUser { Id = PLAYER_1_ID });
+                MultiplayerClient.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready);
             });
 
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
 
-            AddUntilStep("wait for spectating user state", () => Client.LocalUser?.State == MultiplayerUserState.Spectating);
+            AddUntilStep("wait for spectating user state", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.Spectating);
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
-            AddUntilStep("match started", () => Client.Room?.State == MultiplayerRoomState.WaitingForLoad);
+            AddUntilStep("match started", () => MultiplayerClient.Room?.State == MultiplayerRoomState.WaitingForLoad);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 1);
 
-            AddStep("add user", () => Client.AddUser(new APIUser
+            AddStep("add user", () => MultiplayerClient.AddUser(new APIUser
             {
                 Id = 3,
                 Username = "Second",
@@ -50,15 +50,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddAssert("one unique panel", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 1);
 
-            AddStep("add non-resolvable user", () => Client.TestAddUnresolvedUser());
-            AddAssert("null user added", () => Client.Room.AsNonNull().Users.Count(u => u.User == null) == 1);
+            AddStep("add non-resolvable user", () => MultiplayerClient.TestAddUnresolvedUser());
+            AddAssert("null user added", () => MultiplayerClient.Room.AsNonNull().Users.Count(u => u.User == null) == 1);
 
             AddUntilStep("two unique panels", () => this.ChildrenOfType<ParticipantPanel>().Select(p => p.User).Distinct().Count() == 2);
 
             AddStep("kick null user", () => this.ChildrenOfType<ParticipantPanel>().Single(p => p.User.User == null)
                                                 .ChildrenOfType<ParticipantPanel.KickButton>().Single().TriggerClick());
 
-            AddAssert("null user kicked", () => Client.Room.AsNonNull().Users.Count == 1);
+            AddAssert("null user kicked", () => MultiplayerClient.Room.AsNonNull().Users.Count == 1);
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("add a user", () =>
             {
-                Client.AddUser(secondUser = new APIUser
+                MultiplayerClient.AddUser(secondUser = new APIUser
                 {
                     Id = 3,
                     Username = "Second",
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 });
             });
 
-            AddStep("remove host", () => Client.RemoveUser(API.LocalUser.Value));
+            AddStep("remove host", () => MultiplayerClient.RemoveUser(API.LocalUser.Value));
 
             AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().User.User == secondUser);
         }
@@ -84,21 +84,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestGameStateHasPriorityOverDownloadState()
         {
-            AddStep("set to downloading map", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
+            AddStep("set to downloading map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
             checkProgressBarVisibility(true);
 
-            AddStep("make user ready", () => Client.ChangeState(MultiplayerUserState.Results));
+            AddStep("make user ready", () => MultiplayerClient.ChangeState(MultiplayerUserState.Results));
             checkProgressBarVisibility(false);
             AddUntilStep("ready mark visible", () => this.ChildrenOfType<StateDisplay>().Single().IsPresent);
 
-            AddStep("make user ready", () => Client.ChangeState(MultiplayerUserState.Idle));
+            AddStep("make user ready", () => MultiplayerClient.ChangeState(MultiplayerUserState.Idle));
             checkProgressBarVisibility(true);
         }
 
         [Test]
         public void TestCorrectInitialState()
         {
-            AddStep("set to downloading map", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
+            AddStep("set to downloading map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
             createNewParticipantsList();
             checkProgressBarVisibility(true);
         }
@@ -106,23 +106,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestBeatmapDownloadingStates()
         {
-            AddStep("set to no map", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.NotDownloaded()));
-            AddStep("set to downloading map", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
+            AddStep("set to no map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.NotDownloaded()));
+            AddStep("set to downloading map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
 
             checkProgressBarVisibility(true);
 
             AddRepeatStep("increment progress", () =>
             {
                 float progress = this.ChildrenOfType<ParticipantPanel>().Single().User.BeatmapAvailability.DownloadProgress ?? 0;
-                Client.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(progress + RNG.NextSingle(0.1f)));
+                MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(progress + RNG.NextSingle(0.1f)));
             }, 25);
 
             AddAssert("progress bar increased", () => this.ChildrenOfType<ProgressBar>().Single().Current.Value > 0);
 
-            AddStep("set to importing map", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.Importing()));
+            AddStep("set to importing map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Importing()));
             checkProgressBarVisibility(false);
 
-            AddStep("set to available", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable()));
+            AddStep("set to available", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable()));
         }
 
         [Test]
@@ -130,24 +130,24 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddAssert("ready mark invisible", () => !this.ChildrenOfType<StateDisplay>().Single().IsPresent);
 
-            AddStep("make user ready", () => Client.ChangeState(MultiplayerUserState.Ready));
+            AddStep("make user ready", () => MultiplayerClient.ChangeState(MultiplayerUserState.Ready));
             AddUntilStep("ready mark visible", () => this.ChildrenOfType<StateDisplay>().Single().IsPresent);
 
-            AddStep("make user idle", () => Client.ChangeState(MultiplayerUserState.Idle));
+            AddStep("make user idle", () => MultiplayerClient.ChangeState(MultiplayerUserState.Idle));
             AddUntilStep("ready mark invisible", () => !this.ChildrenOfType<StateDisplay>().Single().IsPresent);
         }
 
         [Test]
         public void TestToggleSpectateState()
         {
-            AddStep("make user spectating", () => Client.ChangeState(MultiplayerUserState.Spectating));
-            AddStep("make user idle", () => Client.ChangeState(MultiplayerUserState.Idle));
+            AddStep("make user spectating", () => MultiplayerClient.ChangeState(MultiplayerUserState.Spectating));
+            AddStep("make user idle", () => MultiplayerClient.ChangeState(MultiplayerUserState.Idle));
         }
 
         [Test]
         public void TestCrownChangesStateWhenHostTransferred()
         {
-            AddStep("add user", () => Client.AddUser(new APIUser
+            AddStep("add user", () => MultiplayerClient.AddUser(new APIUser
             {
                 Id = 3,
                 Username = "Second",
@@ -157,7 +157,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("first user crown visible", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(0).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
             AddUntilStep("second user crown hidden", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(1).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
 
-            AddStep("make second user host", () => Client.TransferHost(3));
+            AddStep("make second user host", () => MultiplayerClient.TransferHost(3));
 
             AddUntilStep("first user crown hidden", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(0).ChildrenOfType<SpriteIcon>().First().Alpha == 0);
             AddUntilStep("second user crown visible", () => this.ChildrenOfType<ParticipantPanel>().ElementAt(1).ChildrenOfType<SpriteIcon>().First().Alpha == 1);
@@ -166,7 +166,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestKickButtonOnlyPresentWhenHost()
         {
-            AddStep("add user", () => Client.AddUser(new APIUser
+            AddStep("add user", () => MultiplayerClient.AddUser(new APIUser
             {
                 Id = 3,
                 Username = "Second",
@@ -175,11 +175,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("kick buttons visible", () => this.ChildrenOfType<ParticipantPanel.KickButton>().Count(d => d.IsPresent) == 1);
 
-            AddStep("make second user host", () => Client.TransferHost(3));
+            AddStep("make second user host", () => MultiplayerClient.TransferHost(3));
 
             AddUntilStep("kick buttons not visible", () => this.ChildrenOfType<ParticipantPanel.KickButton>().Count(d => d.IsPresent) == 0);
 
-            AddStep("make local user host again", () => Client.TransferHost(API.LocalUser.Value.Id));
+            AddStep("make local user host again", () => MultiplayerClient.TransferHost(API.LocalUser.Value.Id));
 
             AddUntilStep("kick buttons visible", () => this.ChildrenOfType<ParticipantPanel.KickButton>().Count(d => d.IsPresent) == 1);
         }
@@ -187,7 +187,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestKickButtonKicks()
         {
-            AddStep("add user", () => Client.AddUser(new APIUser
+            AddStep("add user", () => MultiplayerClient.AddUser(new APIUser
             {
                 Id = 3,
                 Username = "Second",
@@ -196,7 +196,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("kick second user", () => this.ChildrenOfType<ParticipantPanel.KickButton>().Single(d => d.IsPresent).TriggerClick());
 
-            AddAssert("second user kicked", () => Client.Room?.Users.Single().UserID == API.LocalUser.Value.Id);
+            AddAssert("second user kicked", () => MultiplayerClient.Room?.Users.Single().UserID == API.LocalUser.Value.Id);
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 for (int i = 0; i < 20; i++)
                 {
-                    Client.AddUser(new APIUser
+                    MultiplayerClient.AddUser(new APIUser
                     {
                         Id = i,
                         Username = $"User {i}",
@@ -220,7 +220,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                     });
 
-                    Client.ChangeUserState(i, (MultiplayerUserState)RNG.Next(0, (int)MultiplayerUserState.Results + 1));
+                    MultiplayerClient.ChangeUserState(i, (MultiplayerUserState)RNG.Next(0, (int)MultiplayerUserState.Results + 1));
 
                     if (RNG.NextBool())
                     {
@@ -229,15 +229,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         switch (beatmapState)
                         {
                             case DownloadState.NotDownloaded:
-                                Client.ChangeUserBeatmapAvailability(i, BeatmapAvailability.NotDownloaded());
+                                MultiplayerClient.ChangeUserBeatmapAvailability(i, BeatmapAvailability.NotDownloaded());
                                 break;
 
                             case DownloadState.Downloading:
-                                Client.ChangeUserBeatmapAvailability(i, BeatmapAvailability.Downloading(RNG.NextSingle()));
+                                MultiplayerClient.ChangeUserBeatmapAvailability(i, BeatmapAvailability.Downloading(RNG.NextSingle()));
                                 break;
 
                             case DownloadState.Importing:
-                                Client.ChangeUserBeatmapAvailability(i, BeatmapAvailability.Importing());
+                                MultiplayerClient.ChangeUserBeatmapAvailability(i, BeatmapAvailability.Importing());
                                 break;
                         }
                     }
@@ -250,7 +250,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add user", () =>
             {
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 0,
                     Username = "User 0",
@@ -264,7 +264,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 });
 
-                Client.ChangeUserMods(0, new Mod[]
+                MultiplayerClient.ChangeUserMods(0, new Mod[]
                 {
                     new OsuModHardRock(),
                     new OsuModDifficultyAdjust { ApproachRate = { Value = 1 } }
@@ -274,12 +274,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             for (var i = MultiplayerUserState.Idle; i < MultiplayerUserState.Results; i++)
             {
                 var state = i;
-                AddStep($"set state: {state}", () => Client.ChangeUserState(0, state));
+                AddStep($"set state: {state}", () => MultiplayerClient.ChangeUserState(0, state));
             }
 
-            AddStep("set state: downloading", () => Client.ChangeUserBeatmapAvailability(0, BeatmapAvailability.Downloading(0)));
+            AddStep("set state: downloading", () => MultiplayerClient.ChangeUserBeatmapAvailability(0, BeatmapAvailability.Downloading(0)));
 
-            AddStep("set state: locally available", () => Client.ChangeUserBeatmapAvailability(0, BeatmapAvailability.LocallyAvailable()));
+            AddStep("set state: locally available", () => MultiplayerClient.ChangeUserBeatmapAvailability(0, BeatmapAvailability.LocallyAvailable()));
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add dummy mods", () =>
             {
-                Client.ChangeUserMods(new Mod[]
+                MultiplayerClient.ChangeUserMods(new Mod[]
                 {
                     new OsuModNoFail(),
                     new OsuModDoubleTime()
@@ -296,7 +296,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("add user with mods", () =>
             {
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 0,
                     Username = "Baka",
@@ -309,34 +309,34 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     },
                     CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 });
-                Client.ChangeUserMods(0, new Mod[]
+                MultiplayerClient.ChangeUserMods(0, new Mod[]
                 {
                     new OsuModHardRock(),
                     new OsuModDoubleTime()
                 });
             });
 
-            AddStep("set 0 ready", () => Client.ChangeState(MultiplayerUserState.Ready));
+            AddStep("set 0 ready", () => MultiplayerClient.ChangeState(MultiplayerUserState.Ready));
 
-            AddStep("set 1 spectate", () => Client.ChangeUserState(0, MultiplayerUserState.Spectating));
+            AddStep("set 1 spectate", () => MultiplayerClient.ChangeUserState(0, MultiplayerUserState.Spectating));
 
             // Have to set back to idle due to status priority.
             AddStep("set 0 no map, 1 ready", () =>
             {
-                Client.ChangeState(MultiplayerUserState.Idle);
-                Client.ChangeBeatmapAvailability(BeatmapAvailability.NotDownloaded());
-                Client.ChangeUserState(0, MultiplayerUserState.Ready);
+                MultiplayerClient.ChangeState(MultiplayerUserState.Idle);
+                MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.NotDownloaded());
+                MultiplayerClient.ChangeUserState(0, MultiplayerUserState.Ready);
             });
 
-            AddStep("set 0 downloading", () => Client.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
+            AddStep("set 0 downloading", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
 
-            AddStep("set 0 spectate", () => Client.ChangeUserState(0, MultiplayerUserState.Spectating));
+            AddStep("set 0 spectate", () => MultiplayerClient.ChangeUserState(0, MultiplayerUserState.Spectating));
 
             AddStep("make both default", () =>
             {
-                Client.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
-                Client.ChangeUserState(0, MultiplayerUserState.Idle);
-                Client.ChangeState(MultiplayerUserState.Idle);
+                MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable());
+                MultiplayerClient.ChangeUserState(0, MultiplayerUserState.Idle);
+                MultiplayerClient.ChangeState(MultiplayerUserState.Idle);
             });
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -28,15 +28,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("initialise gameplay", () =>
             {
-                Stack.Push(player = new MultiplayerPlayer(Client.APIRoom, new PlaylistItem
+                Stack.Push(player = new MultiplayerPlayer(MultiplayerClient.APIRoom, new PlaylistItem
                 {
                     Beatmap = { Value = Beatmap.Value.BeatmapInfo },
                     RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID,
-                }, Client.Room?.Users.ToArray()));
+                }, MultiplayerClient.Room?.Users.ToArray()));
             });
 
             AddUntilStep("wait for player to be current", () => player.IsCurrentScreen() && player.IsLoaded);
-            AddStep("start gameplay", () => ((IMultiplayerClient)Client).MatchStarted());
+            AddStep("start gameplay", () => ((IMultiplayerClient)MultiplayerClient).MatchStarted());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 importedBeatmap = importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0);
             });
 
-            AddStep("change to all players mode", () => Client.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
+            AddStep("change to all players mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
         }
 
         [Test]
@@ -97,19 +97,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
             addItemStep();
             addItemStep();
 
-            AddStep("finish current item", () => Client.FinishCurrentItem().WaitSafely());
+            AddStep("finish current item", () => MultiplayerClient.FinishCurrentItem().WaitSafely());
 
             assertItemInHistoryListStep(1, 0);
             assertItemInQueueListStep(2, 0);
             assertItemInQueueListStep(3, 1);
 
-            AddStep("finish current item", () => Client.FinishCurrentItem().WaitSafely());
+            AddStep("finish current item", () => MultiplayerClient.FinishCurrentItem().WaitSafely());
 
             assertItemInHistoryListStep(2, 0);
             assertItemInHistoryListStep(1, 1);
             assertItemInQueueListStep(3, 0);
 
-            AddStep("finish current item", () => Client.FinishCurrentItem().WaitSafely());
+            AddStep("finish current item", () => MultiplayerClient.FinishCurrentItem().WaitSafely());
 
             assertItemInHistoryListStep(3, 0);
             assertItemInHistoryListStep(2, 1);
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestListsClearedWhenRoomLeft()
         {
             addItemStep();
-            AddStep("finish current item", () => Client.FinishCurrentItem().WaitSafely());
+            AddStep("finish current item", () => MultiplayerClient.FinishCurrentItem().WaitSafely());
 
             AddStep("leave room", () => RoomManager.PartRoom());
             AddUntilStep("wait for room part", () => !RoomJoined);
@@ -167,7 +167,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         /// <summary>
         /// Adds a step to create a new playlist item.
         /// </summary>
-        private void addItemStep(bool expired = false) => AddStep("add item", () => Client.AddPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem
+        private void addItemStep(bool expired = false) => AddStep("add item", () => MultiplayerClient.AddPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem
         {
             Beatmap = { Value = importedBeatmap },
             BeatmapID = importedBeatmap.OnlineID,

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Size = new Vector2(500, 300),
-                    Items = { BindTarget = Client.APIRoom!.Playlist }
+                    Items = { BindTarget = MultiplayerClient.APIRoom!.Playlist }
                 };
             });
 
@@ -61,14 +61,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 importedBeatmap = importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0);
             });
 
-            AddStep("change to all players mode", () => Client.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
+            AddStep("change to all players mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
         }
 
         [Test]
         public void TestDeleteButtonAlwaysVisibleForHost()
         {
-            AddStep("set all players queue mode", () => Client.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
-            AddUntilStep("wait for queue mode change", () => Client.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
+            AddStep("set all players queue mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
+            AddUntilStep("wait for queue mode change", () => MultiplayerClient.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
 
             addPlaylistItem(() => API.LocalUser.Value.OnlineID);
             assertDeleteButtonVisibility(1, true);
@@ -79,18 +79,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestDeleteButtonOnlyVisibleForItemOwnerIfNotHost()
         {
-            AddStep("set all players queue mode", () => Client.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
-            AddUntilStep("wait for queue mode change", () => Client.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
+            AddStep("set all players queue mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
+            AddUntilStep("wait for queue mode change", () => MultiplayerClient.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
 
-            AddStep("join other user", () => Client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("set other user as host", () => Client.TransferHost(1234));
+            AddStep("join other user", () => MultiplayerClient.AddUser(new APIUser { Id = 1234 }));
+            AddStep("set other user as host", () => MultiplayerClient.TransferHost(1234));
 
             addPlaylistItem(() => API.LocalUser.Value.OnlineID);
             assertDeleteButtonVisibility(1, true);
             addPlaylistItem(() => 1234);
             assertDeleteButtonVisibility(2, false);
 
-            AddStep("set local user as host", () => Client.TransferHost(API.LocalUser.Value.OnlineID));
+            AddStep("set local user as host", () => MultiplayerClient.TransferHost(API.LocalUser.Value.OnlineID));
             assertDeleteButtonVisibility(1, true);
             assertDeleteButtonVisibility(2, true);
         }
@@ -98,16 +98,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestCurrentItemDoesNotHaveDeleteButton()
         {
-            AddStep("set all players queue mode", () => Client.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
-            AddUntilStep("wait for queue mode change", () => Client.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
+            AddStep("set all players queue mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
+            AddUntilStep("wait for queue mode change", () => MultiplayerClient.APIRoom?.QueueMode.Value == QueueMode.AllPlayers);
 
             addPlaylistItem(() => API.LocalUser.Value.OnlineID);
 
             assertDeleteButtonVisibility(0, false);
             assertDeleteButtonVisibility(1, true);
 
-            AddStep("finish current item", () => Client.FinishCurrentItem().WaitSafely());
-            AddUntilStep("wait for next item to be selected", () => Client.Room?.Settings.PlaylistItemId == 2);
+            AddStep("finish current item", () => MultiplayerClient.FinishCurrentItem().WaitSafely());
+            AddUntilStep("wait for next item to be selected", () => MultiplayerClient.Room?.Settings.PlaylistItemId == 2);
             AddUntilStep("wait for two items in playlist", () => playlist.ChildrenOfType<DrawableRoomPlaylistItem>().Count() == 2);
 
             assertDeleteButtonVisibility(0, false);
@@ -126,7 +126,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     BeatmapID = importedBeatmap.OnlineID,
                 });
 
-                Client.AddUserPlaylistItem(userId(), item).WaitSafely();
+                MultiplayerClient.AddUserPlaylistItem(userId(), item).WaitSafely();
 
                 itemId = item.ID;
             });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -26,9 +25,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerQueueList : MultiplayerTestScene
     {
-        [Cached(typeof(UserLookupCache))]
-        private readonly TestUserLookupCache userLookupCache = new TestUserLookupCache();
-
         private MultiplayerQueueList playlist;
         private BeatmapManager beatmaps;
         private RulesetStore rulesets;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -74,13 +74,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                     Task.Run(async () =>
                     {
-                        if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                        if (MultiplayerClient.IsHost && MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready)
                         {
-                            await Client.StartMatch();
+                            await MultiplayerClient.StartMatch();
                             return;
                         }
 
-                        await Client.ToggleReady();
+                        await MultiplayerClient.ToggleReady();
 
                         readyClickOperation.Dispose();
                     });
@@ -110,15 +110,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add second user as host", () =>
             {
-                Client.AddUser(new APIUser { Id = 2, Username = "Another user" });
-                Client.TransferHost(2);
+                MultiplayerClient.AddUser(new APIUser { Id = 2, Username = "Another user" });
+                MultiplayerClient.TransferHost(2);
             });
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("user is ready", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Ready);
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddUntilStep("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+            AddUntilStep("user is idle", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Idle);
         }
 
         [TestCase(true)]
@@ -127,14 +127,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("setup", () =>
             {
-                Client.TransferHost(Client.Room?.Users[0].UserID ?? 0);
+                MultiplayerClient.TransferHost(MultiplayerClient.Room?.Users[0].UserID ?? 0);
 
                 if (!allReady)
-                    Client.AddUser(new APIUser { Id = 2, Username = "Another user" });
+                    MultiplayerClient.AddUser(new APIUser { Id = 2, Username = "Another user" });
             });
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("user is ready", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Ready);
 
             verifyGameplayStartFlow();
         }
@@ -144,12 +144,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add host", () =>
             {
-                Client.AddUser(new APIUser { Id = 2, Username = "Another user" });
-                Client.TransferHost(2);
+                MultiplayerClient.AddUser(new APIUser { Id = 2, Username = "Another user" });
+                MultiplayerClient.TransferHost(2);
             });
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddStep("make user host", () => Client.TransferHost(Client.Room?.Users[0].UserID ?? 0));
+            AddStep("make user host", () => MultiplayerClient.TransferHost(MultiplayerClient.Room?.Users[0].UserID ?? 0));
 
             verifyGameplayStartFlow();
         }
@@ -159,17 +159,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("setup", () =>
             {
-                Client.TransferHost(Client.Room?.Users[0].UserID ?? 0);
-                Client.AddUser(new APIUser { Id = 2, Username = "Another user" });
+                MultiplayerClient.TransferHost(MultiplayerClient.Room?.Users[0].UserID ?? 0);
+                MultiplayerClient.AddUser(new APIUser { Id = 2, Username = "Another user" });
             });
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("user is ready", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Ready);
 
-            AddStep("transfer host", () => Client.TransferHost(Client.Room?.Users[1].UserID ?? 0));
+            AddStep("transfer host", () => MultiplayerClient.TransferHost(MultiplayerClient.Room?.Users[1].UserID ?? 0));
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddUntilStep("user is idle (match not started)", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+            AddUntilStep("user is idle (match not started)", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Idle);
             AddAssert("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
         }
 
@@ -180,42 +180,42 @@ namespace osu.Game.Tests.Visual.Multiplayer
             const int users = 10;
             AddStep("setup", () =>
             {
-                Client.TransferHost(Client.Room?.Users[0].UserID ?? 0);
+                MultiplayerClient.TransferHost(MultiplayerClient.Room?.Users[0].UserID ?? 0);
                 for (int i = 0; i < users; i++)
-                    Client.AddUser(new APIUser { Id = i, Username = "Another user" });
+                    MultiplayerClient.AddUser(new APIUser { Id = i, Username = "Another user" });
             });
 
             if (!isHost)
-                AddStep("transfer host", () => Client.TransferHost(2));
+                AddStep("transfer host", () => MultiplayerClient.TransferHost(2));
 
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
 
             AddRepeatStep("change user ready state", () =>
             {
-                Client.ChangeUserState(RNG.Next(0, users), RNG.NextBool() ? MultiplayerUserState.Ready : MultiplayerUserState.Idle);
+                MultiplayerClient.ChangeUserState(RNG.Next(0, users), RNG.NextBool() ? MultiplayerUserState.Ready : MultiplayerUserState.Idle);
             }, 20);
 
             AddRepeatStep("ready all users", () =>
             {
-                var nextUnready = Client.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Idle);
+                var nextUnready = MultiplayerClient.Room?.Users.FirstOrDefault(c => c.State == MultiplayerUserState.Idle);
                 if (nextUnready != null)
-                    Client.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Ready);
+                    MultiplayerClient.ChangeUserState(nextUnready.UserID, MultiplayerUserState.Ready);
             }, users);
         }
 
         private void verifyGameplayStartFlow()
         {
-            AddUntilStep("user is ready", () => Client.Room?.Users[0].State == MultiplayerUserState.Ready);
+            AddUntilStep("user is ready", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Ready);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
-            AddUntilStep("user waiting for load", () => Client.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
+            AddUntilStep("user waiting for load", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
 
             AddAssert("ready button disabled", () => !button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
             AddStep("transitioned to gameplay", () => readyClickOperation.Dispose());
 
             AddStep("finish gameplay", () =>
             {
-                Client.ChangeUserState(Client.Room?.Users[0].UserID ?? 0, MultiplayerUserState.Loaded);
-                Client.ChangeUserState(Client.Room?.Users[0].UserID ?? 0, MultiplayerUserState.FinishedPlay);
+                MultiplayerClient.ChangeUserState(MultiplayerClient.Room?.Users[0].UserID ?? 0, MultiplayerUserState.Loaded);
+                MultiplayerClient.ChangeUserState(MultiplayerClient.Room?.Users[0].UserID ?? 0, MultiplayerUserState.FinishedPlay);
             });
 
             AddUntilStep("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                             Task.Run(async () =>
                             {
-                                await Client.ToggleSpectate();
+                                await MultiplayerClient.ToggleSpectate();
                                 readyClickOperation.Dispose();
                             });
                         }
@@ -94,13 +94,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                             Task.Run(async () =>
                             {
-                                if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                                if (MultiplayerClient.IsHost && MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready)
                                 {
-                                    await Client.StartMatch();
+                                    await MultiplayerClient.StartMatch();
                                     return;
                                 }
 
-                                await Client.ToggleReady();
+                                await MultiplayerClient.ToggleReady();
 
                                 readyClickOperation.Dispose();
                             });
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [TestCase(MultiplayerRoomState.Playing)]
         public void TestEnabledWhenRoomOpenOrInGameplay(MultiplayerRoomState roomState)
         {
-            AddStep($"change room to {roomState}", () => Client.ChangeRoomState(roomState));
+            AddStep($"change room to {roomState}", () => MultiplayerClient.ChangeRoomState(roomState));
             assertSpectateButtonEnablement(true);
         }
 
@@ -124,16 +124,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestToggleWhenIdle(MultiplayerUserState initialState)
         {
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
-            AddUntilStep("user is spectating", () => Client.Room?.Users[0].State == MultiplayerUserState.Spectating);
+            AddUntilStep("user is spectating", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Spectating);
 
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
-            AddUntilStep("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+            AddUntilStep("user is idle", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Idle);
         }
 
         [TestCase(MultiplayerRoomState.Closed)]
         public void TestDisabledWhenClosed(MultiplayerRoomState roomState)
         {
-            AddStep($"change room to {roomState}", () => Client.ChangeRoomState(roomState));
+            AddStep($"change room to {roomState}", () => MultiplayerClient.ChangeRoomState(roomState));
             assertSpectateButtonEnablement(false);
         }
 
@@ -147,8 +147,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestReadyButtonEnabledWhenHostAndUsersReady()
         {
-            AddStep("add user", () => Client.AddUser(new APIUser { Id = PLAYER_1_ID }));
-            AddStep("set user ready", () => Client.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready));
+            AddStep("add user", () => MultiplayerClient.AddUser(new APIUser { Id = PLAYER_1_ID }));
+            AddStep("set user ready", () => MultiplayerClient.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready));
 
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             assertReadyButtonEnablement(true);
@@ -159,11 +159,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add user and transfer host", () =>
             {
-                Client.AddUser(new APIUser { Id = PLAYER_1_ID });
-                Client.TransferHost(PLAYER_1_ID);
+                MultiplayerClient.AddUser(new APIUser { Id = PLAYER_1_ID });
+                MultiplayerClient.TransferHost(PLAYER_1_ID);
             });
 
-            AddStep("set user ready", () => Client.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready));
+            AddStep("set user ready", () => MultiplayerClient.ChangeUserState(PLAYER_1_ID, MultiplayerUserState.Ready));
 
             ClickButtonWhenEnabled<MultiplayerSpectateButton>();
             assertReadyButtonEnablement(false);

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
@@ -4,13 +4,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
-using osu.Game.Database;
 using osu.Game.Graphics.Containers;
 using osu.Game.Models;
 using osu.Game.Online.API;
@@ -20,17 +18,15 @@ using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual.OnlinePlay;
 using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    public class TestScenePlaylistsRoomSettingsPlaylist : OsuManualInputManagerTestScene
+    public class TestScenePlaylistsRoomSettingsPlaylist : OnlinePlayTestScene
     {
         private TestPlaylist playlist;
-
-        [Cached(typeof(UserLookupCache))]
-        private readonly TestUserLookupCache userLookupCache = new TestUserLookupCache();
 
         [Test]
         public void TestItemRemovedOnDeletion()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRankRangePill.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRankRangePill.cs
@@ -25,14 +25,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add user", () =>
             {
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 2,
                     Statistics = { GlobalRank = 1234 }
                 });
 
                 // Remove the local user so only the one above is displayed.
-                Client.RemoveUser(API.LocalUser.Value);
+                MultiplayerClient.RemoveUser(API.LocalUser.Value);
             });
         }
 
@@ -41,26 +41,26 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add users", () =>
             {
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 2,
                     Statistics = { GlobalRank = 1234 }
                 });
 
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 3,
                     Statistics = { GlobalRank = 3333 }
                 });
 
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 4,
                     Statistics = { GlobalRank = 4321 }
                 });
 
                 // Remove the local user so only the ones above are displayed.
-                Client.RemoveUser(API.LocalUser.Value);
+                MultiplayerClient.RemoveUser(API.LocalUser.Value);
             });
         }
 
@@ -75,20 +75,20 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add users", () =>
             {
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 2,
                     Statistics = { GlobalRank = min }
                 });
 
-                Client.AddUser(new APIUser
+                MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 3,
                     Statistics = { GlobalRank = max }
                 });
 
                 // Remove the local user so only the ones above are displayed.
-                Client.RemoveUser(API.LocalUser.Value);
+                MultiplayerClient.RemoveUser(API.LocalUser.Value);
             });
         }
     }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private TestMultiplayerComponents multiplayerComponents;
 
-        private TestMultiplayerClient client => multiplayerComponents.Client;
+        private TestMultiplayerClient multiplayerClient => multiplayerComponents.MultiplayerClient;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -75,8 +75,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddUntilStep("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
-            AddAssert("user state arrived", () => client.Room?.Users.FirstOrDefault()?.MatchState is TeamVersusUserState);
+            AddUntilStep("room type is team vs", () => multiplayerClient.Room?.Settings.MatchType == MatchType.TeamVersus);
+            AddAssert("user state arrived", () => multiplayerClient.Room?.Users.FirstOrDefault()?.MatchState is TeamVersusUserState);
         }
 
         [Test]
@@ -96,25 +96,25 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddAssert("user on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
-            AddStep("add another user", () => client.AddUser(new APIUser { Username = "otheruser", Id = 44 }));
+            AddAssert("user on team 0", () => (multiplayerClient.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
+            AddStep("add another user", () => multiplayerClient.AddUser(new APIUser { Username = "otheruser", Id = 44 }));
 
             AddStep("press own button", () =>
             {
                 InputManager.MoveMouseTo(multiplayerComponents.ChildrenOfType<TeamDisplay>().First());
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("user on team 1", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 1);
+            AddAssert("user on team 1", () => (multiplayerClient.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 1);
 
             AddStep("press own button again", () => InputManager.Click(MouseButton.Left));
-            AddAssert("user on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
+            AddAssert("user on team 0", () => (multiplayerClient.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
 
             AddStep("press other user's button", () =>
             {
                 InputManager.MoveMouseTo(multiplayerComponents.ChildrenOfType<TeamDisplay>().ElementAt(1));
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("user still on team 0", () => (client.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
+            AddAssert("user still on team 0", () => (multiplayerClient.Room?.Users.FirstOrDefault()?.MatchState as TeamVersusUserState)?.TeamID == 0);
         }
 
         [Test]
@@ -134,14 +134,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddUntilStep("match type head to head", () => client.APIRoom?.Type.Value == MatchType.HeadToHead);
+            AddUntilStep("match type head to head", () => multiplayerClient.APIRoom?.Type.Value == MatchType.HeadToHead);
 
-            AddStep("change match type", () => client.ChangeSettings(new MultiplayerRoomSettings
+            AddStep("change match type", () => multiplayerClient.ChangeSettings(new MultiplayerRoomSettings
             {
                 MatchType = MatchType.TeamVersus
             }).WaitSafely());
 
-            AddUntilStep("api room updated to team versus", () => client.APIRoom?.Type.Value == MatchType.TeamVersus);
+            AddUntilStep("api room updated to team versus", () => multiplayerClient.APIRoom?.Type.Value == MatchType.TeamVersus);
         }
 
         [Test]
@@ -160,13 +160,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 }
             });
 
-            AddUntilStep("room type is head to head", () => client.Room?.Settings.MatchType == MatchType.HeadToHead);
+            AddUntilStep("room type is head to head", () => multiplayerClient.Room?.Settings.MatchType == MatchType.HeadToHead);
 
             AddUntilStep("team displays are not displaying teams", () => multiplayerComponents.ChildrenOfType<TeamDisplay>().All(d => d.DisplayedTeam == null));
 
-            AddStep("change to team vs", () => client.ChangeSettings(matchType: MatchType.TeamVersus));
+            AddStep("change to team vs", () => multiplayerClient.ChangeSettings(matchType: MatchType.TeamVersus));
 
-            AddUntilStep("room type is team vs", () => client.Room?.Settings.MatchType == MatchType.TeamVersus);
+            AddUntilStep("room type is team vs", () => multiplayerClient.Room?.Settings.MatchType == MatchType.TeamVersus);
 
             AddUntilStep("team displays are displaying teams", () => multiplayerComponents.ChildrenOfType<TeamDisplay>().All(d => d.DisplayedTeam != null));
         }
@@ -185,7 +185,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddUntilStep("wait for join", () => client.RoomJoined);
+            AddUntilStep("wait for join", () => multiplayerClient.RoomJoined);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -10,7 +10,6 @@ using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
@@ -35,9 +34,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private TestMultiplayerComponents multiplayerComponents;
 
         private TestMultiplayerClient client => multiplayerComponents.Client;
-
-        [Cached(typeof(UserLookupCache))]
-        private UserLookupCache lookupCache = new TestUserLookupCache();
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)

--- a/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
+++ b/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
+using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens;
@@ -39,6 +40,12 @@ namespace osu.Game.Tests.Visual
         [Cached(typeof(MultiplayerClient))]
         public readonly TestMultiplayerClient Client;
 
+        [Cached(typeof(UserLookupCache))]
+        private readonly UserLookupCache userLookupCache = new TestUserLookupCache();
+
+        [Cached]
+        private readonly BeatmapLookupCache beatmapLookupCache = new BeatmapLookupCache();
+
         private readonly OsuScreenStack screenStack;
         private readonly TestMultiplayer multiplayerScreen;
 
@@ -48,6 +55,8 @@ namespace osu.Game.Tests.Visual
 
             InternalChildren = new Drawable[]
             {
+                userLookupCache,
+                beatmapLookupCache,
                 Client = new TestMultiplayerClient(RoomManager),
                 screenStack = new OsuScreenStack
                 {

--- a/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
+++ b/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual
         public new bool IsLoaded => base.IsLoaded && MultiplayerScreen.IsLoaded;
 
         [Cached(typeof(MultiplayerClient))]
-        public readonly TestMultiplayerClient Client;
+        public readonly TestMultiplayerClient MultiplayerClient;
 
         [Cached(typeof(UserLookupCache))]
         private readonly UserLookupCache userLookupCache = new TestUserLookupCache();
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual
             {
                 userLookupCache,
                 beatmapLookupCache,
-                Client = new TestMultiplayerClient(RoomManager),
+                MultiplayerClient = new TestMultiplayerClient(RoomManager),
                 screenStack = new OsuScreenStack
                 {
                     Name = nameof(TestMultiplayerComponents),

--- a/osu.Game/Tests/Visual/Multiplayer/IMultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/IMultiplayerTestSceneDependencies.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Database;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Tests.Visual.OnlinePlay;
@@ -23,11 +22,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         /// The cached <see cref="IRoomManager"/>.
         /// </summary>
         new TestMultiplayerRoomManager RoomManager { get; }
-
-        /// <summary>
-        /// The cached <see cref="UserLookupCache"/>.
-        /// </summary>
-        TestUserLookupCache LookupCache { get; }
 
         /// <summary>
         /// The cached <see cref="osu.Game.Online.Spectator.SpectatorClient"/>.

--- a/osu.Game/Tests/Visual/Multiplayer/IMultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/IMultiplayerTestSceneDependencies.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Tests.Visual.OnlinePlay;
 using osu.Game.Tests.Visual.Spectator;
@@ -14,9 +13,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public interface IMultiplayerTestSceneDependencies : IOnlinePlayTestSceneDependencies
     {
         /// <summary>
-        /// The cached <see cref="MultiplayerClient"/>.
+        /// The cached <see cref="Online.Multiplayer.MultiplayerClient"/>.
         /// </summary>
-        TestMultiplayerClient Client { get; }
+        TestMultiplayerClient MultiplayerClient { get; }
 
         /// <summary>
         /// The cached <see cref="IRoomManager"/>.

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -17,13 +17,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public const int PLAYER_1_ID = 55;
         public const int PLAYER_2_ID = 56;
 
-        public TestMultiplayerClient Client => OnlinePlayDependencies.Client;
+        public TestMultiplayerClient MultiplayerClient => OnlinePlayDependencies.MultiplayerClient;
         public new TestMultiplayerRoomManager RoomManager => OnlinePlayDependencies.RoomManager;
         public TestSpectatorClient SpectatorClient => OnlinePlayDependencies?.SpectatorClient;
 
         protected new MultiplayerTestSceneDependencies OnlinePlayDependencies => (MultiplayerTestSceneDependencies)base.OnlinePlayDependencies;
 
-        public bool RoomJoined => Client.RoomJoined;
+        public bool RoomJoined => MultiplayerClient.RoomJoined;
 
         private readonly bool joinRoom;
 

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public TestMultiplayerClient Client => OnlinePlayDependencies.Client;
         public new TestMultiplayerRoomManager RoomManager => OnlinePlayDependencies.RoomManager;
-        public TestUserLookupCache LookupCache => OnlinePlayDependencies?.LookupCache;
         public TestSpectatorClient SpectatorClient => OnlinePlayDependencies?.SpectatorClient;
 
         protected new MultiplayerTestSceneDependencies OnlinePlayDependencies => (MultiplayerTestSceneDependencies)base.OnlinePlayDependencies;

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
@@ -14,16 +14,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
     /// </summary>
     public class MultiplayerTestSceneDependencies : OnlinePlayTestSceneDependencies, IMultiplayerTestSceneDependencies
     {
-        public TestMultiplayerClient Client { get; }
+        public TestMultiplayerClient MultiplayerClient { get; }
         public TestSpectatorClient SpectatorClient { get; }
         public new TestMultiplayerRoomManager RoomManager => (TestMultiplayerRoomManager)base.RoomManager;
 
         public MultiplayerTestSceneDependencies()
         {
-            Client = new TestMultiplayerClient(RoomManager);
+            MultiplayerClient = new TestMultiplayerClient(RoomManager);
             SpectatorClient = CreateSpectatorClient();
 
-            CacheAs<MultiplayerClient>(Client);
+            CacheAs<MultiplayerClient>(MultiplayerClient);
             CacheAs<SpectatorClient>(SpectatorClient);
         }
 

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestSceneDependencies.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Database;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Spectator;
 using osu.Game.Screens.OnlinePlay;
@@ -16,18 +15,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public class MultiplayerTestSceneDependencies : OnlinePlayTestSceneDependencies, IMultiplayerTestSceneDependencies
     {
         public TestMultiplayerClient Client { get; }
-        public TestUserLookupCache LookupCache { get; }
         public TestSpectatorClient SpectatorClient { get; }
         public new TestMultiplayerRoomManager RoomManager => (TestMultiplayerRoomManager)base.RoomManager;
 
         public MultiplayerTestSceneDependencies()
         {
             Client = new TestMultiplayerClient(RoomManager);
-            LookupCache = new TestUserLookupCache();
             SpectatorClient = CreateSpectatorClient();
 
             CacheAs<MultiplayerClient>(Client);
-            CacheAs<UserLookupCache>(LookupCache);
             CacheAs<SpectatorClient>(SpectatorClient);
         }
 

--- a/osu.Game/Tests/Visual/OnlinePlay/IOnlinePlayTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/IOnlinePlayTestSceneDependencies.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay;
 
@@ -36,5 +37,10 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         /// The cached <see cref="UserLookupCache"/>.
         /// </summary>
         TestUserLookupCache UserLookupCache { get; }
+
+        /// <summary>
+        /// The cached <see cref="BeatmapLookupCache"/>.
+        /// </summary>
+        BeatmapLookupCache BeatmapLookupCache { get; }
     }
 }

--- a/osu.Game/Tests/Visual/OnlinePlay/IOnlinePlayTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/IOnlinePlayTestSceneDependencies.cs
@@ -31,5 +31,10 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         /// The cached <see cref="OnlinePlayBeatmapAvailabilityTracker"/>.
         /// </summary>
         OnlinePlayBeatmapAvailabilityTracker AvailabilityTracker { get; }
+
+        /// <summary>
+        /// The cached <see cref="UserLookupCache"/>.
+        /// </summary>
+        TestUserLookupCache UserLookupCache { get; }
     }
 }

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public IRoomManager RoomManager => OnlinePlayDependencies?.RoomManager;
         public OngoingOperationTracker OngoingOperationTracker => OnlinePlayDependencies?.OngoingOperationTracker;
         public OnlinePlayBeatmapAvailabilityTracker AvailabilityTracker => OnlinePlayDependencies?.AvailabilityTracker;
+        public TestUserLookupCache UserLookupCache => OnlinePlayDependencies?.UserLookupCache;
 
         /// <summary>
         /// All dependencies required for online play components and screens.

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay;
@@ -23,6 +24,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public OngoingOperationTracker OngoingOperationTracker => OnlinePlayDependencies?.OngoingOperationTracker;
         public OnlinePlayBeatmapAvailabilityTracker AvailabilityTracker => OnlinePlayDependencies?.AvailabilityTracker;
         public TestUserLookupCache UserLookupCache => OnlinePlayDependencies?.UserLookupCache;
+        public BeatmapLookupCache BeatmapLookupCache => OnlinePlayDependencies?.BeatmapLookupCache;
 
         /// <summary>
         /// All dependencies required for online play components and screens.

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             });
         }
 
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        protected sealed override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             dependencies = new DelegatedDependencyContainer(base.CreateChildDependencies(parent));
             return dependencies;

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay;
@@ -22,6 +23,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public OngoingOperationTracker OngoingOperationTracker { get; }
         public OnlinePlayBeatmapAvailabilityTracker AvailabilityTracker { get; }
         public TestRoomRequestsHandler RequestsHandler { get; }
+        public TestUserLookupCache UserLookupCache { get; }
 
         /// <summary>
         /// All cached dependencies which are also <see cref="Drawable"/> components.
@@ -38,6 +40,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             OngoingOperationTracker = new OngoingOperationTracker();
             AvailabilityTracker = new OnlinePlayBeatmapAvailabilityTracker();
             RoomManager = CreateRoomManager();
+            UserLookupCache = new TestUserLookupCache();
 
             dependencies = new DependencyContainer(new CachedModelDependencyContainer<Room>(null) { Model = { BindTarget = SelectedRoom } });
 
@@ -47,6 +50,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             CacheAs(OngoingOperationTracker);
             CacheAs(AvailabilityTracker);
             CacheAs(new OverlayColourProvider(OverlayColourScheme.Plum));
+            CacheAs<UserLookupCache>(UserLookupCache);
         }
 
         public object Get(Type type)

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestSceneDependencies.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         public OnlinePlayBeatmapAvailabilityTracker AvailabilityTracker { get; }
         public TestRoomRequestsHandler RequestsHandler { get; }
         public TestUserLookupCache UserLookupCache { get; }
+        public BeatmapLookupCache BeatmapLookupCache { get; }
 
         /// <summary>
         /// All cached dependencies which are also <see cref="Drawable"/> components.
@@ -41,6 +42,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             AvailabilityTracker = new OnlinePlayBeatmapAvailabilityTracker();
             RoomManager = CreateRoomManager();
             UserLookupCache = new TestUserLookupCache();
+            BeatmapLookupCache = new BeatmapLookupCache();
 
             dependencies = new DependencyContainer(new CachedModelDependencyContainer<Room>(null) { Model = { BindTarget = SelectedRoom } });
 
@@ -51,6 +53,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             CacheAs(AvailabilityTracker);
             CacheAs(new OverlayColourProvider(OverlayColourScheme.Plum));
             CacheAs<UserLookupCache>(UserLookupCache);
+            CacheAs(BeatmapLookupCache);
         }
 
         public object Get(Type type)


### PR DESCRIPTION
In my multiplayer refactorings, I wanted to add a `BeatmapLookupCache` following the same structure as the `UserLookupCache`. As it turns out, the way the `UserLookupCache` was cached was already incorrect because these are `Component`s and need to be part of the hierarchy otherwise they don't receive an `IAPIProvider`:
https://github.com/ppy/osu/blob/9b7cc632c035b1734278d1141194f3b8b666150d/osu.Game/Database/OnlineLookupCache.cs#L21-L22

For `TestUserLookupCache`, this isn't a huge issue because it overrides the whole computation anyway, but it seems unsafe to let this go.

I've also added a `BeatmapLookupCache` alongside, which isn't immediately necessary however I felt it in good practice to bundle it here as there are components that resolve a `BeatmapLookupCache` to use as a fallback, that would otherwise forward requests to `dev.ppy.sh` as a result of DIing the game-wide lookup cache instead.

One such component is `DrawableRoomPlaylistItem`, however note that in this case the fallback path is never actually taken since a `MultiplayerClient` is always resolved in - the game-wide one in Playlists tests, which resolves in the game-wide lookup cache and experiences the same issue. This is pretty messy but my further refactorings have removed this code and always go via the `BeatmapLookupCache` fallback path, which is why this change is necessary at some point.
https://github.com/ppy/osu/blob/9b7cc632c035b1734278d1141194f3b8b666150d/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs#L171-L180