### PR TITLE
Fix beatmap overlay leaderboards and links not working

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -124,9 +124,9 @@ namespace osu.Game.Online.API.Requests.Responses
 
                         case 1: return "taiko";
 
-                        case 2: return "catch";
+                        case 2: return "fruits";
 
-                        case 3: return "fruits";
+                        case 3: return "mania";
 
                         default: throw new ArgumentOutOfRangeException();
                     }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -112,7 +112,27 @@ namespace osu.Game.Online.API.Requests.Responses
             public int OnlineID { get; set; } = -1;
 
             public string Name => $@"{nameof(APIRuleset)} (ID: {OnlineID})";
-            public string ShortName => nameof(APIRuleset);
+
+            public string ShortName
+            {
+                get
+                {
+                    // TODO: this should really not exist.
+                    switch (OnlineID)
+                    {
+                        case 0: return "osu";
+
+                        case 1: return "taiko";
+
+                        case 2: return "catch";
+
+                        case 3: return "fruits";
+
+                        default: throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+
             public string InstantiationInfo => string.Empty;
 
             public Ruleset CreateInstance() => throw new NotImplementedException();


### PR DESCRIPTION
Completely aware that this isn't how it should be done, but would like to get this out in a hotfix release today. Maybe changes opinions on https://github.com/ppy/osu/pull/16890 structure?

This is used in two places I found initially:

https://github.com/ppy/osu/blob/b5834044e0d405ec4acbfa9629271d4dc77fa729/osu.Game/Online/API/Requests/GetScoresRequest.cs#L43
https://github.com/ppy/osu/blob/05f7ea6b6d27ea5378b10c1e4f0965e162a5ce96/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs#L221

Is a regression dating back as far as realm, I believe.

Closes issue mentioned in https://github.com/ppy/osu/discussions/16902.