### PR TITLE
Fix `SkinnableSprite`s in storyboards not autosizing to the textures

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -1,11 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Skinning;
@@ -21,6 +23,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Cached]
         private Storyboard storyboard { get; set; } = new Storyboard();
+
+        private IEnumerable<DrawableStoryboardSprite> sprites => this.ChildrenOfType<DrawableStoryboardSprite>();
 
         [Test]
         public void TestSkinSpriteDisallowedByDefault()
@@ -41,9 +45,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("allow skin lookup", () => storyboard.UseSkinSprites = true);
 
-            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.Centre, Vector2.Zero)));
+            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
 
             assertSpritesFromSkin(true);
+
+            AddAssert("skinnable sprite has correct size", () => sprites.Any(s => Precision.AlmostEquals(s.ChildrenOfType<SkinnableSprite>().Single().Size, new Vector2(128, 128))));
         }
 
         private DrawableStoryboardSprite createSprite(string lookupName, Anchor origin, Vector2 initialPosition)
@@ -57,7 +63,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void assertSpritesFromSkin(bool fromSkin) =>
             AddAssert($"sprites are {(fromSkin ? "from skin" : "from storyboard")}",
-                () => this.ChildrenOfType<DrawableStoryboardSprite>()
-                          .All(sprite => sprite.ChildrenOfType<SkinnableSprite>().Any() == fromSkin));
+                () => sprites.All(sprite => sprite.ChildrenOfType<SkinnableSprite>().Any() == fromSkin));
     }
 }

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -104,7 +104,13 @@ namespace osu.Game.Storyboards
                 drawable = new Sprite { Texture = textureStore.Get(storyboardPath) };
             // if the texture isn't available locally in the beatmap, some storyboards choose to source from the underlying skin lookup hierarchy.
             else if (UseSkinSprites)
-                drawable = new SkinnableSprite(path);
+            {
+                drawable = new SkinnableSprite(path)
+                {
+                    RelativeSizeAxes = Axes.None,
+                    AutoSizeAxes = Axes.Both,
+                };
+            }
 
             return drawable;
         }


### PR DESCRIPTION
Noticed while adding test cases for #17237.