### PR TITLE
Adjust legacy combo counter appearance to closer match stable

### DIFF
--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -206,9 +206,6 @@ namespace osu.Game.Screens.Play.HUD
 
             counterContainer.Size = displayedCountSpriteText.Size;
 
-            // In stable, small pop out always starts from its initial size
-            displayedCountSpriteText.ClearTransforms();
-
             displayedCountSpriteText.ScaleTo(1).Then()
                                     .ScaleTo(1.1f, small_pop_out_duration / 2, Easing.InQuad).Then()
                                     .ScaleTo(1, small_pop_out_duration / 2, Easing.OutQuad);

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Play.HUD
 
             Margin = new MarginPadding(10);
 
-            Scale = new Vector2(1.3f);
+            Scale = new Vector2(1.28f);
 
             InternalChildren = new[]
             {
@@ -184,7 +184,7 @@ namespace osu.Game.Screens.Play.HUD
         {
             ((IHasText)popOutCount).Text = formatCount(newValue);
 
-            popOutCount.ScaleTo(1.6f);
+            popOutCount.ScaleTo(1.56f);
             popOutCount.FadeTo(0.6f);
 
             popOutCount.ScaleTo(1, big_pop_out_duration);

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -21,7 +21,9 @@ namespace osu.Game.Screens.Play.HUD
 
         private uint scheduledPopOutCurrentId;
 
-        private const double pop_out_duration = 150;
+        private const double big_pop_out_duration = 300;
+
+        private const double small_pop_out_duration = 100;
 
         private const double fade_out_duration = 100;
 
@@ -65,32 +67,28 @@ namespace osu.Game.Screens.Play.HUD
 
             Margin = new MarginPadding(10);
 
-            Scale = new Vector2(1.2f);
+            Scale = new Vector2(1.3f);
 
             InternalChildren = new[]
             {
                 counterContainer = new Container
                 {
-                    AutoSizeAxes = Axes.Both,
                     AlwaysPresent = true,
                     Children = new[]
                     {
                         popOutCount = new LegacySpriteText(LegacyFont.Combo)
                         {
                             Alpha = 0,
-                            Margin = new MarginPadding(0.05f),
                             Blending = BlendingParameters.Additive,
                             Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
                             BypassAutoSizeAxes = Axes.Both,
                         },
                         displayedCountSpriteText = new LegacySpriteText(LegacyFont.Combo)
                         {
-                            // Initial text and AlwaysPresent allow the counter to have a size before it first displays a combo.
-                            // This is useful for display in the skin editor.
-                            Text = formatCount(0),
-                            AlwaysPresent = true,
                             Alpha = 0,
+                            AlwaysPresent = true,
+                            Anchor = Anchor.BottomLeft,
+                            BypassAutoSizeAxes = Axes.Both,
                         },
                     }
                 }
@@ -120,9 +118,12 @@ namespace osu.Game.Screens.Play.HUD
         }
 
         [BackgroundDependencyLoader]
-        private void load(ScoreProcessor scoreProcessor)
+        private void load(ScoreProcessor scoreProcessor, ISkinSource skin)
         {
             Current.BindTo(scoreProcessor.Combo);
+
+            // Since layout depends on combo font height we need to update it during skin change
+            skin.SourceChanged += updateLayout;
         }
 
         protected override void LoadComplete()
@@ -130,8 +131,26 @@ namespace osu.Game.Screens.Play.HUD
             base.LoadComplete();
 
             ((IHasText)displayedCountSpriteText).Text = formatCount(Current.Value);
+            ((IHasText)popOutCount).Text = formatCount(Current.Value);
+
+            updateLayout();
 
             Current.BindValueChanged(combo => updateCount(combo.NewValue == 0), true);
+        }
+
+        private void updateLayout()
+        {
+            // Eye-balled to match stable
+            const float font_height_ratio = 0.625f;
+            const float vertical_offset = 9;
+
+            displayedCountSpriteText.OriginPosition = new Vector2(0, font_height_ratio * displayedCountSpriteText.Height + vertical_offset);
+            displayedCountSpriteText.Position = new Vector2(0, -(1 - font_height_ratio) * displayedCountSpriteText.Height + vertical_offset);
+
+            popOutCount.OriginPosition = new Vector2(3, font_height_ratio * popOutCount.Height + vertical_offset); // In stable, the bigger pop out scales a bit to the left
+            popOutCount.Position = new Vector2(0, -(1 - font_height_ratio) * popOutCount.Height + vertical_offset);
+
+            counterContainer.Size = displayedCountSpriteText.Size;
         }
 
         private void updateCount(bool rolling)
@@ -165,17 +184,17 @@ namespace osu.Game.Screens.Play.HUD
             ((IHasText)popOutCount).Text = formatCount(newValue);
 
             popOutCount.ScaleTo(1.6f);
-            popOutCount.FadeTo(0.75f);
-            popOutCount.MoveTo(Vector2.Zero);
+            popOutCount.FadeTo(0.6f);
 
-            popOutCount.ScaleTo(1, pop_out_duration);
-            popOutCount.FadeOut(pop_out_duration);
-            popOutCount.MoveTo(displayedCountSpriteText.Position, pop_out_duration);
+            popOutCount.ScaleTo(1, big_pop_out_duration);
+            popOutCount.FadeOut(big_pop_out_duration);
         }
 
         private void transformNoPopOut(int newValue)
         {
             ((IHasText)displayedCountSpriteText).Text = formatCount(newValue);
+
+            counterContainer.Size = displayedCountSpriteText.Size;
 
             displayedCountSpriteText.ScaleTo(1);
         }
