### PR TITLE
Refactor `SkinEditor` to support switching target screens without full reload

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1142,8 +1142,6 @@ namespace osu.Game
 
         private void screenChanged(IScreen current, IScreen newScreen)
         {
-            skinEditor.Reset();
-
             switch (newScreen)
             {
                 case IntroScreen intro:
@@ -1185,6 +1183,8 @@ namespace osu.Game
                 else
                     BackButton.Hide();
             }
+
+            skinEditor.SetTarget((Screen)newScreen);
         }
 
         private void screenPushed(IScreen lastScreen, IScreen newScreen) => screenChanged(lastScreen, newScreen);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1140,7 +1140,7 @@ namespace osu.Game
             MenuCursorContainer.CanShowCursor = (ScreenStack.CurrentScreen as IOsuScreen)?.CursorVisible ?? false;
         }
 
-        protected virtual void ScreenChanged(IScreen current, IScreen newScreen)
+        private void screenChanged(IScreen current, IScreen newScreen)
         {
             skinEditor.Reset();
 
@@ -1187,11 +1187,11 @@ namespace osu.Game
             }
         }
 
-        private void screenPushed(IScreen lastScreen, IScreen newScreen) => ScreenChanged(lastScreen, newScreen);
+        private void screenPushed(IScreen lastScreen, IScreen newScreen) => screenChanged(lastScreen, newScreen);
 
         private void screenExited(IScreen lastScreen, IScreen newScreen)
         {
-            ScreenChanged(lastScreen, newScreen);
+            screenChanged(lastScreen, newScreen);
 
             if (newScreen == null)
                 Exit();

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Skinning.Editor
 
         protected override bool StartHidden => true;
 
-        private readonly Drawable targetScreen;
+        private Drawable targetScreen;
 
         private OsuTextFlowContainer headerText;
 
@@ -42,11 +42,13 @@ namespace osu.Game.Skinning.Editor
 
         private bool hasBegunMutating;
 
+        private Container blueprintContainerContainer;
+
         public SkinEditor(Drawable targetScreen)
         {
-            this.targetScreen = targetScreen;
-
             RelativeSizeAxes = Axes.Both;
+
+            UpdateTargetScreen(targetScreen);
         }
 
         [BackgroundDependencyLoader]
@@ -113,13 +115,9 @@ namespace osu.Game.Skinning.Editor
                                     Origin = Anchor.CentreLeft,
                                     RequestPlacement = placeComponent
                                 },
-                                new Container
+                                blueprintContainerContainer = new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Children = new Drawable[]
-                                    {
-                                        new SkinBlueprintContainer(targetScreen),
-                                    }
                                 },
                             }
                         }
@@ -145,6 +143,21 @@ namespace osu.Game.Skinning.Editor
                 hasBegunMutating = false;
                 Scheduler.AddOnce(skinChanged);
             }, true);
+        }
+
+        public void UpdateTargetScreen(Drawable targetScreen)
+        {
+            this.targetScreen = targetScreen;
+
+            Scheduler.AddOnce(loadBlueprintContainer);
+
+            void loadBlueprintContainer()
+            {
+                blueprintContainerContainer.Children = new Drawable[]
+                {
+                    new SkinBlueprintContainer(targetScreen),
+                };
+            }
         }
 
         private void skinChanged()

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Skinning.Editor
 
         private bool hasBegunMutating;
 
-        private Container blueprintContainerContainer;
+        private Container content;
 
         public SkinEditor(Drawable targetScreen)
         {
@@ -115,7 +115,7 @@ namespace osu.Game.Skinning.Editor
                                     Origin = Anchor.CentreLeft,
                                     RequestPlacement = placeComponent
                                 },
-                                blueprintContainerContainer = new Container
+                                content = new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                 },
@@ -153,7 +153,7 @@ namespace osu.Game.Skinning.Editor
 
             void loadBlueprintContainer()
             {
-                blueprintContainerContainer.Children = new Drawable[]
+                content.Children = new Drawable[]
                 {
                     new SkinBlueprintContainer(targetScreen),
                 };

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -8,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
 
@@ -114,15 +116,36 @@ namespace osu.Game.Skinning.Editor
         }
 
         /// <summary>
-        /// Exit any existing skin editor due to the game state changing.
+        /// Set a new target screen which will be used to find skinnable components.
         /// </summary>
-        public void Reset()
+        public void SetTarget(Screen screen)
         {
-            skinEditor?.Save();
-            skinEditor?.Hide();
-            skinEditor?.Expire();
+            if (skinEditor == null) return;
 
-            skinEditor = null;
+            skinEditor.Save();
+
+            // AddOnce with paramter will ensure the newest target is loaded if there is any overlap.
+            Scheduler.AddOnce(setTarget, screen);
+        }
+
+        private void setTarget(Screen target)
+        {
+            Debug.Assert(skinEditor != null);
+
+            if (!target.IsLoaded)
+            {
+                Scheduler.AddOnce(setTarget, target);
+                return;
+            }
+
+            if (skinEditor.State.Value == Visibility.Visible)
+                skinEditor.UpdateTargetScreen(target);
+            else
+            {
+                skinEditor.Hide();
+                skinEditor.Expire();
+                skinEditor = null;
+            }
         }
     }
 }

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Skinning.Editor
 
             skinEditor.Save();
 
-            // AddOnce with paramter will ensure the newest target is loaded if there is any overlap.
+            // AddOnce with parameter will ensure the newest target is loaded if there is any overlap.
             Scheduler.AddOnce(setTarget, screen);
         }
 

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -132,6 +132,9 @@ namespace osu.Game.Skinning.Editor
         {
             Debug.Assert(skinEditor != null);
 
+            if (!target.IsCurrentScreen())
+                return;
+
             if (!target.IsLoaded)
             {
                 Scheduler.AddOnce(setTarget, target);


### PR DESCRIPTION
This is a preliminary change to basically allow us to not create a new `SkinEditor` instance each time the screen changes. It also means the editor can stay open rather than closing on screen change. This paves the way to having the skin editor able to switch between screens itself, to allow for more seameless editing once there are more than one screen that support skinning.

Wanted to add some `ScreenNavigation` style tests for this flow, but it's hard to do so while there's only one skinnable screen... Will probably come later in the chain.