### PR TITLE
Fix autoplay avatar being clickable on results screen

### DIFF
--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Mods/EmptyFreeformModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Mods/EmptyFreeformModAutoplay.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.EmptyFreeform.Mods
     public class EmptyFreeformModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new EmptyFreeformAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
+            => new ModReplayData(new EmptyFreeformAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Mods/EmptyFreeformModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Mods/EmptyFreeformModAutoplay.cs
@@ -16,7 +16,11 @@ namespace osu.Game.Rulesets.EmptyFreeform.Mods
         {
             ScoreInfo = new ScoreInfo
             {
-                User = new APIUser { Username = "sample" },
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "sample"
+                },
             },
             Replay = new EmptyFreeformAutoGenerator(beatmap).Generate(),
         };

--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Mods/EmptyFreeformModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Mods/EmptyFreeformModAutoplay.cs
@@ -3,26 +3,14 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.EmptyFreeform.Replays;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.EmptyFreeform.Mods
 {
     public class EmptyFreeformModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "sample"
-                },
-            },
-            Replay = new EmptyFreeformAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new EmptyFreeformAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
@@ -16,7 +16,11 @@ namespace osu.Game.Rulesets.Pippidon.Mods
         {
             ScoreInfo = new ScoreInfo
             {
-                User = new APIUser { Username = "sample" },
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "sample"
+                },
             },
             Replay = new PippidonAutoGenerator(beatmap).Generate(),
         };

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
@@ -3,26 +3,14 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Pippidon.Replays;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Pippidon.Mods
 {
     public class PippidonModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "sample"
-                },
-            },
-            Replay = new PippidonAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new PippidonAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Pippidon.Mods
     public class PippidonModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new PippidonAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
+            => new ModReplayData(new PippidonAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Mods/EmptyScrollingModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Mods/EmptyScrollingModAutoplay.cs
@@ -16,7 +16,11 @@ namespace osu.Game.Rulesets.EmptyScrolling.Mods
         {
             ScoreInfo = new ScoreInfo
             {
-                User = new APIUser { Username = "sample" },
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "sample"
+                },
             },
             Replay = new EmptyScrollingAutoGenerator(beatmap).Generate(),
         };

--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Mods/EmptyScrollingModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Mods/EmptyScrollingModAutoplay.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.EmptyScrolling.Mods
     public class EmptyScrollingModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new EmptyScrollingAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
+            => new ModReplayData(new EmptyScrollingAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Mods/EmptyScrollingModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Mods/EmptyScrollingModAutoplay.cs
@@ -1,28 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.EmptyScrolling.Replays;
-using osu.Game.Scoring;
 using System.Collections.Generic;
-using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.EmptyScrolling.Replays;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.EmptyScrolling.Mods
 {
     public class EmptyScrollingModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "sample"
-                },
-            },
-            Replay = new EmptyScrollingAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new EmptyScrollingAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
@@ -16,7 +16,11 @@ namespace osu.Game.Rulesets.Pippidon.Mods
         {
             ScoreInfo = new ScoreInfo
             {
-                User = new APIUser { Username = "sample" },
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "sample"
+                },
             },
             Replay = new PippidonAutoGenerator(beatmap).Generate(),
         };

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
@@ -3,26 +3,14 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Pippidon.Replays;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Pippidon.Mods
 {
     public class PippidonModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "sample"
-                },
-            },
-            Replay = new PippidonAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new PippidonAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
     }
 }

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Mods/PippidonModAutoplay.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Pippidon.Mods
     public class PippidonModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new PippidonAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "sample" });
+            => new ModReplayData(new PippidonAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "sample" });
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Catch.Mods
     public class CatchModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new CatchAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!salad" });
+            => new ModReplayData(new CatchAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "osu!salad" });
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
@@ -3,26 +3,14 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "osu!salad"
-                }
-            },
-            Replay = new CatchAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new CatchAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!salad" });
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
@@ -14,7 +14,14 @@ namespace osu.Game.Rulesets.Catch.Mods
     {
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "osu!salad" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "osu!salad"
+                }
+            },
             Replay = new CatchAutoGenerator(beatmap).Generate(),
         };
     }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Catch.Mods
     public class CatchModCinema : ModCinema<CatchHitObject>
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new CatchAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!salad" });
+            => new ModReplayData(new CatchAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "osu!salad" });
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
@@ -15,7 +15,14 @@ namespace osu.Game.Rulesets.Catch.Mods
     {
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "osu!salad" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "osu!salad"
+                }
+            },
             Replay = new CatchAutoGenerator(beatmap).Generate(),
         };
     }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
