### PR TITLE
Allow skin components to have settings

### DIFF
--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -169,6 +170,39 @@ namespace osu.Game.Configuration
         }
 
         private static readonly ConcurrentDictionary<Type, (SettingSourceAttribute, PropertyInfo)[]> property_info_cache = new ConcurrentDictionary<Type, (SettingSourceAttribute, PropertyInfo)[]>();
+
+        /// <summary>
+        /// Returns the underlying value of the given mod setting object.
+        /// Can be used for serialization and equality comparison purposes.
+        /// </summary>
+        /// <param name="setting">A <see cref="SettingSourceAttribute"/> bindable.</param>
+        public static object GetUnderlyingSettingValue(this object setting)
+        {
+            switch (setting)
+            {
+                case Bindable<double> d:
+                    return d.Value;
+
+                case Bindable<int> i:
+                    return i.Value;
+
+                case Bindable<float> f:
+                    return f.Value;
+
+                case Bindable<bool> b:
+                    return b.Value;
+
+                case IBindable u:
+                    // An unknown (e.g. enum) generic type.
+                    var valueMethod = u.GetType().GetProperty(nameof(IBindable<int>.Value));
+                    Debug.Assert(valueMethod != null);
+                    return valueMethod.GetValue(u);
+
+                default:
+                    // fall back for non-bindable cases.
+                    return setting;
+            }
+        }
 
         public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetSettingsSourceProperties(this object obj)
         {

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Humanizer;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osuTK;
@@ -59,7 +62,17 @@ namespace osu.Game.Extensions
             component.Origin = info.Origin;
 
             if (component is ISkinnableDrawable skinnable)
+            {
                 skinnable.UsesFixedAnchor = info.UsesFixedAnchor;
+
+                foreach (var (_, property) in component.GetSettingsSourceProperties())
+                {
+                    if (!info.Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
+                        continue;
+
+                    skinnable.CopyAdjustedSetting((IBindable)property.GetValue(component), settingValue);
+                }
+            }
 
             if (component is Container container)
             {

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -12,7 +12,6 @@ using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Utils;
 
 namespace osu.Game.Online.API
 {
@@ -43,7 +42,7 @@ namespace osu.Game.Online.API
                 var bindable = (IBindable)property.GetValue(mod);
 
                 if (!bindable.IsDefault)
-                    Settings.Add(property.Name.Underscore(), ModUtils.GetSettingUnderlyingValue(bindable));
+                    Settings.Add(property.Name.Underscore(), bindable.GetUnderlyingSettingValue());
             }
         }
 
@@ -93,13 +92,13 @@ namespace osu.Game.Online.API
 
             public bool Equals(KeyValuePair<string, object> x, KeyValuePair<string, object> y)
             {
-                object xValue = ModUtils.GetSettingUnderlyingValue(x.Value);
-                object yValue = ModUtils.GetSettingUnderlyingValue(y.Value);
+                object xValue = x.Value.GetUnderlyingSettingValue();
+                object yValue = y.Value.GetUnderlyingSettingValue();
 
                 return x.Key == y.Key && EqualityComparer<object>.Default.Equals(xValue, yValue);
             }
 
-            public int GetHashCode(KeyValuePair<string, object> obj) => HashCode.Combine(obj.Key, ModUtils.GetSettingUnderlyingValue(obj.Value));
+            public int GetHashCode(KeyValuePair<string, object> obj) => HashCode.Combine(obj.Key, obj.Value.GetUnderlyingSettingValue());
         }
     }
 }

--- a/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
+++ b/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using MessagePack;
 using MessagePack.Formatters;
-using osu.Game.Utils;
+using osu.Game.Configuration;
 
 namespace osu.Game.Online.API
 {
@@ -23,7 +23,7 @@ namespace osu.Game.Online.API
                 var stringBytes = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(kvp.Key));
                 writer.WriteString(in stringBytes);
 
-                primitiveFormatter.Serialize(ref writer, ModUtils.GetSettingUnderlyingValue(kvp.Value), options);
+                primitiveFormatter.Serialize(ref writer, kvp.Value.GetUnderlyingSettingValue(), options);
             }
         }
 

