### PR TITLE
Add ability to "migrate" data to another folder which has an existing install

### DIFF
--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -64,10 +64,20 @@ namespace osu.Game.IO
         /// </summary>
         public void ResetCustomStoragePath()
         {
-            storageConfig.SetValue(StorageConfig.FullPath, string.Empty);
-            storageConfig.Save();
+            ChangeDataPath(string.Empty);
 
             ChangeTargetStorage(defaultStorage);
+        }
+
+        /// <summary>
+        /// Updates the target data path without immediately switching.
+        /// This does NOT migrate any data.
+        /// The game should immediately be restarted after calling this.
+        /// </summary>
+        public void ChangeDataPath(string newPath)
+        {
+            storageConfig.SetValue(StorageConfig.FullPath, newPath);
+            storageConfig.Save();
         }
 
         /// <summary>
@@ -117,8 +127,7 @@ namespace osu.Game.IO
         {
             bool cleanupSucceeded = base.Migrate(newStorage);
 
-            storageConfig.SetValue(StorageConfig.FullPath, newStorage.GetFullPath("."));
-            storageConfig.Save();
+            ChangeDataPath(newStorage.GetFullPath("."));
 
             return cleanupSucceeded;
         }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Game.IO;
+using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Overlays.Settings.Sections.Maintenance
 {
@@ -15,6 +18,12 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         [Resolved]
         private Storage storage { get; set; }
+
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private DialogOverlay dialogOverlay { get; set; }
 
         protected override DirectoryInfo InitialPath => new DirectoryInfo(storage.GetFullPath(string.Empty)).Parent;
 
@@ -32,8 +41,29 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
             try
             {
-                if (target.GetDirectories().Length > 0 || target.GetFiles().Length > 0)
+                var directoryInfos = target.GetDirectories();
+                var fileInfos = target.GetFiles();
+
+                if (directoryInfos.Length > 0 || fileInfos.Length > 0)
+                {
+                    // Quick test for whether there's already an osu! install at the target path.
+                    if (fileInfos.Any(f => f.Name == @"client.realm"))
+                    {
+                        dialogOverlay.Push(new ConfirmDialog("The target directory already seems to have an osu! install. Use this data instead?", () =>
+                            {
+                                dialogOverlay.Push(new ConfirmDialog("To complete this operation, osu! will close. Please open it again to use the new data location.", () =>
+                                {
+                                    (storage as OsuStorage)?.ChangeDataPath(target.FullName);
+                                    game.GracefullyExit();
+                                }, () => { }));
+                            },
+                            () => { }));
+
+                        return;
+                    }
+
                     target = target.CreateSubdirectory("osu-lazer");
+                }
             }
             catch (Exception e)
             {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     // Quick test for whether there's already an osu! install at the target path.
                     if (fileInfos.Any(f => f.Name == @"client.realm"))
                     {
-                        dialogOverlay.Push(new ConfirmDialog("The target directory already seems to have an osu! install. Use this data instead?", () =>
+                        dialogOverlay.Push(new ConfirmDialog("The target directory already seems to have an osu! install. Use that data instead?", () =>
                             {
                                 dialogOverlay.Push(new ConfirmDialog("To complete this operation, osu! will close. Please open it again to use the new data location.", () =>
                                 {


### PR DESCRIPTION
Until now, migrating would always attempt to move files.

There's a chance that a user is reinstalling osu! but has their data at a custom location. We want to allow the chance for them to continue using the external data. This seems like the easiest way to make it work.

Would be nice if we had a `Game.Restart()` method, but maybe this is enough for now? An alternative would be to implement an `OsuGame.Restart` function and use the squirrel provided method for window (and changing the confirm text if the platform doesn't yet support restarting).

Note that further down the road we will probably prompt the user to potentially select a custom install path (including one with existing data) before osu! gets to writing anything.

Closes https://github.com/ppy/osu/issues/17524.

May see if I can add test coverage for this, but it's a bit different to the existing coverage.