### PR TITLE
Remove usages of binary serialization

### DIFF
--- a/osu.Game/IO/Legacy/SerializationReader.cs
+++ b/osu.Game/IO/Legacy/SerializationReader.cs
@@ -3,11 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 
 namespace osu.Game.IO.Legacy
@@ -186,97 +183,11 @@ namespace osu.Game.IO.Legacy
                     return ReadCharArray();
 
                 case ObjType.otherType:
-                    return DynamicDeserializer.Deserialize(BaseStream);
+                    throw new IOException("Deserialization of arbitrary type is not supported.");
 
                 default:
                     return null;
             }
-        }
-
-        public static class DynamicDeserializer
-        {
-            private static VersionConfigToNamespaceAssemblyObjectBinder versionBinder;
-            private static BinaryFormatter formatter;
-
-            private static void initialize()
-            {
-                versionBinder = new VersionConfigToNamespaceAssemblyObjectBinder();
-                formatter = new BinaryFormatter
-                {
-                    // AssemblyFormat = FormatterAssemblyStyle.Simple,
-                    Binder = versionBinder
-                };
-            }
-
-            public static object Deserialize(Stream stream)
-            {
-                if (formatter == null)
-                    initialize();
-
-                Debug.Assert(formatter != null, "formatter != null");
-
-                // ReSharper disable once PossibleNullReferenceException
-                return formatter.Deserialize(stream);
-            }
-
-            #region Nested type: VersionConfigToNamespaceAssemblyObjectBinder
-
-            public sealed class VersionConfigToNamespaceAssemblyObjectBinder : SerializationBinder
-            {
-                private readonly Dictionary<string, Type> cache = new Dictionary<string, Type>();
-
-                public override Type BindToType(string assemblyName, string typeName)
-                {
-                    if (cache.TryGetValue(assemblyName + typeName, out var typeToDeserialize))
-                        return typeToDeserialize;
-
-                    List<Type> tmpTypes = new List<Type>();
-                    Type genType = null;
-
-                    if (typeName.Contains("System.Collections.Generic") && typeName.Contains("[["))
-                    {
-                        string[] splitTypes = typeName.Split('[');
-
-                        foreach (string typ in splitTypes)
-                        {
-                            if (typ.Contains("Version"))
-                            {
-                                string asmTmp = typ.Substring(typ.IndexOf(',') + 1);
-                                string asmName = asmTmp.Remove(asmTmp.IndexOf(']')).Trim();
-                                string typName = typ.Remove(typ.IndexOf(','));
-                                tmpTypes.Add(BindToType(asmName, typName));
-                            }
-                            else if (typ.Contains("Generic"))
-                            {
-                                genType = BindToType(assemblyName, typ);
-                            }
-                        }
-
-                        if (genType != null && tmpTypes.Count > 0)
-                        {
-                            return genType.MakeGenericType(tmpTypes.ToArray());
-                        }
-                    }
-
-                    string toAssemblyName = assemblyName.Split(',')[0];
-                    Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-
-                    foreach (Assembly a in assemblies)
-                    {
-                        if (a.FullName.Split(',')[0] == toAssemblyName)
-                        {
-                            typeToDeserialize = a.GetType(typeName);
-                            break;
-                        }
-                    }
-
-                    cache.Add(assemblyName + typeName, typeToDeserialize);
-
-                    return typeToDeserialize;
-                }
-            }
-
-            #endregion
         }
     }
 

--- a/osu.Game/IO/Legacy/SerializationReader.cs
+++ b/osu.Game/IO/Legacy/SerializationReader.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Text;
 
 namespace osu.Game.IO.Legacy
@@ -22,15 +21,6 @@ namespace osu.Game.IO.Legacy
         }
 
         public int RemainingBytes => (int)(stream.Length - stream.Position);
-
-        /// <summary> Static method to take a SerializationInfo object (an input to an ISerializable constructor)
-        /// and produce a SerializationReader from which serialized objects can be read </summary>.
-        public static SerializationReader GetReader(SerializationInfo info)
-        {
-            byte[] byteArray = (byte[])info.GetValue("X", typeof(byte[]));
-            MemoryStream ms = new MemoryStream(byteArray);
-            return new SerializationReader(ms);
-        }
 
         /// <summary> Reads a string from the buffer.  Overrides the base implementation so it can cope with nulls. </summary>
         public override string ReadString()

--- a/osu.Game/IO/Legacy/SerializationWriter.cs
+++ b/osu.Game/IO/Legacy/SerializationWriter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Text;
 
 // ReSharper disable ConditionIsAlwaysTrueOrFalse (we're allowing nulls to be passed to the writer where the underlying class doesn't).
@@ -220,13 +219,6 @@ namespace osu.Game.IO.Legacy
                 } // switch
             } // if obj==null
         } // WriteObject
-
-        /// <summary> Adds the SerializationWriter buffer to the SerializationInfo at the end of GetObjectData(). </summary>
-        public void AddToInfo(SerializationInfo info)
-        {
-            byte[] b = ((MemoryStream)BaseStream).ToArray();
-            info.AddValue("X", b, typeof(byte[]));
-        }
 
         public void WriteRawBytes(byte[] b)
         {

--- a/osu.Game/IO/Legacy/SerializationWriter.cs
+++ b/osu.Game/IO/Legacy/SerializationWriter.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 
 // ReSharper disable ConditionIsAlwaysTrueOrFalse (we're allowing nulls to be passed to the writer where the underlying class doesn't).
@@ -218,14 +216,7 @@ namespace osu.Game.IO.Legacy
                         break;
 
                     default:
-                        Write((byte)ObjType.otherType);
-                        BinaryFormatter b = new BinaryFormatter
-                        {
-                            // AssemblyFormat = FormatterAssemblyStyle.Simple,
-                            TypeFormat = FormatterTypeStyle.TypesWhenNeeded
-                        };
-                        b.Serialize(BaseStream, obj);
-                        break;
+                        throw new IOException("Serialization of arbitrary type is not supported.");
                 } // switch
             } // if obj==null
         } // WriteObject


### PR DESCRIPTION
Binary *serialization* (the `BinaryFormatter` type, not `BinaryReader`) is known to be risky (https://aka.ms/binaryformatter). It has been deprecated in .NET 7, and announced to be fully removed in .NET 8.

The legacy reader and writer should focus on constructions existed in legacy data files. If not used in legacy file, binary serialization should be removed.

This PR is separated into two commits. The first commit removes `BinaryFormatter`. The second commit removes other legacy `ISerializable` related code.

#### Further discussion

Actually, the whole serialization logic in legacy reader/writer is unused. Current code is just reading member by member. Seems they were brought from legacy codebase. If it won't ever be used, it should be removed too to minimize risk.