### PR TITLE
Fix mania hit window attribute improperly considering rate-adjustment mods

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -10,10 +10,10 @@ namespace osu.Game.Rulesets.Mania.Difficulty
     public class ManiaDifficultyAttributes : DifficultyAttributes
     {
         /// <summary>
-        /// The perceived hit window for a GREAT hit inclusive of rate-adjusting mods (DT/HT/etc).
+        /// The hit window for a GREAT hit inclusive of rate-adjusting mods (DT/HT/etc).
         /// </summary>
         /// <remarks>
-        /// Rate-adjusting mods don't directly affect the hit window, but have a perceived effect as a result of adjusting audio timing.
+        /// Rate-adjusting mods do not affect the hit window at all in osu-stable.
         /// </remarks>
         [JsonProperty("great_hit_window")]
         public double GreatHitWindow { get; set; }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             {
                 StarRating = skills[0].DifficultyValue() * star_scaling_factor,
                 Mods = mods,
-                GreatHitWindow = Math.Ceiling(getHitWindow300(mods) / clockRate),
+                GreatHitWindow = Math.Ceiling((int)(getHitWindow300(mods) * clockRate) / clockRate),
                 ScoreMultiplier = getScoreMultiplier(mods),
                 MaxCombo = beatmap.HitObjects.Sum(h => h is HoldNote ? 2 : 1),
             };
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             }
         }
 
