### PR TITLE
Remove unnecessary `SetReplayScore` call in `ModCinema`

### DIFF
--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -14,8 +14,6 @@ namespace osu.Game.Rulesets.Mods
     {
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {
-            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, drawableRuleset.Mods));
-
             // AlwaysPresent required for hitsounds
             drawableRuleset.AlwaysPresent = true;
             drawableRuleset.Hide();


### PR DESCRIPTION
Found this while making changes to autoplay structure. I think separating this out from my other changes is best to make sure there's no hidden reason for this being done. Everything still seem to work as expected with this change (the actual `SetReplayScore` call is done automatically by `ReplayPlayer` at https://github.com/ppy/osu/blob/66c307e0eecc4842adbdf9c52f0b56ae8bd1768b/osu.Game/Screens/Play/ReplayPlayer.cs#L39).