### PR TITLE
Allow realm subscriptions to be initiated from any thread

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.314.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.325.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.325.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tournament.Screens.Setup
             dropdown.Current.BindValueChanged(v => Button.Enabled.Value = v.NewValue != startupTournament, true);
 
             Action = () => game.GracefullyExit();
-            folderButton.Action = storage.PresentExternally;
+            folderButton.Action = () => storage.PresentExternally();
 
             ButtonText = "Close osu!";
         }

--- a/osu.Game/IO/WrappedStorage.cs
+++ b/osu.Game/IO/WrappedStorage.cs
@@ -70,9 +70,9 @@ namespace osu.Game.IO
         public override Stream GetStream(string path, FileAccess access = FileAccess.Read, FileMode mode = FileMode.OpenOrCreate) =>
             UnderlyingStorage.GetStream(MutatePath(path), access, mode);
 
-        public override void OpenFileExternally(string filename) => UnderlyingStorage.OpenFileExternally(MutatePath(filename));
+        public override bool OpenFileExternally(string filename) => UnderlyingStorage.OpenFileExternally(MutatePath(filename));
 
-        public override void PresentFileExternally(string filename) => UnderlyingStorage.PresentFileExternally(MutatePath(filename));
+        public override bool PresentFileExternally(string filename) => UnderlyingStorage.PresentFileExternally(MutatePath(filename));
 
         public override Storage GetStorageForDirectory(string path)
         {

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -200,7 +200,7 @@ namespace osu.Game
             if (Storage.Exists(DatabaseContextFactory.DATABASE_NAME))
                 dependencies.Cache(EFContextFactory = new DatabaseContextFactory(Storage));
 
-            dependencies.Cache(realm = new RealmAccess(Storage, "client", EFContextFactory));
+            dependencies.Cache(realm = new RealmAccess(Storage, "client", Host.UpdateThread, EFContextFactory));
 
             dependencies.CacheAs<RulesetStore>(RulesetStore = new RealmRulesetStore(realm, Storage));
             dependencies.CacheAs<IRulesetStore>(RulesetStore);

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 Add(new SettingsButton
                 {
                     Text = GeneralSettingsStrings.OpenOsuFolder,
-                    Action = storage.PresentExternally,
+                    Action = () => storage.PresentExternally(),
                 });
 
                 Add(new SettingsButton

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.325.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.314.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.325.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.314.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.325.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.314.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.325.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.325.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.304.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Prerequisite to having skin realm-backed stores refreshing their file lookup cache for future skin editor improvements.

- [x] Depends on https://github.com/ppy/osu-framework/pull/5079

Usage can be seen on this WIP branch https://github.com/ppy/osu/compare/master...peppy:skin-editor-sprites?expand=1  