### PR TITLE
Add new settings for adjusting the hit error display

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -294,20 +294,20 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 case LabelStyles.Text:
                     labelEarly = new OsuSpriteText
                     {
-                        X = -1,
                         Y = -10,
                         Text = "Early",
                         Font = OsuFont.Default.With(size: 10),
+                        Height = 12,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.Centre,
                     };
 
                     labelLate = new OsuSpriteText
                     {
-                        X = -1,
                         Y = 10,
                         Text = "Late",
                         Font = OsuFont.Default.With(size: 10),
+                        Height = 12,
                         Anchor = Anchor.BottomCentre,
                         Origin = Anchor.Centre,
                     };

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         public Bindable<bool> ShowMovingAverage { get; } = new BindableBool(true);
 
         [SettingSource("Centre marker style", "How to signify the centre of the display")]
-        public Bindable<CentreMarker> CentreMarkerStyle { get; } = new Bindable<CentreMarker>(CentreMarker.Circle);
+        public Bindable<CentreMarkerStyles> CentreMarkerStyle { get; } = new Bindable<CentreMarkerStyles>(CentreMarkerStyles.Circle);
 
         private SpriteIcon arrow;
         private SpriteIcon iconEarly;
@@ -180,7 +180,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             }
         }
 
-        private void recreateCentreMarker(CentreMarker style)
+        private void recreateCentreMarker(CentreMarkerStyles style)
         {
             if (centreMarkerDrawables != null)
             {
@@ -197,10 +197,10 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
             switch (style)
             {
-                case CentreMarker.None:
+                case CentreMarkerStyles.None:
                     break;
 
-                case CentreMarker.Circle:
+                case CentreMarkerStyles.Circle:
                     centreMarkerDrawables = new Drawable[]
                     {
                         new Circle
@@ -219,11 +219,39 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Depth = float.MinValue,
-                            Size = new Vector2(centre_marker_size),
-                            Scale = new Vector2(0.5f),
+                            Size = new Vector2(centre_marker_size / 2f),
                         },
                     };
                     break;
+
+                case CentreMarkerStyles.Line:
+                    const float border_size = 1.5f;
+
+                    centreMarkerDrawables = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Name = "middle marker behind",
+                            Colour = GetColourForHitResult(hitWindows.Last().result),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Depth = float.MaxValue,
+                            Size = new Vector2(judgement_line_width, centre_marker_size / 3f),
+                        },
+                        new Box
+                        {
+                            Name = "middle marker in front",
+                            Colour = GetColourForHitResult(hitWindows.Last().result).Darken(0.3f),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Depth = float.MinValue,
+                            Size = new Vector2(judgement_line_width - border_size, centre_marker_size / 3f - border_size),
+                        },
+                    };
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style), style, null);
             }
 
             if (centreMarkerDrawables != null)
@@ -232,9 +260,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 {
                     colourBars.Add(d);
 
-                    Vector2 originalScale = d.Scale;
                     d.FadeInFromZero(500, Easing.OutQuint)
-                     .ScaleTo(0).ScaleTo(originalScale, 1000, Easing.OutElasticHalf);
+                     .ScaleTo(0).ScaleTo(1, 1000, Easing.OutElasticHalf);
                 }
             }
         }
@@ -386,10 +413,11 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
         public override void Clear() => judgementsContainer.Clear();
 
-        public enum CentreMarker
+        public enum CentreMarkerStyles
         {
             None,
-            Circle
+            Circle,
+            Line
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -294,6 +294,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 case LabelStyles.Text:
                     labelEarly = new OsuSpriteText
                     {
+                        X = -1,
                         Y = -10,
                         Text = "Early",
                         Font = OsuFont.Default.With(size: 10),
@@ -303,6 +304,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
                     labelLate = new OsuSpriteText
                     {
+                        X = -1,
                         Y = 10,
                         Text = "Late",
                         Font = OsuFont.Default.With(size: 10),

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -19,7 +21,14 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
     public class BarHitErrorMeter : HitErrorMeter
     {
         private const int judgement_line_width = 14;
-        private const int judgement_line_height = 4;
+
+        [SettingSource("Judgement line thickness", "How thick the individual lines should be.")]
+        public BindableNumber<float> JudgementLineThickness { get; } = new BindableNumber<float>(4)
+        {
+            MinValue = 1,
+            MaxValue = 8,
+            Precision = 0.1f,
+        };
 
         private SpriteIcon arrow;
         private SpriteIcon iconEarly;
@@ -255,6 +264,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
             judgementsContainer.Add(new JudgementLine
             {
+                JudgementLineThickness = { BindTarget = JudgementLineThickness },
                 Y = getRelativeJudgementPosition(judgement.TimeOffset),
                 Colour = GetColourForHitResult(judgement.Type),
             });
@@ -268,11 +278,12 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
         internal class JudgementLine : CompositeDrawable
         {
+            public readonly BindableNumber<float> JudgementLineThickness = new BindableFloat();
+
             public JudgementLine()
             {
                 RelativeSizeAxes = Axes.X;
                 RelativePositionAxes = Axes.Y;
-                Height = judgement_line_height;
 
                 Blending = BlendingParameters.Additive;
 
@@ -294,6 +305,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
                 Alpha = 0;
                 Width = 0;
+
+                JudgementLineThickness.BindValueChanged(thickness => Height = thickness.NewValue, true);
 
                 this
                     .FadeTo(0.6f, judgement_fade_in_duration, Easing.OutQuint)


### PR DESCRIPTION
Based on feedback received since the last release (with the minor design update for this component). Also the first actual settings attached to a skin component, which will give people something to play with in the skin editor until more are added.

The animation of the component on initial display is also marginally better now.

https://user-images.githubusercontent.com/191335/158967930-5f0ce6f7-0e5b-4ca0-8b57-05c0468fb062.mp4


I can split this out into multiple pull requests if required (each setting is isolated to a commit, only kept in one PR to minimise conflict resolution).