### PR TITLE
Disable ability to use random skin shortcut from within the skin editor

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1061,6 +1061,12 @@ namespace osu.Game
                     return true;
 
                 case GlobalAction.RandomSkin:
+                    // Don't allow random skin selection while in the skin editor.
+                    // This is mainly to stop many "osu! default (modified)" skins being created via the SkinManager.EnsureMutableSkin() path.
+                    // If people want this to work we can potentially avoid selecting default skins when the editor is open, or allow a maximum of one mutable skin somehow.
+                    if (skinEditor.State.Value == Visibility.Visible)
+                        return false;
+
                     SkinManager.SelectRandomSkin();
                     return true;
             }


### PR DESCRIPTION
Reasoning is explained in inline comment.

I knowingly only applied this to the shortcut key. It's still feasible a user can choose the option from the skin dropdown while the editor is open, but that's less of an issue (because a user won't get the same compulsion that I get to mash the key, only to be greeted with 100 new mutable skins created).