### PR TITLE
Refactor channel scrolling container to handle non-user scrolls

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -9,7 +9,6 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Chat;
 using osuTK.Input;
@@ -337,7 +336,7 @@ namespace osu.Game.Tests.Visual.Online
 
             public DrawableChannel DrawableChannel => InternalChildren.OfType<DrawableChannel>().First();
 
-            public UserTrackingScrollContainer ScrollContainer => (UserTrackingScrollContainer)((Container)DrawableChannel.Child).Child;
+            public ChannelScrollContainer ScrollContainer => (ChannelScrollContainer)((Container)DrawableChannel.Child).Child;
 
             public FillFlowContainer FillFlow => (FillFlowContainer)ScrollContainer.Child;
 

--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -207,7 +207,28 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
-        public void TestUserScrollOverride()
+        public void TestOverrideChatScrolling()
+        {
+            fillChat();
+
+            sendMessage();
+            checkScrolledToBottom();
+
+            AddStep("Scroll to start", () => chatDisplay.ScrollContainer.ScrollToStart());
+
+            checkNotScrolledToBottom();
+            sendMessage();
+            checkNotScrolledToBottom();
+
+            AddStep("Scroll to bottom", () => chatDisplay.ScrollContainer.ScrollToEnd());
+
+            checkScrolledToBottom();
+            sendMessage();
+            checkScrolledToBottom();
+        }
+
+        [Test]
+        public void TestOverrideChatScrollingByUser()
         {
             fillChat();
 
@@ -314,9 +335,9 @@ namespace osu.Game.Tests.Visual.Online
             {
             }
 
-            protected DrawableChannel DrawableChannel => InternalChildren.OfType<DrawableChannel>().First();
+            public DrawableChannel DrawableChannel => InternalChildren.OfType<DrawableChannel>().First();
 
-            protected UserTrackingScrollContainer ScrollContainer => (UserTrackingScrollContainer)((Container)DrawableChannel.Child).Child;
+            public UserTrackingScrollContainer ScrollContainer => (UserTrackingScrollContainer)((Container)DrawableChannel.Child).Child;
 
             public FillFlowContainer FillFlow => (FillFlowContainer)ScrollContainer.Child;
 

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public bool UserScrolling { get; private set; }
 
-        public void CancelUserScroll() => UserScrolling = false;
-
         public UserTrackingScrollContainer()
         {
         }

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Graphics.Containers
         }
 
         /// <summary>
-        /// Invoked when any scroll has been performed either automatically or by user.
+        /// Invoked when any scroll has been performed either programmatically or by user.
         /// </summary>
         protected virtual void OnScrollChange(bool byUser) => UserScrolling = byUser;
     }

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public bool UserScrolling { get; private set; }
 
+        public void CancelUserScroll() => UserScrolling = false;
+
         public UserTrackingScrollContainer()
         {
         }
@@ -36,37 +38,26 @@ namespace osu.Game.Graphics.Containers
 
         protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = default)
         {
+            UserScrolling = true;
             base.OnUserScroll(value, animated, distanceDecay);
-            OnScrollChange(true);
         }
 
         public new void ScrollIntoView(Drawable target, bool animated = true)
         {
+            UserScrolling = false;
             base.ScrollIntoView(target, animated);
-            OnScrollChange(false);
         }
 
         public new void ScrollTo(float value, bool animated = true, double? distanceDecay = null)
         {
+            UserScrolling = false;
             base.ScrollTo(value, animated, distanceDecay);
-            OnScrollChange(false);
-        }
-
-        public new void ScrollToStart(bool animated = true, bool allowDuringDrag = false)
-        {
-            base.ScrollToStart(animated, allowDuringDrag);
-            OnScrollChange(false);
         }
 
         public new void ScrollToEnd(bool animated = true, bool allowDuringDrag = false)
         {
+            UserScrolling = false;
             base.ScrollToEnd(animated, allowDuringDrag);
-            OnScrollChange(false);
         }
-
-        /// <summary>
-        /// Invoked when any scroll has been performed either programmatically or by user.
-        /// </summary>
-        protected virtual void OnScrollChange(bool byUser) => UserScrolling = byUser;
     }
 }

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public bool UserScrolling { get; private set; }
 
-        public void CancelUserScroll() => UserScrolling = false;
-
         public UserTrackingScrollContainer()
         {
         }
