### PR TITLE
Improve method of retrieving beatmap maximum combo for results score panels

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -133,7 +133,6 @@ namespace osu.Game.Tests.Resources
                         StarRating = diff,
                         Length = length,
                         BPM = bpm,
-                        MaxCombo = 1000,
                         Hash = Guid.NewGuid().ToString().ComputeMD5Hash(),
                         Ruleset = rulesetInfo,
                         Metadata = metadata,

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -172,9 +172,10 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// The maximum achievable combo on this beatmap, populated for online info purposes only.
-        /// Todo: This should never be used nor exist, but is still relied on in <see cref="ScoresContainer.Scores"/> since <see cref="IBeatmapInfo"/> can't be used yet.
+        /// Todo: This should never be used nor exist, but is still relied on in <see cref="ScoresContainer.Scores"/> since <see cref="IBeatmapInfo"/> can't be used yet. For now this is obsoleted until it is removed.
         /// </summary>
         [Ignored]
+        [Obsolete("Use ScoreManager.GetMaximumAchievableComboAsync instead.")]
         public int? MaxCombo { get; set; }
 
         [Ignored]

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -9,6 +9,7 @@ using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Models;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.BeatmapSet.Scores;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using Realms;
@@ -169,6 +170,10 @@ namespace osu.Game.Beatmaps
         [Ignored]
         public APIBeatmap? OnlineInfo { get; set; }
 
+        /// <summary>
+        /// The maximum achievable combo on this beatmap, populated for online info purposes only.
+        /// Todo: This should never be used nor exist, but is still relied on in <see cref="ScoresContainer.Scores"/> since <see cref="IBeatmapInfo"/> can't be used yet.
+        /// </summary>
         [Ignored]
         public int? MaxCombo { get; set; }
 

--- a/osu.Game/Beatmaps/EFBeatmapInfo.cs
+++ b/osu.Game/Beatmaps/EFBeatmapInfo.cs
@@ -53,9 +53,6 @@ namespace osu.Game.Beatmaps
         [NotMapped]
         public APIBeatmap OnlineInfo { get; set; }
 
-        [NotMapped]
-        public int? MaxCombo { get; set; }
-
         /// <summary>
         /// The playable length in milliseconds of this beatmap.
         /// </summary>

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -295,7 +295,6 @@ namespace osu.Game.Database
                                 TimelineZoom = beatmap.TimelineZoom,
                                 Countdown = beatmap.Countdown,
                                 CountdownOffset = beatmap.CountdownOffset,
-                                MaxCombo = beatmap.MaxCombo,
                                 Bookmarks = beatmap.Bookmarks,
                                 BeatmapSet = realmBeatmapSet,
                             };

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -173,7 +173,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 {
                     Text = score.MaxCombo.ToLocalisableString(@"0\x"),
                     Font = OsuFont.GetFont(size: text_size),
+#pragma warning disable 618
                     Colour = score.MaxCombo == score.BeatmapInfo.MaxCombo ? highAccuracyColour : Color4.White
+#pragma warning restore 618
                 }
             };
 

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -78,7 +78,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 // TODO: temporary. should be removed once `OrderByTotalScore` can accept `IScoreInfo`.
                 var beatmapInfo = new BeatmapInfo
                 {
+#pragma warning disable 618
                     MaxCombo = apiBeatmap.MaxCombo,
+#pragma warning restore 618
                     Status = apiBeatmap.Status,
                     MD5Hash = apiBeatmap.MD5Hash
                 };

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Scoring
         public LocalisableString DisplayAccuracy => Accuracy.FormatAccuracy();
 
         /// <summary>
-        /// Whether this <see cref="EFScoreInfo"/> represents a legacy (osu!stable) score.
+        /// Whether this <see cref="ScoreInfo"/> represents a legacy (osu!stable) score.
         /// </summary>
         [Ignored]
         public bool IsLegacyScore => Mods.OfType<ModClassic>().Any();

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Scoring
         /// </summary>
         /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the process.</param>
