### PR TITLE
Ignore line ending normalisation commit from blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Normalize all the line endings
+32a74f95a5c80a0ed18e693f13a47522099df5c3


### PR DESCRIPTION
GitHub now supports ignoring commits, see https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view.

Preview:
https://github.com/Joehuu/osu/blame/ignore-line-ending-rev/osu.Game/OsuGame.cs
https://github.com/ppy/osu/blame/master/osu.Game/OsuGame.cs

In the preview, there are still instances of that commit, but it's only on newlines.

Not sure if there are other commits, but the line ending commit is the most offending one as seen in https://github.com/ppy/osu/graphs/contributors?from=2016-08-21&to=2022-03-30&type=a.