### PR TITLE
Hide the game toolbar (and overlays) when entering the skin editor

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1184,7 +1184,7 @@ namespace osu.Game
                     BackButton.Hide();
             }
 
-            skinEditor.SetTarget((Screen)newScreen);
+            skinEditor.SetTarget((OsuScreen)newScreen);
         }
 
         private void screenPushed(IScreen lastScreen, IScreen newScreen) => screenChanged(lastScreen, newScreen);

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -49,16 +48,20 @@ namespace osu.Game.Skinning.Editor
 
         private EditorToolboxGroup settingsToolbox;
 
+        public SkinEditor()
+        {
+        }
+
         public SkinEditor(Drawable targetScreen)
         {
-            RelativeSizeAxes = Axes.Both;
-
             UpdateTargetScreen(targetScreen);
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
+            RelativeSizeAxes = Axes.Both;
+
             InternalChild = new OsuContextMenuContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -155,7 +158,7 @@ namespace osu.Game.Skinning.Editor
                 Scheduler.AddOnce(skinChanged);
             }, true);
 
-            SelectedComponents.BindCollectionChanged(selectionChanged);
+            SelectedComponents.BindCollectionChanged((_, __) => Scheduler.AddOnce(populateSettings), true);
         }
 
         public void UpdateTargetScreen(Drawable targetScreen)
@@ -163,6 +166,7 @@ namespace osu.Game.Skinning.Editor
             this.targetScreen = targetScreen;
 
             SelectedComponents.Clear();
+
             Scheduler.AddOnce(loadBlueprintContainer);
 
             void loadBlueprintContainer()
@@ -224,7 +228,7 @@ namespace osu.Game.Skinning.Editor
             SelectedComponents.Add(component);
         }
 
-        private void selectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void populateSettings()
         {
             settingsToolbox.Clear();
 

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -21,16 +21,18 @@ namespace osu.Game.Skinning.Editor
     /// </summary>
     public class SkinEditorOverlay : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
-        private readonly ScalingContainer target;
+        private readonly ScalingContainer scalingContainer;
 
         [CanBeNull]
         private SkinEditor skinEditor;
 
         public const float VISIBLE_TARGET_SCALE = 0.8f;
 
-        public SkinEditorOverlay(ScalingContainer target)
+        private Screen lastTargetScreen;
+
+        public SkinEditorOverlay(ScalingContainer scalingContainer)
         {
-            this.target = target;
+            this.scalingContainer = scalingContainer;
             RelativeSizeAxes = Axes.Both;
         }
 
@@ -77,7 +79,7 @@ namespace osu.Game.Skinning.Editor
                 return;
             }
 
-            var editor = new SkinEditor(target);
+            var editor = new SkinEditor();
             editor.State.BindValueChanged(editorVisibilityChanged);
 
             skinEditor = editor;
@@ -95,6 +97,8 @@ namespace osu.Game.Skinning.Editor
                         return;
 
                     AddInternal(editor);
+
+                    SetTarget(lastTargetScreen);
                 });
             });
         }
@@ -105,11 +109,11 @@ namespace osu.Game.Skinning.Editor
 
             if (visibility.NewValue == Visibility.Visible)
             {
-                target.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.1f, 0.8f - toolbar_padding_requirement, 0.7f), true);
+                scalingContainer.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.1f, 0.8f - toolbar_padding_requirement, 0.7f), true);
             }
             else
             {
-                target.SetCustomRect(null);
+                scalingContainer.SetCustomRect(null);
             }
         }
 
@@ -122,6 +126,8 @@ namespace osu.Game.Skinning.Editor
         /// </summary>
         public void SetTarget(Screen screen)
         {
+            lastTargetScreen = screen;
+
             if (skinEditor == null) return;
 
             skinEditor.Save();

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -84,7 +83,7 @@ namespace osu.Game.Skinning.Editor
             }
 
             var editor = new SkinEditor();
-            editor.State.BindValueChanged(editorVisibilityChanged);
+            editor.State.BindValueChanged(visibility => updateComponentVisibility());
 
             skinEditor = editor;
 
@@ -107,13 +106,13 @@ namespace osu.Game.Skinning.Editor
             });
         }
 
-        private void editorVisibilityChanged(ValueChangedEvent<Visibility> visibility)
+        private void updateComponentVisibility()
         {
             Debug.Assert(skinEditor != null);
 
             const float toolbar_padding_requirement = 0.18f;
 
-            if (visibility.NewValue == Visibility.Visible)
+            if (skinEditor.State.Value == Visibility.Visible)
             {
                 scalingContainer.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.1f, 0.8f - toolbar_padding_requirement, 0.7f), true);
 
@@ -143,6 +142,9 @@ namespace osu.Game.Skinning.Editor
             if (skinEditor == null) return;
 
             skinEditor.Save();
+
+            // ensure the toolbar is re-hidden even if a new screen decides to try and show it.
+            updateComponentVisibility();
 
             // AddOnce with parameter will ensure the newest target is loaded if there is any overlap.
             Scheduler.AddOnce(setTarget, screen);

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -3,15 +3,16 @@
 
 using System.Diagnostics;
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
+using osu.Game.Screens;
 
 namespace osu.Game.Skinning.Editor
 {
@@ -28,7 +29,10 @@ namespace osu.Game.Skinning.Editor
 
         public const float VISIBLE_TARGET_SCALE = 0.8f;
 
-        private Screen lastTargetScreen;
+        [Resolved(canBeNull: true)]
+        private OsuGame game { get; set; }
+
+        private OsuScreen lastTargetScreen;
 
         public SkinEditorOverlay(ScalingContainer scalingContainer)
         {
@@ -105,15 +109,23 @@ namespace osu.Game.Skinning.Editor
 
         private void editorVisibilityChanged(ValueChangedEvent<Visibility> visibility)
         {
+            Debug.Assert(skinEditor != null);
+
             const float toolbar_padding_requirement = 0.18f;
 
             if (visibility.NewValue == Visibility.Visible)
             {
                 scalingContainer.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.1f, 0.8f - toolbar_padding_requirement, 0.7f), true);
+
+                game?.Toolbar.Hide();
+                game?.CloseAllOverlays();
             }
             else
             {
                 scalingContainer.SetCustomRect(null);
+
+                if (lastTargetScreen?.HideOverlaysOnEnter != true)
+                    game?.Toolbar.Show();
             }
         }
 
@@ -124,7 +136,7 @@ namespace osu.Game.Skinning.Editor
         /// <summary>
         /// Set a new target screen which will be used to find skinnable components.
         /// </summary>
-        public void SetTarget(Screen screen)
+        public void SetTarget(OsuScreen screen)
         {
             lastTargetScreen = screen;
 
@@ -136,7 +148,7 @@ namespace osu.Game.Skinning.Editor
             Scheduler.AddOnce(setTarget, screen);
         }
 
-        private void setTarget(Screen target)
+        private void setTarget(OsuScreen target)
         {
             Debug.Assert(skinEditor != null);
 


### PR DESCRIPTION
The bulk of this change is ensuring that the target of `SkinEditorOverlay` is actually an `OsuScreen`. This becomes more meaningful with future PRs which (if I decide to go in that direction) give screens top-level settings that show up when no other component is selected.