### PR TITLE
Fix samples not being preloaded before gameplay starts

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -2,23 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using osuTK;
-using osu.Framework.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Scoring;
-using osuTK.Graphics;
 using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -126,18 +125,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
 
             Samples.Samples = HitObject.TailSamples.Select(s => HitObject.SampleControlPoint.ApplyTo(s)).Cast<ISampleInfo>().ToArray();
-
-            var slidingSamples = new List<ISampleInfo>();
-
-            var normalSample = HitObject.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL);
-            if (normalSample != null)
-                slidingSamples.Add(HitObject.SampleControlPoint.ApplyTo(normalSample).With("sliderslide"));
-
-            var whistleSample = HitObject.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_WHISTLE);
-            if (whistleSample != null)
-                slidingSamples.Add(HitObject.SampleControlPoint.ApplyTo(whistleSample).With("sliderwhistle"));
-
-            slidingSample.Samples = slidingSamples.ToArray();
+            slidingSample.Samples = HitObject.CreateSlidingSamples().Select(s => HitObject.SampleControlPoint.ApplyTo(s)).Cast<ISampleInfo>().ToArray();
         }
 
         public override void StopAllSamples()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -74,6 +74,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue));
         }
 
+        protected override void LoadSamples()
+        {
+            // Tail models don't actually get samples, as the playback is handled by DrawableSlider.
+            // This override is only here for visibility in explaining this weird flow.
+        }
+
+        public override void PlaySamples()
+        {
+            // Tail models don't actually get samples, as the playback is handled by DrawableSlider.
+            // This override is only here for visibility in explaining this weird flow.
+        }
+
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -121,15 +121,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.LoadSamples();
 
-            var firstSample = HitObject.Samples.FirstOrDefault();
-
-            if (firstSample != null)
-            {
-                var clone = HitObject.SampleControlPoint.ApplyTo(firstSample).With("spinnerspin");
-
-                spinningSample.Samples = new ISampleInfo[] { clone };
-                spinningSample.Frequency.Value = spinning_sample_initial_frequency;
-            }
+            spinningSample.Samples = HitObject.CreateSpinningSamples().Select(s => HitObject.SampleControlPoint.ApplyTo(s)).Cast<ISampleInfo>().ToArray();
+            spinningSample.Frequency.Value = spinning_sample_initial_frequency;
         }
 
         private void updateSpinningSample(ValueChangedEvent<bool> tracking)

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -29,6 +29,23 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => throw new System.NotSupportedException($"Adjust via {nameof(RepeatCount)} instead"); // can be implemented if/when needed.
         }
 
+        public override IList<HitSampleInfo> AuxiliarySamples => CreateSlidingSamples();
+
+        public IList<HitSampleInfo> CreateSlidingSamples()
+        {
+            var slidingSamples = new List<HitSampleInfo>();
+
+            var normalSample = Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL);
+            if (normalSample != null)
+                slidingSamples.Add(normalSample.With("sliderslide"));
+
+            var whistleSample = Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_WHISTLE);
+            if (whistleSample != null)
+                slidingSamples.Add(whistleSample.With("sliderwhistle"));
+
+            return slidingSamples;
+        }
+
         private readonly Cached<Vector2> endPositionCache = new Cached<Vector2>();
 
         public override Vector2 EndPosition => endPositionCache.IsValid ? endPositionCache.Value : endPositionCache.Value = Position + this.CurvePositionAt(1);

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => throw new System.NotSupportedException($"Adjust via {nameof(RepeatCount)} instead"); // can be implemented if/when needed.
         }
 
-        public override IList<HitSampleInfo> AuxiliarySamples => CreateSlidingSamples();
+        public override IList<HitSampleInfo> AuxiliarySamples => CreateSlidingSamples().Concat(TailSamples).ToArray();
 
         public IList<HitSampleInfo> CreateSlidingSamples()
         {

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Judgements;
@@ -73,5 +77,20 @@ namespace osu.Game.Rulesets.Osu.Objects
         public override Judgement CreateJudgement() => new OsuJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+
+        public override IList<HitSampleInfo> AuxiliarySamples => CreateSpinningSamples();
+
+        public HitSampleInfo[] CreateSpinningSamples()
+        {
+            var referenceSample = Samples.FirstOrDefault();
+
+            if (referenceSample == null)
+                return Array.Empty<HitSampleInfo>();
+
+            return new[]
+            {
+                SampleControlPoint.ApplyTo(referenceSample).With("spinnerspin")
+            };
+        }
     }
 }

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -66,6 +67,12 @@ namespace osu.Game.Rulesets.Objects
                 SamplesBindable.AddRange(value);
             }
         }
+
+        /// <summary>
+        /// Any samples which may be used by this hit object that are non-standard.
+        /// This is used only to preload these samples ahead of time.
+        /// </summary>
+        public virtual IList<HitSampleInfo> AuxiliarySamples => ImmutableList<HitSampleInfo>.Empty;
 
         public SampleControlPoint SampleControlPoint = SampleControlPoint.DEFAULT;
         public DifficultyControlPoint DifficultyControlPoint = DifficultyControlPoint.DEFAULT;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -505,7 +505,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             public override bool Equals(object? obj)
                 => obj is LegacyHitSampleInfo other && Equals(other);
 
-            public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), CustomSampleBank, IsLayered);
+            public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), CustomSampleBank);
         }
 
         private class FileHitSampleInfo : LegacyHitSampleInfo, IEquatable<FileHitSampleInfo>

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -500,7 +500,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 => new LegacyHitSampleInfo(newName.GetOr(Name), newBank.GetOr(Bank), newVolume.GetOr(Volume), newCustomSampleBank.GetOr(CustomSampleBank), newIsLayered.GetOr(IsLayered));
 
             public bool Equals(LegacyHitSampleInfo? other)
-                => base.Equals(other) && CustomSampleBank == other.CustomSampleBank && IsLayered == other.IsLayered;
+                => base.Equals(other) && CustomSampleBank == other.CustomSampleBank;
 
             public override bool Equals(object? obj)
                 => obj is LegacyHitSampleInfo other && Equals(other);


### PR DESCRIPTION
Should reduce IO stutters during gameplay, especially on beatmaps with heavy custom hitsounding.

Closes https://github.com/ppy/osu/issues/17241. Can be tested with the two provided beatmaps (which both have hundreds of hitsounds) by adding a breakpoint in `Playfield.prepareSamplePool` after entering gameplay (ie. after `PlayerLoader` finishes the load sequence).

A few changes in this PR to make this work. Can be split out as dependencies but quite small and hopefully non-contentious:

## 6d6f73e016 Add overrides in `DrawableSliderTail` to explain/warn that this class never plays its own samples

Not strictly required to make this work, but is part of a flow I really could not understand while working through the tail sample playback logic. This makes things more explicit.

## 8676a2587c Add the ability for `HitObject`s to specify auxiliary samples

Used specifically for this optimisation, and nothing else (for now?).

## 4523393208 Removes `IsLayered` from `LegacyHitSampleInfo` comparison

The equality of samples is generally used to compare the sample equality, not its full properties. For instance, we don't compare `Volume` in the base implementation.

Having `IsLayered` here breaks actual usages of equality, ie. for pooling purposes.

## 39d95aa8cf Adds automatic preloading of sample pools at a `Playfield` level

This is the actual optimisation part of this PR.