### PR TITLE
Add all colour constants for "basic" colour theme to `OsuColour`

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -268,6 +268,11 @@ namespace osu.Game.Graphics
 
         // Reference: https://www.figma.com/file/VIkXMYNPMtQem2RJg9k2iQ/Asset%2FColours?node-id=1838%3A3
 
+        // Note that the colours in this region are also defined in `OverlayColourProvider` as `Colour{0,1,2,3,4}`.
+        // The difference as to which should be used where comes down to context.
+        // If the colour in question is supposed to always match the view in which it is displayed theme-wise, use `OverlayColourProvider`.
+        // If the colour usage is special and in general differs from the surrounding view in choice of hue, use the `OsuColour` constants.
+
         public readonly Color4 Pink0 = Color4Extensions.FromHex(@"ff99c7");
         public readonly Color4 Pink1 = Color4Extensions.FromHex(@"ff66ab");
         public readonly Color4 Pink2 = Color4Extensions.FromHex(@"eb4791");

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -264,32 +264,53 @@ namespace osu.Game.Graphics
         public readonly Color4 GrayE = Color4Extensions.FromHex(@"eee");
         public readonly Color4 GrayF = Color4Extensions.FromHex(@"fff");
 
-        /// <summary>
-        /// Equivalent to <see cref="OverlayColourProvider.Pink"/>'s <see cref="OverlayColourProvider.Colour3"/>.
-        /// </summary>
-        public readonly Color4 Pink3 = Color4Extensions.FromHex(@"cc3378");
+        #region "Basic" colour theme
 
-        /// <summary>
-        /// Equivalent to <see cref="OverlayColourProvider.Blue"/>'s <see cref="OverlayColourProvider.Colour3"/>.
-        /// </summary>
+        // Reference: https://www.figma.com/file/VIkXMYNPMtQem2RJg9k2iQ/Asset%2FColours?node-id=1838%3A3
+
+        public readonly Color4 Pink0 = Color4Extensions.FromHex(@"ff99c7");
+        public readonly Color4 Pink1 = Color4Extensions.FromHex(@"ff66ab");
+        public readonly Color4 Pink2 = Color4Extensions.FromHex(@"eb4791");
+        public readonly Color4 Pink3 = Color4Extensions.FromHex(@"cc3378");
+        public readonly Color4 Pink4 = Color4Extensions.FromHex(@"6b2e49");
+
+        public readonly Color4 Purple0 = Color4Extensions.FromHex(@"b299ff");
+        public readonly Color4 Purple1 = Color4Extensions.FromHex(@"8c66ff");
+        public readonly Color4 Purple2 = Color4Extensions.FromHex(@"7047eb");
+        public readonly Color4 Purple3 = Color4Extensions.FromHex(@"5933cc");
+        public readonly Color4 Purple4 = Color4Extensions.FromHex(@"3d2e6b");
+
+        public readonly Color4 Blue0 = Color4Extensions.FromHex(@"99ddff");
+        public readonly Color4 Blue1 = Color4Extensions.FromHex(@"66ccff");
+        public readonly Color4 Blue2 = Color4Extensions.FromHex(@"47b4eb");
         public readonly Color4 Blue3 = Color4Extensions.FromHex(@"3399cc");
+        public readonly Color4 Blue4 = Color4Extensions.FromHex(@"2e576b");
+
+        public readonly Color4 Green0 = Color4Extensions.FromHex(@"99ffa2");
+        public readonly Color4 Green1 = Color4Extensions.FromHex(@"66ff73");
+        public readonly Color4 Green2 = Color4Extensions.FromHex(@"47eb55");
+        public readonly Color4 Green3 = Color4Extensions.FromHex(@"33cc40");
+        public readonly Color4 Green4 = Color4Extensions.FromHex(@"2e6b33");
 
         public readonly Color4 Lime0 = Color4Extensions.FromHex(@"ccff99");
-
-        /// <summary>
-        /// Equivalent to <see cref="OverlayColourProvider.Lime"/>'s <see cref="OverlayColourProvider.Colour1"/>.
-        /// </summary>
         public readonly Color4 Lime1 = Color4Extensions.FromHex(@"b2ff66");
-
-        /// <summary>
-        /// Equivalent to <see cref="OverlayColourProvider.Lime"/>'s <see cref="OverlayColourProvider.Colour3"/>.
-        /// </summary>
+        public readonly Color4 Lime2 = Color4Extensions.FromHex(@"99eb47");
         public readonly Color4 Lime3 = Color4Extensions.FromHex(@"7fcc33");
+        public readonly Color4 Lime4 = Color4Extensions.FromHex(@"4c6b2e");
 
-        /// <summary>
-        /// Equivalent to <see cref="OverlayColourProvider.Orange"/>'s <see cref="OverlayColourProvider.Colour1"/>.
-        /// </summary>
+        public readonly Color4 Orange0 = Color4Extensions.FromHex(@"ffe699");
         public readonly Color4 Orange1 = Color4Extensions.FromHex(@"ffd966");
+        public readonly Color4 Orange2 = Color4Extensions.FromHex(@"ebc247");
+        public readonly Color4 Orange3 = Color4Extensions.FromHex(@"cca633");
+        public readonly Color4 Orange4 = Color4Extensions.FromHex(@"6b5c2e");
+
+        public readonly Color4 Red0 = Color4Extensions.FromHex(@"ff9b9b");
+        public readonly Color4 Red1 = Color4Extensions.FromHex(@"ff6666");
+        public readonly Color4 Red2 = Color4Extensions.FromHex(@"eb4747");
+        public readonly Color4 Red3 = Color4Extensions.FromHex(@"cc3333");
+        public readonly Color4 Red4 = Color4Extensions.FromHex(@"6b2e2e");
+
+        #endregion
 
         // Content Background
         public readonly Color4 B5 = Color4Extensions.FromHex(@"222a28");

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Game.Graphics;
 using osu.Game.Resources.Localisation.Web;
 using osuTK.Graphics;
 
