### PR TITLE
Apply scaling container transforms at a single point to improve transitions

### DIFF
--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -45,6 +45,8 @@ namespace osu.Game.Graphics.Containers
         /// <summary>
         /// Set a custom position and scale which overrides any user specification.
         /// </summary>
+        /// <param name="rect">A rectangle with positional and sizing information for this container to conform to. <c>null</c> will clear the custom rect and revert to user settings.</param>
+        /// <param name="relativePosition">Whether the position portion of the provided rect is in relative coordinate space or not.</param>
         public void SetCustomRect(RectangleF? rect, bool relativePosition = false)
         {
             customRect = rect;

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -190,9 +190,9 @@ namespace osu.Game.Graphics.Containers
             sizableContainer.MoveTo(targetRect.Location, duration, Easing.OutQuart);
             sizableContainer.ResizeTo(targetRect.Size, duration, Easing.OutQuart);
 
-            // Of note, this will not working great in the case of nested ScalingContainers where multiple are applying corner radius.
-            // There should likely only be masking and corner radius applied at one point in the full game stack to fix this.
-            // An example of how this can occur is it the skin editor is visible and the game screen scaling is set to "Everything".
+            // Of note, this will not work great in the case of nested ScalingContainers where multiple are applying corner radius.
+            // Masking and corner radius should likely only be applied at one point in the full game stack to fix this.
+            // An example of how this can occur is when the skin editor is visible and the game screen scaling is set to "Everything".
             sizableContainer.TransformTo(nameof(CornerRadius), requiresMasking ? corner_radius : 0, duration, requiresMasking ? Easing.OutQuart : Easing.None)
                             .OnComplete(_ => { sizableContainer.Masking = requiresMasking; });
         }

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Graphics.Containers
             }
         }
 
+        private const float corner_radius = 10;
+
         /// <summary>
         /// Create a new instance.
         /// </summary>
@@ -69,7 +71,7 @@ namespace osu.Game.Graphics.Containers
             {
                 RelativeSizeAxes = Axes.Both,
                 RelativePositionAxes = Axes.Both,
-                CornerRadius = 10,
+                CornerRadius = corner_radius,
                 Child = content = new ScalingDrawSizePreservingFillContainer(targetMode != ScalingMode.Gameplay)
             };
         }
@@ -176,6 +178,7 @@ namespace osu.Game.Graphics.Containers
 
             sizableContainer.MoveTo(targetPosition, 500, Easing.OutQuart);
             sizableContainer.ResizeTo(targetSize, 500, Easing.OutQuart).OnComplete(_ => { sizableContainer.Masking = requiresMasking; });
+            sizableContainer.TransformTo(nameof(CornerRadius), requiresMasking ? corner_radius : 0, 500, requiresMasking ? Easing.OutQuart : Easing.None);
         }
 
         private class ScalingBackgroundScreen : BackgroundScreenDefault

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Graphics.Containers
 
         private void updateSize()
         {
-            const float fade_time = 500;
+            const float duration = 500;
 
             if (targetMode == ScalingMode.Everything)
             {
@@ -155,10 +155,10 @@ namespace osu.Game.Graphics.Containers
                         backgroundStack.Push(new ScalingBackgroundScreen());
                     }
 
-                    backgroundStack.FadeIn(fade_time);
+                    backgroundStack.FadeIn(duration);
                 }
                 else
-                    backgroundStack?.FadeOut(fade_time);
+                    backgroundStack?.FadeOut(duration);
             }
 
             RectangleF targetSize = new RectangleF(Vector2.Zero, Vector2.One);
@@ -187,9 +187,14 @@ namespace osu.Game.Graphics.Containers
             if (requiresMasking)
                 sizableContainer.Masking = true;
 
-            sizableContainer.MoveTo(targetSize.Location, 500, Easing.OutQuart);
-            sizableContainer.ResizeTo(targetSize.Size, 500, Easing.OutQuart).OnComplete(_ => { sizableContainer.Masking = requiresMasking; });
-            sizableContainer.TransformTo(nameof(CornerRadius), requiresMasking ? corner_radius : 0, 500, requiresMasking ? Easing.OutQuart : Easing.None);
+            sizableContainer.MoveTo(targetSize.Location, duration, Easing.OutQuart);
+            sizableContainer.ResizeTo(targetSize.Size, duration, Easing.OutQuart);
+
+            // Of note, this will not working great in the case of nested ScalingContainers where multiple are applying corner radius.
+            // There should likely only be masking and corner radius applied at one point in the full game stack to fix this.
+            // An example of how this can occur is it the skin editor is visible and the game screen scaling is set to "Everything".
+            sizableContainer.TransformTo(nameof(CornerRadius), requiresMasking ? corner_radius : 0, duration, requiresMasking ? Easing.OutQuart : Easing.None)
+                            .OnComplete(_ => { sizableContainer.Masking = requiresMasking; });
         }
 
         private class ScalingBackgroundScreen : BackgroundScreenDefault

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -39,16 +39,16 @@ namespace osu.Game.Graphics.Containers
 
         private BackgroundScreenStack backgroundStack;
 
-        private RectangleF? customScale;
-        private bool customScaleIsRelativePosition;
+        private RectangleF? customRect;
+        private bool customRectIsRelativePosition;
 
         /// <summary>
         /// Set a custom position and scale which overrides any user specification.
         /// </summary>
