### PR TITLE
Add a basic scene library to skin editor

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("reload skin editor", () =>
             {
                 skinEditor?.Expire();
-                Player.ScaleTo(SkinEditorOverlay.VISIBLE_TARGET_SCALE);
+                Player.ScaleTo(0.8f);
                 LoadComponentAsync(skinEditor = new SkinEditor(Player), Add);
             });
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -37,6 +37,7 @@ using osu.Game.Graphics.UserInterface;
 using System.Diagnostics;
 using osu.Game.Screens.Play;
 using osu.Game.Database;
+using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Select
 {
@@ -234,6 +235,10 @@ namespace osu.Game.Screens.Select
                             }
                         }
                     }
+                },
+                new SkinnableTargetContainer(SkinnableTarget.SongSelect)
+                {
+                    RelativeSizeAxes = Axes.Both,
                 },
             });
 

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -70,6 +70,14 @@ namespace osu.Game.Skinning
                 case SkinnableTargetComponent target:
                     switch (target.Target)
                     {
+                        case SkinnableTarget.SongSelect:
+                            var songSelectComponents = new SkinnableTargetComponentsContainer(container =>
+                            {
+                                // do stuff when we need to.
+                            });
+
+                            return songSelectComponents;
+
                         case SkinnableTarget.MainHUDComponents:
                             var skinnableTargetWrapper = new SkinnableTargetComponentsContainer(container =>
                             {

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -4,29 +4,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
-using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
-using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Components.Menus;
-using osu.Game.Screens.Play;
-using osu.Game.Screens.Select;
-using osuTK;
 
 namespace osu.Game.Skinning.Editor
 {
@@ -119,7 +111,7 @@ namespace osu.Game.Skinning.Editor
                             },
                         },
                     },
-                    new SceneLibrary
+                    new SkinEditorSceneLibrary
                     {
                         RelativeSizeAxes = Axes.X,
                         Y = menu_height,
@@ -314,107 +306,6 @@ namespace osu.Game.Skinning.Editor
         {
             foreach (var item in items)
                 availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item);
-        }
-
-        private class SceneLibrary : CompositeDrawable
-        {
-            public const float BUTTON_HEIGHT = 40;
-
-            private const float padding = 10;
-
-            [Resolved(canBeNull: true)]
-            private OsuGame game { get; set; }
-
-            [Resolved]
-            private IBindable<RulesetInfo> ruleset { get; set; }
-
-            public SceneLibrary()
-            {
-                Height = BUTTON_HEIGHT + padding * 2;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider overlayColourProvider)
-            {
-                InternalChildren = new Drawable[]
-                {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = overlayColourProvider.Background5,
-                    },
-                    new OsuScrollContainer(Direction.Horizontal)
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Children = new Drawable[]
-                        {
-                            new FillFlowContainer
-                            {
-                                Name = "Scene library",
-                                AutoSizeAxes = Axes.X,
-                                RelativeSizeAxes = Axes.Y,
-                                Spacing = new Vector2(padding),
-                                Padding = new MarginPadding(padding),
-                                Direction = FillDirection.Horizontal,
-                                Children = new Drawable[]
-                                {
-                                    new OsuSpriteText
-                                    {
-                                        Text = "Scene library",
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Margin = new MarginPadding(10),
-                                    },
-                                    new SceneButton
-                                    {
-                                        Text = "Song Select",
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Action = () => game?.PerformFromScreen(screen =>
-                                        {
-                                            if (screen is SongSelect)
-                                                return;
-
-                                            screen.Push(new PlaySongSelect());
-                                        }, new[] { typeof(SongSelect) })
-                                    },
-                                    new SceneButton
-                                    {
-                                        Text = "Gameplay",
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Action = () => game?.PerformFromScreen(screen =>
-                                        {
-                                            if (screen is Player)
-                                                return;
-
-                                            var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
-                                            if (replayGeneratingMod != null)
-                                                screen.Push(new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods)));
-                                        }, new[] { typeof(Player), typeof(SongSelect) })
-                                    },
-                                }
-                            },
-                        }
-                    }
-                };
-            }
-
-            private class SceneButton : OsuButton
-            {
-                public SceneButton()
-                {
-                    Width = 100;
-                    Height = BUTTON_HEIGHT;
-                }
-
-                [BackgroundDependencyLoader(true)]
-                private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
-                {
-                    BackgroundColour = overlayColourProvider?.Background3 ?? colours.Blue3;
-                    Content.CornerRadius = 5;
-                }
-            }
         }
     }
 }

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -18,11 +18,12 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Components.Menus;
-using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osuTK;
@@ -49,6 +50,9 @@ namespace osu.Game.Skinning.Editor
 
         [Resolved]
         private OsuColour colours { get; set; }
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
         private bool hasBegunMutating;
 
