### PR TITLE
Fix `SkinComponentToolbox` attempting to create instances of abstract classes

### DIFF
--- a/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
+++ b/osu.Game/Skinning/Editor/SkinComponentToolbox.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Skinning.Editor
             fill.Clear();
 
             var skinnableTypes = typeof(OsuGame).Assembly.GetTypes()
-                                                .Where(t => !t.IsInterface)
+                                                .Where(t => !t.IsInterface && !t.IsAbstract)
                                                 .Where(t => typeof(ISkinnableDrawable).IsAssignableFrom(t))
                                                 .OrderBy(t => t.Name)
                                                 .ToArray();


### PR DESCRIPTION
Was causing errors to appear when opening the skin editor in certain contexts.