### PR TITLE
Add skinning support for "Welcome" intro sequence

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -209,14 +209,15 @@ namespace osu.Game.Screens.Menu
             // we also handle the exit transition.
             if (MenuVoice.Value)
             {
-                // ensure samples have been updated after resume before playing.
-                ScheduleAfterChildren(() =>
+                if (skinnableSeeya != null)
                 {
-                    if (skinnableSeeya != null)
-                        skinnableSeeya.Play();
-                    else
-                        seeya.Play();
-                });
+                    // resuming a screen (i.e. calling OnResume) happens before the screen itself becomes alive,
+                    // therefore skinnable samples may not be updated yet with the recently selected skin.
+                    // schedule after children to ensure skinnable samples have processed skin changes before playing.
+                    ScheduleAfterChildren(() => skinnableSeeya.Play());
+                }
+                else
+                    seeya.Play();
 
                 // if playing the outro voice, we have more time to have fun with the background track.
                 // initially fade to almost silent then ramp out over the remaining time.

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -13,14 +13,17 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Framework.Utils;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.IO.Archives;
+using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Backgrounds;
+using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 using Realms;
@@ -55,7 +58,8 @@ namespace osu.Game.Screens.Menu
 
         private const int exit_delay = 3000;
 
-        private Sample seeya;
+        private SkinnableSound skinnableSeeya;
+        private ISample seeya;
 
         protected virtual string SeeyaSampleName => "Intro/seeya";
 
@@ -90,14 +94,18 @@ namespace osu.Game.Screens.Menu
         private BeatmapManager beatmaps { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, Framework.Game game, RealmAccess realm)
+        private void load(OsuConfigManager config, Framework.Game game, RealmAccess realm, IAPIProvider api)
         {
             // prevent user from changing beatmap while the intro is still running.
             beatmap = Beatmap.BeginLease(false);
 
             MenuVoice = config.GetBindable<bool>(OsuSetting.MenuVoice);
             MenuMusic = config.GetBindable<bool>(OsuSetting.MenuMusic);
-            seeya = audio.Samples.Get(SeeyaSampleName);
+
+            if (api.LocalUser.Value.IsSupporter)
+                AddInternal(skinnableSeeya = new SkinnableSound(new SampleInfo(SeeyaSampleName)));
+            else
+                seeya = audio.Samples.Get(SeeyaSampleName);
 
             // if the user has requested not to play theme music, we should attempt to find a random beatmap from their collection.
             if (!MenuMusic.Value)
@@ -201,7 +209,14 @@ namespace osu.Game.Screens.Menu
             // we also handle the exit transition.
             if (MenuVoice.Value)
             {
-                seeya.Play();
+                // ensure samples have been updated after resume before playing.
+                ScheduleAfterChildren(() =>
+                {
+                    if (skinnableSeeya != null)
+                        skinnableSeeya.Play();
+                    else
+                        seeya.Play();
+                });
 
                 // if playing the outro voice, we have more time to have fun with the background track.
                 // initially fade to almost silent then ramp out over the remaining time.

--- a/osu.Game/Screens/Menu/IntroWelcome.cs
+++ b/osu.Game/Screens/Menu/IntroWelcome.cs
@@ -100,13 +100,13 @@ namespace osu.Game.Screens.Menu
 
         private class WelcomeIntroSequence : Container
         {
-            private Sprite welcomeText;
+            private Drawable welcomeText;
             private Container scaleContainer;
 
             public LogoVisualisation LogoVisualisation { get; private set; }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
+            private void load(TextureStore textures, IAPIProvider api)
             {
                 Origin = Anchor.Centre;
                 Anchor = Anchor.Centre;
@@ -135,15 +135,17 @@ namespace osu.Game.Screens.Menu
                                 Size = new Vector2(480),
                                 Colour = Color4.Black
                             },
-                            welcomeText = new Sprite
-                            {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                Texture = textures.Get(@"Intro/Welcome/welcome_text")
-                            },
                         }
                     },
                 };
