### PR TITLE
Fix `MultiplayerTestScene` not setting match type correctly

### DIFF
--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return new Room
             {
                 Name = { Value = "test name" },
+                Type = { Value = MatchType.HeadToHead },
                 Playlist =
                 {
                     new PlaylistItem(new TestBeatmap(Ruleset.Value).BeatmapInfo)


### PR DESCRIPTION
Not sure this is too meaninful on its own, but it fixes all multiplayer tests actually dealing with a room of type `Playlist`.