### PR TITLE
Allow skin editor to target different target containers for placement purposes

### DIFF
--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -171,7 +171,12 @@ namespace osu.Game.Skinning.Editor
 
         private void placeComponent(Type type)
         {
-            var targetContainer = getTarget(SkinnableTarget.MainHUDComponents);
+            var target = availableTargets.FirstOrDefault()?.Target;
+
+            if (target == null)
+                return;
+
+            var targetContainer = getTarget(target.Value);
 
             if (targetContainer == null)
                 return;


### PR DESCRIPTION
Doesn't really do much on its own, but going forward it provides the most basic ability to target a different `SkinnableTarget`. Initially only one target will be supported at a time, but this will likely change in the future as the skinning subsystem gets more complex. Keeping it simple for now, though.

Again, hard to add tests for this but if seen as required multiple of my upcoming pull requests can be combined to potentially make that happen. Basically, this shouldn't change behaviour at all for now.