### PR TITLE
Add basic beatmap offset adjustment

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
             AddAssert("Offset is adjusted", () => offsetControl.Current.Value == -average_error);
 
+            AddAssert("Button is disabled", () => !offsetControl.ChildrenOfType<SettingsButton>().Single().Enabled.Value);
             AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
             AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddAssert("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
             AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
-            AddAssert("Offset is adjusted", () => offsetControl.Current.Value == average_error);
+            AddAssert("Offset is adjusted", () => offsetControl.Current.Value == -average_error);
 
             AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
             AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Screens.Play.PlayerSettings;
+using osu.Game.Tests.Visual.Ranking;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public class TestSceneBeatmapOffsetControl : OsuTestScene
+    {
+        [Test]
+        public void TestDisplay()
+        {
+            Child = new PlayerSettingsGroup("Some settings")
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    new BeatmapOffsetControl(TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(-4.5))
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -34,6 +34,20 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestTooShortToDisplay()
+        {
+            AddStep("Set short reference score", () =>
+            {
+                offsetControl.ReferenceScore.Value = new ScoreInfo
+                {
+                    HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(0, 2)
+                };
+            });
+
+            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
+        }
+
+        [Test]
         public void TestDisplay()
         {
             const double average_error = -4.5;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -1,8 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Overlays.Settings;
+using osu.Game.Scoring;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Tests.Visual.Ranking;
 
@@ -10,18 +14,46 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public class TestSceneBeatmapOffsetControl : OsuTestScene
     {
+        private BeatmapOffsetControl offsetControl;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("Create control", () =>
+            {
+                Child = new PlayerSettingsGroup("Some settings")
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        offsetControl = new BeatmapOffsetControl()
+                    }
+                };
+            });
+        }
+
         [Test]
         public void TestDisplay()
         {
-            Child = new PlayerSettingsGroup("Some settings")
+            const double average_error = -4.5;
+
+            AddAssert("Offset is neutral", () => offsetControl.Current.Value == 0);
+            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
+            AddStep("Set reference score", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Children = new Drawable[]
+                offsetControl.ReferenceScore.Value = new ScoreInfo
                 {
-                    new BeatmapOffsetControl(TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(-4.5))
-                }
-            };
+                    HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(average_error)
+                };
+            });
+
+            AddAssert("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
+            AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
+            AddAssert("Offset is adjusted", () => offsetControl.Current.Value == average_error);
+
+            AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
+            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
@@ -131,9 +131,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public double GameplayClockTime => GameplayClockContainer.GameplayClock.CurrentTime;
 
-            protected override void Update()
+            protected override void UpdateAfterChildren()
             {
-                base.Update();
+                base.UpdateAfterChildren();
 
                 if (!FirstFrameClockTime.HasValue)
                 {

--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -71,16 +71,16 @@ namespace osu.Game.Tests.Visual.Ranking
             };
         });
 
-        public static List<HitEvent> CreateDistributedHitEvents()
+        public static List<HitEvent> CreateDistributedHitEvents(double centre = 0, double range = 25)
         {
             var hitEvents = new List<HitEvent>();
 
-            for (int i = 0; i < 50; i++)
+            for (int i = 0; i < range * 2; i++)
             {
-                int count = (int)(Math.Pow(25 - Math.Abs(i - 25), 2));
+                int count = (int)(Math.Pow(range - Math.Abs(i - range), 2));
 
                 for (int j = 0; j < count; j++)
-                    hitEvents.Add(new HitEvent(i - 25, HitResult.Perfect, new HitCircle(), new HitCircle(), null));
+                    hitEvents.Add(new HitEvent(centre + i - range, HitResult.Perfect, new HitCircle(), new HitCircle(), null));
             }
 
             return hitEvents;

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -40,6 +40,8 @@ namespace osu.Game.Beatmaps
         [Backlink(nameof(ScoreInfo.BeatmapInfo))]
         public IQueryable<ScoreInfo> Scores { get; } = null!;
 
+        public BeatmapUserSettings UserSettings { get; set; } = null!;
+
         public BeatmapInfo(RulesetInfo? ruleset = null, BeatmapDifficulty? difficulty = null, BeatmapMetadata? metadata = null)
         {
             ID = Guid.NewGuid();
@@ -51,6 +53,7 @@ namespace osu.Game.Beatmaps
             };
             Difficulty = difficulty ?? new BeatmapDifficulty();
             Metadata = metadata ?? new BeatmapMetadata();
+            UserSettings = new BeatmapUserSettings();
         }
 
         [UsedImplicitly]

