### PR TITLE
Fix multiplayer match settings overlay dropdown Z-ordering

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
@@ -93,7 +94,12 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
         {
         }
 
-        protected class SectionContainer : FillFlowContainer<Section>
+        /// <remarks>
+        /// <see cref="ReverseChildIDFillFlowContainer{T}"/> is used to ensure that if the nested <see cref="Section"/>s
+        /// use expanded overhanging content (like an <see cref="OsuDropdown{T}"/>'s dropdown),
+        /// then the overhanging content will be correctly Z-ordered.
+        /// </remarks>
+        protected class SectionContainer : ReverseChildIDFillFlowContainer<Section>
         {
             public SectionContainer()
             {


### PR DESCRIPTION
| master | this PR |
| :-: | :-: |
| ![2022-03-26-182953_800x213_scrot](https://user-images.githubusercontent.com/20418176/160250820-39655823-db45-4055-8d0b-594eec7b9ebe.png) | ![2022-03-26-183034_796x208_scrot](https://user-images.githubusercontent.com/20418176/160250819-cfda9bd1-f463-440d-8783-7d3ee007826b.png) |

Bit of a stop-gap solution but I figured I'd rather do something quick so that this can get into a release with minimal pain. The placement of dropdown content in the hierarchy is still a large pain point in several places and needs to be tackled in a general manner, similar to what context menus/popovers do.