### PR TITLE
Change `IUpdatableByPlayfield.Update` to be called by the main playfield only

### DIFF
--- a/osu.Game/Rulesets/Mods/IUpdatableByPlayfield.cs
+++ b/osu.Game/Rulesets/Mods/IUpdatableByPlayfield.cs
@@ -5,8 +5,19 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mods
 {
+    /// <summary>
+    /// An interface for <see cref="Mod"/>s that are updated every frame by a <see cref="Playfield"/>.
+    /// </summary>
     public interface IUpdatableByPlayfield : IApplicableMod
     {
+        /// <summary>
+        /// Update this <see cref="Mod"/>.
+        /// </summary>
+        /// <param name="playfield">The main <see cref="Playfield"/></param>
+        /// <remarks>
+        /// This method is called once per frame during gameplay by the main <see cref="Playfield"/> only.
+        /// To access nested <see cref="Playfield"/>s, use <see cref="Playfield.NestedPlayfields"/>.
+        /// </remarks>
         void Update(Playfield playfield);
     }
 }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -80,6 +80,11 @@ namespace osu.Game.Rulesets.UI
         private readonly List<Playfield> nestedPlayfields = new List<Playfield>();
 
         /// <summary>
+        /// Whether this <see cref="Playfield"/> is nested in another <see cref="Playfield"/>.
+        /// </summary>
+        public bool IsNested { get; private set; }
+
+        /// <summary>
         /// Whether judgements should be displayed by this and and all nested <see cref="Playfield"/>s.
         /// </summary>
         public readonly BindableBool DisplayJudgements = new BindableBool(true);
@@ -206,6 +211,8 @@ namespace osu.Game.Rulesets.UI
         /// <param name="otherPlayfield">The <see cref="Playfield"/> to add.</param>
         protected void AddNested(Playfield otherPlayfield)
         {
+            otherPlayfield.IsNested = true;
+
             otherPlayfield.DisplayJudgements.BindTo(DisplayJudgements);
 
             otherPlayfield.NewResult += (d, r) => NewResult?.Invoke(d, r);
@@ -229,7 +236,7 @@ namespace osu.Game.Rulesets.UI
         {
             base.Update();
 
-            if (mods != null)
+            if (!IsNested && mods != null)
             {
                 foreach (var mod in mods)
                 {


### PR DESCRIPTION
Fixes #17064

Adds an `IsNested` property in `Playfield` to track whether the playfield is nested. Only non-nested playfields update `IUpdatableByPlayfield` mods. All existing usages of `IUpdatableByPlayfield` are tested and they are all working fine.