--- a/osu.Game/Beatmaps/BeatmapUserSettings.cs
+++ b/osu.Game/Beatmaps/BeatmapUserSettings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+using Realms;
+
+namespace osu.Game.Beatmaps
+{
+    /// <summary>
+    /// User settings overrides that are attached to a beatmap.
+    /// </summary>
+    public class BeatmapUserSettings : EmbeddedObject
+    {
+        /// <summary>
+        /// An audio offset that can be used for timing adjustments.
+        /// </summary>
+        public double Offset { get; set; }
+    }
+}

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -54,8 +54,9 @@ namespace osu.Game.Database
         /// 11   2021-11-22    Use ShortName instead of RulesetID for ruleset key bindings.
         /// 12   2021-11-24    Add Status to RealmBeatmapSet.
         /// 13   2022-01-13    Final migration of beatmaps and scores to realm (multiple new storage fields).
+        /// 14   2022-03-01    Added BeatmapUserSettings to BeatmapInfo.
         /// </summary>
-        private const int schema_version = 13;
+        private const int schema_version = 14;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -565,6 +565,11 @@ namespace osu.Game.Database
                     }
 
                     break;
+
+                case 14:
+                    foreach (var beatmap in migration.NewRealm.All<BeatmapInfo>())
+                        beatmap.UserSettings = new BeatmapUserSettings();
+                    break;
             }
         }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Development;
 using osu.Framework.Input.Bindings;
@@ -268,6 +269,17 @@ namespace osu.Game.Database
                 using (var realm = getRealmInstance())
                     realm.Write(action);
             }
+        }
+
+        /// <summary>
+        /// Write changes to realm asynchronously, guaranteeing order of execution.
+        /// </summary>
+        /// <param name="action">The work to run.</param>
+        public async Task WriteAsync(Action<Realm> action)
+        {
+            total_writes_async.Value++;
+            using (var realm = getRealmInstance())
+                await realm.WriteAsync(action);
         }
 
         /// <summary>

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Database
             c.CreateMap<BeatmapInfo, BeatmapInfo>()
              .ForMember(s => s.Ruleset, cc => cc.Ignore())
              .ForMember(s => s.Metadata, cc => cc.Ignore())
+             .ForMember(s => s.UserSettings, cc => cc.Ignore())
              .ForMember(s => s.Difficulty, cc => cc.Ignore())
              .ForMember(s => s.BeatmapSet, cc => cc.Ignore())
              .AfterMap((s, d) =>
@@ -154,6 +155,7 @@ namespace osu.Game.Database
 
             c.CreateMap<RealmKeyBinding, RealmKeyBinding>();
             c.CreateMap<BeatmapMetadata, BeatmapMetadata>();
+            c.CreateMap<BeatmapUserSettings, BeatmapUserSettings>();
             c.CreateMap<BeatmapDifficulty, BeatmapDifficulty>();
             c.CreateMap<RulesetInfo, RulesetInfo>();
             c.CreateMap<ScoreInfo, ScoreInfo>();

--- a/osu.Game/Localisation/BeatmapOffsetControlStrings.cs
+++ b/osu.Game/Localisation/BeatmapOffsetControlStrings.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class BeatmapOffsetControlStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.BeatmapOffsetControl";
+
+        /// <summary>
+        /// "Beatmap offset"
+        /// </summary>
+        public static LocalisableString BeatmapOffset => new TranslatableString(getKey(@"beatmap_offset"), @"Beatmap offset");
+
+        /// <summary>
+        /// "Previous play:"
+        /// </summary>
+        public static LocalisableString PreviousPlay => new TranslatableString(getKey(@"previous_play"), @"Previous play:");
+
+        /// <summary>
+        /// "Previous play too short to use for calibration"
+        /// </summary>
+        public static LocalisableString PreviousPlayTooShortToUseForCalibration => new TranslatableString(getKey(@"previous_play_too_short_to_use_for_calibration"), @"Previous play too short to use for calibration");
+
+        /// <summary>
+        /// "Calibrate using last play"
+        /// </summary>
+        public static LocalisableString CalibrateUsingLastPlay => new TranslatableString(getKey(@"calibrate_using_last_play"), @"Calibrate using last play");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -29,8 +29,15 @@ namespace osu.Game.Rulesets.Scoring
         /// A non-null <see langword="double"/> value if unstable rate could be calculated,
         /// and <see langword="null"/> if unstable rate cannot be calculated due to <paramref name="hitEvents"/> being empty.
         /// </returns>
-        public static double? CalculateAverageHitError(this IEnumerable<HitEvent> hitEvents) =>
-            hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset).Average();
+        public static double? CalculateAverageHitError(this IEnumerable<HitEvent> hitEvents)
+        {
+            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset).ToArray();
+
+            if (timeOffsets.Length == 0)
+                return null;
+
+            return timeOffsets.Average();
+        }
 
         private static bool affectsUnstableRate(HitEvent e) => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit();
 

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -61,6 +61,14 @@ namespace osu.Game.Screens.Play
         private Bindable<double> userAudioOffset;
         private double startOffset;
 
