### PR TITLE
Separate randomization and object positioning logic in osu random mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -33,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// </summary>
         private const int preceding_hitobjects_to_shift = 10;
 
-        private Random rng;
+        private Random? rng;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
@@ -58,8 +60,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// <returns>A list of <see cref="RandomObjectInfo"/>s describing how each hit object should be placed.</returns>
         private List<RandomObjectInfo> randomiseObjects(IEnumerable<OsuHitObject> hitObjects)
         {
+            Debug.Assert(rng != null, $"{nameof(ApplyToBeatmap)} was not called before randomising objects");
+
             var randomObjects = new List<RandomObjectInfo>();
-            RandomObjectInfo previous = null;
+            RandomObjectInfo? previous = null;
             float rateOfChangeMultiplier = 0;
 
             foreach (OsuHitObject hitObject in hitObjects)
@@ -102,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// <param name="randomObjects">A list of <see cref="RandomObjectInfo"/> describing how each hit object should be placed.</param>
         private void applyRandomisation(IReadOnlyList<OsuHitObject> hitObjects, IReadOnlyList<RandomObjectInfo> randomObjects)
         {
-            RandomObjectInfo previous = null;
+            RandomObjectInfo? previous = null;
 
             for (int i = 0; i < hitObjects.Count; i++)
             {
@@ -158,7 +162,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// <param name="current">The <see cref="RandomObjectInfo"/> representing the hit object to have the randomised position computed for.</param>
         /// <param name="previous">The <see cref="RandomObjectInfo"/> representing the hit object immediately preceding the current one.</param>
         /// <param name="beforePrevious">The <see cref="RandomObjectInfo"/> representing the hit object immediately preceding the <paramref name="previous"/> one.</param>
-        private void computeRandomisedPosition(RandomObjectInfo current, [CanBeNull] RandomObjectInfo previous, [CanBeNull] RandomObjectInfo beforePrevious)
+        private void computeRandomisedPosition(RandomObjectInfo current, RandomObjectInfo? previous, RandomObjectInfo? beforePrevious)
         {
             float previousAbsoluteAngle = 0f;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -73,19 +73,19 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 if (previous == null)
                 {
-                    current.Distance = (float)(rng.NextDouble() * OsuPlayfield.BASE_SIZE.X / 2);
+                    current.DistanceFromPrevious = (float)(rng.NextDouble() * OsuPlayfield.BASE_SIZE.X / 2);
                     current.RelativeAngle = (float)(rng.NextDouble() * 2 * Math.PI - Math.PI);
                 }
                 else
                 {
-                    current.Distance = Vector2.Distance(previous.EndPositionOriginal, current.PositionOriginal);
+                    current.DistanceFromPrevious = Vector2.Distance(previous.EndPositionOriginal, current.PositionOriginal);
 
                     // The max. angle (relative to the angle of the vector pointing from the 2nd last to the last hit object)
                     // is proportional to the distance between the last and the current hit object
                     // to allow jumps and prevent too sharp turns during streams.
 
                     // Allow maximum jump angle when jump distance is more than half of playfield diagonal length
-                    current.RelativeAngle = rateOfChangeMultiplier * 2 * (float)Math.PI * Math.Min(1f, current.Distance / (playfield_diagonal * 0.5f));
+                    current.RelativeAngle = rateOfChangeMultiplier * 2 * (float)Math.PI * Math.Min(1f, current.DistanceFromPrevious / (playfield_diagonal * 0.5f));
                 }
 
                 previous = current;
@@ -177,8 +177,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             float absoluteAngle = previousAbsoluteAngle + current.RelativeAngle;
 
             var posRelativeToPrev = new Vector2(
-                current.Distance * (float)Math.Cos(absoluteAngle),
-                current.Distance * (float)Math.Sin(absoluteAngle)
+                current.DistanceFromPrevious * (float)Math.Cos(absoluteAngle),
+                current.DistanceFromPrevious * (float)Math.Sin(absoluteAngle)
             );
 
             Vector2 lastEndPosition = previous?.EndPositionRandomised ?? playfield_centre;
@@ -349,9 +349,9 @@ namespace osu.Game.Rulesets.Osu.Mods
             /// The jump distance from the previous hit object to this one.
             /// </summary>
             /// <remarks>
-            /// <see cref="Distance"/> of the first hit object in a beatmap is relative to the playfield center.
+            /// <see cref="DistanceFromPrevious"/> of the first hit object in a beatmap is relative to the playfield center.
             /// </remarks>
-            public float Distance { get; set; }
+            public float DistanceFromPrevious { get; set; }
 
             public Vector2 PositionOriginal { get; }
             public Vector2 PositionRandomised { get; set; }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             if (previous != null)
             {
-                Vector2 earliestPosition = beforePrevious == null ? playfield_centre : beforePrevious.HitObject.EndPosition;
+                Vector2 earliestPosition = beforePrevious?.HitObject.EndPosition ?? playfield_centre;
                 Vector2 relativePosition = previous.HitObject.Position - earliestPosition;
                 previousAbsoluteAngle = (float)Math.Atan2(relativePosition.Y, relativePosition.X);
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -50,6 +50,11 @@ namespace osu.Game.Rulesets.Osu.Mods
             applyRandomisation(hitObjects, randomObjects);
         }
 
+        /// <summary>
+        /// Randomise the position of each hit object and return a list of <see cref="RandomObjectInfo"/>s describing how each hit object should be placed.
+        /// </summary>
+        /// <param name="hitObjects">A list of <see cref="OsuHitObject"/>s to have their positions randomised.</param>
+        /// <returns>A list of <see cref="RandomObjectInfo"/>s describing how each hit object should be placed.</returns>
         private List<RandomObjectInfo> randomiseObjects(IEnumerable<OsuHitObject> hitObjects)
         {
             var randomObjects = new List<RandomObjectInfo>();
@@ -89,6 +94,11 @@ namespace osu.Game.Rulesets.Osu.Mods
             return randomObjects;
         }
 
+        /// <summary>
+        /// Reposition the hit objects according to the information in <paramref name="randomObjects"/>.
+        /// </summary>
+        /// <param name="hitObjects">The hit objects to be repositioned.</param>
+        /// <param name="randomObjects">A list of <see cref="RandomObjectInfo"/> describing how each hit object should be placed.</param>
         private void applyRandomisation(IReadOnlyList<OsuHitObject> hitObjects, IReadOnlyList<RandomObjectInfo> randomObjects)
         {
             RandomObjectInfo previous = null;
@@ -141,6 +151,12 @@ namespace osu.Game.Rulesets.Osu.Mods
             }
         }
 
+        /// <summary>
+        /// Get the absolute angle of a vector pointing from the previous hit object to the one denoted by <paramref name="hitObjectIndex"/>.
+        /// </summary>
+        /// <param name="hitObjects">A list of all hit objects in the beatmap.</param>
+        /// <param name="hitObjectIndex">The hit object that the vector should point to.</param>
+        /// <returns>The absolute angle of the aforementioned vector.</returns>
         private float getAbsoluteAngle(IReadOnlyList<OsuHitObject> hitObjects, int hitObjectIndex)
         {
             if (hitObjectIndex < 0) return 0;
@@ -151,9 +167,11 @@ namespace osu.Game.Rulesets.Osu.Mods
         }
 
         /// <summary>
-        /// Returns the final position of the hit object
+        /// Compute the randomised position of a hit object while attempting to keep it inside the playfield.
         /// </summary>
-        /// <returns>Final position of the hit object</returns>
+        /// <param name="previousAbsoluteAngle">The direction of movement of the player's cursor before it starts to approach the current hit object.</param>
+        /// <param name="previous">The <see cref="RandomObjectInfo"/> representing the hit object immediately preceding the current one.</param>
+        /// <param name="current">The <see cref="RandomObjectInfo"/> representing the hit object to have the randomised position computed for.</param>
         private void computeRandomisedPosition(float previousAbsoluteAngle, RandomObjectInfo previous, RandomObjectInfo current)
         {
             float absoluteAngle = previousAbsoluteAngle + current.RelativeAngle;
@@ -315,7 +333,24 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private class RandomObjectInfo
         {
+            /// <summary>
+            /// The jump angle from the previous hit object to this one, relative to the previous hit object's jump angle.
+            /// </summary>
+            /// <remarks>
+            /// <see cref="RelativeAngle"/> of the first hit object in a beatmap represents the absolute angle from playfield center to the object.
+            /// </remarks>
+            /// <example>
+            /// If <see cref="RelativeAngle"/> is 0, the player's cursor doesn't need to change its direction of movement when passing
+            /// the previous object to reach this one.
+            /// </example>
             public float RelativeAngle { get; set; }
+
+            /// <summary>
+            /// The jump distance from the previous hit object to this one.
+            /// </summary>
+            /// <remarks>
+            /// <see cref="Distance"/> of the first hit object in a beatmap is relative to the playfield center.
+            /// </remarks>
             public float Distance { get; set; }
 
             public Vector2 PositionOriginal { get; }


### PR DESCRIPTION
Separated from #17144 

The major goal of this PR is to decouple the randomization logic from the object positioning logic in random mod, so that the object positioning part can be extracted to a separate class for re-use in a later PR.

The randomization logic lives in `randomiseObjects(...)` while the object positioning logic lives in `applyRandomisation(...)`.

There are 2 side effects that change random mod's behavior due to the refactoring being done:

- Instead of storing the absolute jump angle in `RandomObjectInfo`, the relative angle is stored and resolved to an absolute angle via additional calculation when required. This allows the jump angle of one object to be updated without needing to update all the remaining objects. (This is actually a hidden bug in the previous version of random mod, where an object can be moved via `applyDecreasingShift(...)` but its jump angle isn't updated.)
- Instead of having a completely random position, the first hit object of a map now tends to generate closer to the center of the playfield. It is simply more convenient to do it this way in the new structure rather than keeping the completely randomized position.

There are other small changes to the positioning logic in #17144 that I haven't included here. I want to focus on this one important change first.