### PR TITLE
Implement basic layout & behaviour of new mod select screen

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.405.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("two panels active", () => modSelectScreen.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
             AddAssert("mod multiplier correct", () =>
             {
-                double multiplier = SelectedMods.Value.Aggregate(1d, (multiplier, mod) => multiplier * mod.ScoreMultiplier);
+                double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier);
                 return Precision.AlmostEquals(multiplier, modSelectScreen.ChildrenOfType<DifficultyMultiplierDisplay>().Single().Current.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("two panels active", () => modSelectScreen.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
             AddAssert("mod multiplier correct", () =>
             {
-                double multiplier = SelectedMods.Value.Aggregate(1d, (multiplier, mod) => multiplier * mod.ScoreMultiplier);
+                double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier);
                 return Precision.AlmostEquals(multiplier, modSelectScreen.ChildrenOfType<DifficultyMultiplierDisplay>().Single().Current.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -1,28 +1,76 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public class TestSceneModSelectScreen : OsuTestScene
+    public class TestSceneModSelectScreen : OsuManualInputManagerTestScene
     {
-        [Test]
-        public void TestModSelectScreen()
-        {
-            ModSelectScreen modSelectScreen = null;
+        private ModSelectScreen modSelectScreen;
 
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
             AddStep("create screen", () => Child = modSelectScreen = new ModSelectScreen
             {
                 RelativeSizeAxes = Axes.Both,
-                State = { Value = Visibility.Visible }
+                State = { Value = Visibility.Visible },
+                SelectedMods = { BindTarget = SelectedMods }
+            });
+        }
+
+        [Test]
+        public void TestStateChange()
+        {
+            AddToggleStep("toggle state", visible => modSelectScreen.State.Value = visible ? Visibility.Visible : Visibility.Hidden);
+        }
+
+        [Test]
+        public void TestCustomisationToggleState()
+        {
+            assertCustomisationToggleState(disabled: true, active: false);
+
+            AddStep("select customisable mod", () => SelectedMods.Value = new[] { new OsuModDoubleTime() });
+            assertCustomisationToggleState(disabled: false, active: false);
+
+            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            assertCustomisationToggleState(disabled: false, active: true);
+
+            AddStep("dismiss mod customisation", () =>
+            {
+                InputManager.MoveMouseTo(modSelectScreen.ChildrenOfType<ShearedToggleButton>().Single());
+                InputManager.Click(MouseButton.Left);
             });
 
-            AddToggleStep("toggle state", visible => modSelectScreen.State.Value = visible ? Visibility.Visible : Visibility.Hidden);
+            AddStep("append another mod not requiring config", () => SelectedMods.Value = SelectedMods.Value.Append(new OsuModFlashlight()).ToArray());
+            assertCustomisationToggleState(disabled: false, active: false);
+
+            AddStep("select mod without configuration", () => SelectedMods.Value = new[] { new OsuModAutoplay() });
+            assertCustomisationToggleState(disabled: true, active: false);
+
+            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            assertCustomisationToggleState(disabled: false, active: true);
+
+            AddStep("select mod without configuration", () => SelectedMods.Value = new[] { new OsuModAutoplay() });
+            assertCustomisationToggleState(disabled: true, active: false); // config was dismissed without explicit user action.
+        }
+
+        private void assertCustomisationToggleState(bool disabled, bool active)
+        {
+            ShearedToggleButton getToggle() => modSelectScreen.ChildrenOfType<ShearedToggleButton>().Single();
+
+            AddAssert($"customisation toggle is {(disabled ? "" : "not ")}disabled", () => getToggle().Active.Disabled == disabled);
+            AddAssert($"customisation toggle is {(active ? "" : "not ")}active", () => getToggle().Active.Value == active);
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays.Mods;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestSceneModSelectScreen : OsuTestScene
+    {
+        [Test]
+        public void TestModSelectScreen()
+        {
+            ModSelectScreen modSelectScreen = null;
+
+            AddStep("create screen", () => Child = modSelectScreen = new ModSelectScreen
+            {
+                RelativeSizeAxes = Axes.Both,
+                State = { Value = Visibility.Visible }
+            });
+
+            AddToggleStep("toggle state", visible => modSelectScreen.State.Value = visible ? Visibility.Visible : Visibility.Hidden);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -9,8 +9,12 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Taiko;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -66,6 +70,16 @@ namespace osu.Game.Tests.Visual.UserInterface
                 return Precision.AlmostEquals(multiplier, modSelectScreen.ChildrenOfType<DifficultyMultiplierDisplay>().Single().Current.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
+        }
+
+        [Test]
+        public void TestRulesetChange()
+        {
+            createScreen();
+            AddStep("change to osu!", () => Ruleset.Value = new OsuRuleset().RulesetInfo);
+            AddStep("change to osu!taiko", () => Ruleset.Value = new TaikoRuleset().RulesetInfo);
+            AddStep("change to osu!catch", () => Ruleset.Value = new CatchRuleset().RulesetInfo);
+            AddStep("change to osu!mania", () => Ruleset.Value = new ManiaRuleset().RulesetInfo);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestStateChange()
         {
             createScreen();
-            AddToggleStep("toggle state", visible => modSelectScreen.State.Value = visible ? Visibility.Visible : Visibility.Hidden);
+            AddStep("toggle state", () => modSelectScreen.ToggleVisibility());
         }
 
         [Test]

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -146,8 +146,9 @@ namespace osu.Game.Overlays.Mods
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             current.BindValueChanged(_ => updateState(), true);
-            FinishTransforms(true);
+
             // required to prevent the counter initially rolling up from 0 to 1
             // due to `Current.Value` having a nonstandard default value of 1.
             multiplierCounter.SetCountWithoutRolling(Current.Value);

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Overlays.Mods
 {
     public class DifficultyMultiplierDisplay : CompositeDrawable, IHasCurrentValue<double>
     {
+        public const float HEIGHT = 42;
+
         public Bindable<double> Current
         {
             get => current.Current;
@@ -42,13 +44,12 @@ namespace osu.Game.Overlays.Mods
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; }
 
-        private const float height = 42;
         private const float multiplier_value_area_width = 56;
         private const float transition_duration = 200;
 
         public DifficultyMultiplierDisplay()
         {
-            Height = height;
+            Height = HEIGHT;
             AutoSizeAxes = Axes.X;
 
             InternalChild = new Container

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -195,63 +195,6 @@ namespace osu.Game.Overlays.Mods
             }
         }
 
-        /// <summary>
-        /// A scroll container that handles the case of vertically scrolling content inside a larger horizontally scrolling parent container.
-        /// </summary>
-        private class NestedVerticalScrollContainer : OsuScrollContainer
-        {
-            private OsuScrollContainer? parentScrollContainer;
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                parentScrollContainer = findClosestParent<OsuScrollContainer>();
-            }
-
-            protected override bool OnScroll(ScrollEvent e)
-            {
-                if (parentScrollContainer == null)
-                    return base.OnScroll(e);
-
-                bool topRightInView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.TopRight);
-                bool bottomLeftInView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.BottomLeft);
-
-                // If not completely on-screen, handle scroll but also allow parent to scroll at the same time (to hopefully bring our content into full view).
-                if (!topRightInView || !bottomLeftInView)
-                {
-                    base.OnScroll(e);
-                    return false;
-                }
-
-                bool scrollingPastEnd = e.ScrollDelta.Y < 0 && IsScrolledToEnd();
-                bool scrollingPastStart = e.ScrollDelta.Y > 0 && Target <= 0;
-
-                // If at either of our extents, allow the parent scroll to handle as a horizontal scroll to view more content.
-                if (scrollingPastStart || scrollingPastEnd)
-                {
-                    base.OnScroll(e);
-                    return false;
-                }
-
-                return base.OnScroll(e);
-            }
-
-            // TODO: remove when https://github.com/ppy/osu-framework/pull/5092 is available.
-            private T? findClosestParent<T>() where T : class, IDrawable
-            {
-                Drawable cursor = this;
-
-                while ((cursor = cursor.Parent) != null)
-                {
-                    if (cursor is T match)
-                        return match;
-                }
-
-                return default;
-            }
-        }
-
         private void createHeaderText()
         {
             IEnumerable<string> headerTextWords = ModType.Humanize(LetterCasing.Title).Split(' ');

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -214,11 +214,11 @@ namespace osu.Game.Overlays.Mods
                 if (parentScrollContainer == null)
                     return base.OnScroll(e);
 
-                // If not on screen, handle scroll but also allow parent to scroll at the same time.
-                bool topRightOutsideOfView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.TopRight) == false;
-                bool bottomLeftOutsideOfView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.BottomLeft) == false;
+                bool topRightInView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.TopRight);
+                bool bottomLeftInView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.BottomLeft);
 
-                if (topRightOutsideOfView || bottomLeftOutsideOfView)
+                // If not completely on-screen, handle scroll but also allow parent to scroll at the same time (to hopefully bring our content into full view).
+                if (!topRightInView || !bottomLeftInView)
                 {
                     base.OnScroll(e);
                     return false;
@@ -227,7 +227,7 @@ namespace osu.Game.Overlays.Mods
                 bool scrollingPastEnd = e.ScrollDelta.Y < 0 && IsScrolledToEnd();
                 bool scrollingPastStart = e.ScrollDelta.Y > 0 && Target <= 0;
 
-                // Same deal if at one of the two extents of the view.
+                // If at either of our extents, allow the parent scroll to handle as a horizontal scroll to view more content.
                 if (scrollingPastStart || scrollingPastEnd)
                 {
                     base.OnScroll(e);

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Overlays.Mods
 {
     public class ModColumn : CompositeDrawable
     {
+        public readonly Container TopLevelContent;
+
         public readonly ModType ModType;
 
         private Func<Mod, bool>? filter;
@@ -78,90 +80,97 @@ namespace osu.Game.Overlays.Mods
             Width = 320;
             RelativeSizeAxes = Axes.Y;
             Shear = new Vector2(ModPanel.SHEAR_X, 0);
-            CornerRadius = ModPanel.CORNER_RADIUS;
-            Masking = true;
 
             Container controlContainer;
             InternalChildren = new Drawable[]
             {
-                new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = header_height + ModPanel.CORNER_RADIUS,
-                    Children = new Drawable[]
-                    {
-                        headerBackground = new Box
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = header_height + ModPanel.CORNER_RADIUS
-                        },
-                        headerText = new OsuTextFlowContainer(t =>
-                        {
-                            t.Font = OsuFont.TorusAlternate.With(size: 17);
-                            t.Shadow = false;
-                            t.Colour = Colour4.Black;
-                        })
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Shear = new Vector2(-ModPanel.SHEAR_X, 0),
-                            Padding = new MarginPadding
-                            {
-                                Horizontal = 17,
-                                Bottom = ModPanel.CORNER_RADIUS
-                            }
-                        }
-                    }
-                },
-                new Container
+                TopLevelContent = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Top = header_height },
-                    Child = contentContainer = new Container
+                    CornerRadius = ModPanel.CORNER_RADIUS,
+                    Masking = true,
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Masking = true,
-                        CornerRadius = ModPanel.CORNER_RADIUS,
-                        BorderThickness = 3,
-                        Children = new Drawable[]
+                        new Container
                         {
-                            contentBackground = new Box
+                            RelativeSizeAxes = Axes.X,
+                            Height = header_height + ModPanel.CORNER_RADIUS,
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both
-                            },
-                            new GridContainer
+                                headerBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = header_height + ModPanel.CORNER_RADIUS
+                                },
+                                headerText = new OsuTextFlowContainer(t =>
+                                {
+                                    t.Font = OsuFont.TorusAlternate.With(size: 17);
+                                    t.Shadow = false;
+                                    t.Colour = Colour4.Black;
+                                })
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Shear = new Vector2(-ModPanel.SHEAR_X, 0),
+                                    Padding = new MarginPadding
+                                    {
+                                        Horizontal = 17,
+                                        Bottom = ModPanel.CORNER_RADIUS
+                                    }
+                                }
+                            }
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Top = header_height },
+                            Child = contentContainer = new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                RowDimensions = new[]
+                                Masking = true,
+                                CornerRadius = ModPanel.CORNER_RADIUS,
+                                BorderThickness = 3,
+                                Children = new Drawable[]
                                 {
-                                    new Dimension(GridSizeMode.AutoSize),
-                                    new Dimension()
-                                },
-                                Content = new[]
-                                {
-                                    new Drawable[]
+                                    contentBackground = new Box
                                     {
-                                        controlContainer = new Container
-                                        {
-                                            RelativeSizeAxes = Axes.X,
-                                            Padding = new MarginPadding { Horizontal = 14 }
-                                        }
+                                        RelativeSizeAxes = Axes.Both
                                     },
-                                    new Drawable[]
+                                    new GridContainer
                                     {
-                                        new NestedVerticalScrollContainer
+                                        RelativeSizeAxes = Axes.Both,
+                                        RowDimensions = new[]
                                         {
-                                            RelativeSizeAxes = Axes.Both,
-                                            ClampExtension = 100,
-                                            ScrollbarOverlapsContent = false,
-                                            Child = panelFlow = new FillFlowContainer<ModPanel>
+                                            new Dimension(GridSizeMode.AutoSize),
+                                            new Dimension()
+                                        },
+                                        Content = new[]
+                                        {
+                                            new Drawable[]
                                             {
-                                                RelativeSizeAxes = Axes.X,
-                                                AutoSizeAxes = Axes.Y,
-                                                Spacing = new Vector2(0, 7),
-                                                Padding = new MarginPadding(7)
+                                                controlContainer = new Container
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    Padding = new MarginPadding { Horizontal = 14 }
+                                                }
+                                            },
+                                            new Drawable[]
+                                            {
+                                                new NestedVerticalScrollContainer
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    ClampExtension = 100,
+                                                    ScrollbarOverlapsContent = false,
+                                                    Child = panelFlow = new FillFlowContainer<ModPanel>
+                                                    {
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                        Spacing = new Vector2(0, 7),
+                                                        Padding = new MarginPadding(7)
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Overlays.Mods
             }
         }
 
+        public Action<Mod, bool>? ModStateChanged { get; set; }
+
         private readonly ModType modType;
         private readonly Key[]? toggleKeys;
 
@@ -251,7 +253,14 @@ namespace osu.Game.Overlays.Mods
                 panelFlow.ChildrenEnumerable = loaded;
 
                 foreach (var panel in panelFlow)
-                    panel.Active.BindValueChanged(_ => updateToggleState());
+                {
+                    panel.Active.BindValueChanged(_ =>
+                    {
+                        updateToggleState();
+                        ModStateChanged?.Invoke(panel.Mod, panel.Active.Value);
+                    });
+                }
+
                 updateToggleState();
 
                 updateFilter();

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -234,12 +234,14 @@ namespace osu.Game.Overlays.Mods
 
         private void updateCustomisationVisualState()
         {
-            grid.FadeColour(customisationVisible.Value ? Colour4.Gray : Colour4.White, 800, Easing.OutQuint);
+            const double transition_duration = 700;
+
+            grid.FadeColour(customisationVisible.Value ? Colour4.Gray : Colour4.White, transition_duration, Easing.InOutCubic);
 
             float modAreaHeight = customisationVisible.Value ? ModSettingsArea.HEIGHT : 0;
 
-            modSettingsArea.ResizeHeightTo(modAreaHeight, 800, Easing.InOutCubic);
-            mainContent.TransformTo(nameof(Margin), new MarginPadding { Bottom = modAreaHeight }, 800, Easing.InOutCubic);
+            modSettingsArea.ResizeHeightTo(modAreaHeight, transition_duration, Easing.InOutCubic);
+            mainContent.TransformTo(nameof(Margin), new MarginPadding { Bottom = modAreaHeight }, transition_duration, Easing.InOutCubic);
         }
 
         private bool selectionBindableSyncInProgress;

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -84,13 +84,21 @@ namespace osu.Game.Overlays.Mods
                                 {
                                     new Container
                                     {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        Padding = new MarginPadding { Horizontal = 100, Vertical = 10 },
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        AutoSizeAxes = Axes.X,
+                                        RelativePositionAxes = Axes.X,
+                                        X = 0.3f,
+                                        Height = DifficultyMultiplierDisplay.HEIGHT,
+                                        Margin = new MarginPadding
+                                        {
+                                            Horizontal = 100,
+                                            Vertical = 10
+                                        },
                                         Child = multiplierDisplay = new DifficultyMultiplierDisplay
                                         {
-                                            Anchor = Anchor.CentreRight,
-                                            Origin = Anchor.CentreRight
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre
                                         }
                                     }
                                 },
@@ -283,6 +291,11 @@ namespace osu.Game.Overlays.Mods
             footer.MoveToY(0, fade_in_duration, Easing.OutQuint);
 
             this.FadeIn(fade_in_duration, Easing.OutQuint);
+
+            multiplierDisplay
+                .Delay(300)
+                .FadeIn(200, Easing.OutQuint)
+                .ScaleTo(1, fade_in_duration, Easing.OutElastic);
         }
 
         protected override void PopOut()
@@ -290,6 +303,10 @@ namespace osu.Game.Overlays.Mods
             const double fade_out_duration = 500;
 
             base.PopOut();
+
+            multiplierDisplay
+                .FadeOut(200, Easing.OutQuint)
+                .ScaleTo(0.75f, fade_out_duration, Easing.OutQuint);
 
             header.MoveToY(-header.DrawHeight, fade_out_duration, Easing.OutQuint);
             footer.MoveToY(footer.DrawHeight, fade_out_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Overlays.Mods
                                                     RelativeSizeAxes = Axes.Y,
                                                     AutoSizeAxes = Axes.X,
                                                     Spacing = new Vector2(10, 0),
-                                                    Margin = new MarginPadding { Horizontal = 70 },
+                                                    Margin = new MarginPadding { Right = 70 },
                                                     Children = new[]
                                                     {
                                                         new ModColumn(ModType.DifficultyReduction, false, new[] { Key.Q, Key.W, Key.E, Key.R, Key.T, Key.Y, Key.U, Key.I, Key.O, Key.P }),

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Overlays.Mods
                                 {
                                     new Container
                                     {
+                                        Depth = float.MaxValue,
                                         RelativeSizeAxes = Axes.Both,
                                         RelativePositionAxes = Axes.Both,
                                         Children = new Drawable[]
@@ -296,6 +297,13 @@ namespace osu.Game.Overlays.Mods
                 .Delay(300)
                 .FadeIn(200, Easing.OutQuint)
                 .ScaleTo(1, fade_in_duration, Easing.OutElastic);
+
+            for (int i = 0; i < columnFlow.Count; i++)
+            {
+                columnFlow[i].TopLevelContent
+                             .Delay(i * 30)
+                             .MoveToY(0, fade_in_duration, Easing.OutQuint);
+            }
         }
 
         protected override void PopOut()
@@ -312,6 +320,13 @@ namespace osu.Game.Overlays.Mods
             footer.MoveToY(footer.DrawHeight, fade_out_duration, Easing.OutQuint);
 
             this.FadeOut(fade_out_duration, Easing.OutQuint);
+
+            for (int i = 0; i < columnFlow.Count; i++)
+            {
+                const float distance = 700;
+
+                columnFlow[i].TopLevelContent.MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint);
+            }
         }
 
         private class ModColumnContainer : FillFlowContainer<ModColumn>

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Overlays.Mods
                                             {
                                                 RelativeSizeAxes = Axes.Both,
                                                 Masking = false,
+                                                ClampExtension = 100,
                                                 ScrollbarOverlapsContent = false,
                                                 Child = columnFlow = new ModColumnContainer
                                                 {

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays.Mods
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
 
         [Cached]
-        private Bindable<IReadOnlyList<Mod>> selectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+        public Bindable<IReadOnlyList<Mod>> SelectedMods { get; private set; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         private readonly BindableBool customisationVisible = new BindableBool();
 
@@ -169,9 +169,9 @@ namespace osu.Game.Overlays.Mods
 
             foreach (var column in columnFlow)
             {
-                column.ModStateChanged = (mod, active) => selectedMods.Value = active
-                    ? selectedMods.Value.Append(mod).ToArray()
-                    : selectedMods.Value.Except(new[] { mod }).ToArray();
+                column.ModStateChanged = (mod, active) => SelectedMods.Value = active
+                    ? SelectedMods.Value.Append(mod).ToArray()
+                    : SelectedMods.Value.Except(new[] { mod }).ToArray();
             }
 
             columnFlow.Shear = new Vector2(ModPanel.SHEAR_X, 0);
@@ -181,8 +181,8 @@ namespace osu.Game.Overlays.Mods
         {
             base.LoadComplete();
 
-            ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(selectedMods);
-            selectedMods.BindValueChanged(val =>
+            ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
+            SelectedMods.BindValueChanged(val =>
             {
                 updateMultiplier();
                 updateCustomisation(val);
@@ -196,7 +196,7 @@ namespace osu.Game.Overlays.Mods
         {
             double multiplier = 1.0;
 
-            foreach (var mod in selectedMods.Value)
+            foreach (var mod in SelectedMods.Value)
                 multiplier *= mod.ScoreMultiplier;
 
             multiplierDisplay.Current.Value = multiplier;
@@ -207,7 +207,7 @@ namespace osu.Game.Overlays.Mods
             bool anyCustomisableMod = false;
             bool anyModWithRequiredCustomisationAdded = false;
 
-            foreach (var mod in selectedMods.Value)
+            foreach (var mod in SelectedMods.Value)
             {
                 anyCustomisableMod |= mod.GetSettingsSourceProperties().Any();
                 anyModWithRequiredCustomisationAdded |= !valueChangedEvent.OldValue.Contains(mod) && mod.RequiresConfiguration;

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -235,7 +235,7 @@ namespace osu.Game.Overlays.Mods
 
         private void updateCustomisationVisualState()
         {
-            const double transition_duration = 700;
+            const double transition_duration = 300;
 
             grid.FadeColour(customisationVisible.Value ? Colour4.Gray : Colour4.White, transition_duration, Easing.InOutCubic);
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -1,0 +1,315 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Layout;
+using osu.Game.Configuration;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Mods;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class ModSelectScreen : OsuFocusedOverlayContainer
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
+
+        [Cached]
+        private Bindable<IReadOnlyList<Mod>> selectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+
+        private readonly BindableBool customisationVisible = new BindableBool();
+
+        private DifficultyMultiplierDisplay multiplierDisplay;
+        private ModSettingsArea modSettingsArea;
+        private Container columnContainer;
+        private FillFlowContainer<ModColumn> columnFlow;
+        private GridContainer grid;
+        private Container mainContent;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.Both;
+            RelativePositionAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                mainContent = new Container
+                {
+                    Origin = Anchor.BottomCentre,
+                    Anchor = Anchor.BottomCentre,
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        grid = new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            RowDimensions = new[]
+                            {
+                                new Dimension(GridSizeMode.AutoSize),
+                                new Dimension(GridSizeMode.AutoSize),
+                                new Dimension(),
+                                new Dimension(GridSizeMode.Absolute, 75),
+                            },
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    new PopupScreenTitle
+                                    {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
+                                        Title = "Mod Select",
+                                        Description = "Mods provide different ways to enjoy gameplay. Some have an effect on the score you can achieve during ranked play. Others are just for fun.",
+                                        Close = Hide
+                                    }
+                                },
+                                new Drawable[]
+                                {
+                                    new Container
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Padding = new MarginPadding { Horizontal = 100, Vertical = 10 },
+                                        Child = multiplierDisplay = new DifficultyMultiplierDisplay
+                                        {
+                                            Anchor = Anchor.CentreRight,
+                                            Origin = Anchor.CentreRight
+                                        }
+                                    }
+                                },
+                                new Drawable[]
+                                {
+                                    columnContainer = new Container
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        RelativePositionAxes = Axes.Both,
+                                        X = 1,
+                                        Padding = new MarginPadding { Horizontal = 70 },
+                                        Children = new Drawable[]
+                                        {
+                                            new OsuScrollContainer(Direction.Horizontal)
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Masking = false,
+                                                ScrollbarOverlapsContent = false,
+                                                Child = columnFlow = new ModColumnContainer
+                                                {
+                                                    RelativeSizeAxes = Axes.Y,
+                                                    AutoSizeAxes = Axes.X,
+                                                    Spacing = new Vector2(10, 0),
+                                                    Children = new[]
+                                                    {
+                                                        new ModColumn(ModType.DifficultyReduction, false, new[] { Key.Q, Key.W, Key.E, Key.R, Key.T, Key.Y, Key.U, Key.I, Key.O, Key.P }),
+                                                        new ModColumn(ModType.DifficultyIncrease, false, new[] { Key.A, Key.S, Key.D, Key.F, Key.G, Key.H, Key.J, Key.K, Key.L }),
+                                                        new ModColumn(ModType.Automation, false, new[] { Key.Z, Key.X, Key.C, Key.V, Key.B, Key.N, Key.M }),
+                                                        new ModColumn(ModType.Conversion, false),
+                                                        new ModColumn(ModType.Fun, false)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                new[] { Empty() }
+                            }
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = 50,
+                                    Anchor = Anchor.BottomCentre,
+                                    Origin = Anchor.BottomCentre,
+                                    Colour = colourProvider.Background5
+                                },
+                                new ShearedToggleButton(200)
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Margin = new MarginPadding { Vertical = 14, Left = 70 },
+                                    Text = "Mod Customisation",
+                                    Active = { BindTarget = customisationVisible }
+                                }
+                            }
+                        },
+                        new ClickToReturnContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            HandleMouse = { BindTarget = customisationVisible },
+                            OnClicked = () => customisationVisible.Value = false
+                        }
+                    }
+                },
+                modSettingsArea = new ModSettingsArea
+                {
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre
+                }
+            };
+
+            foreach (var column in columnFlow)
+            {
+                column.ModStateChanged = (mod, active) => selectedMods.Value = active
+                    ? selectedMods.Value.Append(mod).ToArray()
+                    : selectedMods.Value.Except(new[] { mod }).ToArray();
+            }
+
+            columnFlow.Shear = new Vector2(ModPanel.SHEAR_X, 0);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(selectedMods);
+            selectedMods.BindValueChanged(val =>
+            {
+                updateMultiplier();
+                updateCustomisation(val);
+            }, true);
+            customisationVisible.BindValueChanged(_ => updateCustomisationVisualState(), true);
+
+            FinishTransforms(true);
+        }
+
+        private void updateMultiplier()
+        {
+            double multiplier = 1.0;
+
+            foreach (var mod in selectedMods.Value)
+                multiplier *= mod.ScoreMultiplier;
+
+            multiplierDisplay.Current.Value = multiplier;
+        }
+
+        private void updateCustomisation(ValueChangedEvent<IReadOnlyList<Mod>> valueChangedEvent)
+        {
+            bool anyCustomisableMod = false;
+            bool anyModWithRequiredCustomisationAdded = false;
+
+            foreach (var mod in selectedMods.Value)
+            {
+                anyCustomisableMod |= mod.GetSettingsSourceProperties().Any();
+                anyModWithRequiredCustomisationAdded |= !valueChangedEvent.OldValue.Contains(mod) && mod.RequiresConfiguration;
+            }
+
+            if (anyCustomisableMod)
+            {
+                customisationVisible.Disabled = false;
+
+                if (anyModWithRequiredCustomisationAdded && !customisationVisible.Value)
+                    customisationVisible.Value = true;
+            }
+            else
+            {
+                if (customisationVisible.Value)
+                    customisationVisible.Value = false;
+
+                customisationVisible.Disabled = true;
+            }
+        }
+
+        private void updateCustomisationVisualState()
+        {
+            grid.FadeColour(customisationVisible.Value ? Colour4.Gray : Colour4.White, 800, Easing.OutQuint);
+
+            float modAreaHeight = customisationVisible.Value ? ModSettingsArea.HEIGHT : 0;
+
+            modSettingsArea.ResizeHeightTo(modAreaHeight, 800, Easing.InOutCubic);
+            mainContent.TransformTo(nameof(Margin), new MarginPadding { Bottom = modAreaHeight }, 800, Easing.InOutCubic);
+        }
+
+        protected override void PopIn()
+        {
+            base.PopIn();
+            this.MoveToY(0, 800, Easing.OutQuint);
+            columnContainer.MoveToX(0, 800, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            base.PopOut();
+            this.MoveToY(1.2f, 800, Easing.OutQuint);
+            columnContainer.MoveToX(1, 800, Easing.OutQuint);
+        }
+
+        private class ModColumnContainer : FillFlowContainer<ModColumn>
+        {
+            private readonly LayoutValue drawSizeLayout = new LayoutValue(Invalidation.DrawSize);
+
+            public ModColumnContainer()
+            {
+                AddLayout(drawSizeLayout);
+            }
+
+            public override void Add(ModColumn column)
+            {
+                base.Add(column);
+
+                Debug.Assert(column != null);
+                column.Shear = Vector2.Zero;
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (!drawSizeLayout.IsValid)
+                {
+                    Padding = new MarginPadding
+                    {
+                        Left = DrawHeight * ModPanel.SHEAR_X,
+                        Bottom = 10
+                    };
+
+                    drawSizeLayout.Validate();
+                }
+            }
+        }
+
+        private class ClickToReturnContainer : Container
+        {
+            public BindableBool HandleMouse { get; } = new BindableBool();
+
+            public Action OnClicked { get; set; }
+
+            protected override bool Handle(UIEvent e)
+            {
+                if (!HandleMouse.Value)
+                    return base.Handle(e);
+
+                switch (e)
+                {
+                    case ClickEvent _:
+                        OnClicked?.Invoke();
+                        return true;
+
+                    case MouseEvent _:
+                        return true;
+                }
+
+                return base.Handle(e);
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -284,25 +284,25 @@ namespace osu.Game.Overlays.Mods
 
         protected override void PopIn()
         {
-            const double fade_in_duration = 500;
+            const double fade_in_duration = 400;
 
             base.PopIn();
+            this.FadeIn(fade_in_duration, Easing.OutQuint);
 
             header.MoveToY(0, fade_in_duration, Easing.OutQuint);
             footer.MoveToY(0, fade_in_duration, Easing.OutQuint);
 
-            this.FadeIn(fade_in_duration, Easing.OutQuint);
-
             multiplierDisplay
-                .Delay(300)
-                .FadeIn(200, Easing.OutQuint)
+                .Delay(fade_in_duration * 0.65f)
+                .FadeIn(fade_in_duration / 2, Easing.OutQuint)
                 .ScaleTo(1, fade_in_duration, Easing.OutElastic);
 
             for (int i = 0; i < columnFlow.Count; i++)
             {
                 columnFlow[i].TopLevelContent
                              .Delay(i * 30)
-                             .MoveToY(0, fade_in_duration, Easing.OutQuint);
+                             .MoveToY(0, fade_in_duration, Easing.OutQuint)
+                             .FadeIn(fade_in_duration, Easing.OutQuint);
             }
         }
 
@@ -311,21 +311,22 @@ namespace osu.Game.Overlays.Mods
             const double fade_out_duration = 500;
 
             base.PopOut();
+            this.FadeOut(fade_out_duration, Easing.OutQuint);
 
             multiplierDisplay
-                .FadeOut(200, Easing.OutQuint)
+                .FadeOut(fade_out_duration / 2, Easing.OutQuint)
                 .ScaleTo(0.75f, fade_out_duration, Easing.OutQuint);
 
             header.MoveToY(-header.DrawHeight, fade_out_duration, Easing.OutQuint);
             footer.MoveToY(footer.DrawHeight, fade_out_duration, Easing.OutQuint);
 
-            this.FadeOut(fade_out_duration, Easing.OutQuint);
-
             for (int i = 0; i < columnFlow.Count; i++)
             {
                 const float distance = 700;
 
-                columnFlow[i].TopLevelContent.MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint);
+                columnFlow[i].TopLevelContent
+                             .MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint)
+                             .FadeOut(fade_out_duration, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -110,6 +110,7 @@ namespace osu.Game.Overlays.Mods
                                                 ScrollbarOverlapsContent = false,
                                                 Child = columnFlow = new ModColumnContainer
                                                 {
+                                                    Direction = FillDirection.Horizontal,
                                                     RelativeSizeAxes = Axes.Y,
                                                     AutoSizeAxes = Axes.X,
                                                     Spacing = new Vector2(10, 0),

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -100,7 +100,6 @@ namespace osu.Game.Overlays.Mods
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         RelativePositionAxes = Axes.Both,
-                                        Padding = new MarginPadding { Horizontal = 70 },
                                         Children = new Drawable[]
                                         {
                                             new OsuScrollContainer(Direction.Horizontal)
@@ -113,6 +112,7 @@ namespace osu.Game.Overlays.Mods
                                                     RelativeSizeAxes = Axes.Y,
                                                     AutoSizeAxes = Axes.X,
                                                     Spacing = new Vector2(10, 0),
+                                                    Margin = new MarginPadding { Horizontal = 70 },
                                                     Children = new[]
                                                     {
                                                         new ModColumn(ModType.DifficultyReduction, false, new[] { Key.Q, Key.W, Key.E, Key.R, Key.T, Key.Y, Key.U, Key.I, Key.O, Key.P }),

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Overlays.Mods
         private GridContainer grid;
         private Container mainContent;
 
+        private PopupScreenTitle header;
+        private Container footer;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -67,7 +70,7 @@ namespace osu.Game.Overlays.Mods
                             {
                                 new Drawable[]
                                 {
-                                    new PopupScreenTitle
+                                    header = new PopupScreenTitle
                                     {
                                         Anchor = Anchor.TopCentre,
                                         Origin = Anchor.TopCentre,
@@ -96,7 +99,6 @@ namespace osu.Game.Overlays.Mods
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         RelativePositionAxes = Axes.Both,
-                                        X = 1,
                                         Padding = new MarginPadding { Horizontal = 70 },
                                         Children = new Drawable[]
                                         {
@@ -126,7 +128,7 @@ namespace osu.Game.Overlays.Mods
                                 new[] { Empty() }
                             }
                         },
-                        new Container
+                        footer = new Container
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
@@ -269,16 +271,26 @@ namespace osu.Game.Overlays.Mods
 
         protected override void PopIn()
         {
+            const double fade_in_duration = 500;
+
             base.PopIn();
-            this.MoveToY(0, 800, Easing.OutQuint);
-            columnContainer.MoveToX(0, 800, Easing.OutQuint);
+
+            header.MoveToY(0, fade_in_duration, Easing.OutQuint);
+            footer.MoveToY(0, fade_in_duration, Easing.OutQuint);
+
+            this.FadeIn(fade_in_duration, Easing.OutQuint);
         }
 
         protected override void PopOut()
         {
+            const double fade_out_duration = 500;
+
             base.PopOut();
-            this.MoveToY(1.2f, 800, Easing.OutQuint);
-            columnContainer.MoveToX(1, 800, Easing.OutQuint);
+
+            header.MoveToY(-header.DrawHeight, fade_out_duration, Easing.OutQuint);
+            footer.MoveToY(footer.DrawHeight, fade_out_duration, Easing.OutQuint);
+
+            this.FadeOut(fade_out_duration, Easing.OutQuint);
         }
 
         private class ModColumnContainer : FillFlowContainer<ModColumn>

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Overlays.Mods
         [Cached]
         public Bindable<IReadOnlyList<Mod>> SelectedMods { get; private set; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
+        protected override bool StartHidden => true;
+
         private readonly BindableBool customisationVisible = new BindableBool();
 
         private DifficultyMultiplierDisplay multiplierDisplay;
@@ -164,7 +166,8 @@ namespace osu.Game.Overlays.Mods
                 modSettingsArea = new ModSettingsArea
                 {
                     Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre
+                    Origin = Anchor.BottomCentre,
+                    Height = 0
                 }
             };
 
@@ -190,8 +193,6 @@ namespace osu.Game.Overlays.Mods
             }
 
             customisationVisible.BindValueChanged(_ => updateCustomisationVisualState(), true);
-
-            FinishTransforms(true);
         }
 
         private void updateMultiplier()

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Overlays.Mods
 
         private DifficultyMultiplierDisplay multiplierDisplay;
         private ModSettingsArea modSettingsArea;
-        private Container columnContainer;
         private FillFlowContainer<ModColumn> columnFlow;
         private GridContainer grid;
         private Container mainContent;
@@ -95,7 +94,7 @@ namespace osu.Game.Overlays.Mods
                                 },
                                 new Drawable[]
                                 {
-                                    columnContainer = new Container
+                                    new Container
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         RelativePositionAxes = Axes.Both,

--- a/osu.Game/Overlays/Mods/ModSettingsArea.cs
+++ b/osu.Game/Overlays/Mods/ModSettingsArea.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Overlays.Mods
                     {
                         RelativeSizeAxes = Axes.Both,
                         ScrollbarOverlapsContent = false,
+                        ClampExtension = 100,
                         Child = modSettingsFlow = new FillFlowContainer
                         {
                             AutoSizeAxes = Axes.X,
@@ -157,9 +158,10 @@ namespace osu.Game.Overlays.Mods
                         new[] { Empty() },
                         new Drawable[]
                         {
-                            new OsuScrollContainer(Direction.Vertical)
+                            new NestedVerticalScrollContainer
                             {
                                 RelativeSizeAxes = Axes.Both,
+                                ClampExtension = 100,
                                 Child = new FillFlowContainer
                                 {
                                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Mods/ModSettingsArea.cs
+++ b/osu.Game/Overlays/Mods/ModSettingsArea.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Overlays.Mods
     {
         public Bindable<IReadOnlyList<Mod>> SelectedMods { get; } = new Bindable<IReadOnlyList<Mod>>();
 
+        public const float HEIGHT = 250;
+
         private readonly Box background;
         private readonly FillFlowContainer modSettingsFlow;
 
@@ -32,7 +34,7 @@ namespace osu.Game.Overlays.Mods
         public ModSettingsArea()
         {
             RelativeSizeAxes = Axes.X;
-            Height = 250;
+            Height = HEIGHT;
 
             Anchor = Anchor.BottomRight;
             Origin = Anchor.BottomRight;

--- a/osu.Game/Overlays/Mods/NestedVerticalScrollContainer.cs
+++ b/osu.Game/Overlays/Mods/NestedVerticalScrollContainer.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Overlays.Mods
+{
+    /// <summary>
+    /// A scroll container that handles the case of vertically scrolling content inside a larger horizontally scrolling parent container.
+    /// </summary>
+    public class NestedVerticalScrollContainer : OsuScrollContainer
+    {
+        private OsuScrollContainer? parentScrollContainer;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            parentScrollContainer = findClosestParent<OsuScrollContainer>();
+        }
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            if (parentScrollContainer == null)
+                return base.OnScroll(e);
+
+            bool topRightInView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.TopRight);
+            bool bottomLeftInView = parentScrollContainer.ScreenSpaceDrawQuad.Contains(ScreenSpaceDrawQuad.BottomLeft);
+
+            // If not completely on-screen, handle scroll but also allow parent to scroll at the same time (to hopefully bring our content into full view).
+            if (!topRightInView || !bottomLeftInView)
+                return false;
+
+            bool scrollingPastEnd = e.ScrollDelta.Y < 0 && IsScrolledToEnd();
+            bool scrollingPastStart = e.ScrollDelta.Y > 0 && Target <= 0;
+
+            // If at either of our extents, delegate scroll to the horizontal parent container.
+            if (scrollingPastStart || scrollingPastEnd)
+                return false;
+
+            return base.OnScroll(e);
+        }
+
+        // TODO: remove when https://github.com/ppy/osu-framework/pull/5092 is available.
+        private T? findClosestParent<T>() where T : class, IDrawable
+        {
+            Drawable cursor = this;
+
+            while ((cursor = cursor.Parent) != null)
+            {
+                if (cursor is T match)
+                    return match;
+            }
+
+            return default;
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/NestedVerticalScrollContainer.cs
+++ b/osu.Game/Overlays/Mods/NestedVerticalScrollContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Mods
         {
             base.LoadComplete();
 
-            parentScrollContainer = findClosestParent<OsuScrollContainer>();
+            parentScrollContainer = this.FindClosestParent<OsuScrollContainer>();
         }
 
         protected override bool OnScroll(ScrollEvent e)
@@ -42,20 +42,6 @@ namespace osu.Game.Overlays.Mods
                 return false;
 
             return base.OnScroll(e);
-        }
-
-        // TODO: remove when https://github.com/ppy/osu-framework/pull/5092 is available.
-        private T? findClosestParent<T>() where T : class, IDrawable
-        {
-            Drawable cursor = this;
-
-            while ((cursor = cursor.Parent) != null)
-            {
-                if (cursor is T match)
-                    return match;
-            }
-
-            return default;
         }
     }
 }

--- a/osu.Game/Overlays/Mods/NestedVerticalScrollContainer.cs
+++ b/osu.Game/Overlays/Mods/NestedVerticalScrollContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable enable
+
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.405.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.405.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.325.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.325.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.405.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Continuation of #16917.

Note that - as in title - this is not intended to be a full replacement yet. There is still two-three pulls of work to be done before that; that work includes adding back some extension points that are needed to replace the old overlays, porting over existing test coverage, adding some safeties in mod incompatibility rules, etc. Treat this as a visual appearance / component interaction pass.

https://user-images.githubusercontent.com/20418176/161443186-2c6ed09a-7bd8-4192-86de-86bdce9505dd.mp4

All of the motion design is mostly improvised and up for debate, as is the implementation of scrolls.