### PR TITLE
Move `SkinnableInfo` error handling to lower level

### DIFF
--- a/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Skinning;
@@ -84,9 +85,17 @@ namespace osu.Game.Screens.Play.HUD
         /// <returns>The new instance.</returns>
         public Drawable CreateInstance()
         {
-            Drawable d = (Drawable)Activator.CreateInstance(Type);
-            d.ApplySkinnableInfo(this);
-            return d;
+            try
+            {
+                Drawable d = (Drawable)Activator.CreateInstance(Type);
+                d.ApplySkinnableInfo(this);
+                return d;
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, $"Unable to create skin component {Type.Name}");
+                return Drawable.Empty();
+            }
         }
     }
 }

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -155,16 +155,7 @@ namespace osu.Game.Skinning
                     var components = new List<Drawable>();
 
                     foreach (var i in skinnableInfo)
-                    {
-                        try
-                        {
-                            components.Add(i.CreateInstance());
-                        }
-                        catch (Exception e)
-                        {
-                            Logger.Error(e, $"Unable to create skin component {i.Type.Name}");
-                        }
-                    }
+                        components.Add(i.CreateInstance());
 
                     return new SkinnableTargetComponentsContainer
                     {


### PR DESCRIPTION
Handling was recently added to handle the usage in `Skin.GetDrawableCompoent` (in #17448), but it turns out this is also required for `DrawableExtensions.ApplySkinnableInfo` which can throw in a similar fashion.

Found while working on sprite support for the editor, where this becomes an actual issue (ie. switching to a branch where the new sprite support is not present can cause unexpected crashes).