### PR TITLE
Fix potential multiplayer crash with async disposal

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -175,7 +175,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.StartGameplay();
         });
 
-        private void onResultsReady() => resultsReady.SetResult(true);
+        private void onResultsReady() => Scheduler.Add(() =>
+        {
+            resultsReady.SetResult(true);
+        });
 
         protected override async Task PrepareScoreForResultsAsync(Score score)
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -175,10 +175,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.StartGameplay();
         });
 
-        private void onResultsReady() => Scheduler.Add(() =>
+        private void onResultsReady()
         {
-            resultsReady.SetResult(true);
-        });
+            // Schedule is required to ensure that `TaskCompletionSource.SetResult` is not called more than once.
+            // A scenario where this can occur is if this instance is not immediately disposed (ie. async disposal queue).
+            Schedule(() => resultsReady.SetResult(true));
+        }
 
         protected override async Task PrepareScoreForResultsAsync(Score score)
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
+using osu.Framework.Screens;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
@@ -171,6 +172,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void onMatchStarted() => Scheduler.Add(() =>
         {
+            if (!this.IsCurrentScreen())
+                return;
+
             loadingDisplay.Hide();
             base.StartGameplay();
         });
@@ -179,7 +183,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             // Schedule is required to ensure that `TaskCompletionSource.SetResult` is not called more than once.
             // A scenario where this can occur is if this instance is not immediately disposed (ie. async disposal queue).
-            Schedule(() => resultsReady.SetResult(true));
+            Schedule(() =>
+            {
+                if (!this.IsCurrentScreen())
+                    return;
+
+                resultsReady.SetResult(true);
+            });
         }
 
         protected override async Task PrepareScoreForResultsAsync(Score score)


### PR DESCRIPTION
It's possible that the `Dispose()` call is delayed so the event isn't unbound. I think this is probably the easiest way to handle this which isn't completely dodgy (such as using `TrySetResult(true)` instead), and is also done by `onMatchStarted()` in the same class.

Can be tested by adding `Thread.Sleep(2000)` at the end of `BeatmapInfoWedge.load()`.