### PR TITLE
Fix drawable storyboard sprites not flipping origin on negative scale

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -50,6 +51,49 @@ namespace osu.Game.Tests.Visual.Gameplay
             assertSpritesFromSkin(true);
 
             AddAssert("skinnable sprite has correct size", () => sprites.Any(s => Precision.AlmostEquals(s.ChildrenOfType<SkinnableSprite>().Single().Size, new Vector2(128, 128))));
+        }
+
+        [Test]
+        public void TestFlippedSprite()
+        {
+            const string lookup_name = "hitcircleoverlay";
+
+            AddStep("allow skin lookup", () => storyboard.UseSkinSprites = true);
+            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
+            AddStep("flip sprites", () => sprites.ForEach(s =>
+            {
+                s.FlipH = true;
+                s.FlipV = true;
+            }));
+            AddAssert("origin flipped", () => sprites.All(s => s.Origin == Anchor.BottomRight));
+        }
+
+        [Test]
+        public void TestNegativeScale()
+        {
+            const string lookup_name = "hitcircleoverlay";
+
+            AddStep("allow skin lookup", () => storyboard.UseSkinSprites = true);
+            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
+            AddStep("scale sprite", () => sprites.ForEach(s => s.VectorScale = new Vector2(-1)));
+            AddAssert("origin flipped", () => sprites.All(s => s.Origin == Anchor.BottomRight));
+        }
+
+        [Test]
+        public void TestNegativeScaleWithFlippedSprite()
+        {
+            const string lookup_name = "hitcircleoverlay";
+
+            AddStep("allow skin lookup", () => storyboard.UseSkinSprites = true);
+            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
+            AddStep("scale sprite", () => sprites.ForEach(s => s.VectorScale = new Vector2(-1)));
+            AddAssert("origin flipped", () => sprites.All(s => s.Origin == Anchor.BottomRight));
+            AddStep("flip sprites", () => sprites.ForEach(s =>
+            {
+                s.FlipH = true;
+                s.FlipV = true;
+            }));
+            AddAssert("origin back", () => sprites.All(s => s.Origin == Anchor.TopLeft));
         }
 
         private DrawableStoryboardSprite createSprite(string lookupName, Anchor origin, Vector2 initialPosition)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -1,11 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Skinning;
@@ -21,6 +23,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Cached]
         private Storyboard storyboard { get; set; } = new Storyboard();
+
+        private IEnumerable<DrawableStoryboardSprite> sprites => this.ChildrenOfType<DrawableStoryboardSprite>();
 
         [Test]
         public void TestSkinSpriteDisallowedByDefault()
@@ -41,9 +45,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("allow skin lookup", () => storyboard.UseSkinSprites = true);
 
-            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.Centre, Vector2.Zero)));
+            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
 
             assertSpritesFromSkin(true);
+
+            AddAssert("skinnable sprite has correct size", () => sprites.Any(s => Precision.AlmostEquals(s.ChildrenOfType<SkinnableSprite>().Single().Size, new Vector2(128, 128))));
         }
 
         private DrawableStoryboardSprite createSprite(string lookupName, Anchor origin, Vector2 initialPosition)
@@ -57,7 +63,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void assertSpritesFromSkin(bool fromSkin) =>
             AddAssert($"sprites are {(fromSkin ? "from skin" : "from storyboard")}",
-                () => this.ChildrenOfType<DrawableStoryboardSprite>()
-                          .All(sprite => sprite.ChildrenOfType<SkinnableSprite>().Any() == fromSkin));
+                () => sprites.All(sprite => sprite.ChildrenOfType<SkinnableSprite>().Any() == fromSkin));
     }
 }

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Textures;
@@ -70,34 +69,9 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
-        protected override Vector2 DrawScale
-            => new Vector2(FlipH ? -base.DrawScale.X : base.DrawScale.X, FlipV ? -base.DrawScale.Y : base.DrawScale.Y) * VectorScale;
+        protected override Vector2 DrawScale => new Vector2(FlipH ? -base.DrawScale.X : base.DrawScale.X, FlipV ? -base.DrawScale.Y : base.DrawScale.Y) * VectorScale;
 
