### PR TITLE
Make overlay shortcuts able to be toggled instead of repeatable

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -95,8 +95,6 @@ namespace osu.Game
 
         private SkinEditorOverlay skinEditor;
 
-        private NowPlayingOverlay nowPlayingOverlay;
-
         private Container overlayContent;
 
         private Container rightFloatingOverlayContent;
@@ -820,7 +818,7 @@ namespace osu.Game
                 Origin = Anchor.TopRight,
             }, rightFloatingOverlayContent.Add, true);
 
-            loadComponentSingleFile(nowPlayingOverlay = new NowPlayingOverlay
+            loadComponentSingleFile(new NowPlayingOverlay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
@@ -1070,26 +1068,6 @@ namespace osu.Game
                         return false;
 
                     SkinManager.SelectRandomSkin();
-                    return true;
-
-                case GlobalAction.ToggleChat:
-                    chatOverlay.ToggleVisibility();
-                    return true;
-
-                case GlobalAction.ToggleSocial:
-                    dashboard.ToggleVisibility();
-                    return true;
-
-                case GlobalAction.ToggleNowPlaying:
-                    nowPlayingOverlay.ToggleVisibility();
-                    return true;
-
-                case GlobalAction.ToggleBeatmapListing:
-                    beatmapListing.ToggleVisibility();
-                    return true;
-
-                case GlobalAction.ToggleSettings:
-                    Settings.ToggleVisibility();
                     return true;
             }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -95,6 +95,8 @@ namespace osu.Game
 
         private SkinEditorOverlay skinEditor;
 
+        private NowPlayingOverlay nowPlayingOverlay;
+
         private Container overlayContent;
 
         private Container rightFloatingOverlayContent;
@@ -818,7 +820,7 @@ namespace osu.Game
                 Origin = Anchor.TopRight,
             }, rightFloatingOverlayContent.Add, true);
 
-            loadComponentSingleFile(new NowPlayingOverlay
+            loadComponentSingleFile(nowPlayingOverlay = new NowPlayingOverlay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
@@ -1068,6 +1070,26 @@ namespace osu.Game
                         return false;
 
                     SkinManager.SelectRandomSkin();
+                    return true;
+
+                case GlobalAction.ToggleChat:
+                    chatOverlay.ToggleVisibility();
+                    return true;
+
+                case GlobalAction.ToggleSocial:
+                    dashboard.ToggleVisibility();
+                    return true;
+
+                case GlobalAction.ToggleNowPlaying:
+                    nowPlayingOverlay.ToggleVisibility();
+                    return true;
+
+                case GlobalAction.ToggleBeatmapListing:
+                    beatmapListing.ToggleVisibility();
+                    return true;
+
+                case GlobalAction.ToggleSettings:
+                    Settings.ToggleVisibility();
                     return true;
             }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Overlays.Toolbar
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (!e.Repeat && e.Action == Hotkey)
+            if (e.Action == Hotkey && !e.Repeat)
             {
                 TriggerClick();
                 return true;

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Overlays.Toolbar
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (e.Action == Hotkey)
+            if (!e.Repeat && e.Action == Hotkey)
             {
                 TriggerClick();
                 return true;


### PR DESCRIPTION
Currently if you hold any of the shortcuts it just spams the overlay command and personally that's a thing that should be toggable instead of the current behavior.

I don't know if the way I did it is the proper way since I'm not really familiar with the entirety of the codebase.

Let me know if anything isn't as it should.