--- a/osu.Game/Rulesets/Edit/ScrollingToolboxGroup.cs
+++ b/osu.Game/Rulesets/Edit/ScrollingToolboxGroup.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Edit
     {
         protected readonly OsuScrollContainer Scroll;
 
+        protected readonly FillFlowContainer FillFlow;
+
         protected override Container<Drawable> Content { get; }
 
         public ScrollingToolboxGroup(string title, float scrollAreaHeight)
@@ -20,7 +22,7 @@ namespace osu.Game.Rulesets.Edit
             {
                 RelativeSizeAxes = Axes.X,
                 Height = scrollAreaHeight,
-                Child = Content = new FillFlowContainer
+                Child = Content = FillFlow = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Mods
             hashCode.Add(GetType());
 
             foreach (var setting in Settings)
-                hashCode.Add(ModUtils.GetSettingUnderlyingValue(setting));
+                hashCode.Add(setting.GetUnderlyingSettingValue());
 
             return hashCode.ToHashCode();
         }
@@ -208,13 +208,13 @@ namespace osu.Game.Rulesets.Mods
 
             public bool Equals(IBindable x, IBindable y)
             {
-                object xValue = x == null ? null : ModUtils.GetSettingUnderlyingValue(x);
-                object yValue = y == null ? null : ModUtils.GetSettingUnderlyingValue(y);
+                object xValue = x?.GetUnderlyingSettingValue();
+                object yValue = y?.GetUnderlyingSettingValue();
 
                 return EqualityComparer<object>.Default.Equals(xValue, yValue);
             }
 
-            public int GetHashCode(IBindable obj) => ModUtils.GetSettingUnderlyingValue(obj).GetHashCode();
+            public int GetHashCode(IBindable obj) => obj.GetUnderlyingSettingValue().GetHashCode();
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
@@ -4,11 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Humanizer;
 using Newtonsoft.Json;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Skinning;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Screens.Play.HUD
@@ -34,6 +38,8 @@ namespace osu.Game.Screens.Play.HUD
         /// <inheritdoc cref="ISkinnableDrawable.UsesFixedAnchor"/>
         public bool UsesFixedAnchor { get; set; }
 
+        public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
+
         public List<SkinnableInfo> Children { get; } = new List<SkinnableInfo>();
 
         [JsonConstructor]
@@ -57,6 +63,14 @@ namespace osu.Game.Screens.Play.HUD
 
             if (component is ISkinnableDrawable skinnable)
                 UsesFixedAnchor = skinnable.UsesFixedAnchor;
+
+            foreach (var (_, property) in component.GetSettingsSourceProperties())
+            {
+                var bindable = (IBindable)property.GetValue(component);
+
+                if (!bindable.IsDefault)
+                    Settings.Add(property.Name.Underscore(), ModUtils.GetSettingUnderlyingValue(bindable));
+            }
 
             if (component is Container<Drawable> container)
             {

--- a/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Skinning;
-using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Screens.Play.HUD
@@ -69,7 +68,7 @@ namespace osu.Game.Screens.Play.HUD
                 var bindable = (IBindable)property.GetValue(component);
 
                 if (!bindable.IsDefault)
-                    Settings.Add(property.Name.Underscore(), ModUtils.GetSettingUnderlyingValue(bindable));
+                    Settings.Add(property.Name.Underscore(), bindable.GetUnderlyingSettingValue());
             }
 
             if (component is Container<Drawable> container)

--- a/osu.Game/Skinning/Components/BigBlackBox.cs
+++ b/osu.Game/Skinning/Components/BigBlackBox.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Skinning.Components
     {
         public bool UsesFixedAnchor { get; set; }
 
-        [SettingSource("Spining text", "Whether the big text should spin")]
+        [SettingSource("Spinning text", "Whether the big text should spin")]
         public Bindable<bool> TextSpin { get; } = new BindableBool();
 
         [SettingSource("Alpha", "The alpha value of this box")]

--- a/osu.Game/Skinning/Components/BigBlackBox.cs
+++ b/osu.Game/Skinning/Components/BigBlackBox.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Skinning.Components
+{
+    /// <summary>
+    /// Intended to be a test bed for skinning. May be removed at some point in the future.
+    /// </summary>
+    [UsedImplicitly]
+    public class BigBlackBox : CompositeDrawable, ISkinnableDrawable
+    {
+        public bool UsesFixedAnchor { get; set; }
+
+        public BigBlackBox()
+        {
+            Size = new Vector2(150);
+
+            Masking = true;
+            CornerRadius = 20;
+            CornerExponent = 5;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = Color4.Black,
+                    RelativeSizeAxes = Axes.Both,
+                },
+
+                new OsuSpriteText
+                {
+                    Text = "Big Black Box",
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Skinning/Components/BigBlackBox.cs
+++ b/osu.Game/Skinning/Components/BigBlackBox.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using JetBrains.Annotations;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
@@ -19,6 +21,19 @@ namespace osu.Game.Skinning.Components
     {
         public bool UsesFixedAnchor { get; set; }
 
+        [SettingSource("Spin", "Should the text spin")]
+        public Bindable<bool> TextSpin { get; } = new BindableBool();
+
+        [SettingSource("Alpha", "The alpha value of this box")]
+        public BindableNumber<float> BoxAlpha { get; } = new BindableNumber<float>(1)
+        {
+            MinValue = 0,
+            MaxValue = 1,
+        };
+
+        private readonly Box box;
+        private readonly OsuSpriteText text;
+
         public BigBlackBox()
         {
             Size = new Vector2(150);
@@ -29,19 +44,32 @@ namespace osu.Game.Skinning.Components
 
             InternalChildren = new Drawable[]
             {
-                new Box
+                box = new Box
                 {
                     Colour = Color4.Black,
                     RelativeSizeAxes = Axes.Both,
                 },
-
-                new OsuSpriteText
+                text = new OsuSpriteText
                 {
                     Text = "Big Black Box",
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            BoxAlpha.BindValueChanged(alpha => box.Alpha = alpha.NewValue, true);
+            TextSpin.BindValueChanged(spin =>
+            {
+                if (spin.NewValue)
+                    text.Spin(1000, RotationDirection.Clockwise);
+                else
+                    text.ClearTransforms();
+            }, true);
         }
     }
 }

--- a/osu.Game/Skinning/Components/BigBlackBox.cs
+++ b/osu.Game/Skinning/Components/BigBlackBox.cs
@@ -7,6 +7,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
@@ -21,7 +23,7 @@ namespace osu.Game.Skinning.Components
     {
         public bool UsesFixedAnchor { get; set; }
 
-        [SettingSource("Spin", "Should the text spin")]
+        [SettingSource("Spining text", "Whether the big text should spin")]
         public Bindable<bool> TextSpin { get; } = new BindableBool();
 
         [SettingSource("Alpha", "The alpha value of this box")]
@@ -29,14 +31,16 @@ namespace osu.Game.Skinning.Components
         {
             MinValue = 0,
             MaxValue = 1,
+            Precision = 0.01f,
         };
 
         private readonly Box box;
         private readonly OsuSpriteText text;
+        private readonly OsuTextFlowContainer disclaimer;
 
         public BigBlackBox()
         {
-            Size = new Vector2(150);
+            Size = new Vector2(250);
 
             Masking = true;
             CornerRadius = 20;
@@ -54,6 +58,17 @@ namespace osu.Game.Skinning.Components
                     Text = "Big Black Box",
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Font = OsuFont.Default.With(size: 40)
+                },
+                disclaimer = new OsuTextFlowContainer(st => st.Font = OsuFont.Default.With(size: 10))
+                {
+                    Text = "This is intended to be a test component and may disappear in the future!",
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Margin = new MarginPadding(10),
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    TextAnchor = Anchor.TopCentre,
                 }
             };
         }
@@ -70,6 +85,8 @@ namespace osu.Game.Skinning.Components
                 else
                     text.ClearTransforms();
             }, true);
+
+            disclaimer.FadeOutFromOne(5000, Easing.InQuint);
         }
     }
 }

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -101,9 +101,11 @@ namespace osu.Game.Skinning.Editor
 
         private void editorVisibilityChanged(ValueChangedEvent<Visibility> visibility)
         {
+            const float toolbar_padding_requirement = 0.18f;
+
             if (visibility.NewValue == Visibility.Visible)
             {
-                target.SetCustomRect(new RectangleF(0.18f, 0.1f, VISIBLE_TARGET_SCALE, VISIBLE_TARGET_SCALE), true);
+                target.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.1f, 0.8f - toolbar_padding_requirement, 0.7f), true);
             }
             else
             {

--- a/osu.Game/Skinning/Editor/SkinSettingsToolbox.cs
+++ b/osu.Game/Skinning/Editor/SkinSettingsToolbox.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Edit;
+using osuTK;
+
+namespace osu.Game.Skinning.Editor
+{
+    internal class SkinSettingsToolbox : ScrollingToolboxGroup
+    {
+        public const float WIDTH = 200;
+
+        public SkinSettingsToolbox()
+            : base("Settings", 600)
+        {
+            RelativeSizeAxes = Axes.None;
+            Width = WIDTH;
+
+            FillFlow.Spacing = new Vector2(10);
+        }
+    }
+}

--- a/osu.Game/Skinning/ISkinnableDrawable.cs
+++ b/osu.Game/Skinning/ISkinnableDrawable.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Skinning
@@ -21,5 +24,22 @@ namespace osu.Game.Skinning
         /// If <see langword="true"/>, a fixed anchor point has been defined.
         /// </summary>
         bool UsesFixedAnchor { get; set; }
+
+        void CopyAdjustedSetting(IBindable target, object source)
+        {
+            if (source is IBindable sourceBindable)
+            {
+                // copy including transfer of default values.
+                target.BindTo(sourceBindable);
+                target.UnbindFrom(sourceBindable);
+            }
+            else
+            {
+                if (!(target is IParseable parseable))
+                    throw new InvalidOperationException($"Bindable type {target.GetType().ReadableName()} is not {nameof(IParseable)}.");
+
+                parseable.Parse(source);
+            }
+        }
     }
 }

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -1,17 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-
-#nullable enable
 
 namespace osu.Game.Utils
 {
@@ -152,39 +150,6 @@ namespace osu.Game.Utils
             }
             else
                 yield return mod;
