### PR TITLE
Remove some incorrectly-firing asserts

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -481,11 +481,7 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
         {
-            Debug.Assert(APIRoom != null);
-            Debug.Assert(Room != null);
-
             Scheduler.Add(() => updateLocalRoomSettings(newSettings));
-
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
As of https://github.com/ppy/osu/pull/17721, accessing `Room` from the non-update thread now throws an assert.