+        private IDisposable beatmapOffsetSubscription;
+
+        [Resolved]
+        private RealmAccess realm { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
         public MasterGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStartTime, bool startAtGameplayStart = false)
             : base(beatmap.Track)
         {
@@ -70,14 +78,6 @@ namespace osu.Game.Screens.Play
 
             firstHitObjectTime = beatmap.Beatmap.HitObjects.First().StartTime;
         }
-
-        [Resolved]
-        private RealmAccess realm { get; set; }
-
-        [Resolved]
-        private OsuConfigManager config { get; set; }
-
-        private IDisposable beatmapOffsetSubscription;
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 
 namespace osu.Game.Screens.Play
 {
@@ -43,7 +44,7 @@ namespace osu.Game.Screens.Play
             Precision = 0.1,
         };
 
-        private double totalAppliedOffset => userOffsetClock.RateAdjustedOffset + platformOffsetClock.RateAdjustedOffset;
+        private double totalAppliedOffset => userBeatmapOffsetClock.RateAdjustedOffset + userGlobalOffsetClock.RateAdjustedOffset + platformOffsetClock.RateAdjustedOffset;
 
         private readonly BindableDouble pauseFreqAdjust = new BindableDouble(1);
 
@@ -52,7 +53,8 @@ namespace osu.Game.Screens.Play
         private readonly bool startAtGameplayStart;
         private readonly double firstHitObjectTime;
 
-        private HardwareCorrectionOffsetClock userOffsetClock;
+        private HardwareCorrectionOffsetClock userGlobalOffsetClock;
+        private HardwareCorrectionOffsetClock userBeatmapOffsetClock;
         private HardwareCorrectionOffsetClock platformOffsetClock;
         private MasterGameplayClock masterGameplayClock;
         private Bindable<double> userAudioOffset;
