### PR TITLE
Add Spacing Adjust mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpacingAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpacingAdjust.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Osu.Utils;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModSpacingAdjust : Mod, IApplicableToBeatmap
+    {
+        public override string Name => "Spacing Adjust";
+
+        public override string Description => "Adjust object spacing to your liking.";
+
+        public override double ScoreMultiplier => 1;
+
+        public override string Acronym => "SA";
+
+        public override ModType Type => ModType.Conversion;
+
+        public override bool RequiresConfiguration => true;
+
+        [SettingSource("Object spacing", "Modifies the spacing between objects.")]
+        public BindableNumber<float> ObjectSpacing { get; } = new BindableFloat
+        {
+            MinValue = 0.5f,
+            MaxValue = 2,
+            Default = 1,
+            Value = 1,
+            Precision = 0.01f,
+        };
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            if (!(beatmap is OsuBeatmap osuBeatmap))
+                return;
+
+            var positionInfos = OsuHitObjectGenerationUtils.GeneratePositionInfos(osuBeatmap.HitObjects);
+
+            positionInfos.ForEach(p => p.DistanceFromPrevious *= ObjectSpacing.Value);
+
+            osuBeatmap.HitObjects = OsuHitObjectGenerationUtils.RepositionHitObjects(positionInfos);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpacingAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpacingAdjust.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             Precision = 0.01f,
         };
 
+        public override string SettingDescription => ObjectSpacing.IsDefault ? string.Empty : $"{ObjectSpacing.Value:N2}x";
+
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
             if (!(beatmap is OsuBeatmap osuBeatmap))

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpacingAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpacingAdjust.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
@@ -43,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             var positionInfos = OsuHitObjectGenerationUtils.GeneratePositionInfos(osuBeatmap.HitObjects);
 
-            positionInfos.ForEach(p => p.DistanceFromPrevious *= ObjectSpacing.Value);
+            positionInfos.Skip(1).ForEach(p => p.DistanceFromPrevious *= ObjectSpacing.Value);
 
             osuBeatmap.HitObjects = OsuHitObjectGenerationUtils.RepositionHitObjects(positionInfos);
         }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -171,6 +171,7 @@ namespace osu.Game.Rulesets.Osu
                         new OsuModRandom(),
                         new OsuModMirror(),
                         new OsuModAlternate(),
+                        new OsuModSpacingAdjust()
                     };
 
                 case ModType.Automation:


### PR DESCRIPTION
(Finally) resolves #17128

Works better with #17591, but the two PRs are not dependent on each other.

Implementation of the mod itself is very simple since `OsuHitObjectGenerationUtils` do all the heavy lifting.

I marked the mod as `RequiresConfiguration` because users probably want something other than the default 1x value, but note that 1x still changes the beatmap because the generation algorithm is still applied.