### PR TITLE
Fix windows taskbar context menu not popping up correctly

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -123,7 +123,12 @@ namespace osu.Desktop
                 tools.RemoveUninstallerRegistryEntry();
             }, onEveryRun: (version, tools, firstRun) =>
             {
-                tools.SetProcessAppUserModelId();
+                // While setting the `ProcessAppUserModelId` fixes duplicate icons/shortcuts on the taskbar, it currently
+                // causes the right-click context menu to function incorrectly.
+                //
+                // This may turn out to be non-required after an alternative solution is implemented.
+                // see https://github.com/clowd/Clowd.Squirrel/issues/24
+                // tools.SetProcessAppUserModelId();
             });
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/17965.

Note that this will cause a second osu! icon to appear after running the application (after any update). As per the inline comment, this will eventually be resolved via https://github.com/clowd/Clowd.Squirrel/issues/24.

I do think having context menus working is more important than duplicate icons.

Note that for anyone who already has a pinned taskbar icon, it will need to be manually unpinned and repinned after a future update to actually fix this issue.

Thanks to @caesay for help with investigation.