### PR TITLE
Fix storyboard animations getting incorrect positioning due to size not being set

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -5,8 +5,10 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
+using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Storyboards.Drawables
@@ -86,6 +88,14 @@ namespace osu.Game.Storyboards.Drawables
 
             LifetimeStart = animation.StartTime;
             LifetimeEnd = animation.EndTime;
+        }
+
+        protected override Vector2 GetCurrentDisplaySize()
+        {
+            Texture texture = (CurrentFrame as Sprite)?.Texture
+                              ?? ((CurrentFrame as SkinnableSprite)?.Drawable as Sprite)?.Texture;
+
+            return new Vector2(texture?.DisplayWidth ?? 0, texture?.DisplayHeight ?? 0);
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Usually this would be handled by `TextureAnimation`, but because we are inheriting from `DrawableAnimation` here for reasons, we needed to implement this ourselves. Follows the implementation in `TextureAnimation`.

Testing on the first slider in https://osu.ppy.sh/beatmapsets/1236988#osu/2573493 (may require #17700 to display correctly in the first place)

Before:

![osu! 2022-04-07 at 06 17 49](https://user-images.githubusercontent.com/191335/162132772-a9a39cff-84ae-492c-8bd0-f04fb0ef2721.png)

After:

![osu! 2022-04-07 at 06 16 34](https://user-images.githubusercontent.com/191335/162132604-9e5640ce-cd77-4eb8-96cd-d937d1915fcd.png)
