### PR TITLE
Fix mania PP calculator applying incorrect score multiplier

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
@@ -43,14 +43,11 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             countMeh = Score.Statistics.GetValueOrDefault(HitResult.Meh);
             countMiss = Score.Statistics.GetValueOrDefault(HitResult.Miss);
 
-            IEnumerable<Mod> scoreIncreaseMods = Ruleset.GetModsFor(ModType.DifficultyIncrease);
-
-            double scoreMultiplier = 1.0;
-            foreach (var m in mods.Where(m => !scoreIncreaseMods.Contains(m)))
-                scoreMultiplier *= m.ScoreMultiplier;
-
-            // Scale score up, so it's comparable to other keymods
-            scaledScore *= 1.0 / scoreMultiplier;
+            if (Attributes.ScoreMultiplier > 0)
+            {
+                // Scale score up, so it's comparable to other keymods
+                scaledScore *= 1.0 / Attributes.ScoreMultiplier;
+            }
 
             // Arbitrary initial value for scaling pp in order to standardize distributions across game modes.
             // The specific number has no intrinsic meaning and can be adjusted as needed.


### PR DESCRIPTION
Matches osu-performance implementation, which factors in the `ScoreMultiplier` attribute. The current implementation is incorrect since they're not implemented correctly (or at all) - the values actually change based on the beatmap, etc:
https://github.com/ppy/osu/blob/a1b39a96cfe3f4d0f02652ded5ebca09ba1d24e1/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs#L12-L17
Whereas the difficulty calculator correctly computes `ScoreMultiplier`, and is also an osu-web-databased value that we've previously validated:
https://github.com/ppy/osu/blob/a1b39a96cfe3f4d0f02652ded5ebca09ba1d24e1/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs#L140-L164