@@ -38,26 +36,37 @@ namespace osu.Game.Graphics.Containers
 
         protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = default)
         {
-            UserScrolling = true;
             base.OnUserScroll(value, animated, distanceDecay);
+            OnScrollChange(true);
         }
 
         public new void ScrollIntoView(Drawable target, bool animated = true)
         {
-            UserScrolling = false;
             base.ScrollIntoView(target, animated);
+            OnScrollChange(false);
         }
 
         public new void ScrollTo(float value, bool animated = true, double? distanceDecay = null)
         {
-            UserScrolling = false;
             base.ScrollTo(value, animated, distanceDecay);
+            OnScrollChange(false);
+        }
+
+        public new void ScrollToStart(bool animated = true, bool allowDuringDrag = false)
+        {
+            base.ScrollToStart(animated, allowDuringDrag);
+            OnScrollChange(false);
         }
 
         public new void ScrollToEnd(bool animated = true, bool allowDuringDrag = false)
         {
-            UserScrolling = false;
             base.ScrollToEnd(animated, allowDuringDrag);
+            OnScrollChange(false);
         }
+
+        /// <summary>
+        /// Invoked when any scroll has been performed either automatically or by user.
+        /// </summary>
+        protected virtual void OnScrollChange(bool byUser) => UserScrolling = byUser;
     }
 }

--- a/osu.Game/Overlays/Chat/ChannelScrollContainer.cs
+++ b/osu.Game/Overlays/Chat/ChannelScrollContainer.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Utils;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Overlays.Chat
+{
+    /// <summary>
+    /// An <see cref="OsuScrollContainer"/> with functionality to automatically scroll whenever the maximum scrollable distance increases.
+    /// </summary>
+    public class ChannelScrollContainer : OsuScrollContainer
+    {
+        /// <summary>
+        /// The chat will be automatically scrolled to end if and only if
+        /// the distance between the current scroll position and the end of the scroll
+        /// is less than this value.
+        /// </summary>
+        private const float auto_scroll_leniency = 10f;
+
+        private bool trackNewContent = true;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // If our behaviour hasn't been overriden and there has been new content added to the container, we should update our scroll position to track it.
+            bool requiresScrollUpdate = trackNewContent && !IsScrolledToEnd();
+
+            if (requiresScrollUpdate)
+            {
+                // Schedule required to allow FillFlow to be the correct size.
+                Schedule(() =>
+                {
+                    if (trackNewContent)
+                    {
+                        if (Current < ScrollableExtent)
+                            ScrollToEnd();
+                    }
+                });
+            }
+        }
+
+        private void updateTrackState() => trackNewContent = IsScrolledToEnd(auto_scroll_leniency);
+
+        // todo: we may eventually want this encapsulated in a "OnScrollChange" event handler method provided by ScrollContainer.
+        // important to note that this intentionally doesn't consider OffsetScrollPosition, but could make it do so with side changes.
+
+        #region Scroll handling
+
+        protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = null)
+        {
+            base.OnUserScroll(value, animated, distanceDecay);
+            updateTrackState();
+        }
+
+        public new void ScrollIntoView(Drawable d, bool animated = true)
+        {
+            base.ScrollIntoView(d, animated);
+            updateTrackState();
+        }
+
+        public new void ScrollToStart(bool animated = true, bool allowDuringDrag = false)
+        {
+            base.ScrollToStart(animated, allowDuringDrag);
+            updateTrackState();
+        }
+
+        public new void ScrollToEnd(bool animated = true, bool allowDuringDrag = false)
+        {
+            base.ScrollToEnd(animated, allowDuringDrag);
+            updateTrackState();
+        }
+
+        #endregion
+    }
+}

--- a/osu.Game/Overlays/Chat/ChannelScrollContainer.cs
+++ b/osu.Game/Overlays/Chat/ChannelScrollContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Chat
@@ -21,25 +20,12 @@ namespace osu.Game.Overlays.Chat
 
         private bool trackNewContent = true;
 
-        protected override void Update()
+        protected override void UpdateAfterChildren()
         {
-            base.Update();
+            base.UpdateAfterChildren();
 
-            // If our behaviour hasn't been overriden and there has been new content added to the container, we should update our scroll position to track it.
-            bool requiresScrollUpdate = trackNewContent && !IsScrolledToEnd();
-
-            if (requiresScrollUpdate)
-            {
-                // Schedule required to allow FillFlow to be the correct size.
-                Schedule(() =>
-                {
-                    if (trackNewContent)
-                    {
-                        if (Current < ScrollableExtent)
-                            ScrollToEnd();
-                    }
-                });
-            }
+            if (trackNewContent && !IsScrolledToEnd())
+                ScrollToEnd();
         }
 
         private void updateTrackState() => trackNewContent = IsScrolledToEnd(auto_scroll_leniency);

