### PR TITLE
Fix filename lookups on `LegacySkin`s going awry when extension is specified

### DIFF
--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -69,6 +69,20 @@ namespace osu.Game.Tests.NonVisual.Skinning
                 "Gameplay/osu/followpoint",
                 "followpoint", 1
             },
+            new object[]
+            {
+                // Looking up a filename with extension specified should work.
+                new[] { "followpoint.png" },
+                "followpoint.png",
+                "followpoint.png", 1
+            },
+            new object[]
+            {
+                // Looking up a filename with extension specified should also work with @2x sprites.
+                new[] { "followpoint@2x.png" },
+                "followpoint.png",
+                "followpoint@2x.png", 2
+            },
         };
 
         [TestCaseSource(nameof(fallbackTestCases))]

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -443,7 +443,11 @@ namespace osu.Game.Skinning
                 string lookupName = name.Replace(@"@2x", string.Empty);
 
                 float ratio = 2;
-                var texture = Textures?.Get(@$"{lookupName}@2x", wrapModeS, wrapModeT);
+                string twoTimesFilename = Path.HasExtension(lookupName)
+                    ? @$"{Path.GetFileNameWithoutExtension(lookupName)}@2x{Path.GetExtension(lookupName)}"
+                    : @$"{lookupName}@2x";
+
+                var texture = Textures?.Get(twoTimesFilename, wrapModeS, wrapModeT);
 
                 if (texture == null)
                 {


### PR DESCRIPTION
Due to the logic present to handle `@2x` fallback, the extension was potentially being added at the wrong point in the filename. This change ensures that the lookup filenames are always correct.

Closes https://github.com/ppy/osu/issues/17690.

Note that there are still some other issues with the linked beatmap (Time Traveler) which I am looking into separately.