@@ -3,27 +3,15 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModCinema : ModCinema<CatchHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "osu!salad"
-                }
-            },
-            Replay = new CatchAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new CatchAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!salad" });
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!topus" });
+            => new ModReplayData(new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(), new ModCreatedUser { Username = "osu!topus" });
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
@@ -3,27 +3,15 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "osu!topus"
-                }
-            },
-            Replay = new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!topus" });
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
@@ -15,7 +15,14 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "osu!topus" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "osu!topus"
+                }
+            },
             Replay = new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(),
         };
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
@@ -13,6 +13,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModCinema : ModCinema<ManiaHitObject>
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!topus" });
+            => new ModReplayData(new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(), new ModCreatedUser { Username = "osu!topus" });
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
@@ -16,7 +16,14 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "osu!topus" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "osu!topus"
+                }
+            },
             Replay = new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(),
         };
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
@@ -3,28 +3,16 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModCinema : ModCinema<ManiaHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "osu!topus"
-                }
-            },
-            Replay = new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(), new ModCreatedReplayUser { Username = "osu!topus" });
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -13,7 +12,6 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 using osu.Game.Tests.Visual;
 using osuTK;
 
@@ -67,11 +65,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private class TestAutoMod : OsuModAutoplay
         {
-            public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-            {
-                ScoreInfo = new ScoreInfo { User = new APIUser { Username = "Autoplay" } },
-                Replay = new MissingAutoGenerator(beatmap, mods).Generate()
-            };
+            public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+                => new ModReplayData(new MissingAutoGenerator(beatmap, mods).Generate(), new ModCreatedReplayUser { Username = "Autoplay" });
         }
 
         private class MissingAutoGenerator : OsuAutoGeneratorBase

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private class TestAutoMod : OsuModAutoplay
         {
             public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-                => new ModReplayData(new MissingAutoGenerator(beatmap, mods).Generate(), new ModCreatedReplayUser { Username = "Autoplay" });
+                => new ModReplayData(new MissingAutoGenerator(beatmap, mods).Generate(), new ModCreatedUser { Username = "Autoplay" });
         }
 
         private class MissingAutoGenerator : OsuAutoGeneratorBase

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
@@ -15,6 +15,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAimAssist), typeof(OsuModAutopilot), typeof(OsuModSpunOut) }).ToArray();
 
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedReplayUser { Username = "Autoplay" });
+            => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedUser { Username = "Autoplay" });
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
@@ -18,7 +18,14 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "Autoplay" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "Autoplay",
+                }
+            },
             Replay = new OsuAutoGenerator(beatmap, mods).Generate()
         };
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
@@ -5,10 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Replays;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -16,17 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAimAssist), typeof(OsuModAutopilot), typeof(OsuModSpunOut) }).ToArray();
 
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "Autoplay",
-                }
-            },
-            Replay = new OsuAutoGenerator(beatmap, mods).Generate()
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedReplayUser { Username = "Autoplay" });
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAimAssist), typeof(OsuModAutopilot), typeof(OsuModSpunOut) }).ToArray();
 
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedReplayUser { Username = "Autoplay" });
+            => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedUser { Username = "Autoplay" });
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
@@ -19,7 +19,14 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "Autoplay" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "Autoplay"
+                }
+            },
             Replay = new OsuAutoGenerator(beatmap, mods).Generate()
         };
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -17,17 +15,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAimAssist), typeof(OsuModAutopilot), typeof(OsuModSpunOut) }).ToArray();
 
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "Autoplay"
-                }
-            },
-            Replay = new OsuAutoGenerator(beatmap, mods).Generate()
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new OsuAutoGenerator(beatmap, mods).Generate(), new ModCreatedReplayUser { Username = "Autoplay" });
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
@@ -3,26 +3,14 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Replays;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModAutoplay : ModAutoplay
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "mekkadosu!"
-                }
-            },
-            Replay = new TaikoAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "mekkadosu!" });
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     public class TaikoModAutoplay : ModAutoplay
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "mekkadosu!" });
+            => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "mekkadosu!" });
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
@@ -14,7 +14,14 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "mekkadosu!" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "mekkadosu!"
+                }
+            },
             Replay = new TaikoAutoGenerator(beatmap).Generate(),
         };
     }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
