### PR TITLE
Apply minor changes to the issue report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -9,7 +9,7 @@ body:
         Important to note that your issue may have already been reported before. Please check:
         - Pinned issues, at the top of https://github.com/ppy/osu/issues.
         - Current open `priority:0` issues, filterable [here](https://github.com/ppy/osu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority%3A0).
-        - And most importantly, search for your issue. If you find that it already exists, respond with a reaction or add any further information that may be helpful.
+        - And most importantly, search across the [issue listing](https://github.com/ppy/osu/issues) and [Q&A discussion listing](https://github.com/ppy/osu/discussions/categories/q-a) for your issue. If you find that it already exists, respond with a reaction or add any further information that may be helpful.
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -48,19 +48,27 @@ body:
 
         Attaching log files is required for every reported bug. See instructions below on how to find them.
 
+        **Logs are reset when you reopen the game.** If the game crashed or has been closed since you found the bug, retrieve the logs using the file explorer instead.
+
+        ### Desktop platforms
+
         If the game has not yet been closed since you found the bug:
           1. Head on to game settings and click on "Open osu! folder"
           2. Then open the `logs` folder located there
 
-        **Logs are reset when you reopen the game.** If the game crashed or has been closed since you found the bug, retrieve the logs using the file explorer instead.
-
-        The default places to find the logs are as follows:
+        The default places to find the logs on desktop platforms are as follows:
           - `%AppData%/osu/logs` *on Windows*
           - `~/.local/share/osu/logs` *on Linux & macOS*
+
+        If you have selected a custom location for the game files, you can find the `logs` folder there.
+
+        ### Mobile platforms
+
+        The places to find the logs on mobile platforms are as follows:
           - `Android/data/sh.ppy.osulazer/files/logs` *on Android*
           - *On iOS*, they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 
-        If you have selected a custom location for the game files, you can find the `logs` folder there.
+        ---
 
         After locating the `logs` folder, select all log files inside and drag them into the "Logs" box below.
 

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -9,7 +9,7 @@ body:
         Important to note that your issue may have already been reported before. Please check:
         - Pinned issues, at the top of https://github.com/ppy/osu/issues.
         - Current open `priority:0` issues, filterable [here](https://github.com/ppy/osu/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority%3A0).
-        - And most importantly, search across the [issue listing](https://github.com/ppy/osu/issues) and [Q&A discussion listing](https://github.com/ppy/osu/discussions/categories/q-a) for your issue. If you find that it already exists, respond with a reaction or add any further information that may be helpful.
+        - And most importantly, search for your issue both in the [issue listing](https://github.com/ppy/osu/issues) and the [Q&A discussion listing](https://github.com/ppy/osu/discussions/categories/q-a). If you find that it already exists, respond with a reaction or add any further information that may be helpful.
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -65,8 +65,8 @@ body:
         ### Mobile platforms
 
         The places to find the logs on mobile platforms are as follows:
-          - `Android/data/sh.ppy.osulazer/files/logs` *on Android*
-          - *On iOS*, they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
+          - *On Android*, navigate to `Android/data/sh.ppy.osulazer/files/logs` using a file browser app.
+          - *On iOS*, connect your device to a PC and copy the `logs` directory from the app's document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 
         ---
 


### PR DESCRIPTION
- Clarifies that "searching for your issue" involves doing so on both the issue listing and the Q&A discussion listing.
- Separates the logs retrieval procedure between desktop and mobile platforms for clarity, since mobiles don't have the "Open osu! folder" button nor the ability to relocate the game folder, and mobile logs are still necessary.
  - This makes the placement of the "Logs are reset when you reopen the game." note feeling wrong, but I can't think of a better place or a way to keep the note's visibility as intended. Open for suggestions.