### PR TITLE
Implement new sheared search textbox design

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedSearchTextBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedSearchTextBox.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneShearedSearchTextBox : OsuTestScene
+    {
+        [Test]
+        public void TestAllColourSchemes()
+        {
+            foreach (var scheme in Enum.GetValues(typeof(OverlayColourScheme)).Cast<OverlayColourScheme>())
+                AddStep($"set {scheme} scheme", () => Child = createContent(scheme));
+        }
+
+        private Drawable createContent(OverlayColourScheme colourScheme)
+        {
+            var colourProvider = new OverlayColourProvider(colourScheme);
+
+            return new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(OverlayColourProvider), colourProvider)
+                },
+                Children = new Drawable[]
+                {
+                    new ShearedSearchTextBox
+                    {
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        RelativeSizeAxes = Axes.X,
+                        Width = 0.5f
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -21,9 +22,9 @@ namespace osu.Game.Graphics.UserInterface
     public class ShearedSearchTextBox : CompositeDrawable, IHasCurrentValue<string>
     {
         private const float icon_container_width = 50;
-        private const float corner_radius = 10;
+        private const float corner_radius = 7;
         private const float height = 42;
-        private readonly Vector2 shear = new Vector2(0.2f, 0);
+        private readonly Vector2 shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
 
         public FocusedTextBox TextBox;
 
@@ -78,7 +79,7 @@ namespace osu.Game.Graphics.UserInterface
                                             RelativeSizeAxes = Axes.X,
                                             Padding = new MarginPadding
                                             {
-                                                Horizontal = corner_radius
+                                                Horizontal = corner_radius + shear.X
                                             }
                                         }
                                     }

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -22,17 +22,27 @@ namespace osu.Game.Graphics.UserInterface
         private const float corner_radius = 7;
         private const float height = 42;
         private readonly Vector2 shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
-
-        public FocusedTextBox TextBox;
+        private readonly Box background;
+        private readonly Box searchBoxBackground;
+        private readonly SearchTextBox textBox;
 
         public Bindable<string> Current
         {
-            get => TextBox.Current;
-            set => TextBox.Current = value;
+            get => textBox.Current;
+            set => textBox.Current = value;
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        public bool HoldFocus
+        {
+            get => textBox.HoldFocus;
+            set => textBox.HoldFocus = value;
+        }
+
+        public void TakeFocus() => textBox.TakeFocus();
+
+        public void KillFocus() => textBox.KillFocus();
+
+        public ShearedSearchTextBox()
         {
             Height = height;
             Shear = shear;
@@ -43,9 +53,8 @@ namespace osu.Game.Graphics.UserInterface
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new Box
+                    background = new Box
                     {
-                        Colour = colourProvider.Background3,
                         RelativeSizeAxes = Axes.Both
                     },
                     new GridContainer
@@ -63,12 +72,11 @@ namespace osu.Game.Graphics.UserInterface
                                     Masking = true,
                                     Children = new Drawable[]
                                     {
-                                        new Box
+                                        searchBoxBackground = new Box
                                         {
-                                            Colour = colourProvider.Background4,
                                             RelativeSizeAxes = Axes.Both
                                         },
-                                        TextBox = new SearchTextBox
+                                        textBox = new InnerSearchTextBox
                                         {
                                             Shear = -shear,
                                             Anchor = Anchor.CentreLeft,
@@ -108,11 +116,17 @@ namespace osu.Game.Graphics.UserInterface
             };
         }
 
-        public override bool HandleNonPositionalInput => TextBox.HandleNonPositionalInput;
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            background.Colour = colourProvider.Background3;
+            searchBoxBackground.Colour = colourProvider.Background4;
+        }
+
+        public override bool HandleNonPositionalInput => textBox.HandleNonPositionalInput;
 
         private class InnerSearchTextBox : SearchTextBox
         {
-
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -1,0 +1,192 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class ShearedSearchTextBox : CompositeDrawable, IHasCurrentValue<string>
+    {
+        private const float icon_container_width = 50;
+        private const float corner_radius = 10;
+        private const float height = 42;
+        private readonly Vector2 shear = new Vector2(0.2f, 0);
+
+        public FocusedTextBox TextBox;
+
+        public Bindable<string> Current
+        {
+            get => TextBox.Current;
+            set => TextBox.Current = value;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            Height = height;
+            Shear = shear;
+            Masking = true;
+            CornerRadius = corner_radius;
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = colourProvider.Background3,
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    Name = @"Search box container",
+                                    RelativeSizeAxes = Axes.Both,
+                                    CornerRadius = corner_radius,
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = colourProvider.Background4,
+                                            RelativeSizeAxes = Axes.Both
+                                        },
+                                        TextBox = new SearchTextBox
+                                        {
+                                            Shear = -shear,
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            RelativeSizeAxes = Axes.X,
+                                            Padding = new MarginPadding
+                                            {
+                                                Horizontal = corner_radius
+                                            }
+                                        }
+                                    }
+                                },
+                                new Container
+                                {
+                                    Name = @"Icon container",
+                                    RelativeSizeAxes = Axes.Y,
+                                    Width = icon_container_width,
+                                    Origin = Anchor.CentreRight,
+                                    Anchor = Anchor.CentreRight,
+                                    Children = new Drawable[]
+                                    {
+                                        new SpriteIcon
+                                        {
+                                            Icon = FontAwesome.Solid.Search,
+                                            Origin = Anchor.Centre,
+                                            Anchor = Anchor.Centre,
+                                            Size = new Vector2(16),
+                                            Shear = -shear
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        ColumnDimensions = new[] { new Dimension(), new Dimension(GridSizeMode.AutoSize) }
+                    }
+                }
+            };
+        }
+
+        public override bool HandleNonPositionalInput => TextBox.HandleNonPositionalInput;
+
+        private class SearchTextBox : FocusedTextBox
+        {
+            protected virtual bool AllowCommit => false;
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                BackgroundFocused = colourProvider.Background4;
+                BackgroundUnfocused = colourProvider.Background4;
+                Placeholder.Colour = Color4.White;
+                PlaceholderText = @"Search";
+            }
+
+            protected override SpriteText CreatePlaceholder() => new OsuSpriteText
+            {
+                Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold)
+            };
+
+            protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold) },
+            };
+
+            public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+            {
+                switch (e.Action)
+                {
+                    case PlatformAction.MoveBackwardLine:
+                    case PlatformAction.MoveForwardLine:
+                    // Shift+delete is handled via PlatformAction on macOS. this is not so useful in the context of a SearchTextBox
+                    // as we do not allow arrow key navigation in the first place (ie. the caret should always be at the end of text)
+                    // Avoid handling it here to allow other components to potentially consume the shortcut.
+                    case PlatformAction.DeleteForwardChar:
+                        return false;
+                }
+
+                return base.OnPressed(e);
+            }
+
+            protected override bool OnKeyDown(KeyDownEvent e)
+            {
+                if (!e.ControlPressed && !e.ShiftPressed)
+                {
+                    switch (e.Key)
+                    {
+                        case Key.Left:
+                        case Key.Right:
+                        case Key.Up:
+                        case Key.Down:
+                            return false;
+                    }
+                }
+
+                if (!AllowCommit)
+                {
+                    switch (e.Key)
+                    {
+                        case Key.KeypadEnter:
+                        case Key.Enter:
+                            return false;
+                    }
+                }
+
+                if (e.ShiftPressed)
+                {
+                    switch (e.Key)
+                    {
+                        case Key.Delete:
+                            return false;
+                    }
+                }
+
+                return base.OnKeyDown(e);
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -18,10 +18,8 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class ShearedSearchTextBox : CompositeDrawable, IHasCurrentValue<string>
     {
-        private const float icon_container_width = 50;
         private const float corner_radius = 7;
-        private const float height = 42;
-        private readonly Vector2 shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
+
         private readonly Box background;
         private readonly Box searchBoxBackground;
         private readonly SearchTextBox textBox;
@@ -44,8 +42,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public ShearedSearchTextBox()
         {
-            Height = height;
-            Shear = shear;
+            Height = 42;
+            Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
             Masking = true;
             CornerRadius = corner_radius;
             InternalChild = new Container
@@ -78,13 +76,13 @@ namespace osu.Game.Graphics.UserInterface
                                         },
                                         textBox = new InnerSearchTextBox
                                         {
-                                            Shear = -shear,
+                                            Shear = -new Vector2(ShearedOverlayContainer.SHEAR, 0),
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             RelativeSizeAxes = Axes.X,
                                             Padding = new MarginPadding
                                             {
-                                                Horizontal = corner_radius + shear.X
+                                                Horizontal = corner_radius + new Vector2(ShearedOverlayContainer.SHEAR, 0).X
                                             }
                                         }
                                     }
@@ -93,7 +91,7 @@ namespace osu.Game.Graphics.UserInterface
                                 {
                                     Name = @"Icon container",
                                     RelativeSizeAxes = Axes.Y,
-                                    Width = icon_container_width,
+                                    Width = 50,
                                     Origin = Anchor.CentreRight,
                                     Anchor = Anchor.CentreRight,
                                     Children = new Drawable[]
@@ -104,13 +102,17 @@ namespace osu.Game.Graphics.UserInterface
                                             Origin = Anchor.Centre,
                                             Anchor = Anchor.Centre,
                                             Size = new Vector2(16),
-                                            Shear = -shear
+                                            Shear = -new Vector2(ShearedOverlayContainer.SHEAR, 0)
                                         }
                                     }
                                 }
                             }
                         },