-        private int getHitWindow300(Mod[] mods)
+        private double getHitWindow300(Mod[] mods)
         {
             if (isForCurrentRuleset)
             {
@@ -121,19 +121,14 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
             return applyModAdjustments(47, mods);
 
-            static int applyModAdjustments(double value, Mod[] mods)
+            static double applyModAdjustments(double value, Mod[] mods)
             {
                 if (mods.Any(m => m is ManiaModHardRock))
                     value /= 1.4;
                 else if (mods.Any(m => m is ManiaModEasy))
                     value *= 1.4;
 
-                if (mods.Any(m => m is ManiaModDoubleTime))
-                    value *= 1.5;
-                else if (mods.Any(m => m is ManiaModHalfTime))
-                    value *= 0.75;
-
-                return (int)value;
+                return value;
             }
         }
 

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             {
                 StarRating = skills[0].DifficultyValue() * star_scaling_factor,
                 Mods = mods,
+                // In osu-stable mania, rate-adjustment mods don't affect the hit window.
+                // This is done the way it is to introduce fractional differences in order to match osu-stable for the time being.
                 GreatHitWindow = Math.Ceiling((int)(getHitWindow300(mods) * clockRate) / clockRate),
                 ScoreMultiplier = getScoreMultiplier(mods),
                 MaxCombo = beatmap.HitObjects.Sum(h => h is HoldNote ? 2 : 1),


### PR DESCRIPTION
**This issue only applies to osu-tools. It does not affect live values.**

In osu-stable mania, mods do not affect the hit window. This code was not considering the nightcore mod which is provided by osu-tools, and as such it was acting as if NC _did_ affect the hit window.

Before:
```
Getting user data...
Getting user top scores...
User:     Jakads
Live PP:  22037.1 (including 292.2pp from playcount)
Local PP: 22126.5 (+89.4)

╔═══╤═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╤══════════╤════════╤══════╤══════╤═══════╤════════╤═════════╤═══════════════╗
║#  │beatmap                                                                                                                                  │max combo │accuracy│misses│mods  │live pp│local pp│pp change│position change║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║1  │1679790 - xi - Last Resort (Kroytz) [Jakads' LASTING LEGACY]                                                                             │3679/4425x│  99.84%│     1│  None│ 1350.7│  1350.7│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║2  │2220863 - penoreri - Monochrome and Vivid (ruka) [New Palettes]                                                                          │6493/8043x│  98.97%│    17│    NC│ 1349.9│  1349.8│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║3  │2261284 - Fractal Dreamers - Gardens Under A Spring Sky (_Kobii) [Tranquility]                                                           │2032/3503x│   98.2%│     8│    NC│ 1294.0│  1294.0│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║4  │2119517 - Maverick - Shironaga Star Jet -aquamarine mix- (_Kobii) [Cosmic Journey // 7K]                                                 │2797/8372x│   99.3%│    10│    NC│ 1224.1│  1229.0│      4.9│      +1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║5  │2727115 - Camellia feat. Nanahira - Energy * Drin-ko * Fein-chan!  (Camellia's "MONSTERISTIC" D. M. P. Remix) (Kim_GodSSI) [Energy Drink]│920/11847x│  93.13%│   181│    NC│ 1228.3│  1228.2│     -0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║6  │2027282 - Ironami - Melty Sweets (_Kobii) [HEAVENLY]                                                                                     │1630/3479x│  99.18%│     3│    NC│ 1151.3│  1156.9│      5.6│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║7  │2694154 - xi - Halcyon -Long Version- (Kawawa) [Halcyon Days]                                                                            │1842/6657x│  97.05%│    39│    DT│ 1143.3│  1143.4│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║8  │2167361 - eicateve - R.I.P. (Pengdoll) [7K Rest In Peace]                                                                                │1172/3295x│  95.56%│    50│    NC│ 1141.9│  1141.9│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║9  │1023967 - LeaF - Doppelganger (Jinjin) [jakads' Extra]                                                                                   │1245/3137x│  96.52%│    25│    NC│ 1140.7│  1140.7│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║10 │1648263 - SUi - planetarium (Reba) [HEAVENLY]                                                                                            │ 959/3255x│  98.04%│    14│    NC│ 1139.3│  1139.3│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║11 │3144879 - Kankitsu - Moments (Wonki) [Best Memories]                                                                                     │2582/8012x│  99.26%│    10│    NC│ 1132.0│  1135.1│      3.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║12 │1742328 - kamome sano - starlights feat. TEA (K a b i -) [Celestial Radiance // 7K]                                                      │4365/6043x│  99.63%│     5│    NC│ 1093.8│  1128.7│     34.9│      +2       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║13 │3302254 - AAAA - Hiyokko Santa to Yuki no Machi (Maxus) [O Little Town of Bethlehem]                                                     │1196/4603x│  97.91%│    24│    NC│ 1107.2│  1107.2│      0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║14 │884617 - LeaF - Doppelganger (Jinjin) [Alter Ego]                                                                                        │ 344/4335x│  90.49%│    83│    NC│ 1106.9│  1106.9│     -0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║15 │2692497 - Halozy - Deconstruction Star (Flexo123) [Twinkling Stars]                                                                      │5846/6642x│  99.35%│     3│    NC│ 1087.9│  1098.4│     10.5│      +1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║16 │1270895 - technoplanet - Inscape (Reba) [HEAVENLY]                                                                                       │ 729/2631x│  97.33%│    18│    NC│ 1089.2│  1089.2│      0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║17 │2365803 - Camellia - FM Synthesis Experiment (Umo-) [Execute]                                                                            │2579/7564x│   98.9%│    11│    NC│ 1079.3│  1079.3│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║18 │3090158 - ARForest - Rainbow Magic!! (_Stan) [Iridescent]                                                                                │1267/3870x│  97.63%│    22│    NC│ 1073.3│  1073.3│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║19 │1130570 - LeaF - Alice in Misanthrope -Ensei Alice- (Kawawa) [Alice in Wonderland]                                                       │2781/3358x│  99.51%│     4│    NC│ 1038.4│  1058.1│     19.7│      +1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║20 │1684161 - MAZARE - Mazare Party (Insp1r3) [JAKARE's 6K Extra]                                                                            │2471/5092x│  98.64%│     9│    NC│ 1055.8│  1055.8│      0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║21 │1368838 - Nanahira - Petals (Arzenvald) [~ fragments of the night ~ // seven key]                                                        │2882/5137x│  99.29%│     3│    NC│ 1032.4│  1045.8│     13.5│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║22 │830448 - Yooh - Ice Angel (pporse) [Euphoria]                                                                                            │3433/6009x│  99.71%│     4│    NC│ 1001.7│  1039.0│     37.3│      +4       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║23 │888793 - void - Just Hold on (To All Fighters) (Blocko) [Resolve]                                                                        │3469/5778x│  99.05%│    11│    NC│ 1029.0│  1029.0│      0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║24 │948777 - xi - Ascension to Heaven (Jinjin) [Elysium]                                                                                     │1344/5259x│  96.62%│    45│    NC│ 1022.5│  1022.5│     -0.0│      -1       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║25 │1670744 - SUi - planetarium (Reba) [MAXIMUM]                                                                                             │2012/2789x│  99.74%│     2│    NC│  993.9│  1022.5│     28.5│      +4       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║26 │1239794 - BlackYooh vs. siromaru - BLACK or WHITE? (Kawawa) [Monochromatic Horizon]                                                      │1357/7995x│  95.84%│    70│    NC│ 1016.4│  1016.4│     -0.0│      -2       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║27 │1231418 - Chroma - Hoshi ga Furanai Machi (Wonki) [Meteor Shower // pporse's 7K]                                                         │2934/7457x│  99.46%│     4│    DT│ 1003.9│  1003.9│     -0.0│      -2       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║28 │2935047 - Yu_Asahina - eighth-slave (_Rokii) [I'm a slave for this song // VIVID]                                                        │1181/5779x│  99.19%│    15│    NC│  998.6│   999.9│      1.4│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║29 │3165981 - xi - ANiMA (Kawawa) [Piano Symphonia]                                                                                          │ 721/5940x│  97.18%│    57│    NC│  999.1│   999.1│     -0.0│      -2       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║30 │1350666 - Kucchi- - Remilia ~Kyuuketsuki no Tame no Kyousoukyoku (Garalulu) [Concerto Cruento]                                           │1234/2541x│  96.66%│    19│    NC│  993.8│   993.8│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
```

After:
```
Getting user data...
Getting user top scores...
User:     Jakads
Live PP:  22037.1 (including 292.2pp from playcount)
Local PP: 22037.1 (-)

╔═══╤═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╤══════════╤════════╤══════╤══════╤═══════╤════════╤═════════╤═══════════════╗
║#  │beatmap                                                                                                                                  │max combo │accuracy│misses│mods  │live pp│local pp│pp change│position change║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║1  │1679790 - xi - Last Resort (Kroytz) [Jakads' LASTING LEGACY]                                                                             │3679/4425x│  99.84%│     1│  None│ 1350.7│  1350.7│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║2  │2220863 - penoreri - Monochrome and Vivid (ruka) [New Palettes]                                                                          │6493/8043x│  98.97%│    17│    NC│ 1349.9│  1349.8│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║3  │2261284 - Fractal Dreamers - Gardens Under A Spring Sky (_Kobii) [Tranquility]                                                           │2032/3503x│   98.2%│     8│    NC│ 1294.0│  1294.0│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║4  │2727115 - Camellia feat. Nanahira - Energy * Drin-ko * Fein-chan!  (Camellia's "MONSTERISTIC" D. M. P. Remix) (Kim_GodSSI) [Energy Drink]│920/11847x│  93.13%│   181│    NC│ 1228.3│  1228.2│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║5  │2119517 - Maverick - Shironaga Star Jet -aquamarine mix- (_Kobii) [Cosmic Journey // 7K]                                                 │2797/8372x│   99.3%│    10│    NC│ 1224.1│  1224.1│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║6  │2027282 - Ironami - Melty Sweets (_Kobii) [HEAVENLY]                                                                                     │1630/3479x│  99.18%│     3│    NC│ 1151.3│  1151.3│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║7  │2694154 - xi - Halcyon -Long Version- (Kawawa) [Halcyon Days]                                                                            │1842/6657x│  97.05%│    39│    DT│ 1143.3│  1143.4│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║8  │2167361 - eicateve - R.I.P. (Pengdoll) [7K Rest In Peace]                                                                                │1172/3295x│  95.56%│    50│    NC│ 1141.9│  1141.9│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║9  │1023967 - LeaF - Doppelganger (Jinjin) [jakads' Extra]                                                                                   │1245/3137x│  96.52%│    25│    NC│ 1140.7│  1140.7│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║10 │1648263 - SUi - planetarium (Reba) [HEAVENLY]                                                                                            │ 959/3255x│  98.04%│    14│    NC│ 1139.3│  1139.3│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║11 │3144879 - Kankitsu - Moments (Wonki) [Best Memories]                                                                                     │2582/8012x│  99.26%│    10│    NC│ 1132.0│  1132.0│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║12 │3302254 - AAAA - Hiyokko Santa to Yuki no Machi (Maxus) [O Little Town of Bethlehem]                                                     │1196/4603x│  97.91%│    24│    NC│ 1107.2│  1107.2│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║13 │884617 - LeaF - Doppelganger (Jinjin) [Alter Ego]                                                                                        │ 344/4335x│  90.49%│    83│    NC│ 1106.9│  1106.9│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║14 │1742328 - kamome sano - starlights feat. TEA (K a b i -) [Celestial Radiance // 7K]                                                      │4365/6043x│  99.63%│     5│    NC│ 1093.8│  1093.8│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║15 │1270895 - technoplanet - Inscape (Reba) [HEAVENLY]                                                                                       │ 729/2631x│  97.33%│    18│    NC│ 1089.2│  1089.2│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║16 │2692497 - Halozy - Deconstruction Star (Flexo123) [Twinkling Stars]                                                                      │5846/6642x│  99.35%│     3│    NC│ 1087.9│  1087.9│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║17 │2365803 - Camellia - FM Synthesis Experiment (Umo-) [Execute]                                                                            │2579/7564x│   98.9%│    11│    NC│ 1079.3│  1079.3│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║18 │3090158 - ARForest - Rainbow Magic!! (_Stan) [Iridescent]                                                                                │1267/3870x│  97.63%│    22│    NC│ 1073.3│  1073.3│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║19 │1684161 - MAZARE - Mazare Party (Insp1r3) [JAKARE's 6K Extra]                                                                            │2471/5092x│  98.64%│     9│    NC│ 1055.8│  1055.8│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║20 │1130570 - LeaF - Alice in Misanthrope -Ensei Alice- (Kawawa) [Alice in Wonderland]                                                       │2781/3358x│  99.51%│     4│    NC│ 1038.4│  1038.4│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║21 │1368838 - Nanahira - Petals (Arzenvald) [~ fragments of the night ~ // seven key]                                                        │2882/5137x│  99.29%│     3│    NC│ 1032.4│  1032.4│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║22 │888793 - void - Just Hold on (To All Fighters) (Blocko) [Resolve]                                                                        │3469/5778x│  99.05%│    11│    NC│ 1029.0│  1029.0│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║23 │948777 - xi - Ascension to Heaven (Jinjin) [Elysium]                                                                                     │1344/5259x│  96.62%│    45│    NC│ 1022.5│  1022.5│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║24 │1239794 - BlackYooh vs. siromaru - BLACK or WHITE? (Kawawa) [Monochromatic Horizon]                                                      │1357/7995x│  95.84%│    70│    NC│ 1016.4│  1016.4│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║25 │1231418 - Chroma - Hoshi ga Furanai Machi (Wonki) [Meteor Shower // pporse's 7K]                                                         │2934/7457x│  99.46%│     4│    DT│ 1003.9│  1003.9│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║26 │830448 - Yooh - Ice Angel (pporse) [Euphoria]                                                                                            │3433/6009x│  99.71%│     4│    NC│ 1001.7│  1001.7│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║27 │3165981 - xi - ANiMA (Kawawa) [Piano Symphonia]                                                                                          │ 721/5940x│  97.18%│    57│    NC│  999.1│   999.1│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║28 │2935047 - Yu_Asahina - eighth-slave (_Rokii) [I'm a slave for this song // VIVID]                                                        │1181/5779x│  99.19%│    15│    NC│  998.6│   998.6│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║29 │1670744 - SUi - planetarium (Reba) [MAXIMUM]                                                                                             │2012/2789x│  99.74%│     2│    NC│  993.9│   993.9│      0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
║30 │1350666 - Kucchi- - Remilia ~Kyuuketsuki no Tame no Kyousoukyoku (Garalulu) [Concerto Cruento]                                           │1234/2541x│  96.66%│    19│    NC│  993.8│   993.8│     -0.0│       -       ║
╟───┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────┼────────┼──────┼──────┼───────┼────────┼─────────┼───────────────╢
```