@@ -183,8 +202,11 @@ namespace osu.Game.Screens.Play.HUD
         private void transformPopOutSmall(int newValue)
         {
             ((IHasText)displayedCountSpriteText).Text = formatCount(newValue);
-            displayedCountSpriteText.ScaleTo(1.1f);
-            displayedCountSpriteText.ScaleTo(1, pop_out_duration);
+
+            counterContainer.Size = displayedCountSpriteText.Size;
+
+            displayedCountSpriteText.ScaleTo(1.1f, small_pop_out_duration / 2, Easing.InQuad).Then()
+                                    .ScaleTo(1, small_pop_out_duration / 2, Easing.OutQuad);
         }
 
         private void scheduledPopOutSmall(uint id)
@@ -212,7 +234,7 @@ namespace osu.Game.Screens.Play.HUD
             Scheduler.AddDelayed(delegate
             {
                 scheduledPopOutSmall(newTaskId);
-            }, pop_out_duration);
+            }, big_pop_out_duration - 140);
         }
 
         private void onCountRolling(int currentValue, int newValue)

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -142,7 +142,6 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updateLayout()
         {
-            // Eye-balled to match stable
             const float font_height_ratio = 0.625f;
             const float vertical_offset = 9;
 

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -44,9 +44,6 @@ namespace osu.Game.Screens.Play.HUD
 
         private readonly Container counterContainer;
 
-        [Resolved]
-        private ISkinSource skin { get; set; }
-
         /// <summary>
         /// Hides the combo counter internally without affecting its <see cref="SkinnableInfo"/>.
         /// </summary>
@@ -135,8 +132,6 @@ namespace osu.Game.Screens.Play.HUD
 
             Current.BindValueChanged(combo => updateCount(combo.NewValue == 0), true);
 
-            // Since layout depends on combo font height we need to update it during skin change
-            skin.SourceChanged += updateLayout;
             updateLayout();
         }
 
