### PR TITLE
Remove some outdated packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,14 +26,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Label="Project">
-    <!--
-    NU1701:
-      DeepEqual is not netstandard-compatible. This is fine since we run tests with .NET Framework anyway.
-      This is required due to https://github.com/NuGet/Home/issues/5740
-    -->
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
-  </PropertyGroup>
   <PropertyGroup Label="Nuget">
     <IsPackable>false</IsPackable>
     <Authors>ppy Pty Ltd</Authors>

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Clowd.Squirrel" Version="2.8.28-pre" />
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
@@ -33,7 +32,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
   </ItemGroup>
   <ItemGroup Label="Resources">

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="ppy.LocalisationAnalyser" Version="2022.320.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- There's no packages netfx-only now, re-enabling NU1701.
- Microsoft.NETCore.Targets was something in .NET Core 1.x/2.x era, and totally nothing now. It has been removed from source code in 6.0.
- Microsoft.Win32.Registry is in-box. It's not necessary to reference the OOB package in .NET 6 project.