### PR TITLE
Remove `user` from `SubmittableScore`

### DIFF
--- a/osu.Game/Online/Solo/SubmittableScore.cs
+++ b/osu.Game/Online/Solo/SubmittableScore.cs
@@ -46,9 +46,6 @@ namespace osu.Game.Online.Solo
         [JsonProperty("mods")]
         public APIMod[] Mods { get; set; }
 
-        [JsonProperty("user")]
-        public APIUser User { get; set; }
-
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics { get; set; }
 
@@ -67,7 +64,6 @@ namespace osu.Game.Online.Solo
             RulesetID = score.RulesetID;
             Passed = score.Passed;
             Mods = score.APIMods;
-            User = score.User;
             Statistics = score.Statistics;
         }
     }


### PR DESCRIPTION
This wasn't being used by osu-web, and included far too much unnecessary data. Of note, `pp` and `ruleset_id` are also not strictly required, but there's no harm in sending them so I've left them be for now.

Have already checked with web team that this will not cause any issues.