### PR TITLE
Remove osu!taiko playfield's 16:9 aspect ratio lock on "Classic" mod

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
             drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
+            drawableTaikoRuleset.LockPlayfieldAspect.Value = false;
         }
 
         public void Update(Playfield playfield)

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         public new BindableDouble TimeRange => base.TimeRange;
 
+        public readonly BindableBool LockPlayfieldAspect = new BindableBool(true);
+
         protected override ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Overlapping;
 
         protected override bool UserScrollSpeedAdjustment => false;
@@ -70,7 +72,10 @@ namespace osu.Game.Rulesets.Taiko.UI
             return ControlPoints[result];
         }
 
-        public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new TaikoPlayfieldAdjustmentContainer();
+        public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new TaikoPlayfieldAdjustmentContainer
+        {
+            LockPlayfieldAspect = { BindTarget = LockPlayfieldAspect }
+        };
 
         protected override PassThroughInputManager CreateInputManager() => new TaikoInputManager(Ruleset.RulesetInfo);
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.UI;
-using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -13,16 +13,22 @@ namespace osu.Game.Rulesets.Taiko.UI
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
         private const float default_aspect = 16f / 9f;
 
+        public readonly IBindable<bool> LockPlayfieldAspect = new BindableBool(true);
+
         protected override void Update()
         {
             base.Update();
 
-            float aspectAdjust = Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
-            Size = new Vector2(1, default_relative_height * aspectAdjust);
+            float height = default_relative_height;
+
+            if (LockPlayfieldAspect.Value)
+                height *= Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
+
+            Height = height;
 
             // Position the taiko playfield exactly one playfield from the top of the screen.
             RelativePositionAxes = Axes.Y;
-            Y = Size.Y;
+            Y = height;
         }
     }
 }


### PR DESCRIPTION
Closes #14794 

Bringing osu!taiko's "Classic" mod to match with how osu!(stable) behaves on different aspect ratios.

|                 | 4:3 | 16:9 |
|-----------------|-----|------|
| lazer (master)  | ![CleanShot 2022-03-13 at 08 32 40](https://user-images.githubusercontent.com/22781491/158046545-4e8f24ff-038e-400a-a11d-5a880b6ee085.png) | ![CleanShot 2022-03-13 at 08 35 18](https://user-images.githubusercontent.com/22781491/158046597-9d6fc59b-55f3-4420-adcd-b5c4b5a3c082.png) |
| lazer (this PR) | ![CleanShot 2022-03-13 at 08 36 57](https://user-images.githubusercontent.com/22781491/158046667-52234366-93aa-41d2-b848-b731991b2a15.png) | ![CleanShot 2022-03-13 at 08 38 03](https://user-images.githubusercontent.com/22781491/158046695-e70117a4-bad7-428b-a2ff-e0a19f054866.png) | 
| stable          | ![CleanShot 2022-03-13 at 08 38 44](https://user-images.githubusercontent.com/22781491/158046719-91b3f435-f49e-45ed-a61c-24c564bb3068.png) | ![CleanShot 2022-03-13 at 08 39 42](https://user-images.githubusercontent.com/22781491/158046739-5824ded7-1c9f-4981-a877-180b1b07561d.png) |

Also resolves the unintended effect of the playfield scroll speed changing on different aspect ratios. For cross-comparison on the scroll speed, here is a list of videos on different aspect ratios:

<details>
<summary>osu!(stable) 4:3 (1024x768)</summary>

https://user-images.githubusercontent.com/22781491/158036976-fbb3d0d0-4731-45c7-ac6a-ca9382e963de.mp4

</details>
<details>
<summary>osu!(stable) 16:9 (1366x768)</summary>

https://user-images.githubusercontent.com/22781491/158037749-d2e74723-80a8-4e98-89fe-d44dfae34b69.mp4

</details>
<details>
<summary>osu!(lazer) before: 4:3 (1024x768)</summary>

https://user-images.githubusercontent.com/22781491/158037632-19d6efc3-267c-44f2-9afa-e927d23c269d.mp4

</details>
<details>
<summary>osu!(lazer) before: 16:9 (1024x576)</summary>

https://user-images.githubusercontent.com/22781491/158037824-c046177f-c7a9-4d3c-aabd-69079e0c0fd8.mp4

</details>
<details>
<summary>osu!(lazer) after: 4:3 (1024x768)</summary>

https://user-images.githubusercontent.com/22781491/158036962-439a9f69-a248-4c60-926b-b4a6dcebfd44.mp4

</details>
<details>
<summary>osu!(lazer) after: 16:9 (1024x576)</summary>

https://user-images.githubusercontent.com/22781491/158037817-5c9fe986-4741-4c70-a0ed-ac4cb73852cd.mp4

</details>

</details>
<details>
<summary>osu!(lazer) after: screen scaling</summary>

https://user-images.githubusercontent.com/22781491/158039780-0cc7b540-3b23-4366-87f9-79df30c927cf.mp4

</details>
