### PR TITLE
Fix ParticleSpewer outputting NaN values in vertices

### DIFF
--- a/osu.Game/Graphics/ParticleSpewer.cs
+++ b/osu.Game/Graphics/ParticleSpewer.cs
@@ -109,6 +109,9 @@ namespace osu.Game.Graphics
             {
                 foreach (var p in particles)
                 {
+                    if (p.Duration == 0)
+                        continue;
+
                     float timeSinceStart = currentTime - p.StartTime;
 
                     // ignore particles from the future.


### PR DESCRIPTION
Noticed in an internal branch that particles in their default state have a duration of 0, resulting in NaN values being sent as vertices:

![image](https://user-images.githubusercontent.com/1329837/162576343-ac3583f5-8d3e-47bc-a3e3-040e3dc63e22.png)

Can be reproed with https://osu.ppy.sh/beatmapsets/1343884#osu/2783393