### PR TITLE
Fix automatically created "(modified)" skins getting conflicting names

### DIFF
--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -24,6 +24,7 @@ using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Utils;
 
 namespace osu.Game.Skinning
 {
@@ -144,20 +145,26 @@ namespace osu.Game.Skinning
                 if (!s.Protected)
                     return;
 
+                var existingSkinNames = realm.Run(r => r.All<SkinInfo>()
+                                                        .Where(skin => !skin.DeletePending)
+                                                        .AsEnumerable()
+                                                        .Select(skin => skin.Name));
+
                 // if the user is attempting to save one of the default skin implementations, create a copy first.
-                var result = skinModelManager.Import(new SkinInfo
+                var skinInfo = new SkinInfo
                 {
-                    Name = s.Name + @" (modified)",
                     Creator = s.Creator,
                     InstantiationInfo = s.InstantiationInfo,
-                });
+                    Name = NamingUtils.GetNextBestName(existingSkinNames, $"{s.Name} (modified)")
+                };
+
+                var result = skinModelManager.Import(skinInfo);
 
                 if (result != null)
                 {
                     // save once to ensure the required json content is populated.
                     // currently this only happens on save.
                     result.PerformRead(skin => Save(skin.CreateInstance(this)));
-
                     CurrentSkinInfo.Value = result;
                 }
             });

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -145,10 +145,10 @@ namespace osu.Game.Skinning
                 if (!s.Protected)
                     return;
 
-                var existingSkinNames = realm.Run(r => r.All<SkinInfo>()
-                                                        .Where(skin => !skin.DeletePending)
-                                                        .AsEnumerable()
-                                                        .Select(skin => skin.Name));
+                string[] existingSkinNames = realm.Run(r => r.All<SkinInfo>()
+                                                             .Where(skin => !skin.DeletePending)
+                                                             .AsEnumerable()
+                                                             .Select(skin => skin.Name)).ToArray();
 
                 // if the user is attempting to save one of the default skin implementations, create a copy first.
                 var skinInfo = new SkinInfo

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Skinning
                 string[] existingSkinNames = realm.Run(r => r.All<SkinInfo>()
                                                              .Where(skin => !skin.DeletePending)
                                                              .AsEnumerable()
-                                                             .Select(skin => skin.Name)).ToArray();
+                                                             .Select(skin => skin.Name).ToArray());
 
                 // if the user is attempting to save one of the default skin implementations, create a copy first.
                 var skinInfo = new SkinInfo


### PR DESCRIPTION
Applies the already tested and proven method that is used in the editor to the mutable skin creation flow.

Before:

![osu! 2022-04-01 at 05 14 05](https://user-images.githubusercontent.com/191335/161199149-fb2a5c26-6525-4918-a59d-3ecd9f8bac83.png)


After:

![osu! 2022-04-01 at 05 13 17](https://user-images.githubusercontent.com/191335/161199084-fa90a107-7814-4e4c-a365-0ad9ea5db813.png)

