### PR TITLE
Adjust osu!taiko hit size and strong scale to exactly match osu!(stable)

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// <summary>
         /// Default size of a drawable taiko hit object.
         /// </summary>
-        public const float DEFAULT_SIZE = 0.45f;
+        public const float DEFAULT_SIZE = 0.475f;
 
         public override Judgement CreateJudgement() => new TaikoJudgement();
 

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// <summary>
         /// Scale multiplier for a strong drawable taiko hit object.
         /// </summary>
-        public const float STRONG_SCALE = 1.4f;
+        public const float STRONG_SCALE = 1.525f;
 
         /// <summary>
         /// Default size of a strong drawable taiko hit object.

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// <summary>
         /// Scale multiplier for a strong drawable taiko hit object.
         /// </summary>
-        public const float STRONG_SCALE = 1.525f;
+        public const float STRONG_SCALE = 1 / 0.65f;
 
         /// <summary>
         /// Default size of a strong drawable taiko hit object.

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Taiko.Objects;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Skinning.Default
@@ -24,8 +25,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
     /// </summary>
     public abstract class CirclePiece : BeatSyncedContainer, IHasAccentColour
     {
-        public const float SYMBOL_SIZE = 0.45f;
+        public const float SYMBOL_SIZE = TaikoHitObject.DEFAULT_SIZE;
         public const float SYMBOL_BORDER = 8;
+
         private const double pre_beat_transition_time = 80;
 
         private Color4 accentColour;


### PR DESCRIPTION
Resolves the first two points in https://github.com/ppy/osu/issues/17422.

Values were pretty much extracted via comparisons between screenshots taken on stable and lazer (classic):

</details>
<details>
<summary>regular hit size comparison</summary>

<img width="236" alt="CleanShot 2022-04-02 at 23 34 28@2x" src="https://user-images.githubusercontent.com/22781491/161401151-ba251608-010a-499d-82e9-ec055547e286.png">

</details>

<details>
<summary>strong hit size comparison</summary>

<img width="476" alt="CleanShot 2022-04-02 at 23 33 06@2x" src="https://user-images.githubusercontent.com/22781491/161401149-6032738b-2465-4d4e-bc21-e0c722f0387b.png">

</details>

| | objects |
|-|-|
| before | <img width="419" alt="CleanShot 2022-04-02 at 23 37 20@2x" src="https://user-images.githubusercontent.com/22781491/161400914-a012a485-225e-477b-8018-53a09f5f2cca.png"> |
| after | <img width="419" alt="CleanShot 2022-04-02 at 23 40 12@2x" src="https://user-images.githubusercontent.com/22781491/161400915-f0f9e399-9352-4c3f-9dce-8534132b1c18.png"> |
| stable | <img width="419" alt="CleanShot 2022-04-02 at 23 37 14@2x" src="https://user-images.githubusercontent.com/22781491/161400912-16b8568b-82f1-4a15-94ae-5b4ca3ce6482.png"> |