### PR TITLE
Avoid crashing if a skin component cannot be instantiated correctly

### DIFF
--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -144,9 +144,23 @@ namespace osu.Game.Skinning
                     if (!DrawableComponentInfo.TryGetValue(target.Target, out var skinnableInfo))
                         return null;
 
+                    var components = new List<Drawable>();
+
+                    foreach (var i in skinnableInfo)
+                    {
+                        try
+                        {
+                            components.Add(i.CreateInstance());
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error(e, $"Unable to create skin component {i.Type.Name}");
+                        }
+                    }
+
                     return new SkinnableTargetComponentsContainer
                     {
-                        ChildrenEnumerable = skinnableInfo.Select(i => i.CreateInstance())
+                        Children = components,
                     };
             }
 


### PR DESCRIPTION
Reproduced when switching back to `master` after working on some new components. Definitely shouldn't cause a crash.