### PR TITLE
Disallow exiting the editor without saving (unless explicitly confirming)

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -18,6 +18,13 @@ namespace osu.Game.Tests.Visual.Editing
     public class TestSceneEditorSaving : EditorSavingTestScene
     {
         [Test]
+        public void TestCantExitWithoutSaving()
+        {
+            AddRepeatStep("Exit", () => InputManager.Key(Key.Escape), 10);
+            AddAssert("Editor is still active screen", () => Game.ScreenStack.CurrentScreen is Editor);
+        }
+
+        [Test]
         public void TestMetadata()
         {
             AddStep("Set artist and title", () =>

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -28,7 +28,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Screens.Edit
 
         private bool canSave;
 
-        private bool exitConfirmed;
+        protected bool ExitConfirmed { get; private set; }
 
         private string lastSavedHash;
 
@@ -587,7 +587,7 @@ namespace osu.Game.Screens.Edit
 
         public override bool OnExiting(IScreen next)
         {
-            if (!exitConfirmed)
+            if (!ExitConfirmed)
             {
                 // dialog overlay may not be available in visual tests.
                 if (dialogOverlay == null)
@@ -596,12 +596,9 @@ namespace osu.Game.Screens.Edit
                     return true;
                 }
 
-                // if the dialog is already displayed, confirm exit with no save.
+                // if the dialog is already displayed, block exiting until the user explicitly makes a decision.
                 if (dialogOverlay.CurrentDialog is PromptForSaveDialog saveDialog)
-                {
-                    saveDialog.PerformAction<PopupDialogDangerousButton>();
                     return true;
-                }
 
                 if (isNewBeatmap || HasUnsavedChanges)
                 {
@@ -646,7 +643,7 @@ namespace osu.Game.Screens.Edit
         {
             Save();
 
-            exitConfirmed = true;
+            ExitConfirmed = true;
             this.Exit();
         }
 
@@ -669,7 +666,7 @@ namespace osu.Game.Screens.Edit
                 Beatmap.SetDefault();
             }
 
-            exitConfirmed = true;
+            ExitConfirmed = true;
             this.Exit();
         }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -596,7 +596,7 @@ namespace osu.Game.Screens.Edit
                 }
 
                 // if the dialog is already displayed, block exiting until the user explicitly makes a decision.
-                if (dialogOverlay.CurrentDialog is PromptForSaveDialog saveDialog)
+                if (dialogOverlay.CurrentDialog is PromptForSaveDialog)
                     return true;
 
                 if (isNewBeatmap || HasUnsavedChanges)

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -97,6 +97,7 @@ namespace osu.Game.Tests.Visual
         protected class TestEditor : Editor
         {
             [Resolved(canBeNull: true)]
+            [CanBeNull]
             private DialogOverlay dialogOverlay { get; set; }
 
             public new void Undo() => base.Undo();
@@ -120,7 +121,7 @@ namespace osu.Game.Tests.Visual
             public override bool OnExiting(IScreen next)
             {
                 // For testing purposes allow the screen to exit without saving on second attempt.
-                if (!ExitConfirmed && dialogOverlay.CurrentDialog is PromptForSaveDialog saveDialog)
+                if (!ExitConfirmed && dialogOverlay?.CurrentDialog is PromptForSaveDialog saveDialog)
                 {
                     saveDialog.PerformAction<PopupDialogDangerousButton>();
                     return true;

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -7,10 +7,13 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
+using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit;
@@ -93,6 +96,9 @@ namespace osu.Game.Tests.Visual
 
         protected class TestEditor : Editor
         {
+            [Resolved(canBeNull: true)]
+            private DialogOverlay dialogOverlay { get; set; }
+
             public new void Undo() => base.Undo();
 
             public new void Redo() => base.Redo();
@@ -110,6 +116,18 @@ namespace osu.Game.Tests.Visual
             public new void CreateNewDifficulty(RulesetInfo rulesetInfo) => base.CreateNewDifficulty(rulesetInfo);
 
             public new bool HasUnsavedChanges => base.HasUnsavedChanges;
+
+            public override bool OnExiting(IScreen next)
+            {
+                // For testing purposes allow the screen to exit without saving on second attempt.
+                if (!ExitConfirmed && dialogOverlay.CurrentDialog is PromptForSaveDialog saveDialog)
+                {
+                    saveDialog.PerformAction<PopupDialogDangerousButton>();
+                    return true;
+                }
+
+                return base.OnExiting(next);
+            }
 
             public TestEditor(EditorLoader loader = null)
                 : base(loader)


### PR DESCRIPTION
Pressing alt-f4 multiple times will no longer cause the editor to exit without saving changes. The behaviour here matches windows (11) and macOS UX, where the dialog remains present no matter how many times you attempt to exit. Previous versions of windows would cycle display of the dialog for each alt-f4 press but I think keeping it present feels better.

- [x] Depends on #17384.