### PR TITLE
Fix handling of badly-formatted osu:// urls

### DIFF
--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -236,8 +236,7 @@ namespace osu.Game.Online.Chat
                             break;
 
                         default:
-                            linkType = LinkAction.External;
-                            break;
+                            return new LinkDetails(LinkAction.External, url);
                     }
 
                     return new LinkDetails(linkType, args[2]);


### PR DESCRIPTION
Caught this when looking at https://github.com/ppy/osu/pull/16909#discussion_r812437931.

`osu://1/calc.exe` opens... exactly as you'd expect.

![osu_2022-02-23_00-38-08](https://user-images.githubusercontent.com/16479013/155238114-a96090ec-ee62-457e-a11d-d30442057e5c.jpg)

