### PR TITLE
Don't expose "mark as read" errors to the user via notifications

### DIFF
--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -618,7 +618,7 @@ namespace osu.Game.Online.Chat
             var req = new MarkChannelAsReadRequest(channel, message);
 
             req.Success += () => channel.LastReadId = message.Id;
-            req.Failure += e => Logger.Error(e, $"Failed to mark channel {channel} up to '{message}' as read");
+            req.Failure += e => Logger.Log($"Failed to mark channel {channel} up to '{message}' as read ({e.Message})", LoggingTarget.Network, LogLevel.Verbose);
 
             api.Queue(req);
         }

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -618,7 +618,7 @@ namespace osu.Game.Online.Chat
             var req = new MarkChannelAsReadRequest(channel, message);
 
             req.Success += () => channel.LastReadId = message.Id;
-            req.Failure += e => Logger.Log($"Failed to mark channel {channel} up to '{message}' as read ({e.Message})", LoggingTarget.Network, LogLevel.Verbose);
+            req.Failure += e => Logger.Log($"Failed to mark channel {channel} up to '{message}' as read ({e.Message})", LoggingTarget.Network);
 
             api.Queue(req);
         }


### PR DESCRIPTION
This can happen if the user leaves the channel before the request is fired. You can't mark a channel as read when you're not in the channel.

Addresses https://github.com/ppy/osu/discussions/16973.