### PR TITLE
Improve OsuManualInputManagerTestScene button clicking helper function

### DIFF
--- a/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
@@ -127,9 +127,9 @@ namespace osu.Game.Tests.Visual
             where T : Drawable
         {
             if (typeof(T) == typeof(Button))
-                AddUntilStep($"wait for {typeof(T).Name} enabled", () => (this.ChildrenOfType<T>().Single() as Button)?.Enabled.Value == true);
+                AddUntilStep($"wait for {typeof(T).Name} enabled", () => (this.ChildrenOfType<T>().Single() as ClickableContainer)?.Enabled.Value == true);
             else
-                AddUntilStep($"wait for {typeof(T).Name} enabled", () => this.ChildrenOfType<T>().Single().ChildrenOfType<Button>().Single().Enabled.Value);
+                AddUntilStep($"wait for {typeof(T).Name} enabled", () => this.ChildrenOfType<T>().Single().ChildrenOfType<ClickableContainer>().Single().Enabled.Value);
 
             AddStep($"click {typeof(T).Name}", () =>
             {


### PR DESCRIPTION
While implementing multiplayer countdown timers, I found that I couldn't click `IconButton` objects because they have an inheritance hierarchy that ends in `ClickableContainer` instead of `Button`. `Button` itself is a `ClickableContainer` so this doesn't regress existing usages.