@@ -314,7 +318,8 @@ namespace osu.Game.Skinning.Editor
 
         private class SceneLibrary : CompositeDrawable
         {
-            public const float HEIGHT = 30;
+            public const float BUTTON_HEIGHT = 40;
+
             private const float padding = 10;
 
             [Resolved(canBeNull: true)]
@@ -325,18 +330,18 @@ namespace osu.Game.Skinning.Editor
 
             public SceneLibrary()
             {
-                Height = HEIGHT + padding * 2;
+                Height = BUTTON_HEIGHT + padding * 2;
             }
 
             [BackgroundDependencyLoader]
-            private void load()
+            private void load(OverlayColourProvider overlayColourProvider)
             {
                 InternalChildren = new Drawable[]
                 {
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = Color4Extensions.FromHex("222")
+                        Colour = overlayColourProvider.Background5,
                     },
                     new OsuScrollContainer(Direction.Horizontal)
                     {
@@ -353,11 +358,18 @@ namespace osu.Game.Skinning.Editor
                                 Direction = FillDirection.Horizontal,
                                 Children = new Drawable[]
                                 {
-                                    new PurpleTriangleButton
+                                    new OsuSpriteText
+                                    {
+                                        Text = "Scene library",
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Margin = new MarginPadding(10),
+                                    },
+                                    new SceneButton
                                     {
                                         Text = "Song Select",
-                                        Width = 100,
-                                        Height = HEIGHT,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
                                         Action = () => game?.PerformFromScreen(screen =>
                                         {
                                             if (screen is SongSelect)
@@ -366,11 +378,11 @@ namespace osu.Game.Skinning.Editor
                                             screen.Push(new PlaySongSelect());
                                         }, new[] { typeof(SongSelect) })
                                     },
-                                    new PurpleTriangleButton
+                                    new SceneButton
                                     {
                                         Text = "Gameplay",
-                                        Width = 100,
-                                        Height = HEIGHT,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
                                         Action = () => game?.PerformFromScreen(screen =>
                                         {
                                             if (screen is Player)
@@ -386,6 +398,22 @@ namespace osu.Game.Skinning.Editor
                         }
                     }
                 };
+            }
+
+            private class SceneButton : OsuButton
+            {
+                public SceneButton()
+                {
+                    Width = 100;
+                    Height = BUTTON_HEIGHT;
+                }
+
+                [BackgroundDependencyLoader(true)]
+                private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+                {
+                    BackgroundColour = overlayColourProvider?.Background3 ?? colours.Blue3;
+                    Content.CornerRadius = 5;
+                }
             }
         }
     }

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -10,14 +10,20 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Components.Menus;
+using osu.Game.Screens.OnlinePlay.Match.Components;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Select;
+using osuTK;
 
 namespace osu.Game.Skinning.Editor
 {
@@ -41,6 +47,12 @@ namespace osu.Game.Skinning.Editor
 
         [Resolved]
         private OsuColour colours { get; set; }
+
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private OsuGame game { get; set; }
 
         private bool hasBegunMutating;
 
@@ -104,6 +116,47 @@ namespace osu.Game.Skinning.Editor
                                 RelativeSizeAxes = Axes.Y,
                             },
                         },
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Y = 45,
+                        Height = 30,
+                        Name = "Scene library",
+                        Spacing = new Vector2(10),
+                        Padding = new MarginPadding(10),
+                        Direction = FillDirection.Horizontal,
+                        Children = new Drawable[]
+                        {
+                            new PurpleTriangleButton
+                            {
+                                Text = "Song Select",
+                                Width = 100,
+                                Height = 30,
+                                Action = () => game?.PerformFromScreen(screen =>
+                                {
+                                    if (screen is SongSelect)
+                                        return;
+
+                                    screen.Push(new PlaySongSelect());
+                                }, new[] { typeof(SongSelect) })
+                            },
+                            new PurpleTriangleButton
+                            {
+                                Text = "Gameplay",
+                                Width = 100,
+                                Height = 30,
+                                Action = () => game?.PerformFromScreen(screen =>
+                                {
+                                    if (screen is Player)
+                                        return;
+
+                                    var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
+                                    if (replayGeneratingMod != null)
+                                        screen.Push(new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods)));
+                                }, new[] { typeof(Player) })
+                            },
+                        }
                     },
                     new GridContainer
                     {

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -26,7 +26,6 @@ using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Skinning.Editor
 {
@@ -71,6 +70,8 @@ namespace osu.Game.Skinning.Editor
         {
             RelativeSizeAxes = Axes.Both;
 
+            const float menu_height = 40;
+
             InternalChild = new OsuContextMenuContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -78,10 +79,10 @@ namespace osu.Game.Skinning.Editor
                 {
                     new Container
                     {
-                        Name = "Top bar",
+                        Name = "Menu container",
                         RelativeSizeAxes = Axes.X,
                         Depth = float.MinValue,
-                        Height = 40,
+                        Height = menu_height,
                         Children = new Drawable[]
                         {
                             new EditorMenuBar
@@ -117,7 +118,7 @@ namespace osu.Game.Skinning.Editor
                     new SceneLibrary
                     {
                         RelativeSizeAxes = Axes.X,
-                        Y = 45,
+                        Y = menu_height,
                     },
 
                     new GridContainer
@@ -322,22 +323,26 @@ namespace osu.Game.Skinning.Editor
             [Resolved]
             private IBindable<RulesetInfo> ruleset { get; set; }
 
+            public SceneLibrary()
+            {
+                Height = HEIGHT + padding * 2;
+            }
+
             [BackgroundDependencyLoader]
             private void load()
             {
                 InternalChildren = new Drawable[]
                 {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4Extensions.FromHex("222")
+                    },
                     new OsuScrollContainer(Direction.Horizontal)
                     {
-                        RelativeSizeAxes = Axes.X,
-                        Height = HEIGHT + padding * 2,
+                        RelativeSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = Color4.Black.Opacity(0.5f)
-                            },
                             new FillFlowContainer
                             {
                                 Name = "Scene library",

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
@@ -24,6 +26,7 @@ using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Skinning.Editor
 {
@@ -47,12 +50,6 @@ namespace osu.Game.Skinning.Editor
 
         [Resolved]
         private OsuColour colours { get; set; }
-
-        [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; }
-
-        [Resolved(canBeNull: true)]
-        private OsuGame game { get; set; }
 
         private bool hasBegunMutating;
 
@@ -117,47 +114,12 @@ namespace osu.Game.Skinning.Editor
                             },
                         },
                     },
-                    new FillFlowContainer
+                    new SceneLibrary
                     {
                         RelativeSizeAxes = Axes.X,
                         Y = 45,
-                        Height = 30,
-                        Name = "Scene library",
-                        Spacing = new Vector2(10),
-                        Padding = new MarginPadding(10),
-                        Direction = FillDirection.Horizontal,
-                        Children = new Drawable[]
-                        {
-                            new PurpleTriangleButton
-                            {
-                                Text = "Song Select",
-                                Width = 100,
-                                Height = 30,
-                                Action = () => game?.PerformFromScreen(screen =>
-                                {
-                                    if (screen is SongSelect)
-                                        return;
-
-                                    screen.Push(new PlaySongSelect());
-                                }, new[] { typeof(SongSelect) })
-                            },
-                            new PurpleTriangleButton
-                            {
-                                Text = "Gameplay",
-                                Width = 100,
-                                Height = 30,
-                                Action = () => game?.PerformFromScreen(screen =>
-                                {
-                                    if (screen is Player)
-                                        return;
-
-                                    var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
-                                    if (replayGeneratingMod != null)
-                                        screen.Push(new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods)));
-                                }, new[] { typeof(Player) })
-                            },
-                        }
                     },
+
                     new GridContainer
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -226,7 +188,10 @@ namespace osu.Game.Skinning.Editor
             {
                 content.Children = new Drawable[]
                 {
-                    new SkinBlueprintContainer(targetScreen),
+                    new SkinBlueprintContainer(targetScreen)
+                    {
+                        Margin = new MarginPadding { Top = 100 },
+                    }
                 };
             }
         }
@@ -344,6 +309,79 @@ namespace osu.Game.Skinning.Editor
         {
             foreach (var item in items)
                 availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item);
+        }
+
+        private class SceneLibrary : CompositeDrawable
+        {
+            public const float HEIGHT = 30;
+            private const float padding = 10;
+
+            [Resolved(canBeNull: true)]
+            private OsuGame game { get; set; }
+
+            [Resolved]
+            private IBindable<RulesetInfo> ruleset { get; set; }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChildren = new Drawable[]
+                {
+                    new OsuScrollContainer(Direction.Horizontal)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = HEIGHT + padding * 2,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Black.Opacity(0.5f)
+                            },
+                            new FillFlowContainer
+                            {
+                                Name = "Scene library",
+                                AutoSizeAxes = Axes.X,
+                                RelativeSizeAxes = Axes.Y,
+                                Spacing = new Vector2(padding),
+                                Padding = new MarginPadding(padding),
+                                Direction = FillDirection.Horizontal,
+                                Children = new Drawable[]
+                                {
+                                    new PurpleTriangleButton
+                                    {
+                                        Text = "Song Select",
+                                        Width = 100,
+                                        Height = HEIGHT,
+                                        Action = () => game?.PerformFromScreen(screen =>
+                                        {
+                                            if (screen is SongSelect)
+                                                return;
+
+                                            screen.Push(new PlaySongSelect());
+                                        }, new[] { typeof(SongSelect) })
+                                    },
+                                    new PurpleTriangleButton
+                                    {
+                                        Text = "Gameplay",
+                                        Width = 100,
+                                        Height = HEIGHT,
+                                        Action = () => game?.PerformFromScreen(screen =>
+                                        {
+                                            if (screen is Player)
+                                                return;
+
+                                            var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
+                                            if (replayGeneratingMod != null)
+                                                screen.Push(new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods)));
+                                        }, new[] { typeof(Player), typeof(SongSelect) })
+                                    },
+                                }
+                            },
+                        }
+                    }
+                };
+            }
         }
     }
 }

