### PR TITLE
Add SFX for multiplayer lobby countdown timer

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.404.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.405.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.404.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.404.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.325.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -104,7 +104,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             lastTickSampleTime = Time.Current;
 
             if (secondsRemaining < 10) countdownTickSample?.Play();
-            if (secondsRemaining <= 3) countdownTickFinalSample?.Play();
+            // disabled for now pending further work on sound effect
+            // if (secondsRemaining <= 3) countdownTickFinalSample?.Play();
         }
 
         private void updateButtonText()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         private MultiplayerRoom room => multiplayerClient.Room;
 
         private Sample countdownTickSample;
-        private Sample countdownTickFinalSample;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
             countdownTickSample = audio.Samples.Get(@"Multiplayer/countdown-tick");
-            countdownTickFinalSample = audio.Samples.Get(@"Multiplayer/countdown-tick-final");
+            // disabled for now pending further work on sound effect
+            // countdownTickFinalSample = audio.Samples.Get(@"Multiplayer/countdown-tick-final");
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Localisation;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
@@ -26,6 +28,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
         [CanBeNull]
         private MultiplayerRoom room => multiplayerClient.Room;
+
+        private Sample countdownTickSample;
+        private Sample countdownTickFinalSample;
+        private int? lastTickPlayed;
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            countdownTickSample = audio.Samples.Get(@"Multiplayer/countdown-tick");
+            countdownTickFinalSample = audio.Samples.Get(@"Multiplayer/countdown-tick-final");
+        }
 
         protected override void LoadComplete()
         {
@@ -82,6 +95,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     countdownRemaining = TimeSpan.Zero;
                 else
                     countdownRemaining = countdown.TimeRemaining - timeElapsed;
+
+                if (countdownRemaining.Seconds <= 10 && (lastTickPlayed == null || lastTickPlayed != countdownRemaining.Seconds))
+                {
+                    countdownTickSample?.Play();
+
+                    if (countdownRemaining.Seconds <= 3)
+                        countdownTickFinalSample?.Play();
+
+                    lastTickPlayed = countdownRemaining.Seconds;
+                }
 
                 string countdownText = $"Starting in {countdownRemaining:mm\\:ss}";
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -73,8 +73,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             {
                 // The remaining time on a countdown may be at a fractional portion between two seconds.
                 // We want to align certain audio/visual cues to the point at which integer seconds change.
-                // To do so, we schedule to the next whole second.
-                // Note that scheduler invocation isn't guaranteed to be accurate, so this may still occur slightly late.
+                // To do so, we schedule to the next whole second. Note that scheduler invocation isn't
+                // guaranteed to be accurate, so this may still occur slightly late, but even in such a case
+                // the next invocation will be roughly correct.
                 double timeToNextSecond = countdownTimeRemaining.TotalMilliseconds % 1000;
 
                 countdownUpdateDelegate = Scheduler.AddDelayed(onCountdownTick, timeToNextSecond);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -67,9 +67,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
         private void scheduleNextCountdownUpdate()
         {
+            countdownUpdateDelegate?.Cancel();
+
             if (countdown != null)
             {
-                // If a countdown is active, schedule relevant components to update on the next whole second.
+                // The remaining time on a countdown may be at a fractional portion between two seconds.
+                // We want to align certain audio/visual cues to the point at which integer seconds change.
+                // To do so, we schedule to the next whole second.
+                // Note that scheduler invocation isn't guaranteed to be accurate, so this may still occur slightly late.
                 double timeToNextSecond = countdownTimeRemaining.TotalMilliseconds % 1000;
 
                 countdownUpdateDelegate = Scheduler.AddDelayed(onCountdownTick, timeToNextSecond);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -98,16 +98,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             }
         }
 
-        private double? lastTickSampleTime;
-
         private void playTickSound(int secondsRemaining)
         {
-            // Simplified debounce. Ticks should only be played roughly once per second regardless of how often this function is called.
-            if (Time.Current - lastTickSampleTime < 500)
-                return;
-
-            lastTickSampleTime = Time.Current;
-
             if (secondsRemaining < 10) countdownTickSample?.Play();
             // disabled for now pending further work on sound effect
             // if (secondsRemaining <= 3) countdownTickFinalSample?.Play();

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.325.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.404.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.404.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.404.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.405.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.325.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.404.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
   <PropertyGroup>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.404.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.404.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.405.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
Currently plays a tick every second when there are 10 seconds (or less) remaining, with a more obnoxious sample layered on top for the last 3 seconds... open to suggestions for better cutoff values.

I'm also not sure if `MultiplayerReadyButton` is the best place to implement this as I noticed it doesn't seem to update at a consistent interval?

- [x] depends on ppy/osu-resources#184