-                        ColumnDimensions = new[] { new Dimension(), new Dimension(GridSizeMode.AutoSize) }
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize)
+                        }
                     }
                 }
             };

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Graphics.UserInterface
         private const float corner_radius = 7;
 
         private readonly Box background;
-        private readonly Box searchBoxBackground;
         private readonly SearchTextBox textBox;
 
         public Bindable<string> Current
@@ -60,30 +59,12 @@ namespace osu.Game.Graphics.UserInterface
                     {
                         new Drawable[]
                         {
-                            new Container
+                            textBox = new InnerSearchTextBox
                             {
-                                Name = @"Search box container",
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
                                 RelativeSizeAxes = Axes.Both,
-                                CornerRadius = corner_radius,
-                                Masking = true,
-                                Children = new Drawable[]
-                                {
-                                    searchBoxBackground = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both
-                                    },
-                                    textBox = new InnerSearchTextBox
-                                    {
-                                        Shear = -Shear,
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        RelativeSizeAxes = Axes.X,
-                                        Padding = new MarginPadding
-                                        {
-                                            Horizontal = corner_radius + Shear.X
-                                        }
-                                    }
-                                }
+                                Size = Vector2.One
                             },
                             new Container
                             {
@@ -119,7 +100,6 @@ namespace osu.Game.Graphics.UserInterface
         private void load(OverlayColourProvider colourProvider)
         {
             background.Colour = colourProvider.Background3;
-            searchBoxBackground.Colour = colourProvider.Background4;
         }
 
         public override bool HandleNonPositionalInput => textBox.HandleNonPositionalInput;
@@ -134,6 +114,9 @@ namespace osu.Game.Graphics.UserInterface
 
                 Placeholder.Font = OsuFont.GetFont(size: CalculatedTextSize, weight: FontWeight.SemiBold);
                 PlaceholderText = CommonStrings.InputSearch;
+
+                CornerRadius = corner_radius;
+                TextContainer.Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0);
             }
 
             protected override SpriteText CreatePlaceholder() => new SearchPlaceholder();

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -8,14 +8,11 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input;
-using osu.Framework.Input.Events;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -113,9 +110,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public override bool HandleNonPositionalInput => TextBox.HandleNonPositionalInput;
 
