### PR TITLE
Fix game unexpectedly exiting without outro sequence occasionally on macOS

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -79,10 +79,10 @@ namespace osu.Game.Screens.Menu
 
         private readonly ButtonArea buttonArea;
 
-        private readonly Button backButton;
+        private readonly MainMenuButton backButton;
 
-        private readonly List<Button> buttonsTopLevel = new List<Button>();
-        private readonly List<Button> buttonsPlay = new List<Button>();
+        private readonly List<MainMenuButton> buttonsTopLevel = new List<MainMenuButton>();
+        private readonly List<MainMenuButton> buttonsPlay = new List<MainMenuButton>();
 
         private Sample sampleBack;
 
@@ -100,8 +100,8 @@ namespace osu.Game.Screens.Menu
 
             buttonArea.AddRange(new Drawable[]
             {
-                new Button(ButtonSystemStrings.Settings, string.Empty, FontAwesome.Solid.Cog, new Color4(85, 85, 85, 255), () => OnSettings?.Invoke(), -WEDGE_WIDTH, Key.O),
-                backButton = new Button(ButtonSystemStrings.Back, @"button-back-select", OsuIcon.LeftCircle, new Color4(51, 58, 94, 255), () => State = ButtonSystemState.TopLevel, -WEDGE_WIDTH)
+                new MainMenuButton(ButtonSystemStrings.Settings, string.Empty, FontAwesome.Solid.Cog, new Color4(85, 85, 85, 255), () => OnSettings?.Invoke(), -WEDGE_WIDTH, Key.O),
+                backButton = new MainMenuButton(ButtonSystemStrings.Back, @"button-back-select", OsuIcon.LeftCircle, new Color4(51, 58, 94, 255), () => State = ButtonSystemState.TopLevel, -WEDGE_WIDTH)
                 {
                     VisibleState = ButtonSystemState.Play,
                 },
@@ -126,24 +126,24 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, IdleTracker idleTracker, GameHost host)
         {
-            buttonsPlay.Add(new Button(ButtonSystemStrings.Solo, @"button-solo-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
-            buttonsPlay.Add(new Button(ButtonSystemStrings.Multi, @"button-generic-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer, 0, Key.M));
-            buttonsPlay.Add(new Button(ButtonSystemStrings.Playlists, @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onPlaylists, 0, Key.L));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Solo, @"button-solo-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-generic-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer, 0, Key.M));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Playlists, @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onPlaylists, 0, Key.L));
             buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
 
-            buttonsTopLevel.Add(new Button(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));
-            buttonsTopLevel.Add(new Button(ButtonSystemStrings.Edit, @"button-edit-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
-            buttonsTopLevel.Add(new Button(ButtonSystemStrings.Browse, @"button-direct-select", OsuIcon.ChevronDownCircle, new Color4(165, 204, 0, 255), () => OnBeatmapListing?.Invoke(), 0, Key.D));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-edit-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Browse, @"button-direct-select", OsuIcon.ChevronDownCircle, new Color4(165, 204, 0, 255), () => OnBeatmapListing?.Invoke(), 0, Key.D));
 
             if (host.CanExit)
-                buttonsTopLevel.Add(new Button(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q));
+                buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q));
 
             buttonArea.AddRange(buttonsPlay);
             buttonArea.AddRange(buttonsTopLevel);
 
             buttonArea.ForEach(b =>
             {
-                if (b is Button)
+                if (b is MainMenuButton)
                 {
                     b.Origin = Anchor.CentreLeft;
                     b.Anchor = Anchor.CentreLeft;
@@ -305,7 +305,7 @@ namespace osu.Game.Screens.Menu
                 {
                     buttonArea.ButtonSystemState = state;
 
-                    foreach (var b in buttonArea.Children.OfType<Button>())
+                    foreach (var b in buttonArea.Children.OfType<MainMenuButton>())
                         b.ButtonSystemState = state;
                 }
 

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Menu
     /// Button designed specifically for the osu!next main menu.
     /// In order to correctly flow, we have to use a negative margin on the parent container (due to the parallelogram shape).
     /// </summary>
-    public class Button : BeatSyncedContainer, IStateful<ButtonState>
+    public class MainMenuButton : BeatSyncedContainer, IStateful<ButtonState>
     {
         public event Action<ButtonState> StateChanged;
 
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Menu
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
-        public Button(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown)
+        public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown)
         {
             this.sampleName = sampleName;
             this.clickAction = clickAction;

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (e.Repeat || e.ControlPressed || e.ShiftPressed || e.AltPressed)
+            if (e.Repeat || e.ControlPressed || e.ShiftPressed || e.AltPressed || e.SuperPressed)
                 return false;
 
             if (TriggerKey == e.Key && TriggerKey != Key.Unknown)


### PR DESCRIPTION
I've been trying to figure out the cause of this for years now. Finally managed to catch it and notice the issue in logs.

Reproduced by exiting the game with cmd-q.

Normal shutdown:

```csharp
[runtime] 2022-03-25 06:09:00 [verbose]: ButtonSystem's state changed from TopLevel to Exit
[runtime] 2022-03-25 06:09:00 [verbose]: 📺 OsuScreenStack#399(depth:2) exit from MainMenu#568
[runtime] 2022-03-25 06:09:00 [verbose]: 📺 OsuScreenStack#399(depth:2) resume to IntroTriangles#530
[runtime] 2022-03-25 06:09:03 [verbose]: 📺 BackgroundScreenStack#990(depth:0) exit from BackgroundScreenDefault#326
[runtime] 2022-03-25 06:09:03 [verbose]: 📺 BackgroundScreenStack#990(depth:0) resume to [empty]
[runtime] 2022-03-25 06:09:03 [verbose]: 📺 OsuScreenStack#399(depth:1) exit from IntroTriangles#530
[runtime] 2022-03-25 06:09:03 [verbose]: 📺 OsuScreenStack#399(depth:1) resume to Loader#107
[runtime] 2022-03-25 06:09:03 [verbose]: 📺 OsuScreenStack#399(depth:0) exit from Loader#107
[runtime] 2022-03-25 06:09:03 [verbose]: 📺 OsuScreenStack#399(depth:0) resume to [empty]
[runtime] 2022-03-25 06:09:03 [verbose]: Host execution state changed to Stopping
[runtime] 2022-03-25 06:09:03 [verbose]: Host execution state changed to Stopped
```
Bad shutdown:

```csharp
[runtime] 2022-03-25 06:08:02 [debug]: KeyDownEvent(Q, False) handled by Button.
[runtime] 2022-03-25 06:08:02 [verbose]: ButtonSystem's state changed from TopLevel to Exit
[runtime] 2022-03-25 06:08:02 [verbose]: 📺 OsuScreenStack#143(depth:2) exit from MainMenu#601
[runtime] 2022-03-25 06:08:02 [verbose]: 📺 OsuScreenStack#143(depth:2) resume to IntroTriangles#647
[runtime] 2022-03-25 06:08:02 [verbose]: Host execution state changed to Stopping
[runtime] 2022-03-25 06:08:03 [verbose]: Host execution state changed to Stopped
```

I've renamed the button class because I've looked at this log a few times before and it didn't register that the button line was important.