### PR TITLE
Add osu-stable install path for Arch Linux

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -76,6 +76,10 @@ namespace osu.Desktop
             stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".osu");
             if (checkExists(stableInstallPath))
                 return stableInstallPath;
+                
+            stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "osu-stable");
+            if (checkExists(stableInstallPath))
+                return stableInstallPath;
 
             return null;
         }


### PR DESCRIPTION
Arch Linux has an unofficial aur package `osu` for the regular version of osu, that installs into the osu-stable folder in $HOME/.local/share/osu-stable. This patch (even though made with Github's web editor), has been tested locally and is confirmed working.