### PR TITLE
Use existing web localisation for most hardcoded strings

### DIFF
--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmap.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Osu.Objects;
 
 namespace osu.Game.Rulesets.Osu.Beatmaps
@@ -20,13 +21,13 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
             {
                 new BeatmapStatistic
                 {
-                    Name = @"Circle Count",
+                    Name = BeatmapsetsStrings.ShowStatsCountCircles,
                     Content = circles.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles),
                 },
                 new BeatmapStatistic
                 {
-                    Name = @"Slider Count",
+                    Name = BeatmapsetsStrings.ShowStatsCountSliders,
                     Content = sliders.ToString(),
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders),
                 },

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
@@ -55,7 +56,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("no mods selected", () => SelectedMods.Value = Array.Empty<Mod>());
 
-            AddAssert("first bar text is Circle Size", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == "Circle Size");
+            AddAssert("first bar text is correct", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == BeatmapsetsStrings.ShowStatsCs);
             AddAssert("circle size bar is white", () => barIsWhite(advancedStats.FirstValue));
             AddAssert("HP drain bar is white", () => barIsWhite(advancedStats.HpDrain));
             AddAssert("accuracy bar is white", () => barIsWhite(advancedStats.Accuracy));
@@ -78,7 +79,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 StarRating = 8
             });
 
-            AddAssert("first bar text is Key Count", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == "Key Count");
+            AddAssert("first bar text is correct", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == BeatmapsetsStrings.ShowStatsCsMania);
         }
 
         [Test]

--- a/osu.Game/Beatmaps/BeatmapStatistic.cs
+++ b/osu.Game/Beatmaps/BeatmapStatistic.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Beatmaps
 {
@@ -14,6 +15,6 @@ namespace osu.Game.Beatmaps
         public Func<Drawable> CreateIcon;
 
         public string Content;
-        public string Name;
+        public LocalisableString Name;
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapDownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapDownloadButton.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Beatmaps.Drawables
 {
@@ -104,7 +105,7 @@ namespace osu.Game.Beatmaps.Drawables
                         if ((beatmapSet as IBeatmapSetOnlineInfo)?.Availability.DownloadDisabled == true)
                         {
                             button.Enabled.Value = false;
-                            button.TooltipText = "this beatmap is currently not available for download.";
+                            button.TooltipText = BeatmapsetsStrings.AvailabilityDisabled;
                         }
 
                         break;

--- a/osu.Game/Graphics/UserInterface/OsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenuItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -15,7 +16,7 @@ namespace osu.Game.Graphics.UserInterface
         {
         }
 
-        public OsuMenuItem(string text, MenuItemType type, Action action)
+        public OsuMenuItem(LocalisableString text, MenuItemType type, Action action)
             : base(text, action)
         {
             Type = type;

--- a/osu.Game/Graphics/UserInterface/PageSelector/PageSelector.cs
+++ b/osu.Game/Graphics/UserInterface/PageSelector/PageSelector.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics;
 using osu.Framework.Bindables;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Graphics.UserInterface.PageSelector
 {
@@ -29,7 +30,7 @@ namespace osu.Game.Graphics.UserInterface.PageSelector
                 Direction = FillDirection.Horizontal,
                 Children = new Drawable[]
                 {
-                    previousPageButton = new PageSelectorPrevNextButton(false, "prev")
+                    previousPageButton = new PageSelectorPrevNextButton(false, CommonStrings.PaginationPrevious)
                     {
                         Action = () => CurrentPage.Value -= 1,
                     },
@@ -38,7 +39,7 @@ namespace osu.Game.Graphics.UserInterface.PageSelector
                         AutoSizeAxes = Axes.Both,
                         Direction = FillDirection.Horizontal,
                     },
-                    nextPageButton = new PageSelectorPrevNextButton(true, "next")
+                    nextPageButton = new PageSelectorPrevNextButton(true, CommonStrings.PaginationNext)
                     {
                         Action = () => CurrentPage.Value += 1
                     }

--- a/osu.Game/Graphics/UserInterface/PageSelector/PageSelectorPrevNextButton.cs
+++ b/osu.Game/Graphics/UserInterface/PageSelector/PageSelectorPrevNextButton.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 
@@ -13,12 +15,12 @@ namespace osu.Game.Graphics.UserInterface.PageSelector
     public class PageSelectorPrevNextButton : PageSelectorButton
     {
         private readonly bool rightAligned;
-        private readonly string text;
+        private readonly LocalisableString text;
 
         private SpriteIcon icon;
         private OsuSpriteText name;
 
-        public PageSelectorPrevNextButton(bool rightAligned, string text)
+        public PageSelectorPrevNextButton(bool rightAligned, LocalisableString text)
         {
             this.rightAligned = rightAligned;
             this.text = text;

--- a/osu.Game/Graphics/UserInterface/SearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/SearchTextBox.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Input;
 
@@ -27,7 +28,7 @@ namespace osu.Game.Graphics.UserInterface
             });
 
             TextFlow.Padding = new MarginPadding { Right = 35 };
-            PlaceholderText = "type to search";
+            PlaceholderText = HomeStrings.SearchPlaceholder;
         }
 
         public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)

--- a/osu.Game/Graphics/UserInterface/ShowMoreButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShowMoreButton.cs
@@ -11,7 +11,9 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osuTK;
 using System.Collections.Generic;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -80,7 +82,7 @@ namespace osu.Game.Graphics.UserInterface
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
-                            Text = "show more".ToUpper(),
+                            Text = CommonStrings.ButtonsShowMore.ToUpper(),
                         },
                         rightIcon = new ChevronIcon
                         {

--- a/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
@@ -14,6 +14,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
@@ -139,7 +140,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             public MenuItem[] ContextMenuItems => new MenuItem[]
             {
-                new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke())
+                new OsuMenuItem(CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => DeleteRequested?.Invoke())
             };
         }
     }

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -10,16 +10,6 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.Common";
 
         /// <summary>
-        /// "Cancel"
-        /// </summary>
-        public static LocalisableString Cancel => new TranslatableString(getKey(@"cancel"), @"Cancel");
-
-        /// <summary>
-        /// "Clear"
-        /// </summary>
-        public static LocalisableString Clear => new TranslatableString(getKey(@"clear"), @"Clear");
-
-        /// <summary>
         /// "Enabled"
         /// </summary>
         public static LocalisableString Enabled => new TranslatableString(getKey(@"enabled"), @"Enabled");

