### PR TITLE
Add support for arbitrary beat divisors

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -7,6 +7,7 @@ using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 using osuTK.Input;
 
@@ -72,7 +73,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 EditorClock.Seek(slider.StartTime);
                 EditorBeatmap.SelectedHitObjects.Add(slider);
             });
-            AddStep("change beat divisor", () => beatDivisor.Value = 3);
+            AddStep("change beat divisor", () =>
+            {
+                beatDivisor.ValidDivisors.Value = BeatDivisorPresetCollection.TRIPLETS;
+                beatDivisor.Value = 3;
+            });
 
             convertToStream();
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
@@ -26,11 +27,15 @@ namespace osu.Game.Tests.Visual.Editing
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = beatDivisorControl = new BeatDivisorControl(bindableBeatDivisor = new BindableBeatDivisor(16))
+            Child = new PopoverContainer
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Size = new Vector2(90, 90)
+                RelativeSizeAxes = Axes.Both,
+                Child = beatDivisorControl = new BeatDivisorControl(bindableBeatDivisor = new BindableBeatDivisor(16))
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(90, 90)
+                }
             };
         });
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -190,10 +190,6 @@ namespace osu.Game.Tests.Visual.Editing
                 textBox.Text = divisor.ToString();
                 InputManager.Key(Key.Enter);
             });
-            AddStep("dismiss popover", () =>
-            {
-                InputManager.Key(Key.Escape);
-            });
             AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<BeatDivisorControl.CustomDivisorPopover>().Any());
         }
     }

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Tests.Visual.Editing
         private BeatDivisorControl beatDivisorControl;
         private BindableBeatDivisor bindableBeatDivisor;
 
-        private SliderBar<int> tickSliderBar;
-        private EquilateralTriangle tickMarkerHead;
+        private SliderBar<int> tickSliderBar => beatDivisorControl.ChildrenOfType<SliderBar<int>>().Single();
+        private EquilateralTriangle tickMarkerHead => tickSliderBar.ChildrenOfType<EquilateralTriangle>().Single();
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -32,9 +32,6 @@ namespace osu.Game.Tests.Visual.Editing
                 Origin = Anchor.Centre,
                 Size = new Vector2(90, 90)
             };
-
-            tickSliderBar = beatDivisorControl.ChildrenOfType<SliderBar<int>>().Single();
-            tickMarkerHead = tickSliderBar.ChildrenOfType<EquilateralTriangle>().Single();
         });
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -43,10 +43,10 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestBindableBeatDivisor()
         {
-            AddRepeatStep("move previous", () => bindableBeatDivisor.Previous(), 4);
+            AddRepeatStep("move previous", () => bindableBeatDivisor.Previous(), 2);
             AddAssert("divisor is 4", () => bindableBeatDivisor.Value == 4);
-            AddRepeatStep("move next", () => bindableBeatDivisor.Next(), 3);
-            AddAssert("divisor is 12", () => bindableBeatDivisor.Value == 12);
+            AddRepeatStep("move next", () => bindableBeatDivisor.Next(), 1);
+            AddAssert("divisor is 12", () => bindableBeatDivisor.Value == 8);
         }
 
         [Test]

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Beatmaps.ControlPoints
             int closestDivisor = 0;
             double closestTime = double.MaxValue;
 
