### PR TITLE
Fix settings overlay components not invalidating presence on filter change

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsPanel.cs
@@ -33,17 +33,20 @@ namespace osu.Game.Tests.Visual.Settings
                     State = { Value = Visibility.Visible }
                 });
             });
+
+            AddStep("reset mouse", () => InputManager.MoveMouseTo(settings));
         }
 
         [Test]
-        public void TestQuickFiltering()
+        public void TestFiltering([Values] bool beforeLoad)
         {
-            AddStep("set filter", () =>
-            {
-                settings.SectionsContainer.ChildrenOfType<SearchTextBox>().First().Current.Value = "scaling";
-            });
+            if (beforeLoad)
+                AddStep("set filter", () => settings.SectionsContainer.ChildrenOfType<SearchTextBox>().First().Current.Value = "scaling");
 
             AddUntilStep("wait for items to load", () => settings.SectionsContainer.ChildrenOfType<IFilterable>().Any());
+
+            if (!beforeLoad)
+                AddStep("set filter", () => settings.SectionsContainer.ChildrenOfType<SearchTextBox>().First().Current.Value = "scaling");
 
             AddAssert("ensure all items match filter", () => settings.SectionsContainer
                                                                      .ChildrenOfType<SettingsSection>().Where(f => f.IsPresent)
@@ -56,6 +59,15 @@ namespace osu.Game.Tests.Visual.Settings
                                                                      ));
 
             AddAssert("ensure section is current", () => settings.CurrentSection.Value is GraphicsSection);
+            AddAssert("ensure section is placed first", () => settings.CurrentSection.Value.Y == 0);
+        }
+
+        [Test]
+        public void TestFilterAfterLoad()
+        {
+            AddUntilStep("wait for items to load", () => settings.SectionsContainer.ChildrenOfType<IFilterable>().Any());
+
+            AddStep("set filter", () => settings.SectionsContainer.ChildrenOfType<SearchTextBox>().First().Current.Value = "scaling");
         }
 
         [Test]

--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -195,11 +195,8 @@ namespace osu.Game.Graphics.Containers
 
         protected void InvalidateScrollPosition()
         {
-            Schedule(() =>
-            {
-                lastKnownScroll = null;
-                lastClickedSection = null;
-            });
+            lastKnownScroll = null;
+            lastClickedSection = null;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Overlays.Settings
 
         public IEnumerable<string> Keywords { get; set; }
 
-        private bool matchingFilter;
+        private bool matchingFilter = true;
 
         public bool MatchingFilter
         {

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -100,9 +100,23 @@ namespace osu.Game.Overlays.Settings
 
         public IEnumerable<string> Keywords { get; set; }
 
-        public override bool IsPresent => base.IsPresent && MatchingFilter;
+        private bool matchingFilter;
 
-        public bool MatchingFilter { get; set; } = true;
+        public bool MatchingFilter
+        {
+            get => matchingFilter;
+            set
+            {
+                bool wasPresent = IsPresent;
+
+                matchingFilter = value;
+
+                if (IsPresent != wasPresent)
+                    Invalidate(Invalidation.Presence);
+            }
+        }
+
+        public override bool IsPresent => base.IsPresent && MatchingFilter;
 
         public bool FilteringActive { get; set; }
 

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Overlays.Settings
         protected FillFlowContainer FlowContent;
         protected override Container<Drawable> Content => FlowContent;
 
-        public override bool IsPresent => base.IsPresent && MatchingFilter;
-
         private IBindable<SettingsSection> selectedSection;
 
         private Box dim;
@@ -40,7 +38,23 @@ namespace osu.Game.Overlays.Settings
         private const int header_size = 24;
         private const int border_size = 4;
 
-        public bool MatchingFilter { get; set; } = true;
+        private bool matchingFilter;
+
+        public bool MatchingFilter
+        {
+            get => matchingFilter;
+            set
+            {
+                bool wasPresent = IsPresent;
+
+                matchingFilter = value;
+
+                if (IsPresent != wasPresent)
+                    Invalidate(Invalidation.Presence);
+            }
+        }
+
+        public override bool IsPresent => base.IsPresent && MatchingFilter;
 
         public bool FilteringActive { get; set; }
 

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.Settings
         private const int header_size = 24;
         private const int border_size = 4;
 
-        private bool matchingFilter;
+        private bool matchingFilter = true;
 
         public bool MatchingFilter
         {


### PR DESCRIPTION
Fixes #17929, again

Prior to https://github.com/ppy/osu/pull/17823, filtering would update the `Alpha` value of the settings overlay components (sections & items), which would [invalidate `Presence`](https://github.com/ppy/osu-framework/blob/386623bd74e22e4932a3b6d77456cda8147545ed/osu.Framework/Graphics/Drawable.cs#L1299-L1306) along the way, to note to parenting flow containers that [re-performing layout is necessary](https://github.com/ppy/osu-framework/blob/386623bd74e22e4932a3b6d77456cda8147545ed/osu.Framework/Graphics/Containers/FlowContainer.cs#L65).

But now on master, filtering would instead update the `IsPresent` state directly without an invalidation, resulting in the settings panels not laying out properly and get into a completely weird state.

Added test coverage by filtering after load, as that's when the settings overlay starts relying on invalidation to reflow the sections.

Note that this also reverts https://github.com/ppy/osu/pull/17931 as it's still no longer necessary, but I will suggest quadruple-checking the overlay in all ways possible to ensure nothing has regressed yet again. I've tested enough and can't find anything broken now.