### PR TITLE
Fix skin texture lookups not handling paths with extensions

### DIFF
--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -83,6 +83,20 @@ namespace osu.Game.Tests.NonVisual.Skinning
                 "followpoint.png",
                 "followpoint@2x.png", 2
             },
+            new object[]
+            {
+                // Looking up a path with extension specified should work.
+                new[] { "Gameplay/osu/followpoint.png" },
+                "Gameplay/osu/followpoint.png",
+                "Gameplay/osu/followpoint.png", 1
+            },
+            new object[]
+            {
+                // Looking up a path with extension specified should also work with @2x sprites.
+                new[] { "Gameplay/osu/followpoint@2x.png" },
+                "Gameplay/osu/followpoint.png",
+                "Gameplay/osu/followpoint@2x.png", 2
+            },
         };
 
         [TestCaseSource(nameof(fallbackTestCases))]

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -443,9 +443,7 @@ namespace osu.Game.Skinning
                 string lookupName = name.Replace(@"@2x", string.Empty);
 
                 float ratio = 2;
-                string twoTimesFilename = Path.HasExtension(lookupName)
-                    ? @$"{Path.GetFileNameWithoutExtension(lookupName)}@2x{Path.GetExtension(lookupName)}"
-                    : @$"{lookupName}@2x";
+                string twoTimesFilename = $"{Path.ChangeExtension(lookupName, null)}@2x{Path.GetExtension(lookupName)}";
 
                 var texture = Textures?.Get(twoTimesFilename, wrapModeS, wrapModeT);
 


### PR DESCRIPTION
While this may not be all that necessary, noticed in #17700 that it doesn't handle appending `@2x` to paths with extensions properly:

<img width="1231" alt="CleanShot 2022-04-07 at 15 08 56@2x" src="https://user-images.githubusercontent.com/22781491/162195314-21436a81-ee4a-4aa0-ad21-43919471fb49.png">