-        /// <returns>The maximum achievable combo.</returns>
+        /// <returns>The maximum achievable combo. A <see langword="null"/> return value indicates the difficulty cache has failed to retrieve the combo.</returns>
         public async Task<int?> GetMaximumAchievableComboAsync([NotNull] ScoreInfo score, CancellationToken cancellationToken = default)
         {
             if (score.IsLegacyScore)

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Scoring
             if (string.IsNullOrEmpty(score.BeatmapInfo.MD5Hash))
                 return score.TotalScore;
 
-            int? beatmapMaxCombo = await GetBeatmapMaximumComboAsync(score, cancellationToken).ConfigureAwait(false);
+            int? beatmapMaxCombo = await GetMaximumAchievableComboAsync(score, cancellationToken).ConfigureAwait(false);
             if (beatmapMaxCombo == null)
                 return score.TotalScore;
 
@@ -149,12 +149,12 @@ namespace osu.Game.Scoring
         }
 
         /// <summary>
-        /// Retrieves the maximum achievable combo on the beatmap of the provided score.
+        /// Retrieves the maximum achievable combo for the provided score.
         /// </summary>
         /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the process.</param>
         /// <returns>The maximum achievable combo.</returns>
-        public async Task<int?> GetBeatmapMaximumComboAsync([NotNull] ScoreInfo score, CancellationToken cancellationToken = default)
+        public async Task<int?> GetMaximumAchievableComboAsync([NotNull] ScoreInfo score, CancellationToken cancellationToken = default)
         {
             if (score.IsLegacyScore)
             {

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -160,8 +160,10 @@ namespace osu.Game.Scoring
             {
                 // This score is guaranteed to be an osu!stable score.
                 // The combo must be determined through either the beatmap's max combo value or the difficulty calculator, as lazer's scoring has changed and the score statistics cannot be used.
+#pragma warning disable CS0618
                 if (score.BeatmapInfo.MaxCombo != null)
                     return score.BeatmapInfo.MaxCombo.Value;
+#pragma warning restore CS0618
 
                 if (difficulties == null)
                     return null;

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -134,35 +134,9 @@ namespace osu.Game.Scoring
             if (string.IsNullOrEmpty(score.BeatmapInfo.MD5Hash))
                 return score.TotalScore;
 
-            int beatmapMaxCombo;
-
-            if (score.IsLegacyScore)
-            {
-                // This score is guaranteed to be an osu!stable score.
-                // The combo must be determined through either the beatmap's max combo value or the difficulty calculator, as lazer's scoring has changed and the score statistics cannot be used.
-                if (score.BeatmapInfo.MaxCombo != null)
-                    beatmapMaxCombo = score.BeatmapInfo.MaxCombo.Value;
-                else
-                {
-                    if (difficulties == null)
-                        return score.TotalScore;
-
-                    // We can compute the max combo locally after the async beatmap difficulty computation.
-                    var difficulty = await difficulties().GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, cancellationToken).ConfigureAwait(false);
-
-                    // Something failed during difficulty calculation. Fall back to provided score.
-                    if (difficulty == null)
-                        return score.TotalScore;
-
-                    beatmapMaxCombo = difficulty.Value.MaxCombo;
-                }
-            }
-            else
-            {
-                // This is guaranteed to be a non-legacy score.
-                // The combo must be determined through the score's statistics, as both the beatmap's max combo and the difficulty calculator will provide osu!stable combo values.
-                beatmapMaxCombo = Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r.AffectsCombo()).Select(r => score.Statistics.GetValueOrDefault(r)).Sum();
-            }
+            int? beatmapMaxCombo = await GetBeatmapMaximumComboAsync(score, cancellationToken).ConfigureAwait(false);
+            if (beatmapMaxCombo == null)
+                return score.TotalScore;
 
             if (beatmapMaxCombo == 0)
                 return 0;
@@ -171,7 +145,35 @@ namespace osu.Game.Scoring
             var scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = score.Mods;
 
-            return (long)Math.Round(scoreProcessor.ComputeFinalLegacyScore(mode, score, beatmapMaxCombo));
+            return (long)Math.Round(scoreProcessor.ComputeFinalLegacyScore(mode, score, beatmapMaxCombo.Value));
+        }
+
+        /// <summary>
+        /// Retrieves the maximum achievable combo on the beatmap of the provided score.
+        /// </summary>
+        /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the process.</param>
+        /// <returns>The maximum achievable combo.</returns>
+        public async Task<int?> GetBeatmapMaximumComboAsync([NotNull] ScoreInfo score, CancellationToken cancellationToken = default)
+        {
+            if (score.IsLegacyScore)
+            {
+                // This score is guaranteed to be an osu!stable score.
+                // The combo must be determined through either the beatmap's max combo value or the difficulty calculator, as lazer's scoring has changed and the score statistics cannot be used.
+                if (score.BeatmapInfo.MaxCombo != null)
+                    return score.BeatmapInfo.MaxCombo.Value;
+
+                if (difficulties == null)
+                    return null;
+
+                // We can compute the max combo locally after the async beatmap difficulty computation.
+                var difficulty = await difficulties().GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, cancellationToken).ConfigureAwait(false);
+                return difficulty?.MaxCombo;
+            }
+
+            // This is guaranteed to be a non-legacy score.
+            // The combo must be determined through the score's statistics, as both the beatmap's max combo and the difficulty calculator will provide osu!stable combo values.
+            return Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r.AffectsCombo()).Select(r => score.Statistics.GetValueOrDefault(r)).Sum();
         }
 
         /// <summary>

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -65,10 +65,12 @@ namespace osu.Game.Screens.Ranking.Expanded
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
             string creator = metadata.Author.Username;
 
