### PR TITLE
Fix potential crash when highlighting chat messages

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Online
         private int messageIdCounter;
 
         [SetUp]
-        public void Setup()
+        public void Setup() => Schedule(() =>
         {
             if (API is DummyAPIAccess daa)
             {
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual.Online
 
                 testContainer.ChatOverlay.Show();
             });
-        }
+        });
 
         private bool dummyAPIHandleRequest(APIRequest request)
         {

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Overlays.Chat
             if (highlightedMessage.Value == null)
                 return;
 
-            var chatLine = chatLines.SingleOrDefault(c => c.Message.Equals(highlightedMessage.Value));
+            var chatLine = chatLines.FirstOrDefault(c => c.Message.Equals(highlightedMessage.Value));
             if (chatLine == null)
                 return;
 


### PR DESCRIPTION
Test failed locally in `TestPublicChannelMention`. This test seems to specify that the same message may arrive twice with the same ID, so rather than overthinking this one I propose we just use `FirstOrDefault`.

```csharp
TearDown : System.AggregateException : One or more errors occurred.
(Sequence contains more than one matching element)
  ----> System.InvalidOperationException : Sequence contains more than
one matching element
--TearDown
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean
includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout,
CancellationToken cancellationToken)
   at osu.Framework.Extensions.TaskExtensions.WaitSafely(Task task)
   at osu.Framework.Testing.TestScene.checkForErrors()
--InvalidOperationException
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source,
Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1
source, Func`2 predicate)
   at
osu.Game.Overlays.Chat.DrawableChannel.<processMessageHighlighting>b__14_0()
in
/Users/dean/Projects/osu/osu.Game/Overlays/Chat/DrawableChannel.cs:line
102
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
```

This also fixes individual tests from `TestSceneMessageNotifier` not passing.