### PR TITLE
Integrate multiplayer button implementations into the buttons themselves

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -35,8 +33,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private BeatmapManager beatmaps;
         private RulesetStore rulesets;
 
-        private IDisposable readyClickOperation;
-
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
@@ -67,23 +63,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(200, 50),
-                OnReadyClick = () =>
-                {
-                    readyClickOperation = OngoingOperationTracker.BeginOperation();
-
-                    Task.Run(async () =>
-                    {
-                        if (MultiplayerClient.IsHost && MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready)
-                        {
-                            await MultiplayerClient.StartMatch();
-                            return;
-                        }
-
-                        await MultiplayerClient.ToggleReady();
-
-                        readyClickOperation.Dispose();
-                    });
-                }
             });
         });
 
@@ -207,9 +186,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("user is ready", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.Ready);
             ClickButtonWhenEnabled<MultiplayerReadyButton>();
             AddUntilStep("user waiting for load", () => MultiplayerClient.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
-
-            AddAssert("ready button disabled", () => !button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
-            AddStep("transitioned to gameplay", () => readyClickOperation.Dispose());
 
             AddStep("finish gameplay", () =>
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -35,8 +33,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private BeatmapSetInfo importedSet;
         private BeatmapManager beatmaps;
         private RulesetStore rulesets;
-
-        private IDisposable readyClickOperation;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -77,23 +73,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(200, 50),
-                        OnReadyClick = () =>
-                        {
-                            readyClickOperation = OngoingOperationTracker.BeginOperation();
-
-                            Task.Run(async () =>
-                            {
-                                if (MultiplayerClient.IsHost && MultiplayerClient.LocalUser?.State == MultiplayerUserState.Ready)
-                                {
-                                    await MultiplayerClient.StartMatch();
-                                    return;
-                                }
-
-                                await MultiplayerClient.ToggleReady();
-
-                                readyClickOperation.Dispose();
-                            });
-                        }
                     }
                 }
             };

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -71,16 +71,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(200, 50),
-                        OnSpectateClick = () =>
-                        {
-                            readyClickOperation = OngoingOperationTracker.BeginOperation();
-
-                            Task.Run(async () =>
-                            {
-                                await MultiplayerClient.ToggleSpectate();
-                                readyClickOperation.Dispose();
-                            });
-                        }
                     },
                     readyButton = new MultiplayerReadyButton
                     {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -11,13 +10,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
     {
         private const float ready_button_width = 600;
         private const float spectate_button_width = 200;
-
-        public Action OnReadyClick
-        {
-            set => readyButton.OnReadyClick = value;
-        }
-
-        private readonly MultiplayerReadyButton readyButton;
 
         public MultiplayerMatchFooter()
         {
@@ -36,7 +28,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                             RelativeSizeAxes = Axes.Both,
                         },
                         null,
-                        readyButton = new MultiplayerReadyButton
+                        new MultiplayerReadyButton
                         {
                             RelativeSizeAxes = Axes.Both,
                         },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
@@ -17,13 +17,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             set => readyButton.OnReadyClick = value;
         }
 
-        public Action OnSpectateClick
-        {
-            set => spectateButton.OnSpectateClick = value;
-        }
-
         private readonly MultiplayerReadyButton readyButton;
-        private readonly MultiplayerSpectateButton spectateButton;
 
         public MultiplayerMatchFooter()
         {
@@ -37,7 +31,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     new Drawable[]
                     {
                         null,
-                        spectateButton = new MultiplayerSpectateButton
+                        new MultiplayerSpectateButton
                         {
                             RelativeSizeAxes = Axes.Both,
                         },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -15,11 +14,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 {
     public class MultiplayerSpectateButton : MultiplayerRoomComposite
     {
-        public Action OnSpectateClick
-        {
-            set => button.Action = value;
-        }
-
         [Resolved]
         private OngoingOperationTracker ongoingOperationTracker { get; set; }
 
@@ -37,7 +31,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 RelativeSizeAxes = Axes.Both,
                 Size = Vector2.One,
                 Enabled = { Value = true },
+                Action = onClick
             };
+        }
+
+        private void onClick()
+        {
+            var clickOperation = ongoingOperationTracker.BeginOperation();
+
+            Client.ToggleSpectate().ContinueWith(t => endOperation());
+
+            void endOperation() => clickOperation?.Dispose();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -233,7 +233,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override Drawable CreateFooter() => new MultiplayerMatchFooter
         {
             OnReadyClick = onReadyClick,
-            OnSpectateClick = onSpectateClick
         };
 
         protected override RoomSettingsOverlay CreateRoomSettingsOverlay(Room room) => new MultiplayerMatchSettingsOverlay(room);
@@ -356,20 +355,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             client.ToggleReady()
                   .ContinueWith(t => endOperation());
-
-            void endOperation()
-            {
-                readyClickOperation?.Dispose();
-                readyClickOperation = null;
-            }
-        }
-
-        private void onSpectateClick()
-        {
-            Debug.Assert(readyClickOperation == null);
-            readyClickOperation = ongoingOperationTracker.BeginOperation();
-
-            client.ToggleSpectate().ContinueWith(t => endOperation());
 
             void endOperation()
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -46,13 +44,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
-        [Resolved]
-        private OngoingOperationTracker ongoingOperationTracker { get; set; }
-
         private readonly IBindable<bool> isConnected = new Bindable<bool>();
-
-        [CanBeNull]
-        private IDisposable readyClickOperation;
 
         private AddItemButton addItemButton;
 
@@ -230,10 +222,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             this.Push(new MultiplayerMatchSongSelect(Room, itemToEdit));
         }
 
-        protected override Drawable CreateFooter() => new MultiplayerMatchFooter
-        {
-            OnReadyClick = onReadyClick,
-        };
+        protected override Drawable CreateFooter() => new MultiplayerMatchFooter();
 
         protected override RoomSettingsOverlay CreateRoomSettingsOverlay(Room room) => new MultiplayerMatchSettingsOverlay(room);
 
@@ -331,38 +320,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }
         }
 
-        private void onReadyClick()
-        {
-            Debug.Assert(readyClickOperation == null);
-            readyClickOperation = ongoingOperationTracker.BeginOperation();
-
-            if (client.IsHost && (client.LocalUser?.State == MultiplayerUserState.Ready || client.LocalUser?.State == MultiplayerUserState.Spectating))
-            {
-                client.StartMatch()
-                      .ContinueWith(t =>
-                      {
-                          // accessing Exception here silences any potential errors from the antecedent task
-                          if (t.Exception != null)
-                          {
-                              // gameplay was not started due to an exception; unblock button.
-                              endOperation();
-                          }
-
-                          // gameplay is starting, the button will be unblocked on load requested.
-                      });
-                return;
-            }
-
-            client.ToggleReady()
-                  .ContinueWith(t => endOperation());
-
-            void endOperation()
-            {
-                readyClickOperation?.Dispose();
-                readyClickOperation = null;
-            }
-        }
-
         private void onRoomUpdated()
         {
             // may happen if the client is kicked or otherwise removed from the room.
@@ -418,9 +375,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
 
             StartPlay();
-
-            readyClickOperation?.Dispose();
-            readyClickOperation = null;
         }
 
         protected override Screen CreateGameplayScreen()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomComposite.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.LoadComplete();
 
             Client.RoomUpdated += invokeOnRoomUpdated;
+            Client.LoadRequested += invokeOnRoomLoadRequested;
             Client.UserLeft += invokeUserLeft;
             Client.UserKicked += invokeUserKicked;
             Client.UserJoined += invokeUserJoined;
@@ -38,6 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private void invokeItemAdded(MultiplayerPlaylistItem item) => Schedule(() => PlaylistItemAdded(item));
         private void invokeItemRemoved(long item) => Schedule(() => PlaylistItemRemoved(item));
         private void invokeItemChanged(MultiplayerPlaylistItem item) => Schedule(() => PlaylistItemChanged(item));
+        private void invokeOnRoomLoadRequested() => Scheduler.AddOnce(OnRoomLoadRequested);
 
         /// <summary>
         /// Invoked when a user has joined the room.
@@ -91,6 +93,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// Invoked when any change occurs to the multiplayer room.
         /// </summary>
         protected virtual void OnRoomUpdated()
+        {
+        }
+
+        /// <summary>
+        /// Invoked when the room requests the local user to load into gameplay.
+        /// </summary>
+        protected virtual void OnRoomLoadRequested()
         {
         }
 


### PR DESCRIPTION
Clicks from the ready button and spectate button were being propagated all the way up to `MultiplayerMatchSubScreen`. This is messy and led to a doubling of necessary code size + weird test implementations, and is also unmanageable for when these implementations become more complex - `MultiplayerReadyButton` is going to be split into two and will contain logic for starting + cancelling countdowns.

Better to have these buttons do things rather than being dumb objects with implementations elsewhere.