@@ -69,10 +71,12 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, RealmAccess realm)
         {
             userAudioOffset = config.GetBindable<double>(OsuSetting.AudioOffset);
-            userAudioOffset.BindValueChanged(offset => userOffsetClock.Offset = offset.NewValue, true);
+            userAudioOffset.BindValueChanged(offset => userGlobalOffsetClock.Offset = offset.NewValue, true);
+
+            userBeatmapOffsetClock.Offset = realm.Run(r => r.Find<BeatmapInfo>(beatmap.BeatmapInfo.ID).UserSettings?.Offset) ?? 0;
 
             // sane default provided by ruleset.
             startOffset = gameplayStartTime;
@@ -161,9 +165,10 @@ namespace osu.Game.Screens.Play
             platformOffsetClock = new HardwareCorrectionOffsetClock(source, pauseFreqAdjust) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
 
             // the final usable gameplay clock with user-set offsets applied.
-            userOffsetClock = new HardwareCorrectionOffsetClock(platformOffsetClock, pauseFreqAdjust);
+            userGlobalOffsetClock = new HardwareCorrectionOffsetClock(platformOffsetClock, pauseFreqAdjust);
+            userBeatmapOffsetClock = new HardwareCorrectionOffsetClock(userGlobalOffsetClock, pauseFreqAdjust);
 
-            return masterGameplayClock = new MasterGameplayClock(userOffsetClock);
+            return masterGameplayClock = new MasterGameplayClock(userBeatmapOffsetClock);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -88,7 +88,10 @@ namespace osu.Game.Screens.Play
 
             beatmapOffsetSubscription = realm.RegisterCustomSubscription(r =>
             {
-                var userSettings = r.Find<BeatmapInfo>(beatmap.BeatmapInfo.ID).UserSettings;
+                var userSettings = r.Find<BeatmapInfo>(beatmap.BeatmapInfo.ID)?.UserSettings;
+
+                if (userSettings == null) // only the case for tests.
+                    return null;
 
                 void onUserSettingsOnPropertyChanged(object sender, PropertyChangedEventArgs args)
                 {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -136,7 +136,11 @@ namespace osu.Game.Screens.Play
 
         public readonly PlayerConfiguration Configuration;
 
-        protected Score Score { get; private set; }
+        /// <summary>
+        /// The score for the current play session.
+        /// Available only after the player is loaded.
+        /// </summary>
+        public Score Score { get; private set; }
 
         /// <summary>
         /// Create a new player instance.

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -167,6 +167,7 @@ namespace osu.Game.Screens.Play
                         Children = new PlayerSettingsGroup[]
                         {
                             VisualSettings = new VisualSettings(),
+                            new AudioSettings(),
                             new InputSettings()
                         }
                     },

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -23,7 +23,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Input;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Users;
@@ -61,6 +60,8 @@ namespace osu.Game.Screens.Play
         protected FillFlowContainer<PlayerSettingsGroup> PlayerSettings { get; private set; }
 
         protected VisualSettings VisualSettings { get; private set; }
+
+        protected AudioSettings AudioSettings { get; private set; }
 
         protected Task LoadTask { get; private set; }
 
@@ -168,7 +169,7 @@ namespace osu.Game.Screens.Play
                         Children = new PlayerSettingsGroup[]
                         {
                             VisualSettings = new VisualSettings(),
-                            new AudioSettings(),
+                            AudioSettings = new AudioSettings(),
                             new InputSettings()
                         }
                     },
@@ -229,11 +230,7 @@ namespace osu.Game.Screens.Play
 
             var lastScore = player.Score;
 
-            if (lastScore != null)
-            {
-                // TODO: use this
-                double? lastPlayHitError = lastScore.ScoreInfo.HitEvents.CalculateAverageHitError();
-            }
+            AudioSettings.ReferenceScore.Value = lastScore?.ScoreInfo;
 
             // prepare for a retry.
             player = null;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -23,6 +23,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Input;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Users;
@@ -225,6 +226,14 @@ namespace osu.Game.Screens.Play
         public override void OnResuming(IScreen last)
         {
             base.OnResuming(last);
+
+            var lastScore = player.Score;
+
+            if (lastScore != null)
+            {
+                // TODO: use this
+                double? lastPlayHitError = lastScore.ScoreInfo.HitEvents.CalculateAverageHitError();
+            }
 
             // prepare for a retry.
             player = null;

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -2,13 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
     public class AudioSettings : PlayerSettingsGroup
     {
+        public Bindable<ScoreInfo> ReferenceScore { get; } = new Bindable<ScoreInfo>();
+
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
 
         public AudioSettings()
@@ -16,7 +20,11 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             Children = new Drawable[]
             {
-                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hitsounds" }
+                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hitsounds" },
+                new BeatmapOffsetControl
+                {
+                    ReferenceScore = { BindTarget = ReferenceScore },
+                },
             };
         }
 

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Configuration;
+
+namespace osu.Game.Screens.Play.PlayerSettings
+{
+    public class AudioSettings : PlayerSettingsGroup
+    {
+        private readonly PlayerCheckbox beatmapHitsoundsToggle;
+
+        public AudioSettings()
+            : base("Audio Settings")
+        {
+            Children = new Drawable[]
+            {
+                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hitsounds" }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -85,7 +85,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
             beatmapOffsetSubscription = realm.RegisterCustomSubscription(r =>
             {
-                var userSettings = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID).UserSettings;
+                var userSettings = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID)?.UserSettings;
+
+                if (userSettings == null) // only the case for tests.
+                    return null;
 
                 Current.Value = userSettings.Offset;
                 userSettings.PropertyChanged += onUserSettingsOnPropertyChanged;
@@ -122,7 +125,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
                 realmWrite = realm.WriteAsync(r =>
                 {
-                    var settings = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID).UserSettings;
+                    var settings = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID)?.UserSettings;
+
+                    if (settings == null) // only the case for tests.
+                        return;
 
                     if (Precision.AlmostEquals(settings.Offset, Current.Value))
                         return;

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -19,6 +19,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
@@ -57,7 +58,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     new PlayerSliderBar<double>
                     {
                         KeyboardStep = 5,
-                        LabelText = "Beatmap offset",
+                        LabelText = BeatmapOffsetControlStrings.BeatmapOffset,
                         Current = Current,
                     },
                     referenceScoreContainer = new FillFlowContainer
@@ -156,7 +157,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             {
                 new OsuSpriteText
                 {
-                    Text = "Previous play:"
+                    Text = BeatmapOffsetControlStrings.PreviousPlay
                 },
             };
 
@@ -169,7 +170,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Colour = colours.Red1,
-                        Text = "Previous play too short to use for calibration"
+                        Text = BeatmapOffsetControlStrings.PreviousPlayTooShortToUseForCalibration
                     },
                 });
 
@@ -188,7 +189,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 new AverageHitError(hitEvents),
                 useAverageButton = new SettingsButton
                 {
-                    Text = "Calibrate using last play",
+                    Text = BeatmapOffsetControlStrings.CalibrateUsingLastPlay,
                     Action = () => Current.Value = lastPlayAverage
                 },
             });

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -44,6 +44,17 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private readonly FillFlowContainer referenceScoreContainer;
 
+        private IDisposable beatmapOffsetSubscription;
+
+        [Resolved]
+        private RealmAccess realm { get; set; }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
         public BeatmapOffsetControl()
         {
             RelativeSizeAxes = Axes.X;
@@ -73,17 +84,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 }
             };
         }