-        public override Anchor Origin
-        {
-            get
-            {
-                var origin = base.Origin;
-
-                if (FlipH)
-                {
-                    if (origin.HasFlagFast(Anchor.x0))
-                        origin = Anchor.x2 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
-                    else if (origin.HasFlagFast(Anchor.x2))
-                        origin = Anchor.x0 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
-                }
-
-                if (FlipV)
-                {
-                    if (origin.HasFlagFast(Anchor.y0))
-                        origin = Anchor.y2 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));
-                    else if (origin.HasFlagFast(Anchor.y2))
-                        origin = Anchor.y0 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));
-                }
-
-                return origin;
-            }
-        }
+        public override Anchor Origin => StoryboardExtensions.AdjustOrigin(base.Origin, VectorScale, FlipH, FlipV);
 
         public override bool IsPresent
             => !float.IsNaN(DrawPosition.X) && !float.IsNaN(DrawPosition.Y) && base.IsPresent;

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -69,7 +69,8 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
-        protected override Vector2 DrawScale => new Vector2(FlipH ? -base.DrawScale.X : base.DrawScale.X, FlipV ? -base.DrawScale.Y : base.DrawScale.Y) * VectorScale;
+        protected override Vector2 DrawScale
+            => new Vector2(FlipH ? -base.DrawScale.X : base.DrawScale.X, FlipV ? -base.DrawScale.Y : base.DrawScale.Y) * VectorScale;
 
         public override Anchor Origin => StoryboardExtensions.AdjustOrigin(base.Origin, VectorScale, FlipH, FlipV);
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Storyboards.Drawables
             {
                 var origin = base.Origin;
 
-                if (FlipH)
+                if ((FlipH || VectorScale.X < 0) && !(FlipH && VectorScale.X < 0))
                 {
                     if (origin.HasFlagFast(Anchor.x0))
                         origin = Anchor.x2 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
@@ -87,7 +87,7 @@ namespace osu.Game.Storyboards.Drawables
                         origin = Anchor.x0 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
                 }
 
-                if (FlipV)
+                if ((FlipV || VectorScale.Y < 0) && !(FlipV && VectorScale.Y < 0))
                 {
                     if (origin.HasFlagFast(Anchor.y0))
                         origin = Anchor.y2 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
@@ -73,33 +72,7 @@ namespace osu.Game.Storyboards.Drawables
         protected override Vector2 DrawScale
             => new Vector2(FlipH ? -base.DrawScale.X : base.DrawScale.X, FlipV ? -base.DrawScale.Y : base.DrawScale.Y) * VectorScale;
 
-        public override Anchor Origin
-        {
-            get
-            {
-                var origin = base.Origin;
-
-                // Either flip horizontally or negative X scale, but not both.
-                if (FlipH ^ (VectorScale.X < 0))
-                {
-                    if (origin.HasFlagFast(Anchor.x0))
-                        origin = Anchor.x2 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
-                    else if (origin.HasFlagFast(Anchor.x2))
-                        origin = Anchor.x0 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
-                }
-
-                // Either flip vertically or negative Y scale, but not both.
-                if (FlipV ^ (VectorScale.Y < 0))
-                {
-                    if (origin.HasFlagFast(Anchor.y0))
-                        origin = Anchor.y2 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));
-                    else if (origin.HasFlagFast(Anchor.y2))
-                        origin = Anchor.y0 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));
-                }
-
-                return origin;
-            }
-        }
+        public override Anchor Origin => StoryboardExtensions.AdjustOrigin(base.Origin, VectorScale, FlipH, FlipV);
 
         public override bool IsPresent
             => !float.IsNaN(DrawPosition.X) && !float.IsNaN(DrawPosition.Y) && base.IsPresent;

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -79,7 +79,8 @@ namespace osu.Game.Storyboards.Drawables
             {
                 var origin = base.Origin;
 
-                if ((FlipH || VectorScale.X < 0) && !(FlipH && VectorScale.X < 0))
+                // Either flip horizontally or negative X scale, but not both.
+                if (FlipH ^ (VectorScale.X < 0))
                 {
                     if (origin.HasFlagFast(Anchor.x0))
                         origin = Anchor.x2 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
@@ -87,7 +88,8 @@ namespace osu.Game.Storyboards.Drawables
                         origin = Anchor.x0 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
                 }
 
-                if ((FlipV || VectorScale.Y < 0) && !(FlipV && VectorScale.Y < 0))
+                // Either flip vertically or negative Y scale, but not both.
+                if (FlipV ^ (VectorScale.Y < 0))
                 {
                     if (origin.HasFlagFast(Anchor.y0))
                         origin = Anchor.y2 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -104,7 +104,13 @@ namespace osu.Game.Storyboards
                 drawable = new Sprite { Texture = textureStore.Get(storyboardPath) };
             // if the texture isn't available locally in the beatmap, some storyboards choose to source from the underlying skin lookup hierarchy.
             else if (UseSkinSprites)
-                drawable = new SkinnableSprite(path);
+            {
+                drawable = new SkinnableSprite(path)
+                {
+                    RelativeSizeAxes = Axes.None,
+                    AutoSizeAxes = Axes.Both,
+                };
+            }
 
             return drawable;
         }

--- a/osu.Game/Storyboards/StoryboardExtensions.cs
+++ b/osu.Game/Storyboards/StoryboardExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics;
+using osuTK;
+
+namespace osu.Game.Storyboards
+{
+    public static class StoryboardExtensions
+    {
+        /// <summary>
+        /// Given an origin and a set of properties, adjust the origin to display the sprite/animation correctly.
+        /// </summary>
+        /// <param name="origin">The current origin.</param>
+        /// <param name="vectorScale">The vector scale.</param>
+        /// <param name="flipH">Whether the element is flipped horizontally.</param>
+        /// <param name="flipV">Whether the element is flipped vertically.</param>
+        /// <returns>The adjusted origin.</returns>
+        public static Anchor AdjustOrigin(Anchor origin, Vector2 vectorScale, bool flipH, bool flipV)
+        {
+            // Either flip horizontally or negative X scale, but not both.
+            if (flipH ^ (vectorScale.X < 0))
+            {
+                if (origin.HasFlagFast(Anchor.x0))
+                    origin = Anchor.x2 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
+                else if (origin.HasFlagFast(Anchor.x2))
+                    origin = Anchor.x0 | (origin & (Anchor.y0 | Anchor.y1 | Anchor.y2));
+            }
+
+            // Either flip vertically or negative Y scale, but not both.
+            if (flipV ^ (vectorScale.Y < 0))
+            {
+                if (origin.HasFlagFast(Anchor.y0))
+                    origin = Anchor.y2 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));
+                else if (origin.HasFlagFast(Anchor.y2))
+                    origin = Anchor.y0 | (origin & (Anchor.x0 | Anchor.x1 | Anchor.x2));
+            }
+
+            return origin;
+        }
+    }
+}


### PR DESCRIPTION
Closes #17237 

Similar to `FlipH`/`FlipV`, negative scales should flip the origin to be consistent with stable.

- [x] Depends on #17238 for tests to succeed