### PR TITLE
Fix `MultiplayerMatchFooter` test crash due to missing `PopoverContainer`

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 
@@ -17,9 +18,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.X,
-                Height = 50,
-                Child = new MultiplayerMatchFooter()
+                RelativeSizeAxes = Axes.Both,
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 50,
+                    Child = new MultiplayerMatchFooter()
+                }
             };
         });
     }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -3,7 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -13,7 +13,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUp]
         public new void Setup() => Schedule(() =>
         {
-            Child = new Container
+            Child = new PopoverContainer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,


### PR DESCRIPTION
Clicking the countdown button would crash. I did consider removing the test altogether but maybe it'll be useful in the future?