--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Skinning.Editor
 
             if (skinEditor.State.Value == Visibility.Visible)
             {
-                scalingContainer.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.1f, 0.8f - toolbar_padding_requirement, 0.7f), true);
+                scalingContainer.SetCustomRect(new RectangleF(toolbar_padding_requirement, 0.2f, 0.8f - toolbar_padding_requirement, 0.7f), true);
 
                 game?.Toolbar.Hide();
                 game?.CloseAllOverlays();

--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Select;
+using osuTK;
+
+namespace osu.Game.Skinning.Editor
+{
+    public class SkinEditorSceneLibrary : CompositeDrawable
+    {
+        public const float BUTTON_HEIGHT = 40;
+
+        private const float padding = 10;
+
+        [Resolved(canBeNull: true)]
+        private OsuGame game { get; set; }
+
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; }
+
+        public SkinEditorSceneLibrary()
+        {
+            Height = BUTTON_HEIGHT + padding * 2;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider overlayColourProvider)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = overlayColourProvider.Background6,
+                },
+                new OsuScrollContainer(Direction.Horizontal)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new FillFlowContainer
+                        {
+                            Name = "Scene library",
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
+                            Spacing = new Vector2(padding),
+                            Padding = new MarginPadding(padding),
+                            Direction = FillDirection.Horizontal,
+                            Children = new Drawable[]
+                            {
+                                new OsuSpriteText
+                                {
+                                    Text = "Scene library",
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Margin = new MarginPadding(10),
+                                },
+                                new SceneButton
+                                {
+                                    Text = "Song Select",
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Action = () => game?.PerformFromScreen(screen =>
+                                    {
+                                        if (screen is SongSelect)
+                                            return;
+
+                                        screen.Push(new PlaySongSelect());
+                                    }, new[] { typeof(SongSelect) })
+                                },
+                                new SceneButton
+                                {
+                                    Text = "Gameplay",
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Action = () => game?.PerformFromScreen(screen =>
+                                    {
+                                        if (screen is Player)
+                                            return;
+
+                                        var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
+                                        if (replayGeneratingMod != null)
+                                            screen.Push(new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods)));
+                                    }, new[] { typeof(Player), typeof(SongSelect) })
+                                },
+                            }
+                        },
+                    }
+                }
+            };
+        }
+
+        private class SceneButton : OsuButton
+        {
+            public SceneButton()
+            {
+                Width = 100;
+                Height = BUTTON_HEIGHT;
+            }
+
+            [BackgroundDependencyLoader(true)]
+            private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+            {
+                BackgroundColour = overlayColourProvider?.Background3 ?? colours.Blue3;
+                Content.CornerRadius = 5;
+            }
+        }
+    }
+}

--- a/osu.Game/Skinning/SkinnableTarget.cs
+++ b/osu.Game/Skinning/SkinnableTarget.cs
@@ -5,6 +5,7 @@ namespace osu.Game.Skinning
 {
     public enum SkinnableTarget
     {
-        MainHUDComponents
+        MainHUDComponents,
+        SongSelect
     }
 }


### PR DESCRIPTION
I added a target in `SongSelect` as a temporary means of testing this out, but I may change or build on this before the next release. I have intentionally not moved the wedge there in this PR (have it on another branch) to keep things simple.

- [x] Depends on #17272 for conflict avoidance only.