### PR TITLE
Nudge osu!taiko playfield's height to perfectly match with osu!(stable)

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         /// <summary>
         /// Default height of a <see cref="TaikoPlayfield"/> when inside a <see cref="DrawableTaikoRuleset"/>.
         /// </summary>
-        public const float DEFAULT_HEIGHT = 212;
+        public const float DEFAULT_HEIGHT = 200;
 
         private Container<HitExplosion> hitExplosionContainer;
         private Container<KiaiHitExplosion> kiaiExplosionContainer;


### PR DESCRIPTION
Upon measuring between screenshots I took in stable on different aspect ratios, setting a 200px height on lazer matches 1:1 with stable.

|                  | 5:4 | 16:9 | 21:9 |
|------------------|-----|------|------|
| before (212px)   | ![image](https://user-images.githubusercontent.com/22781491/158080832-9da95fd7-f495-4f90-b372-d1e1360fcfc3.png) | ![image](https://user-images.githubusercontent.com/22781491/158080845-1e5b1774-d170-4e84-be26-643aa63fef83.png) | ![image](https://user-images.githubusercontent.com/22781491/158080874-5f73a036-68c9-4a95-a9d4-bf6616da8bf1.png) |
| after (200px)  | ![image](https://user-images.githubusercontent.com/22781491/158080908-99934f3e-67ee-4c02-8d63-ec746ac21f6b.png) | ![image](https://user-images.githubusercontent.com/22781491/158080914-85cdd5ec-d2ee-414e-9eb6-cf4933955773.png) | ![image](https://user-images.githubusercontent.com/22781491/158080926-e5d19623-6c58-45f9-b6b9-a200e6e62138.png) |
| stable               | ![image](https://user-images.githubusercontent.com/22781491/158080942-a01c3aac-2bc6-4c6a-b88b-d54053a9e025.png) | ![image](https://user-images.githubusercontent.com/22781491/158080950-99efeec5-90ae-4b92-923d-1d261a5038c0.png) | ![image](https://user-images.githubusercontent.com/22781491/158080953-4ea4962e-7ac6-467e-9b1c-79395692c264.png) |

(lazer screenshots have been done with #17225 checked out to better compare with stable)