### PR TITLE
Fix countdown timer not refreshing on new countdown

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -36,17 +36,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         }
 
         private MultiplayerCountdown countdown;
-        private DateTimeOffset countdownReceivedTime;
+        private DateTimeOffset countdownChangeTime;
         private ScheduledDelegate countdownUpdateDelegate;
 
         private void onRoomUpdated() => Scheduler.AddOnce(() =>
         {
-            if (countdown == null && room?.Countdown != null)
-                countdownReceivedTime = DateTimeOffset.Now;
+            if (countdown != room?.Countdown)
+            {
+                countdown = room?.Countdown;
+                countdownChangeTime = DateTimeOffset.Now;
+            }
 
-            countdown = room?.Countdown;
-
-            if (room?.Countdown != null)
+            if (countdown != null)
                 countdownUpdateDelegate ??= Scheduler.AddDelayed(updateButtonText, 100, true);
             else
             {
@@ -74,7 +75,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
             if (countdown != null)
             {
-                TimeSpan timeElapsed = DateTimeOffset.Now - countdownReceivedTime;
+                TimeSpan timeElapsed = DateTimeOffset.Now - countdownChangeTime;
                 TimeSpan countdownRemaining;
 
                 if (timeElapsed > countdown.TimeRemaining)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/17507

Caused by the `AddOnce` call. The biggest change I've made is the first conditional, removing the `countdown == null` check thus allowing changes from non-null to non-null countdown objects. The rest is refactoring.

Kinda hard to test this. 