### PR TITLE
Fix `PlaylistResultsScreen` test failures

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -53,11 +53,22 @@ namespace osu.Game.Tests.Visual.Playlists
             userScore.Statistics = new Dictionary<HitResult, int>();
 
             bindHandler();
-
-            // beatmap is required to be an actual beatmap so the scores can get their scores correctly calculated for standardised scoring.
-            // else the tests that rely on ordering will fall over.
-            Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
         });
+
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            // Existing test instances of the results screen hold a leased bindable of the beatmap,
+            // so wait for those screens to be cleaned up by the base SetUpSteps before re-assigning
+            AddStep("Create Working Beatmap", () =>
+            {
+                // Beatmap is required to be an actual beatmap so the scores can get their scores correctly calculated for standardised scoring.
+                // else the tests that rely on ordering will fall over.
+                Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
+            });
+        }
 
         [Test]
         public void TestShowWithUserScore()

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -40,32 +40,30 @@ namespace osu.Game.Tests.Visual.Playlists
         private int totalCount;
         private ScoreInfo userScore;
 
-        [SetUp]
-        public void Setup() => Schedule(() =>
-        {
-            lowestScoreId = 1;
-            highestScoreId = 1;
-            requestComplete = false;
-            totalCount = 0;
-
-            userScore = TestResources.CreateTestScoreInfo();
-            userScore.TotalScore = 0;
-            userScore.Statistics = new Dictionary<HitResult, int>();
-
-            bindHandler();
-        });
-
         [SetUpSteps]
         public override void SetUpSteps()
         {
             base.SetUpSteps();
 
-            // Existing test instances of the results screen hold a leased bindable of the beatmap,
-            // so wait for those screens to be cleaned up by the base SetUpSteps before re-assigning
-            AddStep("Create Working Beatmap", () =>
+            // Previous test instances of the results screen may still exist at this point so wait for
+            // those screens to be cleaned up by the base SetUpSteps before re-initialising test state.
+            // The the screen also holds a leased Beatmap bindable so reassigning it must happen after
+            // the screen as been exited.
+            AddStep("initialise user scores and beatmap", () =>
             {
-                // Beatmap is required to be an actual beatmap so the scores can get their scores correctly calculated for standardised scoring.
-                // else the tests that rely on ordering will fall over.
+                lowestScoreId = 1;
+                highestScoreId = 1;
+                requestComplete = false;
+                totalCount = 0;
+
+                userScore = TestResources.CreateTestScoreInfo();
+                userScore.TotalScore = 0;
+                userScore.Statistics = new Dictionary<HitResult, int>();
+
+                bindHandler();
+
+                // Beatmap is required to be an actual beatmap so the scores can get their scores correctly
+                // calculated for standardised scoring, else the tests that rely on ordering will fall over.
                 Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
             });
         }


### PR DESCRIPTION
As seen: https://github.com/ppy/osu/pull/17252/checks?check_run_id=5545717506

The `PlaylistsResultsScreen` takes a lease on the `Beatmap` bindable
when entered. During `SetUp`, the `Beatmap` bindable is reassigned but
fails in cases where an existing test instance of the screen hasn't been
exited yet. This fix moves the assignment into the `SetUpSteps` function
after `base.SetUpSteps` is called which will exit the existing screens
first.