### PR TITLE
Remove song source from main wedge display

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void testBeatmapLabels(Ruleset ruleset)
         {
             AddAssert("check version", () => infoWedge.Info.VersionLabel.Current.Value == $"{ruleset.ShortName}Version");
-            AddAssert("check title", () => infoWedge.Info.TitleLabel.Current.Value == $"{ruleset.ShortName}Source — {ruleset.ShortName}Title");
+            AddAssert("check title", () => infoWedge.Info.TitleLabel.Current.Value == $"{ruleset.ShortName}Title");
             AddAssert("check artist", () => infoWedge.Info.ArtistLabel.Current.Value == $"{ruleset.ShortName}Artist");
             AddAssert("check author", () => infoWedge.Info.MapperContainer.ChildrenOfType<OsuSpriteText>().Any(s => s.Current.Value == $"{ruleset.ShortName}Author"));
         }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -314,8 +314,8 @@ namespace osu.Game.Screens.Select
                     }
                 };
 
-                titleBinding.BindValueChanged(_ => setMetadata(metadata.Source));
-                artistBinding.BindValueChanged(_ => setMetadata(metadata.Source), true);
+                titleBinding.BindValueChanged(_ => setMetadata());
+                artistBinding.BindValueChanged(_ => setMetadata(), true);
 
                 addInfoLabels();
             }
@@ -352,10 +352,10 @@ namespace osu.Game.Screens.Select
                 }, true);
             }
 
-            private void setMetadata(string source)
+            private void setMetadata()
             {
                 ArtistLabel.Text = artistBinding.Value;
-                TitleLabel.Text = string.IsNullOrEmpty(source) ? titleBinding.Value : source + " — " + titleBinding.Value;
+                TitleLabel.Text = titleBinding.Value;
             }
 
             private void addInfoLabels()

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -287,12 +287,14 @@ namespace osu.Game.Screens.Select
                         {
                             TitleLabel = new OsuSpriteText
                             {
+                                Current = { BindTarget = titleBinding },
                                 Font = OsuFont.GetFont(size: 28, italics: true),
                                 RelativeSizeAxes = Axes.X,
                                 Truncate = true,
                             },
                             ArtistLabel = new OsuSpriteText
                             {
+                                Current = { BindTarget = artistBinding },
                                 Font = OsuFont.GetFont(size: 17, italics: true),
                                 RelativeSizeAxes = Axes.X,
                                 Truncate = true,
@@ -313,9 +315,6 @@ namespace osu.Game.Screens.Select
                         }
                     }
                 };
-
-                titleBinding.BindValueChanged(_ => setMetadata());
-                artistBinding.BindValueChanged(_ => setMetadata(), true);
 
                 addInfoLabels();
             }
@@ -350,12 +349,6 @@ namespace osu.Game.Screens.Select
                     settingChangeTracker = new ModSettingChangeTracker(m.NewValue);
                     settingChangeTracker.SettingChanged += _ => refreshBPMLabel();
                 }, true);
-            }
-
-            private void setMetadata()
-            {
-                ArtistLabel.Text = artistBinding.Value;
-                TitleLabel.Text = titleBinding.Value;
             }
 
             private void addInfoLabels()


### PR DESCRIPTION
Quick QoL fix until the full design is updated.

This was definitely added at someone's request, since I wouldn't have put it here. But it's displayed below in the details section already and also not displayed in the updated "wedge" in the new design.

See https://github.com/ppy/osu/discussions/17537 for discussion.