### PR TITLE
Fix potential test failure on slow realm callback in `TestSceneBeatmapDownloadButton`

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapDownloadButton.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("ensure manager loaded", () => beatmaps != null);
             ensureSoleilyRemoved();
             createButtonWithBeatmap(createSoleily());
-            AddAssert("button state not downloaded", () => downloadButton.DownloadState == DownloadState.NotDownloaded);
+            AddUntilStep("button state not downloaded", () => downloadButton.DownloadState == DownloadState.NotDownloaded);
             AddStep("import soleily", () => beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()));
 
             AddUntilStep("wait for beatmap import", () => beatmaps.GetAllUsableBeatmapSets().Any(b => b.OnlineID == 241526));
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual.Online
             createButtonWithBeatmap(createSoleily());
             AddUntilStep("button state downloaded", () => downloadButton.DownloadState == DownloadState.LocallyAvailable);
             ensureSoleilyRemoved();
-            AddAssert("button state not downloaded", () => downloadButton.DownloadState == DownloadState.NotDownloaded);
+            AddUntilStep("button state not downloaded", () => downloadButton.DownloadState == DownloadState.NotDownloaded);
         }
 
         private void ensureSoleilyRemoved()


### PR DESCRIPTION
As brought to light by https://gist.github.com/smoogipoo/56eda7ab56b9d1966556f2ca7a80a847.