### PR TITLE
Fix performance statistic not handling rulesets with unimplemented calculator

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -17,10 +17,13 @@ using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Scoring;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
+using osu.Game.Screens.Ranking.Expanded.Statistics;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Tests.Resources;
 using osuTK;
@@ -256,6 +259,23 @@ namespace osu.Game.Tests.Visual.Ranking
             AddAssert("download button is enabled", () => screen.ChildrenOfType<DownloadButton>().Last().Enabled.Value);
         }
 
+        [Test]
+        public void TestRulesetWithNoPerformanceCalculator()
+        {
+            var ruleset = new RulesetWithNoPerformanceCalculator();
+            var score = TestResources.CreateTestScoreInfo(ruleset.RulesetInfo);
+
+            AddStep("load results", () => Child = new TestResultsContainer(createResultsScreen(score)));
+            AddUntilStep("wait for load", () => this.ChildrenOfType<ScorePanelList>().Single().AllPanelsVisible);
+
+            AddAssert("PP displayed as 0", () =>
+            {
+                var performance = this.ChildrenOfType<PerformanceStatistic>().Single();
+                var counter = performance.ChildrenOfType<StatisticCounter>().Single();
+                return counter.Current.Value == 0;
+            });
+        }
+
         private TestResultsScreen createResultsScreen(ScoreInfo score = null) => new TestResultsScreen(score ?? TestResources.CreateTestScoreInfo());
 
         private UnrankedSoloResultsScreen createUnrankedSoloResultsScreen() => new UnrankedSoloResultsScreen(TestResources.CreateTestScoreInfo());
@@ -366,6 +386,11 @@ namespace osu.Game.Tests.Visual.Ranking
 
                 RetryOverlay = InternalChildren.OfType<HotkeyRetryOverlay>().SingleOrDefault();
             }
+        }
+
+        private class RulesetWithNoPerformanceCalculator : OsuRuleset
+        {
+            public override PerformanceCalculator CreatePerformanceCalculator(DifficultyAttributes attributes, ScoreInfo score) => null;
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
             else
             {
                 performanceCache.CalculatePerformanceAsync(score, cancellationTokenSource.Token)
-                                .ContinueWith(t => Schedule(() => setPerformanceValue(t.GetResultSafely().Total)), cancellationTokenSource.Token);
+                                .ContinueWith(t => Schedule(() => setPerformanceValue(t.GetResultSafely()?.Total)), cancellationTokenSource.Token);
             }
         }
 


### PR DESCRIPTION
Addresses #17031.

Looks to be an oversight as the method already supports handling null, but `Total` was being accessed without a null-conditional.