--- a/osu.Game/Online/API/Requests/Responses/APIPlayStyle.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIPlayStyle.cs
@@ -1,22 +1,23 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Online.API.Requests.Responses
 {
     public enum APIPlayStyle
     {
-        [Description("Keyboard")]
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.DeviceKeyboard))]
         Keyboard,
 
-        [Description("Mouse")]
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.DeviceMouse))]
         Mouse,
 
-        [Description("Tablet")]
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.DeviceTablet))]
         Tablet,
 
-        [Description("Touch Screen")]
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.DeviceTouch))]
         Touch,
     }
 }

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Chat;
+using osu.Game.Resources.Localisation.Web;
 using osuTK.Graphics;
 
 namespace osu.Game.Online.Chat
@@ -63,7 +64,7 @@ namespace osu.Game.Online.Chat
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = text_box_height,
-                    PlaceholderText = "type your message",
+                    PlaceholderText = ChatStrings.InputPlaceholder,
                     CornerRadius = corner_radius,
                     ReleaseFocusOnCommit = false,
                     HoldFocus = true,

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -30,6 +30,7 @@ using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Online.API;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Utils;
 
 namespace osu.Game.Online.Leaderboards
@@ -291,8 +292,8 @@ namespace osu.Game.Online.Leaderboards
 
         protected virtual IEnumerable<LeaderboardScoreStatistic> GetStatistics(ScoreInfo model) => new[]
         {
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Link, "Max Combo", model.MaxCombo.ToString()),
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, "Accuracy", model.DisplayAccuracy)
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Link, BeatmapsetsStrings.ShowScoreboardHeadersCombo, model.MaxCombo.ToString()),
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, model.DisplayAccuracy)
         };
 
         protected override bool OnHover(HoverEvent e)
@@ -403,9 +404,9 @@ namespace osu.Game.Online.Leaderboards
         {
             public IconUsage Icon;
             public LocalisableString Value;
-            public string Name;
+            public LocalisableString Name;
 
-            public LeaderboardScoreStatistic(IconUsage icon, string name, LocalisableString value)
+            public LeaderboardScoreStatistic(IconUsage icon, LocalisableString name, LocalisableString value)
             {
                 Icon = icon;
                 Name = name;
@@ -426,7 +427,7 @@ namespace osu.Game.Online.Leaderboards
                     items.Add(new OsuMenuItem("Export", MenuItemType.Standard, () => new LegacyScoreExporter(storage).Export(Score)));
 
                 if (!isOnlineScope)
-                    items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, () => dialogOverlay?.Push(new LocalScoreDeleteDialog(Score))));
+                    items.Add(new OsuMenuItem(CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => dialogOverlay?.Push(new LocalScoreDeleteDialog(Score))));
 
                 return items.ToArray();
             }

--- a/osu.Game/Online/Rooms/MatchType.cs
+++ b/osu.Game/Online/Rooms/MatchType.cs
@@ -1,7 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Online.Rooms
 {
@@ -11,10 +12,10 @@ namespace osu.Game.Online.Rooms
 
         Playlists,
 
-        [Description("Head to head")]
+        [LocalisableDescription(typeof(MatchesStrings), nameof(MatchesStrings.MatchTeamTypesHeadToHead))]
         HeadToHead,
 
-        [Description("Team VS")]
+        [LocalisableDescription(typeof(MatchesStrings), nameof(MatchesStrings.MatchTeamTypesTeamVs))]
         TeamVersus,
     }
 }

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Settings;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 
@@ -68,7 +69,7 @@ namespace osu.Game.Overlays.AccountCreation
                         },
                         usernameTextBox = new OsuTextBox
                         {
-                            PlaceholderText = "username",
+                            PlaceholderText = UsersStrings.LoginUsername,
                             RelativeSizeAxes = Axes.X,
                             TabbableContentContainer = this
                         },

--- a/osu.Game/Overlays/BeatmapSet/BeatmapAvailability.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapAvailability.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.BeatmapSet
@@ -69,14 +70,14 @@ namespace osu.Game.Overlays.BeatmapSet
         {
             textContainer.Clear();
             textContainer.AddParagraph(downloadDisabled
-                ? "This beatmap is currently not available for download."
-                : "Portions of this beatmap have been removed at the request of the creator or a third-party rights holder.", t => t.Colour = Color4.Orange);
+                ? BeatmapsetsStrings.AvailabilityDisabled
+                : BeatmapsetsStrings.AvailabilityPartsRemoved, t => t.Colour = Color4.Orange);
 
             if (hasExternalLink)
             {
                 textContainer.NewParagraph();
                 textContainer.NewParagraph();
-                textContainer.AddLink("Check here for more information.", BeatmapSet.Availability.ExternalLink, creationParameters: t => t.Font = OsuFont.GetFont(size: 10));
+                textContainer.AddLink(BeatmapsetsStrings.AvailabilityMoreInfo, BeatmapSet.Availability.ExternalLink, creationParameters: t => t.Font = OsuFont.GetFont(size: 10));
             }
         }
     }

--- a/osu.Game/Overlays/BeatmapSet/Scores/NotSupporterPlaceholder.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/NotSupporterPlaceholder.cs
@@ -7,6 +7,7 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -28,7 +29,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     {
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
-                        Text = @"You need to be an osu!supporter to access the friend and country rankings!",
+                        Text = BeatmapsetsStrings.ShowScoreboardSupporterOnly,
                         Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
                     },
                     text = new LinkFlowContainer(t => t.Font = t.Font.With(size: 11))

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Overlays
                                                 {
                                                     RelativeSizeAxes = Axes.Both,
                                                     Height = 1,
-                                                    PlaceholderText = "type your message",
+                                                    PlaceholderText = Resources.Localisation.Web.ChatStrings.InputPlaceholder,
                                                     ReleaseFocusOnCommit = false,
                                                     HoldFocus = true,
                                                 }

--- a/osu.Game/Overlays/Comments/Buttons/LoadRepliesButton.cs
+++ b/osu.Game/Overlays/Comments/Buttons/LoadRepliesButton.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments.Buttons
 {
@@ -25,7 +26,7 @@ namespace osu.Game.Overlays.Comments.Buttons
         {
             public ButtonContent()
             {
-                Text = "load replies";
+                Text = CommentsStrings.LoadReplies;
             }
         }
     }

