### PR TITLE
Fix skin components toolbox not autosizing properly

### DIFF
--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -162,7 +162,9 @@ namespace osu.Game.Overlays
 
             Expanded.BindValueChanged(v =>
             {
-                content.ClearTransforms();
+                // clearing transforms can break autosizing, see: https://github.com/ppy/osu-framework/issues/5064
+                if (v.NewValue != v.OldValue)
+                    content.ClearTransforms();
 
                 if (v.NewValue)
                     content.AutoSizeAxes = Axes.Y;


### PR DESCRIPTION
- Closes #17147 
- Works around ppy/osu-framework#5064

Indirectly regressed by #16574 as it moved the expansion transforms logic in `SettingsToolboxGroup` to `LoadComplete`, where autosize transforms may potentially be populated already (note that a container doesn't need to be updated at least once to have autosize transforms populated, `childrenSizeDependencies` could be validated beforehand).