### PR TITLE
Fix editor items not being dragged immediately

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         private readonly JuiceStreamPath path = new JuiceStreamPath();
 
+        public override float DragTolerance => 1f;
+
         // Invariant: `path.Vertices.Count == vertexStates.Count`
         private readonly List<VertexState> vertexStates = new List<VertexState>
         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/BlueprintPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/BlueprintPiece.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
     public abstract class BlueprintPiece<T> : CompositeDrawable
         where T : OsuHitObject
     {
+        public override float DragTolerance => 1f;
+
         /// <summary>
         /// Updates this <see cref="BlueprintPiece{T}"/> using the properties of a <see cref="OsuHitObject"/>.
         /// </summary>

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Rulesets.Edit
 
         public override bool HandlePositionalInput => ShouldBeAlive;
         public override bool RemoveWhenNotAlive => false;
+        public override float DragTolerance => 1f;
 
         protected SelectionBlueprint(T item)
         {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     {
         private Drawable marker;
 
+        public override float DragTolerance => 1f;
+
         [Resolved]
         private EditorClock editorClock { get; set; }
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -45,6 +45,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected readonly BindableList<T> SelectedItems = new BindableList<T>();
 
+        public override float DragTolerance => 1f;
+
         protected BlueprintContainer()
         {
             RelativeSizeAxes = Axes.Both;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         public readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
 
+        public override float DragTolerance => 1f;
+
         [Resolved]
         private EditorClock editorClock { get; set; }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -283,6 +283,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             public override bool HandlePositionalInput => hitObject != null;
 
+            public override float DragTolerance => 1f;
+
             public DragArea(HitObject hitObject)
             {
                 this.hitObject = hitObject;


### PR DESCRIPTION
Required PR: https://github.com/ppy/osu-framework/pull/5083

Mappers often make small adjustments to their beatmaps, but currently dragging only starts after moving 10 pixels. This change makes dragging immediate for relevant editor elements.

Before:

https://user-images.githubusercontent.com/1730245/160294061-4a542fb8-1946-4701-b2ca-9de58424141b.mp4

After:

https://user-images.githubusercontent.com/1730245/160294072-73d23321-447f-4ca6-9df1-1547feeeadc9.mp4



