### PR TITLE
Remove beatmap bindable from PlaylistItem

### DIFF
--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -86,9 +86,8 @@ namespace osu.Game.Tests.Online
             Realm.Write(r => r.RemoveAll<BeatmapSetInfo>());
             Realm.Write(r => r.RemoveAll<BeatmapInfo>());
 
-            selectedItem.Value = new PlaylistItem
+            selectedItem.Value = new PlaylistItem(testBeatmapInfo)
             {
-                Beatmap = { Value = testBeatmapInfo },
                 RulesetID = testBeatmapInfo.Ruleset.OnlineID,
             };
 

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -12,6 +13,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Graphics;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -21,6 +23,8 @@ using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Tests.Resources;
@@ -53,6 +57,25 @@ namespace osu.Game.Tests.Online
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
+            ((DummyAPIAccess)API).HandleRequest = req =>
+            {
+                switch (req)
+                {
+                    case GetBeatmapsRequest beatmapsReq:
+                        var beatmap = CreateAPIBeatmap();
+                        beatmap.OnlineID = testBeatmapInfo.OnlineID;
+                        beatmap.OnlineBeatmapSetID = testBeatmapSet.OnlineID;
+                        beatmap.Checksum = testBeatmapInfo.MD5Hash;
+                        beatmap.BeatmapSet!.OnlineID = testBeatmapSet.OnlineID;
+
+                        beatmapsReq.TriggerSuccess(new GetBeatmapsResponse { Beatmaps = new List<APIBeatmap> { beatmap } });
+                        return true;
+
+                    default:
+                        return false;
+                }
+            };
+
             beatmaps.AllowImport = new TaskCompletionSource<bool>();
 
             testBeatmapFile = TestResources.GetQuickTestBeatmapForImport();
@@ -69,11 +92,29 @@ namespace osu.Game.Tests.Online
                 RulesetID = testBeatmapInfo.Ruleset.OnlineID,
             };
 
-            Child = availabilityTracker = new OnlinePlayBeatmapAvailabilityTracker
-            {
-                SelectedItem = { BindTarget = selectedItem, }
-            };
+            recreateChildren();
         });
+
+        private void recreateChildren()
+        {
+            var beatmapLookupCache = new BeatmapLookupCache();
+
+            Child = new DependencyProvidingContainer
+            {
+                CachedDependencies = new[]
+                {
+                    (typeof(BeatmapLookupCache), (object)beatmapLookupCache)
+                },
+                Children = new Drawable[]
+                {
+                    beatmapLookupCache,
+                    availabilityTracker = new OnlinePlayBeatmapAvailabilityTracker
+                    {
+                        SelectedItem = { BindTarget = selectedItem, }
+                    }
+                }
+            };
+        }
 
         [Test]
         public void TestBeatmapDownloadingFlow()
@@ -123,10 +164,7 @@ namespace osu.Game.Tests.Online
             });
             addAvailabilityCheckStep("state not downloaded", BeatmapAvailability.NotDownloaded);
 
-            AddStep("recreate tracker", () => Child = availabilityTracker = new OnlinePlayBeatmapAvailabilityTracker
-            {
-                SelectedItem = { BindTarget = selectedItem }
-            });
+            AddStep("recreate tracker", recreateChildren);
             addAvailabilityCheckStep("state not downloaded as well", BeatmapAvailability.NotDownloaded);
 
             AddStep("reimport original beatmap", () => beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely());
@@ -167,7 +205,8 @@ namespace osu.Game.Tests.Online
 
             public Live<BeatmapSetInfo> CurrentImport { get; private set; }
 
-            public TestBeatmapManager(Storage storage, RealmAccess realm, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources, GameHost host = null, WorkingBeatmap defaultBeatmap = null)
+            public TestBeatmapManager(Storage storage, RealmAccess realm, RulesetStore rulesets, IAPIProvider api, [NotNull] AudioManager audioManager, IResourceStore<byte[]> resources,
+                                      GameHost host = null, WorkingBeatmap defaultBeatmap = null)
                 : base(storage, realm, rulesets, api, audioManager, resources, host, defaultBeatmap)
             {
             }

--- a/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
+++ b/osu.Game.Tests/OnlinePlay/PlaylistExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NUnit.Framework;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 
 namespace osu.Game.Tests.OnlinePlay
@@ -29,9 +30,9 @@ namespace osu.Game.Tests.OnlinePlay
         {
             var items = new[]
             {
-                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1 },
-                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2 },
-                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1001 }) { ID = 1, PlaylistOrder = 1 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1002 }) { ID = 2, PlaylistOrder = 2 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1003 }) { ID = 3, PlaylistOrder = 3 },
             };
 
             Assert.Multiple(() =>
@@ -47,9 +48,9 @@ namespace osu.Game.Tests.OnlinePlay
         {
             var items = new[]
             {
-                new PlaylistItem { ID = 2, BeatmapID = 1002, PlaylistOrder = 2 },
-                new PlaylistItem { ID = 1, BeatmapID = 1001, PlaylistOrder = 1 },
-                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1002 }) { ID = 2, PlaylistOrder = 2 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1001 }) { ID = 1, PlaylistOrder = 1 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1003 }) { ID = 3, PlaylistOrder = 3 },
             };
 
             Assert.Multiple(() =>
@@ -65,9 +66,9 @@ namespace osu.Game.Tests.OnlinePlay
         {
             var items = new[]
             {
-                new PlaylistItem { ID = 1, BeatmapID = 1001, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 55, 0, TimeSpan.Zero) },
-                new PlaylistItem { ID = 2, BeatmapID = 1002, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 53, 0, TimeSpan.Zero) },
-                new PlaylistItem { ID = 3, BeatmapID = 1003, PlaylistOrder = 3 },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1001 }) { ID = 1, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 55, 0, TimeSpan.Zero) },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1002 }) { ID = 2, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 53, 0, TimeSpan.Zero) },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1003 }) { ID = 3, PlaylistOrder = 3 },
             };
 
             Assert.Multiple(() =>
@@ -83,9 +84,9 @@ namespace osu.Game.Tests.OnlinePlay
         {
             var items = new[]
             {
-                new PlaylistItem { ID = 1, BeatmapID = 1001, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 55, 0, TimeSpan.Zero) },
-                new PlaylistItem { ID = 2, BeatmapID = 1002, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 53, 0, TimeSpan.Zero) },
-                new PlaylistItem { ID = 3, BeatmapID = 1002, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 57, 0, TimeSpan.Zero) },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1001 }) { ID = 1, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 55, 0, TimeSpan.Zero) },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1002 }) { ID = 2, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 53, 0, TimeSpan.Zero) },
+                new PlaylistItem(new APIBeatmap { OnlineID = 1002 }) { ID = 3, Expired = true, PlayedAt = new DateTimeOffset(2021, 12, 21, 7, 57, 0, TimeSpan.Zero) },
             };
 
             Assert.Multiple(() =>

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -71,9 +71,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 QueueMode = { Value = Mode },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(InitialBeatmap)
                     {
-                        Beatmap = { Value = InitialBeatmap },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
@@ -53,19 +53,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                             Type = { Value = MatchType.HeadToHead },
                             Playlist =
                             {
-                                new PlaylistItem
+                                new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo)
                                 {
-                                    Beatmap =
+                                    BeatmapInfo =
                                     {
-                                        Value = new TestBeatmap(new OsuRuleset().RulesetInfo)
-                                        {
-                                            BeatmapInfo =
-                                            {
-                                                StarRating = 2.5
-                                            }
-                                        }.BeatmapInfo,
+                                        StarRating = 2.5
                                     }
-                                }
+                                }.BeatmapInfo)
                             }
                         }),
                         createLoungeRoom(new Room
@@ -76,26 +70,20 @@ namespace osu.Game.Tests.Visual.Multiplayer
                             Type = { Value = MatchType.HeadToHead },
                             Playlist =
                             {
-                                new PlaylistItem
+                                new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo)
                                 {
-                                    Beatmap =
+                                    BeatmapInfo =
                                     {
-                                        Value = new TestBeatmap(new OsuRuleset().RulesetInfo)
+                                        StarRating = 2.5,
+                                        Metadata =
                                         {
-                                            BeatmapInfo =
-                                            {
-                                                StarRating = 2.5,
-                                                Metadata =
-                                                {
-                                                    Artist = "very very very very very very very very very long artist",
-                                                    ArtistUnicode = "very very very very very very very very very long artist",
-                                                    Title = "very very very very very very very very very very very long title",
-                                                    TitleUnicode = "very very very very very very very very very very very long title",
-                                                }
-                                            }
-                                        }.BeatmapInfo,
+                                            Artist = "very very very very very very very very very long artist",
+                                            ArtistUnicode = "very very very very very very very very very long artist",
+                                            Title = "very very very very very very very very very very very long title",
+                                            TitleUnicode = "very very very very very very very very very very very long title",
+                                        }
                                     }
-                                }
+                                }.BeatmapInfo)
                             }
                         }),
                         createLoungeRoom(new Room
@@ -105,32 +93,20 @@ namespace osu.Game.Tests.Visual.Multiplayer
                             EndDate = { Value = DateTimeOffset.Now.AddDays(1) },
                             Playlist =
                             {
-                                new PlaylistItem
+                                new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo)
                                 {
-                                    Beatmap =
+                                    BeatmapInfo =
                                     {
-                                        Value = new TestBeatmap(new OsuRuleset().RulesetInfo)
-                                        {
-                                            BeatmapInfo =
-                                            {
-                                                StarRating = 2.5
-                                            }
-                                        }.BeatmapInfo,
+                                        StarRating = 2.5
                                     }
-                                },
-                                new PlaylistItem
+                                }.BeatmapInfo),
+                                new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo)
                                 {
-                                    Beatmap =
+                                    BeatmapInfo =
                                     {
-                                        Value = new TestBeatmap(new OsuRuleset().RulesetInfo)
-                                        {
-                                            BeatmapInfo =
-                                            {
-                                                StarRating = 4.5
-                                            }
-                                        }.BeatmapInfo,
+                                        StarRating = 4.5
                                     }
-                                }
+                                }.BeatmapInfo)
                             }
                         }),
                         createLoungeRoom(new Room

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             assertDownloadButtonVisible(false);
 
             void assertDownloadButtonVisible(bool visible) => AddUntilStep($"download button {(visible ? "shown" : "hidden")}",
-                () => playlist.ChildrenOfType<BeatmapDownloadButton>().Single().Alpha == (visible ? 1 : 0));
+                () => playlist.ChildrenOfType<BeatmapDownloadButton>().SingleOrDefault()?.Alpha == (visible ? 1 : 0));
         }
 
         [Test]
