### PR TITLE
Fix multiple issues with gameplay leaderboard (and tests)

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
@@ -86,7 +86,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUpSteps]
         public virtual void SetUpSteps()
         {
-            AddStep("reset counts", () => spectatorClient.Invocations.Clear());
+            AddStep("reset counts", () =>
+            {
+                spectatorClient.Invocations.Clear();
+                lastHeaders.Clear();
+            });
 
             AddStep("set local user", () => ((DummyAPIAccess)API).LocalUser.Value = new APIUser
             {

--- a/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public abstract class MultiplayerGameplayLeaderboardTestScene : OsuTestScene
     {
+        private const int total_users = 16;
+
         protected readonly BindableList<MultiplayerRoomUser> MultiplayerUsers = new BindableList<MultiplayerRoomUser>();
 
         protected MultiplayerGameplayLeaderboard Leaderboard { get; private set; }
@@ -94,7 +96,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("populate users", () =>
             {
                 MultiplayerUsers.Clear();
-                for (int i = 0; i < 16; i++)
+                for (int i = 0; i < total_users; i++)
                     MultiplayerUsers.Add(CreateUser(i));
             });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using osu.Framework.Graphics;
-using osu.Framework.Utils;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 using osu.Game.Rulesets.Osu.Scoring;
@@ -14,12 +13,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerGameplayLeaderboardTeams : MultiplayerGameplayLeaderboardTestScene
     {
+        private int team;
+
         protected override MultiplayerRoomUser CreateUser(int userId)
         {
             var user = base.CreateUser(userId);
             user.MatchState = new TeamVersusUserState
             {
-                TeamID = RNG.Next(0, 2)
+                TeamID = team++ % 2
             };
             return user;
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerTeamResults.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerTeamResults.cs
@@ -26,10 +26,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 var beatmapInfo = CreateBeatmap(rulesetInfo).BeatmapInfo;
                 var score = TestResources.CreateTestScoreInfo(beatmapInfo);
 
-                SortedDictionary<int, BindableInt> teamScores = new SortedDictionary<int, BindableInt>
+                SortedDictionary<int, BindableLong> teamScores = new SortedDictionary<int, BindableLong>
                 {
-                    { 0, new BindableInt(team1Score) },
-                    { 1, new BindableInt(team2Score) }
+                    { 0, new BindableLong(team1Score) },
+                    { 1, new BindableLong(team2Score) }
                 };
 
                 Stack.Push(screen = new MultiplayerTeamResultsScreen(score, 1, new PlaylistItem(beatmapInfo), teamScores));

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
@@ -24,12 +24,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     public class MultiplayerTeamResultsScreen : MultiplayerResultsScreen
     {
-        private readonly SortedDictionary<int, BindableInt> teamScores;
+        private readonly SortedDictionary<int, BindableLong> teamScores;
 
         private Container winnerBackground;
         private Drawable winnerText;
 
-        public MultiplayerTeamResultsScreen(ScoreInfo score, long roomId, PlaylistItem playlistItem, SortedDictionary<int, BindableInt> teamScores)
+        public MultiplayerTeamResultsScreen(ScoreInfo score, long roomId, PlaylistItem playlistItem, SortedDictionary<int, BindableLong> teamScores)
             : base(score, roomId, playlistItem)
         {
             if (teamScores.Count != 2)

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Screens.Play.HUD
         private const float bar_height = 18;
         private const float font_size = 50;
 
-        public BindableInt Team1Score = new BindableInt();
-        public BindableInt Team2Score = new BindableInt();
+        public BindableLong Team1Score = new BindableLong();
+        public BindableLong Team2Score = new BindableLong();
 
         protected MatchScoreCounter Score1Text;
         protected MatchScoreCounter Score2Text;
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Play.HUD
             var winningBar = Team1Score.Value > Team2Score.Value ? score1Bar : score2Bar;
             var losingBar = Team1Score.Value <= Team2Score.Value ? score1Bar : score2Bar;
 
-            int diff = Math.Max(Team1Score.Value, Team2Score.Value) - Math.Min(Team1Score.Value, Team2Score.Value);
+            long diff = Math.Max(Team1Score.Value, Team2Score.Value) - Math.Min(Team1Score.Value, Team2Score.Value);
 
             losingBar.ResizeWidthTo(0, 400, Easing.OutQuint);
             winningBar.ResizeWidthTo(Math.Min(0.4f, MathF.Pow(diff / 1500000f, 0.5f) / 2), 400, Easing.OutQuint);

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Play.HUD
     {
         protected readonly Dictionary<int, TrackedUserData> UserScores = new Dictionary<int, TrackedUserData>();
 
-        public readonly SortedDictionary<int, BindableInt> TeamScores = new SortedDictionary<int, BindableInt>();
+        public readonly SortedDictionary<int, BindableLong> TeamScores = new SortedDictionary<int, BindableLong>();
 
         [Resolved]
         private OsuColour colours { get; set; }
@@ -82,7 +82,7 @@ namespace osu.Game.Screens.Play.HUD
                 UserScores[user.UserID] = trackedUser;
 
                 if (trackedUser.Team is int team && !TeamScores.ContainsKey(team))
-                    TeamScores.Add(team, new BindableInt());
+                    TeamScores.Add(team, new BindableLong());
             }
 
             userLookupCache.GetUsersAsync(playingUsers.Select(u => u.UserID).ToArray()).ContinueWith(task => Schedule(() =>

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 for (int i = 0; i < users.Length; i++)
                 {
-                    var user = users[i] ??= new APIUser
+                    var user = users[i] ?? new APIUser
                     {
                         Id = playingUsers[i].UserID,
                         Username = "Unknown user",

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -89,10 +89,13 @@ namespace osu.Game.Screens.Play.HUD
             {
                 var users = task.GetResultSafely();
 
-                foreach (var user in users)
+                for (int i = 0; i < users.Length; i++)
                 {
-                    if (user == null)
-                        continue;
+                    var user = users[i] ??= new APIUser
+                    {
+                        Id = playingUsers[i].UserID,
+                        Username = "Unknown user",
+                    };
 
                     var trackedUser = UserScores[user.Id];
 

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -75,7 +75,10 @@ namespace osu.Game.Screens.Play.HUD
             foreach (var user in playingUsers)
             {
                 var trackedUser = CreateUserData(user, ruleset, scoreProcessor);
+
                 trackedUser.ScoringMode.BindTo(scoringMode);
+                trackedUser.Score.BindValueChanged(_ => Scheduler.AddOnce(updateTotals));
+
                 UserScores[user.UserID] = trackedUser;
 
                 if (trackedUser.Team is int team && !TeamScores.ContainsKey(team))
@@ -175,8 +178,6 @@ namespace osu.Game.Screens.Play.HUD
 
             trackedData.Frames.Add(new TimedFrame(bundle.Frames.First().Time, bundle.Header));
             trackedData.UpdateScore();
-
-            updateTotals();
         });
 
         private void updateTotals()


### PR DESCRIPTION
Please see individual commits. Important ones:

8b1cee75fa Use `BindableLong` instead of `BindableInt` for user score tracking

22c75a518e Fix headers not getting reset on re-run of test

0ba95a4483 Ensure all users are shown on leaderboard (even when API lookup fails)

577e29351e Ensure players are always on both leaderboard teams

In a very rare case, the randomisation may cause all users to be on one team, causing a test failure. The odds make it basically impossible, but if adjusting the number of users in the test scene this can more readily be hit.

ebee9e6888 Fix `MultiplayerGameplayLeaderboard` not immediately updating totals on scoring mode change