### PR TITLE
Improve resilience of spectator frame communication to ensure replays are sent in full

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -321,7 +321,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void sendFrames(int count = 10)
         {
-            AddStep("send frames", () => spectatorClient.SendFrames(streamingUser.Id, count));
+            AddStep("send frames", () => spectatorClient.SendFramesFromUser(streamingUser.Id, count));
         }
 
         private void loadSpectatingScreen()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send passed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatedUserState.Passed));
+            AddStep("send passed", () => spectatorClient.SendEndPlay(streamingUser.Id, SpectatedUserState.Passed));
             AddUntilStep("state is passed", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Passed);
 
             start();
@@ -275,7 +275,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send quit", () => spectatorClient.EndPlay(streamingUser.Id));
+            AddStep("send quit", () => spectatorClient.SendEndPlay(streamingUser.Id));
             AddUntilStep("state is quit", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Quit);
 
             start();
@@ -293,7 +293,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            AddStep("send failed", () => spectatorClient.EndPlay(streamingUser.Id, SpectatedUserState.Failed));
+            AddStep("send failed", () => spectatorClient.SendEndPlay(streamingUser.Id, SpectatedUserState.Failed));
             AddUntilStep("state is failed", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Failed);
 
             start();
@@ -312,9 +312,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void waitForPlayer() => AddUntilStep("wait for player", () => (Stack.CurrentScreen as Player)?.IsLoaded == true);
 
-        private void start(int? beatmapId = null) => AddStep("start play", () => spectatorClient.StartPlay(streamingUser.Id, beatmapId ?? importedBeatmapId));
+        private void start(int? beatmapId = null) => AddStep("start play", () => spectatorClient.SendStartPlay(streamingUser.Id, beatmapId ?? importedBeatmapId));
 
-        private void finish(SpectatedUserState state = SpectatedUserState.Quit) => AddStep("end play", () => spectatorClient.EndPlay(streamingUser.Id, state));
+        private void finish(SpectatedUserState state = SpectatedUserState.Quit) => AddStep("end play", () => spectatorClient.SendEndPlay(streamingUser.Id, state));
 
         private void checkPaused(bool state) =>
             AddUntilStep($"game is {(state ? "paused" : "playing")}", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value == state);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
@@ -68,10 +68,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 // For player 2, send frames in sets of 10.
                 for (int i = 0; i < 100; i++)
                 {
-                    SpectatorClient.SendFrames(PLAYER_1_ID, 1);
+                    SpectatorClient.SendFramesFromUser(PLAYER_1_ID, 1);
 
                     if (i % 10 == 0)
-                        SpectatorClient.SendFrames(PLAYER_2_ID, 10);
+                        SpectatorClient.SendFramesFromUser(PLAYER_2_ID, 10);
                 }
             });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 foreach ((int userId, var _) in clocks)
                 {
-                    SpectatorClient.StartPlay(userId, 0);
+                    SpectatorClient.SendStartPlay(userId, 0);
                     OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = userId });
                 }
             });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -70,11 +70,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             loadSpectateScreen(false);
 
             AddWaitStep("wait a bit", 10);
-            AddStep("load player first_player_id", () => SpectatorClient.StartPlay(PLAYER_1_ID, importedBeatmapId));
+            AddStep("load player first_player_id", () => SpectatorClient.SendStartPlay(PLAYER_1_ID, importedBeatmapId));
             AddUntilStep("one player added", () => spectatorScreen.ChildrenOfType<Player>().Count() == 1);
 
             AddWaitStep("wait a bit", 10);
-            AddStep("load player second_player_id", () => SpectatorClient.StartPlay(PLAYER_2_ID, importedBeatmapId));
+            AddStep("load player second_player_id", () => SpectatorClient.SendStartPlay(PLAYER_2_ID, importedBeatmapId));
             AddUntilStep("two players added", () => spectatorScreen.ChildrenOfType<Player>().Count() == 2);
         }
 
@@ -133,8 +133,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     TeamID = 1,
                 };
 