-        }
-
-        /// <summary>
-        /// Returns the underlying value of the given mod setting object.
-        /// Used in <see cref="APIMod"/> for serialization and equality comparison purposes.
-        /// </summary>
-        /// <param name="setting">The mod setting.</param>
-        public static object GetSettingUnderlyingValue(object setting)
-        {
-            switch (setting)
-            {
-                case Bindable<double> d:
-                    return d.Value;
-
-                case Bindable<int> i:
-                    return i.Value;
-
-                case Bindable<float> f:
-                    return f.Value;
-
-                case Bindable<bool> b:
-                    return b.Value;
-
-                case IBindable u:
-                    // A mod with unknown (e.g. enum) generic type.
-                    var valueMethod = u.GetType().GetProperty(nameof(IBindable<int>.Value));
-                    Debug.Assert(valueMethod != null);
-                    return valueMethod.GetValue(u);
-
-                default:
-                    // fall back for non-bindable cases.
-                    return setting;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
This adds a new toolbox in the skin editor to show skin component settings, as well as the groundwork for allowing them to exist in the first place.

Rather than adding settings to existing skinnables, I've created a sample `BigBlackBox` to show how this can work. I'd rather add settings to existing skinnables in separate PRs, but wanted something in this PR to allow for testing. Figure there's no harm in allowing users to test this as well while we expand the system further (and gracefully remove it in the future).

- [x] Depends on https://github.com/ppy/osu/pull/17218 for conflict avoidance
- [x] Depends on https://github.com/ppy/osu/pull/17217 for conflict avoidance