### PR TITLE
Improve legacy hitcircle texture lookup to match 1:1 with stable

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/LegacyMainCirclePieceTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/LegacyMainCirclePieceTest.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 // available textures
                 new[] { @"hitcircle", @"hitcircleoverlay" },
                 // priority lookup
-                @"",
+                null,
                 // expected circle and overlay
                 @"hitcircle", @"hitcircleoverlay",
             },

--- a/osu.Game.Rulesets.Osu.Tests/LegacyMainCirclePieceTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/LegacyMainCirclePieceTest.cs
@@ -72,7 +72,11 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 var skin = new Mock<ISkinSource>();
 
+                // shouldn't be required as GetTexture(string) calls GetTexture(string, WrapMode, WrapMode) by default,
+                // but moq doesn't handle that well, therefore explicitly requiring to use `CallBase`:
+                // https://github.com/moq/moq4/issues/972
                 skin.Setup(s => s.GetTexture(It.IsAny<string>())).CallBase();
+
                 skin.Setup(s => s.GetTexture(It.IsIn(textureFilenames), It.IsAny<WrapMode>(), It.IsAny<WrapMode>()))
                     .Returns((string componentName, WrapMode _, WrapMode __) => new Texture(1, 1) { AssetName = componentName });
 

--- a/osu.Game.Rulesets.Osu.Tests/LegacyMainCirclePieceTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/LegacyMainCirclePieceTest.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Testing;
+using osu.Game.Audio;
+using osu.Game.Rulesets.Osu.Skinning.Legacy;
+using osu.Game.Skinning;
+using osu.Game.Tests.Visual;
+
+#nullable enable
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [HeadlessTest]
+    public class LegacyMainCirclePieceTest : OsuTestScene
+    {
+        private static readonly object?[][] texture_priority_cases =
+        {
+            // default priority lookup
+            new object?[]
+            {
+                // available textures
+                new[] { @"hitcircle", @"hitcircleoverlay" },
+                // priority lookup
+                @"",
+                // expected circle and overlay
+                @"hitcircle", @"hitcircleoverlay",
+            },
+            // custom priority lookup
+            new object?[]
+            {
+                new[] { @"hitcircle", @"hitcircleoverlay", @"sliderstartcircle", @"sliderstartcircleoverlay" },
+                @"sliderstartcircle",
+                @"sliderstartcircle", @"sliderstartcircleoverlay",
+            },
+            // when no sprites are available for the specified prefix, fall back to "hitcircle"/"hitcircleoverlay".
+            new object?[]
+            {
+                new[] { @"hitcircle", @"hitcircleoverlay" },
+                @"sliderstartcircle",
+                @"hitcircle", @"hitcircleoverlay",
+            },
+            // when a circle is available for the specified prefix but no overlay exists, no overlay is displayed.
+            new object?[]
+            {
+                new[] { @"hitcircle", @"hitcircleoverlay", @"sliderstartcircle" },
+                @"sliderstartcircle",
+                @"sliderstartcircle", null
+            },
+            // when no circle is available for the specified prefix but an overlay exists, the overlay is ignored.
+            new object?[]
+            {
+                new[] { @"hitcircle", @"hitcircleoverlay", @"sliderstartcircleoverlay" },
+                @"sliderstartcircle",
+                @"hitcircle", @"hitcircleoverlay",
+            }
+        };
+
+        [TestCaseSource(nameof(texture_priority_cases))]
+        public void TestTexturePriorities(string[] textureFilenames, string priorityLookup, string? expectedCircle, string? expectedOverlay)
+        {
+            Sprite? circleSprite = null;
+            Sprite? overlaySprite = null;
+
+            AddStep("load circle piece", () =>
+            {
+                Child = new DependencyProvidingContainer
+                {
+                    CachedDependencies = new (Type, object)[]
+                    {
+                        (typeof(ISkinSource), new TestSkin(textureFilenames))
+                    },
+                    Child = new LegacyMainCirclePiece(priorityLookup, false),
+                };
+
+                var sprites = this.ChildrenOfType<Sprite>().Where(s => s.Texture.AssetName != null).DistinctBy(s => s.Texture.AssetName).ToArray();
+                Debug.Assert(sprites.Length <= 2);
+
+                circleSprite = sprites.ElementAtOrDefault(0);
+                overlaySprite = sprites.ElementAtOrDefault(1);
+            });
+
+            AddAssert("check circle sprite", () => circleSprite?.Texture?.AssetName == expectedCircle);
+            AddAssert("check overlay sprite", () => overlaySprite?.Texture?.AssetName == expectedOverlay);
+        }
+
+        private class TestSkin : ISkinSource
+        {
+            private readonly string[] textureFilenames;
+
+            public TestSkin(string[] textureFilenames)
+            {
+                this.textureFilenames = textureFilenames;
+            }
+
+            public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
+            {
+                if (textureFilenames.Contains(componentName))
+                    return new Texture(1, 1) { AssetName = componentName };
+
+                return null;
+            }
+
+            public event Action SourceChanged
+            {
+                add { }
+                remove { }
+            }
+
+            public IEnumerable<ISkin> AllSources { get; } = Enumerable.Empty<ISkin>();
+            public Drawable? GetDrawableComponent(ISkinComponent component) => null;
+            public ISample? GetSample(ISampleInfo sampleInfo) => null;
+
+            public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+                where TLookup : notnull
+                where TValue : notnull
+                => null;
+
+            public ISkin? FindProvider(Func<ISkin, bool> lookupFunction) => lookupFunction(this) ? this : null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -1,7 +1,7 @@
+#nullable enable
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -33,9 +33,25 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         /// If the "circle" texture could not be found with this prefix,
         /// then it is nullified and the default prefix "hitcircle" is used instead.
         /// </remarks>
-        private string priorityLookupPrefix;
+        private string? priorityLookupPrefix;
 
-        public LegacyMainCirclePiece(string priorityLookupPrefix = null, bool hasNumber = true)
+        private Drawable hitCircleSprite = null!;
+
+        protected Container OverlayLayer { get; private set; } = null!;
+
+        private Drawable hitCircleOverlay = null!;
+        private SkinnableSpriteText hitCircleText = null!;
+
+        private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
+        private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
+
+        [Resolved(canBeNull: true)]
+        private DrawableHitObject? drawableObject { get; set; }
+
+        [Resolved]
+        private ISkinSource skin { get; set; } = null!;
+
+        public LegacyMainCirclePiece(string? priorityLookupPrefix = null, bool hasNumber = true)
         {
             this.priorityLookupPrefix = priorityLookupPrefix;
             this.hasNumber = hasNumber;
@@ -43,30 +59,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
         }
 
-        private Drawable hitCircleSprite;
-
-        protected Container OverlayLayer { get; private set; }
-
-        private Drawable hitCircleOverlay;
-        private SkinnableSpriteText hitCircleText;
-
-        private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
-        private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
-
-        [Resolved(canBeNull: true)]
-        [CanBeNull]
-        private DrawableHitObject drawableObject { get; set; }
-
-        [Resolved]
-        private ISkinSource skin { get; set; }
-
         [BackgroundDependencyLoader]
         private void load()
         {
-            var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
+            var drawableOsuObject = (DrawableOsuHitObject?)drawableObject;
 
             // attempt lookup using priority specification
-            Texture baseTexture = getTexture(string.Empty);
+            Texture? baseTexture = getTexture(string.Empty);
 
             // if the base texture was not found using the priority specification, nullify the specification and fall back to "hitcircle".
             if (baseTexture == null)
@@ -122,10 +121,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
             }
 
-            Texture getTexture(string name)
+            Texture? getTexture(string name)
                 => skin.GetTexture($"{priorityLookupPrefix ?? @"hitcircle"}{name}");
 
-            Drawable getAnimation(string name, double frameLength)
+            Drawable? getAnimation(string name, double frameLength)
                 => skin.GetAnimation($"{priorityLookupPrefix ?? @"hitcircle"}{name}", true, true, frameLength: frameLength);
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -1,4 +1,3 @@
-#nullable enable
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
@@ -16,6 +15,8 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
+
+#nullable enable
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -43,7 +44,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
+        [CanBeNull]
         private DrawableHitObject drawableObject { get; set; }
 
         [Resolved]
@@ -107,8 +109,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             if (overlayAboveNumber)
                 OverlayLayer.ChangeChildDepth(hitCircleOverlay, float.MinValue);
 
-            accentColour.BindTo(drawableObject.AccentColour);
-            indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
+            if (drawableOsuObject != null)
+            {
+                accentColour.BindTo(drawableOsuObject.AccentColour);
+                indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
+            }
 
             Texture getTextureWithFallback(string name)
             {
@@ -149,15 +154,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             if (hasNumber)
                 indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
 
-            drawableObject.ApplyCustomUpdateState += updateStateTransforms;
-            updateStateTransforms(drawableObject, drawableObject.State.Value);
+            if (drawableObject != null)
+                drawableObject.ApplyCustomUpdateState += updateStateTransforms;
+
+            updateStateTransforms(drawableObject, drawableObject?.State.Value ?? ArmedState.Idle);
         }
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             const double legacy_fade_duration = 240;
 
-            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+            using (BeginAbsoluteSequence(drawableObject?.HitStateUpdateTime ?? 0))
             {
                 switch (state)
                 {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -31,11 +31,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private readonly bool hasNumber;
 
-        private Drawable hitCircleSprite = null!;
+        protected Drawable CircleSprite = null!;
+        protected Drawable OverlaySprite = null!;
 
         protected Container OverlayLayer { get; private set; } = null!;
 
-        private Drawable hitCircleOverlay = null!;
         private SkinnableSpriteText hitCircleText = null!;
 
         private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             InternalChildren = new[]
             {
-                hitCircleSprite = new KiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName) })
+                CircleSprite = new KiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName) })
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Child = hitCircleOverlay = new KiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d))
+                    Child = OverlaySprite = new KiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d))
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             bool overlayAboveNumber = skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.HitCircleOverlayAboveNumber)?.Value ?? true;
 
             if (overlayAboveNumber)
