### PR TITLE
Increase font weight for runtime clock

### DIFF
--- a/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osuTK;
 
 namespace osu.Game.Overlays.Toolbar
 {
@@ -42,7 +41,7 @@ namespace osu.Game.Overlays.Toolbar
                 {
                     Y = 14,
                     Colour = colours.PinkLight,
-                    Scale = new Vector2(0.6f)
+                    Font = OsuFont.Default.With(size: 10, weight: FontWeight.SemiBold),
                 }
             };
 


### PR DESCRIPTION
Fonts this small are required to be `SemiBold` by design guidelines. Somehow missed this.

Before:

![Safari 2022-03-31 at 10 11 42](https://user-images.githubusercontent.com/191335/161031929-4ba84b11-eab3-441b-8d8e-6a49755163a9.png)

After:
![Safari 2022-03-31 at 10 11 53](https://user-images.githubusercontent.com/191335/161031955-0f6afa3d-164d-4e0b-bbc2-df9ba5d5119f.png)
