### PR TITLE
Update multiplayer countdown button text more often

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             countdown = room?.Countdown;
 
             if (room?.Countdown != null)
-                countdownUpdateDelegate ??= Scheduler.AddDelayed(updateButtonText, 1000, true);
+                countdownUpdateDelegate ??= Scheduler.AddDelayed(updateButtonText, 100, true);
             else
             {
                 countdownUpdateDelegate?.Cancel();


### PR DESCRIPTION
At once a second, it regularly skips whole seconds (because scheduler isn't guaranteed to run exactly as often as specified). 10 updates a second seems amicable and less noticeable to my eye.

Tried to repro a video and of course every time I try I can't make it happen. When it does it will sometimes skip a second and sometimes a second will take longer than a second.