### PR TITLE
Implement popup screen title component

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestScenePopupScreenTitle.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestScenePopupScreenTitle.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestScenePopupScreenTitle : OsuTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
+
+        [Test]
+        public void TestPopupScreenTitle()
+        {
+            AddStep("create content", () =>
+            {
+                Child = new PopupScreenTitle
+                {
+                    Title = "Popup Screen Title",
+                    Description = "This is a description.",
+                    Close = () => { }
+                };
+            });
+        }
+
+        [Test]
+        public void TestDisabledExit()
+        {
+            AddStep("create content", () =>
+            {
+                Child = new PopupScreenTitle
+                {
+                    Title = "Popup Screen Title",
+                    Description = "This is a description."
+                };
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestScenePopupScreenTitle.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestScenePopupScreenTitle.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Graphics.UserInterface;
@@ -22,7 +23,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Child = new PopupScreenTitle
                 {
                     Title = "Popup Screen Title",
-                    Description = "This is a description.",
+                    Description = string.Join(" ", Enumerable.Repeat("This is a description.", 20)),
                     Close = () => { }
                 };
             });

--- a/osu.Game/Graphics/UserInterface/PopupScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/PopupScreenTitle.cs
@@ -1,0 +1,151 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class PopupScreenTitle : CompositeDrawable
+    {
+        public LocalisableString Title
+        {
+            get => titleSpriteText.Text;
+            set => titleSpriteText.Text = value;
+        }
+
+        public LocalisableString Description
+        {
+            get => descriptionSpriteText.Text;
+            set => descriptionSpriteText.Text = value;
+        }
+
+        public Action? Close
+        {
+            get => closeButton.Action;
+            set => closeButton.Action = value;
+        }
+
+        private const float corner_radius = 14;
+        private const float main_area_height = 70;
+
+        private readonly Container underlayContainer;
+        private readonly Box underlayBackground;
+        private readonly Container contentContainer;
+        private readonly Box contentBackground;
+        private readonly OsuSpriteText titleSpriteText;
+        private readonly OsuSpriteText descriptionSpriteText;
+        private readonly IconButton closeButton;
+
+        public PopupScreenTitle()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding
+                {
+                    Horizontal = 70,
+                    Top = -corner_radius
+                },
+                Children = new Drawable[]
+                {
+                    underlayContainer = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = main_area_height + 2 * corner_radius,
+                        CornerRadius = corner_radius,
+                        Masking = true,
+                        BorderThickness = 2,
+                        Child = underlayBackground = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        }
+                    },
+                    contentContainer = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = main_area_height + corner_radius,
+                        CornerRadius = corner_radius,
+                        Masking = true,
+                        BorderThickness = 2,
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Type = EdgeEffectType.Shadow,
+                            Colour = Colour4.Black.Opacity(0.1f),
+                            Offset = new Vector2(0, 1),
+                            Radius = 3
+                        },
+                        Children = new Drawable[]
+                        {
+                            contentBackground = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both
+                            },
+                            new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Margin = new MarginPadding { Top = corner_radius },
+                                Padding = new MarginPadding { Horizontal = 100 },
+                                Children = new Drawable[]
+                                {
+                                    titleSpriteText = new OsuSpriteText
+                                    {
+                                        Font = OsuFont.TorusAlternate.With(size: 20)
+                                    },
+                                    descriptionSpriteText = new OsuSpriteText
+                                    {
+                                        Font = OsuFont.Default.With(size: 12)
+                                    }
+                                }
+                            },
+                            closeButton = new IconButton
+                            {
+                                Icon = FontAwesome.Solid.Times,
+                                Scale = new Vector2(0.6f),
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Margin = new MarginPadding
+                                {
+                                    Right = 21,
+                                    Top = corner_radius
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            underlayContainer.BorderColour = ColourInfo.GradientVertical(Colour4.Black, colourProvider.Dark4);
+            underlayBackground.Colour = colourProvider.Dark4;
+
+            contentContainer.BorderColour = ColourInfo.GradientVertical(colourProvider.Dark3, colourProvider.Dark1);
+            contentBackground.Colour = colourProvider.Dark3;
+
+            closeButton.IconHoverColour = colourProvider.Highlight1;
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/PopupScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/PopupScreenTitle.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osuTK;
@@ -22,14 +23,12 @@ namespace osu.Game.Graphics.UserInterface
     {
         public LocalisableString Title
         {
-            get => titleSpriteText.Text;
             set => titleSpriteText.Text = value;
         }
 
         public LocalisableString Description
         {
-            get => descriptionSpriteText.Text;
-            set => descriptionSpriteText.Text = value;
+            set => descriptionText.Text = value;
         }
 
         public Action? Close
@@ -46,7 +45,7 @@ namespace osu.Game.Graphics.UserInterface
         private readonly Container contentContainer;
         private readonly Box contentBackground;
         private readonly OsuSpriteText titleSpriteText;
-        private readonly OsuSpriteText descriptionSpriteText;
+        private readonly OsuTextFlowContainer descriptionText;
         private readonly IconButton closeButton;
 
         public PopupScreenTitle()
@@ -112,9 +111,13 @@ namespace osu.Game.Graphics.UserInterface
                                     {
                                         Font = OsuFont.TorusAlternate.With(size: 20)
                                     },
-                                    descriptionSpriteText = new OsuSpriteText
+                                    descriptionText = new OsuTextFlowContainer(t =>
                                     {
-                                        Font = OsuFont.Default.With(size: 12)
+                                        t.Font = OsuFont.Default.With(size: 12);
+                                    })
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y
                                     }
                                 }
                             },


### PR DESCRIPTION
To be used in the mod select redesign (#16917).

Reference design: https://www.figma.com/file/NkdREXr6wFkA99oLw8PnBv/Client%2FMod-Selection?node-id=542%3A76

![2022-03-06-204208_2560x1014_scrot](https://user-images.githubusercontent.com/20418176/156939503-606fac95-daf3-47a6-b9cf-e3c52e6ba398.png)

Aside from sizing concerns and a few workarounds to get variable corner radius should be relatively straightforward.

Unsure about constructing hierarchy in ctor - this time I don't need nullability annotations, but constructing in ctor lets me have a cleaner implementation of the public properties via immediate delegation to fields, while with BDL I'd have to do the usual `IsLoaded` song-and-dance for the properties to work properly regardless of call timing. Will change on request, however.