### PR TITLE
Avoid multiplayer crashes when events arrive in unexpected order

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -493,11 +493,13 @@ namespace osu.Game.Online.Multiplayer
         {
             Scheduler.Add(() =>
             {
-                if (Room == null)
+                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+
+                // TODO: user should NEVER be null here, see https://github.com/ppy/osu/issues/17713.
+                if (user == null)
                     return;
 
-                Room.Users.Single(u => u.UserID == userId).State = state;
-
+                user.State = state;
                 updateUserPlayingState(userId, state);
 
                 RoomUpdated?.Invoke();
@@ -510,10 +512,13 @@ namespace osu.Game.Online.Multiplayer
         {
             Scheduler.Add(() =>
             {
-                if (Room == null)
+                var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
+
+                // TODO: user should NEVER be null here, see https://github.com/ppy/osu/issues/17713.
+                if (user == null)
                     return;
 
-                Room.Users.Single(u => u.UserID == userId).MatchState = state;
+                user.MatchState = state;
                 RoomUpdated?.Invoke();
             }, false);
 


### PR DESCRIPTION
Intended to be a temporary fix for https://github.com/ppy/osu/issues/17713 while a more permanent solution is established. A proper fix is actually quite simple, but updating the test to work with it is... *slightly* more complicated.

This hotfix will mean that if a `UserJoined` event arrives during the unobserved window during room join (of the local user), the local user still won't see the joining user, but the game won't crash as a result.

An example of how this will look in practice (tested manually with an added `Task.Delay`):

https://user-images.githubusercontent.com/191335/162403348-d6a862e1-4e05-4d97-9928-f52549704b3d.mp4


