### PR TITLE
Fix dangerous realm operation in `TestSceneMultiplayerMatchSongSelect`

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -8,12 +8,10 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.Rooms;
@@ -28,6 +26,7 @@ using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.Select;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -49,41 +48,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(Realm);
 
-            var metadata = new BeatmapMetadata
-            {
-                Artist = "Some Artist",
-                Title = "Some Beatmap",
-                Author = { Username = "Some Author" },
-            };
-
-            var beatmapSetInfo = new BeatmapSetInfo
-            {
-                OnlineID = 10,
-                Hash = Guid.NewGuid().ToString().ComputeMD5Hash(),
-                DateAdded = DateTimeOffset.UtcNow
-            };
-
-            for (int i = 0; i < 8; ++i)
-            {
-                int beatmapId = 10 * 10 + i;
-
-                int length = RNG.Next(30000, 200000);
-                double bpm = RNG.NextSingle(80, 200);
-
-                var beatmap = new BeatmapInfo
-                {
-                    Ruleset = rulesets.GetRuleset(i % 4) ?? throw new InvalidOperationException(),
-                    OnlineID = beatmapId,
-                    Length = length,
-                    BPM = bpm,
-                    Metadata = metadata,
-                    Difficulty = new BeatmapDifficulty()
-                };
-
-                beatmapSetInfo.Beatmaps.Add(beatmap);
-            }
-
-            importedBeatmapSet = manager.Import(beatmapSetInfo);
+            importedBeatmapSet = manager.Import(TestResources.CreateTestBeatmapSetInfo(8, rulesets.AvailableRulesets.ToArray()));
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -15,6 +15,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
@@ -35,9 +36,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private BeatmapManager manager;
         private RulesetStore rulesets;
 
-        private List<BeatmapInfo> beatmaps;
+        private IList<BeatmapInfo> beatmaps => importedBeatmapSet?.PerformRead(s => s.Beatmaps) ?? new List<BeatmapInfo>();
 
         private TestMultiplayerMatchSongSelect songSelect;
+
+        private Live<BeatmapSetInfo> importedBeatmapSet;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -45,8 +48,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, rulesets, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(Realm);
-
-            beatmaps = new List<BeatmapInfo>();
 
             var metadata = new BeatmapMetadata
             {
@@ -79,11 +80,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Difficulty = new BeatmapDifficulty()
                 };
 
-                beatmaps.Add(beatmap);
                 beatmapSetInfo.Beatmaps.Add(beatmap);
             }
 
-            manager.Import(beatmapSetInfo);
+            importedBeatmapSet = manager.Import(beatmapSetInfo);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDeleteLocalScore.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -17,7 +16,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Models;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
@@ -60,20 +58,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                         Anchor = Anchor.Centre,
                         Size = new Vector2(550f, 450f),
                         Scope = BeatmapLeaderboardScope.Local,
-                        BeatmapInfo = new BeatmapInfo
-                        {
-                            ID = Guid.NewGuid(),
-                            Metadata = new BeatmapMetadata
-                            {
-                                Title = "TestSong",
-                                Artist = "TestArtist",
-                                Author = new RealmUser
-                                {
-                                    Username = "TestAuthor"
-                                },
-                            },
-                            DifficultyName = "Insane"
-                        },
+                        BeatmapInfo = TestResources.CreateTestBeatmapSetInfo().Beatmaps.First()
                     }
                 },
                 dialogOverlay = new DialogOverlay()


### PR DESCRIPTION
The import process was running on the async load thread, but then accessed from the access thread later on. This seemed to somehow pass fine in headless runs, but would fail on visual test execution (specifically on `TestBeatmapConfirmed()`).

Note that this test method will still fail further in the process, will
be addressed separately.