### PR TITLE
Add hold-to-confirm flow for discarding editor changes

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -13,6 +13,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Database;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Osu;
@@ -23,6 +24,7 @@ using osu.Game.Screens.Edit.Setup;
 using osu.Game.Storyboards;
 using osu.Game.Tests.Resources;
 using osuTK;
+using osuTK.Input;
 using SharpCompress.Archives;
 using SharpCompress.Archives.Zip;
 
@@ -63,13 +65,19 @@ namespace osu.Game.Tests.Visual.Editing
             EditorBeatmap editorBeatmap = null;
 
             AddStep("store editor beatmap", () => editorBeatmap = EditorBeatmap);
-            AddStep("exit without save", () =>
+
+            AddStep("exit without save", () => Editor.Exit());
+            AddStep("hold to confirm", () =>
             {
-                Editor.Exit();
-                DialogOverlay.CurrentDialog.PerformOkAction();
+                var confirmButton = DialogOverlay.CurrentDialog.ChildrenOfType<PopupDialogDangerousButton>().First();
+
+                InputManager.MoveMouseTo(confirmButton);
+                InputManager.PressButton(MouseButton.Left);
             });
 
             AddUntilStep("wait for exit", () => !Editor.IsCurrentScreen());
+            AddStep("release", () => InputManager.ReleaseButton(MouseButton.Left));
+
             AddAssert("new beatmap not persisted", () => beatmapManager.QueryBeatmapSet(s => s.ID == editorBeatmap.BeatmapInfo.BeatmapSet.ID)?.Value.DeletePending == true);
         }
 

--- a/osu.Game.Tests/Visual/UserInterface/TestScenePopupDialog.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestScenePopupDialog.cs
@@ -40,6 +40,10 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         Text = @"You're a fake!",
                     },
+                    new PopupDialogDangerousButton
+                    {
+                        Text = @"Careful with this one..",
+                    },
                 };
             }
         }

--- a/osu.Game/Graphics/Containers/HoldToConfirmContainer.cs
+++ b/osu.Game/Graphics/Containers/HoldToConfirmContainer.cs
@@ -28,6 +28,14 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         protected virtual bool AllowMultipleFires => false;
 
+        /// <summary>
+        /// Specify a custom activation delay, overriding the game-wide user setting.
+        /// </summary>
+        /// <remarks>
+        /// This should be used in special cases where we want to be extra sure the user knows what they are doing. An example is when changes would be lost.
+        /// </remarks>
+        protected virtual double? HoldActivationDelay => null;
+
         public Bindable<double> Progress = new BindableDouble();
 
         private Bindable<double> holdActivationDelay;
@@ -35,7 +43,9 @@ namespace osu.Game.Graphics.Containers
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            holdActivationDelay = config.GetBindable<double>(OsuSetting.UIHoldActivationDelay);
+            holdActivationDelay = HoldActivationDelay != null
+                ? new Bindable<double>(HoldActivationDelay.Value)
+                : config.GetBindable<double>(OsuSetting.UIHoldActivationDelay);
         }
 
         protected void BeginConfirm()

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -45,8 +45,9 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
+        protected readonly Container ColourContainer;
+
         private readonly Container backgroundContainer;
-        private readonly Container colourContainer;
         private readonly Container glowContainer;
         private readonly Box leftGlow;
         private readonly Box centerGlow;
@@ -113,7 +114,7 @@ namespace osu.Game.Graphics.UserInterface
                     Masking = true,
                     Children = new Drawable[]
                     {
-                        colourContainer = new Container
+                        ColourContainer = new Container
                         {
                             RelativeSizeAxes = Axes.Both,
                             Origin = Anchor.Centre,
@@ -182,7 +183,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 buttonColour = value;
                 updateGlow();
-                colourContainer.Colour = value;
+                ColourContainer.Colour = value;
             }
         }
 
@@ -230,11 +231,11 @@ namespace osu.Game.Graphics.UserInterface
                 Alpha = 0.05f
             };
 
-            colourContainer.Add(flash);
+            ColourContainer.Add(flash);
             flash.FadeOutFromOne(100).Expire();
 
             clickAnimating = true;
