### PR TITLE
Deselect mods incompatible with "Autoplay" when entering gameplay via scene library

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -59,8 +59,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("wait for player", () =>
             {
-                // dismiss any notifications that may appear (ie. muted notification).
-                clickMouseInCentre();
+                DismissAnyNotifications();
                 return player != null;
             });
 
@@ -71,12 +70,6 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddStep("press 's'", () => InputManager.Key(Key.S));
             AddAssert("key counter did increase", () => keyCounter.CountPresses == 1);
-        }
-
-        private void clickMouseInCentre()
-        {
-            InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre);
-            InputManager.Click(MouseButton.Left);
         }
 
         private KeyBindingsSubsection osuBindingSubsection => keyBindingPanel

--- a/osu.Game.Tests/Visual/Navigation/TestSceneMouseWheelVolumeAdjust.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneMouseWheelVolumeAdjust.cs
@@ -89,18 +89,11 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("wait for player", () =>
             {
-                // dismiss any notifications that may appear (ie. muted notification).
-                clickMouseInCentre();
+                DismissAnyNotifications();
                 return (player = Game.ScreenStack.CurrentScreen as Player) != null;
             });
 
             AddUntilStep("wait for play time active", () => !player.IsBreakTime.Value);
-        }
-
-        private void clickMouseInCentre()
-        {
-            InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre);
-            InputManager.Click(MouseButton.Left);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -8,7 +8,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -16,7 +15,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
-using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
@@ -24,12 +22,10 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.Play;
-using osu.Game.Screens.Play.HUD.HitErrorMeters;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Screens.Select.Options;
-using osu.Game.Skinning.Editor;
 using osu.Game.Tests.Beatmaps.IO;
 using osuTK;
 using osuTK.Input;
@@ -69,73 +65,6 @@ namespace osu.Game.Tests.Visual.Navigation
             PushAndConfirm(() => songSelect = new TestPlaySongSelect());
             AddStep("Show mods overlay", () => InputManager.Key(Key.F1));
             AddAssert("Overlay was shown", () => songSelect.ModSelectOverlay.State.Value == Visibility.Visible);