-        private class SearchTextBox : FocusedTextBox
+        private class InnerSearchTextBox : SearchTextBox
         {
-            protected virtual bool AllowCommit => false;
 
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
@@ -136,58 +132,6 @@ namespace osu.Game.Graphics.UserInterface
                 AutoSizeAxes = Axes.Both,
                 Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold) },
             };
-
-            public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
-            {
-                switch (e.Action)
-                {
-                    case PlatformAction.MoveBackwardLine:
-                    case PlatformAction.MoveForwardLine:
-                    // Shift+delete is handled via PlatformAction on macOS. this is not so useful in the context of a SearchTextBox
-                    // as we do not allow arrow key navigation in the first place (ie. the caret should always be at the end of text)
-                    // Avoid handling it here to allow other components to potentially consume the shortcut.
-                    case PlatformAction.DeleteForwardChar:
-                        return false;
-                }
-
-                return base.OnPressed(e);
-            }
-
-            protected override bool OnKeyDown(KeyDownEvent e)
-            {
-                if (!e.ControlPressed && !e.ShiftPressed)
-                {
-                    switch (e.Key)
-                    {
-                        case Key.Left:
-                        case Key.Right:
-                        case Key.Up:
-                        case Key.Down:
-                            return false;
-                    }
-                }
-
-                if (!AllowCommit)
-                {
-                    switch (e.Key)
-                    {
-                        case Key.KeypadEnter:
-                        case Key.Enter:
-                            return false;
-                    }
-                }
-
-                if (e.ShiftPressed)
-                {
-                    switch (e.Key)
-                    {
-                        case Key.Delete:
-                            return false;
-                    }
-                }
-
-                return base.OnKeyDown(e);
-            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -11,8 +11,8 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -132,14 +132,29 @@ namespace osu.Game.Graphics.UserInterface
             {
                 BackgroundFocused = colourProvider.Background4;
                 BackgroundUnfocused = colourProvider.Background4;
-                Placeholder.Colour = Color4.White;
-                PlaceholderText = @"Search";
+
+                Placeholder.Font = OsuFont.GetFont(size: CalculatedTextSize, weight: FontWeight.SemiBold);
+                PlaceholderText = CommonStrings.InputSearch;
             }
 
-            protected override SpriteText CreatePlaceholder() => new OsuSpriteText
+            protected override SpriteText CreatePlaceholder() => new SearchPlaceholder();
+
+            internal class SearchPlaceholder : SpriteText
             {
-                Font = OsuFont.GetFont(size: 20, weight: FontWeight.SemiBold)
-            };
+                public override void Show()
+                {
+                    this
+                        .MoveToY(0, 250, Easing.OutQuint)
+                        .FadeIn(250, Easing.OutQuint);
+                }
+
+                public override void Hide()
+                {
+                    this
+                        .MoveToY(3, 250, Easing.OutQuint)
+                        .FadeOut(250, Easing.OutQuint);
+                }
+            }
 
             protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
             {

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -66,31 +66,20 @@ namespace osu.Game.Graphics.UserInterface
                                 RelativeSizeAxes = Axes.Both,
                                 Size = Vector2.One
                             },