--- a/osu.Game/Overlays/Comments/Buttons/ShowMoreRepliesButton.cs
+++ b/osu.Game/Overlays/Comments/Buttons/ShowMoreRepliesButton.cs
@@ -9,6 +9,7 @@ using osu.Game.Graphics.Sprites;
 using System.Collections.Generic;
 using osuTK;
 using osu.Framework.Allocation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments.Buttons
 {
@@ -38,7 +39,7 @@ namespace osu.Game.Overlays.Comments.Buttons
             {
                 AlwaysPresent = true,
                 Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
-                Text = "show more"
+                Text = CommonStrings.ButtonsShowMore
             }
         };
 

--- a/osu.Game/Overlays/Comments/CancellableCommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CancellableCommentEditor.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments
 {
@@ -54,7 +55,7 @@ namespace osu.Game.Overlays.Comments
                             Origin = Anchor.Centre,
                             Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                             Margin = new MarginPadding { Horizontal = 20 },
-                            Text = @"Cancel"
+                            Text = CommonStrings.ButtonsCancel
                         }
                     }
                 };

--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -16,6 +16,7 @@ using osu.Framework.Threading;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
 
 namespace osu.Game.Overlays.Comments
@@ -328,7 +329,7 @@ namespace osu.Game.Overlays.Comments
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         Margin = new MarginPadding { Left = 50 },
-                        Text = @"No comments yet."
+                        Text = CommentsStrings.Empty
                     }
                 });
             }

--- a/osu.Game/Overlays/Comments/CommentsHeader.cs
+++ b/osu.Game/Overlays/Comments/CommentsHeader.cs
@@ -12,7 +12,9 @@ using osu.Game.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments
 {
@@ -91,7 +93,7 @@ namespace osu.Game.Overlays.Comments
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                             Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold),
-                            Text = @"Show deleted"
+                            Text = CommonStrings.ButtonsShowDeleted
                         }
                     },
                 });
@@ -126,9 +128,13 @@ namespace osu.Game.Overlays.Comments
 
     public enum CommentsSortCriteria
     {
-        [System.ComponentModel.Description(@"Recent")]
+        [LocalisableDescription(typeof(SortStrings), nameof(SortStrings.New))]
         New,
+
+        [LocalisableDescription(typeof(SortStrings), nameof(SortStrings.Old))]
         Old,
+
+        [LocalisableDescription(typeof(SortStrings), nameof(SortStrings.Top))]
         Top
     }
 }

--- a/osu.Game/Overlays/Comments/CommentsShowMoreButton.cs
+++ b/osu.Game/Overlays/Comments/CommentsShowMoreButton.cs
@@ -2,7 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments
 {
@@ -18,7 +21,8 @@ namespace osu.Game.Overlays.Comments
 
         private void onCurrentChanged(ValueChangedEvent<int> count)
         {
-            Text = $@"Show More ({count.NewValue})".ToUpper();
+            Text = new TranslatableString(@"_", "{0} ({1})",
+                CommonStrings.ButtonsShowMore.ToUpper(), count.NewValue);
         }
     }
 }

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Overlays.Comments
                                                         {
                                                             Alpha = Comment.IsDeleted ? 1 : 0,
                                                             Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
-                                                            Text = "deleted"
+                                                            Text = CommentsStrings.Deleted
                                                         }
                                                     }
                                                 },

--- a/osu.Game/Overlays/Comments/TotalCommentsCounter.cs
+++ b/osu.Game/Overlays/Comments/TotalCommentsCounter.cs
@@ -9,6 +9,7 @@ using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments
 {
@@ -39,7 +40,7 @@ namespace osu.Game.Overlays.Comments
                         Origin = Anchor.CentreLeft,
                         Font = OsuFont.GetFont(size: 20, italics: true),
                         Colour = colourProvider.Light1,
-                        Text = @"Comments"
+                        Text = CommentsStrings.Title
                     },
                     new CircularContainer
                     {

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -14,6 +14,7 @@ using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Spectator;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.Play;
@@ -138,7 +139,7 @@ namespace osu.Game.Overlays.Dashboard
                             new PurpleTriangleButton
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Text = "Watch",
+                                Text = CommonStrings.ButtonsWatchTo1,
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 Action = () => performer?.PerformFromScreen(s => s.Push(new SoloSpectator(User))),

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Overlays.Dashboard
                             new PurpleTriangleButton
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Text = CommonStrings.ButtonsWatchTo1,
+                                Text = "Spectate",
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 Action = () => performer?.PerformFromScreen(s => s.Push(new SoloSpectator(User))),

--- a/osu.Game/Overlays/Dashboard/Home/DrawableBeatmapList.cs
+++ b/osu.Game/Overlays/Dashboard/Home/DrawableBeatmapList.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
@@ -49,7 +50,7 @@ namespace osu.Game.Overlays.Dashboard.Home
             flow.AddRange(beatmapSets.Select(CreateBeatmapPanel));
         }
 
-        protected abstract string Title { get; }
+        protected abstract LocalisableString Title { get; }
 
         protected abstract DashboardBeatmapPanel CreateBeatmapPanel(APIBeatmapSet beatmapSet);
     }

--- a/osu.Game/Overlays/Dashboard/Home/DrawableNewBeatmapList.cs
+++ b/osu.Game/Overlays/Dashboard/Home/DrawableNewBeatmapList.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Dashboard.Home
 {
@@ -15,6 +17,6 @@ namespace osu.Game.Overlays.Dashboard.Home
 
         protected override DashboardBeatmapPanel CreateBeatmapPanel(APIBeatmapSet beatmapSet) => new DashboardNewBeatmapPanel(beatmapSet);
 
-        protected override string Title => "New Ranked Beatmaps";
+        protected override LocalisableString Title => HomeStrings.UserBeatmapsNew;
     }
 }

--- a/osu.Game/Overlays/Dashboard/Home/DrawablePopularBeatmapList.cs
+++ b/osu.Game/Overlays/Dashboard/Home/DrawablePopularBeatmapList.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Dashboard.Home
 {
@@ -15,6 +17,6 @@ namespace osu.Game.Overlays.Dashboard.Home
 
         protected override DashboardBeatmapPanel CreateBeatmapPanel(APIBeatmapSet beatmapSet) => new DashboardPopularBeatmapPanel(beatmapSet);
 
-        protected override string Title => "Popular Beatmaps";
+        protected override LocalisableString Title => HomeStrings.UserBeatmapsPopular;
     }
 }

