### PR TITLE
Implement difficulty multiplier display for new mod select design

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDifficultyMultiplierDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDifficultyMultiplierDisplay.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestSceneDifficultyMultiplierDisplay : OsuTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
+
+        [Test]
+        public void TestDifficultyMultiplierDisplay()
+        {
+            DifficultyMultiplierDisplay multiplierDisplay = null;
+
+            AddStep("create content", () => Child = multiplierDisplay = new DifficultyMultiplierDisplay
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            });
+
+            AddStep("set multiplier below 1", () => multiplierDisplay.Current.Value = 0.5);
+            AddStep("set multiplier to 1", () => multiplierDisplay.Current.Value = 1);
+            AddStep("set multiplier above 1", () => multiplierDisplay.Current.Value = 1.5);
+
+            AddSliderStep("set multiplier", 0, 2, 1d, multiplier =>
+            {
+                if (multiplierDisplay != null)
+                    multiplierDisplay.Current.Value = multiplier;
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Mods
 
         private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1)
         {
-            Precision = 0.1
+            Precision = 0.01
         };
 
         private readonly Box underlayBackground;
@@ -43,6 +43,7 @@ namespace osu.Game.Overlays.Mods
         private OverlayColourProvider colourProvider { get; set; }
 
         private const float height = 42;
+        private const float multiplier_value_area_width = 56;
         private const float transition_duration = 200;
 
         public DifficultyMultiplierDisplay()
@@ -64,7 +65,7 @@ namespace osu.Game.Overlays.Mods
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                         RelativeSizeAxes = Axes.Y,
-                        Width = height + ModPanel.CORNER_RADIUS
+                        Width = multiplier_value_area_width + ModPanel.CORNER_RADIUS
                     },
                     new GridContainer
                     {
@@ -73,7 +74,7 @@ namespace osu.Game.Overlays.Mods
                         ColumnDimensions = new[]
                         {
                             new Dimension(GridSizeMode.AutoSize),
-                            new Dimension(GridSizeMode.Absolute, height)
+                            new Dimension(GridSizeMode.Absolute, multiplier_value_area_width)
                         },
                         Content = new[]
                         {
@@ -171,7 +172,7 @@ namespace osu.Game.Overlays.Mods
         {
             protected override double RollingDuration => 500;
 
-            protected override LocalisableString FormatCount(double count) => count.ToLocalisableString(@"N1");
+            protected override LocalisableString FormatCount(double count) => count.ToLocalisableString(@"N2");
 
             protected override OsuSpriteText CreateSpriteText() => new OsuSpriteText
             {

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -9,8 +9,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 
@@ -24,12 +26,15 @@ namespace osu.Game.Overlays.Mods
             set => current.Current = value;
         }
 
-        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1);
+        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1)
+        {
+            Precision = 0.1
+        };
 
         private readonly Box underlayBackground;
         private readonly Box contentBackground;
         private readonly FillFlowContainer multiplierFlow;
-        private readonly OsuSpriteText multiplierText;
+        private readonly MultiplierCounter multiplierCounter;
 
         [Resolved]
         private OsuColour colours { get; set; }
@@ -107,11 +112,11 @@ namespace osu.Game.Overlays.Mods
                                     Spacing = new Vector2(2, 0),
                                     Children = new Drawable[]
                                     {
-                                        multiplierText = new OsuSpriteText
+                                        multiplierCounter = new MultiplierCounter
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
-                                            Font = OsuFont.Default.With(size: 17, weight: FontWeight.SemiBold)
+                                            Current = { BindTarget = Current }
                                         },
                                         new SpriteIcon
                                         {
@@ -141,12 +146,11 @@ namespace osu.Game.Overlays.Mods
             base.LoadComplete();
             current.BindValueChanged(_ => updateState(), true);
             FinishTransforms(true);
+            multiplierCounter.StopRolling();
         }
 
         private void updateState()
         {
-            multiplierText.Text = current.Value.ToLocalisableString(@"N1");
-
             if (Current.IsDefault)
             {
                 underlayBackground.FadeColour(colourProvider.Background3, transition_duration, Easing.OutQuint);
@@ -161,6 +165,18 @@ namespace osu.Game.Overlays.Mods
                 underlayBackground.FadeColour(backgroundColour, transition_duration, Easing.OutQuint);
                 multiplierFlow.FadeColour(colourProvider.Background5, transition_duration, Easing.OutQuint);
             }
+        }
+
+        private class MultiplierCounter : RollingCounter<double>
+        {
+            protected override double RollingDuration => 500;
+
+            protected override LocalisableString FormatCount(double count) => count.ToLocalisableString(@"N1");
+
+            protected override OsuSpriteText CreateSpriteText() => new OsuSpriteText
+            {
+                Font = OsuFont.Default.With(size: 17, weight: FontWeight.SemiBold)
+            };
         }
     }
 }

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -147,7 +147,9 @@ namespace osu.Game.Overlays.Mods
             base.LoadComplete();
             current.BindValueChanged(_ => updateState(), true);
             FinishTransforms(true);
