### PR TITLE
Visually improve AnchorOriginVisualiser

### DIFF
--- a/osu.Game/Skinning/Editor/SkinBlueprint.cs
+++ b/osu.Game/Skinning/Editor/SkinBlueprint.cs
@@ -146,8 +146,10 @@ namespace osu.Game.Skinning.Editor
             {
                 anchorLine = new Box
                 {
-                    Colour = Color4.Yellow,
                     Height = 2,
+                    Origin = Anchor.CentreLeft,
+                    Colour = Color4.Yellow,
+                    EdgeSmoothness = Vector2.One
                 },
                 originBox = new Box
                 {


### PR DESCRIPTION
Aliasing was triggering me a bit too much

|before|after|
|---|---|
|![before](https://user-images.githubusercontent.com/22874522/164398005-d0c66932-58a2-47b2-b488-a7806cb8c196.png)|![After](https://user-images.githubusercontent.com/22874522/164398067-78fbbd93-ce3b-48a0-bb1f-346ea9dfcb90.png)|