@@ -260,7 +260,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         private void moveToItem(int index, Vector2? offset = null)
-            => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<DifficultyIcon>().ElementAt(index), offset));
+            => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<DrawableRoomPlaylistItem>().ElementAt(index), offset));
 
         private void moveToDragger(int index, Vector2? offset = null) => AddStep($"move mouse to dragger {index}", () =>
         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -209,10 +209,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Size = new Vector2(500, 300),
                     Items =
                     {
-                        new PlaylistItem
+                        new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                         {
                             ID = 0,
-                            Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                             RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                             Expired = true,
                             RequiredMods = new[]
@@ -222,10 +221,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                                 new APIMod(new OsuModAutoplay())
                             }
                         },
-                        new PlaylistItem
+                        new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                         {
                             ID = 1,
-                            Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                             RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                             RequiredMods = new[]
                             {
@@ -293,25 +291,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 for (int i = 0; i < 20; i++)
                 {
-                    playlist.Items.Add(new PlaylistItem
+                    playlist.Items.Add(new PlaylistItem(i % 2 == 1
+                        ? new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo
+                        : new BeatmapInfo
+                        {
+                            Metadata = new BeatmapMetadata
+                            {
+                                Artist = "Artist",
+                                Author = new RealmUser { Username = "Creator name here" },
+                                Title = "Long title used to check background colour",
+                            },
+                            BeatmapSet = new BeatmapSetInfo()
+                        })
                     {
                         ID = i,
                         OwnerID = 2,
-                        Beatmap =
-                        {
-                            Value = i % 2 == 1
-                                ? new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo
-                                : new BeatmapInfo
-                                {
-                                    Metadata = new BeatmapMetadata
-                                    {
-                                        Artist = "Artist",
-                                        Author = new RealmUser { Username = "Creator name here" },
-                                        Title = "Long title used to check background colour",
-                                    },
-                                    BeatmapSet = new BeatmapSetInfo()
-                                }
-                        },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                         RequiredMods = new[]
                         {
@@ -341,11 +335,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 foreach (var b in beatmaps())
                 {
-                    playlist.Items.Add(new PlaylistItem
+                    playlist.Items.Add(new PlaylistItem(b)
                     {
                         ID = index++,
                         OwnerID = 2,
-                        Beatmap = { Value = b },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                         RequiredMods = new[]
                         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -57,12 +57,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             RunGameplay();
 
             IBeatmapInfo firstBeatmap = null;
-            AddStep("get first playlist item beatmap", () => firstBeatmap = Client.APIRoom?.Playlist[0].Beatmap.Value);
+            AddStep("get first playlist item beatmap", () => firstBeatmap = Client.APIRoom?.Playlist[0].Beatmap);
 
             selectNewItem(() => OtherBeatmap);
 
-            AddAssert("first playlist item hasn't changed", () => Client.APIRoom?.Playlist[0].Beatmap.Value == firstBeatmap);
-            AddAssert("second playlist item changed", () => Client.APIRoom?.Playlist[1].Beatmap.Value != firstBeatmap);
+            AddAssert("first playlist item hasn't changed", () => Client.APIRoom?.Playlist[0].Beatmap == firstBeatmap);
+            AddAssert("second playlist item changed", () => Client.APIRoom?.Playlist[1].Beatmap != firstBeatmap);
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(otherBeatmap = beatmap()));
 
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
-            AddUntilStep("selected item is new beatmap", () => (CurrentSubScreen as MultiplayerMatchSubScreen)?.SelectedItem.Value?.BeatmapID == otherBeatmap.OnlineID);
+            AddUntilStep("selected item is new beatmap", () => (CurrentSubScreen as MultiplayerMatchSubScreen)?.SelectedItem.Value?.Beatmap.OnlineID == otherBeatmap.OnlineID);
         }
 
         private void addItem(Func<BeatmapInfo> beatmap)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchBeatmapDetailArea.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchBeatmapDetailArea.cs
@@ -32,10 +32,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void createNewItem()
         {
-            SelectedRoom.Value.Playlist.Add(new PlaylistItem
+            SelectedRoom.Value.Playlist.Add(new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
             {
                 ID = SelectedRoom.Value.Playlist.Count,
-                Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                 RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                 RequiredMods = new[]
                 {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -93,9 +93,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -229,9 +228,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -251,9 +249,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Name = { Value = "Test Room" },
                     Playlist =
                     {
-                        new PlaylistItem
+                        new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                         {
-                            Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                             RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                         }
                     }
@@ -281,9 +278,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Name = { Value = "Test Room" },
                     Playlist =
                     {
-                        new PlaylistItem
+                        new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                         {
-                            Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                             RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                         }
                     }
@@ -312,9 +308,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Password = { Value = "password" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -334,9 +329,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Password = { Value = "password" },
                     Playlist =
                     {
-                        new PlaylistItem
+                        new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                         {
-                            Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                             RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                         }
                     }
@@ -367,9 +361,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Password = { Value = "password" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -387,9 +380,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -409,9 +401,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -448,9 +439,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -487,9 +477,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -526,9 +515,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -560,9 +548,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -600,9 +587,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -620,9 +606,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                         AllowedMods = new[] { new APIMod(new OsuModHidden()) }
                     }
@@ -660,10 +645,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });
@@ -691,10 +675,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     QueueMode = { Value = QueueMode.AllPlayers },
                     Playlist =
                     {
-                        new PlaylistItem
+                        new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                         {
-                            Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                            RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                            RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                         }
                     }
                 }, API.LocalUser.Value);
@@ -708,11 +691,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("change server-side settings", () =>
             {
                 roomManager.ServerSideRooms[0].Name.Value = "New name";
-                roomManager.ServerSideRooms[0].Playlist.Add(new PlaylistItem
+                roomManager.ServerSideRooms[0].Playlist.Add(new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                 {
                     ID = 2,
-                    Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                    RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                    RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                 });
             });
 
@@ -737,10 +719,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 QueueMode = { Value = QueueMode.AllPlayers },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });
@@ -773,10 +754,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 QueueMode = { Value = QueueMode.AllPlayers },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });
@@ -812,10 +792,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 QueueMode = { Value = QueueMode.AllPlayers },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });
@@ -823,10 +802,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             enterGameplay();
 
             AddStep("join other user", () => client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("add item as other user", () => client.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(new PlaylistItem
-            {
-                BeatmapID = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo.OnlineID
-            })));
+            AddStep("add item as other user", () => client.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(
+                new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
+                {
+                    RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                })));
 
             AddUntilStep("item arrived in playlist", () => client.Room?.Playlist.Count == 2);
 
@@ -843,10 +823,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 QueueMode = { Value = QueueMode.AllPlayers },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });
@@ -854,10 +833,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             enterGameplay();
 
             AddStep("join other user", () => client.AddUser(new APIUser { Id = 1234 }));
-            AddStep("add item as other user", () => client.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(new PlaylistItem
-            {
-                BeatmapID = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo.OnlineID
-            })));
+            AddStep("add item as other user", () => client.AddUserPlaylistItem(1234, new MultiplayerPlaylistItem(
+                new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
+                {
+                    RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                })));
 
             AddUntilStep("item arrived in playlist", () => client.Room?.Playlist.Count == 2);
 
@@ -876,9 +856,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -73,9 +73,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add playlist item", () =>
             {
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                 {
-                    Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });
@@ -90,9 +89,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add playlist item", () =>
             {
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(new TestBeatmap(new TaikoRuleset().RulesetInfo).BeatmapInfo)
                 {
-                    Beatmap = { Value = new TestBeatmap(new TaikoRuleset().RulesetInfo).BeatmapInfo },
                     RulesetID = new TaikoRuleset().RulesetInfo.OnlineID,
                     AllowedMods = new[] { new APIMod(new TaikoModSwap()) }
                 });
@@ -113,9 +111,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("set playlist", () =>
             {
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                 {
-                    Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });
@@ -128,9 +125,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("set playlist", () =>
             {
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First()).BeatmapInfo)
                 {
-                    Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First()).BeatmapInfo },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });
@@ -159,9 +155,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("add playlist item with allowed mod", () =>
             {
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                 {
-                    Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     AllowedMods = new[] { new APIMod(new OsuModDoubleTime()) }
                 });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -28,9 +28,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("initialise gameplay", () =>
             {
-                Stack.Push(player = new MultiplayerPlayer(Client.APIRoom, new PlaylistItem
+                Stack.Push(player = new MultiplayerPlayer(Client.APIRoom, new PlaylistItem(Beatmap.Value.BeatmapInfo)
                 {
-                    Beatmap = { Value = Beatmap.Value.BeatmapInfo },
                     RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID,
                 }, Client.Room?.Users.ToArray()));
             });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
@@ -143,14 +143,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Name = { Value = "test name" },
                     Playlist =
                     {
-                        new PlaylistItem
+                        new PlaylistItem(new TestBeatmap(Ruleset.Value).BeatmapInfo)
                         {
-                            Beatmap = { Value = new TestBeatmap(Ruleset.Value).BeatmapInfo },
-                            RulesetID = Ruleset.Value.OnlineID,
+                            RulesetID = Ruleset.Value.OnlineID
                         },
-                        new PlaylistItem
+                        new PlaylistItem(new TestBeatmap(Ruleset.Value).BeatmapInfo)
                         {
-                            Beatmap = { Value = new TestBeatmap(Ruleset.Value).BeatmapInfo },
                             RulesetID = Ruleset.Value.OnlineID,
                             Expired = true
                         }
@@ -167,10 +165,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         /// <summary>
         /// Adds a step to create a new playlist item.
         /// </summary>
-        private void addItemStep(bool expired = false) => AddStep("add item", () => Client.AddPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem
+        private void addItemStep(bool expired = false) => AddStep("add item", () => Client.AddPlaylistItem(new MultiplayerPlaylistItem(new PlaylistItem(importedBeatmap)
         {
-            Beatmap = { Value = importedBeatmap },
-            BeatmapID = importedBeatmap.OnlineID,
             Expired = expired,
             PlayedAt = DateTimeOffset.Now
         })));

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -120,11 +120,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("add playlist item", () =>
             {
-                MultiplayerPlaylistItem item = new MultiplayerPlaylistItem(new PlaylistItem
-                {
-                    Beatmap = { Value = importedBeatmap },
-                    BeatmapID = importedBeatmap.OnlineID,
-                });
+                MultiplayerPlaylistItem item = new MultiplayerPlaylistItem(new PlaylistItem(importedBeatmap));
 
                 Client.AddUserPlaylistItem(userId(), item);
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -54,9 +54,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             importedSet = beatmaps.GetAllUsableBeatmapSets().First();
             Beatmap.Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First());
-            selectedItem.Value = new PlaylistItem
+            selectedItem.Value = new PlaylistItem(Beatmap.Value.BeatmapInfo)
             {
-                Beatmap = { Value = Beatmap.Value.BeatmapInfo },
                 RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID
             };
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerResults.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerResults.cs
@@ -22,12 +22,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 var beatmapInfo = CreateBeatmap(rulesetInfo).BeatmapInfo;
                 var score = TestResources.CreateTestScoreInfo(beatmapInfo);
 
-                PlaylistItem playlistItem = new PlaylistItem
-                {
-                    BeatmapID = beatmapInfo.OnlineID,
-                };
-
-                Stack.Push(screen = new MultiplayerResultsScreen(score, 1, playlistItem));
+                Stack.Push(screen = new MultiplayerResultsScreen(score, 1, new PlaylistItem(beatmapInfo)));
             });
 
             AddUntilStep("wait for loaded", () => screen.IsLoaded);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -55,9 +55,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             importedSet = beatmaps.GetAllUsableBeatmapSets().First();
             Beatmap.Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First());
-            selectedItem.Value = new PlaylistItem
+            selectedItem.Value = new PlaylistItem(Beatmap.Value.BeatmapInfo)
             {
-                Beatmap = { Value = Beatmap.Value.BeatmapInfo },
                 RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID,
             };
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerTeamResults.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerTeamResults.cs
@@ -26,18 +26,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 var beatmapInfo = CreateBeatmap(rulesetInfo).BeatmapInfo;
                 var score = TestResources.CreateTestScoreInfo(beatmapInfo);
 
-                PlaylistItem playlistItem = new PlaylistItem
-                {
-                    BeatmapID = beatmapInfo.OnlineID,
-                };
-
                 SortedDictionary<int, BindableInt> teamScores = new SortedDictionary<int, BindableInt>
                 {
                     { 0, new BindableInt(team1Score) },
                     { 1, new BindableInt(team2Score) }
                 };
 
-                Stack.Push(screen = new MultiplayerTeamResultsScreen(score, 1, playlistItem, teamScores));
+                Stack.Push(screen = new MultiplayerTeamResultsScreen(score, 1, new PlaylistItem(beatmapInfo), teamScores));
             });
 
             AddUntilStep("wait for loaded", () => screen.IsLoaded);

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
@@ -107,16 +107,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("item 0 is selected", () => playlist.SelectedItem.Value == playlist.Items[0]);
         }
 
-        [Test]
-        public void TestChangeBeatmapAndRemove()
-        {
-            createPlaylist();
-
-            AddStep("change beatmap of first item", () => playlist.Items[0].BeatmapID = 30);
-            moveToDeleteButton(0);
-            AddStep("click delete button", () => InputManager.Click(MouseButton.Left));
-        }
-
         private void moveToItem(int index, Vector2? offset = null)
             => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<DifficultyIcon>().ElementAt(index), offset));
 