-        }
-
-        [Test]
-        public void TestEditComponentDuringGameplay()
-        {
-            Screens.Select.SongSelect songSelect = null;
-            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
-            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
-
-            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
-
-            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
-
-            SkinEditor skinEditor = null;
-
-            AddStep("open skin editor", () =>
-            {
-                InputManager.PressKey(Key.ControlLeft);
-                InputManager.PressKey(Key.ShiftLeft);
-                InputManager.Key(Key.S);
-                InputManager.ReleaseKey(Key.ControlLeft);
-                InputManager.ReleaseKey(Key.ShiftLeft);
-            });
-
-            AddUntilStep("get skin editor", () => (skinEditor = Game.ChildrenOfType<SkinEditor>().FirstOrDefault()) != null);
-
-            AddStep("Click gameplay scene button", () =>
-            {
-                skinEditor.ChildrenOfType<SkinEditorSceneLibrary.SceneButton>().First(b => b.Text == "Gameplay").TriggerClick();
-            });
-
-            AddUntilStep("wait for player", () =>
-            {
-                // dismiss any notifications that may appear (ie. muted notification).
-                clickMouseInCentre();
-                return Game.ScreenStack.CurrentScreen is Player;
-            });
-
-            BarHitErrorMeter hitErrorMeter = null;
-
-            AddUntilStep("select bar hit error blueprint", () =>
-            {
-                var blueprint = skinEditor.ChildrenOfType<SkinBlueprint>().FirstOrDefault(b => b.Item is BarHitErrorMeter);
-
-                if (blueprint == null)
-                    return false;
-
-                hitErrorMeter = (BarHitErrorMeter)blueprint.Item;
-                skinEditor.SelectedComponents.Clear();
-                skinEditor.SelectedComponents.Add(blueprint.Item);
-                return true;
-            });
-
-            AddAssert("value is default", () => hitErrorMeter.JudgementLineThickness.IsDefault);
-
-            AddStep("hover first slider", () =>
-            {
-                InputManager.MoveMouseTo(
-                    skinEditor.ChildrenOfType<SkinSettingsToolbox>().First()
-                              .ChildrenOfType<SettingsSlider<float>>().First()
-                              .ChildrenOfType<SliderBar<float>>().First()
-                );
-            });
-
-            AddStep("adjust slider via keyboard", () => InputManager.Key(Key.Left));
-
-            AddAssert("value is less than default", () => hitErrorMeter.JudgementLineThickness.Value < hitErrorMeter.JudgementLineThickness.Default);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -155,8 +155,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("wait for player", () =>
             {
-                // dismiss any notifications that may appear (ie. muted notification).
-                clickMouseInCentre();
+                DismissAnyNotifications();
                 return (player = Game.ScreenStack.CurrentScreen as Player) != null;
             });
 
@@ -280,8 +279,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("wait for player", () =>
             {
-                // dismiss any notifications that may appear (ie. muted notification).
-                clickMouseInCentre();
+                DismissAnyNotifications();
                 return (player = Game.ScreenStack.CurrentScreen as Player) != null;
             });
 
@@ -596,8 +594,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("wait for player", () =>
             {
-                // dismiss any notifications that may appear (ie. muted notification).
-                clickMouseInCentre();
+                DismissAnyNotifications();
                 return (player = Game.ScreenStack.CurrentScreen as Player) != null;
             });
 
@@ -605,12 +602,6 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("seek to near end", () => player.ChildrenOfType<GameplayClockContainer>().First().Seek(beatmap().Beatmap.HitObjects[^1].StartTime - 1000));
             AddUntilStep("wait for pass", () => (Game.ScreenStack.CurrentScreen as ResultsScreen)?.IsLoaded == true);
             return () => player;
-        }
-
-        private void clickMouseInCentre()
-        {
-            InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre);
-            InputManager.Click(MouseButton.Left);
         }
 
         private void pushEscape() =>

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.HUD.HitErrorMeters;
+using osu.Game.Skinning.Editor;
+using osu.Game.Tests.Beatmaps.IO;
+using osuTK.Input;
+using static osu.Game.Tests.Visual.Navigation.TestSceneScreenNavigation;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public class TestSceneSkinEditorSceneLibrary : OsuGameTestScene
+    {
+        private SkinEditor skinEditor;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            Screens.Select.SongSelect songSelect = null;
+            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("open skin editor", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.S);
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+            });
+
+            AddUntilStep("get skin editor", () => (skinEditor = Game.ChildrenOfType<SkinEditor>().FirstOrDefault()) != null);
+        }
+
+        [Test]
+        public void TestEditComponentDuringGameplay()
+        {
+            switchToGameplayScene();
+
+            BarHitErrorMeter hitErrorMeter = null;
+
+            AddUntilStep("select bar hit error blueprint", () =>
+            {
+                var blueprint = skinEditor.ChildrenOfType<SkinBlueprint>().FirstOrDefault(b => b.Item is BarHitErrorMeter);
+
+                if (blueprint == null)
+                    return false;
+
+                hitErrorMeter = (BarHitErrorMeter)blueprint.Item;
+                skinEditor.SelectedComponents.Clear();
+                skinEditor.SelectedComponents.Add(blueprint.Item);
+                return true;
+            });
+
+            AddAssert("value is default", () => hitErrorMeter.JudgementLineThickness.IsDefault);
+
+            AddStep("hover first slider", () =>
+            {
+                InputManager.MoveMouseTo(
+                    skinEditor.ChildrenOfType<SkinSettingsToolbox>().First()
+                              .ChildrenOfType<SettingsSlider<float>>().First()
+                              .ChildrenOfType<SliderBar<float>>().First()
+                );
+            });
+
+            AddStep("adjust slider via keyboard", () => InputManager.Key(Key.Left));
+
+            AddAssert("value is less than default", () => hitErrorMeter.JudgementLineThickness.Value < hitErrorMeter.JudgementLineThickness.Default);
+        }
+
+        private void switchToGameplayScene()
+        {
+            AddStep("Click gameplay scene button", () => skinEditor.ChildrenOfType<SkinEditorSceneLibrary.SceneButton>().First(b => b.Text == "Gameplay").TriggerClick());
+
+            AddUntilStep("wait for player", () =>
+            {
+                DismissAnyNotifications();
+                return Game.ScreenStack.CurrentScreen is Player;
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
@@ -83,6 +83,46 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("value is less than default", () => hitErrorMeter.JudgementLineThickness.Value < hitErrorMeter.JudgementLineThickness.Default);
         }
 
+        [Test]
+        public void TestAutoplayCompatibleModsRetainedOnEnteringGameplay()
+        {
+            AddStep("select DT", () => Game.SelectedMods.Value = new Mod[] { new OsuModDoubleTime() });
+
+            switchToGameplayScene();
+
+            AddAssert("DT still selected", () => ((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Single() is OsuModDoubleTime);
+        }
+
+        [Test]
+        public void TestAutoplayIncompatibleModsRemovedOnEnteringGameplay()
+        {
+            AddStep("select no fail and spun out", () => Game.SelectedMods.Value = new Mod[] { new OsuModNoFail(), new OsuModSpunOut() });
+
+            switchToGameplayScene();
+
+            AddAssert("no mod selected", () => !((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Any());
+        }
+
+        [Test]
+        public void TestDuplicateAutoplayModRemovedOnEnteringGameplay()
+        {
+            AddStep("select autoplay", () => Game.SelectedMods.Value = new Mod[] { new OsuModAutoplay() });
+
+            switchToGameplayScene();
+
+            AddAssert("no mod selected", () => !((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Any());
+        }
+
+        [Test]
+        public void TestCinemaModRemovedOnEnteringGameplay()
+        {
+            AddStep("select cinema", () => Game.SelectedMods.Value = new Mod[] { new OsuModCinema() });
+
+            switchToGameplayScene();
+
+            AddAssert("no mod selected", () => !((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Any());
+        }
+
         private void switchToGameplayScene()
         {
             AddStep("Click gameplay scene button", () => skinEditor.ChildrenOfType<SkinEditorSceneLibrary.SceneButton>().First(b => b.Text == "Gameplay").TriggerClick());

--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -18,6 +20,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Skinning.Editor
@@ -33,6 +36,9 @@ namespace osu.Game.Skinning.Editor
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; }
+
+        [Resolved]
+        private Bindable<IReadOnlyList<Mod>> mods { get; set; }
 
         public SkinEditorSceneLibrary()
         {
@@ -95,6 +101,10 @@ namespace osu.Game.Skinning.Editor
                                             return;
 
                                         var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
+
+                                        if (!ModUtils.CheckCompatibleSet(mods.Value.Append(replayGeneratingMod), out var invalid))
+                                            mods.Value = mods.Value.Except(invalid).ToArray();
+
                                         if (replayGeneratingMod != null)
                                             screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))));
                                     }, new[] { typeof(Player), typeof(SongSelect) })

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -25,7 +25,6 @@ using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osuTK.Graphics;
-using osuTK.Input;
 using IntroSequence = osu.Game.Configuration.IntroSequence;
 
 namespace osu.Game.Tests.Visual

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -23,7 +23,9 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
+using osu.Game.Screens.Play;
 using osuTK.Graphics;
+using osuTK.Input;
 using IntroSequence = osu.Game.Configuration.IntroSequence;
 
 namespace osu.Game.Tests.Visual
@@ -105,6 +107,11 @@ namespace osu.Game.Tests.Visual
         }
 
         protected void ConfirmAtMainMenu() => AddUntilStep("Wait for main menu", () => Game.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);
+
+        /// <summary>
+        /// Dismisses any notifications pushed which block from interacting with the game (or block screens from loading, e.g. <see cref="Player"/>).
+        /// </summary>
+        protected void DismissAnyNotifications() => Game.Notifications.State.Value = Visibility.Hidden;
 
         public class TestOsuGame : OsuGame
         {


### PR DESCRIPTION
- Closes #17936 

Also includes simplifying and sharing notification dismiss method across `OsuGameTestScene`s, rather than declaring a "click mouse in centre" method in every test scene.

When incompatible mods are deselected, they'll not return back after finishing from gameplay. Not entirely sure how that should be handled, and I also feel it's unnecessary since I don't think that's how we want users to select mods while testing gameplay (going into song select, selecting mods, then launching skin editor and opening gameplay).