### PR TITLE
Allow any key to trigger the osu! cookie in the initial state

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Screens.Menu;
+using osu.Game.Screens.Select;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public class TestSceneButtonSystemNavigation : OsuGameTestScene
+    {
+        private ButtonSystem buttons => ((MainMenu)Game.ScreenStack.CurrentScreen).ChildrenOfType<ButtonSystem>().Single();
+
+        [Test]
+        public void TestGlobalActionHasPriority()
+        {
+            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+
+            // triggering the cookie in the initial state with any key should only happen if no other action is bound to that key.
+            // here, F10 is bound to GlobalAction.ToggleGameplayMouseButtons.
+            AddStep("press F10", () => InputManager.Key(Key.F10));
+            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+
+            AddStep("press P", () => InputManager.Key(Key.P));
+            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+        }
+
+        [Test]
+        public void TestShortcutKeys()
+        {
+            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+
+            AddStep("press P", () => InputManager.Key(Key.P));
+            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+
+            AddStep("press P", () => InputManager.Key(Key.P));
+            AddAssert("state is play", () => buttons.State == ButtonSystemState.Play);
+
+            AddStep("press P", () => InputManager.Key(Key.P));
+            AddAssert("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneButtonSystem.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneButtonSystem.cs
@@ -10,11 +10,12 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Screens.Menu;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public class TestSceneButtonSystem : OsuTestScene
+    public class TestSceneButtonSystem : OsuManualInputManagerTestScene
     {
         private OsuLogo logo;
         private ButtonSystem buttons;
@@ -62,6 +63,66 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestSmoothExit()
         {
             AddStep("Enter mode", performEnterMode);
+        }
+
+        [TestCase(Key.P, true)]
+        [TestCase(Key.M, true)]
+        [TestCase(Key.L, true)]
+        [TestCase(Key.E, false)]
+        [TestCase(Key.D, false)]
+        [TestCase(Key.Q, false)]
+        [TestCase(Key.O, false)]
+        public void TestShortcutKeys(Key key, bool entersPlay)
+        {
+            int activationCount = -1;
+            AddStep("set up action", () =>
+            {
+                activationCount = 0;
+                void action() => activationCount++;
+
+                switch (key)
+                {
+                    case Key.P:
+                        buttons.OnSolo = action;
+                        break;
+
+                    case Key.M:
+                        buttons.OnMultiplayer = action;
+                        break;
+
+                    case Key.L:
+                        buttons.OnPlaylists = action;
+                        break;
+
+                    case Key.E:
+                        buttons.OnEdit = action;
+                        break;
+
+                    case Key.D:
+                        buttons.OnBeatmapListing = action;
+                        break;
+
+                    case Key.Q:
+                        buttons.OnExit = action;
+                        break;
+
+                    case Key.O:
+                        buttons.OnSettings = action;
+                        break;
+                }
+            });
+
+            AddStep($"press {key}", () => InputManager.Key(key));
+            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+
+            if (entersPlay)
+            {
+                AddStep("press P", () => InputManager.Key(Key.P));
+                AddAssert("state is play", () => buttons.State == ButtonSystemState.Play);
+            }
+
+            AddStep($"press {key}", () => InputManager.Key(key));
+            AddAssert("action triggered", () => activationCount == 1);
         }
 
         private void performEnterMode()

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -196,11 +196,8 @@ namespace osu.Game.Screens.Menu
 
             if (State == ButtonSystemState.Initial)
             {
-                if (buttonsTopLevel.Any(b => e.Key == b.TriggerKey))
-                {
-                    logo?.TriggerClick();
-                    return true;
-                }
+                logo?.TriggerClick();
+                return true;
             }
 
             return base.OnKeyDown(e);


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/17854.

Works really wells since `GlobalAction`s are handled with priority. If they weren't, handling all keys would prevent from exiting as it would consume the Escape/back key.

Full OsuGame tests are added to ensure this behaviour isn't broken in the future by the 'eventual solution':

https://github.com/ppy/osu/blob/866ae3472bb654af5bde50f79ecb0ae2cbd884e5/osu.Game/Input/Bindings/GlobalActionContainer.cs#L131-L135