### PR TITLE
Fix playlists not allowing entry with partial mods

### DIFF
--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -121,6 +121,17 @@ namespace osu.Game.Tests.Online
             Assert.That((deserialised?.Mods[0])?.Settings["speed_change"], Is.EqualTo(2));
         }
 
+        [Test]
+        public void TestAPIModDetachedFromSource()
+        {
+            var mod = new OsuModDoubleTime { SpeedChange = { Value = 1.01 } };
+            var apiMod = new APIMod(mod);
+
+            mod.SpeedChange.Value = 1.5;
+
+            Assert.That(apiMod.Settings["speed_change"], Is.EqualTo(1.01d));
+        }
+
         private class TestRuleset : Ruleset
         {
             public override IEnumerable<Mod> GetModsFor(ModType type) => new Mod[]

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Online.API
                 var bindable = (IBindable)property.GetValue(mod);
 
                 if (!bindable.IsDefault)
-                    Settings.Add(property.Name.Underscore(), bindable);
+                    Settings.Add(property.Name.Underscore(), ModUtils.GetSettingUnderlyingValue(bindable));
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -9,7 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Screens;
 using osu.Game.Extensions;
-using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
@@ -40,8 +39,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             if (ruleset.Value.OnlineID != PlaylistItem.RulesetID)
                 throw new InvalidOperationException("Current Ruleset does not match PlaylistItem's Ruleset");
 
-            var localMods = Mods.Value.Select(m => new APIMod(m)).ToArray();
-            if (!PlaylistItem.RequiredMods.All(m => localMods.Any(m.Equals)))
+            var requiredLocalMods = PlaylistItem.RequiredMods.Select(m => m.ToMod(GameplayState.Ruleset));
+            if (!requiredLocalMods.All(m => Mods.Value.Any(m.Equals)))
                 throw new InvalidOperationException("Current Mods do not match PlaylistItem's RequiredMods");
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/16978

There are two issues here.

The first is that APIMod would store the `Bindable` rather than the value, which allowed the bindable to change when further playlist items were added because mod select overlay shares the same global instance. To trigger this issue you'd add the classic mod first with one setting changed, and then reset the classic mod setting.

The above would fix the cause of the issue, however wouldn't fix an already-broken playlist item. In the broken state, the classic mod would arrive at the client containing one setting set to its default state (`true`). From the POV of both the client and server, this is still a correct state to be in even though the setting is redundant.
In order to fix this I've applied a second fix which converts the APIMods to local mods before comparing to the gameplay mods, rather than the inverse (converting gameplay mods to APIMods before comparing).