-                SpectatorClient.StartPlay(player1.UserID, importedBeatmapId);
-                SpectatorClient.StartPlay(player2.UserID, importedBeatmapId);
+                SpectatorClient.SendStartPlay(player1.UserID, importedBeatmapId);
+                SpectatorClient.SendStartPlay(player2.UserID, importedBeatmapId);
 
                 playingUsers.Add(player1);
                 playingUsers.Add(player2);
@@ -397,7 +397,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     };
 
                     OnlinePlayDependencies.MultiplayerClient.AddUser(user.User, true);
-                    SpectatorClient.StartPlay(id, beatmapId ?? importedBeatmapId);
+                    SpectatorClient.SendStartPlay(id, beatmapId ?? importedBeatmapId);
 
                     playingUsers.Add(user);
                 }
@@ -411,7 +411,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 var user = playingUsers.Single(u => u.UserID == userId);
 
                 OnlinePlayDependencies.MultiplayerClient.RemoveUser(user.User.AsNonNull());
-                SpectatorClient.EndPlay(userId);
+                SpectatorClient.SendEndPlay(userId);
 
                 playingUsers.Remove(user);
             });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -360,7 +360,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             // to ensure negative gameplay start time does not affect spectator, send frames exactly after StartGameplay().
             // (similar to real spectating sessions in which the first frames get sent between StartGameplay() and player load complete)
-            AddStep("send frames at gameplay start", () => getInstance(PLAYER_1_ID).OnGameplayStarted += () => SpectatorClient.SendFrames(PLAYER_1_ID, 100));
+            AddStep("send frames at gameplay start", () => getInstance(PLAYER_1_ID).OnGameplayStarted += () => SpectatorClient.SendFramesFromUser(PLAYER_1_ID, 100));
 
             AddUntilStep("wait for player load", () => spectatorScreen.AllPlayersLoaded);
 
@@ -424,7 +424,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("send frames", () =>
             {
                 foreach (int id in userIds)
-                    SpectatorClient.SendFrames(id, count);
+                    SpectatorClient.SendFramesFromUser(id, count);
             });
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 foreach (int user in users)
                 {
-                    SpectatorClient.StartPlay(user, Beatmap.Value.BeatmapInfo.OnlineID);
+                    SpectatorClient.SendStartPlay(user, Beatmap.Value.BeatmapInfo.OnlineID);
                     multiplayerUsers.Add(OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = user }, true));
                 }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 foreach (int user in users)
                 {
-                    SpectatorClient.StartPlay(user, Beatmap.Value.BeatmapInfo.OnlineID);
+                    SpectatorClient.SendStartPlay(user, Beatmap.Value.BeatmapInfo.OnlineID);
                     var roomUser = OnlinePlayDependencies.MultiplayerClient.AddUser(new APIUser { Id = user }, true);
 
                     roomUser.MatchState = new TeamVersusUserState

--- a/osu.Game.Tests/Visual/Online/TestSceneCurrentlyPlayingDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneCurrentlyPlayingDisplay.cs
@@ -56,9 +56,9 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestBasicDisplay()
         {
-            AddStep("Add playing user", () => spectatorClient.StartPlay(streamingUser.Id, 0));
+            AddStep("Add playing user", () => spectatorClient.SendStartPlay(streamingUser.Id, 0));
             AddUntilStep("Panel loaded", () => currentlyPlaying.ChildrenOfType<UserGridPanel>()?.FirstOrDefault()?.User.Id == 2);
-            AddStep("Remove playing user", () => spectatorClient.EndPlay(streamingUser.Id));
+            AddStep("Remove playing user", () => spectatorClient.SendEndPlay(streamingUser.Id));
             AddUntilStep("Panel no longer present", () => !currentlyPlaying.ChildrenOfType<UserGridPanel>().Any());
         }
 

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -57,14 +57,14 @@ namespace osu.Game.Online.Spectator
             return connection.SendAsync(nameof(ISpectatorServer.BeginPlaySession), state);
         }
 