@@ -3,27 +3,15 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Replays;
-using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModCinema : ModCinema<TaikoHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
-        {
-            ScoreInfo = new ScoreInfo
-            {
-                User = new APIUser
-                {
-                    Id = APIUser.SYSTEM_USER_ID,
-                    Username = "mekkadosu!"
-                }
-            },
-            Replay = new TaikoAutoGenerator(beatmap).Generate(),
-        };
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "mekkadosu!" });
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     public class TaikoModCinema : ModCinema<TaikoHitObject>
     {
         public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
-            => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedReplayUser { Username = "mekkadosu!" });
+            => new ModReplayData(new TaikoAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "mekkadosu!" });
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
@@ -15,7 +15,14 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
-            ScoreInfo = new ScoreInfo { User = new APIUser { Username = "mekkadosu!" } },
+            ScoreInfo = new ScoreInfo
+            {
+                User = new APIUser
+                {
+                    Id = APIUser.SYSTEM_USER_ID,
+                    Username = "mekkadosu!"
+                }
+            },
             Replay = new TaikoAutoGenerator(beatmap).Generate(),
         };
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -5,12 +5,14 @@ using System.ComponentModel;
 using System.Linq;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.Break;
 using osu.Game.Screens.Ranking;
+using osu.Game.Users.Drawables;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -39,10 +41,17 @@ namespace osu.Game.Tests.Visual.Gameplay
             seekToBreak(1);
 
             AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
-            AddUntilStep("results displayed", () => getResultsScreen() != null);
+
+            AddUntilStep("results displayed", () => getResultsScreen()?.IsLoaded == true);
 
             AddAssert("score has combo", () => getResultsScreen().Score.Combo > 100);
             AddAssert("score has no misses", () => getResultsScreen().Score.Statistics[HitResult.Miss] == 0);
+
+            AddUntilStep("avatar dispalyed", () => getAvatar() != null);
+            AddAssert("avatar not clickable", () => getAvatar().ChildrenOfType<OsuClickableContainer>().First().Action == null);
+
+            ClickableAvatar getAvatar() => getResultsScreen()
+                                           .ChildrenOfType<ClickableAvatar>().FirstOrDefault();
 
             ResultsScreen getResultsScreen() => Stack.CurrentScreen as ResultsScreen;
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("score has combo", () => getResultsScreen().Score.Combo > 100);
             AddAssert("score has no misses", () => getResultsScreen().Score.Statistics[HitResult.Miss] == 0);
 
-            AddUntilStep("avatar dispalyed", () => getAvatar() != null);
+            AddUntilStep("avatar displayed", () => getAvatar() != null);
             AddAssert("avatar not clickable", () => getAvatar().ChildrenOfType<OsuClickableContainer>().First().Action == null);
 
             ClickableAvatar getAvatar() => getResultsScreen()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Array.Empty<Mod>());
 
