### PR TITLE
Display star ratings in tournament mode using two decimal places

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps.Legacy;
+using osu.Game.Tests.Visual;
+using osu.Game.Tournament.Components;
+
+namespace osu.Game.Tournament.Tests.Components
+{
+    [TestFixture]
+    public class TestSceneSongBar : OsuTestScene
+    {
+        [Test]
+        public void TestSongBar()
+        {
+            SongBar songBar = null;
+
+            AddStep("create bar", () => Child = songBar = new SongBar
+            {
+                RelativeSizeAxes = Axes.X,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            });
+            AddUntilStep("wait for loaded", () => songBar.IsLoaded);
+
+            AddStep("set beatmap", () =>
+            {
+                var beatmap = CreateAPIBeatmap(Ruleset.Value);
+                beatmap.CircleSize = 3.4f;
+                beatmap.ApproachRate = 6.8f;
+                beatmap.OverallDifficulty = 5.5f;
+                beatmap.StarRating = 4.56f;
+                beatmap.Length = 123456;
+                beatmap.BPM = 133;
+
+                songBar.Beatmap = beatmap;
+            });
+            AddStep("set mods to HR", () => songBar.Mods = LegacyMods.HardRock);
+            AddStep("set mods to DT", () => songBar.Mods = LegacyMods.DoubleTime);
+            AddStep("unset mods", () => songBar.Mods = LegacyMods.None);
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Tournament.Components
                                         Children = new Drawable[]
                                         {
                                             new DiffPiece(stats),
-                                            new DiffPiece(("Star Rating", $"{beatmap.StarRating:0.#}{srExtra}"))
+                                            new DiffPiece(("Star Rating", $"{beatmap.StarRating:0.##}{srExtra}"))
                                         }
                                     },
                                     new FillFlowContainer

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -24,9 +24,6 @@ namespace osu.Game.Tournament.Components
 
         private readonly string mod;
 
-        private const float horizontal_padding = 10;
-        private const float vertical_padding = 10;
-
         public const float HEIGHT = 50;
 
         private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();


### PR DESCRIPTION
This is already the case everywhere else in the game so it makes sense to also show two decimal places here.

As proposed in https://github.com/ppy/osu/discussions/17005.