--- a/osu.Game/Overlays/Dashboard/Home/News/ShowMoreNewsPanel.cs
+++ b/osu.Game/Overlays/Dashboard/Home/News/ShowMoreNewsPanel.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Dashboard.Home.News
@@ -35,7 +36,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Margin = new MarginPadding { Vertical = 20 },
-                    Text = "see more"
+                    Text = CommonStrings.ButtonsSeeMore
                 }
             };
 

--- a/osu.Game/Overlays/Dialog/ConfirmDialog.cs
+++ b/osu.Game/Overlays/Dialog/ConfirmDialog.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Dialog
 {
@@ -33,7 +34,7 @@ namespace osu.Game.Overlays.Dialog
                 },
                 new PopupDialogCancelButton
                 {
-                    Text = Localisation.CommonStrings.Cancel,
+                    Text = CommonStrings.ButtonsCancel,
                     Action = onCancel
                 },
             };

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Settings;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Overlays.Login
@@ -50,14 +51,14 @@ namespace osu.Game.Overlays.Login
             {
                 username = new OsuTextBox
                 {
-                    PlaceholderText = "username",
+                    PlaceholderText = UsersStrings.LoginUsername,
                     RelativeSizeAxes = Axes.X,
                     Text = api?.ProvidedUsername ?? string.Empty,
                     TabbableContentContainer = this
                 },
                 password = new OsuPasswordTextBox
                 {
-                    PlaceholderText = "password",
+                    PlaceholderText = UsersStrings.LoginPassword,
                     RelativeSizeAxes = Axes.X,
                     TabbableContentContainer = this,
                 },
@@ -88,7 +89,7 @@ namespace osu.Game.Overlays.Login
                             AutoSizeAxes = Axes.Y,
                             Child = new SettingsButton
                             {
-                                Text = "Sign in",
+                                Text = UsersStrings.LoginButton,
                                 Action = performLogin
                             },
                         }