-            return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod()?.CreateReplayScore(beatmap, Array.Empty<Mod>()));
+            return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod()?.CreateScoreFromReplayData(beatmap, Array.Empty<Mod>()));
         }
 
         protected override void AddCheckSteps()

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Online.API.Requests.Responses
     [JsonObject(MemberSerialization.OptIn)]
     public class APIUser : IEquatable<APIUser>, IUser
     {
+        /// <summary>
+        /// A user ID which can be used to represent any system user which is not attached to a user profile.
+        /// </summary>
+        public const int SYSTEM_USER_ID = 0;
+
         [JsonProperty(@"id")]
         public int Id { get; set; } = 1;
 
@@ -238,7 +243,7 @@ namespace osu.Game.Online.API.Requests.Responses
         /// </summary>
         public static readonly APIUser SYSTEM_USER = new APIUser
         {
-            Id = 0,
+            Id = SYSTEM_USER_ID,
             Username = "system",
             Colour = @"9c0101",
         };

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays
 
         public void ShowUser(IUser user)
         {
-            if (user == APIUser.SYSTEM_USER)
+            if (user.OnlineID == APIUser.SYSTEM_USER_ID)
                 return;
 
             Show();

--- a/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Edit
         private void regenerateAutoplay()
         {
             var autoplayMod = drawableRuleset.Mods.OfType<ModAutoplay>().Single();
-            drawableRuleset.SetReplayScore(autoplayMod.CreateReplayScore(drawableRuleset.Beatmap, drawableRuleset.Mods));
+            drawableRuleset.SetReplayScore(autoplayMod.CreateScoreFromReplayData(drawableRuleset.Beatmap, drawableRuleset.Mods));
         }
 
         private void addHitObject(HitObject hitObject)

--- a/osu.Game/Rulesets/Mods/ICreateReplay.cs
+++ b/osu.Game/Rulesets/Mods/ICreateReplay.cs
@@ -1,14 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public interface ICreateReplay
+    [Obsolete("Use ICreateReplayData instead")] // Can be removed 20220929
+    public interface ICreateReplay : ICreateReplayData
     {
         public Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods);
+
+        ModReplayData ICreateReplayData.CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+        {
+            var replayScore = CreateReplayScore(beatmap, mods);
+            return new ModReplayData(replayScore.Replay, new ModCreatedReplayUser { Username = replayScore.ScoreInfo.User.Username });
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ICreateReplay.cs
+++ b/osu.Game/Rulesets/Mods/ICreateReplay.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         ModReplayData ICreateReplayData.CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
         {
             var replayScore = CreateReplayScore(beatmap, mods);
-            return new ModReplayData(replayScore.Replay, new ModCreatedReplayUser { Username = replayScore.ScoreInfo.User.Username });
+            return new ModReplayData(replayScore.Replay, new ModCreatedUser { Username = replayScore.ScoreInfo.User.Username });
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ICreateReplayData.cs
+++ b/osu.Game/Rulesets/Mods/ICreateReplayData.cs
@@ -41,19 +41,19 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Placeholder user data to show in place of the local user when the associated mod is active.
         /// </summary>
-        public readonly ModCreatedReplayUser User;
+        public readonly ModCreatedUser User;
 
-        public ModReplayData(Replay replay, ModCreatedReplayUser user = null)
+        public ModReplayData(Replay replay, ModCreatedUser user = null)
         {
             Replay = replay;
-            User = user ?? new ModCreatedReplayUser();
+            User = user ?? new ModCreatedUser();
         }
     }
 
     /// <summary>
     /// A user which is associated with a replay that was created by a mod (ie. autoplay or cinema).
     /// </summary>
-    public class ModCreatedReplayUser : IUser
+    public class ModCreatedUser : IUser
     {
         public int OnlineID => APIUser.SYSTEM_USER_ID;
         public bool IsBot => true;

--- a/osu.Game/Rulesets/Mods/ICreateReplayData.cs
+++ b/osu.Game/Rulesets/Mods/ICreateReplayData.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Replays;
+using osu.Game.Users;
+
+namespace osu.Game.Rulesets.Mods
+{
+    /// <summary>
+    /// A mod which creates full replay data, which is to be played back in place of a local user playing the game.
+    /// </summary>
+    public interface ICreateReplayData
+    {
+        /// <summary>
+        /// Create replay data.
+        /// </summary>
+        /// <param name="beatmap"></param>
+        /// <param name="mods"></param>
+        /// <returns></returns>
+        public ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods);
+    }
+
+    /// <summary>
+    /// Data created by a mod that implements <see cref="ICreateReplayData"/>.
+    /// </summary>
+    public class ModReplayData
+    {
+        /// <summary>
+        /// The full replay data.
+        /// </summary>
+        public readonly Replay Replay;
+
+        /// <summary>
+        /// Placeholder user data to show in place of the local user when the associated mod is active.
+        /// </summary>
+        public readonly ModCreatedReplayUser User;
+
+        public ModReplayData(Replay replay, ModCreatedReplayUser user = null)
+        {
+            Replay = replay;
+            User = user ?? new ModCreatedReplayUser();
+        }
+    }
+
+    /// <summary>
+    /// A user which is associated with a replay that was created by a mod (ie. autoplay or cinema).
+    /// </summary>
+    public class ModCreatedReplayUser : IUser
+    {
+        public int OnlineID => APIUser.SYSTEM_USER_ID;
+        public bool IsBot => true;
+
+        public string Username { get; set; } = string.Empty;
+    }
+}

--- a/osu.Game/Rulesets/Mods/ICreateReplayData.cs
+++ b/osu.Game/Rulesets/Mods/ICreateReplayData.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Replays;
+using osu.Game.Scoring;
 using osu.Game.Users;
 
 namespace osu.Game.Rulesets.Mods
@@ -17,9 +18,13 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Create replay data.
         /// </summary>
-        /// <param name="beatmap"></param>
-        /// <param name="mods"></param>
-        /// <returns></returns>
+        /// <param name="beatmap">The beatmap to create replay data for.</param>
+        /// <param name="mods">The mods to take into account when creating the replay data.</param>
+        /// <returns>A <see cref="ModReplayData"/> structure, containing the generated replay data.</returns>
+        /// <remarks>
+        /// For callers that want to receive a directly usable <see cref="Score"/> instance,
+        /// the <see cref="ModExtensions.CreateScoreFromReplayData"/> extension method is provided for convenience.
+        /// </remarks>
         public ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods);
     }
 

--- a/osu.Game/Rulesets/Mods/ICreateReplayData.cs
+++ b/osu.Game/Rulesets/Mods/ICreateReplayData.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
         /// For callers that want to receive a directly usable <see cref="Score"/> instance,
         /// the <see cref="ModExtensions.CreateScoreFromReplayData"/> extension method is provided for convenience.
         /// </remarks>
-        public ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods);
+        ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods);
     }
 
     /// <summary>

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -36,8 +36,6 @@ namespace osu.Game.Rulesets.Mods
 
         public virtual ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
         {
-            Logger.Log($"Ruleset mod implementation for {GetType().Name} should be updated to newer {nameof(ICreateReplayData)} signature.", LoggingTarget.Information);
-
 #pragma warning disable CS0618
             var replayScore = CreateReplayScore(beatmap, mods);
 #pragma warning restore CS0618

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool HasImplementation => GetType().GenericTypeArguments.Length == 0;
 
-        [Obsolete("Use CreateScoreFromReplayData(IBeatmap, IReadOnlyList<Mod>) instead")] // Can be removed 20220929
+        [Obsolete("Override CreateReplayData(IBeatmap, IReadOnlyList<Mod>) instead")] // Can be removed 20220929
         public virtual Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score { Replay = new Replay() };
 
         public virtual ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Replays;

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Replays;
@@ -11,7 +12,7 @@ using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModAutoplay : Mod, IApplicableFailOverride, ICreateReplay
+    public abstract class ModAutoplay : Mod, IApplicableFailOverride, ICreateReplayData
     {
         public override string Name => "Autoplay";
         public override string Acronym => "AT";
@@ -30,6 +31,18 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool HasImplementation => GetType().GenericTypeArguments.Length == 0;
 
+        [Obsolete("Use CreateScoreFromReplayData(IBeatmap, IReadOnlyList<Mod>) instead")] // Can be removed 20220929
         public virtual Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score { Replay = new Replay() };
+
+        public virtual ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+        {
+            Logger.Log($"Ruleset mod implementation for {GetType().Name} should be updated to newer {nameof(ICreateReplayData)} signature.", LoggingTarget.Information);
+
+#pragma warning disable CS0618
+            var replayScore = CreateReplayScore(beatmap, mods);
+#pragma warning restore CS0618
+
+            return new ModReplayData(replayScore.Replay, new ModCreatedReplayUser { Username = replayScore.ScoreInfo.User.Username });
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mods
             var replayScore = CreateReplayScore(beatmap, mods);
 #pragma warning restore CS0618
 
-            return new ModReplayData(replayScore.Replay, new ModCreatedReplayUser { Username = replayScore.ScoreInfo.User.Username });
+            return new ModReplayData(replayScore.Replay, new ModCreatedUser { Username = replayScore.ScoreInfo.User.Username });
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -14,8 +14,6 @@ namespace osu.Game.Rulesets.Mods
     {
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {
-            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, drawableRuleset.Mods));
-
             // AlwaysPresent required for hitsounds
             drawableRuleset.AlwaysPresent = true;
             drawableRuleset.Hide();

--- a/osu.Game/Rulesets/Mods/ModExtensions.cs
+++ b/osu.Game/Rulesets/Mods/ModExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public static class ModExtensions
+    {
+        public static Score CreateScoreFromReplayData(this ICreateReplayData mod, IBeatmap beatmap, IReadOnlyList<Mod> mods)
+        {
+            var replayData = mod.CreateReplayData(beatmap, mods);
+
+            return new Score
+            {
+                Replay = replayData.Replay,
+                ScoreInfo =
+                {
+                    User = new APIUser
+                    {
+                        Id = APIUser.SYSTEM_USER_ID,
+                        Username = replayData.User.Username,
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mods;
@@ -111,9 +112,28 @@ namespace osu.Game.Screens.Select
 
             Player createPlayer()
             {
-                var replayGeneratingMod = Mods.Value.OfType<ICreateReplay>().FirstOrDefault();
+                var replayGeneratingMod = Mods.Value.OfType<ICreateReplayData>().FirstOrDefault();
+
                 if (replayGeneratingMod != null)
-                    return new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods));
+                {
+                    return new ReplayPlayer((beatmap, mods) =>
+                    {
+                        var replayData = replayGeneratingMod.CreateReplayData(beatmap, mods);
+
+                        return new Score
+                        {
+                            Replay = replayData.Replay,
+                            ScoreInfo =
+                            {
+                                User = new APIUser
+                                {
+                                    Id = APIUser.SYSTEM_USER_ID,
+                                    Username = replayData.User.Username,
+                                }
+                            }
+                        };
+                    });
+                }
 
                 return new SoloPlayer();
             }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mods;
@@ -103,23 +102,7 @@ namespace osu.Game.Screens.Select
 
                 if (replayGeneratingMod != null)
                 {
-                    return new ReplayPlayer((beatmap, mods) =>
-                    {
-                        var replayData = replayGeneratingMod.CreateReplayData(beatmap, mods);
-
-                        return new Score
-                        {
-                            Replay = replayData.Replay,
-                            ScoreInfo =
-                            {
-                                User = new APIUser
-                                {
-                                    Id = APIUser.SYSTEM_USER_ID,
-                                    Username = replayData.User.Username,
-                                }
-                            }
-                        };
-                    });
+                    return new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods));
                 }
 
                 return new SoloPlayer();

--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osuTK;
@@ -94,7 +95,7 @@ namespace osu.Game.Skinning.Editor
 
                                         var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
                                         if (replayGeneratingMod != null)
-                                            screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateReplayScore(beatmap, mods))));
+                                            screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))));
                                     }, new[] { typeof(Player), typeof(SongSelect) })
                                 },
                             }

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Visual
 
             if (autoplayMod != null)
             {
-                DrawableRuleset?.SetReplayScore(autoplayMod.CreateReplayScore(GameplayState.Beatmap, Mods.Value));
+                DrawableRuleset?.SetReplayScore(autoplayMod.CreateScoreFromReplayData(GameplayState.Beatmap, Mods.Value));
                 return;
             }
 

