### PR TITLE
Add chat display to multiplayer spectator

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -15,6 +15,7 @@ using osu.Game.Configuration;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
+using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
 using osu.Game.Screens.Play;
@@ -377,7 +378,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Beatmap.Value = beatmapManager.GetWorkingBeatmap(importedBeatmap);
                 Ruleset.Value = importedBeatmap.Ruleset;
 
-                LoadScreen(spectatorScreen = new TestMultiSpectatorScreen(playingUsers.ToArray(), gameplayStartTime));
+                LoadScreen(spectatorScreen = new TestMultiSpectatorScreen(SelectedRoom.Value, playingUsers.ToArray(), gameplayStartTime));
             });
 
             AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded && (!waitForPlayerLoad || spectatorScreen.AllPlayersLoaded));
@@ -465,8 +466,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             private readonly double? gameplayStartTime;
 
-            public TestMultiSpectatorScreen(MultiplayerRoomUser[] users, double? gameplayStartTime = null)
-                : base(users)
+            public TestMultiSpectatorScreen(Room room, MultiplayerRoomUser[] users, double? gameplayStartTime = null)
+                : base(room, users)
             {
                 this.gameplayStartTime = gameplayStartTime;
             }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -838,7 +838,8 @@ namespace osu.Game
                 channelManager.HighPollRate.Value =
                     chatOverlay.State.Value == Visibility.Visible
                     || API.Activity.Value is UserActivity.InLobby
-                    || API.Activity.Value is UserActivity.InMultiplayerGame;
+                    || API.Activity.Value is UserActivity.InMultiplayerGame
+                    || API.Activity.Value is UserActivity.SpectatingMultiplayerGame;
             }
 
             Add(difficultyRecommender);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -15,10 +16,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     public class GameplayChatDisplay : MatchChatDisplay, IKeyBindingHandler<GlobalAction>
     {
-        [Resolved]
+        [Resolved(CanBeNull = true)]
+        [CanBeNull]
         private ILocalUserPlayInfo localUserInfo { get; set; }
 
-        private IBindable<bool> localUserPlaying = new Bindable<bool>();
+        private readonly IBindable<bool> localUserPlaying = new Bindable<bool>();
 
         public override bool PropagatePositionalInputSubTree => !localUserPlaying.Value;
 
@@ -46,7 +48,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            localUserPlaying = localUserInfo.IsPlaying.GetBoundCopy();
+            if (localUserInfo != null)
+                localUserPlaying.BindTo(localUserInfo.IsPlaying);
+
             localUserPlaying.BindValueChanged(playing =>
             {
                 // for now let's never hold focus. this avoid misdirected gameplay keys entering chat.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -449,7 +449,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             switch (client.LocalUser.State)
             {
                 case MultiplayerUserState.Spectating:
-                    return new MultiSpectatorScreen(users.Take(PlayerGrid.MAX_PLAYERS).ToArray());
+                    return new MultiSpectatorScreen(Room, users.Take(PlayerGrid.MAX_PLAYERS).ToArray());
 
                 default:
                     return new MultiplayerPlayerLoader(() => new MultiplayerPlayer(Room, SelectedItem.Value, users));

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -11,10 +11,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Game.Online.Spectator;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Spectate;
+using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 {
@@ -48,15 +50,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private PlayerArea currentAudioSource;
         private bool canStartMasterClock;
 
+        private readonly Room room;
         private readonly MultiplayerRoomUser[] users;
 
         /// <summary>
         /// Creates a new <see cref="MultiSpectatorScreen"/>.
         /// </summary>
+        /// <param name="room">The room.</param>
         /// <param name="users">The players to spectate.</param>
-        public MultiSpectatorScreen(MultiplayerRoomUser[] users)
+        public MultiSpectatorScreen(Room room, MultiplayerRoomUser[] users)
             : base(users.Select(u => u.UserID).ToArray())
         {
+            this.room = room;
             this.users = users;
 
             instances = new PlayerArea[Users.Count];
@@ -65,7 +70,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         [BackgroundDependencyLoader]
         private void load()
         {
-            Container leaderboardContainer;
+            FillFlowContainer leaderboardFlow;
             Container scoreDisplayContainer;
 
             masterClockContainer = CreateMasterGameplayClockContainer(Beatmap.Value);
@@ -97,10 +102,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                                 {
                                     new Drawable[]
                                     {
-                                        leaderboardContainer = new Container
+                                        leaderboardFlow = new FillFlowContainer
                                         {
-                                            RelativeSizeAxes = Axes.Y,
-                                            AutoSizeAxes = Axes.X
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Vertical,
+                                            Spacing = new Vector2(5)
                                         },
                                         grid = new PlayerGrid { RelativeSizeAxes = Axes.Both }
                                     }
@@ -125,14 +133,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             LoadComponentAsync(leaderboard = new MultiSpectatorLeaderboard(scoreProcessor, users)
             {
                 Expanded = { Value = true },
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
             }, l =>
             {
                 foreach (var instance in instances)
                     leaderboard.AddClock(instance.UserId, instance.GameplayClock);
 
-                leaderboardContainer.Add(leaderboard);
+                leaderboardFlow.Insert(0, leaderboard);
 
                 if (leaderboard.TeamScores.Count == 2)
                 {
@@ -143,6 +149,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                     }, scoreDisplayContainer.Add);
                 }
             });
+
+            LoadComponentAsync(new GameplayChatDisplay(room)
+            {
+                Expanded = { Value = true },
+            }, chat => leaderboardFlow.Insert(1, chat));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -16,6 +16,7 @@ using osu.Game.Online.Spectator;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Spectate;
+using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
@@ -35,6 +36,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// Whether all spectating players have finished loading.
         /// </summary>
         public bool AllPlayersLoaded => instances.All(p => p?.PlayerLoaded == true);
+
+        protected override UserActivity InitialActivity => new UserActivity.SpectatingMultiplayerGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
 
         [Resolved]
         private OsuColour colours { get; set; }

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -50,6 +50,16 @@ namespace osu.Game.Users
             public override string Status => $@"{base.Status} with others";
         }
 
+        public class SpectatingMultiplayerGame : InGame
+        {
+            public SpectatingMultiplayerGame(IBeatmapInfo beatmapInfo, IRulesetInfo ruleset)
+                : base(beatmapInfo, ruleset)
+            {
+            }
+
+            public override string Status => $"Watching others {base.Status.ToLowerInvariant()}";
+        }
+
         public class InPlaylistGame : InGame
         {
             public InPlaylistGame(IBeatmapInfo beatmapInfo, IRulesetInfo ruleset)


### PR DESCRIPTION
As per discussion in https://github.com/ppy/osu/discussions/16965.

Preview:

https://user-images.githubusercontent.com/1329837/155670128-ad0f2436-a3b6-45ed-9e1f-c43710e667c7.mp4

I initially thought about splitting out the implementation from `MultiplayerPlayer`, however there's very slight changes in layout and usage of classes (e.g. the multiplayer spectator one adds clocks to the leaderboard) that make it hard to do so.