### PR TITLE
Add `EditorSidebar` component

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneEditorSidebar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneEditorSidebar.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                                                 })
                                             },
                                         },
-                                        new EditorSidebarSection("Section 2")
+                                        new EditorSidebarSection("Section with a really long section header")
                                         {
                                             Child = new FillFlowContainer
                                             {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneEditorSidebar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneEditorSidebar.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays;
+using osu.Game.Screens.Edit.Components;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneEditorSidebar : OsuTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
+        [Test]
+        public void TestSidebars()
+        {
+            AddStep("Add sidebars", () =>
+            {
+                Children = new Drawable[]
+                {
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize),
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new EditorSidebar
+                                {
+                                    Children = new[]
+                                    {
+                                        new EditorSidebarSection("Section 1")
+                                        {
+                                            Child = new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Direction = FillDirection.Full,
+                                                Spacing = new Vector2(3),
+                                                ChildrenEnumerable = Enumerable.Range(0, 10).Select(_ => new Box
+                                                {
+                                                    Colour = Color4.White,
+                                                    Size = new Vector2(32),
+                                                })
+                                            },
+                                        },
+                                        new EditorSidebarSection("Section 2")
+                                        {
+                                            Child = new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Direction = FillDirection.Full,
+                                                Spacing = new Vector2(3),
+                                                ChildrenEnumerable = Enumerable.Range(0, 400).Select(_ => new Box
+                                                {
+                                                    Colour = Color4.Gray,
+                                                    Size = new Vector2(32),
+                                                })
+                                            },
+                                        },
+                                    },
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                                new EditorSidebar
+                                {
+                                    Children = new[]
+                                    {
+                                        new EditorSidebarSection("Section 1"),
+                                        new EditorSidebarSection("Section 2"),
+                                    },
+                                },
+                            }
+                        }
+                    }
+                };
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Components/EditorSidebar.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebar.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Screens/Edit/Components/EditorSidebar.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebar.cs
@@ -1,0 +1,52 @@
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.Edit.Components
+{
+    /// <summary>
+    /// A sidebar area that can be attached to the left or right edge of the screen.
+    /// Houses scrolling sectionised content.
+    /// </summary>
+    internal class EditorSidebar : Container<EditorSidebarSection>
+    {
+        private readonly Box background;
+
+        protected override Container<EditorSidebarSection> Content { get; }
+
+        public EditorSidebar()
+        {
+            Width = 250;
+            RelativeSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuScrollContainer
+                {
+                    Padding = new MarginPadding { Left = 20 },
+                    ScrollbarOverlapsContent = false,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = Content = new FillFlowContainer<EditorSidebarSection>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                    },
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            background.Colour = colourProvider.Background5;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
@@ -1,0 +1,73 @@
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Components
+{
+    public class EditorSidebarSection : Container
+    {
+        protected override Container<Drawable> Content { get; }
+
+        public EditorSidebarSection(LocalisableString sectionName)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    new SectionHeader(sectionName),
+                    Content = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                    },
+                }
+            };
+        }
+
+        public class SectionHeader : CompositeDrawable
+        {
+            private readonly LocalisableString text;
+
+            public SectionHeader(LocalisableString text)
+            {
+                this.text = text;
+
+                Margin = new MarginPadding { Vertical = 10, Horizontal = 5 };
+
+                AutoSizeAxes = Axes.Both;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                InternalChildren = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = text,
+                        Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold),
+                    },
+                    new Circle
+                    {
+                        Y = 18,
+                        Colour = colourProvider.Highlight1,
+                        Size = new Vector2(28, 2),
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
@@ -27,11 +27,10 @@ namespace osu.Game.Screens.Edit.Components
                 Children = new Drawable[]
                 {
                     new SectionHeader(sectionName),
-                    Content = new FillFlowContainer
+                    Content = new Container
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Direction = FillDirection.Vertical,
                     },
                 }
             };

--- a/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -49,24 +49,32 @@ namespace osu.Game.Screens.Edit.Components
 
                 Margin = new MarginPadding { Vertical = 10, Horizontal = 5 };
 
-                AutoSizeAxes = Axes.Both;
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
             }
 
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {
-                InternalChildren = new Drawable[]
+                InternalChild = new FillFlowContainer
                 {
-                    new OsuSpriteText
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(2),
+                    Children = new Drawable[]
                     {
-                        Text = text,
-                        Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold),
-                    },
-                    new Circle
-                    {
-                        Y = 18,
-                        Colour = colourProvider.Highlight1,
-                        Size = new Vector2(28, 2),
+                        new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold))
+                        {
+                            Text = text,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                        },
+                        new Circle
+                        {
+                            Colour = colourProvider.Highlight1,
+                            Size = new Vector2(28, 2),
+                        }
                     }
                 };
             }


### PR DESCRIPTION
As per new designs. Will eventually replace the floating toolbox displays we currently use. Intending on using this immediately in the skin editor to clean up its janky interface.

![osu Game Tests 2022-03-15 at 07 39 03](https://user-images.githubusercontent.com/191335/158329230-3e08fa2a-65d0-404e-9a7a-142b2b9688ee.png)

Note that some metrics were done via eyeballing. There's some disconnect between what can be gained from figma due to the differences in how text height is calculated.