### PR TITLE
Add support for 12-hour time on toolbar clock

### DIFF
--- a/osu.Game/Configuration/ToolbarClockDisplayMode.cs
+++ b/osu.Game/Configuration/ToolbarClockDisplayMode.cs
@@ -7,7 +7,10 @@ namespace osu.Game.Configuration
     {
         Analog,
         Digital,
+        Digital12H,
         DigitalWithRuntime,
-        Full
+        DigitalWithRuntime12H,
+        Full,
+        Full12H
     }
 }

--- a/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Overlays.Toolbar
 {
     public class DigitalClockDisplay : ClockDisplay
     {
+        private bool format12Hour;
+
         private OsuSpriteText realTime;
         private OsuSpriteText gameTime;
 
@@ -27,6 +29,11 @@ namespace osu.Game.Overlays.Toolbar
                 showRuntime = value;
                 updateMetrics();
             }
+        }
+
+        public DigitalClockDisplay(bool format12Hour = false)
+        {
+            this.format12Hour = format12Hour;
         }
 
         [BackgroundDependencyLoader]
@@ -50,13 +57,13 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override void UpdateDisplay(DateTimeOffset now)
         {
-            realTime.Text = $"{now:HH:mm:ss}";
+            realTime.Text = format12Hour ? $"{now:hh:mm:ss tt}" : $"{now:HH:mm:ss}";
             gameTime.Text = $"running {new TimeSpan(TimeSpan.TicksPerSecond * (int)(Clock.CurrentTime / 1000)):c}";
         }
 
         private void updateMetrics()
         {
-            Width = showRuntime ? 66 : 45; // Allows for space for game time up to 99 days (in the padding area since this is quite rare).
+            Width = showRuntime || format12Hour ? 66 : 45; // Allows for space for game time up to 99 days (in the padding area since this is quite rare).
             gameTime.FadeTo(showRuntime ? 1 : 0);
         }
     }

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Overlays.Toolbar
         private Box hoverBackground;
         private Box flashBackground;
 
+        private DigitalClockDisplay digital12h;
         private DigitalClockDisplay digital;
         private AnalogClockDisplay analog;
 
@@ -73,6 +74,11 @@ namespace osu.Game.Overlays.Toolbar
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
+                        },
+                        digital12h = new DigitalClockDisplay(true)
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
                         }
                     }
                 }
@@ -85,12 +91,16 @@ namespace osu.Game.Overlays.Toolbar
 
             clockDisplayMode.BindValueChanged(displayMode =>
             {
-                bool showAnalog = displayMode.NewValue == ToolbarClockDisplayMode.Analog || displayMode.NewValue == ToolbarClockDisplayMode.Full;
-                bool showDigital = displayMode.NewValue != ToolbarClockDisplayMode.Analog;
-                bool showRuntime = displayMode.NewValue == ToolbarClockDisplayMode.DigitalWithRuntime || displayMode.NewValue == ToolbarClockDisplayMode.Full;
+                bool showAnalog = displayMode.NewValue == ToolbarClockDisplayMode.Analog || displayMode.NewValue == ToolbarClockDisplayMode.Full || displayMode.NewValue == ToolbarClockDisplayMode.Full12H;
+                bool showDigital = displayMode.NewValue == ToolbarClockDisplayMode.Digital || displayMode.NewValue == ToolbarClockDisplayMode.DigitalWithRuntime || displayMode.NewValue == ToolbarClockDisplayMode.Full;
+                bool showDigital12H = displayMode.NewValue == ToolbarClockDisplayMode.Digital12H || displayMode.NewValue == ToolbarClockDisplayMode.DigitalWithRuntime12H || displayMode.NewValue == ToolbarClockDisplayMode.Full12H;
+                bool showRuntime = displayMode.NewValue == ToolbarClockDisplayMode.DigitalWithRuntime || displayMode.NewValue == ToolbarClockDisplayMode.DigitalWithRuntime12H || displayMode.NewValue == ToolbarClockDisplayMode.Full || displayMode.NewValue == ToolbarClockDisplayMode.Full12H;
 
                 digital.FadeTo(showDigital ? 1 : 0);
                 digital.ShowRuntime = showRuntime;
+
+                digital12h.FadeTo(showDigital12H ? 1 : 0);
+                digital12h.ShowRuntime = showRuntime;
 
                 analog.FadeTo(showAnalog ? 1 : 0);
             }, true);
@@ -128,14 +138,26 @@ namespace osu.Game.Overlays.Toolbar
                     break;
 
                 case ToolbarClockDisplayMode.Digital:
+                    clockDisplayMode.Value = ToolbarClockDisplayMode.Digital12H;
+                    break;
+
+                case ToolbarClockDisplayMode.Digital12H:
                     clockDisplayMode.Value = ToolbarClockDisplayMode.Analog;
                     break;
 
                 case ToolbarClockDisplayMode.DigitalWithRuntime:
+                    clockDisplayMode.Value = ToolbarClockDisplayMode.DigitalWithRuntime12H;
+                    break;
+
+                case ToolbarClockDisplayMode.DigitalWithRuntime12H:
                     clockDisplayMode.Value = ToolbarClockDisplayMode.Digital;
                     break;
 
                 case ToolbarClockDisplayMode.Full:
+                    clockDisplayMode.Value = ToolbarClockDisplayMode.Full12H;
+                    break;
+
+                case ToolbarClockDisplayMode.Full12H:
                     clockDisplayMode.Value = ToolbarClockDisplayMode.DigitalWithRuntime;
                     break;
             }


### PR DESCRIPTION
Super simple PR to expand the toolbar clock a little bit.
![image](https://user-images.githubusercontent.com/20259300/161672638-64d67323-72b0-4657-a17f-5376ab011291.png)

It looks like the addition of 12-hour was briefly discussed (https://github.com/ppy/osu/pull/17459#pullrequestreview-922305888) before being dismissed, but I think it would still be nice to have the option.