### PR TITLE
Add Mania mod No Drain

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -98,7 +98,8 @@ namespace osu.Game.Rulesets.Catch
                     {
                         new CatchModEasy(),
                         new CatchModNoFail(),
-                        new MultiMod(new CatchModHalfTime(), new CatchModDaycore())
+                        new MultiMod(new CatchModHalfTime(), new CatchModDaycore()),
+                        new ModNoDrain(),
                     };
 
                 case ModType.DifficultyIncrease:

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -212,6 +212,7 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModEasy(),
                         new ManiaModNoFail(),
                         new MultiMod(new ManiaModHalfTime(), new ManiaModDaycore()),
+                        new ManiaModNoDrain(),
                     };
 
                 case ModType.DifficultyIncrease:

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -212,7 +212,7 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModEasy(),
                         new ManiaModNoFail(),
                         new MultiMod(new ManiaModHalfTime(), new ManiaModDaycore()),
-                        new ManiaModNoDrain(),
+                        new ModNoDrain(),
                     };
 
                 case ModType.DifficultyIncrease:

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoDrain.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoDrain.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override string Description => "No drain for mania!";
 
-        //public override IconUsage? Icon => FontAwesome.Solid.Equals;
-
         public override ModType Type => ModType.DifficultyReduction;
         public virtual void ReadFromDifficulty(BeatmapDifficulty difficulty)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoDrain.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoDrain.cs
@@ -1,0 +1,32 @@
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+
+
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModNoDrain : Mod, IApplicableToDifficulty
+    {
+        public override string Name => "No Drain";
+
+        public override string Acronym => "ND";
+
+        public override double ScoreMultiplier => 0.5;
+
+        public override string Description => "No drain for mania!";
+
+        //public override IconUsage? Icon => FontAwesome.Solid.Equals;
+
+        public override ModType Type => ModType.DifficultyReduction;
+        public virtual void ReadFromDifficulty(BeatmapDifficulty difficulty)
+        {
+        }
+
+        public virtual void ApplyToDifficulty(BeatmapDifficulty difficulty)
+        {
+            difficulty.DrainRate *= 0;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -149,6 +149,7 @@ namespace osu.Game.Rulesets.Osu
                         new OsuModEasy(),
                         new OsuModNoFail(),
                         new MultiMod(new OsuModHalfTime(), new OsuModDaycore()),
+                        new ModNoDrain(),
                     };
 
                 case ModType.DifficultyIncrease:

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -118,6 +118,7 @@ namespace osu.Game.Rulesets.Taiko
                         new TaikoModEasy(),
                         new TaikoModNoFail(),
                         new MultiMod(new TaikoModHalfTime(), new TaikoModDaycore()),
+                        new ModNoDrain(),
                     };
 
                 case ModType.DifficultyIncrease:

--- a/osu.Game/Rulesets/Mods/ModNoDrain.cs
+++ b/osu.Game/Rulesets/Mods/ModNoDrain.cs
@@ -5,17 +5,17 @@ using osu.Game.Graphics;
 
 
 
-namespace osu.Game.Rulesets.Mania.Mods
+namespace osu.Game.Rulesets.Mods
 {
-    public class ManiaModNoDrain : Mod, IApplicableToDifficulty
+    public class ModNoDrain : Mod, IApplicableToDifficulty
     {
         public override string Name => "No Drain";
 
         public override string Acronym => "ND";
 
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier => 1;
 
-        public override string Description => "No drain for mania!";
+        public override string Description => "Disables Drain!";
 
         public override ModType Type => ModType.DifficultyReduction;
         public virtual void ReadFromDifficulty(BeatmapDifficulty difficulty)


### PR DESCRIPTION
A lot of players have complained about the health drain in osu mania, but since it seems the developers wanna keep it I thought it was best to create a mod for it instead. This mod disables drain when used and halfs the score.
Should at the very least be a great temporary solution and makes it possible to play a lot of older maps.