### PR TITLE
Fix mania SR inflation for hold note releases in quick succession

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             var maniaCurrent = (ManiaDifficultyHitObject)current;
             double endTime = maniaCurrent.EndTime;
             int column = maniaCurrent.BaseObject.Column;
-            double closestEndTime = endTime - maniaCurrent.LastObject.StartTime; // Lowest value we can assume with the current information
+            double closestEndTime = Math.Abs(endTime - maniaCurrent.LastObject.StartTime); // Lowest value we can assume with the current information
 
             double holdFactor = 1.0; // Factor to all additional strains in case something else is held
             double holdAddition = 0; // Addition to the current note in case it's a hold and has to be released awkwardly

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             var maniaCurrent = (ManiaDifficultyHitObject)current;
             double endTime = maniaCurrent.EndTime;
             int column = maniaCurrent.BaseObject.Column;
-            double closestEndTime = 100;
+            double closestEndTime = endTime - maniaCurrent.LastObject.StartTime; // Lowest value we can assume with the current information
 
             double holdFactor = 1.0; // Factor to all additional strains in case something else is held
             double holdAddition = 0; // Addition to the current note in case it's a hold and has to be released awkwardly

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
     {
         private const double individual_decay_base = 0.125;
         private const double overall_decay_base = 0.30;
+        private const double release_threshold = 24;
 
         protected override double SkillMultiplier => 1;
         protected override double StrainDecayBase => 1;
@@ -62,9 +63,17 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             holdEndTimes[column] = endTime;
 
             // The hold addition is given if there was an overlap, however it is only valid if there are no other note with a similar ending.
-            // Releasing multiple notes is just as easy as releasing 1. Nerfs the hold addition by half if the closest release is 24ms away.
+            // Releasing multiple notes is just as easy as releasing 1. Nerfs the hold addition by half if the closest release is release_threshold away.
+            // holdAddition
+            //     ^
+            // 1.0 + - - - - - -+-----------
+            //     |           /
+            // 0.5 + - - - - -/   Sigmoid Curve
+            //     |         /|
+            // 0.0 +--------+-+---------------> Release Difference / ms
+            //         release_threshold
             if (isOverlapping)
-                holdAddition = 1 / (1 + Math.Exp(0.5 * (24 - closestEndTime)));
+                holdAddition = 1 / (1 + Math.Exp(0.5 * (release_threshold - closestEndTime)));
 
             // Increase individual strain in own column
             individualStrains[column] += 2.0 * holdFactor;

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -62,8 +62,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             holdEndTimes[column] = endTime;
 
             // The hold addition only is valid if there is _no_ other note with the same ending. Releasing multiple notes at the same time is just as easy as releasing 1
-            if (closestEndTime < 1)
-                holdAddition = 0;
+            holdAddition *= 1 / (1 + Math.Exp(0.5 * (24 - closestEndTime)));
 
             // Increase individual strain in own column
             individualStrains[column] += 2.0 * holdFactor;

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -62,7 +62,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             holdEndTimes[column] = endTime;
 
             // The hold addition only is valid if there is _no_ other note with the same ending. Releasing multiple notes at the same time is just as easy as releasing 1
-            holdAddition *= 1 / (1 + Math.Exp(0.5 * (24 - closestEndTime)));
+            // Nerfs the hold addition by half if the closest release is 24ms away
+            if (holdAddition > 0)
+                holdAddition *= 1 / (1 + Math.Exp(0.5 * (24 - closestEndTime)));
 
             // Increase individual strain in own column
             individualStrains[column] += 2.0 * holdFactor;


### PR DESCRIPTION
This change fixes 2 critical issues with mania release holds:

- Hold releases can change difficulty depending on what column they are in (e.g. mirroring a map changes star rating in some circumstances)
- Hold releases in quick succession can inflate the difficulty as they are treated independently, despite how the player might actually play them

[Visual explanation for the new LN release nerf](https://www.desmos.com/calculator/7eboanfzne) created by @Eve-ning

Both of these changes should just be nerfing maps with holds and nothing else.
