### PR TITLE
Focus focus not being transferred correctly to parent settings panel on exiting nested panel

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsPanel.cs
@@ -1,16 +1,21 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Settings.Sections;
+using osu.Game.Overlays.Settings.Sections.Input;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Settings
 {
     [TestFixture]
-    public class TestSceneSettingsPanel : OsuTestScene
+    public class TestSceneSettingsPanel : OsuManualInputManagerTestScene
     {
         private SettingsPanel settings;
         private DialogOverlay dialogOverlay;
@@ -33,7 +38,55 @@ namespace osu.Game.Tests.Visual.Settings
         public void ToggleVisibility()
         {
             AddWaitStep("wait some", 5);
-            AddToggleStep("toggle editor visibility", visible => settings.ToggleVisibility());
+            AddToggleStep("toggle visibility", visible => settings.ToggleVisibility());
+        }
+
+        [Test]
+        public void TestTextboxFocusAfterNestedPanelBackButton()
+        {
+            AddUntilStep("sections loaded", () => settings.SectionsContainer.Children.Count > 0);
+            AddUntilStep("top-level textbox focused", () => settings.SectionsContainer.ChildrenOfType<FocusedTextBox>().FirstOrDefault()?.HasFocus == true);
+
+            AddStep("open key binding subpanel", () =>
+            {
+                settings.SectionsContainer
+                        .ChildrenOfType<InputSection>().FirstOrDefault()?
+                        .ChildrenOfType<OsuButton>().FirstOrDefault()?
+                        .TriggerClick();
+            });
+
+            AddUntilStep("binding panel textbox focused", () => settings
+                                                                .ChildrenOfType<KeyBindingPanel>().FirstOrDefault()?
+                                                                .ChildrenOfType<FocusedTextBox>().FirstOrDefault()?.HasFocus == true);
+
+            AddStep("Press back", () => settings
+                                        .ChildrenOfType<KeyBindingPanel>().FirstOrDefault()?
+                                        .ChildrenOfType<SettingsSubPanel.BackButton>().FirstOrDefault()?.TriggerClick());
+
+            AddUntilStep("top-level textbox focused", () => settings.SectionsContainer.ChildrenOfType<FocusedTextBox>().FirstOrDefault()?.HasFocus == true);
+        }
+
+        [Test]
+        public void TestTextboxFocusAfterNestedPanelEscape()
+        {
+            AddUntilStep("sections loaded", () => settings.SectionsContainer.Children.Count > 0);
+            AddUntilStep("top-level textbox focused", () => settings.SectionsContainer.ChildrenOfType<FocusedTextBox>().FirstOrDefault()?.HasFocus == true);
+
+            AddStep("open key binding subpanel", () =>
+            {
+                settings.SectionsContainer
+                        .ChildrenOfType<InputSection>().FirstOrDefault()?
+                        .ChildrenOfType<OsuButton>().FirstOrDefault()?
+                        .TriggerClick();
+            });
+
+            AddUntilStep("binding panel textbox focused", () => settings
+                                                                .ChildrenOfType<KeyBindingPanel>().FirstOrDefault()?
+                                                                .ChildrenOfType<FocusedTextBox>().FirstOrDefault()?.HasFocus == true);
+
+            AddStep("Escape", () => InputManager.Key(Key.Escape));
+
+            AddUntilStep("top-level textbox focused", () => settings.SectionsContainer.ChildrenOfType<FocusedTextBox>().FirstOrDefault()?.HasFocus == true);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Graphics.UserInterface
             if (!allowImmediateFocus)
                 return;
 
-            Scheduler.Add(() => GetContainingInputManager().ChangeFocus(this), false);
+            Scheduler.Add(() => GetContainingInputManager().ChangeFocus(this));
         }
 
         public new void KillFocus() => base.KillFocus();

--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays
 
         protected override bool DimMainContent => false; // dimming is handled by main overlay
 
-        private class BackButton : SidebarButton
+        public class BackButton : SidebarButton
         {
             private Container content;
 


### PR DESCRIPTION
Seemingly harmless schedule delay ommission meant that the textbox may not be in a state it can handle the incoming focus event. Regressed in https://github.com/ppy/osu/pull/14345#discussion_r690697501.

Closes https://github.com/ppy/osu/issues/17564.