### PR TITLE
Change score accuracy grading logic to be inclusive

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -375,13 +375,13 @@ namespace osu.Game.Rulesets.Scoring
         {
             if (acc == 1)
                 return ScoreRank.X;
-            if (acc > 0.95)
+            if (acc >= 0.95)
                 return ScoreRank.S;
-            if (acc > 0.9)
+            if (acc >= 0.9)
                 return ScoreRank.A;
-            if (acc > 0.8)
+            if (acc >= 0.8)
                 return ScoreRank.B;
-            if (acc > 0.7)
+            if (acc >= 0.7)
                 return ScoreRank.C;
 
             return ScoreRank.D;

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
@@ -212,12 +212,12 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                     Padding = new MarginPadding { Vertical = -15, Horizontal = -20 },
                     Children = new[]
                     {
-                        new RankBadge(1f, getRank(ScoreRank.X)),
-                        new RankBadge(0.95f, getRank(ScoreRank.S)),
-                        new RankBadge(0.9f, getRank(ScoreRank.A)),
-                        new RankBadge(0.8f, getRank(ScoreRank.B)),
-                        new RankBadge(0.7f, getRank(ScoreRank.C)),
-                        new RankBadge(0.35f, getRank(ScoreRank.D)),
+                        new RankBadge(1, getRank(ScoreRank.X)),
+                        new RankBadge(0.95, getRank(ScoreRank.S)),
+                        new RankBadge(0.9, getRank(ScoreRank.A)),
+                        new RankBadge(0.8, getRank(ScoreRank.B)),
+                        new RankBadge(0.7, getRank(ScoreRank.C)),
+                        new RankBadge(0.35, getRank(ScoreRank.D)),
                     }
                 },
                 rankText = new RankText(score.Rank)

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/RankBadge.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/RankBadge.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
         /// <summary>
         /// The accuracy value corresponding to the <see cref="ScoreRank"/> displayed by this badge.
         /// </summary>
-        public readonly float Accuracy;
+        public readonly double Accuracy;
 
         private readonly ScoreRank rank;
 
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
         /// </summary>
         /// <param name="accuracy">The accuracy value corresponding to <paramref name="rank"/>.</param>
         /// <param name="rank">The <see cref="ScoreRank"/> to be displayed in this <see cref="RankBadge"/>.</param>
-        public RankBadge(float accuracy, ScoreRank rank)
+        public RankBadge(double accuracy, ScoreRank rank)
         {
             Accuracy = accuracy;
             this.rank = rank;
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
             base.Update();
 
             // Starts at -90deg (top) and moves counter-clockwise by the accuracy
-            rankContainer.Position = circlePosition(-MathF.PI / 2 - (1 - Accuracy) * MathF.PI * 2);
+            rankContainer.Position = circlePosition(-MathF.PI / 2 - (1 - (float)Accuracy) * MathF.PI * 2);
         }
 
         private Vector2 circlePosition(float t)


### PR DESCRIPTION
- Closes #17974 

Also includes a minor fix in `AccuracyCircle` where it stores accuracy values in `float` rather than `double`, which could lead to unexpected behavior during comparison since `score.Accuracy` is `double`:

https://github.com/ppy/osu/blob/f958010d29ae5040c37b89e88f00fc29e1123d12/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs#L290-L291

<img width="257" alt="CleanShot 2022-04-26 at 04 59 48@2x" src="https://user-images.githubusercontent.com/22781491/165204343-e8223d25-9374-456a-80b1-e9e97093a22a.png">

Not relevant in this PR, since the case that would happen here is `0.9f (rank badge) > 0.9 (score)`, which still returns `false` as expected.