-                            new Container
+                            new SpriteIcon
                             {
-                                Name = @"Icon container",
-                                RelativeSizeAxes = Axes.Y,
-                                Width = 50,
-                                Origin = Anchor.CentreRight,
-                                Anchor = Anchor.CentreRight,
-                                Children = new Drawable[]
-                                {
-                                    new SpriteIcon
-                                    {
-                                        Icon = FontAwesome.Solid.Search,
-                                        Origin = Anchor.Centre,
-                                        Anchor = Anchor.Centre,
-                                        Size = new Vector2(16),
-                                        Shear = -Shear
-                                    }
-                                }
+                                Icon = FontAwesome.Solid.Search,
+                                Origin = Anchor.Centre,
+                                Anchor = Anchor.Centre,
+                                Size = new Vector2(16),
+                                Shear = -Shear
                             }
                         }
                     },
                     ColumnDimensions = new[]
                     {
                         new Dimension(),
-                        new Dimension(GridSizeMode.AutoSize)
+                        new Dimension(GridSizeMode.Absolute, 50),
                     }
                 }
             };

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -46,73 +46,70 @@ namespace osu.Game.Graphics.UserInterface
             Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
             Masking = true;
             CornerRadius = corner_radius;
-            InternalChild = new Container
+
+            InternalChildren = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                background = new Box
                 {
-                    background = new Box
+                    RelativeSizeAxes = Axes.Both
+                },
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Content = new[]
                     {
-                        RelativeSizeAxes = Axes.Both
-                    },
-                    new GridContainer
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Content = new[]
+                        new Drawable[]
                         {
-                            new Drawable[]
+                            new Container
                             {
-                                new Container
+                                Name = @"Search box container",
+                                RelativeSizeAxes = Axes.Both,
+                                CornerRadius = corner_radius,
+                                Masking = true,
+                                Children = new Drawable[]
                                 {
-                                    Name = @"Search box container",
-                                    RelativeSizeAxes = Axes.Both,
-                                    CornerRadius = corner_radius,
-                                    Masking = true,
-                                    Children = new Drawable[]
+                                    searchBoxBackground = new Box
                                     {
-                                        searchBoxBackground = new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both
-                                        },
-                                        textBox = new InnerSearchTextBox
-                                        {
-                                            Shear = -new Vector2(ShearedOverlayContainer.SHEAR, 0),
-                                            Anchor = Anchor.CentreLeft,
-                                            Origin = Anchor.CentreLeft,
-                                            RelativeSizeAxes = Axes.X,
-                                            Padding = new MarginPadding
-                                            {
-                                                Horizontal = corner_radius + new Vector2(ShearedOverlayContainer.SHEAR, 0).X
-                                            }
-                                        }
-                                    }
-                                },
-                                new Container
-                                {
-                                    Name = @"Icon container",
-                                    RelativeSizeAxes = Axes.Y,
-                                    Width = 50,
-                                    Origin = Anchor.CentreRight,
-                                    Anchor = Anchor.CentreRight,
-                                    Children = new Drawable[]
+                                        RelativeSizeAxes = Axes.Both
+                                    },
+                                    textBox = new InnerSearchTextBox
                                     {
-                                        new SpriteIcon
+                                        Shear = -Shear,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        RelativeSizeAxes = Axes.X,
+                                        Padding = new MarginPadding
                                         {
-                                            Icon = FontAwesome.Solid.Search,
-                                            Origin = Anchor.Centre,
-                                            Anchor = Anchor.Centre,
-                                            Size = new Vector2(16),
-                                            Shear = -new Vector2(ShearedOverlayContainer.SHEAR, 0)
+                                            Horizontal = corner_radius + Shear.X
                                         }
                                     }
                                 }
