### PR TITLE
Allow room category to be copied even if `Spotlight`

### DIFF
--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -168,8 +168,7 @@ namespace osu.Game.Online.Rooms
             RoomID.Value = other.RoomID.Value;
             Name.Value = other.Name.Value;
 
-            if (other.Category.Value != RoomCategory.Spotlight)
-                Category.Value = other.Category.Value;
+            Category.Value = other.Category.Value;
 
             if (other.Host.Value != null && Host.Value?.Id != other.Host.Value.Id)
                 Host.Value = other.Host.Value;


### PR DESCRIPTION
I remember that this conditional copy was added to support making copies of spotlight rooms without carrying across the `Spotlight` type, but in testing this is already handled web side to the point that it's not required.

The rationale for allowing the copy is that this method is used for tests, where it was not being copied correctly from the input as expected (used at https://github.com/ppy/osu/blob/bdc3b76df0b58406796e2b08db13be7f2140fa7e/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs#L38

in conjunction with:
https://github.com/ppy/osu/blob/ccd265ebe7237e50ecb7241dca5e3f3703b47a86/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs#L49
)

Changes can be observed in `TestSceneLoungeRoomsContainer`

Before:
![osu Game Tests 2022-02-21 at 08 49 59](https://user-images.githubusercontent.com/191335/154920097-c4650f3a-28ac-4897-b804-e5bad08f5c42.png)

After:
![osu Game Tests 2022-02-21 at 08 48 43](https://user-images.githubusercontent.com/191335/154920037-5de6a8aa-f99e-46ca-9f80-3bcc10604920.png)