--- a/osu.Game/Tests/Visual/TestReplayPlayer.cs
+++ b/osu.Game/Tests/Visual/TestReplayPlayer.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Tests.Visual
         /// Instantiate a replay player that renders an autoplay mod.
         /// </summary>
         public TestReplayPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)
-            : base((beatmap, mods) => mods.OfType<ModAutoplay>().First().CreateReplayScore(beatmap, mods), new PlayerConfiguration
+            : base((beatmap, mods) => mods.OfType<ModAutoplay>().First().CreateScoreFromReplayData(beatmap, mods), new PlayerConfiguration
             {
                 AllowPause = allowPause,
                 ShowResults = showResults

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public bool OpenOnClick
         {
-            set => clickableArea.Enabled.Value = value;
+            set => clickableArea.Enabled.Value = clickableArea.Action != null && value;
         }
 
         /// <summary>
@@ -52,8 +52,10 @@ namespace osu.Game.Users.Drawables
             Add(clickableArea = new ClickableArea
             {
                 RelativeSizeAxes = Axes.Both,
-                Action = openProfile
             });
+
+            if (user?.Id != APIUser.SYSTEM_USER_ID)
+                clickableArea.Action = openProfile;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Closes #17479 

Not sure there's a better way to do this. It would be nice to blanket apply without each ruleset implementation needing to, but to do so would mean either making a central path to create an autoplay score (and overwriting the user ID post-creation, which feels a bit haphazard?) or changing the ruleset API to have it only provide a `Replay` and `string` for username, which is a breaking change.

Open to opinion on direction.