### PR TITLE
Add keyword "delay" to hold-to-confirm activation time setting

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                 {
                     LabelText = UserInterfaceStrings.HoldToConfirmActivationTime,
                     Current = config.GetBindable<double>(OsuSetting.UIHoldActivationDelay),
+                    Keywords = new[] { @"delay" },
                     KeyboardStep = 50
                 },
             };


### PR DESCRIPTION
Always made me stumble whenever I look for that setting.