### PR TITLE
Fix "Barrel Roll" tooltip not limiting decimal places for spin speed

### DIFF
--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "The whole playfield is on a wheel!";
         public override double ScoreMultiplier => 1;
 
-        public override string SettingDescription => $"{SpinSpeed.Value} rpm {Direction.Value.GetDescription().ToLowerInvariant()}";
+        public override string SettingDescription => $"{SpinSpeed.Value:N2} rpm {Direction.Value.GetDescription().ToLowerInvariant()}";
 
         public void Update(Playfield playfield)
         {


### PR DESCRIPTION
- Closes #17529 

On a quick check on all `SettingDescription` overrides, "Barrel Roll" is the only mod with this issue.