### PR TITLE
Fix flaky test in free mod select test scene

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
@@ -21,8 +21,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 State = { Value = Visibility.Visible }
             });
+            AddUntilStep("all column content loaded",
+                () => freeModSelectScreen.ChildrenOfType<ModColumn>().Any()
+                      && freeModSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
 
-            AddAssert("all visible mods are playable",
+            AddUntilStep("all visible mods are playable",
                 () => this.ChildrenOfType<ModPanel>()
                           .Where(panel => panel.IsPresent)
                           .All(panel => panel.Mod.HasImplementation && panel.Mod.UserPlayable));


### PR DESCRIPTION
I don't have a reproduction locally, and the only evidence that this fixes anything is one CI run on my fork and evidence of some not-loaded panels in CI logs, so this is a bit of a hail mary, but PRing anyway with fingers crossed since the test has been failing quite a lot. The lack of an "items loaded" check is the most obvious glaring difference between `TestSceneModSelectScreen` and `TestSceneFreeModSelectScreen`, and only one of those has been failing, so I'm hoping that adding it to the failing one suffices...