-        protected override Task SendFramesInternal(FrameDataBundle data)
+        protected override Task SendFramesInternal(FrameDataBundle bundle)
         {
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             Debug.Assert(connection != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.SendFrameData), data);
+            return connection.SendAsync(nameof(ISpectatorServer.SendFrameData), bundle);
         }
 
         protected override Task EndPlayingInternal(SpectatorState state)

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -86,8 +86,6 @@ namespace osu.Game.Online.Spectator
 
         private Task? lastSend;
 
-        private int totalBundledFrames;
-
         private const int max_pending_frames = 30;
 
         [BackgroundDependencyLoader]
@@ -168,8 +166,6 @@ namespace osu.Game.Online.Spectator
                     throw new InvalidOperationException($"Cannot invoke {nameof(BeginPlaying)} when already playing");
 
                 IsPlaying = true;
-
-                totalBundledFrames = 0;
 
                 // transfer state at point of beginning play
                 currentState.BeatmapID = score.ScoreInfo.BeatmapInfo.OnlineID;
@@ -276,10 +272,6 @@ namespace osu.Game.Online.Spectator
 
             var frames = pendingFrames.ToArray();
             var bundle = new FrameDataBundle(currentScore.ScoreInfo, frames);
-
-            totalBundledFrames += frames.Length;
-
-            Logger.Log($"Purging {pendingFrames.Count} frames (total {totalBundledFrames})");
 
             pendingFrames.Clear();
             lastPurgeTime = Time.Current;

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Online.Spectator
 
             totalBundledFrames += frames.Length;
 
-            Console.WriteLine($"Purging {pendingFrames.Count} frames (total {totalBundledFrames})");
+            Logger.Log($"Purging {pendingFrames.Count} frames (total {totalBundledFrames})");
 
             pendingFrames.Clear();
             lastPurgeTime = Time.Current;

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Online.Spectator
 
                     // re-send state in case it wasn't received
                     if (IsPlaying)
+                        // TODO: this is likely sent out of order after a reconnect scenario. needs further consideration.
                         BeginPlayingInternal(currentState);
                 }
                 else

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Tests.Visual.Spectator
         /// </summary>
         public bool ShouldFailSendingFrames { get; set; }
 
+        public int FrameSendAttempts { get; private set; }
+
         public override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
 
         public IReadOnlyDictionary<int, ReplayFrame> LastReceivedUserFrames => lastReceivedUserFrames;
