### PR TITLE
Don't start gameplay if quick retry is being held

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using ManagedBass.Fx;
@@ -21,6 +22,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Menu;
@@ -94,7 +96,9 @@ namespace osu.Game.Screens.Play
             // don't push if the user is dragging a slider or otherwise.
             && inputManager?.DraggedDrawable == null
             // don't push if a focused overlay is visible, like settings.
-            && inputManager?.FocusedDrawable == null;
+            && inputManager?.FocusedDrawable == null
+            // don't push if the quick retry key is still held.
+            && !globalActionContainer.PressedActions.Contains(GlobalAction.QuickRetry);
 
         private readonly Func<Player> createPlayer;
 
@@ -129,6 +133,9 @@ namespace osu.Game.Screens.Play
 
         [Resolved(CanBeNull = true)]
         private BatteryInfo batteryInfo { get; set; }
+
+        [Resolved]
+        private GlobalActionContainer globalActionContainer { get; set; }
 
         public PlayerLoader(Func<Player> createPlayer)
         {


### PR DESCRIPTION
This PR attempts to replicate stable behaviour in regards to quick retry: when entering gameplay or restarting, holding quick retry will delay gameplay until it is released.

Is using `GlobalActionContainer` directly like this acceptable? I've tried to do this in multiple ways, but wasn't sure which one would be the best, as `KeyBindingContainer` only passes `OnReleased` events to the drawable that triggered it.
* Having `PlayerLoader` bind to a value in `HoldToConfirmContainer`, indicating whether or not the key is held => Bindings are cleared when the player is disposed, and binding "downwards" in the tree seemed a little messy to me
* Handling the key events in `PlayerLoader` and binding `HotkeyRetryOverlay` to it => `PlayerLoader` won't receive the event when `Player` is at the top of the screen stack

Is there any better way to achieve this/track GlobalActions over multiple screens/components?