### PR TITLE
Fix run-from-menu operations not working correctly when initiated from inside multiplayer

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
@@ -10,7 +10,6 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Screens;
-using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Beatmaps.IO;

--- a/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Screens;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Beatmaps.IO;
@@ -171,6 +172,46 @@ namespace osu.Game.Tests.Visual.Navigation
             }
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestPerformBlockedByDialogSubScreen(bool confirm)
+        {
+            TestScreenWithNestedStack screenWithNestedStack = null;
+
+            PushAndConfirm(() => screenWithNestedStack = new TestScreenWithNestedStack());
+
+            AddAssert("wait for nested screen", () => screenWithNestedStack.SubScreenStack.CurrentScreen == screenWithNestedStack.Blocker);
+
+            AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
+
+            AddUntilStep("wait for dialog", () => screenWithNestedStack.Blocker.ExitAttempts == 1);
+
+            AddWaitStep("wait a bit", 10);
+
+            AddUntilStep("wait for dialog display", () => Game.Dependencies.Get<DialogOverlay>().IsLoaded);
+
+            AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen == screenWithNestedStack);
+            AddAssert("nested screen didn't change", () => screenWithNestedStack.SubScreenStack.CurrentScreen == screenWithNestedStack.Blocker);
+
+            AddAssert("did not perform", () => !actionPerformed);
+
+            AddAssert("only one exit attempt", () => screenWithNestedStack.Blocker.ExitAttempts == 1);
+
+            if (confirm)
+            {
+                AddStep("accept dialog", () => InputManager.Key(Key.Number1));
+                AddAssert("nested screen changed", () => screenWithNestedStack.SubScreenStack.CurrentScreen != screenWithNestedStack.Blocker);
+                AddUntilStep("did perform", () => actionPerformed);
+            }
+            else
+            {
+                AddStep("cancel dialog", () => InputManager.Key(Key.Number2));
+                AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen == screenWithNestedStack);
+                AddAssert("nested screen didn't change", () => screenWithNestedStack.SubScreenStack.CurrentScreen == screenWithNestedStack.Blocker);
+                AddAssert("did not perform", () => !actionPerformed);
+            }
+        }
+
         private void importAndWaitForSongSelect()
         {
             AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
@@ -194,6 +235,31 @@ namespace osu.Game.Tests.Visual.Navigation
                 if (dialogDisplayCount++ < 1)
                 {
                     dialogOverlay.Push(new ConfirmExitDialog(this.Exit, () => { }));
+                    return true;
+                }
+
+                return base.OnExiting(next);
+            }
+        }
+
+        public class TestScreenWithNestedStack : OsuScreen, IHasSubScreenStack
+        {
+            public DialogBlockingScreen Blocker { get; private set; }
+
+            public ScreenStack SubScreenStack { get; } = new ScreenStack();
+
+            public TestScreenWithNestedStack()
+            {
+                AddInternal(SubScreenStack);
+
+                SubScreenStack.Push(Blocker = new DialogBlockingScreen());
+            }
+
+            public override bool OnExiting(IScreen next)
+            {
+                if (SubScreenStack.CurrentScreen != null)
+                {
+                    SubScreenStack.CurrentScreen.Exit();
                     return true;
                 }
 

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -87,12 +87,13 @@ namespace osu.Game.Overlays.Dialog
                     {
                         if (actionInvoked) return;
 
+                        actionInvoked = true;
+
                         // Hide the dialog before running the action.
                         // This is important as the code which is performed may check for a dialog being present (ie. `OsuGame.PerformFromScreen`)
                         // and we don't want it to see the already dismissed dialog.
                         Hide();
 
-                        actionInvoked = true;
                         action?.Invoke();
                     };
                 }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -87,10 +87,13 @@ namespace osu.Game.Overlays.Dialog
                     {
                         if (actionInvoked) return;
 
+                        // Hide the dialog before running the action.
+                        // This is important as the code which is performed may check for a dialog being present (ie. `OsuGame.PerformFromScreen`)
+                        // and we don't want it to see the already dismissed dialog.
+                        Hide();
+
                         actionInvoked = true;
                         action?.Invoke();
-
-                        Hide();
                     };
                 }
             }

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -97,11 +97,14 @@ namespace osu.Game
                 // if this has a sub stack, recursively check the screens within it.
                 if (current is IHasSubScreenStack currentSubScreen)
                 {
-                    if (findValidTarget(currentSubScreen.SubScreenStack.CurrentScreen))
+                    var nestedCurrent = currentSubScreen.SubScreenStack.CurrentScreen;
+
+                    if (nestedCurrent != null)
                     {
                         // should be correct in theory, but currently untested/unused in existing implementations.
-                        current.MakeCurrent();
-                        return true;
+                        // note that calling findValidTarget actually performs the final operation.
+                        if (findValidTarget(nestedCurrent))
+                            return true;
                     }
                 }
 

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -125,6 +125,18 @@ namespace osu.Game
         /// <returns>Whether a dialog blocked interaction.</returns>
         private bool checkForDialog(IScreen current)
         {
+            // An exit process may traverse multiple levels.
+            // When checking for dismissing dialogs, let's also consider sub screens.
+            while (current is IHasSubScreenStack currentWithSubScreenStack)
+            {
+                var nestedCurrent = currentWithSubScreenStack.SubScreenStack.CurrentScreen;
+
+                if (nestedCurrent == null)
+                    break;
+
+                current = nestedCurrent;
+            }
+
             var currentDialog = dialogOverlay.CurrentDialog;
 
             if (lastEncounteredDialog != null)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/17793.

This was due to lack of support for nested screen stacks when confirming that exit dialogs are progressing forwards.

This fixes two issues in the video that were demonstrated: the buttons did not restore to a clickable state after cancellation, and the whole process of returning to the menu failed.

8b901fe60b Fixes a seemingly unrelated null reference that occurs in the new tests due to lack of null check, and also removes a redundant `MakeCurrent` call. I've explained this with an inline comment for clarity.