### PR TITLE
Fix storyboard background replacement logic not working for beatmaps with multiple backgrounds

### DIFF
--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Storyboards
         {
             get
             {
-                string backgroundPath = BeatmapInfo.BeatmapSet?.Metadata.BackgroundFile;
+                string backgroundPath = BeatmapInfo.Metadata.BackgroundFile;
 
                 if (string.IsNullOrEmpty(backgroundPath))
                     return false;


### PR DESCRIPTION
In the case where the background image of individual difficulties is different, querying the beatmap *set*'s metadata as we were will cause issues.

I haven't added test coverage for this but can if required. Can be manually tested using https://osu.ppy.sh/beatmapsets/1595773#osu/3377474 (specifically the highest difficulty).

Closes https://github.com/ppy/osu/discussions/16873.