@@ -130,6 +132,8 @@ namespace osu.Game.Tests.Visual.Spectator
 
         protected override Task SendFramesInternal(FrameDataBundle bundle)
         {
+            FrameSendAttempts++;
+
             if (ShouldFailSendingFrames)
                 return Task.FromException(new InvalidOperationException());
 

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -47,7 +46,7 @@ namespace osu.Game.Tests.Visual.Spectator
         /// </summary>
         /// <param name="userId">The user to start play for.</param>
         /// <param name="beatmapId">The playing beatmap id.</param>
-        public void StartPlay(int userId, int beatmapId)
+        public void SendStartPlay(int userId, int beatmapId)
         {
             userBeatmapDictionary[userId] = beatmapId;
             userNextFrameDictionary[userId] = 0;
@@ -59,7 +58,7 @@ namespace osu.Game.Tests.Visual.Spectator
         /// </summary>
         /// <param name="userId">The user to end play for.</param>
         /// <param name="state">The spectator state to end play with.</param>
-        public void EndPlay(int userId, SpectatedUserState state = SpectatedUserState.Quit)
+        public void SendEndPlay(int userId, SpectatedUserState state = SpectatedUserState.Quit)
         {
             if (!userBeatmapDictionary.ContainsKey(userId))
                 return;
@@ -73,8 +72,6 @@ namespace osu.Game.Tests.Visual.Spectator
 
             userBeatmapDictionary.Remove(userId);
         }
-
-        public new void Schedule(Action action) => base.Schedule(action);
 
         /// <summary>
         /// Sends frames for an arbitrary user, in bundles containing 10 frames each.

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -20,9 +21,14 @@ namespace osu.Game.Tests.Visual.Spectator
     public class TestSpectatorClient : SpectatorClient
     {
         /// <summary>
-        /// Maximum number of frames sent per bundle via <see cref="SendFrames"/>.
+        /// Maximum number of frames sent per bundle via <see cref="SendFramesFromUser"/>.
         /// </summary>
         public const int FRAME_BUNDLE_SIZE = 10;
+
+        /// <summary>
+        /// Whether to force send operations to fail (simulating a network issue).
+        /// </summary>
+        public bool ShouldFailSendingFrames { get; set; }
 
         public override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
 
@@ -75,10 +81,12 @@ namespace osu.Game.Tests.Visual.Spectator
 
         /// <summary>
         /// Sends frames for an arbitrary user, in bundles containing 10 frames each.
+        /// This bypasses the standard queueing mechanism completely and should only be used to test cases where multiple users need to be sending data.
+        /// Importantly, <see cref="ShouldFailSendingFrames"/> will have no effect.
         /// </summary>
         /// <param name="userId">The user to send frames for.</param>
         /// <param name="count">The total number of frames to send.</param>
-        public void SendFrames(int userId, int count)
+        public void SendFramesFromUser(int userId, int count)
         {
             var frames = new List<LegacyReplayFrame>();
 
@@ -120,7 +128,13 @@ namespace osu.Game.Tests.Visual.Spectator
             return ((ISpectatorClient)this).UserBeganPlaying(api.LocalUser.Value.Id, state);
         }
 
-        protected override Task SendFramesInternal(FrameDataBundle data) => ((ISpectatorClient)this).UserSentFrames(api.LocalUser.Value.Id, data);
+        protected override Task SendFramesInternal(FrameDataBundle bundle)
+        {
+            if (ShouldFailSendingFrames)
+                return Task.FromException(new InvalidOperationException());
+
+            return ((ISpectatorClient)this).UserSentFrames(api.LocalUser.Value.Id, bundle);
+        }
 
         protected override Task EndPlayingInternal(SpectatorState state) => ((ISpectatorClient)this).UserFinishedPlaying(api.LocalUser.Value.Id, state);
 


### PR DESCRIPTION
As we work through the requirements to get lazer scores sent to the server with all required data, one missing piece is [storing of replay data](https://github.com/ppy/osu-infrastructure/blob/master/score-submission.md#-add-replay-saving-support-for-lazer-scores). This has already been sent for quite some time now via the spectator flow, and from the beginning this was done with the intention that we can likely use this to reconstruct the final replays at the server end rather than sending a second copy at the end of gameplay (aka stable). There are multiple benefits to doing it this way, if we can make it work.

I'm not yet at a state I can make a call on how well this will work, but this PR is the first of multiple steps I have planned to get things into a state where I can attempt to make things work. The basic plan forward is:

- Make sure all frames are sent, regardless of disconnections (this PR).
- Fix discrepancies with begin/end messaging, which may be out of order with frame communications (not sure if this will be an issue, depends if those are used server-side as part of the replay construction or not). Left a TODO comment in [cff6f85](https://github.com/ppy/osu/pull/16975/commits/cff6f854724c8ce4f8ba8935734664a5e5f7c048) regarding this.
- Add support server-side to reconstruct replays and save to an arbitrary location.

I was planning on potentially splitting this PR up into multiple pieces, but then I accidentally submitted it in the current state, so a few notes on less-related changes:

14c8ce50a0849fb97882db3f9dd2a9553ac118bc Adds a prefix to test methods, because I found it very hard to know what was a local implementation in `TestSpectatorClient` vs an actual call against `SpectatorClient`

47b84295a6c32c4b9ac4ae4a8cd6d3d26d5206be Adds matching schedules to ensure correct order of execution between `Begin`/`Handle`/`End`. This wasn't there until now so might be responsible for some missing frames on `master`. I'd really like to remove these `Schedule`s altogether, maybe with update thread assertion instead, but that's for another day.