### PR TITLE
Fix tournament bracket parsing's ruleset refetch logic not working correctly

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
@@ -1,9 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Game.Rulesets;
 using osu.Game.Tests;
@@ -13,13 +17,52 @@ namespace osu.Game.Tournament.Tests.NonVisual
     public class DataLoadTest : TournamentHostTest
     {
         [Test]
+        public void TestRulesetGetsValidOnlineID()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            {
+                try
+                {
+                    var osu = new TestTournament(runOnLoadComplete: () =>
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        var storage = host.Storage.GetStorageForDirectory(Path.Combine("tournaments", "default"));
+
+                        using (var stream = storage.GetStream("bracket.json", FileAccess.Write, FileMode.Create))
+                        using (var writer = new StreamWriter(stream))
+                        {
+                            writer.Write(@"{
+                        ""Ruleset"": {
+                            ""ShortName"": ""taiko"",
+                            ""OnlineID"": -1,
+                            ""Name"": ""osu!taiko"",
+                            ""InstantiationInfo"": ""osu.Game.Rulesets.OsuTaiko.TaikoRuleset, osu.Game.Rulesets.Taiko"",
+                            ""Available"": true
+                        } }");
+                        }
+                    });
+
+                    LoadTournament(host, osu);
+
+                    osu.BracketLoadTask.WaitSafely();
+
+                    Assert.That(osu.Dependencies.Get<IBindable<RulesetInfo>>().Value.OnlineID, Is.EqualTo(1));
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
         public void TestUnavailableRuleset()
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
             {
                 try
                 {
-                    var osu = new TestTournament();
+                    var osu = new TestTournament(true);
 
                     LoadTournament(host, osu);
                     var storage = osu.Dependencies.Get<Storage>();
@@ -35,10 +78,23 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
         public class TestTournament : TournamentGameBase
         {
+            private readonly bool resetRuleset;
+            private readonly Action runOnLoadComplete;
+
+            public new Task BracketLoadTask => base.BracketLoadTask;
+
+            public TestTournament(bool resetRuleset = false, Action runOnLoadComplete = null)
+            {
+                this.resetRuleset = resetRuleset;
+                this.runOnLoadComplete = runOnLoadComplete;
+            }
+
             protected override void LoadComplete()
             {
+                runOnLoadComplete?.Invoke();
                 base.LoadComplete();
-                Ruleset.Value = new RulesetInfo(); // not available
+                if (resetRuleset)
+                    Ruleset.Value = new RulesetInfo(); // not available
             }
         }
     }

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -64,8 +64,6 @@ namespace osu.Game.Tournament
             Textures.AddStore(new TextureLoaderStore(new StorageBackedResourceStore(storage)));
 
             dependencies.CacheAs(new StableInfo(storage));
-
-            Task.Run(readBracket);
         }
 
         private void readBracket()
@@ -290,6 +288,8 @@ namespace osu.Game.Tournament
             MenuCursorContainer.Cursor.Alpha = 0;
 
             base.LoadComplete();
+
+            Task.Run(readBracket);
         }
 
         protected virtual void SaveChanges()

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -66,6 +66,18 @@ namespace osu.Game.Tournament
             dependencies.CacheAs(new StableInfo(storage));
         }
 
+        protected override void LoadComplete()
+        {
+            MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
+
+            // we don't want to show the menu cursor as it would appear on stream output.
+            MenuCursorContainer.Cursor.Alpha = 0;
+
+            base.LoadComplete();
+
+            Task.Run(readBracket);
+        }
+
         private void readBracket()
         {
             try
@@ -79,9 +91,13 @@ namespace osu.Game.Tournament
 
                 ladder ??= new LadderInfo();
 
-                ladder.Ruleset.Value = ladder.Ruleset.Value != null
+                var resolvedRuleset = ladder.Ruleset.Value != null
                     ? RulesetStore.GetRuleset(ladder.Ruleset.Value.ShortName)
                     : RulesetStore.AvailableRulesets.First();
+
+                // Must set to null initially to avoid the following re-fetch hitting `ShortName` based equality check.
+                ladder.Ruleset.Value = null;
+                ladder.Ruleset.Value = resolvedRuleset;
 
                 bool addedInfo = false;
 
@@ -278,18 +294,6 @@ namespace osu.Game.Tournament
 
                 success?.Invoke();
             }
-        }
-
-        protected override void LoadComplete()
-        {
-            MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
-
-            // we don't want to show the menu cursor as it would appear on stream output.
-            MenuCursorContainer.Cursor.Alpha = 0;
-
-            base.LoadComplete();
-
-            Task.Run(readBracket);
         }
 
         protected virtual void SaveChanges()


### PR DESCRIPTION
Due to equality being based on `ShortName`, it was feasible that the re-fetch exited early (in bindable shortcutting logic) causing the ruleset's `OnlineID` to remain `-1` or something equally wrong.

Resolves issue pointed out at https://github.com/ppy/osu/discussions/17538#discussioncomment-2471746.