@@ -139,25 +129,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 for (int i = 0; i < 20; i++)
                 {
-                    playlist.Items.Add(new PlaylistItem
+                    playlist.Items.Add(new PlaylistItem(i % 2 == 1
+                        ? new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo
+                        : new BeatmapInfo
+                        {
+                            Metadata = new BeatmapMetadata
+                            {
+                                Artist = "Artist",
+                                Author = new RealmUser { Username = "Creator name here" },
+                                Title = "Long title used to check background colour",
+                            },
+                            BeatmapSet = new BeatmapSetInfo()
+                        })
                     {
                         ID = i,
                         OwnerID = 2,
-                        Beatmap =
-                        {
-                            Value = i % 2 == 1
-                                ? new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo
-                                : new BeatmapInfo
-                                {
-                                    Metadata = new BeatmapMetadata
-                                    {
-                                        Artist = "Artist",
-                                        Author = new RealmUser { Username = "Creator name here" },
-                                        Title = "Long title used to check background colour",
-                                    },
-                                    BeatmapSet = new BeatmapSetInfo()
-                                }
-                        },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                         RequiredMods = new[]
                         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics.Containers;
 using osu.Game.Models;
 using osu.Game.Online.API;
@@ -108,7 +107,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         private void moveToItem(int index, Vector2? offset = null)
-            => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<DifficultyIcon>().ElementAt(index), offset));
+            => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<DrawableRoomPlaylistItem>().ElementAt(index), offset));
 
         private void moveToDeleteButton(int index, Vector2? offset = null) => AddStep($"move mouse to delete button {index}", () =>
         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 SelectedRoom.Value.Playlist.AddRange(new[]
                 {
-                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarRating = min } } },
-                    new PlaylistItem { Beatmap = { Value = new BeatmapInfo { StarRating = max } } },
+                    new PlaylistItem(new BeatmapInfo { StarRating = min }),
+                    new PlaylistItem(new BeatmapInfo { StarRating = max }),
                 });
             });
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTeamVersus.cs
@@ -67,9 +67,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Type = { Value = MatchType.TeamVersus },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -88,9 +87,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Type = { Value = MatchType.TeamVersus },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
                         RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                     }
                 }
@@ -126,10 +124,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Type = { Value = MatchType.HeadToHead },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });
@@ -152,10 +149,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "Test Room" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo)
                     {
-                        Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0)).BeatmapInfo },
-                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
                     }
                 }
             });

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsMatchSettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsMatchSettingsOverlay.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.Visual.Playlists
             AddStep("set name", () => SelectedRoom.Value.Name.Value = "Room name");
             AddAssert("button disabled", () => !settings.ApplyButton.Enabled.Value);
 
