### PR TITLE
Fix editor legacy beatmap skins not wrapped in `LegacySkinTransformer`s

### DIFF
--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -22,12 +22,17 @@ namespace osu.Game.Screens.Edit
         public event Action BeatmapSkinChanged;
 
         /// <summary>
+        /// The underlying beatmap skin.
+        /// </summary>
+        protected internal ISkin Skin => skin;
+
+        private readonly Skin skin;
+
+        /// <summary>
         /// The combo colours of this skin.
         /// If empty, the default combo colours will be used.
         /// </summary>
-        public readonly BindableList<Colour4> ComboColours;
-
-        private readonly Skin skin;
+        public BindableList<Colour4> ComboColours { get; }
 
         public EditorBeatmapSkin(Skin skin)
         {

--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -24,9 +24,7 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// The underlying beatmap skin.
         /// </summary>
-        protected internal ISkin Skin => skin;
-
-        private readonly Skin skin;
+        protected internal readonly Skin Skin;
 
         /// <summary>
         /// The combo colours of this skin.
@@ -36,11 +34,11 @@ namespace osu.Game.Screens.Edit
 
         public EditorBeatmapSkin(Skin skin)
         {
-            this.skin = skin;
+            Skin = skin;
 
             ComboColours = new BindableList<Colour4>();
-            if (skin.Configuration.ComboColours != null)
-                ComboColours.AddRange(skin.Configuration.ComboColours.Select(c => (Colour4)c));
+            if (Skin.Configuration.ComboColours != null)
+                ComboColours.AddRange(Skin.Configuration.ComboColours.Select(c => (Colour4)c));
             ComboColours.BindCollectionChanged((_, __) => updateColours());
         }
 
@@ -48,16 +46,16 @@ namespace osu.Game.Screens.Edit
 
         private void updateColours()
         {
-            skin.Configuration.CustomComboColours = ComboColours.Select(c => (Color4)c).ToList();
+            Skin.Configuration.CustomComboColours = ComboColours.Select(c => (Color4)c).ToList();
             invokeSkinChanged();
         }
 
         #region Delegated ISkin implementation
 
-        public Drawable GetDrawableComponent(ISkinComponent component) => skin.GetDrawableComponent(component);
-        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => skin.GetTexture(componentName, wrapModeS, wrapModeT);
-        public ISample GetSample(ISampleInfo sampleInfo) => skin.GetSample(sampleInfo);
-        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => skin.GetConfig<TLookup, TValue>(lookup);
+        public Drawable GetDrawableComponent(ISkinComponent component) => Skin.GetDrawableComponent(component);
+        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
+        public ISample GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
+        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => Skin.GetConfig<TLookup, TValue>(lookup);
 
         #endregion
     }

--- a/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
+++ b/osu.Game/Screens/Edit/EditorSkinProvidingContainer.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit
         private readonly EditorBeatmapSkin? beatmapSkin;
 
         public EditorSkinProvidingContainer(EditorBeatmap editorBeatmap)
-            : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin)
+            : base(editorBeatmap.PlayableBeatmap.BeatmapInfo.Ruleset.CreateInstance(), editorBeatmap.PlayableBeatmap, editorBeatmap.BeatmapSkin?.Skin)
         {
             beatmapSkin = editorBeatmap.BeatmapSkin;
         }


### PR DESCRIPTION
- Closes #17745 

See https://github.com/ppy/osu/issues/17745#issuecomment-1100478994 for details and discussion.

As concluded, `EditorSkinProvidingContainer` should pass the underlying beatmap skin instance to the skin source hierarchy for passing the pattern-match and get wrapped in a `LegacySkinTransformer` properly, rather than `EditorBeatmapSkin` which is only an `ISkin` wrapper.