### PR TITLE
Ignore EF-to-realm migration tests on M1 ARM architectures

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestEFToRealmMigration.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestEFToRealmMigration.cs
@@ -3,7 +3,9 @@
 
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using NUnit.Framework;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -26,6 +28,23 @@ namespace osu.Game.Tests.Visual.Navigation
             using (var outStream = LocalStorage.GetStream(DatabaseContextFactory.DATABASE_NAME, FileAccess.Write, FileMode.Create))
             using (var stream = TestResources.OpenResource(DatabaseContextFactory.DATABASE_NAME))
                 stream.CopyTo(outStream);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS && RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                Assert.Ignore("EF-to-realm migrations are not supported on M1 ARM architectures.");
+        }
+
+        public override void SetUpSteps()
+        {
+            // base SetUpSteps are executed before the above SetUp, therefore early-return to allow ignoring test properly.
+            // attempting to ignore here would yield a TargetInvocationException instead.
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS && RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                return;
+
+            base.SetUpSteps();
         }
 
         [Test]

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Tests.Visual
         [TearDownSteps]
         public void TearDownSteps()
         {
-            if (DebugUtils.IsNUnitRunning)
+            if (DebugUtils.IsNUnitRunning && Game != null)
             {
                 AddStep("exit game", () => Game.Exit());
                 AddUntilStep("wait for game exit", () => Game.Parent == null);


### PR DESCRIPTION
Otherwise would fail on every test run on M1 chips.

<img width="788" alt="CleanShot 2022-03-30 at 01 27 22@2x" src="https://user-images.githubusercontent.com/22781491/160717174-9e3273b7-2fc5-481b-a19b-3f791c5ac787.png">
<img width="764" alt="CleanShot 2022-03-30 at 01 27 11@2x" src="https://user-images.githubusercontent.com/22781491/160717136-9b32f5f6-35e5-4f38-a3a0-ddaebf266c33.png">

This makes me wonder if this issue only affects macOS, or is actually an issue across all ARM-based systems (i.e. Windows ARM).