### PR TITLE
Implement mod panel for new mod select design

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPanel.cs
@@ -1,14 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -36,6 +39,42 @@ namespace osu.Game.Tests.Visual.UserInterface
                     new ModPanel(new OsuModAlternate()),
                     new ModPanel(new OsuModApproachDifferent())
                 }
+            });
+        }
+
+        [Test]
+        public void TestIncompatibilityDisplay()
+        {
+            IncompatibilityDisplayingModPanel panel = null;
+
+            AddStep("create panel with DT", () => Child = panel = new IncompatibilityDisplayingModPanel(new OsuModDoubleTime())
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.None,
+                Width = 300
+            });
+
+            clickPanel();
+            AddAssert("panel active", () => panel.Active.Value);
+
+            clickPanel();
+            AddAssert("panel not active", () => !panel.Active.Value);
+
+            AddStep("set incompatible mod", () => SelectedMods.Value = new[] { new OsuModHalfTime() });
+
+            clickPanel();
+            AddAssert("panel not active", () => !panel.Active.Value);
+
+            AddStep("reset mods", () => SelectedMods.Value = Array.Empty<Mod>());
+
+            clickPanel();
+            AddAssert("panel active", () => panel.Active.Value);
+
+            void clickPanel() => AddStep("click panel", () =>
+            {
+                InputManager.MoveMouseTo(panel);
+                InputManager.Click(MouseButton.Left);
             });
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPanel.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestSceneModPanel : OsuManualInputManagerTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
+
+        [Test]
+        public void TestVariousPanels()
+        {
+            AddStep("create content", () => Child = new FillFlowContainer
+            {
+                Width = 300,
+                AutoSizeAxes = Axes.Y,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Spacing = new Vector2(0, 5),
+                Children = new[]
+                {
+                    new ModPanel(new OsuModHalfTime()),
+                    new ModPanel(new OsuModFlashlight()),
+                    new ModPanel(new OsuModAutoplay()),
+                    new ModPanel(new OsuModAlternate()),
+                    new ModPanel(new OsuModApproachDifferent())
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModButton.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModButton.cs
@@ -8,11 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Utils;
 using osuTK;
 
@@ -66,52 +62,5 @@ namespace osu.Game.Overlays.Mods
         }
 
         public override ITooltip<Mod> GetCustomTooltip() => new IncompatibilityDisplayingTooltip();
-
-        private class IncompatibilityDisplayingTooltip : ModButtonTooltip
-        {
-            private readonly OsuSpriteText incompatibleText;
-
-            private readonly Bindable<IReadOnlyList<Mod>> incompatibleMods = new Bindable<IReadOnlyList<Mod>>();
-
-            [Resolved]
-            private Bindable<RulesetInfo> ruleset { get; set; }
-
-            public IncompatibilityDisplayingTooltip()
-            {
-                AddRange(new Drawable[]
-                {
-                    incompatibleText = new OsuSpriteText
-                    {
-                        Margin = new MarginPadding { Top = 5 },
-                        Font = OsuFont.GetFont(weight: FontWeight.Regular),
-                        Text = "Incompatible with:"
-                    },
-                    new ModDisplay
-                    {
-                        Current = incompatibleMods,
-                        ExpansionMode = ExpansionMode.AlwaysExpanded,
-                        Scale = new Vector2(0.7f)
-                    }
-                });
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
-            {
-                incompatibleText.Colour = colours.BlueLight;
-            }
-
-            protected override void UpdateDisplay(Mod mod)
-            {
-                base.UpdateDisplay(mod);
-
-                var incompatibleTypes = mod.IncompatibleMods;
-
-                var allMods = ruleset.Value.CreateInstance().AllMods;
-
-                incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).Select(m => m.CreateInstance()).ToList();
-                incompatibleText.Text = incompatibleMods.Value.Any() ? "Incompatible with:" : "Compatible with all mods";
-            }
-        }
     }
 }

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class IncompatibilityDisplayingModPanel : ModPanel, IHasCustomTooltip<Mod>
+    {
+        private readonly BindableBool incompatible = new BindableBool();
+
+        [Resolved]
+        private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; }
+
+        public IncompatibilityDisplayingModPanel(Mod mod)
+            : base(mod)
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            selectedMods.BindValueChanged(_ => updateIncompatibility(), true);
+            incompatible.BindValueChanged(_ => Scheduler.AddOnce(UpdateState));
+            // base call will run `UpdateState()` first time and finish transforms.
+            base.LoadComplete();
+        }
+
+        private void updateIncompatibility()
+        {
+            incompatible.Value = selectedMods.Value.Count > 0 && !selectedMods.Value.Contains(Mod) && !ModUtils.CheckCompatibleSet(selectedMods.Value.Append(Mod));
+        }
+
+        protected override void UpdateState()
+        {
+            Action = incompatible.Value ? () => { } : (Action)Active.Toggle;
+
+            if (incompatible.Value)
+            {
+                Colour4 backgroundColour = ColourProvider.Background5;
+                Colour4 textBackgroundColour = ColourProvider.Background4;
+
+                Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, textBackgroundColour), TRANSITION_DURATION, Easing.OutQuint);
+                Background.FadeColour(backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+
+                SwitchContainer.ResizeWidthTo(IDLE_SWITCH_WIDTH, TRANSITION_DURATION, Easing.OutQuint);
+                SwitchContainer.FadeColour(Colour4.Gray, TRANSITION_DURATION, Easing.OutQuint);
+                MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
+                {
+                    Left = IDLE_SWITCH_WIDTH,
+                    Right = CORNER_RADIUS
+                }, TRANSITION_DURATION, Easing.OutQuint);
+
+                TextBackground.FadeColour(textBackgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+                TextFlow.FadeColour(Colour4.White.Opacity(0.5f), TRANSITION_DURATION, Easing.OutQuint);
+                return;
+            }
+
+            SwitchContainer.FadeColour(Colour4.White, TRANSITION_DURATION, Easing.OutQuint);
+            base.UpdateState();
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (incompatible.Value)
+                return true; // bypasses base call purposely in order to not play out the intermediate state animation.
+
+            return base.OnMouseDown(e);
+        }
+
+        #region IHasCustomTooltip
+
+        public ITooltip<Mod> GetCustomTooltip() => new IncompatibilityDisplayingTooltip();
+
+        public Mod TooltipContent => Mod;
+
+        #endregion
+    }
+}

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingTooltip.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingTooltip.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Play.HUD;
+using osuTK;
+
+namespace osu.Game.Overlays.Mods
+{
+    internal class IncompatibilityDisplayingTooltip : ModButtonTooltip
+    {
+        private readonly OsuSpriteText incompatibleText;
+
+        private readonly Bindable<IReadOnlyList<Mod>> incompatibleMods = new Bindable<IReadOnlyList<Mod>>();
+
+        [Resolved]
+        private Bindable<RulesetInfo> ruleset { get; set; }
+
+        public IncompatibilityDisplayingTooltip()
+        {
+            AddRange(new Drawable[]
+            {
+                incompatibleText = new OsuSpriteText
+                {
+                    Margin = new MarginPadding { Top = 5 },
+                    Font = OsuFont.GetFont(weight: FontWeight.Regular),
+                    Text = "Incompatible with:"
+                },
+                new ModDisplay
+                {
+                    Current = incompatibleMods,
+                    ExpansionMode = ExpansionMode.AlwaysExpanded,
+                    Scale = new Vector2(0.7f)
+                }
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            incompatibleText.Colour = colours.BlueLight;
+        }
+
+        protected override void UpdateDisplay(Mod mod)
+        {
+            base.UpdateDisplay(mod);
+
+            var incompatibleTypes = mod.IncompatibleMods;
+
+            var allMods = ruleset.Value.CreateInstance().AllMods;
+
+            incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).Select(m => m.CreateInstance()).ToList();
+            incompatibleText.Text = incompatibleMods.Value.Any() ? "Incompatible with:" : "Compatible with all mods";
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -1,0 +1,272 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osuTK;
+using osuTK.Input;
+
+#nullable enable
+
+namespace osu.Game.Overlays.Mods
+{
+    public class ModPanel : OsuClickableContainer
+    {
+        public Mod Mod { get; }
+        public BindableBool Active { get; } = new BindableBool();
+
+        protected readonly Box Background;
+        protected readonly Container SwitchContainer;
+        protected readonly Container MainContentContainer;
+        protected readonly Box TextBackground;
+        protected readonly FillFlowContainer TextFlow;
+
+        [Resolved]
+        protected OverlayColourProvider ColourProvider { get; private set; } = null!;
+
+        protected const double TRANSITION_DURATION = 150;
+        protected const float SHEAR_X = 0.2f;
+
+        protected const float HEIGHT = 42;
+        protected const float CORNER_RADIUS = 7;
+        protected const float IDLE_SWITCH_WIDTH = 54;
+        protected const float EXPANDED_SWITCH_WIDTH = 70;
+
+        private Colour4 activeColour;
+        private Colour4 activeHoverColour;
+
+        private Sample? sampleOff;
+        private Sample? sampleOn;
+
+        public ModPanel(Mod mod)
+        {
+            Mod = mod;
+
+            RelativeSizeAxes = Axes.X;
+            Height = 42;
+
+            // all below properties are applied to `Content` rather than the `ModPanel` in its entirety
+            // to allow external components to set these properties on the panel without affecting
+            // its "internal" appearance.
+            Content.Masking = true;
+            Content.CornerRadius = CORNER_RADIUS;
+            Content.BorderThickness = 2;
+            Content.Shear = new Vector2(SHEAR_X, 0);
+
+            Children = new Drawable[]
+            {
+                Background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                SwitchContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    Child = new ModSwitchSmall(mod)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Active = { BindTarget = Active },
+                        Shear = new Vector2(-SHEAR_X, 0),
+                        Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
+                    }
+                },
+                MainContentContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = CORNER_RADIUS,
+                        Children = new Drawable[]
+                        {
+                            TextBackground = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both
+                            },
+                            TextFlow = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding
+                                {
+                                    Horizontal = 17.5f,
+                                    Vertical = 4
+                                },
+                                Direction = FillDirection.Vertical,
+                                Children = new[]
+                                {
+                                    new OsuSpriteText
+                                    {
+                                        Text = mod.Name,
+                                        Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
+                                        Shear = new Vector2(-SHEAR_X, 0),
+                                        Margin = new MarginPadding
+                                        {
+                                            Left = -18 * SHEAR_X
+                                        }
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Text = mod.Description,
+                                        Font = OsuFont.Default.With(size: 12),
+                                        RelativeSizeAxes = Axes.X,
+                                        Truncate = true,
+                                        Shear = new Vector2(-SHEAR_X, 0)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Action = Active.Toggle;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio, OsuColour colours)
+        {
+            sampleOn = audio.Samples.Get(@"UI/check-on");
+            sampleOff = audio.Samples.Get(@"UI/check-off");
+
+            activeColour = colours.ForModType(Mod.Type);
+            activeHoverColour = activeColour.Lighten(0.3f);
+        }
+
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds(sampleSet);
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Active.BindValueChanged(_ =>
+            {
+                playStateChangeSamples();
+                UpdateState();
+            });
+
+            UpdateState();
+            FinishTransforms(true);
+        }
+
+        private void playStateChangeSamples()
+        {
+            if (Active.Value)
+                sampleOn?.Play();
+            else
+                sampleOff?.Play();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            UpdateState();
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            UpdateState();
+            base.OnHoverLost(e);
+        }
+
+        private double? mouseDownTime;
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (e.Button == MouseButton.Left)
+                mouseDownTime = Time.Current;
+            return true;
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            mouseDownTime = null;
+            base.OnMouseUp(e);
+        }
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            mouseDownTime = null;
+            return true;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (mouseDownTime != null)
+            {
+                double startTime = mouseDownTime.Value;
+                double endTime = startTime + 600;
+
+                float startValue = Active.Value ? EXPANDED_SWITCH_WIDTH : IDLE_SWITCH_WIDTH;
+                float endValue = IDLE_SWITCH_WIDTH + (EXPANDED_SWITCH_WIDTH - IDLE_SWITCH_WIDTH) * (Active.Value ? 0.2f : 0.8f);
+
+                float targetWidth = Interpolation.ValueAt<float>(Math.Clamp(Time.Current, startTime, endTime), startValue, endValue, startTime, endTime, Easing.OutQuint);
+
+                SwitchContainer.Width = targetWidth;
+                MainContentContainer.Padding = new MarginPadding
+                {
+                    Left = targetWidth,
+                    Right = CORNER_RADIUS
+                };
+            }
+        }
+
+        protected virtual void UpdateState()
+        {
+            if (Active.Value)
+            {
+                Colour4 backgroundTextColour = IsHovered ? activeHoverColour : activeColour;
+                Colour4 backgroundColour = Interpolation.ValueAt<Colour4>(0.7f, Colour4.Black, backgroundTextColour, 0, 1);
+
+                Content.TransformTo(nameof(BorderColour), (ColourInfo)backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+                Background.FadeColour(backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+                SwitchContainer.ResizeWidthTo(EXPANDED_SWITCH_WIDTH, TRANSITION_DURATION, Easing.OutQuint);
+                MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
+                {
+                    Left = EXPANDED_SWITCH_WIDTH,
+                    Right = CORNER_RADIUS
+                }, TRANSITION_DURATION, Easing.OutQuint);
+                TextBackground.FadeColour(backgroundTextColour, TRANSITION_DURATION, Easing.OutQuint);
+                TextFlow.FadeColour(ColourProvider.Background6, TRANSITION_DURATION, Easing.OutQuint);
+            }
+            else
+            {
+                Colour4 backgroundColour = ColourProvider.Background3;
+                if (IsHovered)
+                    backgroundColour = Interpolation.ValueAt<Colour4>(0.25f, backgroundColour, activeColour, 0, 1);
+
+                Colour4 textBackgroundColour = ColourProvider.Background2;
+                if (IsHovered)
+                    textBackgroundColour = Interpolation.ValueAt<Colour4>(0.25f, textBackgroundColour, activeColour, 0, 1);
+
+                Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, textBackgroundColour), TRANSITION_DURATION, Easing.OutQuint);
+                Background.FadeColour(backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+                SwitchContainer.ResizeWidthTo(IDLE_SWITCH_WIDTH, TRANSITION_DURATION, Easing.OutQuint);
+                MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
+                {
+                    Left = IDLE_SWITCH_WIDTH,
+                    Right = CORNER_RADIUS
+                }, TRANSITION_DURATION, Easing.OutQuint);
+                TextBackground.FadeColour(textBackgroundColour, TRANSITION_DURATION, Easing.OutQuint);
+                TextFlow.FadeColour(Colour4.White, TRANSITION_DURATION, Easing.OutQuint);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Continuation of #16917.

Reference design: https://www.figma.com/file/NkdREXr6wFkA99oLw8PnBv/Client%2FMod-Selection?node-id=0%3A17

The diff is a bit larger than I would have liked but most of this is UI code, somewhat artificially inflated by me moving out one tooltip class from the current implementation to share (which makes up for ~100 lines of the diffstat).

https://user-images.githubusercontent.com/20418176/155420531-ae401365-c922-4eee-ba92-344f98354fdd.mp4

List of changes / enhancements made to design that are very much up for discussion:

* Hover state has been changed to add accents to background of both parts of the panel rather than just the content panel as on design.
* Colours in active state have been inverted to preserve consistency (larger panel always darker, inner content panel always brighter)
* Hover + active state has been added (not there on designs at all).
* When the button is held down, a partial resize animation plays in order to better convey what is about to happen when the button is released.
* Check on/off click samples are used to match the old mod icons.
* An "incompatible" state for the panel has been implemented, in which case the panel is basically darkened and disabled. This is a change from the current mod select, in which the buttons will always be active, and clicking them will cause the other incompatible mod to be excluded from the set of active mods.
* Multi mods are not present on design in any way and so no consideration has been made here for that. The designs depict a flat list and that's the assumption I'm currently working with.
* All measurements from figma have been scaled down by a factor of 1.4 and rounded by eye to make numbers less ugly. The 1.4 number comes from the fact that the design is spec'd at 1920x1080, while the game has a `DrawSizePreservingFillContainer` with a size of 1366x768. 1920/1366 works out roughly to 1.4.

  Note that test scenes have their own `DrawSizePreservingFillContainer` and as such the real pixel measurements on screen will be ~5 pixels smaller than they will actually be in game.
* I'm aware that the shared incompatibility displaying tooltip has the mod description on it. I'm keeping it there for now until the old implementation goes away (?) and the description can finally be removed. May also be a decent fallback for cases where the description doesn't fully fit in the panel?
