### PR TITLE
Fix test failures in skin editor test scene

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Player.ScaleTo(0.4f);
                 LoadComponentAsync(skinEditor = new SkinEditor(Player), Add);
             });
+            AddUntilStep("wait for loaded", () => skinEditor.IsLoaded);
         }
 
         [Test]


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/5703080172?check_suite_focus=true

Can be reproduced locally with following patch:

```diff
diff --git a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
index 38d83058c0..8409947ed4 100644
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -35,7 +35,7 @@ public override void SetUpSteps()
             {
                 skinEditor?.Expire();
                 Player.ScaleTo(0.4f);
-                LoadComponentAsync(skinEditor = new SkinEditor(Player), Add);
+                LoadComponentAsync(skinEditor = new SkinEditor(Player), loaded => Scheduler.AddDelayed(() => Add(loaded), 1000));
             });
         }
 
```