### PR TITLE
Forcefully leave room when local user leaves

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -401,19 +401,9 @@ namespace osu.Game.Online.Multiplayer
             });
         }
 
-        Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user) =>
-            handleUserLeft(user, UserLeft);
+        Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user) => handleUserLeft(user, UserLeft);
 
-        Task IMultiplayerClient.UserKicked(MultiplayerRoomUser user)
-        {
-            if (LocalUser == null)
-                return Task.CompletedTask;
-
-            if (user.Equals(LocalUser))
-                LeaveRoom();
-
-            return handleUserLeft(user, UserKicked);
-        }
+        Task IMultiplayerClient.UserKicked(MultiplayerRoomUser user) => handleUserLeft(user, UserKicked);
 
         private void addUserToAPIRoom(MultiplayerRoomUser user)
         {
@@ -431,6 +421,9 @@ namespace osu.Game.Online.Multiplayer
         {
             if (Room == null)
                 return Task.CompletedTask;
+
+            if (user.Equals(LocalUser))
+                LeaveRoom();
 
             Scheduler.Add(() =>
             {


### PR DESCRIPTION
Requires osu-server-spectator changes to have any effect, but is a no-op otherwise. https://github.com/ppy/osu-server-spectator/pull/118

Suppose the following:
1. Client0 connected as "user1", joined to room.
2. Client1 connected as "user2", joined to room.

Then Client2 logs into "user1". When this happens, the server should be sending a `UserLeft` callback to Client0 to forcefully leave the room since its connection is no longer considered valid.

There was already handling for this in `UserKicked`, so I've also added it to the `UserLeft` path.