### PR TITLE
Fix intermittent match song select test failures

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -27,6 +27,7 @@ using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.Select;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -34,8 +35,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         private BeatmapManager manager;
         private RulesetStore rulesets;
-
-        private List<BeatmapInfo> beatmaps;
 
         private TestMultiplayerMatchSongSelect songSelect;
 
@@ -45,8 +44,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(Realm);
-
-            beatmaps = new List<BeatmapInfo>();
 
             var metadata = new BeatmapMetadata
             {
@@ -79,7 +76,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Difficulty = new BeatmapDifficulty()
                 };
 
-                beatmaps.Add(beatmap);
                 beatmapSetInfo.Beatmaps.Add(beatmap);
             }
 
@@ -140,7 +136,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("change ruleset", () => Ruleset.Value = new TaikoRuleset().RulesetInfo);
             AddStep("select beatmap",
-                () => songSelect.Carousel.SelectBeatmap(selectedBeatmap = beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == new TaikoRuleset().LegacyID)));
+                () => songSelect.Carousel.SelectBeatmap(selectedBeatmap = manager.GetAllUsableBeatmapSets().First().Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == new TaikoRuleset().LegacyID)));
             AddUntilStep("wait for selection", () => Beatmap.Value.BeatmapInfo.Equals(selectedBeatmap));
             AddStep("set mods", () => SelectedMods.Value = new[] { new TaikoModDoubleTime() });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -104,14 +104,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestBeatmapRevertedOnExitIfNoSelection()
         {
-            BeatmapInfo selectedBeatmap = null;
+            BeatmapInfo initialBeatmap = null;
 
-            AddStep("select beatmap",
-                () => songSelect.Carousel.SelectBeatmap(selectedBeatmap = beatmaps.Where(beatmap => beatmap.Ruleset.OnlineID == new OsuRuleset().LegacyID).ElementAt(1)));
-            AddUntilStep("wait for selection", () => Beatmap.Value.BeatmapInfo.Equals(selectedBeatmap));
+            AddStep("get current beatmap", () => initialBeatmap = songSelect.Beatmap.Value.BeatmapInfo);
+
+            AddStep("select next and enter", () => InputManager.Key(Key.Down));
+            AddUntilStep("ensure selection changed", () => !songSelect.Beatmap.Value.BeatmapInfo.Equals(initialBeatmap));
 
             AddStep("exit song select", () => songSelect.Exit());
-            AddAssert("beatmap reverted", () => Beatmap.IsDefault);
+            AddUntilStep("beatmap reverted", () => songSelect.Beatmap.Value.BeatmapInfo.Equals(initialBeatmap));
         }
 
         [Test]


### PR DESCRIPTION
Can be tested by adding `Thread.Sleep(2000)` at the end of `BeatmapInfoWedge.load()`. I'm not 100% sure why this specifically causes the issue so I focused on the issues only at a surface level. Others are welcome to investigate if they see this as a requirement.

619c1861cd9939d54dbf85893aeea82e6ee35f68: Fixes a test which fails when other tests are run alongside it.

It seems like this is because the current `DrawableTrack` finishes and `MusicController` changes to another beatmap. It just so happens that this happens after the `.SetDefault()` call in `SetUpSteps()`. I'm unsure why this happens atm.

Fixed by checking against the default value of the song select's `Beatmap` bindable instead.

6611ca10c2917fe5f7cfde80694c8688cd73746d: Fixes running the tests in the browser failing with:
```
[runtime] 2022-03-10 10:22:04 [error]: Realms.Exceptions.RealmClosedException: This object belongs to a closed realm.
[runtime] 2022-03-10 10:22:04 [error]: at Realms.RealmHandle.EnsureIsOpen()
[runtime] 2022-03-10 10:22:04 [error]: at Realms.ObjectHandle.GetValue(String propertyName, Metadata metadata, Realm realm)
[runtime] 2022-03-10 10:22:04 [error]: at osu.Game.Beatmaps.BeatmapInfo.get_Ruleset()
[runtime] 2022-03-10 10:22:04 [error]: at osu.Game.Tests.Visual.Multiplayer.TestSceneMultiplayerMatchSongSelect.<>c.<TestBeatmapConfirmed>b__9_9(BeatmapInfo beatmap) in /home/smgi/Repos/osu/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs:line 144
[runtime] 2022-03-10 10:22:04 [error]: at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
[runtime] 2022-03-10 10:22:04 [error]: at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)
[runtime] 2022-03-10 10:22:04 [error]: at osu.Game.Tests.Visual.Multiplayer.TestSceneMultiplayerMatchSongSelect.<>c__DisplayClass9_0.<TestBeatmapConfirmed>b__1() in /home/smgi/Repos/osu/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs:line 144
[runtime] 2022-03-10 10:22:04 [error]: at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
[runtime] 2022-03-10 10:22:04 [error]: at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
[runtime] 2022-03-10 10:22:04 [error]: at osu.Framework.Testing.Drawables.Steps.StepButton.OnClick(ClickEvent e)
```