### PR TITLE
Fix loading player via skin editor still allowing changing current audio track

### DIFF
--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Skinning.Editor
 
                                         var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
                                         if (replayGeneratingMod != null)
-                                            screen.Push(new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods)));
+                                            screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods))));
                                     }, new[] { typeof(Player), typeof(SongSelect) })
                                 },
                             }


### PR DESCRIPTION
`PlayerLoader` is required in the sequence to get the game into the
correct state for gameplay right now. Applying ths simplest fix here.

Closes https://github.com/ppy/osu/issues/17351.