--- a/osu.Game/Overlays/Login/UserAction.cs
+++ b/osu.Game/Overlays/Login/UserAction.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Login
 {
     public enum UserAction
     {
+        [LocalisableDescription(typeof(UsersStrings), nameof(UsersStrings.StatusOnline))]
         Online,
 
         [Description(@"Do not disturb")]

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -20,6 +20,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens;
 using osu.Game.Utils;
@@ -317,7 +318,7 @@ namespace osu.Game.Overlays.Mods
                                             CloseButton = new TriangleButton
                                             {
                                                 Width = 180,
-                                                Text = "Close",
+                                                Text = CommonStrings.ButtonsClose,
                                                 Action = Hide,
                                                 Origin = Anchor.CentreLeft,
                                                 Anchor = Anchor.CentreLeft,

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -15,7 +15,8 @@ using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
-using osu.Game.Localisation;
+using osu.Game.Resources.Localisation.Web;
+using NotificationsStrings = osu.Game.Localisation.NotificationsStrings;
 
 namespace osu.Game.Overlays
 {
@@ -61,7 +62,7 @@ namespace osu.Game.Overlays
                             RelativeSizeAxes = Axes.X,
                             Children = new[]
                             {
-                                new NotificationSection(@"Notifications", @"Clear All")
+                                new NotificationSection(AccountsStrings.NotificationsTitle, "Clear All")
                                 {
                                     AcceptTypes = new[] { typeof(SimpleNotification) }
                                 },

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
@@ -34,9 +35,9 @@ namespace osu.Game.Overlays.Notifications
 
         private readonly string clearButtonText;
 
-        private readonly string titleText;
+        private readonly LocalisableString titleText;
 
-        public NotificationSection(string title, string clearButtonText)
+        public NotificationSection(LocalisableString title, string clearButtonText)
         {
             this.clearButtonText = clearButtonText.ToUpperInvariant();
             titleText = title;
@@ -84,7 +85,7 @@ namespace osu.Game.Overlays.Notifications
                             {
                                 new OsuSpriteText
                                 {
-                                    Text = titleText.ToUpperInvariant(),
+                                    Text = titleText.ToUpper(),
                                     Font = OsuFont.GetFont(weight: FontWeight.Bold)
                                 },
                                 countDrawable = new OsuSpriteText

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -11,10 +10,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 
@@ -83,7 +84,7 @@ namespace osu.Game.Overlays.Profile.Header
             if (user == null) return;
 
             if (user.JoinDate.ToUniversalTime().Year < 2008)
-                topLinkContainer.AddText("Here since the beginning");
+                topLinkContainer.AddText(UsersStrings.ShowFirstMembers);
             else
             {
                 topLinkContainer.AddText("Joined ");
@@ -94,7 +95,7 @@ namespace osu.Game.Overlays.Profile.Header
 
             if (user.IsOnline)
             {
-                topLinkContainer.AddText("Currently online");
+                topLinkContainer.AddText(UsersStrings.ShowLastvisitOnline);
                 addSpacer(topLinkContainer);
             }
             else if (user.LastVisit.HasValue)
@@ -108,7 +109,16 @@ namespace osu.Game.Overlays.Profile.Header
             if (user.PlayStyles?.Length > 0)
             {
                 topLinkContainer.AddText("Plays with ");
-                topLinkContainer.AddText(string.Join(", ", user.PlayStyles.Select(style => style.GetDescription())), embolden);
+
+                LocalisableString playStylesString = user.PlayStyles[0].GetLocalisableDescription();
+
+                for (int i = 1; i < user.PlayStyles.Length; i++)
+                {
+                    playStylesString = new TranslatableString(@"_", @"{0}{1}", playStylesString, CommonStrings.ArrayAndWordsConnector);
+                    playStylesString = new TranslatableString(@"_", @"{0}{1}", playStylesString, user.PlayStyles[i].GetLocalisableDescription());
+                }
+
+                topLinkContainer.AddText(playStylesString, embolden);
 
                 addSpacer(topLinkContainer);
             }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -21,7 +21,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
-using osu.Game.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -402,7 +402,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             public CancelButton()
             {
-                Text = CommonStrings.Cancel;
+                Text = CommonStrings.ButtonsCancel;
                 Size = new Vector2(80, 20);
             }
         }
@@ -411,7 +411,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             public ClearButton()
             {
-                Text = CommonStrings.Clear;
+                Text = CommonStrings.ButtonsClear;
                 Size = new Vector2(80, 20);
             }
         }

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Game.Graphics;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
@@ -62,7 +63,7 @@ namespace osu.Game.Overlays.Toolbar
             switch (state.NewValue)
             {
                 default:
-                    Text = @"Guest";
+                    Text = UsersStrings.AnonymousUsername;
                     avatar.User = new APIUser();
                     break;
 

--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -7,7 +7,9 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Wiki.Markdown
 {
@@ -46,14 +48,14 @@ namespace osu.Game.Overlays.Wiki.Markdown
             {
                 Add(new NoticeBox
                 {
-                    Text = "The content on this page is incomplete or outdated. If you are able to help out, please consider updating the article!",
+                    Text = WikiStrings.ShowIncompleteOrOutdated,
                 });
             }
             else if (needsCleanup)
             {
                 Add(new NoticeBox
                 {
-                    Text = "This page does not meet the standards of the osu! wiki and needs to be cleaned up or rewritten. If you are able to help out, please consider updating the article!",
+                    Text = WikiStrings.ShowNeedsCleanupOrRewrite,
                 });
             }
         }
@@ -63,7 +65,7 @@ namespace osu.Game.Overlays.Wiki.Markdown
             [Resolved]
             private IMarkdownTextFlowComponent parentFlowComponent { get; set; }
 
-            public string Text { get; set; }
+            public LocalisableString Text { get; set; }
 
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider, OsuColour colour)

--- a/osu.Game/Overlays/Wiki/WikiSidebar.cs
+++ b/osu.Game/Overlays/Wiki/WikiSidebar.cs
@@ -3,11 +3,13 @@
 
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Wiki
 {
@@ -24,7 +26,7 @@ namespace osu.Game.Overlays.Wiki
             {
                 new OsuSpriteText
                 {
-                    Text = "CONTENTS",
+                    Text = WikiStrings.ShowToc.ToUpper(),
                     Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                     Margin = new MarginPadding { Bottom = 5 },
                 },

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -17,6 +17,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Edit;
 using osuTK;
 using osuTK.Input;
@@ -358,7 +359,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (SelectedBlueprints.Count == 1)
                     items.AddRange(SelectedBlueprints[0].ContextMenuItems);
 
-                items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, DeleteSelected));
+                items.Add(new OsuMenuItem(CommonStrings.ButtonsDelete, MenuItemType.Destructive, DeleteSelected));
 
                 return items.ToArray();
             }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -29,6 +29,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Components;
@@ -252,7 +253,7 @@ namespace osu.Game.Screens.Edit
                                     {
                                         Items = createFileMenuItems()
                                     },
-                                    new MenuItem("Edit")
+                                    new MenuItem(CommonStrings.ButtonsEdit)
                                     {
                                         Items = new[]
                                         {

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Edit.Setup
 {
@@ -27,7 +28,7 @@ namespace osu.Game.Screens.Edit.Setup
             {
                 circleSizeSlider = new LabelledSliderBar<float>
                 {
-                    Label = "Object Size",
+                    Label = BeatmapsetsStrings.ShowStatsCs,
                     FixedLabelWidth = LABEL_WIDTH,
                     Description = "The size of all hit objects",
                     Current = new BindableFloat(Beatmap.Difficulty.CircleSize)
@@ -40,7 +41,7 @@ namespace osu.Game.Screens.Edit.Setup
                 },
                 healthDrainSlider = new LabelledSliderBar<float>
                 {
-                    Label = "Health Drain",
+                    Label = BeatmapsetsStrings.ShowStatsDrain,
                     FixedLabelWidth = LABEL_WIDTH,
                     Description = "The rate of passive health drain throughout playable time",
                     Current = new BindableFloat(Beatmap.Difficulty.DrainRate)
@@ -53,7 +54,7 @@ namespace osu.Game.Screens.Edit.Setup
                 },
                 approachRateSlider = new LabelledSliderBar<float>
                 {
-                    Label = "Approach Rate",
+                    Label = BeatmapsetsStrings.ShowStatsAr,
                     FixedLabelWidth = LABEL_WIDTH,
                     Description = "The speed at which objects are presented to the player",
                     Current = new BindableFloat(Beatmap.Difficulty.ApproachRate)
@@ -66,7 +67,7 @@ namespace osu.Game.Screens.Edit.Setup
                 },
                 overallDifficultySlider = new LabelledSliderBar<float>
                 {
-                    Label = "Overall Difficulty",
+                    Label = BeatmapsetsStrings.ShowStatsAccuracy,
                     FixedLabelWidth = LABEL_WIDTH,
                     Description = "The harshness of hit windows and difficulty of special objects (ie. spinners)",
                     Current = new BindableFloat(Beatmap.Difficulty.OverallDifficulty)

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Edit.Setup
 {
@@ -48,15 +49,15 @@ namespace osu.Game.Screens.Edit.Setup
 
                 creatorTextBox = createTextBox<LabelledTextBox>("Creator", metadata.Author.Username),
                 difficultyTextBox = createTextBox<LabelledTextBox>("Difficulty Name", Beatmap.BeatmapInfo.DifficultyName),
-                sourceTextBox = createTextBox<LabelledTextBox>("Source", metadata.Source),
-                tagsTextBox = createTextBox<LabelledTextBox>("Tags", metadata.Tags)
+                sourceTextBox = createTextBox<LabelledTextBox>(BeatmapsetsStrings.ShowInfoSource, metadata.Source),
+                tagsTextBox = createTextBox<LabelledTextBox>(BeatmapsetsStrings.ShowInfoTags, metadata.Tags)
             };
 
             foreach (var item in Children.OfType<LabelledTextBox>())
                 item.OnCommit += onCommit;
         }
 
-        private TTextBox createTextBox<TTextBox>(string label, string initialValue)
+        private TTextBox createTextBox<TTextBox>(LocalisableString label, string initialValue)
             where TTextBox : LabelledTextBox, new()
             => new TTextBox
             {

--- a/osu.Game/Screens/OnlinePlay/Components/OverlinedHeader.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OverlinedHeader.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
@@ -34,7 +35,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
         private readonly Circle line;
         private readonly OsuSpriteText details;
 
-        public OverlinedHeader(string title)
+        public OverlinedHeader(LocalisableString title)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -26,6 +26,7 @@ using osu.Game.Online;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.BeatmapSet;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
@@ -449,7 +450,7 @@ namespace osu.Game.Screens.OnlinePlay
                 Size = new Vector2(30, 30),
                 Alpha = AllowEditing ? 1 : 0,
                 Action = () => RequestEdit?.Invoke(Item),
-                TooltipText = "Edit"
+                TooltipText = CommonStrings.ButtonsEdit
             },
             removeButton = new PlaylistRemoveButton
             {

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboardScore.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboardScore.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.OnlinePlay.Match.Components
@@ -30,8 +31,8 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
         protected override IEnumerable<LeaderboardScoreStatistic> GetStatistics(ScoreInfo model) => new[]
         {
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, "Accuracy", model.DisplayAccuracy),
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Sync, "Total Attempts", score.TotalAttempts.ToString()),
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, RankingsStrings.StatAccuracy, model.DisplayAccuracy),
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Sync, RankingsStrings.StatPlayCount, score.TotalAttempts.ToString()),
             new LeaderboardScoreStatistic(FontAwesome.Solid.Check, "Completed Beatmaps", score.CompletedBeatmaps.ToString()),
         };
     }

--- a/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/DrawableMatchRoom.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osuTK;
@@ -49,7 +50,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
                 {
                     RelativeSizeAxes = Axes.Y,
                     Size = new Vector2(100, 1),
-                    Text = "Edit",
+                    Text = CommonStrings.ButtonsEdit,
                     Action = () => OnEdit?.Invoke()
                 });
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsListHeader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsListHeader.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.OnlinePlay.Components;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
@@ -13,7 +14,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         private MultiplayerClient client { get; set; }
 
         public ParticipantsListHeader()
-            : base("Participants")
+            : base(RankingsStrings.SpotlightParticipants)
         {
         }
 

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -14,6 +14,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
@@ -158,7 +159,7 @@ namespace osu.Game.Screens.Play
                             {
                                 new Drawable[]
                                 {
-                                    new MetadataLineLabel("Source"),
+                                    new MetadataLineLabel(BeatmapsetsStrings.ShowInfoSource),
                                     new MetadataLineInfo(metadata.Source)
                                 },
                                 new Drawable[]
@@ -213,7 +214,7 @@ namespace osu.Game.Screens.Play
 
         private class MetadataLineLabel : OsuSpriteText
         {
-            public MetadataLineLabel(string text)
+            public MetadataLineLabel(LocalisableString text)
             {
                 Anchor = Anchor.TopRight;
                 Origin = Anchor.TopRight;
@@ -225,10 +226,10 @@ namespace osu.Game.Screens.Play
 
         private class MetadataLineInfo : OsuSpriteText
         {
-            public MetadataLineInfo(string text)
+            public MetadataLineInfo(LocalisableString text)
             {
                 Margin = new MarginPadding { Left = 5 };
-                Text = string.IsNullOrEmpty(text) ? @"-" : text;
+                Text = string.IsNullOrEmpty(text.ToString()) ? @"-" : text;
             }
         }
     }

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -226,10 +226,10 @@ namespace osu.Game.Screens.Play
 
         private class MetadataLineInfo : OsuSpriteText
         {
-            public MetadataLineInfo(LocalisableString text)
+            public MetadataLineInfo(string text)
             {
                 Margin = new MarginPadding { Left = 5 };
-                Text = string.IsNullOrEmpty(text.ToString()) ? @"-" : text;
+                Text = string.IsNullOrEmpty(text) ? @"-" : text;
             }
         }
     }

--- a/osu.Game/Screens/Play/Break/BreakInfo.cs
+++ b/osu.Game/Screens/Play/Break/BreakInfo.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
 using osuTK;
 
@@ -42,7 +43,7 @@ namespace osu.Game.Screens.Play.Break
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            AccuracyDisplay = new PercentageBreakInfoLine("Accuracy"),
+                            AccuracyDisplay = new PercentageBreakInfoLine(BeatmapsetsStrings.ShowStatsAccuracy),
 
                             // See https://github.com/ppy/osu/discussions/15185
                             // RankDisplay = new BreakInfoLine<int>("Rank"),

--- a/osu.Game/Screens/Play/Break/BreakInfoLine.cs
+++ b/osu.Game/Screens/Play/Break/BreakInfoLine.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Play.Break
 
         private readonly string prefix;
 
-        public BreakInfoLine(string name, string prefix = @"")
+        public BreakInfoLine(LocalisableString name, string prefix = @"")
         {
             this.prefix = prefix;
 
@@ -82,7 +82,7 @@ namespace osu.Game.Screens.Play.Break
 
     public class PercentageBreakInfoLine : BreakInfoLine<double>
     {
-        public PercentageBreakInfoLine(string name, string prefix = "")
+        public PercentageBreakInfoLine(LocalisableString name, string prefix = "")
             : base(name, prefix)
         {
         }

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -19,6 +19,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Judgements;
@@ -200,7 +201,7 @@ namespace osu.Game.Screens.Play.HUD
                         {
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
-                            Text = @"pp",
+                            Text = BeatmapsetsStrings.ShowScoreboardHeaderspp,
                             Font = OsuFont.Numeric.With(size: 8),
                             Padding = new MarginPadding { Bottom = 1.5f }, // align baseline better
                         }

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Localisation;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play.PlayerSettings
@@ -20,7 +21,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             Children = new Drawable[]
             {
-                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hitsounds" },
+                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = SkinSettingsStrings.BeatmapHitsounds },
                 new BeatmapOffsetControl
                 {
                     ReferenceScore = { BindTarget = ReferenceScore },

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
@@ -23,7 +24,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             {
                 new OsuSpriteText
                 {
-                    Text = "Background dim:"
+                    Text = GameplaySettingsStrings.BackgroundDim
                 },
                 dimSliderBar = new PlayerSliderBar<double>
                 {
@@ -31,7 +32,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
                 new OsuSpriteText
                 {
-                    Text = "Background blur:"
+                    Text = GameplaySettingsStrings.BackgroundBlur
                 },
                 blurSliderBar = new PlayerSliderBar<double>
                 {
@@ -41,9 +42,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 {
                     Text = "Toggles:"
                 },
-                showStoryboardToggle = new PlayerCheckbox { LabelText = "Storyboard / Video" },
-                beatmapSkinsToggle = new PlayerCheckbox { LabelText = "Beatmap skins" },
-                beatmapColorsToggle = new PlayerCheckbox { LabelText = "Beatmap colours" },
+                showStoryboardToggle = new PlayerCheckbox { LabelText = GraphicsSettingsStrings.StoryboardVideo },
+                beatmapSkinsToggle = new PlayerCheckbox { LabelText = SkinSettingsStrings.BeatmapSkins },
+                beatmapColorsToggle = new PlayerCheckbox { LabelText = SkinSettingsStrings.BeatmapColours },
             };
         }
 

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -9,9 +9,11 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Leaderboards;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
@@ -127,8 +129,8 @@ namespace osu.Game.Screens.Ranking.Contracted
                                             Spacing = new Vector2(0, 5),
                                             Children = new[]
                                             {
-                                                createStatistic("Max Combo", $"x{score.MaxCombo}"),
-                                                createStatistic("Accuracy", $"{score.Accuracy.FormatAccuracy()}"),
+                                                createStatistic(BeatmapsetsStrings.ShowScoreboardHeadersCombo, $"x{score.MaxCombo}"),
+                                                createStatistic(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, $"{score.Accuracy.FormatAccuracy()}"),
                                             }
                                         },
                                         new ModFlowDisplay
@@ -200,7 +202,7 @@ namespace osu.Game.Screens.Ranking.Contracted
         private Drawable createStatistic(HitResultDisplayStatistic result)
             => createStatistic(result.DisplayName, result.MaxCount == null ? $"{result.Count}" : $"{result.Count}/{result.MaxCount}");
 
-        private Drawable createStatistic(string key, string value) => new Container
+        private Drawable createStatistic(LocalisableString key, string value) => new Container
         {
             RelativeSizeAxes = Axes.X,
             AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
@@ -6,6 +6,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osu.Game.Utils;
 using osuTK;
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         /// </summary>
         /// <param name="accuracy">The accuracy to display.</param>
         public AccuracyStatistic(double accuracy)
-            : base("accuracy")
+            : base(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy)
         {
             this.accuracy = accuracy;
         }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osuTK;
 
@@ -27,7 +28,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         /// <param name="combo">The combo to be displayed.</param>
         /// <param name="maxCombo">The maximum value of <paramref name="combo"/>.</param>
         public ComboStatistic(int combo, int? maxCombo)
-            : base("combo", combo, maxCombo)
+            : base(BeatmapsetsStrings.ShowScoreboardHeadersCombo, combo, maxCombo)
         {
             isPerfect = combo == maxCombo;
         }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         /// <param name="header">The name of the statistic.</param>
         /// <param name="count">The value to display.</param>
         /// <param name="maxCount">The maximum value of <paramref name="count"/>. Not displayed if null.</param>
-        public CounterStatistic(string header, int count, int? maxCount = null)
+        public CounterStatistic(LocalisableString header, int count, int? maxCount = null)
             : base(header)
         {
             this.count = count;

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Ranking.Expanded.Statistics
@@ -23,7 +24,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         private RollingCounter<int> counter;
 
         public PerformanceStatistic(ScoreInfo score)
-            : base("PP")
+            : base(BeatmapsetsStrings.ShowScoreboardHeaderspp)
         {
             this.score = score;
         }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/StatisticDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/StatisticDisplay.cs
@@ -3,10 +3,12 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 
@@ -19,14 +21,14 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
     {
         protected SpriteText HeaderText { get; private set; }
 
-        private readonly string header;
+        private readonly LocalisableString header;
         private Drawable content;
 
         /// <summary>
         /// Creates a new <see cref="StatisticDisplay"/>.
         /// </summary>
         /// <param name="header">The name of the statistic.</param>
-        protected StatisticDisplay(string header)
+        protected StatisticDisplay(LocalisableString header)
         {
             this.header = header;
             RelativeSizeAxes = Axes.X;
@@ -60,7 +62,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
                                 Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold),
-                                Text = header.ToUpperInvariant(),
+                                Text = header.ToUpper(),
                             }
                         }
                     },

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -16,6 +16,7 @@ using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.BeatmapSet;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.Select.Details;
 using osuTK;
 using osuTK.Graphics;
@@ -155,7 +156,7 @@ namespace osu.Game.Screens.Select
                                         {
                                             new OsuSpriteText
                                             {
-                                                Text = "Points of Failure",
+                                                Text = BeatmapsetsStrings.ShowInfoPointsOfFailure,
                                                 Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 14),
                                             },
                                             failRetryGraph = new FailRetryGraph

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -24,6 +24,7 @@ using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 
@@ -136,14 +137,7 @@ namespace osu.Game.Screens.Select.Carousel
                                         },
                                         new OsuSpriteText
                                         {
-                                            Text = "mapped by",
-                                            Anchor = Anchor.BottomLeft,
-                                            Origin = Anchor.BottomLeft
-                                        },
-                                        new OsuSpriteText
-                                        {
-                                            Text = $"{beatmapInfo.Metadata.Author.Username}",
-                                            Font = OsuFont.GetFont(italics: true),
+                                            Text = BeatmapsetsStrings.ShowDetailsMappedBy(beatmapInfo.Metadata.Author.Username),
                                             Anchor = Anchor.BottomLeft,
                                             Origin = Anchor.BottomLeft
                                         },
@@ -235,7 +229,7 @@ namespace osu.Game.Screens.Select.Carousel
                     items.Add(new OsuMenuItem("Play", MenuItemType.Highlighted, () => startRequested(beatmapInfo)));
 
                 if (editRequested != null)
-                    items.Add(new OsuMenuItem("Edit", MenuItemType.Standard, () => editRequested(beatmapInfo)));
+                    items.Add(new OsuMenuItem(CommonStrings.ButtonsEdit, MenuItemType.Standard, () => editRequested(beatmapInfo)));
 
                 if (beatmapInfo.OnlineID > 0 && beatmapOverlay != null)
                     items.Add(new OsuMenuItem("Details...", MenuItemType.Standard, () => beatmapOverlay.FetchAndShowBeatmap(beatmapInfo.OnlineID)));
@@ -250,7 +244,7 @@ namespace osu.Game.Screens.Select.Carousel
                 }
 
                 if (hideRequested != null)
-                    items.Add(new OsuMenuItem("Hide", MenuItemType.Destructive, () => hideRequested(beatmapInfo)));
+                    items.Add(new OsuMenuItem(CommonStrings.ButtonsHide, MenuItemType.Destructive, () => hideRequested(beatmapInfo)));
 
                 return items.ToArray();
             }

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -21,6 +21,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 
 namespace osu.Game.Screens.Select.Details
@@ -63,10 +64,10 @@ namespace osu.Game.Screens.Select.Details
                 Children = new[]
                 {
                     FirstValue = new StatisticRow(), // circle size/key amount
-                    HpDrain = new StatisticRow { Title = "HP Drain" },
-                    Accuracy = new StatisticRow { Title = "Accuracy" },
-                    ApproachRate = new StatisticRow { Title = "Approach Rate" },
-                    starDifficulty = new StatisticRow(10, true) { Title = "Star Difficulty" },
+                    HpDrain = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsDrain },
+                    Accuracy = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAccuracy },
+                    ApproachRate = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAr },
+                    starDifficulty = new StatisticRow(10, true) { Title = BeatmapsetsStrings.ShowStatsStars },
                 },
             };
         }
