### PR TITLE
Display beatmap maximum combo next to score combo in results panel

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -133,6 +133,7 @@ namespace osu.Game.Tests.Resources
                         StarRating = diff,
                         Length = length,
                         BPM = bpm,
+                        MaxCombo = 1000,
                         Hash = Guid.NewGuid().ToString().ComputeMD5Hash(),
                         Ruleset = rulesetInfo,
                         Metadata = metadata,

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -122,19 +122,33 @@ namespace osu.Game.Rulesets.Scoring
     public static class HitResultExtensions
     {
         /// <summary>
-        /// Whether a <see cref="HitResult"/> increases/decreases the combo, and affects the combo portion of the score.
+        /// Whether a <see cref="HitResult"/> increases the combo.
         /// </summary>
-        public static bool AffectsCombo(this HitResult result)
+        public static bool IncreasesCombo(this HitResult result)
         {
             switch (result)
             {
-                case HitResult.Miss:
                 case HitResult.Meh:
                 case HitResult.Ok:
                 case HitResult.Good:
                 case HitResult.Great:
                 case HitResult.Perfect:
                 case HitResult.LargeTickHit:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> breaks the combo and resets it back to zero.
+        /// </summary>
+        public static bool BreaksCombo(this HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
                 case HitResult.LargeTickMiss:
                     return true;
 
@@ -142,6 +156,12 @@ namespace osu.Game.Rulesets.Scoring
                     return false;
             }
         }
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> increases/breaks the combo, and affects the combo portion of the score.
+        /// </summary>
+        public static bool AffectsCombo(this HitResult result)
+            => IncreasesCombo(result) || BreaksCombo(result);
 
         /// <summary>
         /// Whether a <see cref="HitResult"/> affects the accuracy portion of the score.

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -166,20 +166,10 @@ namespace osu.Game.Rulesets.Scoring
             if (!result.Type.IsScorable())
                 return;
 
-            if (result.Type.AffectsCombo())
-            {
-                switch (result.Type)
-                {
-                    case HitResult.Miss:
-                    case HitResult.LargeTickMiss:
-                        Combo.Value = 0;
-                        break;
-
-                    default:
-                        Combo.Value++;
-                        break;
-                }
-            }
+            if (result.Type.IncreasesCombo())
+                Combo.Value++;
+            else if (result.Type.BreaksCombo())
+                Combo.Value = 0;
 
             double scoreIncrease = result.Type.IsHit() ? result.Judgement.NumericResultFor(result) : 0;
 

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -65,14 +65,10 @@ namespace osu.Game.Screens.Ranking.Expanded
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
             string creator = metadata.Author.Username;
 
-            bool isPerfect = true;
-            isPerfect &= !score.Statistics.TryGetValue(HitResult.Miss, out int missCount) || missCount == 0;
-            isPerfect &= !score.Statistics.TryGetValue(HitResult.LargeTickMiss, out int largeTickMissCount) || largeTickMissCount == 0;
-
             var topStatistics = new List<StatisticDisplay>
             {
                 new AccuracyStatistic(score.Accuracy),
-                new ComboStatistic(score.MaxCombo, beatmap.MaxCombo, isPerfect),
+                new ComboStatistic(score.MaxCombo, beatmap.MaxCombo, score.Statistics.All(stat => !stat.Key.BreaksCombo() || stat.Value == 0)),
                 new PerformanceStatistic(score),
             };
 

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -65,10 +65,14 @@ namespace osu.Game.Screens.Ranking.Expanded
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
             string creator = metadata.Author.Username;
 
+            bool isPerfect = true;
+            isPerfect &= !score.Statistics.TryGetValue(HitResult.Miss, out int missCount) || missCount == 0;
+            isPerfect &= !score.Statistics.TryGetValue(HitResult.LargeTickMiss, out int largeTickMissCount) || largeTickMissCount == 0;
+
             var topStatistics = new List<StatisticDisplay>
             {
                 new AccuracyStatistic(score.Accuracy),
-                new ComboStatistic(score.MaxCombo, beatmap.MaxCombo, !score.Statistics.TryGetValue(HitResult.Miss, out int missCount) || missCount == 0),
+                new ComboStatistic(score.MaxCombo, beatmap.MaxCombo, isPerfect),
                 new PerformanceStatistic(score),
             };
 

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Ranking.Expanded
             var topStatistics = new List<StatisticDisplay>
             {
                 new AccuracyStatistic(score.Accuracy),
-                new ComboStatistic(score.MaxCombo, !score.Statistics.TryGetValue(HitResult.Miss, out int missCount) || missCount == 0),
+                new ComboStatistic(score.MaxCombo, beatmap.MaxCombo, !score.Statistics.TryGetValue(HitResult.Miss, out int missCount) || missCount == 0),
                 new PerformanceStatistic(score),
             };
 

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
@@ -25,9 +25,10 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         /// Creates a new <see cref="ComboStatistic"/>.
         /// </summary>
         /// <param name="combo">The combo to be displayed.</param>
+        /// <param name="maxCombo">The maximum value of <paramref name="combo"/>.</param>
         /// <param name="isPerfect">Whether this is a perfect combo.</param>
-        public ComboStatistic(int combo, bool isPerfect)
-            : base("combo", combo)
+        public ComboStatistic(int combo, int? maxCombo, bool isPerfect)
+            : base("combo", combo, maxCombo)
         {
             this.isPerfect = isPerfect;
         }


### PR DESCRIPTION
Addresses #17303.

![CleanShot 2022-03-18 at 13 04 38](https://user-images.githubusercontent.com/22781491/158983198-633abdc5-f2d6-40bc-b9be-f2549a337b6a.png)

While at it, this also updates the "combo perfect" check to account for `HitResult.LargeTickMiss`, as that also affects combo:
https://github.com/ppy/osu/blob/a352a140bc145f342fadc300797a2b05ade3f920/osu.Game/Rulesets/Scoring/HitResult.cs#L124-L144

Note that this is not enough to mark #15354 as resolved since "slider ticks" and "slider ends" are not calculated on legacy scores. We can however consider using `Beatmap.MaxCombo` and fall back to the miss statistics check otherwise.