### PR TITLE
Fix various breakage in delete local score test scene

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -44,9 +44,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private BeatmapInfo beatmapInfo;
 
-        [Resolved]
-        private RealmAccess realm { get; set; }
-
         [Cached]
         private readonly DialogOverlay dialogOverlay;
 
@@ -92,6 +89,12 @@ namespace osu.Game.Tests.Visual.UserInterface
             dependencies.Cache(scoreManager = new ScoreManager(dependencies.Get<RulesetStore>(), () => beatmapManager, LocalStorage, Realm, Scheduler));
             Dependencies.Cache(Realm);
 
+            return dependencies;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load() => Schedule(() =>
+        {
             var imported = beatmapManager.Import(new ImportTask(TestResources.GetQuickTestBeatmapForImport())).GetResultSafely();
 
             imported?.PerformRead(s =>
@@ -115,26 +118,26 @@ namespace osu.Game.Tests.Visual.UserInterface
                     importedScores.Add(scoreManager.Import(score).Value);
                 }
             });
-
-            return dependencies;
-        }
-
-        [SetUp]
-        public void Setup() => Schedule(() =>
-        {
-            realm.Run(r =>
-            {
-                // Due to soft deletions, we can re-use deleted scores between test runs
-                scoreManager.Undelete(r.All<ScoreInfo>().Where(s => s.DeletePending).ToList());
-            });
-
-            leaderboard.BeatmapInfo = beatmapInfo;
-            leaderboard.RefetchScores(); // Required in the case that the beatmap hasn't changed
         });
 
         [SetUpSteps]
         public void SetupSteps()
         {
+            AddUntilStep("ensure scores imported", () => importedScores.Count == 50);
+            AddStep("undelete scores", () =>
+            {
+                Realm.Run(r =>
+                {
+                    // Due to soft deletions, we can re-use deleted scores between test runs
+                    scoreManager.Undelete(r.All<ScoreInfo>().Where(s => s.DeletePending).ToList());
+                });
+            });
+            AddStep("set up leaderboard", () =>
+            {
+                leaderboard.BeatmapInfo = beatmapInfo;
+                leaderboard.RefetchScores(); // Required in the case that the beatmap hasn't changed
+            });
+
             // Ensure the leaderboard items have finished showing up
             AddStep("finish transforms", () => leaderboard.FinishTransforms(true));
             AddUntilStep("wait for drawables", () => leaderboard.ChildrenOfType<LeaderboardScore>().Any());


### PR DESCRIPTION
* test was crashing when ran non-headless due to realm accesses on a load thread as vaguely hinted at in conversation in https://github.com/ppy/osu/pull/17650
* really weird practice to be running imports inside `CreateChildDependencies()` of all places anyway, so moved to BDL (as scheduled) - as i gather this is supposed to be "setup" code for the entire scene anyway, and there is no other facility available for this sort of thing that i know of
* merged scheduled `[SetUp]` into `[SetUpSteps]` because the former is kind of bad practice anyway, and it was failing `TestConstructor` otherwise
* fixed issue where the undelete step would do nothing due to using resolved `realm` instead of `Realm`

probably not the prettiest set of fixes but i don't really want to be spending more time on fixing this than absolutely necessary right now.