### PR TITLE
Add button to open currently selected tournament in file explorer

### DIFF
--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -35,15 +35,15 @@ namespace osu.Game.Tournament.Screens.Setup
         {
             var drawable = base.CreateComponent();
 
-            FlowContainer.Insert(-1, dropdown = new OsuDropdown<string>
-            {
-                Width = 510
-            });
-
-            FlowContainer.Insert(-2, folderButton = new TriangleButton
+            FlowContainer.Insert(-1, folderButton = new TriangleButton
             {
                 Text = "Open folder",
                 Width = 100
+            });
+
+            FlowContainer.Insert(-2, dropdown = new OsuDropdown<string>
+            {
+                Width = 510
             });
 
             return drawable;

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -11,6 +11,7 @@ namespace osu.Game.Tournament.Screens.Setup
     internal class TournamentSwitcher : ActionableInfo
     {
         private OsuDropdown<string> dropdown;
+        private OsuButton folderButton;
 
         [Resolved]
         private TournamentGameBase game { get; set; }
@@ -25,6 +26,7 @@ namespace osu.Game.Tournament.Screens.Setup
             dropdown.Current.BindValueChanged(v => Button.Enabled.Value = v.NewValue != startupTournament, true);
 
             Action = () => game.GracefullyExit();
+            folderButton.Action = storage.PresentExternally;
 
             ButtonText = "Close osu!";
         }
@@ -36,6 +38,12 @@ namespace osu.Game.Tournament.Screens.Setup
             FlowContainer.Insert(-1, dropdown = new OsuDropdown<string>
             {
                 Width = 510
+            });
+
+            FlowContainer.Insert(-2, folderButton = new TriangleButton
+            {
+                Text = "Open folder",
+                Width = 100
             });
 
             return drawable;


### PR DESCRIPTION
As the title already suggests this adds a button to the `SetupScreen` in tournament that opens the file explorer for the currently selected tournament. 

![image](https://user-images.githubusercontent.com/803255/155723954-63d03ef3-7ff9-4307-ad8a-991573fbe4dd.png)
