### PR TITLE
Fix SignalR union workaround resolver failing on multiple union'd types

### DIFF
--- a/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
+++ b/osu.Game/Online/SignalRUnionWorkaroundResolver.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Online
 
             // This should not be required. The fallback should work. But something is weird with the way caching is done.
             // For future adventurers, I would not advise looking into this further. It's likely not worth the effort.
-            baseMap = baseMap.Concat(baseMap.Select(t => (t.baseType, t.baseType)));
+            baseMap = baseMap.Concat(baseMap.Select(t => (t.baseType, t.baseType)).Distinct());
 
             return new Dictionary<Type, IMessagePackFormatter>(baseMap.Select(t =>
             {


### PR DESCRIPTION
Without this, when adding a new union'd type, Messagepack throws the following at startup:
```
[network] 2022-02-24 11:26:32 [verbose]: SpectatorClient connection error: System.TypeInitializationException: The type initializer for 'osu.Game.Online.SignalRUnionWorkaroundResolver' threw an exception.
[network] 2022-02-24 11:26:32 [verbose]: ---> System.ArgumentException: An item with the same key has already been added. Key: osu.Game.Online.Multiplayer.MatchUserRequest
[network] 2022-02-24 11:26:32 [verbose]: at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
[network] 2022-02-24 11:26:32 [verbose]: at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
[network] 2022-02-24 11:26:32 [verbose]: at System.Collections.Generic.Dictionary`2.AddRange(IEnumerable`1 collection)
[network] 2022-02-24 11:26:32 [verbose]: at System.Collections.Generic.Dictionary`2..ctor(IEnumerable`1 collection, IEqualityComparer`1 comparer)
[network] 2022-02-24 11:26:32 [verbose]: at System.Collections.Generic.Dictionary`2..ctor(IEnumerable`1 collection)
[network] 2022-02-24 11:26:32 [verbose]: at osu.Game.Online.SignalRUnionWorkaroundResolver.createFormatterMap() in /home/smgi/Repos/osu/osu.Game/Online/SignalRUnionWorkaroundResolver.cs:line 32
[network] 2022-02-24 11:26:32 [verbose]: at osu.Game.Online.SignalRUnionWorkaroundResolver..cctor() in /home/smgi/Repos/osu/osu.Game/Online/SignalRUnionWorkaroundResolver.cs:line 22

```