### PR TITLE
Handle repeated `OnPressed()` on `FooterButton` (without `FooterButtonRandom`)

### DIFF
--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Screens.Select
 
         public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (e.Action == Hotkey)
+            if (e.Action == Hotkey && !e.Repeat)
             {
                 TriggerClick();
                 return true;


### PR DESCRIPTION
This handles the same behavior observed in #17617 in the footer buttons.

It would make sense to apply it to the 3 of them but I'm kinda hesitant on doing it with the random button because I sometimes like to hold it and the people I asked about it all seems to also enjoy this behavior of the random button. The current behavior can be seen here:

https://user-images.githubusercontent.com/85121274/161642950-f2b0a425-a695-4b93-a7a5-6e0bcdc39841.mp4

Let me know what you think about it and if I should include `FooterButtonRandom`, I already have a change with it included so I can push it.