+                            },
+                            new Container
+                            {
+                                Name = @"Icon container",
+                                RelativeSizeAxes = Axes.Y,
+                                Width = 50,
+                                Origin = Anchor.CentreRight,
+                                Anchor = Anchor.CentreRight,
+                                Children = new Drawable[]
+                                {
+                                    new SpriteIcon
+                                    {
+                                        Icon = FontAwesome.Solid.Search,
+                                        Origin = Anchor.Centre,
+                                        Anchor = Anchor.Centre,
+                                        Size = new Vector2(16),
+                                        Shear = -Shear
+                                    }
+                                }
                             }
-                        },
-                        ColumnDimensions = new[]
-                        {
-                            new Dimension(),
-                            new Dimension(GridSizeMode.AutoSize)
                         }
+                    },
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(GridSizeMode.AutoSize)
                     }
                 }
             };


### PR DESCRIPTION
depends on:
- [x] https://github.com/ppy/osu/pull/18063

PR-ing for comments.

my initial attempt for implementing new multiplayer design (https://github.com/ppy/osu/discussions/17746)
design reference: https://www.figma.com/file/DXKwqZhD5yyb1igc3mKo1P/Song-Select-Draft-2?node-id=0%3A1

https://user-images.githubusercontent.com/6506864/164532361-170b6ba4-4840-45fb-934a-6a956e62e5b4.mp4

example usage (not included in this PR):
![image](https://user-images.githubusercontent.com/6506864/164531627-80abb3ec-81c8-407a-a59a-61575dfb2c13.png)

notes:
- sizes are downscaled by 1.4x as stated on the linked discussion
- missing "typing with result" from the figma. will do on the follow-up changes
- I'm not entirely sure about exposing `FocusedTextField` for sake of focus handling. asking if there's a more elegant way to do it.
- I'm also not sure about the naming convention here. is `ShearedSomething` is on-the-go component naming for the new design? 