-            colourContainer.ResizeWidthTo(colourContainer.Width * 1.05f, 100, Easing.OutQuint)
+            ColourContainer.ResizeWidthTo(ColourContainer.Width * 1.05f, 100, Easing.OutQuint)
                            .OnComplete(_ =>
                            {
                                clickAnimating = false;
@@ -246,14 +247,14 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            colourContainer.ResizeWidthTo(hover_width * 0.98f, click_duration * 4, Easing.OutQuad);
+            ColourContainer.ResizeWidthTo(hover_width * 0.98f, click_duration * 4, Easing.OutQuad);
             return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
             if (State == SelectionState.Selected)
-                colourContainer.ResizeWidthTo(hover_width, click_duration, Easing.In);
+                ColourContainer.ResizeWidthTo(hover_width, click_duration, Easing.In);
             base.OnMouseUp(e);
         }
 
@@ -279,12 +280,12 @@ namespace osu.Game.Graphics.UserInterface
             if (newState == SelectionState.Selected)
             {
                 spriteText.TransformSpacingTo(hoverSpacing, hover_duration, Easing.OutElastic);
-                colourContainer.ResizeWidthTo(hover_width, hover_duration, Easing.OutElastic);
+                ColourContainer.ResizeWidthTo(hover_width, hover_duration, Easing.OutElastic);
                 glowContainer.FadeIn(hover_duration, Easing.OutQuint);
             }
             else
             {
-                colourContainer.ResizeWidthTo(idle_width, hover_duration, Easing.OutElastic);
+                ColourContainer.ResizeWidthTo(idle_width, hover_duration, Easing.OutElastic);
                 spriteText.TransformSpacingTo(Vector2.Zero, hover_duration, Easing.OutElastic);
                 glowContainer.FadeOut(hover_duration, Easing.OutQuint);
             }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -219,7 +219,12 @@ namespace osu.Game.Overlays.Dialog
         /// <summary>
         /// Programmatically clicks the first <see cref="PopupDialogOkButton"/>.
         /// </summary>
-        public void PerformOkAction() => Buttons.OfType<PopupDialogOkButton>().First().TriggerClick();
+        public void PerformOkAction() => PerformAction<PopupDialogOkButton>();
+
+        /// <summary>
+        /// Programmatically clicks the first button of the provided type.
+        /// </summary>
+        public void PerformAction<T>() where T : PopupDialogButton => Buttons.OfType<T>().First().TriggerClick();
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {

--- a/osu.Game/Overlays/Dialog/PopupDialogDangerousButton.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialogDangerousButton.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Overlays.Dialog
+{
+    public class PopupDialogDangerousButton : PopupDialogButton
+    {
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            ButtonColour = colours.Red3;
+
+            ColourContainer.Add(new ConfirmFillBox
+            {
+                Action = () => Action(),
+                RelativeSizeAxes = Axes.Both,
+                Blending = BlendingParameters.Additive,
+            });
+        }
+
+        private class ConfirmFillBox : HoldToConfirmContainer
+        {
+            private Box box;
+
+            protected override double? HoldActivationDelay => 500;
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Child = box = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+
+                Progress.BindValueChanged(progress => box.Width = (float)progress.NewValue, true);
+            }
+
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                BeginConfirm();
+                return true;
+            }
+
+            protected override void OnMouseUp(MouseUpEvent e)
+            {
+                if (!e.HasAnyButtonPressed)
+                    AbortConfirm();
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -28,6 +28,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
@@ -598,7 +599,7 @@ namespace osu.Game.Screens.Edit
                 // if the dialog is already displayed, confirm exit with no save.
                 if (dialogOverlay.CurrentDialog is PromptForSaveDialog saveDialog)
                 {
-                    saveDialog.PerformOkAction();
+                    saveDialog.PerformAction<PopupDialogDangerousButton>();
                     return true;
                 }
 

--- a/osu.Game/Screens/Edit/PromptForSaveDialog.cs
+++ b/osu.Game/Screens/Edit/PromptForSaveDialog.cs
@@ -17,12 +17,12 @@ namespace osu.Game.Screens.Edit
 
             Buttons = new PopupDialogButton[]
             {
-                new PopupDialogCancelButton
+                new PopupDialogOkButton
                 {
                     Text = @"Save my masterpiece!",
                     Action = saveAndExit
                 },
-                new PopupDialogOkButton
+                new PopupDialogDangerousButton
                 {
                     Text = @"Forget all changes",
                     Action = exit


### PR DESCRIPTION
Addresses feedback in https://github.com/ppy/osu/discussions/17363. Note that this intentionally only applies to the click flow, and not the associated hotkey dismissal methods as it's much easier to accidentally click the discard button.

https://user-images.githubusercontent.com/191335/159217787-9efbcde7-dfca-4460-abae-04e64c2f59ee.mp4