-                OverlayLayer.ChangeChildDepth(hitCircleOverlay, float.MinValue);
+                OverlayLayer.ChangeChildDepth(OverlaySprite, float.MinValue);
 
             if (drawableOsuObject != null)
             {
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             base.LoadComplete();
 
-            accentColour.BindValueChanged(colour => hitCircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
+            accentColour.BindValueChanged(colour => CircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
             if (hasNumber)
                 indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
 
@@ -136,11 +136,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 switch (state)
                 {
                     case ArmedState.Hit:
-                        hitCircleSprite.FadeOut(legacy_fade_duration, Easing.Out);
-                        hitCircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
+                        CircleSprite.FadeOut(legacy_fade_duration, Easing.Out);
+                        CircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
-                        hitCircleOverlay.FadeOut(legacy_fade_duration, Easing.Out);
-                        hitCircleOverlay.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
+                        OverlaySprite.FadeOut(legacy_fade_duration, Easing.Out);
+                        OverlaySprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
                         if (hasNumber)
                         {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -137,16 +138,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
 
             if (drawableObject != null)
+            {
                 drawableObject.ApplyCustomUpdateState += updateStateTransforms;
-
-            updateStateTransforms(drawableObject, drawableObject?.State.Value ?? ArmedState.Idle);
+                updateStateTransforms(drawableObject, drawableObject.State.Value);
+            }
         }
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             const double legacy_fade_duration = 240;
 
-            using (BeginAbsoluteSequence(drawableObject?.HitStateUpdateTime ?? 0))
+            using (BeginAbsoluteSequence(drawableObject.AsNonNull().HitStateUpdateTime))
             {
                 switch (state)
                 {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -25,11 +25,18 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private readonly bool hasNumber;
 
-        private string priorityLookup;
+        /// <summary>
+        /// A prioritised prefix to perform texture lookups with.
+        /// </summary>
+        /// <remarks>
+        /// If the "circle" texture could not be found with this prefix,
+        /// then it is nullified and the default prefix "hitcircle" is used instead.
+        /// </remarks>
+        private string priorityLookupPrefix;
 
-        public LegacyMainCirclePiece(string priorityLookup = null, bool hasNumber = true)
+        public LegacyMainCirclePiece(string priorityLookupPrefix = null, bool hasNumber = true)
         {
-            this.priorityLookup = priorityLookup;
+            this.priorityLookupPrefix = priorityLookupPrefix;
             this.hasNumber = hasNumber;
 
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
@@ -63,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             // if the base texture was not found using the priority specification, nullify the specification and fall back to "hitcircle".
             if (baseTexture == null)
             {
-                priorityLookup = null;
+                priorityLookupPrefix = null;
                 baseTexture = getTexture(string.Empty);
             }
 
@@ -115,10 +122,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             }
 
             Texture getTexture(string name)
-                => skin.GetTexture($"{priorityLookup ?? @"hitcircle"}{name}");
+                => skin.GetTexture($"{priorityLookupPrefix ?? @"hitcircle"}{name}");
 
             Drawable getAnimation(string name, double frameLength)
-                => skin.GetAnimation($"{priorityLookup ?? @"hitcircle"}{name}", true, true, frameLength: frameLength);
+                => skin.GetAnimation($"{priorityLookupPrefix ?? @"hitcircle"}{name}", true, true, frameLength: frameLength);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
- Closes #17869 

On stable, in the case of a slider head piece (same applies to slider tail): 
 - if `sliderstartcircle` exists but `sliderstartcircleoverlay` doesn't, then nothing is displayed.
 - if `sliderstartcircle` doesn't exist but `sliderstartcircleoverlay` does, then the overlay is ignored and `hitcircle` + `hitcircleoverlay` is used instead.

On master, the first bullet is satisfied by not looking up with `hitcircle` subsequently if `sliderstartcircle` exists, but the second is not (resulting in #17869).

I've simplified things so that there's no "fallback" logic, and the first lookup with `priorityLookup` decides whether subsequent lookups should be done with either `priorityLookup` or `hitcircle`, without falling back between.

| before | after |
|--------|-------|
| ![CleanShot 2022-04-19 at 04 57 26@2x](https://user-images.githubusercontent.com/22781491/163920571-3cef8ca4-ba51-4baa-a791-58506baaa69f.png) | ![CleanShot 2022-04-19 at 04 55 56@2x](https://user-images.githubusercontent.com/22781491/163920534-51556eb9-dfeb-42ca-a3ca-db8d88279774.png) |

Test coverage included to ensure this doesn't potentially regress in the future.