+            int? beatmapMaxCombo = scoreManager.GetBeatmapMaximumComboAsync(score).GetResultSafely();
+
             var topStatistics = new List<StatisticDisplay>
             {
                 new AccuracyStatistic(score.Accuracy),
-                new ComboStatistic(score.MaxCombo, beatmap.MaxCombo, score.Statistics.All(stat => !stat.Key.BreaksCombo() || stat.Value == 0)),
+                new ComboStatistic(score.MaxCombo, beatmapMaxCombo),
                 new PerformanceStatistic(score),
             };
 
@@ -79,8 +81,6 @@ namespace osu.Game.Screens.Ranking.Expanded
 
             statisticDisplays.AddRange(topStatistics);
             statisticDisplays.AddRange(bottomStatistics);
-
-            var starDifficulty = beatmapDifficultyCache.GetDifficultyAsync(beatmap, score.Ruleset, score.Mods).GetResultSafely();
 
             AddInternal(new FillFlowContainer
             {
@@ -223,6 +223,8 @@ namespace osu.Game.Screens.Ranking.Expanded
 
             if (score.Date != default)
                 AddInternal(new PlayedOnText(score.Date));
+
+            var starDifficulty = beatmapDifficultyCache.GetDifficultyAsync(beatmap, score.Ruleset, score.Mods).GetResultSafely();
 
             if (starDifficulty != null)
             {

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Ranking.Expanded
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
             string creator = metadata.Author.Username;
 
-            int? beatmapMaxCombo = scoreManager.GetBeatmapMaximumComboAsync(score).GetResultSafely();
+            int? beatmapMaxCombo = scoreManager.GetMaximumAchievableComboAsync(score).GetResultSafely();
 
             var topStatistics = new List<StatisticDisplay>
             {

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
@@ -26,11 +26,10 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         /// </summary>
         /// <param name="combo">The combo to be displayed.</param>
         /// <param name="maxCombo">The maximum value of <paramref name="combo"/>.</param>
-        /// <param name="isPerfect">Whether this is a perfect combo.</param>
-        public ComboStatistic(int combo, int? maxCombo, bool isPerfect)
+        public ComboStatistic(int combo, int? maxCombo)
             : base("combo", combo, maxCombo)
         {
-            this.isPerfect = isPerfect;
+            isPerfect = combo == maxCombo;
         }
 
         public override void Appear()


### PR DESCRIPTION
Closes #17347 
Closes #13238 

Preliminarily, this adds an explicit todo on `BeatmapInfo.MaxCombo` to never use it, I was under the thought it gets populated properly since I've seen no todo on it, but alas.

Since `StarDifficulty.MaxCombo` can't always be relied on due to being valid for stable/legacy scores only, I've exposed the local logic `GetTotalScoreAsync` has for computing max combo to its own `GetMaximumAchievableComboAsync` method and used it instead.

In turn, this resolves the long standing issue of "Perfect" incorrectly displaying on non-FC legacy scores (#13238), by comparing against the computed maximum combo instead.

| lazer | classic | stable |
|-------|---------|--------|
| ![CleanShot 2022-03-20 at 06 04 43](https://user-images.githubusercontent.com/22781491/159146242-8b3f616c-8744-4e8b-9735-2e204fa86b9a.png) | ![CleanShot 2022-03-20 at 06 05 34](https://user-images.githubusercontent.com/22781491/159146265-9137f858-1703-43af-9b77-8bca7a39d768.png) | ![CleanShot 2022-03-20 at 06 06 26](https://user-images.githubusercontent.com/22781491/159146297-daaca92c-c85c-4120-92c7-bb4f53056525.png) |