### PR TITLE
Fix beatmap carousel panels accepting input while marked as not-visible

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -17,6 +17,9 @@ namespace osu.Game.Screens.Select.Carousel
 
         public override bool IsPresent => base.IsPresent || Item?.Visible == true;
 
+        public override bool HandlePositionalInput => Item?.Visible == true;
+        public override bool PropagatePositionalInputSubTree => Item?.Visible == true;
+
         public readonly CarouselHeader Header;
 
         /// <summary>


### PR DESCRIPTION
This is an issue as carousel panels manage their own animated state. If they are marked as not-visible (done at a higher level, from filtering or update pathways) but clicked while fading out, they will animate back to a visible state but not be marked as visible.

No tests for this one as it's probably not worthwhile to test (and hard to do so). Manual testing can be done with the following patch:

```diff
diff --git a/osu.Game/Screens/Select/BeatmapCarousel.cs
b/osu.Game/Screens/Select/BeatmapCarousel.cs
index c3d340ac61..3372242acc 100644
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -255,7 +255,7 @@ private void
beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeS
             }

             foreach (int i in changes.NewModifiedIndices)
-                UpdateBeatmapSet(sender[i].Detach());
+                Scheduler.AddDelayed(() => UpdateBeatmapSet(sender[i].Detach()), 100, true);

             foreach (int i in changes.InsertedIndices)
                 UpdateBeatmapSet(sender[i].Detach());

```

- Enter gameplay and adjust beatmap offset then return to song select and click the flashing panel.

OR

- Enter editor and save then return to song select and click the flashing panel.

Closes https://github.com/ppy/osu/issues/17182.