+
+                if (api.LocalUser.Value.IsSupporter)
+                    scaleContainer.Add(welcomeText = new SkinnableSprite(@"Intro/Welcome/welcome_text"));
+                else
+                    scaleContainer.Add(welcomeText = new Sprite { Texture = textures.Get(@"Intro/Welcome/welcome_text") });
+
+                welcomeText.Anchor = Anchor.Centre;
+                welcomeText.Origin = Anchor.Centre;
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/Menu/IntroWelcome.cs
+++ b/osu.Game/Screens/Menu/IntroWelcome.cs
@@ -13,7 +13,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Online.API;
 using osu.Game.Screens.Backgrounds;
+using osu.Game.Skinning;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Menu
@@ -23,8 +26,11 @@ namespace osu.Game.Screens.Menu
         protected override string BeatmapHash => "64e00d7022195959bfa3109d09c2e2276c8f12f486b91fcf6175583e973b48f2";
         protected override string BeatmapFile => "welcome.osz";
         private const double delay_step_two = 2142;
-        private Sample welcome;
-        private Sample pianoReverb;
+
+        private SkinnableSound skinnableWelcome;
+        private ISample welcome;
+
+        private ISample pianoReverb;
         protected override string SeeyaSampleName => "Intro/Welcome/seeya";
 
         protected override BackgroundScreen CreateBackground() => background = new BackgroundScreenDefault(false)
@@ -40,10 +46,15 @@ namespace osu.Game.Screens.Menu
         }
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load(AudioManager audio, IAPIProvider api)
         {
             if (MenuVoice.Value)
-                welcome = audio.Samples.Get(@"Intro/Welcome/welcome");
+            {
+                if (api.LocalUser.Value.IsSupporter)
+                    AddInternal(skinnableWelcome = new SkinnableSound(new SampleInfo(@"Intro/Welcome/welcome")));
+                else
+                    welcome = audio.Samples.Get(@"Intro/Welcome/welcome");
+            }
 
             pianoReverb = audio.Samples.Get(@"Intro/Welcome/welcome_piano");
         }
@@ -65,7 +76,10 @@ namespace osu.Game.Screens.Menu
 
                     AddInternal(intro);
 
-                    welcome?.Play();
+                    if (skinnableWelcome != null)
+                        skinnableWelcome.Play();
+                    else
+                        welcome?.Play();
 
                     var reverbChannel = pianoReverb?.Play();
                     if (reverbChannel != null)


### PR DESCRIPTION
Addresses #17140

Bringing back the osu!supporter-exclusive skinning support osu!(stable) had for the "Welcome" intro sequence:

https://user-images.githubusercontent.com/22781491/157579191-85134f0f-2902-4bfc-8be5-7485b05b9dda.mp4

https://user-images.githubusercontent.com/22781491/157579169-b452e393-9889-4b07-8b15-d803fd00a606.mp4

I'm not sure this should be toggleable as per the discussion, because at that point you might as well just export the skin, remove the samples, and re-import it back.

Few notes:
- Covering skins in tests using `SkinnableTestScene` isn't quite feasible as only one `IntroScreen` can be loaded at the same time (since it begins a lease on the game-wide beatmap bindable).
- The current `welcome_piano` sample has a bit of the "welcome to osu!" sound within it (unlike osu!stable). Not sure whether that should block this PR, however.
- Switching from a non-supporter to a supporter state after intro will not update the "seeya" sample to use the skinnable one. A bit complicated to resolve and I think it doesn't matter all that much, but can look into it if deemed required (can imagine the "is supporter" logic potentially being encapsulated within `SkinReloadableDrawable` one day anyways).

One other thing to mention is that I noticed the "seeya" sample sometimes not updating after changing skin, but the chances of reproducing that are low enough that I decided to PR this for now.