### PR TITLE
Ensure that mods grouped into multi mods are pairwise incompatible

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.DifficultyIncrease;
 
         public override double ScoreMultiplier => 1.12;
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight) };
+
         private DrawableOsuBlinds blinds;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
@@ -19,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModFlashlight : ModFlashlight<OsuHitObject>, IApplicableToDrawableHitObject
     {
         public override double ScoreMultiplier => 1.12;
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModBlinds)).ToArray();
 
         private const double default_follow_delay = 120;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected virtual float EndScale => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn), typeof(OsuModObjectScaleTween) };
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {

--- a/osu.Game.Tests/Mods/MultiModIncompatibilityTest.cs
+++ b/osu.Game.Tests/Mods/MultiModIncompatibilityTest.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Utils;
+
+namespace osu.Game.Tests.Mods
+{
+    [TestFixture]
+    public class MultiModIncompatibilityTest
+    {
+        /// <summary>
+        /// Ensures that all mods grouped into <see cref="MultiMod"/>s, as declared by the default rulesets, are pairwise incompatible with each other.
+        /// </summary>
+        [TestCase(typeof(OsuRuleset))]
+        [TestCase(typeof(TaikoRuleset))]
+        [TestCase(typeof(CatchRuleset))]
+        [TestCase(typeof(ManiaRuleset))]
+        public void TestAllMultiModsFromRulesetAreIncompatible(Type rulesetType)
+        {
+            var ruleset = (Ruleset)Activator.CreateInstance(rulesetType);
+            Assert.That(ruleset, Is.Not.Null);
+
+            var allMultiMods = getMultiMods(ruleset);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var multiMod in allMultiMods)
+                {
+                    int modCount = multiMod.Mods.Length;
+
+                    for (int i = 0; i < modCount; ++i)
+                    {
+                        // indexing from i + 1 ensures that only pairs of different mods are checked, and are checked only once
+                        // (indexing from 0 would check each pair twice, and also check each mod against itself).
+                        for (int j = i + 1; j < modCount; ++j)
+                        {
+                            var firstMod = multiMod.Mods[i];
+                            var secondMod = multiMod.Mods[j];
+
+                            Assert.That(
+                                ModUtils.CheckCompatibleSet(new[] { firstMod, secondMod }), Is.False,
+                                $"{firstMod.Name} ({firstMod.Acronym}) and {secondMod.Name} ({secondMod.Acronym}) should be incompatible.");
+                        }
+                    }
+                }
+            });
+        }
+
+        /// <remarks>
+        /// This local helper is used rather than <see cref="Ruleset.CreateAllMods"/>, because the aforementioned method flattens multi mods.
+        /// </remarks>>
+        private static IEnumerable<MultiMod> getMultiMods(Ruleset ruleset)
+            => Enum.GetValues(typeof(ModType)).Cast<ModType>().SelectMany(ruleset.GetModsFor).OfType<MultiMod>();
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
@@ -17,8 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModDoubleTime;
         public override ModType Type => ModType.DifficultyIncrease;
         public override string Description => "Zoooooooooom...";
-
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModHalfTime)).ToArray();
 
         [SettingSource("Speed increase", "The actual increase to apply")]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
@@ -17,8 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHalftime;
         public override ModType Type => ModType.DifficultyReduction;
         public override string Description => "Less zoom...";
-
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModDoubleTime)).ToArray();
 
         [SettingSource("Speed decrease", "The actual decrease to apply")]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble

--- a/osu.Game/Rulesets/Mods/ModRateAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModRateAdjust.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
 
         public double ApplyToRate(double time, double rate) => rate * SpeedChange.Value;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ModTimeRamp), typeof(ModAdaptiveSpeed) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModTimeRamp), typeof(ModAdaptiveSpeed), typeof(ModRateAdjust) };
 
         public override string SettingDescription => SpeedChange.IsDefault ? string.Empty : $"{SpeedChange.Value:N2}x";
     }

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -115,7 +115,9 @@ namespace osu.Game.Utils
         {
             mods = mods.ToArray();
 
-            CheckCompatibleSet(mods, out invalidMods);
+            // exclude multi mods from compatibility checks.
+            // the loop below automatically marks all multi mods as not valid for gameplay anyway.
+            CheckCompatibleSet(mods.Where(m => !(m is MultiMod)), out invalidMods);
 
             foreach (var mod in mods)
             {


### PR DESCRIPTION
This is a companion piece to #16917, as foreshadowed in https://github.com/ppy/osu/issues/17508#issuecomment-1080713738. I need this change in order for the new flat list of mods to work correctly with respect to incompatibility rules (or in other words, to make it impossible for players to select double time *and* nightcore simultaneously, for instance).

I've added a relatively simple test to make sure this property holds for now, but in the long run it may not need to exist anymore if multi mods cease to exist, or if the mod logic gets refactored to use incompatibility groups rather than each mod having to declare its own incompatibilities (i.e. see #7155). I don't want to commit to either of those directions for now yet, though, unless there is a clear agreement that one of these paths should be taken.