### PR TITLE
Improve visual behaviour of "hold for menu" to not distract players

### DIFF
--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Screens.Play.HUD
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            positionalAdjust = Vector2.Distance(e.MousePosition, button.ToSpaceOfOtherDrawable(button.DrawRectangle.Centre, Parent)) / 200;
+            positionalAdjust = Vector2.Distance(e.MousePosition, button.ToSpaceOfOtherDrawable(button.DrawRectangle.Centre, Parent)) / 100;
             return base.OnMouseMove(e);
         }
 

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Screens.Play.HUD
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            positionalAdjust = Vector2.Distance(e.ScreenSpaceMousePosition, button.ScreenSpaceDrawQuad.Centre) / 200;
+            positionalAdjust = Vector2.Distance(e.MousePosition, button.ToSpaceOfOtherDrawable(button.DrawRectangle.Centre, Parent)) / 200;
             return base.OnMouseMove(e);
         }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -111,8 +111,11 @@ namespace osu.Game.Screens.Play
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        KeyCounter = CreateKeyCounter(),
                         HoldToQuit = CreateHoldForMenuButton(),
+                        KeyCounter = CreateKeyCounter().With(k =>
+                        {
+                            k.Margin = new MarginPadding { Horizontal = 10 };
+                        }),
                     }
                 }
             };
@@ -235,13 +238,11 @@ namespace osu.Game.Screens.Play
             {
                 PlayerSettingsOverlay.Show();
                 ModDisplay.FadeIn(200);
-                KeyCounter.Margin = new MarginPadding(10) { Bottom = 30 };
             }
             else
             {
                 PlayerSettingsOverlay.Hide();
                 ModDisplay.Delay(2000).FadeOut(200);
-                KeyCounter.Margin = new MarginPadding(10);
             }
 
             updateVisibility();

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -111,11 +111,8 @@ namespace osu.Game.Screens.Play
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
+                        KeyCounter = CreateKeyCounter(),
                         HoldToQuit = CreateHoldForMenuButton(),
-                        KeyCounter = CreateKeyCounter().With(k =>
-                        {
-                            k.Margin = new MarginPadding { Horizontal = 10 };
-                        }),
                     }
                 }
             };
@@ -238,11 +235,13 @@ namespace osu.Game.Screens.Play
             {
                 PlayerSettingsOverlay.Show();
                 ModDisplay.FadeIn(200);
+                KeyCounter.Margin = new MarginPadding(10) { Bottom = 30 };
             }
             else
             {
                 PlayerSettingsOverlay.Hide();
                 ModDisplay.Delay(2000).FadeOut(200);
+                KeyCounter.Margin = new MarginPadding(10);
             }
 
             updateVisibility();


### PR DESCRIPTION
Closes #17313 

- https://github.com/ppy/osu/commit/486be831778a6b57fdb210bfe9ce646b51c0c3b8: Calculate position adjustment distance in local parent space: 

  This fixes an issue where if the game gets downscaled, the button's visibility radius grows massively, due to the distance being calculated in screen space rather than local space.

- https://github.com/ppy/osu/commit/ad9b119e3dd85d4207c477da59ef45366936fde9: Reduce "hold for menu" visibility radius:

  | before | after |
  |:------:|:-----:|
  | ![CleanShot 2022-03-19 at 04 56 14](https://user-images.githubusercontent.com/22781491/159103530-193a186d-5e65-4e70-9dff-f3b318ed53f1.gif) | ![CleanShot 2022-03-19 at 04 57 01](https://user-images.githubusercontent.com/22781491/159103419-43f9ddea-e826-4b3a-b4a0-53a108c6fa5e.gif) |