--- a/osu.Game/Overlays/Chat/ChannelScrollContainer.cs
+++ b/osu.Game/Overlays/Chat/ChannelScrollContainer.cs
@@ -18,6 +18,12 @@ namespace osu.Game.Overlays.Chat
         /// </summary>
         private const float auto_scroll_leniency = 10f;
 
+        /// <summary>
+        /// Whether to keep this container scrolled to end on new content.
+        /// </summary>
+        /// <remarks>
+        /// This is specifically controlled by whether the latest scroll operation made the container scrolled to end.
+        /// </remarks>
         private bool trackNewContent = true;
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -249,31 +249,32 @@ namespace osu.Game.Overlays.Chat
             /// </summary>
             private const float auto_scroll_leniency = 10f;
 
+            private bool trackNewContent = true;
             private float? lastExtent;
 
-            protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = default)
+            protected override void OnScrollChange(bool byUser)
             {
-                base.OnUserScroll(value, animated, distanceDecay);
-                lastExtent = null;
+                base.OnScrollChange(byUser);
+
+                if (byUser)
+                    lastExtent = null;
+
+                trackNewContent = IsScrolledToEnd(auto_scroll_leniency);
             }
 
             protected override void Update()
             {
                 base.Update();
 
-                // If the user has scrolled to the bottom of the container, we should resume tracking new content.
-                if (UserScrolling && IsScrolledToEnd(auto_scroll_leniency))
-                    CancelUserScroll();
-
                 // If the user hasn't overridden our behaviour and there has been new content added to the container, we should update our scroll position to track it.
-                bool requiresScrollUpdate = !UserScrolling && (lastExtent == null || Precision.AlmostBigger(ScrollableExtent, lastExtent.Value));
+                bool requiresScrollUpdate = trackNewContent && (lastExtent == null || Precision.AlmostBigger(ScrollableExtent, lastExtent.Value));
 
                 if (requiresScrollUpdate)
                 {
                     // Schedule required to allow FillFlow to be the correct size.
                     Schedule(() =>
                     {
-                        if (!UserScrolling)
+                        if (trackNewContent)
                         {
                             if (Current < ScrollableExtent)
                                 ScrollToEnd();

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -11,9 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Utils;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Chat;
@@ -234,54 +232,6 @@ namespace osu.Game.Overlays.Chat
                         }
                     }
                 };
-            }
-        }
-
-        /// <summary>
-        /// An <see cref="OsuScrollContainer"/> with functionality to automatically scroll whenever the maximum scrollable distance increases.
-        /// </summary>
-        private class ChannelScrollContainer : UserTrackingScrollContainer
-        {
-            /// <summary>
-            /// The chat will be automatically scrolled to end if and only if
-            /// the distance between the current scroll position and the end of the scroll
-            /// is less than this value.
-            /// </summary>
-            private const float auto_scroll_leniency = 10f;
-
-            private bool trackNewContent = true;
-            private float? lastExtent;
-
-            protected override void OnScrollChange(bool byUser)
-            {
-                base.OnScrollChange(byUser);
-
-                if (byUser)
-                    lastExtent = null;
-
-                trackNewContent = IsScrolledToEnd(auto_scroll_leniency);
-            }
-
-            protected override void Update()
-            {
-                base.Update();
-
-                // If the user hasn't overridden our behaviour and there has been new content added to the container, we should update our scroll position to track it.
-                bool requiresScrollUpdate = trackNewContent && (lastExtent == null || Precision.AlmostBigger(ScrollableExtent, lastExtent.Value));
-
-                if (requiresScrollUpdate)
-                {
-                    // Schedule required to allow FillFlow to be the correct size.
-                    Schedule(() =>
-                    {
-                        if (trackNewContent)
-                        {
-                            if (Current < ScrollableExtent)
-                                ScrollToEnd();
-                            lastExtent = ScrollableExtent;
-                        }
-                    });
-                }
             }
         }
     }


### PR DESCRIPTION
`ChannelScrollContainer` was simplified to always track new content when the last scroll is not from user, but that limits from scrolling to a specific message via `ScrollIntoView` (e.g. highlighting a message), as doing so will get overriden by `ChannelScrollContainer` scrolling back to bottom next frame.

I've updated it to not rely on `UserScrolling` for that, but instead store a separate `trackNewContent` field that is updated every scroll (excluding `OffsetScrollPosition`).

All tests look to pass, but would appreciate a double-check on all possible cases where this could regress.