### PR TITLE
Fix incorrect copied room end dates

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -334,6 +334,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                 // ID must be unset as we use this as a marker for whether this is a client-side (not-yet-created) room or not.
                 r.RoomID.Value = null;
 
+                // Null out dates because end date is not supported client-side and the settings overlay will populate a duration.
+                r.EndDate.Value = null;
+                r.Duration.Value = null;
+
                 Open(r);
 
                 joiningRoomOperation?.Dispose();


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/ppy/osu/discussions/17154#discussioncomment-2361824

[osu-web prefers `ends_at` if present](https://github.com/ppy/osu-web/blob/f246b78acfcc368adbee1a1071d2c8eea6f41590/app/Models/Multiplayer/Room.php#L490-L496), which is also returned to us by the API. Since this is a fresh room, it's supposed to not be present until the `RoomSettingsOverlay` decides its value.