### PR TITLE
Fix nested song select in first-run dialog fiddling with global audio

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                                 new Drawable[]
                                 {
                                     new SampleScreenContainer(new PinnedMainMenu()),
-                                    new SampleScreenContainer(new PlaySongSelect()),
+                                    new SampleScreenContainer(new NestedSongSelect()),
                                 },
                                 // TODO: add more screens here in the future (gameplay / results)
                                 // requires a bit more consideration to isolate their behaviour from the "parent" game.
@@ -93,6 +93,11 @@ namespace osu.Game.Overlays.FirstRunSetup
             {
                 Size = initialSize / CurrentScale;
             }
+        }
+
+        private class NestedSongSelect : PlaySongSelect
+        {
+            protected override bool ControlGlobalMusic => false;
         }
 
         private class PinnedMainMenu : MainMenu


### PR DESCRIPTION
Closes #17924.

Still figuring out how to write test coverage for this, if it's required..

The following works if you wait a bit before running the final step in visual tests, but fails in headless. Can't figure how to wait long enough to ensure the looping is applied.

```diff
diff --git a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenUIScale.cs b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenUIScale.cs
index 5ca09b34aa..5cd6086221 100644
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenUIScale.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenUIScale.cs
@@ -1,19 +1,27 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Game.Overlays.FirstRunSetup;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     public class TestSceneFirstRunScreenUIScale : OsuManualInputManagerTestScene
     {
+        private ScreenUIScale screen;
+
         public TestSceneFirstRunScreenUIScale()
         {
             AddStep("load screen", () =>
             {
-                Child = new ScreenStack(new ScreenUIScale());
+                Child = new ScreenStack(screen = new ScreenUIScale());
             });
+
+            AddUntilStep("wait for nested screen load", () => screen.ChildrenOfType<Screens.Select.SongSelect>().FirstOrDefault()?.Beatmap.Value != null);
+
+            AddAssert("music not looping", () => !MusicController.CurrentTrack.Looping);
         }
     }
 }

```