### PR TITLE
Update `OsuFont` to support CSS-style font sizing and supply osu! font with metrics

### DIFF
--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.IO.Stores;
 
 namespace osu.Game.Graphics
 {
@@ -33,9 +34,13 @@ namespace osu.Game.Graphics
         /// <param name="weight">The font weight.</param>
         /// <param name="italics">Whether the font is italic.</param>
         /// <param name="fixedWidth">Whether all characters should be spaced the same distance apart.</param>
+        /// <param name="css">
+        /// Whether the text glyphs should scale according to their respective <see cref="IGlyphStore.Metrics"/>, matching CSS.
+        /// It is recommended to enable this for better alignment with other fonts.
+        /// </param>
         /// <returns>The <see cref="FontUsage"/>.</returns>
-        public static FontUsage GetFont(Typeface typeface = Typeface.Torus, float size = DEFAULT_FONT_SIZE, FontWeight weight = FontWeight.Medium, bool italics = false, bool fixedWidth = false)
-            => new FontUsage(GetFamilyString(typeface), size, GetWeightString(typeface, weight), getItalics(italics), fixedWidth);
+        public static FontUsage GetFont(Typeface typeface = Typeface.Torus, float size = DEFAULT_FONT_SIZE, FontWeight weight = FontWeight.Medium, bool italics = false, bool fixedWidth = false, bool css = false)
+            => new FontUsage(GetFamilyString(typeface), size, GetWeightString(typeface, weight), getItalics(italics), fixedWidth, css);
 
         private static bool getItalics(in bool italicsRequested)
         {
@@ -104,13 +109,17 @@ namespace osu.Game.Graphics
         /// <param name="weight">The font weight. If null, the value is copied from this <see cref="FontUsage"/>.</param>
         /// <param name="italics">Whether the font is italic. If null, the value is copied from this <see cref="FontUsage"/>.</param>
         /// <param name="fixedWidth">Whether all characters should be spaced apart the same distance. If null, the value is copied from this <see cref="FontUsage"/>.</param>
+        /// <param name="css">
+        /// Whether the text glyphs should scale according to their respective <see cref="IGlyphStore.Metrics"/>, matching CSS.
+        /// It is recommended to enable this for better alignment with other fonts.
+        /// </param>
         /// <returns>The resulting <see cref="FontUsage"/>.</returns>
-        public static FontUsage With(this FontUsage usage, Typeface? typeface = null, float? size = null, FontWeight? weight = null, bool? italics = null, bool? fixedWidth = null)
+        public static FontUsage With(this FontUsage usage, Typeface? typeface = null, float? size = null, FontWeight? weight = null, bool? italics = null, bool? fixedWidth = null, bool? css = null)
         {
             string familyString = typeface != null ? OsuFont.GetFamilyString(typeface.Value) : usage.Family;
             string weightString = weight != null ? OsuFont.GetWeightString(familyString, weight.Value) : usage.Weight;
 
-            return usage.With(familyString, size, weightString, italics, fixedWidth);
+            return usage.With(familyString, size, weightString, italics, fixedWidth, css);
         }
     }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -20,6 +20,7 @@ using osu.Framework.Input;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Framework.Text;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
@@ -352,34 +353,40 @@ namespace osu.Game
         {
             AddFont(Resources, @"Fonts/osuFont");
 
-            AddFont(Resources, @"Fonts/Torus/Torus-Regular");
-            AddFont(Resources, @"Fonts/Torus/Torus-Light");
-            AddFont(Resources, @"Fonts/Torus/Torus-SemiBold");
-            AddFont(Resources, @"Fonts/Torus/Torus-Bold");
+            var torusMetrics = new FontMetrics(ascent: 800, descent: 200, emSize: 1000, lineGap: 200);
+            var interMetrics = new FontMetrics(ascent: 2728, descent: 680, emSize: 2816, lineGap: 0);
+            var notoCjkMetrics = new FontMetrics(ascent: 880, descent: 120, emSize: 1000, lineGap: 0);
+            var notoThaiMetrics = new FontMetrics(ascent: 1061, descent: 450, emSize: 1000, lineGap: 0);
+            var veneraMetrics = new FontMetrics(ascent: 750, descent: 250, emSize: 1000, lineGap: 200);
 
-            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Regular");
-            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Light");
-            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-SemiBold");
-            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Bold");
+            AddFont(Resources, @"Fonts/Torus/Torus-Regular", metrics: torusMetrics);
+            AddFont(Resources, @"Fonts/Torus/Torus-Light", metrics: torusMetrics);
+            AddFont(Resources, @"Fonts/Torus/Torus-SemiBold", metrics: torusMetrics);
+            AddFont(Resources, @"Fonts/Torus/Torus-Bold", metrics: torusMetrics);
 
-            AddFont(Resources, @"Fonts/Inter/Inter-Regular");
-            AddFont(Resources, @"Fonts/Inter/Inter-RegularItalic");
-            AddFont(Resources, @"Fonts/Inter/Inter-Light");
-            AddFont(Resources, @"Fonts/Inter/Inter-LightItalic");
-            AddFont(Resources, @"Fonts/Inter/Inter-SemiBold");
-            AddFont(Resources, @"Fonts/Inter/Inter-SemiBoldItalic");
-            AddFont(Resources, @"Fonts/Inter/Inter-Bold");
-            AddFont(Resources, @"Fonts/Inter/Inter-BoldItalic");
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Regular", metrics: torusMetrics);
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Light", metrics: torusMetrics);
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-SemiBold", metrics: torusMetrics);
+            AddFont(Resources, @"Fonts/Torus-Alternate/Torus-Alternate-Bold", metrics: torusMetrics);
 
-            AddFont(Resources, @"Fonts/Noto/Noto-Basic");
-            AddFont(Resources, @"Fonts/Noto/Noto-Hangul");
-            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Basic");
-            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Compatibility");
-            AddFont(Resources, @"Fonts/Noto/Noto-Thai");
+            AddFont(Resources, @"Fonts/Inter/Inter-Regular", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-RegularItalic", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-Light", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-LightItalic", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-SemiBold", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-SemiBoldItalic", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-Bold", metrics: interMetrics);
+            AddFont(Resources, @"Fonts/Inter/Inter-BoldItalic", metrics: interMetrics);
 
-            AddFont(Resources, @"Fonts/Venera/Venera-Light");
-            AddFont(Resources, @"Fonts/Venera/Venera-Bold");
-            AddFont(Resources, @"Fonts/Venera/Venera-Black");
+            AddFont(Resources, @"Fonts/Noto/Noto-Basic", metrics: notoCjkMetrics);
+            AddFont(Resources, @"Fonts/Noto/Noto-Hangul", metrics: notoCjkMetrics);
+            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Basic", metrics: notoCjkMetrics);
+            AddFont(Resources, @"Fonts/Noto/Noto-CJK-Compatibility", metrics: notoCjkMetrics);
+            AddFont(Resources, @"Fonts/Noto/Noto-Thai", metrics: notoThaiMetrics);
+
+            AddFont(Resources, @"Fonts/Venera/Venera-Light", metrics: veneraMetrics);
+            AddFont(Resources, @"Fonts/Venera/Venera-Bold", metrics: veneraMetrics);
+            AddFont(Resources, @"Fonts/Venera/Venera-Black", metrics: veneraMetrics);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Skinning/LegacySpriteText.cs
+++ b/osu.Game/Skinning/LegacySpriteText.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.IO.Stores;
 using osu.Framework.Text;
 using osu.Game.Graphics.Sprites;
 using osuTK;
@@ -78,6 +79,8 @@ namespace osu.Game.Skinning
             }
 
             public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+
+            public IGlyphStore GetFont(string name) => null;
         }
     }
 }


