### PR TITLE
Mark both "Autoplay" and "Cinema" mods as mutually exclusive

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -68,7 +68,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("reset defaults", () =>
             {
                 Ruleset.Value = new OsuRuleset().RulesetInfo;
+
                 Beatmap.SetDefault();
+                SelectedMods.SetDefault();
 
                 songSelect = null;
             });
@@ -563,7 +565,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
-        public void TestAutoplayViaCtrlEnter()
+        public void TestAutoplayShortcut()
         {
             addRulesetImportStep(0);
 
@@ -580,11 +582,65 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
 
-            AddAssert("autoplay enabled", () => songSelect.Mods.Value.FirstOrDefault() is ModAutoplay);
+            AddAssert("autoplay selected", () => songSelect.Mods.Value.Single() is ModAutoplay);
 
             AddUntilStep("wait for return to ss", () => songSelect.IsCurrentScreen());
 
-            AddAssert("mod disabled", () => songSelect.Mods.Value.Count == 0);
+            AddAssert("no mods selected", () => songSelect.Mods.Value.Count == 0);
+        }
+
+        [Test]
+        public void TestAutoplayShortcutKeepsAutoplayIfSelectedAlready()
+        {
+            addRulesetImportStep(0);
+
+            createSongSelect();
+
+            AddUntilStep("wait for selection", () => !Beatmap.IsDefault);
+
+            changeMods(new OsuModAutoplay());
+
+            AddStep("press ctrl+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("autoplay selected", () => songSelect.Mods.Value.Single() is ModAutoplay);
+
+            AddUntilStep("wait for return to ss", () => songSelect.IsCurrentScreen());
+
+            AddAssert("autoplay still selected", () => songSelect.Mods.Value.Single() is ModAutoplay);
+        }
+
+        [Test]
+        public void TestAutoplayShortcutReturnsInitialModsOnExit()
+        {
+            addRulesetImportStep(0);
+
+            createSongSelect();
+
+            AddUntilStep("wait for selection", () => !Beatmap.IsDefault);
+
+            changeMods(new OsuModRelax());
+
+            AddStep("press ctrl+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Enter);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("only autoplay selected", () => songSelect.Mods.Value.Single() is ModAutoplay);
+
+            AddUntilStep("wait for return to ss", () => songSelect.IsCurrentScreen());
+
+            AddAssert("relax returned", () => songSelect.Mods.Value.Single() is ModRelax);
         }
 
         [Test]

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool UserPlayable => false;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModCinema), typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail) };
 
         public override bool HasImplementation => GetType().GenericTypeArguments.Length == 0;
 

--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
@@ -26,6 +28,8 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "CN";
         public override IconUsage? Icon => OsuIcon.ModCinema;
         public override string Description => "Watch the video without visual distractions.";
+
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModAutoplay)).ToArray();
 
         public void ApplyToHUD(HUDOverlay overlay)
         {


### PR DESCRIPTION
- Closes #17508 
- Closes https://github.com/ppy/osu/issues/9244

Marking both mods as mutually exclusive is simple, but the existing Ctrl+Enter shortcut implementation required more work to still keep the autoplay mod in place.

I've refactored the shortcut logic to instead force "Autoplay" to be appended (by excluding any other offending mod), and return back the initially selected mods on resume from gameplay.