### PR TITLE
Guard against potential null `CurrentItem` in `ParticipantPanel`

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -171,6 +171,8 @@ namespace osu.Game.Online.Multiplayer
                     Room = joinedRoom;
                     APIRoom = room;
 
+                    Debug.Assert(joinedRoom.Playlist.Count > 0);
+
                     APIRoom.Playlist.Clear();
                     APIRoom.Playlist.AddRange(joinedRoom.Playlist.Select(createPlaylistItem));
 
@@ -682,6 +684,8 @@ namespace osu.Game.Online.Multiplayer
 
                 Room.Playlist.Remove(Room.Playlist.Single(existing => existing.ID == playlistItemId));
                 APIRoom.Playlist.RemoveAll(existing => existing.ID == playlistItemId);
+
+                Debug.Assert(Room.Playlist.Count > 0);
 
                 ItemRemoved?.Invoke(playlistItemId);
                 RoomUpdated?.Invoke();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -187,8 +186,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             const double fade_time = 50;
 
             var currentItem = Playlist.GetCurrentItem();
-            Debug.Assert(currentItem != null);
-
             var ruleset = currentItem != null ? rulesets.GetRuleset(currentItem.RulesetID)?.CreateInstance() : null;
 
             int? currentModeRank = ruleset != null ? User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.GlobalRank : null;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             var currentItem = Playlist.GetCurrentItem();
             Debug.Assert(currentItem != null);
 
-            var ruleset = rulesets.GetRuleset(currentItem.RulesetID)?.CreateInstance();
+            var ruleset = currentItem != null ? rulesets.GetRuleset(currentItem.RulesetID)?.CreateInstance() : null;
 
             int? currentModeRank = ruleset != null ? User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.GlobalRank : null;
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;


### PR DESCRIPTION
Should fix the crash reported in https://github.com/ppy/osu/issues/12939#issuecomment-1077372689.

Note that I've added `Debug.Assert`s at the point where the playlist could be in an incorrect state. I've intentionally left them as debug-early as I don't want to induce more client-side crashes in the wild. Can reconsider making this noisier if it is seen as an important issue (or if fixing this one case leads to more similar issues elsewhere). Alternative would be to `Logger.Error()` and wait for errors to arrive via sentry or user reports.