@@ -120,12 +121,12 @@ namespace osu.Game.Screens.Select.Details
                 case 3:
                     // Account for mania differences locally for now
                     // Eventually this should be handled in a more modular way, allowing rulesets to return arbitrary difficulty attributes
-                    FirstValue.Title = "Key Count";
+                    FirstValue.Title = BeatmapsetsStrings.ShowStatsCsMania;
                     FirstValue.Value = (baseDifficulty?.CircleSize ?? 0, null);
                     break;
 
                 default:
-                    FirstValue.Title = "Circle Size";
+                    FirstValue.Title = BeatmapsetsStrings.ShowStatsCs;
                     FirstValue.Value = (baseDifficulty?.CircleSize ?? 0, adjustedDifficulty?.CircleSize);
                     break;
             }

--- a/osu.Game/Screens/Select/Filter/SortMode.cs
+++ b/osu.Game/Screens/Select/Filter/SortMode.cs
@@ -2,36 +2,38 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Select.Filter
 {
     public enum SortMode
     {
-        [Description("Artist")]
+        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchSortingArtist))]
         Artist,
 
         [Description("Author")]
         Author,
 
-        [Description("BPM")]
+        [LocalisableDescription(typeof(BeatmapsetsStrings), nameof(BeatmapsetsStrings.ShowStatsBpm))]
         BPM,
 
         [Description("Date Added")]
         DateAdded,
 
