### PR TITLE
Handle all legacy skin component types explicitly and remove texture fallback

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -90,6 +90,9 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                             return new LegacyHitExplosion();
 
                         return null;
+
+                    default:
+                        throw new UnsupportedSkinComponentException(component);
                 }
             }
 

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -116,9 +116,10 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
                         case ManiaSkinComponents.StageForeground:
                             return new LegacyStageForeground();
-                    }
 
-                    break;
+                        default:
+                            throw new UnsupportedSkinComponentException(component);
+                    }
             }
 
             return base.GetDrawableComponent(component);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
@@ -70,7 +70,9 @@ namespace osu.Game.Rulesets.Osu.Tests
                 var tintingSkin = skinManager.GetSkin(DefaultLegacySkin.CreateInfo());
                 tintingSkin.Configuration.ConfigDictionary["AllowSliderBallTint"] = "1";
 
-                Child = new SkinProvidingContainer(tintingSkin)
+                var provider = Ruleset.Value.CreateInstance().CreateLegacySkinProvider(tintingSkin, Beatmap.Value.Beatmap);
+
+                Child = new SkinProvidingContainer(provider)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Child = dho = new DrawableSlider(prepareObject(new Slider

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -35,6 +35,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     case OsuSkinComponents.FollowPoint:
                         return this.GetAnimation(component.LookupName, true, true, true, startAtCurrentTime: false);
 
+                    case OsuSkinComponents.SliderScorePoint:
+                        return this.GetAnimation(component.LookupName, false, false);
+
                     case OsuSkinComponents.SliderFollowCircle:
                         var followCircle = this.GetAnimation("sliderfollowcircle", true, true, true);
                         if (followCircle != null)
@@ -123,6 +126,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
                     case OsuSkinComponents.ApproachCircle:
                         return new LegacyApproachCircle();
+
+                    default:
+                        throw new UnsupportedSkinComponentException(component);
                 }
             }
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -57,6 +57,10 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                     case TaikoSkinComponents.DrumRollTick:
                         return this.GetAnimation("sliderscorepoint", false, false);
 
+                    case TaikoSkinComponents.Swell:
+                        // todo: support taiko legacy swell (https://github.com/ppy/osu/issues/13601).
+                        return null;
+
                     case TaikoSkinComponents.HitTarget:
                         if (GetTexture("taikobigcircle") != null)
                             return new TaikoLegacyHitTarget();
@@ -119,6 +123,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
                     case TaikoSkinComponents.Mascot:
                         return new DrawableTaikoMascot();
+
+                    default:
+                        throw new UnsupportedSkinComponentException(component);
                 }
             }
 

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Skinning
                             return skinnableTargetWrapper;
                     }
 
-                    break;
+                    return null;
             }
 
             switch (component.LookupName)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -392,8 +392,11 @@ namespace osu.Game.Skinning
 
                     return null;
 
+                case SkinnableSprite.SpriteComponent sprite:
+                    return this.GetAnimation(sprite.LookupName, false, false);
+
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(component));
+                    throw new UnsupportedSkinComponentException(component);
             }
         }
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -391,9 +391,10 @@ namespace osu.Game.Skinning
                     }
 
                     return null;
-            }
 
-            return this.GetAnimation(component.LookupName, false, false);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(component));
+            }
         }
 
         private Texture? getParticleTexture(HitResult result)

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Skinning
 
         public bool UsesFixedAnchor { get; set; }
 
-        public class SpriteComponent : ISkinComponent
+        internal class SpriteComponent : ISkinComponent
         {
             public string LookupName { get; set; }
 

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Skinning
 
         public bool UsesFixedAnchor { get; set; }
 
-        private class SpriteComponent : ISkinComponent
+        public class SpriteComponent : ISkinComponent
         {
             public string LookupName { get; set; }
 

--- a/osu.Game/Skinning/UnsupportedSkinComponentException.cs
+++ b/osu.Game/Skinning/UnsupportedSkinComponentException.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Skinning
+{
+    public class UnsupportedSkinComponentException : Exception
+    {
+        public UnsupportedSkinComponentException(ISkinComponent component)
+            : base($@"Unsupported component type: {component.GetType()}(""{component.LookupName}"").")
+        {
+        }
+    }
+}

--- a/osu.Game/Skinning/UnsupportedSkinComponentException.cs
+++ b/osu.Game/Skinning/UnsupportedSkinComponentException.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Skinning
     public class UnsupportedSkinComponentException : Exception
     {
         public UnsupportedSkinComponentException(ISkinComponent component)
-            : base($@"Unsupported component type: {component.GetType()}(""{component.LookupName}"").")
+            : base($@"Unsupported component type: {component.GetType()} (lookup: ""{component.LookupName}"").")
         {
         }
     }

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -74,10 +74,14 @@ namespace osu.Game.Tests.Visual
 
             createdDrawables.Add(created);
 
-            SkinProvidingContainer mainProvider;
             Container childContainer;
             OutlineBox outlineBox;
             SkinProvidingContainer skinProvider;
+
+            ISkin provider = skin;
+
+            if (provider is LegacySkin legacyProvider)
+                provider = Ruleset.Value.CreateInstance().CreateLegacySkinProvider(legacyProvider, beatmap);
 
             var children = new Container
             {
@@ -107,12 +111,10 @@ namespace osu.Game.Tests.Visual
                         Children = new Drawable[]
                         {
                             outlineBox = new OutlineBox(),
-                            (mainProvider = new SkinProvidingContainer(skin)).WithChild(
-                                skinProvider = new SkinProvidingContainer(Ruleset.Value.CreateInstance().CreateLegacySkinProvider(mainProvider, beatmap))
-                                {
-                                    Child = created,
-                                }
-                            )
+                            skinProvider = new SkinProvidingContainer(provider)
+                            {
+                                Child = created,
+                            }
                         }
                     },
                 }
@@ -130,7 +132,7 @@ namespace osu.Game.Tests.Visual
             {
                 bool autoSize = created.RelativeSizeAxes == Axes.None;
 
-                foreach (var c in new[] { mainProvider, childContainer, skinProvider })
+                foreach (var c in new[] { childContainer, skinProvider })
                 {
                     c.RelativeSizeAxes = Axes.None;
                     c.AutoSizeAxes = Axes.None;


### PR DESCRIPTION
- [x] Depends on #17939 
- Originally sparked in https://github.com/ppy/osu/issues/17934#issuecomment-1106869976

This has always been a source of hiding actual issues like in:
 - #17745 
   - no transformer actually applied but components are still looked up using the texture lookup fallback.
 - #17934
   - because it doesn't skin any hit animation, but has a texture named `ok`, and that matches the lookup name of the requested component (`HitResult.Ok`). therefore gets retrieved using the texture lookup fallback.

To simplify things and avoid magic, `LegacySkin` and transformers handle all skin component types explicitly, and the texture lookup fallback logic is removed, replaced with an `ArgumentOutOfRangeException` to notify newer implementations that the component they added is not handled appropriately.

PR'ing this for feedback on direction and testing before merge, have checked all lookups paths and updated accordingly.