-            foreach (int divisor in BindableBeatDivisor.VALID_DIVISORS)
+            foreach (int divisor in BindableBeatDivisor.PREDEFINED_DIVISORS)
             {
                 double distanceFromSnap = Math.Abs(time - getClosestSnappedTime(timingPoint, time, divisor));
 

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -52,10 +52,11 @@ namespace osu.Game.Screens.Edit
 
         public override void BindTo(Bindable<int> them)
         {
-            base.BindTo(them);
-
+            // bind to valid divisors first (if applicable) to ensure correct transfer of the actual divisor.
             if (them is BindableBeatDivisor otherBeatDivisor)
                 ValidDivisors.BindTo(otherBeatDivisor.ValidDivisors);
+
+            base.BindTo(them);
         }
 
         protected override Bindable<int> CreateInstance() => new BindableBeatDivisor();

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -1,45 +1,62 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Graphics;
+using osu.Game.Screens.Edit.Compose.Components;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit
 {
     public class BindableBeatDivisor : BindableInt
     {
-        public static readonly int[] VALID_DIVISORS = { 1, 2, 3, 4, 6, 8, 12, 16 };
+        public static readonly int[] PREDEFINED_DIVISORS = { 1, 2, 3, 4, 6, 8, 12, 16 };
+
+        public Bindable<BeatDivisorPresetCollection> ValidDivisors { get; } = new Bindable<BeatDivisorPresetCollection>(BeatDivisorPresetCollection.COMMON);
 
         public BindableBeatDivisor(int value = 1)
             : base(value)
         {
+            ValidDivisors.BindValueChanged(_ => updateBindableProperties(), true);
+            BindValueChanged(_ => ensureValidDivisor());
         }
 
-        public void Next() => Value = VALID_DIVISORS[Math.Min(VALID_DIVISORS.Length - 1, Array.IndexOf(VALID_DIVISORS, Value) + 1)];
-
-        public void Previous() => Value = VALID_DIVISORS[Math.Max(0, Array.IndexOf(VALID_DIVISORS, Value) - 1)];
-
-        public override int Value
+        private void updateBindableProperties()
         {
-            get => base.Value;
-            set
-            {
-                if (!VALID_DIVISORS.Contains(value))
-                {
-                    // If it doesn't match, value will be 0, but will be clamped to the valid range via DefaultMinValue
-                    value = Array.FindLast(VALID_DIVISORS, d => d < value);
-                }
+            ensureValidDivisor();
 
-                base.Value = value;
-            }
+            MinValue = ValidDivisors.Value.Presets.Min();
+            MaxValue = ValidDivisors.Value.Presets.Max();
         }
 
-        protected override int DefaultMinValue => VALID_DIVISORS.First();
-        protected override int DefaultMaxValue => VALID_DIVISORS.Last();
+        private void ensureValidDivisor()
+        {
+            if (!ValidDivisors.Value.Presets.Contains(Value))
+                Value = 1;
+        }
+
+        public void Next()
+        {
+            var presets = ValidDivisors.Value.Presets;
+            Value = presets.Cast<int?>().SkipWhile(preset => preset != Value).ElementAtOrDefault(1) ?? presets[0];
+        }
+
+        public void Previous()
+        {
+            var presets = ValidDivisors.Value.Presets;
+            Value = presets.Cast<int?>().TakeWhile(preset => preset != Value).LastOrDefault() ?? presets[^1];
+        }
+
         protected override int DefaultPrecision => 1;
+
+        public override void BindTo(Bindable<int> them)
+        {
+            base.BindTo(them);
+
+            if (them is BindableBeatDivisor otherBeatDivisor)
+                ValidDivisors.BindTo(otherBeatDivisor.ValidDivisors);
+        }
 
         protected override Bindable<int> CreateInstance() => new BindableBeatDivisor();
 
@@ -92,7 +109,7 @@ namespace osu.Game.Screens.Edit
         {
             int beat = index % beatDivisor;
 
-            foreach (int divisor in BindableBeatDivisor.VALID_DIVISORS)
+            foreach (int divisor in PREDEFINED_DIVISORS)
             {
                 if ((beat * divisor) % beatDivisor == 0)
                     return divisor;

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -16,7 +16,6 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -214,7 +214,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private class DivisorDisplay : OsuAnimatedButton, IHasPopover
+        internal class DivisorDisplay : OsuAnimatedButton, IHasPopover
         {
             public BindableBeatDivisor BeatDivisor { get; } = new BindableBeatDivisor();
 
@@ -264,7 +264,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
         }
 
-        private class CustomDivisorPopover : OsuPopover
+        internal class CustomDivisorPopover : OsuPopover
         {
             public BindableBeatDivisor BeatDivisor { get; } = new BindableBeatDivisor();
 
@@ -347,7 +347,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private class ChevronButton : IconButton
+        internal class ChevronButton : IconButton
         {
             public ChevronButton()
             {

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -288,7 +288,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Text = "All other applicable smaller divisors will be automatically added to the list of presets."
+                            Text = "Related divisors will be added to the list of presets."
                         }
                     }
                 };

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -299,6 +300,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 base.LoadComplete();
                 BeatDivisor.BindValueChanged(_ => updateState(), true);
                 divisorTextBox.OnCommit += (_, __) => setPresets();
+
+                Schedule(() => GetContainingInputManager().ChangeFocus(divisorTextBox));
             }
 
             private void setPresets()
@@ -320,6 +323,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 }
 
                 BeatDivisor.Value = divisor;
+
+                this.HidePopover();
             }
 
             private void updateState()

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorPresetCollection.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorPresetCollection.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public class BeatDivisorPresetCollection
+    {
+        public BeatDivisorType Type { get; }
+        public IReadOnlyList<int> Presets { get; }
+
+        private BeatDivisorPresetCollection(BeatDivisorType type, IEnumerable<int> presets)
+        {
+            Type = type;
+            Presets = presets.ToArray();
+        }
+
+        public static readonly BeatDivisorPresetCollection COMMON = new BeatDivisorPresetCollection(BeatDivisorType.Common, new[] { 1, 2, 4, 8, 16 });
+
+        public static readonly BeatDivisorPresetCollection TRIPLETS = new BeatDivisorPresetCollection(BeatDivisorType.Triplets, new[] { 1, 3, 6, 12 });
+
+        public static BeatDivisorPresetCollection Custom(int maxDivisor)
+        {
+            var presets = new List<int>();
+
+            for (int candidate = 1; candidate <= Math.Sqrt(maxDivisor); ++candidate)
+            {
+                if (maxDivisor % candidate != 0)
+                    continue;
+
+                presets.Add(candidate);
+                presets.Add(maxDivisor / candidate);
+            }
+
+            return new BeatDivisorPresetCollection(BeatDivisorType.Custom, presets.Distinct().OrderBy(d => d));
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorType.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorType.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public enum BeatDivisorType
+    {
+        /// <summary>
+        /// Most common divisors, all with denominators being powers of two.
+        /// </summary>
+        Common,
+
+        /// <summary>
+        /// Divisors with denominators divisible by 3.
+        /// </summary>
+        Triplets,
+
+        /// <summary>
+        /// Fully arbitrary/custom beat divisors.
+        /// </summary>
+        Custom,
+
+        Last = Custom
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorType.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorType.cs
@@ -19,8 +19,5 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Fully arbitrary/custom beat divisors.
         /// </summary>
         Custom,
-
-        First = Common,
-        Last = Custom
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorType.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorType.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         Custom,
 
+        First = Common,
         Last = Custom
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private OsuColour colours { get; set; }
 
-        private static readonly int highest_divisor = BindableBeatDivisor.VALID_DIVISORS.Last();
+        private static readonly int highest_divisor = BindableBeatDivisor.PREDEFINED_DIVISORS.Last();
 
         public TimelineTickDisplay()
         {


### PR DESCRIPTION
...Or, well, up to 1/64 I guess. I added that limit only to keep some semblance of sanity. I'd hope nobody seriously ever needs higher.

https://user-images.githubusercontent.com/20418176/155896470-eb266b3f-a6e8-428b-a57c-94fa0c0b49be.mp4

The [feedback](https://github.com/ppy/osu/issues/2316#issuecomment-1038774385) from my initial attempt has been addressed, I think.

Stable obviously does not (and will not) support the fully custom presets aside from what it already can support but it degrades "gracefully" (i.e. doesn't die and instead chooses smallest closer available divisor).

Diff's a bit large again but a substantial portion of it is tests.

* Closes #2316
* Supersedes / closes #2403