### PR TITLE
Avoid throwing unobserved exception when `PerformancePointsCounter` requests timed attributes

### DIFF
--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -80,13 +79,16 @@ namespace osu.Game.Screens.Play.HUD
                 difficultyCache.GetTimedDifficultyAttributesAsync(gameplayWorkingBeatmap, gameplayState.Ruleset, clonedMods, loadCancellationSource.Token)
                                .ContinueWith(task => Schedule(() =>
                                {
+                                   if (task.Exception != null)
+                                       return;
+
                                    timedAttributes = task.GetResultSafely();
 
                                    IsValid = true;
 
                                    if (lastJudgement != null)
                                        onJudgementChanged(lastJudgement);
-                               }), TaskContinuationOptions.OnlyOnRanToCompletion);
+                               }));
             }
         }
 


### PR DESCRIPTION
Makes sense for this to be done at the call site, as it's an asynchronous call.

As mentioned in https://github.com/ppy/osu/discussions/17754.