### PR TITLE
Fix `MultiplayerMatchSongSelect` potentially attempting to exit when not the current screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -80,6 +80,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 {
                     Schedule(() =>
                     {
+                        // If an error or server side trigger occurred this screen may have already exited by external means.
+                        if (!this.IsCurrentScreen())
+                            return;
+
                         loadingLayer.Hide();
 
                         if (t.IsFaulted)


### PR DESCRIPTION
Noticed while investigating #17487.