### PR TITLE
Extract hit object placement logic from osu random mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
@@ -1,0 +1,317 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Osu.Utils;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    /// <summary>
+    /// Places hit objects
+    /// </summary>
+    public class OsuHitObjectPositionModifier
+    {
+        /// <summary>
+        /// Number of previous hitobjects to be shifted together when an object is being moved.
+        /// </summary>
+        private const int preceding_hitobjects_to_shift = 10;
+
+        private readonly List<OsuHitObject> hitObjects;
+
+        private readonly List<HitObjectPositionInfo> hitObjectPositions = new List<HitObjectPositionInfo>();
+
+        public IReadOnlyList<IHitObjectPositionInfo> HitObjectPositions => hitObjectPositions;
+
+        public OsuHitObjectPositionModifier(List<OsuHitObject> hitObjects)
+        {
+            this.hitObjects = hitObjects;
+            populateHitObjectPositions();
+        }
+
+        private void populateHitObjectPositions()
+        {
+            Vector2 lastPosition = Vector2.Zero;
+            float lastAngle = 0;
+
+            for (int i = 0; i < hitObjects.Count; i++)
+            {
+                var hitObject = hitObjects[i];
+
+                Vector2 relativePosition = hitObject.Position - lastPosition;
+                float absoluteAngle = (float)Math.Atan2(relativePosition.Y, relativePosition.X);
+                float relativeAngle = absoluteAngle - lastAngle;
+
+                hitObjectPositions.Add(new HitObjectPositionInfo(hitObject)
+                {
+                    AngleRad = relativeAngle,
+                    Distance = relativePosition.Length
+                });
+
+                lastPosition = hitObject.EndPosition;
+                lastAngle = absoluteAngle;
+            }
+        }
+
+        public void RepositionHitObjects()
+        {
+            HitObjectPositionInfo previous = null;
+
+            for (int i = 0; i < hitObjects.Count; i++)
+            {
+                var hitObject = hitObjects[i];
+
+                var current = hitObjectPositions[i];
+
+                if (hitObject is Spinner)
+                {
+                    previous = current;
+                    continue;
+                }
+
+                float lastAngleAbsolute = 0;
+
+                if (i == 1)
+                    lastAngleAbsolute = previous!.AngleRad;
+                else if (i > 1)
+                {
+                    Vector2 lastPositionRelative = hitObjects[i - 1].Position - hitObjects[i - 2].EndPosition;
+                    lastAngleAbsolute = (float)Math.Atan2(lastPositionRelative.Y, lastPositionRelative.X);
+                }
+
+                applyModification(lastAngleAbsolute, previous, current);
+
+                // Move hit objects back into the playfield if they are outside of it
+                Vector2 shift = Vector2.Zero;
+
+                switch (hitObject)
+                {
+                    case HitCircle circle:
+                        shift = clampHitCircleToPlayfield(circle, current);
+                        break;
+
+                    case Slider slider:
+                        shift = clampSliderToPlayfield(slider, current);
+                        break;
+                }
+
+                // Vector2 relativePosition = current.PositionModified - previous?.EndPositionModified ?? Vector2.Zero;
+                // current.Distance = relativePosition.Length;
+                // current.AngleRad = (float)Math.Atan2(relativePosition.Y, relativePosition.X) - lastAngleAbsolute;
+
+                if (shift != Vector2.Zero)
+                {
+                    var toBeShifted = new List<OsuHitObject>();
+
+                    for (int j = i - 1; j >= i - preceding_hitobjects_to_shift && j >= 0; j--)
+                    {
+                        // only shift hit circles
+                        if (!(hitObjects[j] is HitCircle)) break;
+
+                        toBeShifted.Add(hitObjects[j]);
+                    }
+
+                    if (toBeShifted.Count > 0)
+                        applyDecreasingShift(toBeShifted, shift);
+                }
+
+                previous = current;
+            }
+        }
+
+        /// <summary>
+        /// Returns the final position of the hit object
+        /// </summary>
+        /// <returns>Final position of the hit object</returns>
+        private void applyModification(float lastAngleAbsolute, HitObjectPositionInfo previous, HitObjectPositionInfo current)
+        {
+            double absoluteAngle = lastAngleAbsolute + current.AngleRad;
+
+            var posRelativeToPrev = new Vector2(
+                current.Distance * (float)Math.Cos(absoluteAngle),
+                current.Distance * (float)Math.Sin(absoluteAngle)
+            );
+
+            Vector2 lastEndPosition = previous?.EndPositionModified ?? Vector2.Zero;
+
+            posRelativeToPrev = OsuHitObjectGenerationUtils.RotateAwayFromEdge(lastEndPosition, posRelativeToPrev);
+
+            current.AngleRad = (float)Math.Atan2(posRelativeToPrev.Y, posRelativeToPrev.X) - lastAngleAbsolute;
+
+            current.PositionModified = lastEndPosition + posRelativeToPrev;
+        }
+
+        /// <summary>
+        /// Move the randomised position of a hit circle so that it fits inside the playfield.
+        /// </summary>
+        /// <returns>The deviation from the original randomised position in order to fit within the playfield.</returns>
+        private Vector2 clampHitCircleToPlayfield(HitCircle circle, HitObjectPositionInfo objectInfo)
+        {
+            var previousPosition = objectInfo.PositionModified;
+            objectInfo.EndPositionModified = objectInfo.PositionModified = clampToPlayfieldWithPadding(
+                objectInfo.PositionModified,
+                (float)circle.Radius
+            );
+
+            circle.Position = objectInfo.PositionModified;
+
+            return objectInfo.PositionModified - previousPosition;
+        }
+
+        /// <summary>
+        /// Moves the <see cref="Slider"/> and all necessary nested <see cref="OsuHitObject"/>s into the <see cref="OsuPlayfield"/> if they aren't already.
+        /// </summary>
+        /// <returns>The deviation from the original randomised position in order to fit within the playfield.</returns>
+        private Vector2 clampSliderToPlayfield(Slider slider, HitObjectPositionInfo objectInfo)
+        {
+            var possibleMovementBounds = calculatePossibleMovementBounds(slider);
+
+            var previousPosition = objectInfo.PositionModified;
+
+            // Clamp slider position to the placement area
+            // If the slider is larger than the playfield, force it to stay at the original position
+            float newX = possibleMovementBounds.Width < 0
+                ? objectInfo.PositionOriginal.X
+                : Math.Clamp(previousPosition.X, possibleMovementBounds.Left, possibleMovementBounds.Right);
+
+            float newY = possibleMovementBounds.Height < 0
+                ? objectInfo.PositionOriginal.Y
+                : Math.Clamp(previousPosition.Y, possibleMovementBounds.Top, possibleMovementBounds.Bottom);
+
+            slider.Position = objectInfo.PositionModified = new Vector2(newX, newY);
+            objectInfo.EndPositionModified = slider.EndPosition;
+
+            shiftNestedObjects(slider, objectInfo.PositionModified - objectInfo.PositionOriginal);
+
+            return objectInfo.PositionModified - previousPosition;
+        }
+
+        /// <summary>
+        /// Decreasingly shift a list of <see cref="OsuHitObject"/>s by a specified amount.
+        /// The first item in the list is shifted by the largest amount, while the last item is shifted by the smallest amount.
+        /// </summary>
+        /// <param name="hitObjects">The list of hit objects to be shifted.</param>
+        /// <param name="shift">The amount to be shifted.</param>
+        private void applyDecreasingShift(IList<OsuHitObject> hitObjects, Vector2 shift)
+        {
+            for (int i = 0; i < hitObjects.Count; i++)
+            {
+                var hitObject = hitObjects[i];
+                // The first object is shifted by a vector slightly smaller than shift
+                // The last object is shifted by a vector slightly larger than zero
+                Vector2 position = hitObject.Position + shift * ((hitObjects.Count - i) / (float)(hitObjects.Count + 1));
+
+                hitObject.Position = clampToPlayfieldWithPadding(position, (float)hitObject.Radius);
+            }
+        }
+
+        /// <summary>
+        /// Calculates a <see cref="RectangleF"/> which contains all of the possible movements of the slider (in relative X/Y coordinates)
+        /// such that the entire slider is inside the playfield.
+        /// </summary>
+        /// <remarks>
+        /// If the slider is larger than the playfield, the returned <see cref="RectangleF"/> may have negative width/height.
+        /// </remarks>
+        private RectangleF calculatePossibleMovementBounds(Slider slider)
+        {
+            var pathPositions = new List<Vector2>();
+            slider.Path.GetPathToProgress(pathPositions, 0, 1);
+
+            float minX = float.PositiveInfinity;
+            float maxX = float.NegativeInfinity;
+
+            float minY = float.PositiveInfinity;
+            float maxY = float.NegativeInfinity;
+
+            // Compute the bounding box of the slider.
+            foreach (var pos in pathPositions)
+            {
+                minX = MathF.Min(minX, pos.X);
+                maxX = MathF.Max(maxX, pos.X);
+
+                minY = MathF.Min(minY, pos.Y);
+                maxY = MathF.Max(maxY, pos.Y);
+            }
+
+            // Take the circle radius into account.
+            float radius = (float)slider.Radius;
+
+            minX -= radius;
+            minY -= radius;
+
+            maxX += radius;
+            maxY += radius;
+
+            // Given the bounding box of the slider (via min/max X/Y),
+            // the amount that the slider can move to the left is minX (with the sign flipped, since positive X is to the right),
+            // and the amount that it can move to the right is WIDTH - maxX.
+            // Same calculation applies for the Y axis.
+            float left = -minX;
+            float right = OsuPlayfield.BASE_SIZE.X - maxX;
+            float top = -minY;
+            float bottom = OsuPlayfield.BASE_SIZE.Y - maxY;
+
+            return new RectangleF(left, top, right - left, bottom - top);
+        }
+
+        /// <summary>
+        /// Shifts all nested <see cref="SliderTick"/>s and <see cref="SliderRepeat"/>s by the specified shift.
+        /// </summary>
+        /// <param name="slider"><see cref="Slider"/> whose nested <see cref="SliderTick"/>s and <see cref="SliderRepeat"/>s should be shifted</param>
+        /// <param name="shift">The <see cref="Vector2"/> the <see cref="Slider"/>'s nested <see cref="SliderTick"/>s and <see cref="SliderRepeat"/>s should be shifted by</param>
+        private void shiftNestedObjects(Slider slider, Vector2 shift)
+        {
+            foreach (var hitObject in slider.NestedHitObjects.Where(o => o is SliderTick || o is SliderRepeat))
+            {
+                if (!(hitObject is OsuHitObject osuHitObject))
+                    continue;
+
+                osuHitObject.Position += shift;
+            }
+        }
+
+        /// <summary>
+        /// Clamp a position to playfield, keeping a specified distance from the edges.
+        /// </summary>
+        /// <param name="position">The position to be clamped.</param>
+        /// <param name="padding">The minimum distance allowed from playfield edges.</param>
+        /// <returns>The clamped position.</returns>
+        private Vector2 clampToPlayfieldWithPadding(Vector2 position, float padding)
+        {
+            return new Vector2(
+                Math.Clamp(position.X, padding, OsuPlayfield.BASE_SIZE.X - padding),
+                Math.Clamp(position.Y, padding, OsuPlayfield.BASE_SIZE.Y - padding)
+            );
+        }
+
+        public interface IHitObjectPositionInfo
+        {
+            public float AngleRad { get; set; }
+
+            public float Distance { get; set; }
+        }
+
+        private class HitObjectPositionInfo : IHitObjectPositionInfo
+        {
+            public float AngleRad { get; set; }
+
+            public float Distance { get; set; }
+
+            public Vector2 PositionOriginal { get; }
+            public Vector2 PositionModified { get; set; }
+
+            public Vector2 EndPositionOriginal { get; }
+            public Vector2 EndPositionModified { get; set; }
+
+            public HitObjectPositionInfo(OsuHitObject hitObject)
+            {
+                PositionOriginal = PositionModified = hitObject.Position;
+                EndPositionOriginal = EndPositionModified = hitObject.EndPosition;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
@@ -38,10 +38,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             Vector2 lastPosition = Vector2.Zero;
             float lastAngle = 0;
 
-            for (int i = 0; i < hitObjects.Count; i++)
+            foreach (OsuHitObject hitObject in hitObjects)
             {
-                var hitObject = hitObjects[i];
-
                 Vector2 relativePosition = hitObject.Position - lastPosition;
                 float absoluteAngle = (float)Math.Atan2(relativePosition.Y, relativePosition.X);
                 float relativeAngle = absoluteAngle - lastAngle;
@@ -64,7 +62,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             for (int i = 0; i < hitObjects.Count; i++)
             {
                 var hitObject = hitObjects[i];
-
                 var current = hitObjectPositions[i];
 
                 if (hitObject is Spinner)
@@ -76,7 +73,9 @@ namespace osu.Game.Rulesets.Osu.Mods
                 float lastAngleAbsolute = 0;
 
                 if (i == 1)
+                {
                     lastAngleAbsolute = previous!.AngleRad;
+                }
                 else if (i > 1)
                 {
                     Vector2 lastPositionRelative = hitObjects[i - 1].Position - hitObjects[i - 2].EndPosition;
@@ -98,10 +97,6 @@ namespace osu.Game.Rulesets.Osu.Mods
                         shift = clampSliderToPlayfield(slider, current);
                         break;
                 }
-
-                // Vector2 relativePosition = current.PositionModified - previous?.EndPositionModified ?? Vector2.Zero;
-                // current.Distance = relativePosition.Length;
-                // current.AngleRad = (float)Math.Atan2(relativePosition.Y, relativePosition.X) - lastAngleAbsolute;
 
                 if (shift != Vector2.Zero)
                 {
@@ -303,14 +298,12 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             public Vector2 PositionOriginal { get; }
             public Vector2 PositionModified { get; set; }
-
-            public Vector2 EndPositionOriginal { get; }
             public Vector2 EndPositionModified { get; set; }
 
             public HitObjectPositionInfo(OsuHitObject hitObject)
             {
                 PositionOriginal = PositionModified = hitObject.Position;
-                EndPositionOriginal = EndPositionModified = hitObject.EndPosition;
+                EndPositionModified = hitObject.EndPosition;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
@@ -158,10 +158,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         private Vector2 clampHitCircleToPlayfield(HitCircle circle, HitObjectPositionInfo objectInfo)
         {
             var previousPosition = objectInfo.PositionModified;
-            objectInfo.EndPositionModified = objectInfo.PositionModified = clampToPlayfieldWithPadding(
-                objectInfo.PositionModified,
-                (float)circle.Radius
-            );
+            objectInfo.EndPositionModified = objectInfo.PositionModified = clampToPlayfield(objectInfo.PositionModified);
 
             circle.Position = objectInfo.PositionModified;
 
@@ -211,7 +208,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 // The last object is shifted by a vector slightly larger than zero
                 Vector2 position = hitObject.Position + shift * ((hitObjects.Count - i) / (float)(hitObjects.Count + 1));
 
-                hitObject.Position = clampToPlayfieldWithPadding(position, (float)hitObject.Radius);
+                hitObject.Position = clampToPlayfield(position);
             }
         }
 
@@ -281,16 +278,15 @@ namespace osu.Game.Rulesets.Osu.Mods
         }
 
         /// <summary>
-        /// Clamp a position to playfield, keeping a specified distance from the edges.
+        /// Clamp a position to playfield.
         /// </summary>
         /// <param name="position">The position to be clamped.</param>
-        /// <param name="padding">The minimum distance allowed from playfield edges.</param>
         /// <returns>The clamped position.</returns>
-        private Vector2 clampToPlayfieldWithPadding(Vector2 position, float padding)
+        private Vector2 clampToPlayfield(Vector2 position)
         {
             return new Vector2(
-                Math.Clamp(position.X, padding, OsuPlayfield.BASE_SIZE.X - padding),
-                Math.Clamp(position.Y, padding, OsuPlayfield.BASE_SIZE.Y - padding)
+                Math.Clamp(position.X, 0, OsuPlayfield.BASE_SIZE.X),
+                Math.Clamp(position.Y, 0, OsuPlayfield.BASE_SIZE.Y)
             );
         }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
@@ -42,14 +42,14 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private void populateHitObjectPositions()
         {
-            Vector2 lastPosition = playfield_centre;
-            float lastAngle = 0;
+            Vector2 prevPosition = playfield_centre;
+            float prevAngle = 0;
 
             foreach (OsuHitObject hitObject in hitObjects)
             {
-                Vector2 relativePosition = hitObject.Position - lastPosition;
+                Vector2 relativePosition = hitObject.Position - prevPosition;
                 float absoluteAngle = (float)Math.Atan2(relativePosition.Y, relativePosition.X);
-                float relativeAngle = normaliseAngle(absoluteAngle - lastAngle);
+                float relativeAngle = normaliseAngle(absoluteAngle - prevAngle);
 
                 hitObjectPositions.Add(new HitObjectPositionInfo(hitObject)
                 {
@@ -57,15 +57,15 @@ namespace osu.Game.Rulesets.Osu.Mods
                     Distance = relativePosition.Length
                 });
 
-                lastPosition = hitObject.EndPosition;
-                lastAngle = absoluteAngle;
+                prevPosition = hitObject.EndPosition;
+                prevAngle = absoluteAngle;
             }
         }
 
         /// <summary>
         /// Reposition all hit objects according to information in <see cref="HitObjectPositions"/>.
         /// </summary>
-        public void RepositionHitObjects()
+        public void ApplyModifications()
         {
             HitObjectPositionInfo previous = null;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 Vector2 relativePosition = hitObject.Position - lastPosition;
                 float absoluteAngle = (float)Math.Atan2(relativePosition.Y, relativePosition.X);
-                float relativeAngle = absoluteAngle - lastAngle;
+                float relativeAngle = normaliseAngle(absoluteAngle - lastAngle);
 
                 hitObjectPositions.Add(new HitObjectPositionInfo(hitObject)
                 {
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// <param name="current">Info for the hit object to be processed.</param>
         private void applyModification(float prevAngleAbsolute, HitObjectPositionInfo previous, HitObjectPositionInfo current)
         {
-            double absoluteAngle = prevAngleAbsolute + current.RelativeAngle;
+            double absoluteAngle = normaliseAngle(prevAngleAbsolute + current.RelativeAngle);
 
             var posRelativeToPrev = new Vector2(
                 current.Distance * (float)Math.Cos(absoluteAngle),
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             posRelativeToPrev = OsuHitObjectGenerationUtils.RotateAwayFromEdge(lastEndPosition, posRelativeToPrev);
 
-            current.RelativeAngle = (float)Math.Atan2(posRelativeToPrev.Y, posRelativeToPrev.X) - prevAngleAbsolute;
+            current.RelativeAngle = normaliseAngle((float)Math.Atan2(posRelativeToPrev.Y, posRelativeToPrev.X) - prevAngleAbsolute);
 
             current.PositionModified = lastEndPosition + posRelativeToPrev;
         }
@@ -290,6 +290,21 @@ namespace osu.Game.Rulesets.Osu.Mods
                 Math.Clamp(position.X, 0, OsuPlayfield.BASE_SIZE.X),
                 Math.Clamp(position.Y, 0, OsuPlayfield.BASE_SIZE.Y)
             );
+        }
+
+        /// <summary>
+        /// Normalise an angle between -<see cref="Math.PI"/> and <see cref="Math.PI"/>.
+        /// </summary>
+        /// <param name="angle">The angle to be normalised.</param>
+        /// <returns>Normalised result.</returns>
+        private float normaliseAngle(float angle)
+        {
+            const float pi = (float)Math.PI;
+            const float two_pi = pi * 2;
+
+            angle = (angle + pi) % two_pi;
+            if (angle < 0) angle += two_pi;
+            return angle - pi;
         }
 
         public interface IHitObjectPositionInfo

--- a/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuHitObjectPositionModifier.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// </summary>
         private const int preceding_hitobjects_to_shift = 10;
 
+        private static readonly Vector2 playfield_centre = OsuPlayfield.BASE_SIZE / 2;
+
         private readonly List<OsuHitObject> hitObjects;
 
         private readonly List<HitObjectPositionInfo> hitObjectPositions = new List<HitObjectPositionInfo>();
@@ -40,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private void populateHitObjectPositions()
         {
-            Vector2 lastPosition = Vector2.Zero;
+            Vector2 lastPosition = playfield_centre;
             float lastAngle = 0;
 
             foreach (OsuHitObject hitObject in hitObjects)
@@ -142,7 +144,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 current.Distance * (float)Math.Sin(absoluteAngle)
             );
 
-            Vector2 lastEndPosition = previous?.EndPositionModified ?? Vector2.Zero;
+            Vector2 lastEndPosition = previous?.EndPositionModified ?? playfield_centre;
 
             posRelativeToPrev = OsuHitObjectGenerationUtils.RotateAwayFromEdge(lastEndPosition, posRelativeToPrev);
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 }
             }
 
-            positionModifier.RepositionHitObjects();
+            positionModifier.ApplyModifications();
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -2,18 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Beatmaps;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
-using osu.Game.Rulesets.Osu.Utils;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -26,11 +21,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private static readonly float playfield_diagonal = OsuPlayfield.BASE_SIZE.LengthFast;
 
-        /// <summary>
-        /// Number of previous hitobjects to be shifted together when another object is being moved.
-        /// </summary>
-        private const int preceding_hitobjects_to_shift = 10;
-
         private Random rng;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
@@ -38,269 +28,33 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (!(beatmap is OsuBeatmap osuBeatmap))
                 return;
 
-            var hitObjects = osuBeatmap.HitObjects;
-
             Seed.Value ??= RNG.Next();
 
             rng = new Random((int)Seed.Value);
 
-            RandomObjectInfo previous = null;
+            var positionModifier = new OsuHitObjectPositionModifier(osuBeatmap.HitObjects);
 
             float rateOfChangeMultiplier = 0;
 
-            for (int i = 0; i < hitObjects.Count; i++)
+            foreach (var positionInfo in positionModifier.HitObjectPositions)
             {
-                var hitObject = hitObjects[i];
-
-                var current = new RandomObjectInfo(hitObject);
-
                 // rateOfChangeMultiplier only changes every 5 iterations in a combo
                 // to prevent shaky-line-shaped streams
-                if (hitObject.IndexInCurrentCombo % 5 == 0)
+                if (positionInfo.HitObject.IndexInCurrentCombo % 5 == 0)
                     rateOfChangeMultiplier = (float)rng.NextDouble() * 2 - 1;
 
-                if (hitObject is Spinner)
+                if (positionInfo == positionModifier.HitObjectPositions.First())
                 {
-                    previous = null;
-                    continue;
+                    positionInfo.Distance = (float)rng.NextDouble() * OsuPlayfield.BASE_SIZE.Y / 2;
+                    positionInfo.RelativeAngle = (float)(rng.NextDouble() * 2 * Math.PI - Math.PI);
                 }
-
-                applyRandomisation(rateOfChangeMultiplier, previous, current);
-
-                // Move hit objects back into the playfield if they are outside of it
-                Vector2 shift = Vector2.Zero;
-
-                switch (hitObject)
+                else
                 {
-                    case HitCircle circle:
-                        shift = clampHitCircleToPlayfield(circle, current);
-                        break;
-
-                    case Slider slider:
-                        shift = clampSliderToPlayfield(slider, current);
-                        break;
+                    positionInfo.RelativeAngle = (float)(rateOfChangeMultiplier * 2 * Math.PI * Math.Min(1f, positionInfo.Distance / (playfield_diagonal * 0.5f)));
                 }
-
-                if (shift != Vector2.Zero)
-                {
-                    var toBeShifted = new List<OsuHitObject>();
-
-                    for (int j = i - 1; j >= i - preceding_hitobjects_to_shift && j >= 0; j--)
-                    {
-                        // only shift hit circles
-                        if (!(hitObjects[j] is HitCircle)) break;
-
-                        toBeShifted.Add(hitObjects[j]);
-                    }
-
-                    if (toBeShifted.Count > 0)
-                        applyDecreasingShift(toBeShifted, shift);
-                }
-
-                previous = current;
-            }
-        }
-
-        /// <summary>
-        /// Returns the final position of the hit object
-        /// </summary>
-        /// <returns>Final position of the hit object</returns>
-        private void applyRandomisation(float rateOfChangeMultiplier, RandomObjectInfo previous, RandomObjectInfo current)
-        {
-            if (previous == null)
-            {
-                var playfieldSize = OsuPlayfield.BASE_SIZE;
-
-                current.AngleRad = (float)(rng.NextDouble() * 2 * Math.PI - Math.PI);
-                current.PositionRandomised = new Vector2((float)rng.NextDouble() * playfieldSize.X, (float)rng.NextDouble() * playfieldSize.Y);
-
-                return;
             }
 
-            float distanceToPrev = Vector2.Distance(previous.EndPositionOriginal, current.PositionOriginal);
-
-            // The max. angle (relative to the angle of the vector pointing from the 2nd last to the last hit object)
-            // is proportional to the distance between the last and the current hit object
-            // to allow jumps and prevent too sharp turns during streams.
-
-            // Allow maximum jump angle when jump distance is more than half of playfield diagonal length
-            double randomAngleRad = rateOfChangeMultiplier * 2 * Math.PI * Math.Min(1f, distanceToPrev / (playfield_diagonal * 0.5f));
-
-            current.AngleRad = (float)randomAngleRad + previous.AngleRad;
-            if (current.AngleRad < 0)
-                current.AngleRad += 2 * (float)Math.PI;
-
-            var posRelativeToPrev = new Vector2(
-                distanceToPrev * (float)Math.Cos(current.AngleRad),
-                distanceToPrev * (float)Math.Sin(current.AngleRad)
-            );
-
-            posRelativeToPrev = OsuHitObjectGenerationUtils.RotateAwayFromEdge(previous.EndPositionRandomised, posRelativeToPrev);
-
-            current.AngleRad = (float)Math.Atan2(posRelativeToPrev.Y, posRelativeToPrev.X);
-
-            current.PositionRandomised = previous.EndPositionRandomised + posRelativeToPrev;
-        }
-
-        /// <summary>
-        /// Move the randomised position of a hit circle so that it fits inside the playfield.
-        /// </summary>
-        /// <returns>The deviation from the original randomised position in order to fit within the playfield.</returns>
-        private Vector2 clampHitCircleToPlayfield(HitCircle circle, RandomObjectInfo objectInfo)
-        {
-            var previousPosition = objectInfo.PositionRandomised;
-            objectInfo.EndPositionRandomised = objectInfo.PositionRandomised = clampToPlayfieldWithPadding(
-                objectInfo.PositionRandomised,
-                (float)circle.Radius
-            );
-
-            circle.Position = objectInfo.PositionRandomised;
-
-            return objectInfo.PositionRandomised - previousPosition;
-        }
-
-        /// <summary>
-        /// Moves the <see cref="Slider"/> and all necessary nested <see cref="OsuHitObject"/>s into the <see cref="OsuPlayfield"/> if they aren't already.
-        /// </summary>
-        /// <returns>The deviation from the original randomised position in order to fit within the playfield.</returns>
-        private Vector2 clampSliderToPlayfield(Slider slider, RandomObjectInfo objectInfo)
-        {
-            var possibleMovementBounds = calculatePossibleMovementBounds(slider);
-
-            var previousPosition = objectInfo.PositionRandomised;
-
-            // Clamp slider position to the placement area
-            // If the slider is larger than the playfield, force it to stay at the original position
-            float newX = possibleMovementBounds.Width < 0
-                ? objectInfo.PositionOriginal.X
-                : Math.Clamp(previousPosition.X, possibleMovementBounds.Left, possibleMovementBounds.Right);
-
-            float newY = possibleMovementBounds.Height < 0
-                ? objectInfo.PositionOriginal.Y
-                : Math.Clamp(previousPosition.Y, possibleMovementBounds.Top, possibleMovementBounds.Bottom);
-
-            slider.Position = objectInfo.PositionRandomised = new Vector2(newX, newY);
-            objectInfo.EndPositionRandomised = slider.EndPosition;
-
-            shiftNestedObjects(slider, objectInfo.PositionRandomised - objectInfo.PositionOriginal);
-
-            return objectInfo.PositionRandomised - previousPosition;
-        }
-
-        /// <summary>
-        /// Decreasingly shift a list of <see cref="OsuHitObject"/>s by a specified amount.
-        /// The first item in the list is shifted by the largest amount, while the last item is shifted by the smallest amount.
-        /// </summary>
-        /// <param name="hitObjects">The list of hit objects to be shifted.</param>
-        /// <param name="shift">The amount to be shifted.</param>
-        private void applyDecreasingShift(IList<OsuHitObject> hitObjects, Vector2 shift)
-        {
-            for (int i = 0; i < hitObjects.Count; i++)
-            {
-                var hitObject = hitObjects[i];
-                // The first object is shifted by a vector slightly smaller than shift
-                // The last object is shifted by a vector slightly larger than zero
-                Vector2 position = hitObject.Position + shift * ((hitObjects.Count - i) / (float)(hitObjects.Count + 1));
-
-                hitObject.Position = clampToPlayfieldWithPadding(position, (float)hitObject.Radius);
-            }
-        }
-
-        /// <summary>
-        /// Calculates a <see cref="RectangleF"/> which contains all of the possible movements of the slider (in relative X/Y coordinates)
-        /// such that the entire slider is inside the playfield.
-        /// </summary>
-        /// <remarks>
-        /// If the slider is larger than the playfield, the returned <see cref="RectangleF"/> may have negative width/height.
-        /// </remarks>
-        private RectangleF calculatePossibleMovementBounds(Slider slider)
-        {
-            var pathPositions = new List<Vector2>();
-            slider.Path.GetPathToProgress(pathPositions, 0, 1);
-
-            float minX = float.PositiveInfinity;
-            float maxX = float.NegativeInfinity;
-
-            float minY = float.PositiveInfinity;
-            float maxY = float.NegativeInfinity;
-
-            // Compute the bounding box of the slider.
-            foreach (var pos in pathPositions)
-            {
-                minX = MathF.Min(minX, pos.X);
-                maxX = MathF.Max(maxX, pos.X);
-
-                minY = MathF.Min(minY, pos.Y);
-                maxY = MathF.Max(maxY, pos.Y);
-            }
-
-            // Take the circle radius into account.
-            float radius = (float)slider.Radius;
-
-            minX -= radius;
-            minY -= radius;
-
-            maxX += radius;
-            maxY += radius;
-
-            // Given the bounding box of the slider (via min/max X/Y),
-            // the amount that the slider can move to the left is minX (with the sign flipped, since positive X is to the right),
-            // and the amount that it can move to the right is WIDTH - maxX.
-            // Same calculation applies for the Y axis.
-            float left = -minX;
-            float right = OsuPlayfield.BASE_SIZE.X - maxX;
-            float top = -minY;
-            float bottom = OsuPlayfield.BASE_SIZE.Y - maxY;
-
-            return new RectangleF(left, top, right - left, bottom - top);
-        }
-
-        /// <summary>
-        /// Shifts all nested <see cref="SliderTick"/>s and <see cref="SliderRepeat"/>s by the specified shift.
-        /// </summary>
-        /// <param name="slider"><see cref="Slider"/> whose nested <see cref="SliderTick"/>s and <see cref="SliderRepeat"/>s should be shifted</param>
-        /// <param name="shift">The <see cref="Vector2"/> the <see cref="Slider"/>'s nested <see cref="SliderTick"/>s and <see cref="SliderRepeat"/>s should be shifted by</param>
-        private void shiftNestedObjects(Slider slider, Vector2 shift)
-        {
-            foreach (var hitObject in slider.NestedHitObjects.Where(o => o is SliderTick || o is SliderRepeat))
-            {
-                if (!(hitObject is OsuHitObject osuHitObject))
-                    continue;
-
-                osuHitObject.Position += shift;
-            }
-        }
-
-        /// <summary>
-        /// Clamp a position to playfield, keeping a specified distance from the edges.
-        /// </summary>
-        /// <param name="position">The position to be clamped.</param>
-        /// <param name="padding">The minimum distance allowed from playfield edges.</param>
-        /// <returns>The clamped position.</returns>
-        private Vector2 clampToPlayfieldWithPadding(Vector2 position, float padding)
-        {
-            return new Vector2(
-                Math.Clamp(position.X, padding, OsuPlayfield.BASE_SIZE.X - padding),
-                Math.Clamp(position.Y, padding, OsuPlayfield.BASE_SIZE.Y - padding)
-            );
-        }
-
-        private class RandomObjectInfo
-        {
-            public float AngleRad { get; set; }
-
-            public Vector2 PositionOriginal { get; }
-            public Vector2 PositionRandomised { get; set; }
-
-            public Vector2 EndPositionOriginal { get; }
-            public Vector2 EndPositionRandomised { get; set; }
-
-            public RandomObjectInfo(OsuHitObject hitObject)
-            {
-                PositionRandomised = PositionOriginal = hitObject.Position;
-                EndPositionRandomised = EndPositionOriginal = hitObject.EndPosition;
-                AngleRad = 0;
-            }
+            positionModifier.RepositionHitObjects();
         }
     }
 }


### PR DESCRIPTION
A pre-requisite for #17128

The hit object placement logic in osu random mod is extracted out to a new class called `OsuHitObjectPositionModifier`. This class allows you to change the jump angle and distance (i.e. the polar coordinates) of each hit object, and will then attempt to reposition the hit objects to fit those requirements while keeping the objects inside the playfield.

Note that random mod's behavior is changed as a result of this refactoring. Some changes are necessary while others are just minor improvements to the algorithm that I thought could be included in this PR:
- Instead of having a completely random position, the first hit object of the beatmap will now appear near the center of the playfield. This is because the position of the first object is also specified in polar coordinates, and the coordinates are relative to the playfield center. See https://github.com/hlysine/osu/blob/26d1bb4ca3a1342a79886265bc173ede5a601ec2/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs#L46-L50
- The generation algorithm now considers jump angles relative to the previous jump instead of absolute angles. (So objects arranged in a straight line will have a jump angle of 0 instead of `atan(slope of line)`) This fixes a hidden bug in the old implementation where the position of an object is changed but the absolute angles that rely on this object are not updated.
- Objects can now be partially outside the playfield border. 