### PR TITLE
Disallow interaction with carousel set difficulty icons unless selected

### DIFF
--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -16,6 +16,9 @@ namespace osu.Game.Screens.Select.Carousel
 {
     public class SetPanelContent : CompositeDrawable
     {
+        // Disallow interacting with difficulty icons on a panel until the panel has been selected.
+        public override bool PropagatePositionalInputSubTree => carouselSet.State.Value == CarouselItemState.Selected;
+
         private readonly CarouselBeatmapSet carouselSet;
 
         public SetPanelContent(CarouselBeatmapSet carouselSet)


### PR DESCRIPTION
I kinda liked this flow, but from multiple reports from users it definitely seems in the way. We can revisit after the new design is applied to song select.

Note that this means the tooltips also don't display. If it is preferred that they should (arguable from a UX perspective, since I'd expect to be able to click at that point) then the issue can be addressed using a slightly different path (a few more lines - nothing too complex).

See https://github.com/ppy/osu/discussions/17136 https://github.com/ppy/osu/issues/9017 https://github.com/ppy/osu/issues/9032 (doesn't fix the convert case, but stops it from being a "misclick").