### PR TITLE
Adjust osu!taiko legacy hit target size to match osu!(stable)

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyHitTarget.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyHitTarget.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                     new Sprite
                     {
                         Texture = skin.GetTexture("approachcircle"),
-                        Scale = new Vector2(0.73f),
+                        Scale = new Vector2(0.83f),
                         Alpha = 0.47f, // eyeballed to match stable
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                     new Sprite
                     {
                         Texture = skin.GetTexture("taikobigcircle"),
-                        Scale = new Vector2(0.7f),
+                        Scale = new Vector2(0.8f),
                         Alpha = 0.22f, // eyeballed to match stable
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,


### PR DESCRIPTION
Noticed while I was comparing on https://github.com/ppy/osu/pull/17619, I'm presuming the previous values no longer match stable since they were extracted from before the "Classic" mod behavior was added.

Values are still, as usual, eyeball'd via screenshots:

<img width="200" alt="CleanShot 2022-04-03 at 01 54 19@2x" src="https://user-images.githubusercontent.com/22781491/161404001-b4cf6260-c33d-49a1-bb08-3e141d49bf51.png">

| | target |
|-|-|
| before | <img width="200" alt="CleanShot 2022-04-03 at 01 49 20@2x" src="https://user-images.githubusercontent.com/22781491/161403922-0cfcf314-0c0e-499e-a978-a5fcf128247b.png"> |
| after | <img width="200" alt="CleanShot 2022-04-03 at 01 49 13@2x" src="https://user-images.githubusercontent.com/22781491/161403932-1a8bae31-ef41-4860-8ccb-93c17a04ebea.png"> |
| stable | <img width="200" alt="CleanShot 2022-04-03 at 01 48 45@2x" src="https://user-images.githubusercontent.com/22781491/161403937-b5147442-32ae-4ed8-a1b7-b3e93d9ff68b.png"> |