### PR TITLE
Add debug language to help with localisation efforts

### DIFF
--- a/osu.Game/Localisation/DebugLocalisationStore.cs
+++ b/osu.Game/Localisation/DebugLocalisationStore.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Localisation
 
         public IEnumerable<string> GetAvailableResources() => throw new NotImplementedException();
 
-        public CultureInfo EffectiveCulture { get; } = new CultureInfo(@"debug");
+        public CultureInfo EffectiveCulture { get; } = CultureInfo.CurrentCulture;
 
         public void Dispose()
         {

--- a/osu.Game/Localisation/DebugLocalisationStore.cs
+++ b/osu.Game/Localisation/DebugLocalisationStore.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public class DebugLocalisationStore : ILocalisationStore
+    {
+        public string Get(string lookup) => $@"[[{lookup.Substring(lookup.LastIndexOf('.') + 1)}]]";
+
+        public Task<string> GetAsync(string lookup, CancellationToken cancellationToken = default) => Task.FromResult(Get(lookup));
+
+        public Stream GetStream(string name) => throw new NotImplementedException();
+
+        public IEnumerable<string> GetAvailableResources() => throw new NotImplementedException();
+
+        public CultureInfo EffectiveCulture { get; } = new CultureInfo(@"debug");
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -110,6 +110,11 @@ namespace osu.Game.Localisation
         // zh_hk,
 
         [Description(@"繁體中文（台灣）")]
-        zh_hant
+        zh_hant,
+
+#if DEBUG
+        [Description(@"Debug (show raw keys)")]
+        DebugLocalisation
+#endif
     }
 }

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Localisation
 
 #if DEBUG
         [Description(@"Debug (show raw keys)")]
-        DebugLocalisation
+        debug
 #endif
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -628,6 +628,14 @@ namespace osu.Game
 
             foreach (var language in Enum.GetValues(typeof(Language)).OfType<Language>())
             {
+#if DEBUG
+                if (language == Language.DebugLocalisation)
+                {
+                    Localisation.AddLanguage(Language.DebugLocalisation.ToString(), new DebugLocalisationStore());
+                    continue;
+                }
+#endif
+
                 string cultureCode = language.ToCultureCode();
 
                 try

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -629,9 +629,9 @@ namespace osu.Game
             foreach (var language in Enum.GetValues(typeof(Language)).OfType<Language>())
             {
 #if DEBUG
-                if (language == Language.DebugLocalisation)
+                if (language == Language.debug)
                 {
-                    Localisation.AddLanguage(Language.DebugLocalisation.ToString(), new DebugLocalisationStore());
+                    Localisation.AddLanguage(Language.debug.ToString(), new DebugLocalisationStore());
                     continue;
                 }
 #endif


### PR DESCRIPTION
The idea is to allow a developer to immediately see which text on a component or screen has already got localisation support. It can be a bit of a challenge to see this when creating a new component that doesn't yet have any translations populated.

Curious to hear thoughts on this. I could see it working very well as a visual tests checkbox (implemented at o!f side), potentially in addition to having this at the game level, or replacing this PR.

https://user-images.githubusercontent.com/191335/163926835-538ff373-6df5-41fc-a96d-93d0cfeb03f3.mp4