@@ -33,7 +35,10 @@ namespace osu.Game.Overlays.BeatmapListing
             {
             }
 
-            protected override Color4 GetStateColour() => OverlayColourProvider.Orange.Colour1;
+            [Resolved]
+            private OsuColour colours { get; set; }
+
+            protected override Color4 GetStateColour() => colours.Orange1;
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -44,7 +44,14 @@ namespace osu.Game.Overlays.BeatmapListing
             });
 
             Enabled.Value = true;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
             updateState();
+            FinishTransforms(true);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/BeatmapSet/ExplicitContentBeatmapPill.cs
+++ b/osu.Game/Overlays/BeatmapSet/ExplicitContentBeatmapPill.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         Margin = new MarginPadding { Horizontal = 10f, Vertical = 2f },
                         Text = BeatmapsetsStrings.NsfwBadgeLabel.ToUpper(),
                         Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
-                        Colour = OverlayColourProvider.Orange.Colour2,
+                        Colour = colours.Orange2
                     }
                 }
             };

--- a/osu.Game/Overlays/BeatmapSet/FeaturedArtistBeatmapPill.cs
+++ b/osu.Game/Overlays/BeatmapSet/FeaturedArtistBeatmapPill.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         Margin = new MarginPadding { Horizontal = 10f, Vertical = 2f },
                         Text = BeatmapsetsStrings.FeaturedArtistBadgeLabel.ToUpper(),
                         Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
-                        Colour = OverlayColourProvider.Blue.Colour1,
+                        Colour = colours.Blue1
                     }
                 }
             };

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Overlays
         // The difference as to which should be used where comes down to context.
         // If the colour in question is supposed to always match the view in which it is displayed theme-wise, use `OverlayColourProvider`.
         // If the colour usage is special and in general differs from the surrounding view in choice of hue, use the `OsuColour` constants.
+        public Color4 Colour0 => getColour(1, 0.8f);
         public Color4 Colour1 => getColour(1, 0.7f);
         public Color4 Colour2 => getColour(0.8f, 0.6f);
         public Color4 Colour3 => getColour(0.6f, 0.5f);

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -11,15 +11,6 @@ namespace osu.Game.Overlays
     {
         private readonly OverlayColourScheme colourScheme;
 
-        public static OverlayColourProvider Red { get; } = new OverlayColourProvider(OverlayColourScheme.Red);
-        public static OverlayColourProvider Pink { get; } = new OverlayColourProvider(OverlayColourScheme.Pink);
-        public static OverlayColourProvider Orange { get; } = new OverlayColourProvider(OverlayColourScheme.Orange);
-        public static OverlayColourProvider Lime { get; } = new OverlayColourProvider(OverlayColourScheme.Lime);
-        public static OverlayColourProvider Green { get; } = new OverlayColourProvider(OverlayColourScheme.Green);
-        public static OverlayColourProvider Purple { get; } = new OverlayColourProvider(OverlayColourScheme.Purple);
-        public static OverlayColourProvider Blue { get; } = new OverlayColourProvider(OverlayColourScheme.Blue);
-        public static OverlayColourProvider Plum { get; } = new OverlayColourProvider(OverlayColourScheme.Plum);
-
         public OverlayColourProvider(OverlayColourScheme colourScheme)
         {
             this.colourScheme = colourScheme;

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -25,6 +25,10 @@ namespace osu.Game.Overlays
             this.colourScheme = colourScheme;
         }
 
+        // Note that the following five colours are also defined in `OsuColour` as `{colourScheme}{0,1,2,3,4}`.
+        // The difference as to which should be used where comes down to context.
+        // If the colour in question is supposed to always match the view in which it is displayed theme-wise, use `OverlayColourProvider`.
+        // If the colour usage is special and in general differs from the surrounding view in choice of hue, use the `OsuColour` constants.
         public Color4 Colour1 => getColour(1, 0.7f);
         public Color4 Colour2 => getColour(0.8f, 0.6f);
         public Color4 Colour3 => getColour(0.6f, 0.5f);


### PR DESCRIPTION
This is a preparatory / refactoring PR for #16917.

In the mod select overlay redesign, I'm about to begin using the ["basic" colour scheme](https://www.figma.com/file/VIkXMYNPMtQem2RJg9k2iQ/Asset%2FColours?node-id=1838%3A3) quite a bit more, because each mod type gets one of those hues for its corresponding section. In the past, [it was suggested](https://github.com/ppy/osu/pull/14675#discussion_r705831333) that wherever a component purposefully uses a different hue than its surrounding components, then `OsuColour` should be used, rather than the static `OverlayColourProvider`s that currently exist in `master`.

This PR is exactly that change. It adds all the colours from the basic colour scheme to `OsuColour`, migrates all existing references to static `OverlayColourProvider`s to that, and removes the static `OverlayColourProvider`s.

`Colour0` is also added to `OverlayColourProvider` for parity.

I've trimmed the existing singular xmldocs from the `OsuColour` members and replaced them with a single catch-all comment, because it was getting ridiculously hard to read / navigate / cross-reference otherwise.