### PR TITLE
Fix osu! logo being clicked when exiting via cmd-q on initial state

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -207,6 +207,9 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            if (e.Repeat || e.ControlPressed || e.ShiftPressed || e.AltPressed || e.SuperPressed)
+                return false;
+
             if (State == ButtonSystemState.Initial)
             {
                 if (buttonsTopLevel.Any(b => e.Key == b.TriggerKey))


### PR DESCRIPTION
Copied the logic from `MainMenuButton` to be consistent with button presses because currently ctrl-p will click the logo but not the main menu buttons, for example.

| Before | After |
| --- | --- |
| ![Kapture 2022-03-30 at 21 32 42](https://user-images.githubusercontent.com/35318437/160977147-fc7a98d4-a004-4b27-a56b-daeb52fb1099.gif) | ![Kapture 2022-03-30 at 21 34 40](https://user-images.githubusercontent.com/35318437/160977295-3a71f451-9987-40e3-8a5a-fcb560634ee0.gif) |