### PR TITLE
Fix `BeatmapLeaderboard` refreshing on changes in local offset setting

### DIFF
--- a/osu.Game/Database/RealmExtensions.cs
+++ b/osu.Game/Database/RealmExtensions.cs
@@ -4,6 +4,8 @@
 using System;
 using Realms;
 
+#nullable enable
+
 namespace osu.Game.Database
 {
     public static class RealmExtensions
@@ -22,5 +24,14 @@ namespace osu.Game.Database
             transaction.Commit();
             return result;
         }
+
+        /// <summary>
+        /// Whether the provided change set has changes to the top level collection.
+        /// </summary>
+        /// <remarks>
+        /// Realm subscriptions fire on both collection and property changes (including *all* nested properties).
+        /// Quite often we only care about changes at a collection level. This can be used to guard and early-return when no such changes are in a callback.
+        /// </remarks>
+        public static bool HasCollectionChanges(this ChangeSet changes) => changes.InsertedIndices.Length > 0 || changes.DeletedIndices.Length > 0 || changes.Moves.Length > 0;
     }
 }

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -191,6 +191,11 @@ namespace osu.Game.Screens.Select.Leaderboards
                 if (cancellationToken.IsCancellationRequested)
                     return;
 
+                // This subscription may fire from changes to linked beatmaps, which we don't care about.
+                // It's currently not possible for a score to be modified after insertion, so we can safely ignore callbacks with only modifications.
+                if (changes?.HasCollectionChanges() == false)
+                    return;
+
                 var scores = sender.AsEnumerable();
 
                 if (filterMods && !mods.Value.Any())


### PR DESCRIPTION
This could cause considerable overhead if a user had many local scores present. As reported by @smoogipoo. Touches on #17142.