### PR TITLE
Fix incorrect cursor parameterisation in test scene

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -259,7 +259,7 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 multiplayerUserScore.ScoresAround.Lower.Scores.Add(new MultiplayerScore
                 {
-                    ID = --highestScoreId,
+                    ID = getNextLowestScoreId(),
                     Accuracy = userScore.Accuracy,
                     Passed = true,
                     Rank = userScore.Rank,
@@ -274,7 +274,7 @@ namespace osu.Game.Tests.Visual.Playlists
 
                 multiplayerUserScore.ScoresAround.Higher.Scores.Add(new MultiplayerScore
                 {
-                    ID = ++lowestScoreId,
+                    ID = getNextHighestScoreId(),
                     Accuracy = userScore.Accuracy,
                     Passed = true,
                     Rank = userScore.Rank,
@@ -306,7 +306,7 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 result.Scores.Add(new MultiplayerScore
                 {
-                    ID = sort == "score_asc" ? --highestScoreId : ++lowestScoreId,
+                    ID = sort == "score_asc" ? getNextHighestScoreId() : getNextLowestScoreId(),
                     Accuracy = 1,
                     Passed = true,
                     Rank = ScoreRank.X,
@@ -327,6 +327,17 @@ namespace osu.Game.Tests.Visual.Playlists
             return result;
         }
 
+        /// <summary>
+        /// The next highest score ID to appear at the left of the list. Monotonically decreasing.
+        /// </summary>
+        private int getNextHighestScoreId() => --highestScoreId;
+
+        /// <summary>
+        /// The next lowest score ID to appear at the right of the list. Monotonically increasing.
+        /// </summary>
+        /// <returns></returns>
+        private int getNextLowestScoreId() => ++lowestScoreId;
+
         private void addCursor(MultiplayerScores scores)
         {
             scores.Cursor = new Cursor
@@ -342,7 +353,9 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 Properties = new Dictionary<string, JToken>
                 {
-                    { "sort", JToken.FromObject(scores.Scores[^1].ID > scores.Scores[^2].ID ? "score_asc" : "score_desc") }
+                    // [ 1, 2, 3, ... ] => score_desc (will be added to the right of the list)
+                    // [ 3, 2, 1, ... ] => score_asc (will be added to the left of the list)
+                    { "sort", JToken.FromObject(scores.Scores[^1].ID > scores.Scores[^2].ID ? "score_desc" : "score_asc") }
                 }
             };
         }


### PR DESCRIPTION
In investigating https://github.com/ppy/osu/runs/5966758514?check_suite_focus=true, I found that this test scene was incorrectly parameterising the cursor.

Specifically - the user response route was adding scores with the reverse score ID orderings, which was once again reversed in `addCursor`, making future calls to `createIndexResponse()` for either pivot do the reverse of what it should because it would receive the incorrect `sort` mode.

This would show up as adding panels to the opposite side of the direction which was scrolled, once for every scroll, before then adding a second set of panels to the correct side on a subsequent request.

I'm not sure if this 100% fixes the timing out tests as I couldn't repro the failures locally.