### PR TITLE
Fix legacy skin hit animation lookup falling back to `LookupName`

### DIFF
--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -390,7 +390,7 @@ namespace osu.Game.Skinning
                             return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }
 
-                    break;
+                    return null;
             }
 
             return this.GetAnimation(component.LookupName, false, false);


### PR DESCRIPTION
- Closes #17934 

When no hit animation is found, it should not bother falling back to `GetAnimation(component.LookupName)`.

Unsure if it's sensible to add a test case which checks if a texture name with `ok` doesn't break `hit100` lookup...