@@ -291,14 +286,6 @@ namespace osu.Game.Screens.Play.HUD
         {
             double difference = currentValue > newValue ? currentValue - newValue : newValue - currentValue;
             return difference * rolling_duration;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (skin != null)
-                skin.SourceChanged -= updateLayout;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -206,7 +206,11 @@ namespace osu.Game.Screens.Play.HUD
 
             counterContainer.Size = displayedCountSpriteText.Size;
 
-            displayedCountSpriteText.ScaleTo(1.1f, small_pop_out_duration / 2, Easing.InQuad).Then()
+            // In stable, small pop out always starts from its initial size
+            displayedCountSpriteText.ClearTransforms();
+
+            displayedCountSpriteText.ScaleTo(1).Then()
+                                    .ScaleTo(1.1f, small_pop_out_duration / 2, Easing.InQuad).Then()
                                     .ScaleTo(1, small_pop_out_duration / 2, Easing.OutQuad);
         }
 

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -207,8 +207,8 @@ namespace osu.Game.Screens.Play.HUD
             counterContainer.Size = displayedCountSpriteText.Size;
 
             displayedCountSpriteText.ScaleTo(1).Then()
-                                    .ScaleTo(1.1f, small_pop_out_duration / 2, Easing.InQuad).Then()
-                                    .ScaleTo(1, small_pop_out_duration / 2, Easing.OutQuad);
+                                    .ScaleTo(1.1f, small_pop_out_duration / 2, Easing.In).Then()
+                                    .ScaleTo(1, small_pop_out_duration / 2, Easing.Out);
         }
 
         private void scheduledPopOutSmall(uint id)

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Screens.Play.HUD
 
         private readonly Container counterContainer;
 
+        [Resolved]
+        private ISkinSource skin { get; set; }
+
         /// <summary>
         /// Hides the combo counter internally without affecting its <see cref="SkinnableInfo"/>.
         /// </summary>
@@ -118,12 +121,9 @@ namespace osu.Game.Screens.Play.HUD
         }
 
         [BackgroundDependencyLoader]
-        private void load(ScoreProcessor scoreProcessor, ISkinSource skin)
+        private void load(ScoreProcessor scoreProcessor)
         {
             Current.BindTo(scoreProcessor.Combo);
-
-            // Since layout depends on combo font height we need to update it during skin change
-            skin.SourceChanged += updateLayout;
         }
 
         protected override void LoadComplete()
@@ -133,9 +133,11 @@ namespace osu.Game.Screens.Play.HUD
             ((IHasText)displayedCountSpriteText).Text = formatCount(Current.Value);
             ((IHasText)popOutCount).Text = formatCount(Current.Value);
 
-            updateLayout();
-
             Current.BindValueChanged(combo => updateCount(combo.NewValue == 0), true);
+
+            // Since layout depends on combo font height we need to update it during skin change
+            skin.SourceChanged += updateLayout;
+            updateLayout();
         }
 
         private void updateLayout()
@@ -289,6 +291,14 @@ namespace osu.Game.Screens.Play.HUD
         {
             double difference = currentValue > newValue ? currentValue - newValue : newValue - currentValue;
             return difference * rolling_duration;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (skin != null)
+                skin.SourceChanged -= updateLayout;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LegacyComboCounter.cs
@@ -184,11 +184,11 @@ namespace osu.Game.Screens.Play.HUD
         {
             ((IHasText)popOutCount).Text = formatCount(newValue);
 
-            popOutCount.ScaleTo(1.56f);
-            popOutCount.FadeTo(0.6f);
+            popOutCount.ScaleTo(1.56f)
+                       .ScaleTo(1, big_pop_out_duration);
 
-            popOutCount.ScaleTo(1, big_pop_out_duration);
-            popOutCount.FadeOut(big_pop_out_duration);
+            popOutCount.FadeTo(0.6f)
+                       .FadeOut(big_pop_out_duration);
         }
 
         private void transformNoPopOut(int newValue)


### PR DESCRIPTION
Current legacy counter was pretty distracting to me so I decided to update it to closer match stable.

It seems there aren't any issues/discussions opened for that.

Preview: https://img.wieku.me/videos/counterprcomp.mp4 (video was too big to upload directly)