### PR TITLE
Reduce 'cursor-tap' sample playback volume on MouseUp

### DIFF
--- a/osu.Game/Graphics/Cursor/MenuCursor.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursor.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Graphics.Cursor
             // Scale to [-0.75, 0.75] so that the sample isn't fully panned left or right (sounds weird)
             channel.Balance.Value = ((activeCursor.X / DrawWidth) * 2 - 1) * 0.75;
             channel.Frequency.Value = baseFrequency - (random_range / 2f) + RNG.NextDouble(random_range);
+            channel.Volume.Value = baseFrequency;
 
             channel.Play();
         }


### PR DESCRIPTION
It's subtle, but I think it sounds nicer.