### PR TITLE
Fix beatmap overlay not re-fetching results after initial login

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -67,6 +67,8 @@ namespace osu.Game.Overlays.BeatmapListing
         [Resolved]
         private IAPIProvider api { get; set; }
 
+        private IBindable<APIUser> apiUser;
+
         public BeatmapListingFilterControl()
         {
             RelativeSizeAxes = Axes.X;
@@ -127,7 +129,7 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load(OverlayColourProvider colourProvider, IAPIProvider api)
         {
             sortControlBackground.Colour = colourProvider.Background4;
         }
@@ -161,6 +163,9 @@ namespace osu.Game.Overlays.BeatmapListing
 
             sortCriteria.BindValueChanged(_ => queueUpdateSearch());
             sortDirection.BindValueChanged(_ => queueUpdateSearch());
+
+            apiUser = api.LocalUser.GetBoundCopy();
+            apiUser.BindValueChanged(_ => queueUpdateSearch());
         }
 
         public void TakeFocus() => searchControl.TakeFocus();
@@ -189,6 +194,9 @@ namespace osu.Game.Overlays.BeatmapListing
             SearchStarted?.Invoke();
 
             resetSearch();
+
+            if (!api.IsLoggedIn)
+                return;
 
             queryChangedDebounce = Scheduler.AddDelayed(() =>
             {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Localisation;
 using osu.Framework.Graphics;
@@ -19,6 +20,7 @@ using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.Containers;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Resources.Localisation.Web;
@@ -31,6 +33,11 @@ namespace osu.Game.Overlays
     {
         [Resolved]
         private PreviewTrackManager previewTrackManager { get; set; }
+
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        private IBindable<APIUser> apiUser;
 
         private Drawable currentContent;
         private Container panelTarget;
@@ -93,6 +100,13 @@ namespace osu.Game.Overlays
         {
             base.LoadComplete();
             filterControl.CardSize.BindValueChanged(_ => onCardSizeChanged());
+
+            apiUser = api.LocalUser.GetBoundCopy();
+            apiUser.BindValueChanged(_ =>
+            {
+                if (api.IsLoggedIn)
+                    addContentToResultsArea(Drawable.Empty());
+            });
         }
 
         public void ShowWithSearch(string query)


### PR DESCRIPTION
d6032a2335: Fixes beatmap overlay not re-fetching results after login
e744840d07: Ensures old results are cleared from beatmap overlay on logout. Without this, you can see old results briefly after perfoming a login-logout-login with the overlay visible the whole time.

Closes #16958.