### PR TITLE
Confine the host cursor when using "everything" screen scaling

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.308.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.314.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.308.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.314.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.308.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.314.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.308.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.314.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ppy/osu-framework/pull/5066
- [x] framework bump

Closes https://github.com/ppy/osu/issues/16956.

Using `LayoutValue(RequiredParentSizeToFit)`, as suggested [by frenzibyte on discord](https://discord.com/channels/188630481301012481/188630652340404224/951538111123447868), seems to work fine for the use case. Covering the following cases:
- changing window modes
- resizing the window
- changing screen scaling size/position trough `OsuConfig`