### PR TITLE
Fix crash when clicking chat mention notification before opening chat overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -534,11 +534,33 @@ namespace osu.Game.Tests.Visual.Online
                 });
             });
 
-            AddStep("Highlight message and open chat", () =>
+            AddStep("Highlight message", () => chatOverlay.HighlightMessage(message, channel1));
+        }
+
+        [Test]
+        public void TestHighlightWithNullChannel()
+        {
+            Message message = null;
+
+            AddStep("Join channel 1", () => channelManager.JoinChannel(channel1));
+
+            AddStep("Send message in channel 1", () =>
             {
-                chatOverlay.HighlightMessage(message, channel1);
-                chatOverlay.Show();
+                channel1.AddNewMessages(message = new Message
+                {
+                    ChannelId = channel1.Id,
+                    Content = "Message to highlight!",
+                    Timestamp = DateTimeOffset.Now,
+                    Sender = new APIUser
+                    {
+                        Id = 2,
+                        Username = "Someone",
+                    }
+                });
             });
+
+            AddStep("Set null channel", () => channelManager.CurrentChannel.Value = null);
+            AddStep("Highlight message", () => chatOverlay.HighlightMessage(message, channel1));
         }
 
         private void pressChannelHotkey(int number)

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -178,8 +178,6 @@ namespace osu.Game.Online.Chat
                 {
                     notificationOverlay.Hide();
                     chatOverlay.HighlightMessage(message, channel);
-                    chatOverlay.Show();
-
                     return true;
                 };
             }

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Overlays
 
             Debug.Assert(channel.Id == message.ChannelId);
 
-            if (currentChannel.Value.Id != channel.Id)
+            if (currentChannel.Value?.Id != channel.Id)
             {
                 if (!channel.Joined.Value)
                     channel = channelManager.JoinChannel(channel);

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -313,6 +313,8 @@ namespace osu.Game.Overlays
         /// <param name="channel">The channel containing the message.</param>
         public void HighlightMessage(Message message, Channel channel)
         {
+            Show();
+
             Debug.Assert(channel.Id == message.ChannelId);
 
             if (currentChannel.Value.Id != channel.Id)

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -313,8 +313,6 @@ namespace osu.Game.Overlays
         /// <param name="channel">The channel containing the message.</param>
         public void HighlightMessage(Message message, Channel channel)
         {
-            Show();
-
             Debug.Assert(channel.Id == message.ChannelId);
 
             if (currentChannel.Value?.Id != channel.Id)
@@ -326,6 +324,8 @@ namespace osu.Game.Overlays
             }
 
             channel.HighlightedMessage.Value = message;
+
+            Show();
         }
 
         private float startDragChatHeight;


### PR DESCRIPTION
Channel may be null if called too early.

Closes #17727.