### PR TITLE
Name newly created difficulties in a better way

### DIFF
--- a/osu.Game.Tests/Utils/NamingUtilsTest.cs
+++ b/osu.Game.Tests/Utils/NamingUtilsTest.cs
@@ -1,0 +1,132 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Utils;
+
+namespace osu.Game.Tests.Utils
+{
+    [TestFixture]
+    public class NamingUtilsTest
+    {
+        [Test]
+        public void TestEmptySet()
+        {
+            string nextBestName = NamingUtils.GetNextBestName(Enumerable.Empty<string>(), "New Difficulty");
+
+            Assert.AreEqual("New Difficulty", nextBestName);
+        }
+
+        [Test]
+        public void TestNotTaken()
+        {
+            string[] existingNames =
+            {
+                "Something",
+                "Entirely",
+                "Different"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty", nextBestName);
+        }
+
+        [Test]
+        public void TestNotTakenButClose()
+        {
+            string[] existingNames =
+            {
+                "New Difficulty(1)",
+                "New Difficulty (abcd)",
+                "New Difficulty but not really"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty", nextBestName);
+        }
+
+        [Test]
+        public void TestAlreadyTaken()
+        {
+            string[] existingNames =
+            {
+                "New Difficulty"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty (1)", nextBestName);
+        }
+
+        [Test]
+        public void TestAlreadyTakenWithDifferentCase()
+        {
+            string[] existingNames =
+            {
+                "new difficulty"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty (1)", nextBestName);
+        }
+
+        [Test]
+        public void TestAlreadyTakenWithBrackets()
+        {
+            string[] existingNames =
+            {
+                "new difficulty (copy)"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty (copy)");
+
+            Assert.AreEqual("New Difficulty (copy) (1)", nextBestName);
+        }
+
+        [Test]
+        public void TestMultipleAlreadyTaken()
+        {
+            string[] existingNames =
+            {
+                "New Difficulty",
+                "New difficulty (1)",
+                "new Difficulty (2)",
+                "New DIFFICULTY (3)"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty (4)", nextBestName);
+        }
+
+        [Test]
+        public void TestEvenMoreAlreadyTaken()
+        {
+            string[] existingNames = Enumerable.Range(1, 30).Select(i => $"New Difficulty ({i})").Append("New Difficulty").ToArray();
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty (31)", nextBestName);
+        }
+
+        [Test]
+        public void TestMultipleAlreadyTakenWithGaps()
+        {
+            string[] existingNames =
+            {
+                "New Difficulty",
+                "New Difficulty (1)",
+                "New Difficulty (4)",
+                "New Difficulty (9)"
+            };
+
+            string nextBestName = NamingUtils.GetNextBestName(existingNames, "New Difficulty");
+
+            Assert.AreEqual("New Difficulty (2)", nextBestName);
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -22,6 +22,7 @@ using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Skinning;
 using osu.Game.Stores;
+using osu.Game.Utils;
 
 #nullable enable
 
@@ -123,7 +124,10 @@ namespace osu.Game.Beatmaps
         {
             var playableBeatmap = referenceWorkingBeatmap.GetPlayableBeatmap(rulesetInfo);
 
-            var newBeatmapInfo = new BeatmapInfo(rulesetInfo, new BeatmapDifficulty(), playableBeatmap.Metadata.DeepClone());
+            var newBeatmapInfo = new BeatmapInfo(rulesetInfo, new BeatmapDifficulty(), playableBeatmap.Metadata.DeepClone())
+            {
+                DifficultyName = NamingUtils.GetNextBestName(targetBeatmapSet.Beatmaps.Select(b => b.DifficultyName), "New Difficulty")
+            };
             var newBeatmap = new Beatmap { BeatmapInfo = newBeatmapInfo };
             foreach (var timingPoint in playableBeatmap.ControlPointInfo.TimingPoints)
                 newBeatmap.ControlPointInfo.Add(timingPoint.Time, timingPoint.DeepClone());
@@ -150,8 +154,10 @@ namespace osu.Game.Beatmaps
             newBeatmap.BeatmapInfo = newBeatmapInfo = referenceWorkingBeatmap.BeatmapInfo.Clone();
             // assign a new ID to the clone.
             newBeatmapInfo.ID = Guid.NewGuid();
-            // add "(copy)" suffix to difficulty name to avoid clashes on save.
-            newBeatmapInfo.DifficultyName += " (copy)";
+            // add "(copy)" suffix to difficulty name, and additionally ensure that it doesn't conflict with any other potentially pre-existing copies.
+            newBeatmapInfo.DifficultyName = NamingUtils.GetNextBestName(
+                targetBeatmapSet.Beatmaps.Select(b => b.DifficultyName),
+                $"{newBeatmapInfo.DifficultyName} (copy)");
             // clear the hash, as that's what is used to match .osu files with their corresponding realm beatmaps.
             newBeatmapInfo.Hash = string.Empty;
             // clear online properties.

--- a/osu.Game/Utils/NamingUtils.cs
+++ b/osu.Game/Utils/NamingUtils.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.Utils
+{
+    public static class NamingUtils
+    {
+        public static string GetNextBestName(IEnumerable<string> existingNames, string desiredName)
+        {
+            return null;
+        }
+    }
+}

--- a/osu.Game/Utils/NamingUtils.cs
+++ b/osu.Game/Utils/NamingUtils.cs
@@ -2,14 +2,60 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace osu.Game.Utils
 {
     public static class NamingUtils
     {
+        /// <summary>
+        /// Given a set of <paramref name="existingNames"/> and a target <paramref name="desiredName"/>,
+        /// finds a "best" name closest to <paramref name="desiredName"/> that is not in <paramref name="existingNames"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This helper is most useful in scenarios when creating new objects in a set
+        /// (such as adding new difficulties to a beatmap set, or creating a clone of an existing object that needs a unique name).
+        /// If <paramref name="desiredName"/> is already present in <paramref name="existingNames"/>,
+        /// this method will append the lowest possible number in brackets that doesn't conflict with <paramref name="existingNames"/>
+        /// to <paramref name="desiredName"/> and return that.
+        /// See <c>osu.Game.Tests.Utils.NamingUtilsTest</c> for concrete examples of behaviour.
+        /// </para>
+        /// <para>
+        /// <paramref name="desiredName"/> and <paramref name="existingNames"/> are compared in a case-insensitive manner,
+        /// so this method is safe to use for naming files in a platform-invariant manner.
+        /// </para>
+        /// </remarks>
         public static string GetNextBestName(IEnumerable<string> existingNames, string desiredName)
         {
-            return null;
+            string pattern = $@"^(?i){Regex.Escape(desiredName)}(?-i)( \((?<copyNumber>[1-9][0-9]*)\))?$";
+            var regex = new Regex(pattern, RegexOptions.Compiled);
+            var takenNumbers = new HashSet<int>();
+
+            foreach (string name in existingNames)
+            {
+                var match = regex.Match(name);
+                if (!match.Success)
+                    continue;
+
+                string copyNumberString = match.Groups[@"copyNumber"].Value;
+
+                if (string.IsNullOrEmpty(copyNumberString))
+                {
+                    takenNumbers.Add(0);
+                    continue;
+                }
+
+                takenNumbers.Add(int.Parse(copyNumberString));
+            }
+
+            int bestNumber = 0;
+            while (takenNumbers.Contains(bestNumber))
+                bestNumber += 1;
+
+            return bestNumber == 0
+                ? desiredName
+                : $"{desiredName} ({bestNumber})";
         }
     }
 }


### PR DESCRIPTION
In #16861 it was brought up that the fact that [you could make an error notification show when trying to create a new difficulty twice in a row](https://github.com/ppy/osu/pull/16861#issuecomment-1039981793) felt bad, as well as that [a copy numbering scheme would be a good idea](https://github.com/ppy/osu/pull/16861#issuecomment-1040726811). This is an implementation of that.

The actual name generation part was split off to a helper method that could potentially be used in more contexts later - seems like it'd be generally useful? See the test cases as to how it behaves, but basically, it will work in the following way:

* New difficulties will receive the following names: `New Difficulty`, then if that exists - `New Difficulty (1)`, then if that exists - `New Difficulty (2)`, etc.
* Copies will always receive a `(copy)` suffix, but if there is already another difficulty with the `(copy)` suffix, then the next names in order are: `(copy) (1)`, `(copy) (2)`, etc. Note that a copy of a `(copy)` difficulty will show ` (copy) (copy)` but... I didn't feel like that was worth fixing? Will change on request.

Kind of a lot of work for this behaviour, but it feels similar to how OSes do these sorts of things, and also gets rid of the errors, so... maybe worth?