### PR TITLE
Adjust hold to confirm animation curve to better show intention

### DIFF
--- a/osu.Game/Graphics/Containers/HoldToConfirmContainer.cs
+++ b/osu.Game/Graphics/Containers/HoldToConfirmContainer.cs
@@ -70,7 +70,10 @@ namespace osu.Game.Graphics.Containers
             confirming = false;
             Fired = false;
 
-            this.TransformBindableTo(Progress, 0, fadeout_delay, Easing.Out);
+            this
+                .TransformBindableTo(Progress, Progress.Value)
+                .Delay(200)
+                .TransformBindableTo(Progress, 0, fadeout_delay, Easing.InSine);
         }
     }
 }


### PR DESCRIPTION
Proposed improvement based on a user reportedly not understanding the hold-to-confirm animation (https://github.com/ppy/osu/issues/17806).

Responds better to button mashing and probably gives a better hint at requiring hold?

https://user-images.githubusercontent.com/191335/163304781-0759bfe6-c4c4-42a2-b4fe-2a14203f64f9.mp4

https://user-images.githubusercontent.com/191335/163317891-9344b4e5-8592-428c-9904-1744e44494a1.mp4

Note that videos were taking with 250ms delay, I adjusted down to 200ms as it feels a touch more responsive.
