### PR TITLE
Fix graceful exit failing with recent framework changes

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -575,6 +575,19 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("test dispose doesn't crash", () => Game.Dispose());
         }
 
+        [Test]
+        public void TestExitIsBlocked()
+        {
+            DialogOverlay getDialogOverlay() => Game.ChildrenOfType<DialogOverlay>().FirstOrDefault();
+
+            AddUntilStep("wait for dialog overlay loaded", () => getDialogOverlay() != null);
+            AddAssert("confirmation notification not displayed", () => getDialogOverlay().State.Value == Visibility.Hidden);
+
+            AddStep("attempt exit", () => Game.GracefullyExit());
+
+            AddUntilStep("confirmation notification was displayed", () => getDialogOverlay().State.Value == Visibility.Visible);
+        }
+
         private Func<Player> playToResults()
         {
             Player player = null;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1117,12 +1117,12 @@ namespace osu.Game
         protected override bool OnExiting()
         {
             if (ScreenStack.CurrentScreen is Loader)
-                return false;
+                return true;
 
             if (introScreen?.DidLoadMenu == true && !(ScreenStack.CurrentScreen is IntroScreen))
             {
                 Scheduler.Add(introScreen.MakeCurrent);
-                return true;
+                return false;
             }
 
             return base.OnExiting();

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -416,7 +416,7 @@ namespace osu.Game
         /// </summary>
         public void GracefullyExit()
         {
-            if (!OnExiting())
+            if (OnExiting())
                 Exit();
             else
                 Scheduler.AddDelayed(GracefullyExit, 2000);


### PR DESCRIPTION
We also seem to have had this back-to-front until now... Please triple check this, I don't know how it's worked until now. I've gone over my framework side changes and can't see anywhere that flipped this logic (so somehow it's just happened to work correctly until this point due to `base.` calls with the wrong o!f return value?)