-        public void SetCustomScale(RectangleF? scale, bool relativePosition = false)
+        public void SetCustomRect(RectangleF? rect, bool relativePosition = false)
         {
-            customScale = scale;
-            customScaleIsRelativePosition = relativePosition;
+            customRect = rect;
+            customRectIsRelativePosition = relativePosition;
 
             if (IsLoaded) Scheduler.AddOnce(updateSize);
         }
@@ -161,13 +161,13 @@ namespace osu.Game.Graphics.Containers
                     backgroundStack?.FadeOut(duration);
             }
 
-            RectangleF targetSize = new RectangleF(Vector2.Zero, Vector2.One);
+            RectangleF targetRect = new RectangleF(Vector2.Zero, Vector2.One);
 
-            if (customScale != null)
+            if (customRect != null)
             {
-                sizableContainer.RelativePositionAxes = customScaleIsRelativePosition ? Axes.Both : Axes.None;
+                sizableContainer.RelativePositionAxes = customRectIsRelativePosition ? Axes.Both : Axes.None;
 
-                targetSize = customScale.Value;
+                targetRect = customRect.Value;
             }
             else if (targetMode == null || scalingMode.Value == targetMode)
             {
@@ -176,10 +176,10 @@ namespace osu.Game.Graphics.Containers
                 Vector2 scale = new Vector2(sizeX.Value, sizeY.Value);
                 Vector2 pos = new Vector2(posX.Value, posY.Value) * (Vector2.One - scale);
 
-                targetSize = new RectangleF(pos, scale);
+                targetRect = new RectangleF(pos, scale);
             }
 
-            bool requiresMasking = targetSize.Size != Vector2.One
+            bool requiresMasking = targetRect.Size != Vector2.One
                                    // For the top level scaling container, for now we apply masking if safe areas are in use.
                                    // In the future this can likely be removed as more of the actual UI supports overflowing into the safe areas.
                                    || (targetMode == ScalingMode.Everything && safeAreaPadding.Value.Total != Vector2.Zero);
@@ -187,8 +187,8 @@ namespace osu.Game.Graphics.Containers
             if (requiresMasking)
                 sizableContainer.Masking = true;
 
-            sizableContainer.MoveTo(targetSize.Location, duration, Easing.OutQuart);
-            sizableContainer.ResizeTo(targetSize.Size, duration, Easing.OutQuart);
+            sizableContainer.MoveTo(targetRect.Location, duration, Easing.OutQuart);
+            sizableContainer.ResizeTo(targetRect.Size, duration, Easing.OutQuart);
 
             // Of note, this will not working great in the case of nested ScalingContainers where multiple are applying corner radius.
             // There should likely only be masking and corner radius applied at one point in the full game stack to fix this.

--- a/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
+++ b/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Skinning.Editor
 {
     public class SkinComponentToolbox : ScrollingToolboxGroup
     {
+        public const float WIDTH = 200;
+
         public Action<Type> RequestPlacement;
 
         private const float component_display_scale = 0.8f;
@@ -41,7 +43,7 @@ namespace osu.Game.Skinning.Editor
             : base("Components", height)
         {
             RelativeSizeAxes = Axes.None;
-            Width = 200;
+            Width = WIDTH;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -101,11 +101,11 @@ namespace osu.Game.Skinning.Editor
         {
             if (visibility.NewValue == Visibility.Visible)
             {
-                target.SetCustomScale(new RectangleF(0.18f, 0.1f, VISIBLE_TARGET_SCALE, VISIBLE_TARGET_SCALE), true);
+                target.SetCustomRect(new RectangleF(0.18f, 0.1f, VISIBLE_TARGET_SCALE, VISIBLE_TARGET_SCALE), true);
             }
             else
             {
-                target.SetCustomScale(null);
+                target.SetCustomRect(null);
             }
         }
 

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
@@ -100,28 +101,12 @@ namespace osu.Game.Skinning.Editor
         {
             if (visibility.NewValue == Visibility.Visible)
             {
-                updateMasking();
-                target.AllowScaling = false;
-                target.RelativePositionAxes = Axes.Both;
-
-                target.ScaleTo(VISIBLE_TARGET_SCALE, SkinEditor.TRANSITION_DURATION, Easing.OutQuint);
-                target.MoveToX(0.095f, SkinEditor.TRANSITION_DURATION, Easing.OutQuint);
+                target.SetCustomScale(new RectangleF(0.18f, 0.1f, VISIBLE_TARGET_SCALE, VISIBLE_TARGET_SCALE), true);
             }
             else
             {
-                target.AllowScaling = true;
-
-                target.ScaleTo(1, SkinEditor.TRANSITION_DURATION, Easing.OutQuint).OnComplete(_ => updateMasking());
-                target.MoveToX(0f, SkinEditor.TRANSITION_DURATION, Easing.OutQuint);
+                target.SetCustomScale(null);
             }
-        }
-
-        private void updateMasking()
-        {
-            if (skinEditor == null)
-                return;
-
-            target.Masking = skinEditor.State.Value == Visibility.Visible;
         }
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)


### PR DESCRIPTION
## Corner radius now tweened between states

Before:

https://user-images.githubusercontent.com/191335/156353633-e67b067d-9312-44ee-bd6c-699157c63e2a.mp4

After:

https://user-images.githubusercontent.com/191335/156353359-d0784303-acf9-4a31-96a2-47fe13ea1bef.mp4

## Changes between two disparate scaling scenarios now feels smoother

Before:

https://user-images.githubusercontent.com/191335/156353565-ab23777e-f6f7-4647-9da9-dbc1e04ab487.mp4

After:

https://user-images.githubusercontent.com/191335/156353259-8a46064d-6ce7-40eb-b377-bb3a319d41e9.mp4


