### PR TITLE
Ensure intro beatmap has protected flag set

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.Menu
 
             bool loadThemedIntro()
             {
-                var setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == BeatmapHash);
+                var setInfo = beatmaps.QueryBeatmapSet(b => b.Protected && b.Hash == BeatmapHash);
 
                 if (setInfo == null)
                     return false;


### PR DESCRIPTION
In cases this isn't set, the beatmap has likely entered a bad state.  Triggering the standard re-import flow is enough to fix the issue.

Closes https://github.com/ppy/osu/issues/17659.