### PR TITLE
Refactor `TestSceneMatchStartControl` to avoid usage of `TestMultiplayerClient`

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchStartControl.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchStartControl.cs
@@ -281,9 +281,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 return readyButton.Enabled.Value;
             });
 
-            // TODO: AddStep("delete beatmap", () => beatmaps.Delete(importedSet));
+            AddStep("mark beatmap not available", () => beatmapAvailability.Value = BeatmapAvailability.NotDownloaded());
             AddUntilStep("ready button disabled", () => !readyButton.Enabled.Value);
-            // TODO: AddStep("undelete beatmap", () => beatmaps.Undelete(importedSet));
+            AddStep("mark beatmap available", () => beatmapAvailability.Value = BeatmapAvailability.LocallyAvailable());
             AddUntilStep("ready button enabled back", () => readyButton.Enabled.Value);
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchStartControl.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchStartControl.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             multiplayerClient.SetupGet(m => m.Room).Returns(() => multiplayerRoom);
 
             // By default, the local user is to be the host.
-            multiplayerClient.SetupGet(m => m.IsHost).Returns(true);
+            multiplayerClient.SetupGet(m => m.IsHost).Returns(() => ReferenceEquals(multiplayerRoom.Host, localUser));
 
             // Assume all state changes are accepted by the server.
             multiplayerClient.Setup(m => m.ChangeState(It.IsAny<MultiplayerUserState>()))

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -114,12 +114,12 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// The <see cref="MultiplayerRoomUser"/> corresponding to the local player, if available.
         /// </summary>
-        public MultiplayerRoomUser? LocalUser => Room?.Users.SingleOrDefault(u => u.User?.Id == API.LocalUser.Value.Id);
+        public virtual MultiplayerRoomUser? LocalUser => Room?.Users.SingleOrDefault(u => u.User?.Id == API.LocalUser.Value.Id);
 
         /// <summary>
         /// Whether the <see cref="LocalUser"/> is the host in <see cref="Room"/>.
         /// </summary>
-        public bool IsHost
+        public virtual bool IsHost
         {
             get
             {

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// Invoked when the multiplayer server requests the current beatmap to be loaded into play.
         /// </summary>
-        public event Action? LoadRequested;
+        public virtual event Action? LoadRequested;
 
         /// <summary>
         /// Invoked when the multiplayer server requests gameplay to be started.

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Online.Rooms
     /// This differs from a regular download tracking composite as this accounts for the
     /// databased beatmap set's checksum, to disallow from playing with an altered version of the beatmap.
     /// </summary>
-    public sealed class OnlinePlayBeatmapAvailabilityTracker : CompositeDrawable
+    public class OnlinePlayBeatmapAvailabilityTracker : CompositeDrawable
     {
         public readonly IBindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
 
@@ -41,7 +41,7 @@ namespace osu.Game.Online.Rooms
         /// <summary>
         /// The availability state of the currently selected playlist item.
         /// </summary>
-        public IBindable<BeatmapAvailability> Availability => availability;
+        public virtual IBindable<BeatmapAvailability> Availability => availability;
 
         private readonly Bindable<BeatmapAvailability> availability = new Bindable<BeatmapAvailability>(BeatmapAvailability.NotDownloaded());
 


### PR DESCRIPTION
A few notes:

- The goal here is to test the `MatchStartComponent` rather than the behaviour of `MultiplayerClient` itself. I've added the bare minimum implementation intentionally (for instance, changing setting to autostart will not actually start a countdown. this could be added if we also want to be able to visually play with the control better, open to feedback).
- The mocked object is currently `MultiplayerClient`. That class still has some local logic, but none is relied upon by this test scene. This allows switching to an interface or potentially combining the implementation into a single class (if we ever reach a point where `TestMultiplayerClient` is not required).
- I've finished this without revisiting `CurrentPlaylistItem` woes (aka https://github.com/ppy/osu/pull/17702). Some of the room-specific logic can likely be removed when refactoring is done around that, as discussed today in voice.
- An argument could be made that this isn't testing the fact that things don't happen immediately with `MultiplayerClient` (scheduled + server delays). If this is something we want to account for, it's quite easy to add `Schedule` or `Task.Delay`s to the moq implementations. That said, I'm not sure that this is something we should be testing for on a per-component level.

Wanted to attempt this one to see how easily the moq approach will work with a more complicated component.

I'm pretty happy with how this turned out, and think it's a good direction for testing individual components going forward 🤞