-
-        [Resolved]
-        private RealmAccess realm { get; set; }
-
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; }
-
-        [Resolved]
-        private OsuColour colours { get; set; }
-
-        private IDisposable beatmapOffsetSubscription;
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
+using osuTK;
+
+namespace osu.Game.Screens.Play.PlayerSettings
+{
+    public class BeatmapOffsetControl : CompositeDrawable
+    {
+        private readonly SettingsButton useAverageButton;
+
+        private readonly double lastPlayAverage;
+
+        public Bindable<double> Current { get; } = new BindableDouble
+        {
+            Default = 0,
+            Value = 0,
+            MinValue = -50,
+            MaxValue = 50,
+            Precision = 0.1,
+        };
+
+        public BeatmapOffsetControl(IReadOnlyList<HitEvent> hitEvents)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            FillFlowContainer flow;
+
+            InternalChild = flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(10),
+                Children = new Drawable[]
+                {
+                    new PlayerSliderBar<double>
+                    {
+                        KeyboardStep = 5,
+                        LabelText = "Beatmap offset",
+                        Current = Current,
+                    },
+                }
+            };
+
+            if (hitEvents.CalculateAverageHitError() is double average)
+            {
+                lastPlayAverage = average;
+
+                flow.AddRange(new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = "Last play:"
+                    },
+                    new HitEventTimingDistributionGraph(hitEvents)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 50,
+                    },
+                    new AverageHitError(hitEvents),
+                    useAverageButton = new SettingsButton
+                    {
+                        Text = "Calibrate using last play",
+                        Action = () => Current.Value = lastPlayAverage
+                    },
+                });
+            }
+
+            Current.BindValueChanged(offset =>
+            {
+                if (useAverageButton != null)
+                {
+                    useAverageButton.Enabled.Value = offset.NewValue != lastPlayAverage;
+                }
+            }, true);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 }
 
                 if (useAverageButton != null)
-                    useAverageButton.Enabled.Value = !Precision.AlmostEquals(lastPlayAverage, Current.Value, Current.Precision);
+                    useAverageButton.Enabled.Value = !Precision.AlmostEquals(lastPlayAverage, -Current.Value, Current.Precision);
 
                 realmWriteTask = realm.WriteAsync(r =>
                 {

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -20,6 +21,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
 using osu.Game.Localisation;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
@@ -146,11 +148,17 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private void scoreChanged(ValueChangedEvent<ScoreInfo> score)
         {
-            var hitEvents = score.NewValue?.HitEvents;
-
             referenceScoreContainer.Clear();
 
-            if (!(hitEvents?.CalculateAverageHitError() is double average))
+            if (score.NewValue == null)
+                return;
+
+            if (score.NewValue.Mods.Any(m => m is ModAutoplay))
+                return;
+
+            var hitEvents = score.NewValue.HitEvents;
+
+            if (!(hitEvents.CalculateAverageHitError() is double average))
                 return;
 
             referenceScoreContainer.Children = new Drawable[]

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 useAverageButton = new SettingsButton
                 {
                     Text = BeatmapOffsetControlStrings.CalibrateUsingLastPlay,
-                    Action = () => Current.Value = lastPlayAverage
+                    Action = () => Current.Value = -lastPlayAverage
                 },
             });
         }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -15,13 +15,12 @@ using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
