### PR TITLE
Change `WorkingBeatmap.GetVirtualTrack` to use length provided by `BeatmapInfo`

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -17,7 +17,6 @@ using osu.Framework.Logging;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
@@ -152,24 +151,7 @@ namespace osu.Game.Beatmaps
         {
             const double excess_length = 1000;
 
-            var lastObject = Beatmap?.HitObjects.LastOrDefault();
-
-            double length;
-
-            switch (lastObject)
-            {
-                case null:
-                    length = emptyLength;
-                    break;
-
-                case IHasDuration endTime:
-                    length = endTime.EndTime + excess_length;
-                    break;
-
-                default:
-                    length = lastObject.StartTime + excess_length;
-                    break;
-            }
+            double length = (BeatmapInfo?.Length + excess_length) ?? emptyLength;
 
             return audioManager.Tracks.GetVirtual(length);
         }


### PR DESCRIPTION
A lot of tests are using test resources that populate the length field, but do not populate hitobjects. The general expectation is that components should be using the cached length in cases where hitobjects are not relevant, but `GetVirtualTrack` was doing its own local calculation.

This could cause tests to fail due to `MusicController` changing track in the background.

All tests seem to still pass, thankfully.