### PR TITLE
Automatically bind `BlueprintContainer`'s `SelectedItems` with its `SelectionHandler`

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             SelectionHandler = CreateSelectionHandler();
             SelectionHandler.DeselectAll = deselectAll;
+            SelectionHandler.SelectedItems.BindTo(SelectedItems);
 
             AddRangeInternal(new[]
             {

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -29,11 +29,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // bring in updates from selection changes
             EditorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(UpdateTernaryStates);
 
-            SelectedItems.BindTo(EditorBeatmap.SelectedHitObjects);
-            SelectedItems.CollectionChanged += (sender, args) =>
-            {
-                Scheduler.AddOnce(UpdateTernaryStates);
-            };
+            SelectedItems.CollectionChanged += (sender, args) => Scheduler.AddOnce(UpdateTernaryStates);
         }
 
         protected override void DeleteItems(IEnumerable<HitObject> items) => EditorBeatmap.RemoveRange(items);


### PR DESCRIPTION
Until now it was up to each implementation to connect `BlueprintContainer` to its `SelectionHandler`, which didn't make much sense at all.

Came to light as I started to use the flow of items being selected by the `SelectionHandler` for the sking editor and saw no updates to the editor-level bindable that looked to be linked.