### PR DESCRIPTION
- [ ] Depends on ppy/osu-framework#5123
- [ ] Depends on framework bump

Font metrics have been retrieved from the following sources:
 - `Torus`/`Torus-Alternate`: https://github.com/ppy/osu-web/blob/master/resources/assets/fonts/torus/Torus-Regular.otf
 - `Venera`: https://github.com/ppy/osu-web/blob/master/resources/assets/fonts/venera/Venera-500.otf
 - `Inter`: https://fonts.google.com/specimen/Inter
 - `Noto-Basic`: https://fonts.google.com/earlyaccess#Noto+Sans+Japanese
 - `Noto-Hangul`: https://fonts.google.com/noto/specimen/Noto+Sans+KR
   - I feel like this one is wrong, but I don't really know what other early-access font variant exists for this.
 - `Noto-CJK-Basic`/`Noto-CJK-Compatibility`: https://fonts.google.com/noto/specimen/Noto+Sans+SC?noto.query=Noto+Sans+SC / https://fonts.google.com/noto/specimen/Noto+Sans+TC?noto.query=Noto+Sans+TC
   - I also feel this one is wrong, but both fonts along with `Noto-Hangul` and `Noto-Basic` share the same exact metric, so gonna roll with it for now.
 - `Noto-Thai`: https://fonts.google.com/noto/specimen/Noto+Sans+Thai

In addition, `OsuFont` has been updated to start supporting to use the CSS-style font size option.

We could also start migrating from right here, by prefixing the current non-CSS ones with `Old` for old designs only, or vice-versa. Gonna wait to see how things settle in the framework-side PR first.