-using osu.Game.Localisation;
-using osu.Game.Rulesets.Mods;
 
 #nullable enable
 
@@ -155,7 +154,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             if (score.NewValue == null)
                 return;
 
-            if (score.NewValue.Mods.Any(m => m is ModAutoplay))
+            if (score.NewValue.Mods.Any(m => !m.UserPlayable))
                 return;
 
             var hitEvents = score.NewValue.HitEvents;

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     if (settings == null) // only the case for tests.
                         return;
 
-                    if (Precision.AlmostEquals(settings.Offset, Current.Value))
+                    if (settings.Offset == Current.Value)
                         return;
 
                     settings.Offset = Current.Value;

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 }
 
                 if (useAverageButton != null)
-                    useAverageButton.Enabled.Value = !Precision.AlmostEquals(lastPlayAverage, -Current.Value, Current.Precision);
+                    useAverageButton.Enabled.Value = !Precision.AlmostEquals(lastPlayAverage, -Current.Value, Current.Precision / 2);
 
                 realmWriteTask = realm.WriteAsync(r =>
                 {

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly PlayerCheckbox showStoryboardToggle;
         private readonly PlayerCheckbox beatmapSkinsToggle;
         private readonly PlayerCheckbox beatmapColorsToggle;
-        private readonly PlayerCheckbox beatmapHitsoundsToggle;
 
         public VisualSettings()
             : base("Visual Settings")
@@ -45,7 +44,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 showStoryboardToggle = new PlayerCheckbox { LabelText = "Storyboard / Video" },
                 beatmapSkinsToggle = new PlayerCheckbox { LabelText = "Beatmap skins" },
                 beatmapColorsToggle = new PlayerCheckbox { LabelText = "Beatmap colours" },
-                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hitsounds" }
             };
         }
 
@@ -57,7 +55,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
             showStoryboardToggle.Current = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
             beatmapSkinsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
             beatmapColorsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapColours);
-            beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
         }
     }
 }


### PR DESCRIPTION
This is an initial PR to get some feedback on the structure before I add more features around this.

Things which are broken or missing:

- The distribution graph looks pretty broke in the tests (and in some actual usages). I plan on looking into this as a separate effort.
- The offset can't be changed during gameplay. It is strictly accessible from the loader screen. I have added support for the loader screen to react to changes for this future functionality
- The property changed watch code is in my opinion... very ugly. I'd like to replace this with some kind of component to handle things for us, but this needs a bit more thought. Based on @smoogipoo saying that he's okay with the code I have here, I've decided to push through with it for now and address that as a follow-up.
- `TestSceneLeadIn` is failing because the first frame clock `CurrentTime` is no longer working (is zero rather than the expected value). This is probably going to require an external fix, or further investigation.
- Tooltip should probably have a "ms" suffix. A bit of a convoluted thing to add unfortunately. Will probably be follow-up work.

Things of note:
- I added and used `WriteAsync` because normal writes are slow. This is because they trigger an implicit `Refresh`, which we've already seen as being super slow. Other cases which are using `Write` have not had this concern as they don't write as often.
- There's potential to use `RealmLive` in `BeatmapOffsetControl` to tidy the multiple `Find` fetches up, but without the aforementioned clean-ups to property binding code it doesn't seem like a worthwhile change. If anything, that bind flow could be implemented as part of `RealmLive`.
- I've disabled the calibration controls for autoplay but left it in place for replays. I don't see this as being too harmful, and players may want to calibrate from previous plays.
- I have an idea for a more animated hit error display but will leave this for a future effort.
- Curious on opinions of whether this whole thing should be a bindable flow, with the realm part being managed at a single point (ie. `WorkingBeatmap`). I'm very unsure of the path forward here as we implement more systems which are relying on realm. Realm has its own "bindable" like flow, but right now using it means we are working with a very different pattern which doesn't mesh well with what we currently have.

https://user-images.githubusercontent.com/191335/156155032-5e7a779f-8fe0-4667-aed0-b4a731b7fb68.mp4

- [x] Depends on #17023
- [x] Needs tests fixed, as noted above