### PR TITLE
Fix crash during kiai section on specific map due to negative transform duration

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             Child
                 .FadeTo(flash_opacity, EarlyActivationMilliseconds, Easing.OutQuint)
                 .Then()
-                .FadeOut(Math.Max(0, timingPoint.BeatLength - fade_length), Easing.OutSine);
+                .FadeOut(Math.Max(fade_length, timingPoint.BeatLength - fade_length), Easing.OutSine);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -37,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             Child
                 .FadeTo(flash_opacity, EarlyActivationMilliseconds, Easing.OutQuint)
                 .Then()
-                .FadeOut(timingPoint.BeatLength - fade_length, Easing.OutSine);
+                .FadeOut(Math.Max(0, timingPoint.BeatLength - fade_length), Easing.OutSine);
         }
     }
 }


### PR DESCRIPTION
## How to reproduce

Select default skin (triangles)

DETRO - volcanic [Beginner] mapped by spro
https://osu.ppy.sh/beatmapsets/243337#osu/561335

Open map in editor or open any replay and scroll to 1:49 press play
When the 1528BPM section hits game crashes.

---

[logs.zip](https://github.com/ppy/osu/files/8200247/logs.zip)

Relevant log section:

```c#
2022-03-07 18:59:09 [error]: An unhandled error has occurred.
2022-03-07 18:59:09 [error]: System.ArgumentOutOfRangeException: duration must be positive. (Parameter 'duration')
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.TransformableExtensions.PopulateTransform[TValue,TEasing,TThis](TThis t, Transform`3 transform, TValue newValue, Double duration, TEasing& easing)
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping)
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Transforms.TransformSequence`1.Append(Generator childGenerator)
2022-03-07 18:59:09 [error]: at osu.Game.Rulesets.Osu.Skinning.Default.KiaiFlash.OnNewBeat(Int32 beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes) in /var/lib/buildkite-agent/builds/debian-gnu-linux-vm-2/ppy/osu/osu.Game.Rulesets.Osu/Skinning/Default/KiaiFlash.cs:line 41
2022-03-07 18:59:09 [error]: at osu.Game.Graphics.Containers.BeatSyncedContainer.Update() in /var/lib/buildkite-agent/builds/debian-gnu-linux-vm-2/ppy/osu/osu.Game/Graphics/Containers/BeatSyncedContainer.cs:line 165
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Drawable.UpdateSubTree()
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
2022-03-07 18:59:09 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
```

I also tested this in windows 10, same thing happens.

## Why this happens (I'm guessing)

`timingPoint.BeatLength - fade_length` becomes negative when BPM>750 as fade_length is 80 (750BPM = 80 ms BeatLength)

