### PR TITLE
Add "bug report" GitHub issue form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -9,8 +9,7 @@ body:
         Important to note that your issue may have already been reported before. Please check:
         - Pinned issues, at the top of https://github.com/ppy/osu/issues.
         - Current open `priority:0` issues, filterable [here](https://github.com/ppy/osu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority%3A0).
-
-        And also search for your issue. If you find that it already exists, respond with a reaction or add any further information that may be helpful.
+        - And most importantly, search for your issue. If you find that it already exists, respond with a reaction or add any further information that may be helpful.
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Encountered a clear bug or crash with logs backing it? Fill it up!
+description: Report a very clearly broken issue.
 body:
   - type: markdown
     attributes:
@@ -20,9 +20,9 @@ body:
           - Cosmetic bug: something looks wrong (e.g. misaligned component, text not wrapping, etc.)
       options:
         - Crash to desktop
-        - Game behaviour bug
-        - Performance bug
-        - Cosmetic bug
+        - Game behaviour
+        - Performance
+        - Cosmetic
         - Other
     validations:
       required: true
@@ -35,14 +35,14 @@ body:
   - type: textarea
     attributes:
       label: Screenshots or videos
-      description: May also help in reproducing the encountered bug, in addition to descriptions.
+      description: Share any kind of visuals you can which show the bug or issue taking place.
       placeholder: You can attach by dragging and dropping the screenshots/videos into this box.
     validations:
       required: false
   - type: input
     attributes:
       label: Version
-      description: The version of osu!(lazer) you encountered this bug on.
+      description: The version you encountered this bug on. This is shown at the bottom of the main menu and also at the end of the settings screen.
     validations:
       required: true
   - type: markdown
@@ -66,7 +66,7 @@ body:
 
         If you have relocated your game folder, head into that location and open the `logs` folder.
 
-        Finally, select all log files and attach them in the "Logs" box below.
+        Finally, select all log files and drag them into the "Logs" box below.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -31,8 +31,8 @@ body:
   - type: textarea
     attributes:
       label: Screenshots or videos
-      description: Share any kind of visuals you can which show the bug or issue taking place.
-      placeholder: You can attach by dragging and dropping the screenshots/videos into this box.
+      description: Add screenshots or videos that show the bug here.
+      placeholder: Drag and drop the screenshots/videos into this box.
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -14,9 +14,6 @@ body:
   - type: dropdown
     attributes:
       label: Type
-      description: |
-          - Game behaviour bug: game gets into an unexpected state (e.g. incorrect scoring, wrong multiplayer room state, etc.).
-          - Cosmetic bug: something looks wrong (e.g. misaligned component, text not wrapping, etc.)
       options:
         - Crash to desktop
         - Game behaviour

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -54,11 +54,11 @@ body:
 
         **Logs are reset when you reopen the game.** If the game crashed or has been closed since you found the bug, retrieve the logs using the file explorer instead.
 
-        By default logs can be found in:
-          - `%AppData%/osu/logs` *(on Windows)*
-          - `~/.local/share/osu/logs` *(on Linux & macOS)*
-          - `Android/data/sh.ppy.osulazer/files/logs` *(on Android)*
-          - on iOS they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
+        The default places to find the logs are as follows:
+          - `%AppData%/osu/logs` *on Windows*
+          - `~/.local/share/osu/logs` *on Linux & macOS*
+          - `Android/data/sh.ppy.osulazer/files/logs` *on Android*
+          - *On iOS*, they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 
         If you have selected a custom location for the game files, you can find the `logs` folder there.
 

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -25,7 +25,7 @@ body:
   - type: textarea
     attributes:
       label: Bug description
-      description: What are the steps for reproducing the bug? Any additional details that might be of help?
+      description: How did you find the bug? Any additional details that might help?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Encountered a clear bug or crash with logs backing it? Fill it up!
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # osu! bug report
+
+        Important to note that your issue may have already been reported before. Please check:
+        - Pinned issues, at the top of https://github.com/ppy/osu/issues.
+        - Current open `priority:0` issues, filterable [here](https://github.com/ppy/osu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority%3A0).
+
+        And also search for your issue. If you find that it already exists, respond with a reaction or add any further information that may be helpful.
+
+  - type: dropdown
+    attributes:
+      label: Type
+      description: |
+          - Game behaviour bug: game gets into an unexpected state (e.g. incorrect scoring, wrong multiplayer room state, etc.).
+          - Cosmetic bug: something looks wrong (e.g. misaligned component, text not wrapping, etc.)
+      options:
+        - Crash to desktop
+        - Game behaviour bug
+        - Performance bug
+        - Cosmetic bug
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Bug description
+      description: What are the steps for reproducing the bug? Any additional details that might be of help?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Screenshots or videos
+      description: May also help in reproducing the encountered bug, in addition to descriptions.
+      placeholder: You can attach by dragging and dropping the screenshots/videos into this box.
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Version
+      description: The version of osu!(lazer) you encountered this bug on.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Logs attachments
+
+        Logs are necessary to further investigate this bug. They are reset every new game session, so you need to ensure the logs are preserved by not starting/restarting osu! after encountering the bug.
+
+        In the case this isn't a "Crash to Desktop" report, to retrieve logs:
+          1. Head on to game settings and click on "Open osu! folder"
+          2. Then open the `logs` folder located there
+
+        Otherwise, logs can *only* be retrieved via file explorer, as running the game will reset them.
+
+        Logs are, by default, located at:
+          - `%AppData%/osu/logs` *(on Windows),*
+          - `~/.local/share/osu/logs` *(on Linux & macOS).*
+          - `Android/data/sh.ppy.osulazer/files/logs` *(on Android)*,
+          - on iOS they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
+
+        If you have relocated your game folder, head into that location and open the `logs` folder.
+
+        Finally, select all log files and attach them in the "Logs" box below.
+
+  - type: textarea
+    attributes:
+      label: Logs
+      placeholder: You can attach by dragging and dropping the log files into this box.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -67,6 +67,6 @@ body:
   - type: textarea
     attributes:
       label: Logs
-      placeholder: You can attach by dragging and dropping the log files into this box.
+      placeholder: Drag and drop the log files into this box.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -44,25 +44,25 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Logs attachments
+        ## Logs
 
-        Logs are necessary to further investigate this bug. They are reset every new game session, so you need to ensure the logs are preserved by not starting/restarting osu! after encountering the bug.
+        Attaching log files is required for every reported bug. Instructions how to find the log files are listed below.
 
-        In the case this isn't a "Crash to Desktop" report, to retrieve logs:
+        If the game has not yet been closed since you found the bug:
           1. Head on to game settings and click on "Open osu! folder"
           2. Then open the `logs` folder located there
 
-        Otherwise, logs can *only* be retrieved via file explorer, as running the game will reset them.
+        If the game crashed or has been closed since you found the bug, **do not** restart the game to retrieve the logs as they will reset. You must find them using the file explorer.
 
-        Logs are, by default, located at:
+        By default logs can be found in:
           - `%AppData%/osu/logs` *(on Windows),*
           - `~/.local/share/osu/logs` *(on Linux & macOS).*
           - `Android/data/sh.ppy.osulazer/files/logs` *(on Android)*,
           - on iOS they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 
-        If you have relocated your game folder, head into that location and open the `logs` folder.
+        However, if you have selected a custom location for the game files via settings, you must find that custom folder and open the `logs` folder there.
 
-        Finally, select all log files and drag them into the "Logs" box below.
+        After locating the `logs` folder, select all log files inside and drag them into the "Logs" box below.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -46,21 +46,21 @@ body:
       value: |
         ## Logs
 
-        Attaching log files is required for every reported bug. Instructions how to find the log files are listed below.
+        Attaching log files is required for every reported bug. See instructions below on how to find them.
 
         If the game has not yet been closed since you found the bug:
           1. Head on to game settings and click on "Open osu! folder"
           2. Then open the `logs` folder located there
 
-        If the game crashed or has been closed since you found the bug, **do not** restart the game to retrieve the logs as they will reset. You must find them using the file explorer.
+        **Logs are reset when you reopen the game.** If the game crashed or has been closed since you found the bug, retrieve the logs using the file explorer instead.
 
         By default logs can be found in:
-          - `%AppData%/osu/logs` *(on Windows),*
-          - `~/.local/share/osu/logs` *(on Linux & macOS).*
-          - `Android/data/sh.ppy.osulazer/files/logs` *(on Android)*,
+          - `%AppData%/osu/logs` *(on Windows)*
+          - `~/.local/share/osu/logs` *(on Linux & macOS)*
+          - `Android/data/sh.ppy.osulazer/files/logs` *(on Android)*
           - on iOS they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 
-        However, if you have selected a custom location for the game files via settings, you must find that custom folder and open the `logs` folder there.
+        If you have selected a custom location for the game files, you can find the `logs` folder there.
 
         After locating the `logs` folder, select all log files inside and drag them into the "Logs" box below.
 


### PR DESCRIPTION
This now brings back the ability to report bugs as issue threads directly, but more stricted and using the new [GitHub issue form templates](https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/) system.

This is done with mostly bringing the basic structure in. Open for better wording and English corrections.

Can be experimented with in https://github.com/frenzibyte/osu/issues/new/choose. 