### PR TITLE
Make `TestSceneLeadIn` run on a manual clock for better time comparison

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
@@ -107,7 +108,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("create player", () =>
             {
-                Beatmap.Value = CreateWorkingBeatmap(beatmap, storyboard);
+                Beatmap.Value = new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), Audio);
                 LoadScreen(player = new LeadInPlayer());
             });
 


### PR DESCRIPTION
After `TestSceneLeadIn` has changed to capture the first gameplay frame time after `GameplayClockContainer` has been processed once, there's a potential for the time to progress beyond the expected point given how `TrackVirtualManual` works currently (I've noticed a test failure for that somewhere, but I can't find it anymore as GitHub doesn't provide the ability to filter CIs by specific log messages).

This makes the test scene run on a manual clock since all that matters for testing is the seeking that has been applied before the `GameplayClockContainer` started processing.

---

Note that I currently have no clue if that's the actual solution to the test failure or there's more to that than meets the eyes (nor do I have the ability to stress-test that yet).