-        [Description("Difficulty")]
+        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchSortingDifficulty))]
         Difficulty,
 
-        [Description("Length")]
+        [LocalisableDescription(typeof(SortStrings), nameof(SortStrings.ArtistTracksLength))]
         Length,
 
-        [Description("Rank Achieved")]
+        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchFiltersRank))]
         RankAchieved,
 
-        [Description("Source")]
+        [LocalisableDescription(typeof(BeatmapsetsStrings), nameof(BeatmapsetsStrings.ShowInfoSource))]
         Source,
 
-        [Description("Title")]
+        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchSortingTitle))]
         Title,
     }
 }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
@@ -139,7 +140,7 @@ namespace osu.Game.Screens.Select
                                             },
                                             new OsuSpriteText
                                             {
-                                                Text = "Sort by",
+                                                Text = SortStrings.Default,
                                                 Font = OsuFont.GetFont(size: 14),
                                                 Margin = new MarginPadding(5),
                                                 Anchor = Anchor.BottomRight,

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -13,6 +13,7 @@ using osuTK.Input;
 using osu.Game.Graphics.Containers;
 using osu.Framework.Input.Events;
 using System.Linq;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Screens.Select.Options
 {
@@ -63,7 +64,7 @@ namespace osu.Game.Screens.Select.Options
         /// <param name="colour">Colour of the button.</param>
         /// <param name="icon">Icon of the button.</param>
         /// <param name="action">Binding the button does.</param>
-        public void AddButton(string firstLine, string secondLine, IconUsage icon, Color4 colour, Action action)
+        public void AddButton(LocalisableString firstLine, string secondLine, IconUsage icon, Color4 colour, Action action)
         {
             var button = new BeatmapOptionsButton
             {

--- a/osu.Game/Users/UserStatus.cs
+++ b/osu.Game/Users/UserStatus.cs
@@ -1,20 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osuTK.Graphics;
 using osu.Game.Graphics;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Users
 {
     public abstract class UserStatus
     {
-        public abstract string Message { get; }
+        public abstract LocalisableString Message { get; }
         public abstract Color4 GetAppropriateColour(OsuColour colours);
     }
 
     public class UserStatusOnline : UserStatus
     {
-        public override string Message => @"Online";
+        public override LocalisableString Message => UsersStrings.StatusOnline;
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.GreenLight;
     }
 
@@ -25,13 +27,13 @@ namespace osu.Game.Users
 
     public class UserStatusOffline : UserStatus
     {
-        public override string Message => @"Offline";
+        public override LocalisableString Message => UsersStrings.StatusOffline;
         public override Color4 GetAppropriateColour(OsuColour colours) => Color4.Black;
     }
 
     public class UserStatusDoNotDisturb : UserStatus
     {
-        public override string Message => @"Do not disturb";
+        public override LocalisableString Message => "Do not disturb";
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.RedDark;
     }
 }


### PR DESCRIPTION
This does not fix:
- pluralisable strings (not supported yet, see https://github.com/ppy/osu-framework/pull/4918)
- multiple drawable strings (i.e. `OsuSpriteText` + `DrawableDate`) (not supported yet)

This is not titled `Add localisation support to...` because that is for adding new strings to crowdin for people to translate. This PR is just using the already existing web strings for lazer.

Picking the web strings are best effort as they are a duplicated mess right now with some that can be a common string but is named specifically for one place.

I had these changes before the debug language was implemented. It has helped me PR these changes, but I may have missed some strings. Mod strings were intentionally omitted here as they are not really translatable and want it to be in a separate PR.