-            AddStep("set beatmap", () => SelectedRoom.Value.Playlist.Add(new PlaylistItem { Beatmap = { Value = CreateBeatmap(Ruleset.Value).BeatmapInfo } }));
+            AddStep("set beatmap", () => SelectedRoom.Value.Playlist.Add(new PlaylistItem(CreateBeatmap(Ruleset.Value).BeatmapInfo)));
             AddAssert("button enabled", () => settings.ApplyButton.Enabled.Value);
 
             AddStep("clear name", () => SelectedRoom.Value.Name.Value = "");
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 settings.NameField.Current.Value = expected_name;
                 settings.DurationField.Current.Value = expectedDuration;
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem { Beatmap = { Value = CreateBeatmap(Ruleset.Value).BeatmapInfo } });
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(CreateBeatmap(Ruleset.Value).BeatmapInfo));
 
                 RoomManager.CreateRequested = r =>
                 {
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Visual.Playlists
                 var beatmap = CreateBeatmap(Ruleset.Value).BeatmapInfo;
 
                 SelectedRoom.Value.Name.Value = "Test Room";
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem { Beatmap = { Value = beatmap } });
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(beatmap));
 
                 errorMessage = $"{not_found_prefix} {beatmap.OnlineID}";
 
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Playlists
             AddStep("setup", () =>
             {
                 SelectedRoom.Value.Name.Value = "Test Room";
-                SelectedRoom.Value.Playlist.Add(new PlaylistItem { Beatmap = { Value = CreateBeatmap(Ruleset.Value).BeatmapInfo } });
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(CreateBeatmap(Ruleset.Value).BeatmapInfo));
 
                 RoomManager.CreateRequested = _ => failText;
             });

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -165,9 +165,8 @@ namespace osu.Game.Tests.Visual.Playlists
         {
             AddStep("load results", () =>
             {
-                LoadScreen(resultsScreen = new TestResultsScreen(getScore?.Invoke(), 1, new PlaylistItem
+                LoadScreen(resultsScreen = new TestResultsScreen(getScore?.Invoke(), 1, new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
                 {
-                    Beatmap = { Value = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 }));
             });

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -64,9 +64,8 @@ namespace osu.Game.Tests.Visual.Playlists
                 room.Host.Value = API.LocalUser.Value;
                 room.RecentParticipants.Add(room.Host.Value);
                 room.EndDate.Value = DateTimeOffset.Now.AddMinutes(5);
-                room.Playlist.Add(new PlaylistItem
+                room.Playlist.Add(new PlaylistItem(importedBeatmap.Beatmaps.First())
                 {
-                    Beatmap = { Value = importedBeatmap.Beatmaps.First() },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });
@@ -89,9 +88,8 @@ namespace osu.Game.Tests.Visual.Playlists
                 room.Host.Value = API.LocalUser.Value;
                 room.RecentParticipants.Add(room.Host.Value);
                 room.EndDate.Value = DateTimeOffset.Now.AddMinutes(5);
-                room.Playlist.Add(new PlaylistItem
+                room.Playlist.Add(new PlaylistItem(importedBeatmap.Beatmaps.First())
                 {
-                    Beatmap = { Value = importedBeatmap.Beatmaps.First() },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });
@@ -106,9 +104,8 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 room.Name.Value = "my awesome room";
                 room.Host.Value = API.LocalUser.Value;
-                room.Playlist.Add(new PlaylistItem
+                room.Playlist.Add(new PlaylistItem(importedBeatmap.Beatmaps.First())
                 {
-                    Beatmap = { Value = importedBeatmap.Beatmaps.First() },
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });
@@ -158,21 +155,17 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 room.Name.Value = "my awesome room";
                 room.Host.Value = API.LocalUser.Value;
-                room.Playlist.Add(new PlaylistItem
+                room.Playlist.Add(new PlaylistItem(new BeatmapInfo
                 {
-                    Beatmap =
+                    MD5Hash = realHash,
+                    OnlineID = realOnlineId,
+                    Metadata = new BeatmapMetadata(),
+                    BeatmapSet = new BeatmapSetInfo
                     {
-                        Value = new BeatmapInfo
-                        {
-                            MD5Hash = realHash,
-                            OnlineID = realOnlineId,
-                            Metadata = new BeatmapMetadata(),
-                            BeatmapSet = new BeatmapSetInfo
-                            {
-                                OnlineID = realOnlineSetId,
-                            }
-                        }
-                    },
+                        OnlineID = realOnlineSetId,
+                    }
+                })
+                {
                     RulesetID = new OsuRuleset().RulesetInfo.OnlineID
                 });
             });

--- a/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
+++ b/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Database;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Screens;
@@ -46,6 +47,9 @@ namespace osu.Game.Tests.Visual
         [Cached]
         private readonly BeatmapLookupCache beatmapLookupCache = new BeatmapLookupCache();
 
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; }
+
         private readonly OsuScreenStack screenStack;
         private readonly TestMultiplayer multiplayerScreen;
 
@@ -69,9 +73,9 @@ namespace osu.Game.Tests.Visual
         }
 
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api, OsuGameBase game)
+        private void load(IAPIProvider api)
         {
-            ((DummyAPIAccess)api).HandleRequest = request => multiplayerScreen.RequestsHandler.HandleRequest(request, api.LocalUser.Value, game);
+            ((DummyAPIAccess)api).HandleRequest = request => multiplayerScreen.RequestsHandler.HandleRequest(request, api.LocalUser.Value, beatmapManager);
         }
 
         public override bool OnBackButton() => (screenStack.CurrentScreen as OsuScreen)?.OnBackButton() ?? base.OnBackButton();

--- a/osu.Game/Online/API/Requests/GetBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapsRequest.cs
@@ -2,12 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 
 namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapsRequest : APIRequest<GetBeatmapsResponse>
     {
-        public readonly int[] BeatmapIds;
+        public readonly IReadOnlyList<int> BeatmapIds;
 
         private const int max_ids_per_request = 50;
 

--- a/osu.Game/Online/API/Requests/GetBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapsRequest.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapsRequest : APIRequest<GetBeatmapsResponse>
     {
-        private readonly int[] beatmapIds;
+        public readonly int[] BeatmapIds;
 
         private const int max_ids_per_request = 50;
 
@@ -16,9 +16,9 @@ namespace osu.Game.Online.API.Requests
             if (beatmapIds.Length > max_ids_per_request)
                 throw new ArgumentException($"{nameof(GetBeatmapsRequest)} calls only support up to {max_ids_per_request} IDs at once");
 
-            this.beatmapIds = beatmapIds;
+            BeatmapIds = beatmapIds;
         }
 
-        protected override string Target => "beatmaps/?ids[]=" + string.Join("&ids[]=", beatmapIds);
+        protected override string Target => "beatmaps/?ids[]=" + string.Join("&ids[]=", BeatmapIds);
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -727,10 +727,9 @@ namespace osu.Game.Online.Multiplayer
             RoomUpdated?.Invoke();
         }
 
-        private PlaylistItem createPlaylistItem(MultiplayerPlaylistItem item) => new PlaylistItem
+        private PlaylistItem createPlaylistItem(MultiplayerPlaylistItem item) => new PlaylistItem(new APIBeatmap { OnlineID = item.BeatmapID })
         {
             ID = item.ID,
-            BeatmapID = item.BeatmapID,
             OwnerID = item.OwnerID,
             RulesetID = item.RulesetID,
             Expired = item.Expired,
@@ -739,14 +738,6 @@ namespace osu.Game.Online.Multiplayer
             RequiredMods = item.RequiredMods.ToArray(),
             AllowedMods = item.AllowedMods.ToArray()
         };
-
-        /// <summary>
-        /// Retrieves a <see cref="APIBeatmap"/> from an online source.
-        /// </summary>
-        /// <param name="beatmapId">The beatmap ID.</param>
-        /// <param name="cancellationToken">A token to cancel the request.</param>
-        /// <returns>The <see cref="APIBeatmap"/> retrieval task.</returns>
-        public abstract Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// For the provided user ID, update whether the user is included in <see cref="CurrentMatchPlayingUserIds"/>.

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -9,9 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Game.Database;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 
 namespace osu.Game.Online.Multiplayer
@@ -28,9 +26,6 @@ namespace osu.Game.Online.Multiplayer
         public override IBindable<bool> IsConnected { get; } = new BindableBool();
 
         private HubConnection? connection => connector?.CurrentConnection;
-
-        [Resolved]
-        private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
 
         public OnlineMultiplayerClient(EndpointConfiguration endpoints)
         {
@@ -184,11 +179,6 @@ namespace osu.Game.Online.Multiplayer
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.RemovePlaylistItem), playlistItemId);
-        }
-
-        public override Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default)
-        {
-            return beatmapLookupCache.GetBeatmapAsync(beatmapId, cancellationToken);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Online/Rooms/MultiplayerPlaylistItem.cs
+++ b/osu.Game/Online/Rooms/MultiplayerPlaylistItem.cs
@@ -63,8 +63,8 @@ namespace osu.Game.Online.Rooms
         {
             ID = item.ID;
             OwnerID = item.OwnerID;
-            BeatmapID = item.BeatmapID;
-            BeatmapChecksum = item.Beatmap.Value?.MD5Hash ?? string.Empty;
+            BeatmapID = item.Beatmap.OnlineID;
+            BeatmapChecksum = item.Beatmap.MD5Hash;
             RulesetID = item.RulesetID;
             RequiredMods = item.RequiredMods.ToArray();
             AllowedMods = item.AllowedMods.ToArray();

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -64,11 +64,11 @@ namespace osu.Game.Online.Rooms
 
                 downloadTracker?.RemoveAndDisposeImmediately();
 
-                beatmapLookupCache.GetBeatmapAsync(item.NewValue.Beatmap.Value.OnlineID).ContinueWith(task => Schedule(() =>
+                beatmapLookupCache.GetBeatmapAsync(item.NewValue.Beatmap.OnlineID).ContinueWith(task => Schedule(() =>
                 {
                     var beatmap = task.GetResultSafely();
 
-                    if (SelectedItem.Value?.Beatmap.Value.OnlineID == beatmap.OnlineID)
+                    if (SelectedItem.Value?.Beatmap.OnlineID == beatmap.OnlineID)
                         beginTracking(beatmap);
                 }), TaskContinuationOptions.OnlyOnRanToCompletion);
             }, true);
@@ -96,7 +96,7 @@ namespace osu.Game.Online.Rooms
 
             // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
             realmSubscription?.Dispose();
-            realmSubscription = realm.RegisterForNotifications(r => QueryBeatmapForOnlinePlay(r, SelectedItem.Value.Beatmap.Value), (items, changes, ___) =>
+            realmSubscription = realm.RegisterForNotifications(r => QueryBeatmapForOnlinePlay(r, SelectedItem.Value.Beatmap), (items, changes, ___) =>
             {
                 if (changes == null)
                     return;

--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -41,6 +41,6 @@ namespace osu.Game.Online.Rooms
         }
 
         public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>
-            playlist.Select(p => p.Beatmap.Value.Length).Sum().Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2);
+            playlist.Select(p => p.Beatmap.Length).Sum().Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Components/BeatmapTitle.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/BeatmapTitle.cs
@@ -68,14 +68,14 @@ namespace osu.Game.Screens.OnlinePlay.Components
             }
             else
             {
-                var metadataInfo = beatmap.Value.Metadata;
+                var metadataInfo = beatmap.Metadata;
 
                 string artistUnicode = string.IsNullOrEmpty(metadataInfo.ArtistUnicode) ? metadataInfo.Artist : metadataInfo.ArtistUnicode;
                 string titleUnicode = string.IsNullOrEmpty(metadataInfo.TitleUnicode) ? metadataInfo.Title : metadataInfo.TitleUnicode;
 
                 var title = new RomanisableString($"{artistUnicode} - {titleUnicode}".Trim(), $"{metadataInfo.Artist} - {metadataInfo.Title}".Trim());
 
-                textFlow.AddLink(title, LinkAction.OpenBeatmap, beatmap.Value.OnlineID.ToString(), "Open beatmap");
+                textFlow.AddLink(title, LinkAction.OpenBeatmap, beatmap.OnlineID.ToString(), "Open beatmap");
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Components/ModeTypeInfo.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/ModeTypeInfo.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
                 var mods = item.RequiredMods.Select(m => m.ToMod(ruleset)).ToArray();
 
                 drawableRuleset.FadeIn(transition_duration);
-                drawableRuleset.Child = new DifficultyIcon(item.Beatmap.Value, ruleset.RulesetInfo, mods) { Size = new Vector2(height) };
+                drawableRuleset.Child = new DifficultyIcon(item.Beatmap, ruleset.RulesetInfo, mods) { Size = new Vector2(height) };
             }
             else
                 drawableRuleset.FadeOut(transition_duration);

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
         {
             Schedule(() =>
             {
-                var beatmap = playlistItem?.Beatmap.Value;
+                var beatmap = playlistItem?.Beatmap;
 
                 string? lastCover = (background?.Beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;
                 string? newCover = (beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.Covers.Cover;

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundSprite.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         private void updateBeatmap()
         {
-            sprite.Beatmap.Value = Playlist.GetCurrentItem()?.Beatmap.Value;
+            sprite.Beatmap.Value = Playlist.GetCurrentItem()?.Beatmap;
         }
 
         protected virtual UpdateableBeatmapBackgroundSprite CreateBackgroundSprite() => new UpdateableBeatmapBackgroundSprite(BeatmapSetCoverType) { RelativeSizeAxes = Axes.Both };

--- a/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         public PlaylistItemBackground(PlaylistItem? playlistItem)
         {
-            Beatmap = playlistItem?.Beatmap.Value;
+            Beatmap = playlistItem?.Beatmap;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -112,9 +112,6 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             try
             {
-                foreach (var pi in room.Playlist)
-                    pi.MapObjects();
-
                 var existing = rooms.FirstOrDefault(e => e.RoomID.Value == room.RoomID.Value);
                 if (existing == null)
                     rooms.Add(room);

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
         private void updateRange(object sender, NotifyCollectionChangedEventArgs e)
         {
-            var orderedDifficulties = Playlist.Where(p => p.Beatmap.Value != null).Select(p => p.Beatmap.Value).OrderBy(b => b.StarRating).ToArray();
+            var orderedDifficulties = Playlist.Select(p => p.Beatmap).OrderBy(b => b.StarRating).ToArray();
 
             StarDifficulty minDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[0].StarRating : 0, 0);
             StarDifficulty maxDifficulty = new StarDifficulty(orderedDifficulties.Length > 0 ? orderedDifficulties[^1].StarRating : 0, 0);

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -430,34 +430,31 @@ namespace osu.Game.Screens.OnlinePlay
             };
         }
 
-        private IEnumerable<Drawable> createButtons()
+        private IEnumerable<Drawable> createButtons() => new[]
         {
-            return new[]
+            showResultsButton = new GrayButton(FontAwesome.Solid.ChartPie)
             {
-                showResultsButton = new GrayButton(FontAwesome.Solid.ChartPie)
-                {
-                    Size = new Vector2(30, 30),
-                    Action = () => RequestResults?.Invoke(Item),
-                    Alpha = AllowShowingResults ? 1 : 0,
-                    TooltipText = "View results"
-                },
-                beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
-                editButton = new PlaylistEditButton
-                {
-                    Size = new Vector2(30, 30),
-                    Alpha = AllowEditing ? 1 : 0,
-                    Action = () => RequestEdit?.Invoke(Item),
-                    TooltipText = "Edit"
-                },
-                removeButton = new PlaylistRemoveButton
-                {
-                    Size = new Vector2(30, 30),
-                    Alpha = AllowDeletion ? 1 : 0,
-                    Action = () => RequestDeletion?.Invoke(Item),
-                    TooltipText = "Remove from playlist"
-                },
-            };
-        }
+                Size = new Vector2(30, 30),
+                Action = () => RequestResults?.Invoke(Item),
+                Alpha = AllowShowingResults ? 1 : 0,
+                TooltipText = "View results"
+            },
+            beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
+            editButton = new PlaylistEditButton
+            {
+                Size = new Vector2(30, 30),
+                Alpha = AllowEditing ? 1 : 0,
+                Action = () => RequestEdit?.Invoke(Item),
+                TooltipText = "Edit"
+            },
+            removeButton = new PlaylistRemoveButton
+            {
+                Size = new Vector2(30, 30),
+                Alpha = AllowDeletion ? 1 : 0,
+                Action = () => RequestDeletion?.Invoke(Item),
+                TooltipText = "Remove from playlist"
+            },
+        };
 
         protected override bool OnClick(ClickEvent e)
         {

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -97,9 +97,6 @@ namespace osu.Game.Screens.OnlinePlay
         [Resolved]
         private BeatmapLookupCache beatmapLookupCache { get; set; }
 
-        [Resolved]
-        private RealmAccess realm { get; set; }
-
         protected override bool ShouldBeConsideredForInput(Drawable child) => AllowReordering || AllowDeletion || !AllowSelection || SelectedItem.Value == Model;
 
         public DrawableRoomPlaylistItem(PlaylistItem item)
@@ -444,7 +441,7 @@ namespace osu.Game.Screens.OnlinePlay
                     Alpha = AllowShowingResults ? 1 : 0,
                     TooltipText = "View results"
                 },
-                OnlinePlayBeatmapAvailabilityTracker.QueryBeatmapForOnlinePlay(realm.Realm, beatmap).Any() ? Empty() : new PlaylistDownloadButton(beatmap),
+                beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
                 editButton = new PlaylistEditButton
                 {
                     Size = new Vector2(30, 30),

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -25,7 +24,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Online.Chat;
-using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Rulesets;
@@ -68,8 +66,8 @@ namespace osu.Game.Screens.OnlinePlay
 
         private readonly DelayedLoadWrapper onScreenLoader = new DelayedLoadWrapper(Empty) { RelativeSizeAxes = Axes.Both };
         private readonly IBindable<bool> valid = new Bindable<bool>();
-        private readonly Bindable<IBeatmapInfo> beatmap = new Bindable<IBeatmapInfo>();
 
+        private IBeatmapInfo beatmap;
         private IRulesetInfo ruleset;
         private Mod[] requiredMods;
 
@@ -96,12 +94,11 @@ namespace osu.Game.Screens.OnlinePlay
         [Resolved]
         private UserLookupCache userLookupCache { get; set; }
 
-        [CanBeNull]
-        [Resolved(CanBeNull = true)]
-        private MultiplayerClient multiplayerClient { get; set; }
-
         [Resolved]
         private BeatmapLookupCache beatmapLookupCache { get; set; }
+
+        [Resolved]
+        private RealmAccess realm { get; set; }
 
         protected override bool ShouldBeConsideredForInput(Drawable child) => AllowReordering || AllowDeletion || !AllowSelection || SelectedItem.Value == Model;
 
@@ -110,7 +107,6 @@ namespace osu.Game.Screens.OnlinePlay
         {
             Item = item;
 
-            beatmap.BindTo(item.Beatmap);
             valid.BindTo(item.Valid);
 
             if (item.Expired)
@@ -151,7 +147,6 @@ namespace osu.Game.Screens.OnlinePlay
                 maskingContainer.BorderThickness = isCurrent ? 5 : 0;
             }, true);
 
-            beatmap.BindValueChanged(_ => Scheduler.AddOnce(refresh));
             valid.BindValueChanged(_ => Scheduler.AddOnce(refresh));
 
             onScreenLoader.DelayedLoadStarted += _ =>
@@ -166,19 +161,9 @@ namespace osu.Game.Screens.OnlinePlay
                             Schedule(() => ownerAvatar.User = foundUser);
                         }
 
-                        if (Item.Beatmap.Value == null)
-                        {
-                            IBeatmapInfo foundBeatmap;
+                        beatmap = await beatmapLookupCache.GetBeatmapAsync(Item.Beatmap.Value.OnlineID).ConfigureAwait(false);
 
-                            if (multiplayerClient != null)
-                                // This call can eventually go away (and use the else case below).
-                                // Currently required only due to the method being overridden to provide special behaviour in tests.
-                                foundBeatmap = await multiplayerClient.GetAPIBeatmap(Item.BeatmapID).ConfigureAwait(false);
-                            else
-                                foundBeatmap = await beatmapLookupCache.GetBeatmapAsync(Item.BeatmapID).ConfigureAwait(false);
-
-                            Schedule(() => Item.Beatmap.Value = foundBeatmap);
-                        }
+                        Scheduler.AddOnce(refresh);
                     }
                     catch (Exception e)
                     {
@@ -280,18 +265,18 @@ namespace osu.Game.Screens.OnlinePlay
                 maskingContainer.BorderColour = colours.Red;
             }
 
-            if (Item.Beatmap.Value != null)
-                difficultyIconContainer.Child = new DifficultyIcon(Item.Beatmap.Value, ruleset, requiredMods, performBackgroundDifficultyLookup: false) { Size = new Vector2(icon_height) };
+            if (beatmap != null)
+                difficultyIconContainer.Child = new DifficultyIcon(beatmap, ruleset, requiredMods, performBackgroundDifficultyLookup: false) { Size = new Vector2(icon_height) };
             else
                 difficultyIconContainer.Clear();
 
-            panelBackground.Beatmap.Value = Item.Beatmap.Value;
+            panelBackground.Beatmap.Value = beatmap;
 
             beatmapText.Clear();
 
-            if (Item.Beatmap.Value != null)
+            if (beatmap != null)
             {
-                beatmapText.AddLink(Item.Beatmap.Value.GetDisplayTitleRomanisable(), LinkAction.OpenBeatmap, Item.Beatmap.Value.OnlineID.ToString(), null, text =>
+                beatmapText.AddLink(beatmap.GetDisplayTitleRomanisable(), LinkAction.OpenBeatmap, beatmap.OnlineID.ToString(), null, text =>
                 {
                     text.Truncate = true;
                 });
@@ -299,13 +284,13 @@ namespace osu.Game.Screens.OnlinePlay
 
             authorText.Clear();
 
-            if (!string.IsNullOrEmpty(Item.Beatmap.Value?.Metadata.Author.Username))
+            if (!string.IsNullOrEmpty(beatmap?.Metadata.Author.Username))
             {
                 authorText.AddText("mapped by ");
-                authorText.AddUserLink(Item.Beatmap.Value.Metadata.Author);
+                authorText.AddUserLink(beatmap.Metadata.Author);
             }
 
-            bool hasExplicitContent = (Item.Beatmap.Value?.BeatmapSet as IBeatmapSetOnlineInfo)?.HasExplicitContent == true;
+            bool hasExplicitContent = (beatmap?.BeatmapSet as IBeatmapSetOnlineInfo)?.HasExplicitContent == true;
             explicitContentPill.Alpha = hasExplicitContent ? 1 : 0;
 
             modDisplay.Current.Value = requiredMods.ToArray();
@@ -448,31 +433,34 @@ namespace osu.Game.Screens.OnlinePlay
             };
         }
 
-        private IEnumerable<Drawable> createButtons() => new[]
+        private IEnumerable<Drawable> createButtons()
         {
-            showResultsButton = new GrayButton(FontAwesome.Solid.ChartPie)
+            return new[]
             {
-                Size = new Vector2(30, 30),
-                Action = () => RequestResults?.Invoke(Item),
-                Alpha = AllowShowingResults ? 1 : 0,
-                TooltipText = "View results"
-            },
-            Item.Beatmap.Value == null ? Empty() : new PlaylistDownloadButton(Item),
-            editButton = new PlaylistEditButton
-            {
-                Size = new Vector2(30, 30),
-                Alpha = AllowEditing ? 1 : 0,
-                Action = () => RequestEdit?.Invoke(Item),
-                TooltipText = "Edit"
-            },
-            removeButton = new PlaylistRemoveButton
-            {
-                Size = new Vector2(30, 30),
-                Alpha = AllowDeletion ? 1 : 0,
-                Action = () => RequestDeletion?.Invoke(Item),
-                TooltipText = "Remove from playlist"
-            },
-        };
+                showResultsButton = new GrayButton(FontAwesome.Solid.ChartPie)
+                {
+                    Size = new Vector2(30, 30),
+                    Action = () => RequestResults?.Invoke(Item),
+                    Alpha = AllowShowingResults ? 1 : 0,
+                    TooltipText = "View results"
+                },
+                OnlinePlayBeatmapAvailabilityTracker.QueryBeatmapForOnlinePlay(realm.Realm, beatmap).Any() ? Empty() : new PlaylistDownloadButton(beatmap),
+                editButton = new PlaylistEditButton
+                {
+                    Size = new Vector2(30, 30),
+                    Alpha = AllowEditing ? 1 : 0,
+                    Action = () => RequestEdit?.Invoke(Item),
+                    TooltipText = "Edit"
+                },
+                removeButton = new PlaylistRemoveButton
+                {
+                    Size = new Vector2(30, 30),
+                    Alpha = AllowDeletion ? 1 : 0,
+                    Action = () => RequestDeletion?.Invoke(Item),
+                    TooltipText = "Remove from playlist"
+                },
+            };
+        }
 
         protected override bool OnClick(ClickEvent e)
         {
@@ -499,7 +487,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         private sealed class PlaylistDownloadButton : BeatmapDownloadButton
         {
-            private readonly PlaylistItem playlistItem;
+            private readonly IBeatmapInfo beatmap;
 
             [Resolved]
             private BeatmapManager beatmapManager { get; set; }
@@ -509,10 +497,10 @@ namespace osu.Game.Screens.OnlinePlay
 
             private const float width = 50;
 
-            public PlaylistDownloadButton(PlaylistItem playlistItem)
-                : base(playlistItem.Beatmap.Value.BeatmapSet)
+            public PlaylistDownloadButton(IBeatmapInfo beatmap)
+                : base(beatmap.BeatmapSet)
             {
-                this.playlistItem = playlistItem;
+                this.beatmap = beatmap;
 
                 Size = new Vector2(width, 30);
                 Alpha = 0;
@@ -532,7 +520,7 @@ namespace osu.Game.Screens.OnlinePlay
                 {
                     case DownloadState.LocallyAvailable:
                         // Perform a local query of the beatmap by beatmap checksum, and reset the state if not matching.
-                        if (beatmapManager.QueryBeatmap(b => b.MD5Hash == playlistItem.Beatmap.Value.MD5Hash) == null)
+                        if (beatmapManager.QueryBeatmap(b => b.MD5Hash == beatmap.MD5Hash) == null)
                             State.Value = DownloadState.NotDownloaded;
                         else
                         {

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Screens.OnlinePlay
                             Schedule(() => ownerAvatar.User = foundUser);
                         }
 
-                        beatmap = await beatmapLookupCache.GetBeatmapAsync(Item.Beatmap.Value.OnlineID).ConfigureAwait(false);
+                        beatmap = await beatmapLookupCache.GetBeatmapAsync(Item.Beatmap.OnlineID).ConfigureAwait(false);
 
                         Scheduler.AddOnce(refresh);
                     }

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -12,6 +14,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -328,6 +331,9 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
             [Resolved]
             private OsuColour colours { get; set; }
 
+            [Resolved]
+            private BeatmapLookupCache beatmapLookupCache { get; set; }
+
             private SpriteText statusText;
             private LinkFlowContainer beatmapText;
 
@@ -385,8 +391,11 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 SelectedItem.BindValueChanged(onSelectedItemChanged, true);
             }
 
+            private CancellationTokenSource beatmapLookupCancellation;
+
             private void onSelectedItemChanged(ValueChangedEvent<PlaylistItem> item)
             {
+                beatmapLookupCancellation?.Cancel();
                 beatmapText.Clear();
 
                 if (Type.Value == MatchType.Playlists)
@@ -395,17 +404,25 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     return;
                 }
 
-                if (item.NewValue?.Beatmap.Value != null)
-                {
-                    statusText.Text = "Currently playing ";
-                    beatmapText.AddLink(item.NewValue.Beatmap.Value.GetDisplayTitleRomanisable(),
-                        LinkAction.OpenBeatmap,
-                        item.NewValue.Beatmap.Value.OnlineID.ToString(),
-                        creationParameters: s =>
-                        {
-                            s.Truncate = true;
-                        });
-                }
+                var beatmap = item.NewValue?.Beatmap;
+                if (beatmap == null)
+                    return;
+
+                var cancellationSource = beatmapLookupCancellation = new CancellationTokenSource();
+                beatmapLookupCache.GetBeatmapAsync(beatmap.Value.OnlineID, cancellationSource.Token)
+                                  .ContinueWith(task => Schedule(() =>
+                                  {
+                                      if (cancellationSource.IsCancellationRequested)
+                                          return;
+
+                                      var retrievedBeatmap = task.GetResultSafely();
+
+                                      statusText.Text = "Currently playing ";
+                                      beatmapText.AddLink(retrievedBeatmap.GetDisplayTitleRomanisable(),
+                                          LinkAction.OpenBeatmap,
+                                          retrievedBeatmap.OnlineID.ToString(),
+                                          creationParameters: s => s.Truncate = true);
+                                  }), cancellationSource.Token);
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -409,7 +409,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     return;
 
                 var cancellationSource = beatmapLookupCancellation = new CancellationTokenSource();
-                beatmapLookupCache.GetBeatmapAsync(beatmap.Value.OnlineID, cancellationSource.Token)
+                beatmapLookupCache.GetBeatmapAsync(beatmap.OnlineID, cancellationSource.Token)
                                   .ContinueWith(task => Schedule(() =>
                                   {
                                       if (cancellationSource.IsCancellationRequested)

--- a/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             if (editButton != null)
                 host.BindValueChanged(h => editButton.Alpha = h.NewValue?.Equals(api.LocalUser.Value) == true ? 1 : 0, true);
 
-            SelectedItem.BindValueChanged(item => background.Beatmap.Value = item.NewValue?.Beatmap.Value, true);
+            SelectedItem.BindValueChanged(item => background.Beatmap.Value = item.NewValue?.Beatmap, true);
         }
 
         protected override Drawable CreateBackground() => background = new BackgroundSprite();

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -376,7 +376,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         private void updateWorkingBeatmap()
         {
-            var beatmap = SelectedItem.Value?.Beatmap.Value;
+            var beatmap = SelectedItem.Value?.Beatmap;
 
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info
             var localBeatmap = beatmap == null ? null : beatmapManager.QueryBeatmap(b => b.OnlineID == beatmap.OnlineID);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -67,8 +67,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 var multiplayerItem = new MultiplayerPlaylistItem
                 {
                     ID = itemToEdit ?? 0,
-                    BeatmapID = item.BeatmapID,
-                    BeatmapChecksum = item.Beatmap.Value.MD5Hash,
+                    BeatmapID = item.Beatmap.OnlineID,
+                    BeatmapChecksum = item.Beatmap.MD5Hash,
                     RulesetID = item.RulesetID,
                     RequiredMods = item.RequiredMods.ToArray(),
                     AllowedMods = item.AllowedMods.ToArray()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -398,38 +397,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private void updateCurrentItem()
         {
             Debug.Assert(client.Room != null);
-
-            var expectedSelectedItem = Room.Playlist.SingleOrDefault(i => i.ID == client.Room.Settings.PlaylistItemId);
-
-            if (expectedSelectedItem == null)
-                return;
-
-            // There's no reason to renew the selected item if its content hasn't changed.
-            if (SelectedItem.Value?.Equals(expectedSelectedItem) == true && expectedSelectedItem.Beatmap.Value != null)
-                return;
-
-            // Clear the selected item while the lookup is performed, so components like the ready button can enter their disabled states.
-            SelectedItem.Value = null;
-
-            if (expectedSelectedItem.Beatmap.Value == null)
-            {
-                Task.Run(async () =>
-                {
-                    var beatmap = await client.GetAPIBeatmap(expectedSelectedItem.BeatmapID).ConfigureAwait(false);
-
-                    Schedule(() =>
-                    {
-                        expectedSelectedItem.Beatmap.Value = beatmap;
-
-                        if (Room.Playlist.SingleOrDefault(i => i.ID == client.Room?.Settings.PlaylistItemId)?.Equals(expectedSelectedItem) == true)
-                            applyCurrentItem();
-                    });
-                });
-            }
-            else
-                applyCurrentItem();
-
-            void applyCurrentItem() => SelectedItem.Value = expectedSelectedItem;
+            SelectedItem.Value = Room.Playlist.SingleOrDefault(i => i.ID == client.Room.Settings.PlaylistItemId);
         }
 
         private void handleRoomLost() => Schedule(() =>

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -113,12 +113,8 @@ namespace osu.Game.Screens.OnlinePlay
         {
             itemSelected = true;
 
-            var item = new PlaylistItem
+            var item = new PlaylistItem(Beatmap.Value.BeatmapInfo)
             {
-                Beatmap =
-                {
-                    Value = Beatmap.Value.BeatmapInfo
-                },
                 RulesetID = Ruleset.Value.OnlineID,
                 RequiredMods = Mods.Value.Select(m => new APIMod(m)).ToArray(),
                 AllowedMods = FreeMods.Value.Select(m => new APIMod(m)).ToArray()

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         private void load(IBindable<RulesetInfo> ruleset)
         {
             // Sanity checks to ensure that PlaylistsPlayer matches the settings for the current PlaylistItem
-            if (!Beatmap.Value.BeatmapInfo.MatchesOnlineID(PlaylistItem.Beatmap.Value))
+            if (!Beatmap.Value.BeatmapInfo.MatchesOnlineID(PlaylistItem.Beatmap))
                 throw new InvalidOperationException("Current Beatmap does not match PlaylistItem's Beatmap");
 
             if (ruleset.Value.OnlineID != PlaylistItem.RulesetID)

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
@@ -392,7 +392,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
                     foreach (var item in Playlist)
                     {
-                        if (invalidBeatmapIDs.Contains(item.BeatmapID))
+                        if (invalidBeatmapIDs.Contains(item.Beatmap.OnlineID))
                             item.MarkInvalid();
                     }
                 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -41,10 +41,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         private void createNewItem()
         {
-            PlaylistItem item = new PlaylistItem
+            PlaylistItem item = new PlaylistItem(Beatmap.Value.BeatmapInfo)
             {
                 ID = Playlist.Count == 0 ? 0 : Playlist.Max(p => p.ID) + 1,
-                Beatmap = { Value = Beatmap.Value.BeatmapInfo },
                 RulesetID = Ruleset.Value.OnlineID,
                 RequiredMods = Mods.Value.Select(m => new APIMod(m)).ToArray(),
                 AllowedMods = FreeMods.Value.Select(m => new APIMod(m)).ToArray()

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -46,9 +46,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Name = { Value = "test name" },
                 Playlist =
                 {
-                    new PlaylistItem
+                    new PlaylistItem(new TestBeatmap(Ruleset.Value).BeatmapInfo)
                     {
-                        Beatmap = { Value = new TestBeatmap(Ruleset.Value).BeatmapInfo },
                         RulesetID = Ruleset.Value.OnlineID
                     }
                 }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -7,14 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
-using osu.Game.Beatmaps;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Online.Rooms;
@@ -38,9 +35,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
-
-        [Resolved]
-        private BeatmapManager beatmaps { get; set; } = null!;
 
         private readonly TestMultiplayerRoomManager roomManager;
 
@@ -406,23 +400,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         public override Task RemovePlaylistItem(long playlistItemId) => RemoveUserPlaylistItem(api.LocalUser.Value.OnlineID, playlistItemId);
-
-        public override Task<APIBeatmap> GetAPIBeatmap(int beatmapId, CancellationToken cancellationToken = default)
-        {
-            IBeatmapInfo? beatmap = roomManager.ServerSideRooms.SelectMany(r => r.Playlist)
-                                               .FirstOrDefault(p => p.BeatmapID == beatmapId)?.Beatmap.Value
-                                    ?? beatmaps.QueryBeatmap(b => b.OnlineID == beatmapId);
-
-            if (beatmap == null)
-                throw new InvalidOperationException("Beatmap not found.");
-
-            return Task.FromResult(new APIBeatmap
-            {
-                BeatmapSet = new APIBeatmapSet { OnlineID = beatmap.BeatmapSet?.OnlineID ?? -1 },
-                OnlineID = beatmapId,
-                Checksum = beatmap.MD5Hash
-            });
-        }
 
         private async Task changeMatchType(MatchType type)
         {

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Database;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay;
@@ -32,9 +33,6 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         protected OnlinePlayTestSceneDependencies OnlinePlayDependencies => dependencies?.OnlinePlayDependencies;
 
         protected override Container<Drawable> Content => content;
-
-        [Resolved]
-        private OsuGameBase game { get; set; }
 
         private readonly Container content;
         private readonly Container drawableDependenciesContainer;
@@ -71,7 +69,12 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             AddStep("setup API", () =>
             {
                 var handler = OnlinePlayDependencies.RequestsHandler;
-                ((DummyAPIAccess)API).HandleRequest = request => handler.HandleRequest(request, API.LocalUser.Value, game);
+
+                // Resolving the BeatmapManager in the test scene will inject the game-wide BeatmapManager, while many test scenes cache their own BeatmapManager instead.
+                // To get around this, the BeatmapManager is looked up from the dependencies provided to the children of the test scene instead.
+                var beatmapManager = dependencies.Get<BeatmapManager>();
+
+                ((DummyAPIAccess)API).HandleRequest = request => handler.HandleRequest(request, API.LocalUser.Value, beatmapManager);
             });
         }
 

--- a/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/OnlinePlayTestScene.cs
@@ -60,23 +60,15 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             drawableDependenciesContainer.Clear();
             dependencies.OnlinePlayDependencies = CreateOnlinePlayDependencies();
             drawableDependenciesContainer.AddRange(OnlinePlayDependencies.DrawableComponents);
+
+            var handler = OnlinePlayDependencies.RequestsHandler;
+
+            // Resolving the BeatmapManager in the test scene will inject the game-wide BeatmapManager, while many test scenes cache their own BeatmapManager instead.
+            // To get around this, the BeatmapManager is looked up from the dependencies provided to the children of the test scene instead.
+            var beatmapManager = dependencies.Get<BeatmapManager>();
+
+            ((DummyAPIAccess)API).HandleRequest = request => handler.HandleRequest(request, API.LocalUser.Value, beatmapManager);
         });
-
-        public override void SetUpSteps()
-        {
-            base.SetUpSteps();
-
-            AddStep("setup API", () =>
-            {
-                var handler = OnlinePlayDependencies.RequestsHandler;
-
-                // Resolving the BeatmapManager in the test scene will inject the game-wide BeatmapManager, while many test scenes cache their own BeatmapManager instead.
-                // To get around this, the BeatmapManager is looked up from the dependencies provided to the children of the test scene instead.
-                var beatmapManager = dependencies.Get<BeatmapManager>();
-
-                ((DummyAPIAccess)API).HandleRequest = request => handler.HandleRequest(request, API.LocalUser.Value, beatmapManager);
-            });
-        }
 
         /// <summary>
         /// Creates the room dependencies. Called every <see cref="Setup"/>.

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs
@@ -43,16 +43,9 @@ namespace osu.Game.Tests.Visual.OnlinePlay
 
                 if (ruleset != null)
                 {
-                    room.Playlist.Add(new PlaylistItem
+                    room.Playlist.Add(new PlaylistItem(new BeatmapInfo { Metadata = new BeatmapMetadata() })
                     {
                         RulesetID = ruleset.OnlineID,
-                        Beatmap =
-                        {
-                            Value = new BeatmapInfo
-                            {
-                                Metadata = new BeatmapMetadata()
-                            }
-                        }
                     });
                 }
 

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -225,12 +225,24 @@ namespace osu.Game.Tests.Visual
         protected virtual IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset);
 
         /// <summary>
-        /// Returns a sample API Beatmap with BeatmapSet populated.
+        /// Returns a sample API beatmap with a populated beatmap set.
         /// </summary>
         /// <param name="ruleset">The ruleset to create the sample model using. osu! ruleset will be used if not specified.</param>
-        protected APIBeatmap CreateAPIBeatmap(RulesetInfo ruleset = null)
+        protected APIBeatmap CreateAPIBeatmap(RulesetInfo ruleset = null) => CreateAPIBeatmap(CreateBeatmap(ruleset ?? Ruleset.Value).BeatmapInfo);
+
+        /// <summary>
+        /// Constructs a sample API beatmap set containing a beatmap.
+        /// </summary>
+        /// <param name="ruleset">The ruleset to create the sample model using. osu! ruleset will be used if not specified.</param>
+        protected APIBeatmapSet CreateAPIBeatmapSet(RulesetInfo ruleset = null) => CreateAPIBeatmapSet(CreateBeatmap(ruleset ?? Ruleset.Value).BeatmapInfo);
+
+        /// <summary>
+        /// Constructs a sample API beatmap with a populated beatmap set from a given source beatmap.
+        /// </summary>
+        /// <param name="original">The source beatmap.</param>
+        public static APIBeatmap CreateAPIBeatmap(IBeatmapInfo original)
         {
-            var beatmapSet = CreateAPIBeatmapSet(ruleset ?? Ruleset.Value);
+            var beatmapSet = CreateAPIBeatmapSet(original);
 
             // Avoid circular reference.
             var beatmap = beatmapSet.Beatmaps.First();
@@ -243,18 +255,16 @@ namespace osu.Game.Tests.Visual
         }
 
         /// <summary>
-        /// Returns a sample API BeatmapSet with beatmaps populated.
+        /// Constructs a sample API beatmap set containing a beatmap from a given source beatmap.
         /// </summary>
-        /// <param name="ruleset">The ruleset to create the sample model using. osu! ruleset will be used if not specified.</param>
-        protected APIBeatmapSet CreateAPIBeatmapSet(RulesetInfo ruleset = null)
+        /// <param name="original">The source beatmap.</param>
+        public static APIBeatmapSet CreateAPIBeatmapSet(IBeatmapInfo original)
         {
-            var beatmap = CreateBeatmap(ruleset ?? Ruleset.Value).BeatmapInfo;
-
-            Debug.Assert(beatmap.BeatmapSet != null);
+            Debug.Assert(original.BeatmapSet != null);
 
             return new APIBeatmapSet
             {
-                OnlineID = ((IBeatmapSetInfo)beatmap.BeatmapSet).OnlineID,
+                OnlineID = original.BeatmapSet.OnlineID,
                 Status = BeatmapOnlineStatus.Ranked,
                 Covers = new BeatmapSetOnlineCovers
                 {
@@ -262,29 +272,29 @@ namespace osu.Game.Tests.Visual
                     Card = "https://assets.ppy.sh/beatmaps/163112/covers/card.jpg",
                     List = "https://assets.ppy.sh/beatmaps/163112/covers/list.jpg"
                 },
-                Title = beatmap.Metadata.Title,
-                TitleUnicode = beatmap.Metadata.TitleUnicode,
-                Artist = beatmap.Metadata.Artist,
-                ArtistUnicode = beatmap.Metadata.ArtistUnicode,
+                Title = original.Metadata.Title,
+                TitleUnicode = original.Metadata.TitleUnicode,
+                Artist = original.Metadata.Artist,
+                ArtistUnicode = original.Metadata.ArtistUnicode,
                 Author = new APIUser
                 {
-                    Username = beatmap.Metadata.Author.Username,
-                    Id = beatmap.Metadata.Author.OnlineID
+                    Username = original.Metadata.Author.Username,
+                    Id = original.Metadata.Author.OnlineID
                 },
-                Source = beatmap.Metadata.Source,
-                Tags = beatmap.Metadata.Tags,
+                Source = original.Metadata.Source,
+                Tags = original.Metadata.Tags,
                 Beatmaps = new[]
                 {
                     new APIBeatmap
                     {
-                        OnlineID = ((IBeatmapInfo)beatmap).OnlineID,
-                        OnlineBeatmapSetID = ((IBeatmapSetInfo)beatmap.BeatmapSet).OnlineID,
-                        Status = beatmap.Status,
-                        Checksum = beatmap.MD5Hash,
-                        AuthorID = beatmap.Metadata.Author.OnlineID,
-                        RulesetID = beatmap.Ruleset.OnlineID,
-                        StarRating = beatmap.StarRating,
-                        DifficultyName = beatmap.DifficultyName,
+                        OnlineID = original.OnlineID,
+                        OnlineBeatmapSetID = original.BeatmapSet.OnlineID,
+                        Status = ((BeatmapInfo)original).Status,
+                        Checksum = original.MD5Hash,
+                        AuthorID = original.Metadata.Author.OnlineID,
+                        RulesetID = original.Ruleset.OnlineID,
+                        StarRating = original.StarRating,
+                        DifficultyName = original.DifficultyName,
                     }
                 }
             };


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/16879

This is the last part of my multiplayer refactorings, which removes the `Beatmap` bindable from `PlaylistItem`.

- Online lookups are performed where required (e.g. `DrawableRoomPlaylistItem` / `OnlinePlayBeatmapAvailabilityTracker`).
- Removes the `PlaylistItem.MapObjects()` method.
- Removes the async lookup before setting the `SelectedItem` from `MultiplayerMatchSubScreen`. I believe this would also fix the issue fixed in https://github.com/ppy/osu/pull/16773, but I haven't tested deeply enough to make sure there's no edge cases, so it's not changed in this PR.