### PR TITLE
Update skin editor toolbox design to suck less

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Skinning.Editor;
@@ -15,6 +17,9 @@ namespace osu.Game.Tests.Visual.Gameplay
         private SkinEditor skinEditor;
 
         protected override bool Autoplay => true;
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
         [SetUpSteps]
         public override void SetUpSteps()

--- a/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
+++ b/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Skinning.Editor
             var skinnableTypes = typeof(OsuGame).Assembly.GetTypes()
                                                 .Where(t => !t.IsInterface)
                                                 .Where(t => typeof(ISkinnableDrawable).IsAssignableFrom(t))
+                                                .OrderBy(t => t.Name)
                                                 .ToArray();
 
             foreach (var type in skinnableTypes)

--- a/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
+++ b/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
@@ -109,6 +109,9 @@ namespace osu.Game.Skinning.Editor
 
             private Container innerContainer;
 
+            private const float contracted_size = 60;
+            private const float expanded_size = 120;
+
             public ToolboxComponentButton(Drawable component)
             {
                 this.component = component;
@@ -116,7 +119,19 @@ namespace osu.Game.Skinning.Editor
                 Enabled.Value = true;
 
                 RelativeSizeAxes = Axes.X;
-                Height = 60;
+                Height = contracted_size;
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                this.Delay(300).ResizeHeightTo(expanded_size, 500, Easing.OutQuint);
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                base.OnHoverLost(e);
+                this.ResizeHeightTo(contracted_size, 500, Easing.OutQuint);
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
Some general usability/design improvements.

- Make less ugly
- Order components by name for now
- Expand toolbox component items on hover