### PR TITLE
Add C# extension to recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp"
+    ]
+}


### PR DESCRIPTION
The [official C# extension] is maintained by Microsoft and enables IDE-like support for C# in VS Code.

If a user opens this repository in VS Code, they will be prompted to install it if they haven't already installed it. After installation, the extension will also prompt the user to install the .NET SDK if it's not found.

[official C# extension]: https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp