### PR TITLE
Add extension points to new mod select screen required to replace old design

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Screens.OnlinePlay;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    public class TestSceneFreeModSelectScreen : MultiplayerTestScene
+    {
+        [Test]
+        public void TestFreeModSelect()
+        {
+            FreeModSelectScreen freeModSelectScreen = null;
+
+            AddStep("create free mod select screen", () => Child = freeModSelectScreen = new FreeModSelectScreen
+            {
+                State = { Value = Visibility.Visible }
+            });
+            AddToggleStep("toggle visibility", visible =>
+            {
+                if (freeModSelectScreen != null)
+                    freeModSelectScreen.State.Value = visible ? Visibility.Visible : Visibility.Hidden;
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Overlays.Mods;
 using osu.Game.Screens.OnlinePlay;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -18,6 +21,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 State = { Value = Visibility.Visible }
             });
+
+            AddAssert("all visible mods are playable",
+                () => this.ChildrenOfType<ModPanel>()
+                          .Where(panel => panel.IsPresent)
+                          .All(panel => panel.Mod.HasImplementation && panel.Mod.UserPlayable));
+
             AddToggleStep("toggle visibility", visible =>
             {
                 if (freeModSelectScreen != null)

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Resolved]
         private RulesetStore rulesetStore { get; set; }
 
-        private ModSelectScreen modSelectScreen;
+        private UserModSelectScreen modSelectScreen;
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private void createScreen()
         {
-            AddStep("create screen", () => Child = modSelectScreen = new ModSelectScreen
+            AddStep("create screen", () => Child = modSelectScreen = new UserModSelectScreen
             {
                 RelativeSizeAxes = Axes.Both,
                 State = { Value = Visibility.Visible },

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Overlays.Mods
 
             if (incompatible.Value)
             {
-                Colour4 backgroundColour = ColourProvider.Background5;
-                Colour4 textBackgroundColour = ColourProvider.Background4;
+                Colour4 backgroundColour = ColourProvider.Background6;
+                Colour4 textBackgroundColour = ColourProvider.Background5;
 
                 Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, textBackgroundColour), TRANSITION_DURATION, Easing.OutQuint);
                 Background.FadeColour(backgroundColour, TRANSITION_DURATION, Easing.OutQuint);

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
@@ -37,7 +37,9 @@ namespace osu.Game.Overlays.Mods
 
         private void updateIncompatibility()
         {
-            incompatible.Value = selectedMods.Value.Count > 0 && !selectedMods.Value.Contains(Mod) && !ModUtils.CheckCompatibleSet(selectedMods.Value.Append(Mod));
+            incompatible.Value = selectedMods.Value.Count > 0
+                                 && selectedMods.Value.All(selected => selected.GetType() != Mod.GetType())
+                                 && !ModUtils.CheckCompatibleSet(selectedMods.Value.Append(Mod));
         }
 
         protected override void UpdateState()

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -54,6 +54,8 @@ namespace osu.Game.Overlays.Mods
 
         public Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
+        protected virtual ModPanel CreateModPanel(Mod mod) => new ModPanel(mod);
+
         private readonly Key[]? toggleKeys;
 
         private readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>();
@@ -258,10 +260,7 @@ namespace osu.Game.Overlays.Mods
 
             cancellationTokenSource?.Cancel();
 
-            var panels = newMods.Select(mod => new ModPanel(mod)
-            {
-                Shear = new Vector2(-ModPanel.SHEAR_X, 0)
-            });
+            var panels = newMods.Select(mod => CreateModPanel(mod).With(panel => panel.Shear = new Vector2(-ModPanel.SHEAR_X, 0)));
 
             Task? loadTask;
 

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Overlays.Mods
                 playStateChangeSamples();
                 UpdateState();
             });
-            Filtered.BindValueChanged(_ => updateFilterState());
+            Filtered.BindValueChanged(_ => updateFilterState(), true);
 
             UpdateState();
             FinishTransforms(true);

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays.Mods
         /// <summary>
         /// Whether configurable <see cref="Mod"/>s can be configured by the local user.
         /// </summary>
-        protected virtual bool AllowConfiguration => true;
+        protected virtual bool AllowCustomisation => true;
 
         /// <summary>
         /// Whether the total score multiplier calculated from the current selected set of mods should be shown.
@@ -87,27 +87,10 @@ namespace osu.Game.Overlays.Mods
             {
                 new Container
                 {
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight,
-                    AutoSizeAxes = Axes.X,
-                    Height = DifficultyMultiplierDisplay.HEIGHT,
-                    Margin = new MarginPadding
-                    {
-                        Horizontal = 100,
-                    },
-                    Child = multiplierDisplay = new DifficultyMultiplierDisplay
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre
-                    }
-                },
-                new Container
-                {
                     Padding = new MarginPadding
                     {
-                        Top = DifficultyMultiplierDisplay.HEIGHT + PADDING,
+                        Top = (ShowTotalMultiplier ? DifficultyMultiplierDisplay.HEIGHT : 0) + PADDING,
                     },
-                    Depth = float.MaxValue,
                     RelativeSizeAxes = Axes.Both,
                     RelativePositionAxes = Axes.Both,
                     Children = new Drawable[]
@@ -140,14 +123,34 @@ namespace osu.Game.Overlays.Mods
                 }
             });
 
-            Footer.Add(new ShearedToggleButton(200)
+            if (ShowTotalMultiplier)
             {
-                Anchor = Anchor.BottomLeft,
-                Origin = Anchor.BottomLeft,
-                Margin = new MarginPadding { Vertical = PADDING, Left = 70 },
-                Text = "Mod Customisation",
-                Active = { BindTarget = customisationVisible }
-            });
+                MainAreaContent.Add(new Container
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    AutoSizeAxes = Axes.X,
+                    Height = DifficultyMultiplierDisplay.HEIGHT,
+                    Margin = new MarginPadding { Horizontal = 100 },
+                    Child = multiplierDisplay = new DifficultyMultiplierDisplay
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre
+                    },
+                });
+            }
+
+            if (AllowCustomisation)
+            {
+                Footer.Add(new ShearedToggleButton(200)
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Margin = new MarginPadding { Vertical = PADDING, Left = 70 },
+                    Text = "Mod Customisation",
+                    Active = { BindTarget = customisationVisible }
+                });
+            }
         }
 
         protected override void LoadComplete()
@@ -194,7 +197,7 @@ namespace osu.Game.Overlays.Mods
 
         private void updateCustomisation(ValueChangedEvent<IReadOnlyList<Mod>> valueChangedEvent)
         {
-            if (!AllowConfiguration)
+            if (!AllowCustomisation)
                 return;
 
             bool anyCustomisableMod = false;

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -180,14 +180,6 @@ namespace osu.Game.Overlays.Mods
                                     Origin = Anchor.BottomCentre,
                                     Colour = colourProvider.Background5
                                 },
-                                new ShearedToggleButton(200)
-                                {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    Margin = new MarginPadding { Vertical = 14, Left = 70 },
-                                    Text = "Mod Customisation",
-                                    Active = { BindTarget = customisationVisible }
-                                }
                             }
                         },
                         new ClickToReturnContainer
@@ -205,6 +197,18 @@ namespace osu.Game.Overlays.Mods
                     Height = 0
                 }
             };
+
+            if (AllowConfiguration)
+            {
+                footer.Add(new ShearedToggleButton(200)
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Margin = new MarginPadding { Vertical = 14, Left = 70 },
+                    Text = "Mod Customisation",
+                    Active = { BindTarget = customisationVisible }
+                });
+            }
 
             if (ShowTotalMultiplier)
             {

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -23,7 +23,7 @@ using osuTK.Input;
 
 namespace osu.Game.Overlays.Mods
 {
-    public class ModSelectScreen : OsuFocusedOverlayContainer
+    public abstract class ModSelectScreen : OsuFocusedOverlayContainer
     {
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);

--- a/osu.Game/Overlays/Mods/UserModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/UserModSelectScreen.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Game.Rulesets.Mods;
+using osuTK.Input;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class UserModSelectScreen : ModSelectScreen
+    {
+        protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new UserModColumn(modType, false, toggleKeys);
+
+        private class UserModColumn : ModColumn
+        {
+            public UserModColumn(ModType modType, bool allowBulkSelection, [CanBeNull] Key[] toggleKeys = null)
+                : base(modType, allowBulkSelection, toggleKeys)
+            {
+            }
+
+            protected override ModPanel CreateModPanel(Mod mod) => new IncompatibilityDisplayingModPanel(mod);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Mods;
+using osuTK.Input;
+
+namespace osu.Game.Screens.OnlinePlay
+{
+    public class FreeModSelectScreen : ModSelectScreen
+    {
+        protected override bool AllowConfiguration => false;
+        protected override bool ShowTotalMultiplier => false;
+
+        public new Func<Mod, bool> IsValidMod
+        {
+            get => base.IsValidMod;
+            set => base.IsValidMod = m => m.HasImplementation && m.UserPlayable && value.Invoke(m);
+        }
+
+        public FreeModSelectScreen()
+        {
+            IsValidMod = _ => true;
+        }
+
+        protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new ModColumn(modType, true, toggleKeys);
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Screens.OnlinePlay
 {
     public class FreeModSelectScreen : ModSelectScreen
     {
-        protected override bool AllowConfiguration => false;
+        protected override bool AllowCustomisation => false;
         protected override bool ShowTotalMultiplier => false;
 
         public new Func<Mod, bool> IsValidMod


### PR DESCRIPTION
#16917, continued.

This pull adds the required extension points and variants that the old design uses to work in multiple places (primarily, the solo mod select screen, the free mod select screen, and the user mod select screen in multi).

https://user-images.githubusercontent.com/20418176/163732806-6bea3fe5-69fd-46df-8c1a-df4527afcb03.mp4

There are also some assorted fixes and adjustments to make things work or look correctly/better:

* ffb5c1e86c71003c6d6f8cda6e173948936e64f1: "Incompatibility" mod panel variant colours in the incompatible state dropped down a shade to avoid clashing with column background.
* 8af865a1c5766d850743f2654b48a50a63aa3316: Was broken all along and would cause the incompatibility logic to work wrong when mods are set externally via the `SelectedMods` bindable (it would potentially check incompatibility on a set of e.g. DT, DT, HD which is nonsensical).
* 881df7663d8ee8fab93759c57651e78c4ddfcab7: Obvious oversight in filtering logic, surfaced by the new free mod variant screen.

The next pull after this is going to be porting across all test coverage from `TestSceneModSelectOverlay` and fixing several issues that doing so unearthed. I am splitting that off because that's going to be a moderately large diff, and there is going to be some... potentially controversial mod reference juggling there. But after that, the old design could be replaced with the new one.

The new features present on design (search box and mod presets) I'm leaving for until the new design is in place.