### PR TITLE
Update paginated profile subsections to display items inline with web

### DIFF
--- a/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Online.API.Requests
 
         private readonly BeatmapSetType type;
 
-        public GetUserBeatmapsRequest(long userId, BeatmapSetType type, int page, int itemsPerPage, int initialItems)
-            : base(page, itemsPerPage, initialItems)
+        public GetUserBeatmapsRequest(long userId, BeatmapSetType type, Pagination pagination)
+            : base(pagination)
         {
             this.userId = userId;
             this.type = type;

--- a/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Online.API.Requests
 
         private readonly BeatmapSetType type;
 
-        public GetUserBeatmapsRequest(long userId, BeatmapSetType type, int page = 0, int itemsPerPage = 6)
-            : base(page, itemsPerPage)
+        public GetUserBeatmapsRequest(long userId, BeatmapSetType type, int page, int itemsPerPage, int initialItems)
+            : base(page, itemsPerPage, initialItems)
         {
             this.userId = userId;
             this.type = type;

--- a/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Online.API.Requests
 
         private readonly BeatmapSetType type;
 
-        public GetUserBeatmapsRequest(long userId, BeatmapSetType type, Pagination pagination)
+        public GetUserBeatmapsRequest(long userId, BeatmapSetType type, PaginationParameters pagination)
             : base(pagination)
         {
             this.userId = userId;

--- a/osu.Game/Online/API/Requests/GetUserKudosuHistoryRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserKudosuHistoryRequest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserKudosuHistoryRequest(long userId, Pagination pagination)
+        public GetUserKudosuHistoryRequest(long userId, PaginationParameters pagination)
             : base(pagination)
         {
             this.userId = userId;

--- a/osu.Game/Online/API/Requests/GetUserKudosuHistoryRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserKudosuHistoryRequest.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserKudosuHistoryRequest(long userId, int page = 0, int itemsPerPage = 5)
-            : base(page, itemsPerPage)
+        public GetUserKudosuHistoryRequest(long userId, int page, int itemsPerPage, int initialItems)
+            : base(page, itemsPerPage, initialItems)
         {
             this.userId = userId;
         }

--- a/osu.Game/Online/API/Requests/GetUserKudosuHistoryRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserKudosuHistoryRequest.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserKudosuHistoryRequest(long userId, int page, int itemsPerPage, int initialItems)
-            : base(page, itemsPerPage, initialItems)
+        public GetUserKudosuHistoryRequest(long userId, Pagination pagination)
+            : base(pagination)
         {
             this.userId = userId;
         }

--- a/osu.Game/Online/API/Requests/GetUserMostPlayedBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserMostPlayedBeatmapsRequest.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserMostPlayedBeatmapsRequest(long userId, int page = 0, int itemsPerPage = 5)
-            : base(page, itemsPerPage)
+        public GetUserMostPlayedBeatmapsRequest(long userId, int page, int itemsPerPage, int initialItems)
+            : base(page, itemsPerPage, initialItems)
         {
             this.userId = userId;
         }

--- a/osu.Game/Online/API/Requests/GetUserMostPlayedBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserMostPlayedBeatmapsRequest.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserMostPlayedBeatmapsRequest(long userId, int page, int itemsPerPage, int initialItems)
-            : base(page, itemsPerPage, initialItems)
+        public GetUserMostPlayedBeatmapsRequest(long userId, Pagination pagination)
+            : base(pagination)
         {
             this.userId = userId;
         }

--- a/osu.Game/Online/API/Requests/GetUserMostPlayedBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserMostPlayedBeatmapsRequest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserMostPlayedBeatmapsRequest(long userId, Pagination pagination)
+        public GetUserMostPlayedBeatmapsRequest(long userId, PaginationParameters pagination)
             : base(pagination)
         {
             this.userId = userId;

--- a/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserRecentActivitiesRequest(long userId, Pagination pagination)
+        public GetUserRecentActivitiesRequest(long userId, PaginationParameters pagination)
             : base(pagination)
         {
             this.userId = userId;

--- a/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserRecentActivitiesRequest(long userId, int page, int itemsPerPage, int initialItems)
-            : base(page, itemsPerPage, initialItems)
+        public GetUserRecentActivitiesRequest(long userId, Pagination pagination)
+            : base(pagination)
         {
             this.userId = userId;
         }

--- a/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly long userId;
 
-        public GetUserRecentActivitiesRequest(long userId, int page = 0, int itemsPerPage = 5)
-            : base(page, itemsPerPage)
+        public GetUserRecentActivitiesRequest(long userId, int page, int itemsPerPage, int initialItems)
+            : base(page, itemsPerPage, initialItems)
         {
             this.userId = userId;
         }

--- a/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Online.API.Requests
         private readonly ScoreType type;
         private readonly RulesetInfo ruleset;
 
-        public GetUserScoresRequest(long userId, ScoreType type, int page = 0, int itemsPerPage = 5, RulesetInfo ruleset = null)
-            : base(page, itemsPerPage)
+        public GetUserScoresRequest(long userId, ScoreType type, int page, int itemsPerPage, int initialItems, RulesetInfo ruleset = null)
+            : base(page, itemsPerPage, initialItems)
         {
             this.userId = userId;
             this.type = type;

--- a/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Online.API.Requests
         private readonly ScoreType type;
         private readonly RulesetInfo ruleset;
 
-        public GetUserScoresRequest(long userId, ScoreType type, int page, int itemsPerPage, int initialItems, RulesetInfo ruleset = null)
-            : base(page, itemsPerPage, initialItems)
+        public GetUserScoresRequest(long userId, ScoreType type, Pagination pagination, RulesetInfo ruleset = null)
+            : base(pagination)
         {
             this.userId = userId;
             this.type = type;

--- a/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserScoresRequest.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Online.API.Requests
         private readonly ScoreType type;
         private readonly RulesetInfo ruleset;
 
-        public GetUserScoresRequest(long userId, ScoreType type, Pagination pagination, RulesetInfo ruleset = null)
+        public GetUserScoresRequest(long userId, ScoreType type, PaginationParameters pagination, RulesetInfo ruleset = null)
             : base(pagination)
         {
             this.userId = userId;

--- a/osu.Game/Online/API/Requests/PaginatedAPIRequest.cs
+++ b/osu.Game/Online/API/Requests/PaginatedAPIRequest.cs
@@ -8,28 +8,19 @@ namespace osu.Game.Online.API.Requests
 {
     public abstract class PaginatedAPIRequest<T> : APIRequest<T> where T : class
     {
-        private readonly int page;
-        private readonly int initialItems;
-        private readonly int itemsPerPage;
+        private readonly Pagination pagination;
 
-        protected PaginatedAPIRequest(int page, int itemsPerPage, int initialItems)
+        protected PaginatedAPIRequest(Pagination pagination)
         {
-            this.page = page;
-            this.initialItems = initialItems;
-            this.itemsPerPage = itemsPerPage;
+            this.pagination = pagination;
         }
 
         protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
 
-            if (page == 0)
-                req.AddParameter("limit", initialItems.ToString(CultureInfo.InvariantCulture));
-            else
-            {
-                req.AddParameter("offset", (initialItems + (page - 1) * itemsPerPage).ToString(CultureInfo.InvariantCulture));
-                req.AddParameter("limit", itemsPerPage.ToString(CultureInfo.InvariantCulture));
-            }
+            req.AddParameter("offset", pagination.Offset.ToString(CultureInfo.InvariantCulture));
+            req.AddParameter("limit", pagination.Limit.ToString(CultureInfo.InvariantCulture));
 
             return req;
         }

--- a/osu.Game/Online/API/Requests/PaginatedAPIRequest.cs
+++ b/osu.Game/Online/API/Requests/PaginatedAPIRequest.cs
@@ -8,9 +8,9 @@ namespace osu.Game.Online.API.Requests
 {
     public abstract class PaginatedAPIRequest<T> : APIRequest<T> where T : class
     {
-        private readonly Pagination pagination;
+        private readonly PaginationParameters pagination;
 
-        protected PaginatedAPIRequest(Pagination pagination)
+        protected PaginatedAPIRequest(PaginationParameters pagination)
         {
             this.pagination = pagination;
         }

--- a/osu.Game/Online/API/Requests/PaginatedAPIRequest.cs
+++ b/osu.Game/Online/API/Requests/PaginatedAPIRequest.cs
@@ -9,11 +9,13 @@ namespace osu.Game.Online.API.Requests
     public abstract class PaginatedAPIRequest<T> : APIRequest<T> where T : class
     {
         private readonly int page;
+        private readonly int initialItems;
         private readonly int itemsPerPage;
 
-        protected PaginatedAPIRequest(int page, int itemsPerPage)
+        protected PaginatedAPIRequest(int page, int itemsPerPage, int initialItems)
         {
             this.page = page;
+            this.initialItems = initialItems;
             this.itemsPerPage = itemsPerPage;
         }
 
@@ -21,8 +23,13 @@ namespace osu.Game.Online.API.Requests
         {
             var req = base.CreateWebRequest();
 
-            req.AddParameter("offset", (page * itemsPerPage).ToString(CultureInfo.InvariantCulture));
-            req.AddParameter("limit", itemsPerPage.ToString(CultureInfo.InvariantCulture));
+            if (page == 0)
+                req.AddParameter("limit", initialItems.ToString(CultureInfo.InvariantCulture));
+            else
+            {
+                req.AddParameter("offset", (initialItems + (page - 1) * itemsPerPage).ToString(CultureInfo.InvariantCulture));
+                req.AddParameter("limit", itemsPerPage.ToString(CultureInfo.InvariantCulture));
+            }
 
             return req;
         }

--- a/osu.Game/Online/API/Requests/Pagination.cs
+++ b/osu.Game/Online/API/Requests/Pagination.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Online.API.Requests
+{
+    /// <summary>
+    /// Represents a pagination data used for <see cref="PaginatedAPIRequest{T}"/>.
+    /// </summary>
+    public readonly struct Pagination
+    {
+        /// <summary>
+        /// The starting point of the request.
+        /// </summary>
+        public int Offset { get; }
+
+        /// <summary>
+        /// The maximum number of items to return in this request.
+        /// </summary>
+        public int Limit { get; }
+
+        public Pagination(int offset, int limit)
+        {
+            Offset = offset;
+            Limit = limit;
+        }
+
+        public Pagination(int limit)
+            : this(0, limit)
+        {
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Pagination"/> of the next number of items defined by <paramref name="limit"/> after this.
+        /// </summary>
+        /// <param name="limit">The limit of the next pagination.</param>
+        public Pagination TakeNext(int limit) => new Pagination(Offset + Limit, limit);
+    }
+}

--- a/osu.Game/Online/API/Requests/PaginationParameters.cs
+++ b/osu.Game/Online/API/Requests/PaginationParameters.cs
@@ -6,7 +6,7 @@ namespace osu.Game.Online.API.Requests
     /// <summary>
     /// Represents a pagination data used for <see cref="PaginatedAPIRequest{T}"/>.
     /// </summary>
-    public readonly struct Pagination
+    public readonly struct PaginationParameters
     {
         /// <summary>
         /// The starting point of the request.
@@ -18,21 +18,21 @@ namespace osu.Game.Online.API.Requests
         /// </summary>
         public int Limit { get; }
 
-        public Pagination(int offset, int limit)
+        public PaginationParameters(int offset, int limit)
         {
             Offset = offset;
             Limit = limit;
         }
 
-        public Pagination(int limit)
+        public PaginationParameters(int limit)
             : this(0, limit)
         {
         }
 
         /// <summary>
-        /// Returns a <see cref="Pagination"/> of the next number of items defined by <paramref name="limit"/> after this.
+        /// Returns a <see cref="PaginationParameters"/> of the next number of items defined by <paramref name="limit"/> after this.
         /// </summary>
         /// <param name="limit">The limit of the next pagination.</param>
-        public Pagination TakeNext(int limit) => new Pagination(Offset + Limit, limit);
+        public PaginationParameters TakeNext(int limit) => new PaginationParameters(Offset + Limit, limit);
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -58,8 +58,8 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
             }
         }
 
-        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(int itemsPerPage, int initialItems) =>
-            new GetUserBeatmapsRequest(User.Value.Id, type, VisiblePages++, itemsPerPage, initialItems);
+        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(Pagination pagination) =>
+            new GetUserBeatmapsRequest(User.Value.Id, type, pagination);
 
         protected override Drawable CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0
             ? new BeatmapCardNormal(model)

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
             }
         }
 
-        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(Pagination pagination) =>
+        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(PaginationParameters pagination) =>
             new GetUserBeatmapsRequest(User.Value.Id, type, pagination);
 
         protected override Drawable CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -20,11 +20,12 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
         private const float panel_padding = 10f;
         private readonly BeatmapSetType type;
 
+        protected override int InitialItemsCount => type == BeatmapSetType.Graveyard ? 2 : 6;
+
         public PaginatedBeatmapContainer(BeatmapSetType type, Bindable<APIUser> user, LocalisableString headerText)
             : base(user, headerText)
         {
             this.type = type;
-            ItemsPerPage = 6;
         }
 
         [BackgroundDependencyLoader]
@@ -57,8 +58,8 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
             }
         }
 
-        protected override APIRequest<List<APIBeatmapSet>> CreateRequest() =>
-            new GetUserBeatmapsRequest(User.Value.Id, type, VisiblePages++, ItemsPerPage);
+        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(int itemsPerPage, int initialItems) =>
+            new GetUserBeatmapsRequest(User.Value.Id, type, VisiblePages++, itemsPerPage, initialItems);
 
         protected override Drawable CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0
             ? new BeatmapCardNormal(model)

--- a/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
@@ -29,8 +29,8 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override int GetCount(APIUser user) => user.BeatmapPlayCountsCount;
 
-        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(int itemsPerPage, int initialItems) =>
-            new GetUserMostPlayedBeatmapsRequest(User.Value.Id, VisiblePages++, itemsPerPage, initialItems);
+        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(Pagination pagination) =>
+            new GetUserMostPlayedBeatmapsRequest(User.Value.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIUserMostPlayedBeatmap mostPlayed) =>
             new DrawableMostPlayedBeatmap(mostPlayed);

--- a/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
         public PaginatedMostPlayedBeatmapContainer(Bindable<APIUser> user)
             : base(user, UsersStrings.ShowExtraHistoricalMostPlayedTitle)
         {
-            ItemsPerPage = 5;
         }
 
         [BackgroundDependencyLoader]
@@ -30,8 +29,8 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override int GetCount(APIUser user) => user.BeatmapPlayCountsCount;
 
-        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest() =>
-            new GetUserMostPlayedBeatmapsRequest(User.Value.Id, VisiblePages++, ItemsPerPage);
+        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(int itemsPerPage, int initialItems) =>
+            new GetUserMostPlayedBeatmapsRequest(User.Value.Id, VisiblePages++, itemsPerPage, initialItems);
 
         protected override Drawable CreateDrawableItem(APIUserMostPlayedBeatmap mostPlayed) =>
             new DrawableMostPlayedBeatmap(mostPlayed);

--- a/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override int GetCount(APIUser user) => user.BeatmapPlayCountsCount;
 
-        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(Pagination pagination) =>
+        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(PaginationParameters pagination) =>
             new GetUserMostPlayedBeatmapsRequest(User.Value.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIUserMostPlayedBeatmap mostPlayed) =>

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
@@ -17,11 +17,10 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
         public PaginatedKudosuHistoryContainer(Bindable<APIUser> user)
             : base(user, missingText: UsersStrings.ShowExtraKudosuEntryEmpty)
         {
-            ItemsPerPage = 5;
         }
 
-        protected override APIRequest<List<APIKudosuHistory>> CreateRequest()
-            => new GetUserKudosuHistoryRequest(User.Value.Id, VisiblePages++, ItemsPerPage);
+        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(int itemsPerPage, int initialItems)
+            => new GetUserKudosuHistoryRequest(User.Value.Id, VisiblePages++, itemsPerPage, initialItems);
 
         protected override Drawable CreateDrawableItem(APIKudosuHistory item) => new DrawableKudosuHistoryItem(item);
     }

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
         {
         }
 
-        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(int itemsPerPage, int initialItems)
-            => new GetUserKudosuHistoryRequest(User.Value.Id, VisiblePages++, itemsPerPage, initialItems);
+        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(Pagination pagination)
+            => new GetUserKudosuHistoryRequest(User.Value.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIKudosuHistory item) => new DrawableKudosuHistoryItem(item);
     }

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
         {
         }
 
-        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(Pagination pagination)
+        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(PaginationParameters pagination)
             => new GetUserKudosuHistoryRequest(User.Value.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIKudosuHistory item) => new DrawableKudosuHistoryItem(item);

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Profile.Sections
         [Resolved]
         private IAPIProvider api { get; set; }
 
-        protected Pagination? CurrentPage { get; private set; }
+        protected PaginationParameters? CurrentPage { get; private set; }
 
         protected ReverseChildIDFillFlowContainer<Drawable> ItemsContainer { get; private set; }
 
@@ -111,7 +111,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             loadCancellation = new CancellationTokenSource();
 
-            CurrentPage = CurrentPage?.TakeNext(ItemsPerPage) ?? new Pagination(InitialItemsCount);
+            CurrentPage = CurrentPage?.TakeNext(ItemsPerPage) ?? new PaginationParameters(InitialItemsCount);
 
             retrievalRequest = CreateRequest(CurrentPage.Value);
             retrievalRequest.Success += UpdateItems;
@@ -151,7 +151,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
         }
 
-        protected abstract APIRequest<List<TModel>> CreateRequest(Pagination pagination);
+        protected abstract APIRequest<List<TModel>> CreateRequest(PaginationParameters pagination);
 
         protected abstract Drawable CreateDrawableItem(TModel model);
 

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -21,11 +21,20 @@ namespace osu.Game.Overlays.Profile.Sections
 {
     public abstract class PaginatedProfileSubsection<TModel> : ProfileSubsection
     {
+        /// <summary>
+        /// The number of items displayed per page.
+        /// </summary>
+        protected virtual int ItemsPerPage => 50;
+
+        /// <summary>
+        /// The number of items displayed initially.
+        /// </summary>
+        protected virtual int InitialItemsCount => 5;
+
         [Resolved]
         private IAPIProvider api { get; set; }
 
         protected int VisiblePages;
-        protected int ItemsPerPage;
 
         protected ReverseChildIDFillFlowContainer<Drawable> ItemsContainer { get; private set; }
 
@@ -101,7 +110,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             loadCancellation = new CancellationTokenSource();
 
-            retrievalRequest = CreateRequest();
+            retrievalRequest = CreateRequest(ItemsPerPage, InitialItemsCount);
             retrievalRequest.Success += UpdateItems;
 
             api.Queue(retrievalRequest);
@@ -125,7 +134,9 @@ namespace osu.Game.Overlays.Profile.Sections
             LoadComponentsAsync(items.Select(CreateDrawableItem).Where(d => d != null), drawables =>
             {
                 missing.Hide();
-                moreButton.FadeTo(items.Count == ItemsPerPage ? 1 : 0);
+
+                int maxCount = VisiblePages == 1 ? InitialItemsCount : ItemsPerPage;
+                moreButton.FadeTo(items.Count == maxCount ? 1 : 0);
                 moreButton.IsLoading = false;
 
                 ItemsContainer.AddRange(drawables);
@@ -138,7 +149,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
         }
 
-        protected abstract APIRequest<List<TModel>> CreateRequest();
+        protected abstract APIRequest<List<TModel>> CreateRequest(int itemsPerPage, int initialItems);
 
         protected abstract Drawable CreateDrawableItem(TModel model);
 

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Graphics.Containers;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osuTK;
 
@@ -34,7 +35,7 @@ namespace osu.Game.Overlays.Profile.Sections
         [Resolved]
         private IAPIProvider api { get; set; }
 
-        protected int VisiblePages;
+        protected Pagination? CurrentPage { get; private set; }
 
         protected ReverseChildIDFillFlowContainer<Drawable> ItemsContainer { get; private set; }
 
@@ -96,7 +97,7 @@ namespace osu.Game.Overlays.Profile.Sections
             loadCancellation?.Cancel();
             retrievalRequest?.Cancel();
 
-            VisiblePages = 0;
+            CurrentPage = null;
             ItemsContainer.Clear();
 
             if (e.NewValue != null)
@@ -110,7 +111,9 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             loadCancellation = new CancellationTokenSource();
 
-            retrievalRequest = CreateRequest(ItemsPerPage, InitialItemsCount);
+            CurrentPage = CurrentPage?.TakeNext(ItemsPerPage) ?? new Pagination(InitialItemsCount);
+
+            retrievalRequest = CreateRequest(CurrentPage.Value);
             retrievalRequest.Success += UpdateItems;
 
             api.Queue(retrievalRequest);
@@ -120,7 +123,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
             OnItemsReceived(items);
 
-            if (!items.Any() && VisiblePages == 1)
+            if (!items.Any() && CurrentPage?.Offset == 0)
             {
                 moreButton.Hide();
                 moreButton.IsLoading = false;
@@ -135,8 +138,7 @@ namespace osu.Game.Overlays.Profile.Sections
             {
                 missing.Hide();
 
-                int maxCount = VisiblePages == 1 ? InitialItemsCount : ItemsPerPage;
-                moreButton.FadeTo(items.Count == maxCount ? 1 : 0);
+                moreButton.FadeTo(items.Count == CurrentPage?.Limit ? 1 : 0);
                 moreButton.IsLoading = false;
 
                 ItemsContainer.AddRange(drawables);
@@ -149,7 +151,7 @@ namespace osu.Game.Overlays.Profile.Sections
         {
         }
 
-        protected abstract APIRequest<List<TModel>> CreateRequest(int itemsPerPage, int initialItems);
+        protected abstract APIRequest<List<TModel>> CreateRequest(Pagination pagination);
 
         protected abstract Drawable CreateDrawableItem(TModel model);
 

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -23,8 +23,6 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
             : base(user, headerText)
         {
             this.type = type;
-
-            ItemsPerPage = 5;
         }
 
         [BackgroundDependencyLoader]
@@ -62,8 +60,8 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
             base.OnItemsReceived(items);
         }
 
-        protected override APIRequest<List<APIScore>> CreateRequest() =>
-            new GetUserScoresRequest(User.Value.Id, type, VisiblePages++, ItemsPerPage);
+        protected override APIRequest<List<APIScore>> CreateRequest(int itemsPerPage, int initialItems) =>
+            new GetUserScoresRequest(User.Value.Id, type, VisiblePages++, itemsPerPage, initialItems);
 
         private int drawableItemIndex;
 

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
             base.OnItemsReceived(items);
         }
 
-        protected override APIRequest<List<APIScore>> CreateRequest(Pagination pagination) =>
+        protected override APIRequest<List<APIScore>> CreateRequest(PaginationParameters pagination) =>
             new GetUserScoresRequest(User.Value.Id, type, pagination);
 
         private int drawableItemIndex;

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
 
         protected override void OnItemsReceived(List<APIScore> items)
         {
-            if (VisiblePages == 0)
+            if (CurrentPage == null || CurrentPage?.Offset == 0)
                 drawableItemIndex = 0;
 
             base.OnItemsReceived(items);
         }
 
-        protected override APIRequest<List<APIScore>> CreateRequest(int itemsPerPage, int initialItems) =>
-            new GetUserScoresRequest(User.Value.Id, type, VisiblePages++, itemsPerPage, initialItems);
+        protected override APIRequest<List<APIScore>> CreateRequest(Pagination pagination) =>
+            new GetUserScoresRequest(User.Value.Id, type, pagination);
 
         private int drawableItemIndex;
 

--- a/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
         public PaginatedRecentActivityContainer(Bindable<APIUser> user)
             : base(user, missingText: EventsStrings.Empty)
         {
-            ItemsPerPage = 10;
         }
 
         [BackgroundDependencyLoader]
@@ -28,8 +27,8 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
             ItemsContainer.Spacing = new Vector2(0, 8);
         }
 
-        protected override APIRequest<List<APIRecentActivity>> CreateRequest() =>
-            new GetUserRecentActivitiesRequest(User.Value.Id, VisiblePages++, ItemsPerPage);
+        protected override APIRequest<List<APIRecentActivity>> CreateRequest(int itemsPerPage, int initialItems) =>
+            new GetUserRecentActivitiesRequest(User.Value.Id, VisiblePages++, itemsPerPage, initialItems);
 
         protected override Drawable CreateDrawableItem(APIRecentActivity model) => new DrawableRecentActivity(model);
     }

--- a/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
             ItemsContainer.Spacing = new Vector2(0, 8);
         }
 
-        protected override APIRequest<List<APIRecentActivity>> CreateRequest(Pagination pagination) =>
+        protected override APIRequest<List<APIRecentActivity>> CreateRequest(PaginationParameters pagination) =>
             new GetUserRecentActivitiesRequest(User.Value.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIRecentActivity model) => new DrawableRecentActivity(model);

--- a/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
@@ -27,8 +27,8 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
             ItemsContainer.Spacing = new Vector2(0, 8);
         }
 
-        protected override APIRequest<List<APIRecentActivity>> CreateRequest(int itemsPerPage, int initialItems) =>
-            new GetUserRecentActivitiesRequest(User.Value.Id, VisiblePages++, itemsPerPage, initialItems);
+        protected override APIRequest<List<APIRecentActivity>> CreateRequest(Pagination pagination) =>
+            new GetUserRecentActivitiesRequest(User.Value.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIRecentActivity model) => new DrawableRecentActivity(model);
     }


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/17867

On osu!web, only 5-6 items are displayed on initial load, and pressing the "Show More" button will display the next 50 items in the list.

The beatmaps section has a special behavior of initially showing 6 items on favourited/ranked/loved/pending, while showing only 2 items on graveyard.