### PR TITLE
Allow selecting mods regardless of incompatibility state on new mod select

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPanel.cs
@@ -47,12 +47,22 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             IncompatibilityDisplayingModPanel panel = null;
 
-            AddStep("create panel with DT", () => Child = panel = new IncompatibilityDisplayingModPanel(new OsuModDoubleTime())
+            AddStep("create panel with DT", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.None,
-                Width = 300
+                Child = panel = new IncompatibilityDisplayingModPanel(new OsuModDoubleTime())
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.None,
+                    Width = 300,
+                };
+
+                panel.Active.BindValueChanged(active =>
+                {
+                    SelectedMods.Value = active.NewValue
+                        ? Array.Empty<Mod>()
+                        : new[] { panel.Mod };
+                });
             });
 
             clickPanel();
@@ -62,11 +72,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("panel not active", () => !panel.Active.Value);
 
             AddStep("set incompatible mod", () => SelectedMods.Value = new[] { new OsuModHalfTime() });
-
-            clickPanel();
-            AddAssert("panel not active", () => !panel.Active.Value);
-
-            AddStep("reset mods", () => SelectedMods.Value = Array.Empty<Mod>());
 
             clickPanel();
             AddAssert("panel active", () => panel.Active.Value);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -90,6 +91,27 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestIncompatibilityToggling()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("activate DT", () => getPanelForMod(typeof(OsuModDoubleTime)).TriggerClick());
+            AddAssert("DT active", () => SelectedMods.Value.Single().GetType() == typeof(OsuModDoubleTime));
+
+            AddStep("activate NC", () => getPanelForMod(typeof(OsuModNightcore)).TriggerClick());
+            AddAssert("only NC active", () => SelectedMods.Value.Single().GetType() == typeof(OsuModNightcore));
+
+            AddStep("activate HR", () => getPanelForMod(typeof(OsuModHardRock)).TriggerClick());
+            AddAssert("NC+HR active", () => SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModNightcore))
+                                            && SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModHardRock)));
+
+            AddStep("activate MR", () => getPanelForMod(typeof(OsuModMirror)).TriggerClick());
+            AddAssert("NC+MR active", () => SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModNightcore))
+                                            && SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModMirror)));
+        }
+
+        [Test]
         public void TestCustomisationToggleState()
         {
             createScreen();
@@ -136,5 +158,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert($"customisation toggle is {(disabled ? "" : "not ")}disabled", () => getToggle().Active.Disabled == disabled);
             AddAssert($"customisation toggle is {(active ? "" : "not ")}active", () => getToggle().Active.Value == active);
         }
+
+        private ModPanel getPanelForMod(Type modType)
+            => modSelectScreen.ChildrenOfType<ModPanel>().Single(panel => panel.Mod.GetType() == modType);
     }
 }

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
@@ -1,15 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
 
@@ -42,41 +39,13 @@ namespace osu.Game.Overlays.Mods
                                  && !ModUtils.CheckCompatibleSet(selectedMods.Value.Append(Mod));
         }
 
+        protected override Colour4 BackgroundColour => incompatible.Value ? (Colour4)ColourProvider.Background6 : base.BackgroundColour;
+        protected override Colour4 ForegroundColour => incompatible.Value ? (Colour4)ColourProvider.Background5 : base.ForegroundColour;
+
         protected override void UpdateState()
         {
-            Action = incompatible.Value ? () => { } : (Action)Active.Toggle;
-
-            if (incompatible.Value)
-            {
-                Colour4 backgroundColour = ColourProvider.Background6;
-                Colour4 textBackgroundColour = ColourProvider.Background5;
-
-                Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, textBackgroundColour), TRANSITION_DURATION, Easing.OutQuint);
-                Background.FadeColour(backgroundColour, TRANSITION_DURATION, Easing.OutQuint);
-
-                SwitchContainer.ResizeWidthTo(IDLE_SWITCH_WIDTH, TRANSITION_DURATION, Easing.OutQuint);
-                SwitchContainer.FadeColour(Colour4.Gray, TRANSITION_DURATION, Easing.OutQuint);
-                MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
-                {
-                    Left = IDLE_SWITCH_WIDTH,
-                    Right = CORNER_RADIUS
-                }, TRANSITION_DURATION, Easing.OutQuint);
-
-                TextBackground.FadeColour(textBackgroundColour, TRANSITION_DURATION, Easing.OutQuint);
-                TextFlow.FadeColour(Colour4.White.Opacity(0.5f), TRANSITION_DURATION, Easing.OutQuint);
-                return;
-            }
-
-            SwitchContainer.FadeColour(Colour4.White, TRANSITION_DURATION, Easing.OutQuint);
             base.UpdateState();
