### PR TITLE
Fix potential crash on rare incorrect firing of skin dropdown update methods

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -134,6 +134,9 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private void updateSelectedSkinFromConfig()
         {
+            if (!skinDropdown.Items.Any())
+                return;
+
             Live<SkinInfo> skin = null;
 
             if (Guid.TryParse(configBindable.Value, out var configId))


### PR DESCRIPTION
As brought to light by https://gist.github.com/smoogipoo/56eda7ab56b9d1966556f2ca7a80a847.

There's a chance that the dropdown is not populated by the time `updateSelectedSkinFromConfig` is fired via an external means (config changes).