### PR TITLE
Fix LogoVisualisation draw thread safety

### DIFF
--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Screens.Menu
 
             private static readonly Color4 transparent_white = Color4.White.Opacity(0.2f);
 
-            private float[] audioData;
+            private readonly float[] audioData = new float[256];
 
             private readonly QuadBatch<TexturedVertex2D> vertexBatch = new QuadBatch<TexturedVertex2D>(100, 10);
 
@@ -192,7 +192,8 @@ namespace osu.Game.Screens.Menu
                 shader = Source.shader;
                 texture = Source.texture;
                 size = Source.DrawSize.X;
-                audioData = Source.frequencyAmplitudes;
+
+                Source.frequencyAmplitudes.AsSpan().CopyTo(audioData);
             }
 
             public override void Draw(Action<TexturedVertex2D> vertexAction)


### PR DESCRIPTION
I'm not sure if this would be noticed normally, but I noticed it on a private branch which requires VBOs to be 100% internally consistent between drawnode invalidations, The failure scenario here is:
1. DrawNode draws half the vertices using the new values and half vertices using old values.
2. Without having been invalidated, in the next frame, the DrawNode draws all new values.

Performance impact should be minimal - copying 1024 values across takes ~50ns in an isolated benchmark.