-        }
-
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            if (incompatible.Value)
-                return true; // bypasses base call purposely in order to not play out the intermediate state animation.
-
-            return base.OnMouseDown(e);
+            SwitchContainer.FadeColour(incompatible.Value ? Colour4.Gray : Colour4.White, TRANSITION_DURATION, Easing.OutQuint);
         }
 
         #region IHasCustomTooltip

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -203,20 +203,24 @@ namespace osu.Game.Overlays.Mods
             base.OnMouseUp(e);
         }
 
+        protected virtual Colour4 BackgroundColour => Active.Value ? activeColour.Darken(0.3f) : (Colour4)ColourProvider.Background3;
+        protected virtual Colour4 ForegroundColour => Active.Value ? activeColour : (Colour4)ColourProvider.Background2;
+        protected virtual Colour4 TextColour => Active.Value ? (Colour4)ColourProvider.Background6 : Colour4.White;
+
         protected virtual void UpdateState()
         {
             float targetWidth = Active.Value ? EXPANDED_SWITCH_WIDTH : IDLE_SWITCH_WIDTH;
             double transitionDuration = TRANSITION_DURATION;
 
-            Colour4 textBackgroundColour = Active.Value ? activeColour : (Colour4)ColourProvider.Background2;
-            Colour4 mainBackgroundColour = Active.Value ? activeColour.Darken(0.3f) : (Colour4)ColourProvider.Background3;
-            Colour4 textColour = Active.Value ? (Colour4)ColourProvider.Background6 : Colour4.White;
+            Colour4 backgroundColour = BackgroundColour;
+            Colour4 foregroundColour = ForegroundColour;
+            Colour4 textColour = TextColour;
 
             // Hover affects colour of button background
             if (IsHovered)
             {
-                textBackgroundColour = textBackgroundColour.Lighten(0.1f);
-                mainBackgroundColour = mainBackgroundColour.Lighten(0.1f);
+                backgroundColour = backgroundColour.Lighten(0.1f);
+                foregroundColour = foregroundColour.Lighten(0.1f);
             }
 
             // Mouse down adds a halfway tween of the movement
@@ -226,15 +230,15 @@ namespace osu.Game.Overlays.Mods
                 transitionDuration *= 4;
             }
 
-            Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(mainBackgroundColour, textBackgroundColour), transitionDuration, Easing.OutQuint);
-            Background.FadeColour(mainBackgroundColour, transitionDuration, Easing.OutQuint);
+            Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, foregroundColour), transitionDuration, Easing.OutQuint);
+            Background.FadeColour(backgroundColour, transitionDuration, Easing.OutQuint);
             SwitchContainer.ResizeWidthTo(targetWidth, transitionDuration, Easing.OutQuint);
             MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
             {
                 Left = targetWidth,
                 Right = CORNER_RADIUS
             }, transitionDuration, Easing.OutQuint);
-            TextBackground.FadeColour(textBackgroundColour, transitionDuration, Easing.OutQuint);
+            TextBackground.FadeColour(foregroundColour, transitionDuration, Easing.OutQuint);
             TextFlow.FadeColour(textColour, transitionDuration, Easing.OutQuint);
         }
 

--- a/osu.Game/Overlays/Mods/UserModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/UserModSelectScreen.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
 using osuTK.Input;
 
 namespace osu.Game.Overlays.Mods
@@ -10,6 +13,24 @@ namespace osu.Game.Overlays.Mods
     public class UserModSelectScreen : ModSelectScreen
     {
         protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new UserModColumn(modType, false, toggleKeys);
+
+        protected override IReadOnlyList<Mod> ComputeNewModsFromSelection(IEnumerable<Mod> addedMods, IEnumerable<Mod> removedMods)
+        {
+            IEnumerable<Mod> modsAfterRemoval = SelectedMods.Value.Except(removedMods).ToList();
+
+            // the preference is that all new mods should override potential incompatible old mods.
+            // in general that's a bit difficult to compute if more than one mod is added at a time,
+            // so be conservative and just remove all mods that aren't compatible with any one added mod.
+            foreach (var addedMod in addedMods)
+            {
+                if (!ModUtils.CheckCompatibleSet(modsAfterRemoval.Append(addedMod), out var invalidMods))
+                    modsAfterRemoval = modsAfterRemoval.Except(invalidMods);
+
+                modsAfterRemoval = modsAfterRemoval.Append(addedMod).ToList();
+            }
+
+            return modsAfterRemoval.ToList();
+        }
 
         private class UserModColumn : ModColumn
         {


### PR DESCRIPTION
#16917 continued, although this is a bit of an unplanned detour after https://github.com/ppy/osu/pull/17853#issuecomment-1101093763. PRing primarily for UX and code feedback.

https://user-images.githubusercontent.com/20418176/164565557-861b1c27-5dfe-41f6-9f2b-cc8682056e6f.mp4

I kept the dimmed look of the incompatible panels since I like that way more than the old design's barely visible icons, but not sure it works super well. The colours are a bit unfortunate but there's really not enough leeway given the number of available background shades, I've tried a few things and they all pretty much sucked.

The code is a bit convoluted as well but the logic just isn't very simple in the first place...
