### PR TITLE
Allow tabbing between textboxes in sample point popover

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             set => Component.Text = value;
         }
 
-        public Container TabbableContentContainer
+        public CompositeDrawable TabbableContentContainer
         {
             set => Component.TabbableContentContainer = value;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -75,9 +75,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             [BackgroundDependencyLoader]
             private void load()
             {
+                FillFlowContainer flow;
+
                 Children = new Drawable[]
                 {
-                    new FillFlowContainer
+                    flow = new FillFlowContainer
                     {
                         Width = 200,
                         Direction = FillDirection.Vertical,
@@ -93,6 +95,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         }
                     }
                 };
+
+                bank.TabbableContentContainer = flow;
+                volume.TabbableContentContainer = flow;
 
                 // if the piece belongs to a currently selected object, assume that the user wants to change all selected objects.
                 // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Screens.Edit.Timing
             set => slider.KeyboardStep = value;
         }
 
+        public CompositeDrawable TabbableContentContainer
+        {
+            set => textBox.TabbableContentContainer = value;
+        }
+
         private readonly BindableWithCurrent<T?> current = new BindableWithCurrent<T?>();
 
         public Bindable<T?> Current


### PR DESCRIPTION
Fixes #17111

Tests not added because at that point I would be testing that `Tabbable{Content}Container` works. Which I'd hope is something that framework does already.