### PR TITLE
Remove padding from distribution graph bars to fix some bars becoming invisible at low sizes

### DIFF
--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -160,8 +160,6 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                 RelativeSizeAxes = Axes.Both;
 
-                Padding = new MarginPadding { Horizontal = 1 };
-
                 InternalChild = new Circle
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
This looks better in my opinion, plus fixes cases where the bars became invisible at smaller display sizes.

Before:

![osu Game Tests 2022-03-03 at 06 41 34](https://user-images.githubusercontent.com/191335/156510735-154de8e3-9ab2-4ce2-8608-7bf0546b6ae6.png)


After:

![osu Game Tests 2022-03-03 at 06 38 37](https://user-images.githubusercontent.com/191335/156510280-cfaf311f-365e-446b-9a6c-c57f3e0d55f1.png)