### PR TITLE
Fix intermittent failures on `TestBeatmapDownloadingFlow` due to slow realm refresh

### DIFF
--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Tests.Online
         [Test]
         public void TestBeatmapDownloadingFlow()
         {
-            AddAssert("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapSet));
+            AddUntilStep("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapSet));
             addAvailabilityCheckStep("state not downloaded", BeatmapAvailability.NotDownloaded);
 
             AddStep("start downloading", () => beatmapDownloader.Download(testBeatmapSet));
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Online
 
             AddStep("allow importing", () => beatmaps.AllowImport.SetResult(true));
             AddUntilStep("wait for import", () => beatmaps.CurrentImport != null);
-            AddAssert("ensure beatmap available", () => beatmaps.IsAvailableLocally(testBeatmapSet));
+            AddUntilStep("ensure beatmap available", () => beatmaps.IsAvailableLocally(testBeatmapSet));
             addAvailabilityCheckStep("state is locally available", BeatmapAvailability.LocallyAvailable);
         }
 


### PR DESCRIPTION
Got this one locally while running a normal test run...

```csharp
TearDown : osu.Framework.Testing.Drawables.Steps.AssertButton+TracedException : ensure beatmap available
--TearDown
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Platform.GameHost.UpdateFrame()
   at osu.Framework.Threading.GameThread.processFrame()
   at osu.Framework.Threading.GameThread.RunSingleFrame()
   at osu.Framework.Threading.GameThread.<createThread>g__runWork|64_0()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

-----

One or more child tests had errors
  Exception doesn't have a stacktrace

[runtime] 2022-03-10 11:24:55 [verbose]: 💨 Class: TestSceneOnlinePlayBeatmapAvailabilityTracker
[runtime] 2022-03-10 11:24:55 [verbose]: 🔶 Test:  TestBeatmapDownloadingFlow
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #1 ensure beatmap unavailable
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #2 state not downloaded
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #3 start downloading
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #4 state downloading 0%
[runtime] 2022-03-10 11:24:55 [verbose]: ✔️ 7 repetitions
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #5 set progress 40%
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #6 state downloading 40%
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #7 finish download
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #8 state importing
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #9 allow importing
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #10 wait for import
[database] 2022-03-10 11:24:55 [verbose]: [dce8f] Beginning import...
[database] 2022-03-10 11:24:55 [verbose]: [dce8f] Import successfully completed!
[runtime] 2022-03-10 11:24:55 [verbose]: ✔️ 170 repetitions
[runtime] 2022-03-10 11:24:55 [verbose]: 🔸 Step #11 ensure beatmap available
[runtime] 2022-03-10 11:24:55 [verbose]: 💥 Failed
[runtime] 2022-03-10 11:24:55 [verbose]: ⏳ Currently loading components (0)
[runtime] 2022-03-10 11:24:55 [verbose]: 🧵 Task schedulers
[runtime] 2022-03-10 11:24:55 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-03-10 11:24:55 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-03-10 11:24:55 [verbose]: 🎱 Thread pool
[runtime] 2022-03-10 11:24:55 [verbose]: worker:          min 32     max 32,767 available 32,766
[runtime] 2022-03-10 11:24:55 [verbose]: completion:      min 32     max 1,000  available 1,000

```