-            multiplierCounter.StopRolling();
+            // required to prevent the counter initially rolling up from 0 to 1
+            // due to `Current.Value` having a nonstandard default value of 1.
+            multiplierCounter.SetCountWithoutRolling(Current.Value);
         }
 
         private void updateState()

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -1,0 +1,166 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Mods;
+using osuTK;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class DifficultyMultiplierDisplay : CompositeDrawable, IHasCurrentValue<double>
+    {
+        public Bindable<double> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1);
+
+        private readonly Box underlayBackground;
+        private readonly Box contentBackground;
+        private readonly FillFlowContainer multiplierFlow;
+        private readonly OsuSpriteText multiplierText;
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; }
+
+        private const float height = 42;
+        private const float transition_duration = 200;
+
+        public DifficultyMultiplierDisplay()
+        {
+            Height = height;
+            AutoSizeAxes = Axes.X;
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Y,
+                AutoSizeAxes = Axes.X,
+                Masking = true,
+                CornerRadius = ModPanel.CORNER_RADIUS,
+                Shear = new Vector2(ModPanel.SHEAR_X, 0),
+                Children = new Drawable[]
+                {
+                    underlayBackground = new Box
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        RelativeSizeAxes = Axes.Y,
+                        Width = height + ModPanel.CORNER_RADIUS
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        AutoSizeAxes = Axes.X,
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(GridSizeMode.Absolute, height)
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Y,
+                                    AutoSizeAxes = Axes.X,
+                                    Masking = true,
+                                    CornerRadius = ModPanel.CORNER_RADIUS,
+                                    Children = new Drawable[]
+                                    {
+                                        contentBackground = new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Margin = new MarginPadding { Horizontal = 18 },
+                                            Shear = new Vector2(-ModPanel.SHEAR_X, 0),
+                                            Text = "Difficulty Multiplier",
+                                            Font = OsuFont.Default.With(size: 17, weight: FontWeight.SemiBold)
+                                        }
+                                    }
+                                },
+                                multiplierFlow = new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Shear = new Vector2(-ModPanel.SHEAR_X, 0),
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(2, 0),
+                                    Children = new Drawable[]
+                                    {
+                                        multiplierText = new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Font = OsuFont.Default.With(size: 17, weight: FontWeight.SemiBold)
+                                        },
+                                        new SpriteIcon
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Icon = FontAwesome.Solid.Times,
+                                            Size = new Vector2(7),
+                                            Margin = new MarginPadding { Top = 1 }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            contentBackground.Colour = colourProvider.Background4;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            current.BindValueChanged(_ => updateState(), true);
+            FinishTransforms(true);
+        }
+
+        private void updateState()
+        {
+            multiplierText.Text = current.Value.ToLocalisableString(@"N1");
+
+            if (Current.IsDefault)
+            {
+                underlayBackground.FadeColour(colourProvider.Background3, transition_duration, Easing.OutQuint);
+                multiplierFlow.FadeColour(Colour4.White, transition_duration, Easing.OutQuint);
+            }
+            else
+            {
+                var backgroundColour = Current.Value < 1
+                    ? colours.ForModType(ModType.DifficultyReduction)
+                    : colours.ForModType(ModType.DifficultyIncrease);
+
+                underlayBackground.FadeColour(backgroundColour, transition_duration, Easing.OutQuint);
+                multiplierFlow.FadeColour(colourProvider.Background5, transition_duration, Easing.OutQuint);
+            }
+        }
+    }
+}


### PR DESCRIPTION
#16917, continued.

Baseline design: https://www.figma.com/file/NkdREXr6wFkA99oLw8PnBv/Client%2FMod-Selection?node-id=0%3A17

https://user-images.githubusercontent.com/20418176/157126795-8c8e5c89-1efe-4990-95c0-caa950d9dfe8.mp4

Caveats:

* The multiplier display on figma only uses one colour and it's yellow. Not sure if yellow was supposed to indicate difficulty increase, and if so what multipliers <1 and =1 should look like, so I've taken "artistic license" and just decided on stuff that seemed good to me, i.e. matching difficulty reduction/increase mod type colours for values other than 1 and a neutral look for a value of 1.
* Added rolling to the counter because rolling counters are cool. And it looked flat with just an instantaneous change anyhow.
* Multiplier is printed with 2 decimal digits rather than 1, because it's what stable does, it's what song select footer does, and the extra decimal does matter when more than 1 mod is selected. This is a late change, only decided to do this today.
