### PR TITLE
Change conditions for HUD being shown to include pause/fail states

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
@@ -21,7 +21,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override void AddCheckSteps()
         {
+            AddUntilStep("player is playing", () => Player.LocalUserPlaying.Value);
             AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
+            AddAssert("player is not playing", () => !Player.LocalUserPlaying.Value);
             AddUntilStep("wait for multiple judgements", () => ((FailPlayer)Player).ScoreProcessor.JudgedHits > 1);
             AddAssert("total number of results == 1", () =>
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -85,7 +85,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
             pauseAndConfirm();
+            AddAssert("player not playing", () => !Player.LocalUserPlaying.Value);
+
             resumeAndConfirm();
+            AddUntilStep("player playing", () => Player.LocalUserPlaying.Value);
         }
 
         [Test]

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Play
         private readonly FillFlowContainer bottomRightElements;
         private readonly FillFlowContainer topRightElements;
 
-        internal readonly IBindable<bool> IsBreakTime = new Bindable<bool>();
+        internal readonly IBindable<bool> IsPlaying = new Bindable<bool>();
 
         private bool holdingForHUD;
 
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Play
 
             ShowHud.BindValueChanged(visible => hideTargets.ForEach(d => d.FadeTo(visible.NewValue ? 1 : 0, FADE_DURATION, FADE_EASING)));
 
-            IsBreakTime.BindValueChanged(_ => updateVisibility());
+            IsPlaying.BindValueChanged(_ => updateVisibility());
             configVisibilityMode.BindValueChanged(_ => updateVisibility(), true);
 
             replayLoaded.BindValueChanged(replayLoadedValueChanged, true);
@@ -218,7 +218,7 @@ namespace osu.Game.Screens.Play
 
                 case HUDVisibilityMode.HideDuringGameplay:
                     // always show during replay as we want the seek bar to be visible.
-                    ShowHud.Value = replayLoaded.Value || IsBreakTime.Value;
+                    ShowHud.Value = replayLoaded.Value || !IsPlaying.Value;
                     break;
 
                 case HUDVisibilityMode.Always:

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -457,7 +457,7 @@ namespace osu.Game.Screens.Play
 
         private void updateGameplayState()
         {
-            bool inGameplay = !DrawableRuleset.HasReplayLoaded.Value && !DrawableRuleset.IsPaused.Value && !breakTracker.IsBreakTime.Value;
+            bool inGameplay = !DrawableRuleset.HasReplayLoaded.Value && !DrawableRuleset.IsPaused.Value && !breakTracker.IsBreakTime.Value && !GameplayState.HasFailed;
             OverlayActivationMode.Value = inGameplay ? OverlayActivation.Disabled : OverlayActivation.UserTriggered;
             localUserPlaying.Value = inGameplay;
         }
@@ -812,6 +812,8 @@ namespace osu.Game.Screens.Play
             GameplayState.HasFailed = true;
             Score.ScoreInfo.Passed = false;
 
+            updateGameplayState();
+
             // There is a chance that we could be in a paused state as the ruleset's internal clock (see FrameStabilityContainer)
             // could process an extra frame after the GameplayClock is stopped.
             // In such cases we want the fail state to precede a user triggered pause.
@@ -945,7 +947,7 @@ namespace osu.Game.Screens.Play
                 failAnimationLayer.Background = b;
             });
 
-            HUDOverlay.IsBreakTime.BindTo(breakTracker.IsBreakTime);
+            HUDOverlay.IsPlaying.BindTo(localUserPlaying);
             DimmableStoryboard.IsBreakTime.BindTo(breakTracker.IsBreakTime);
 
             DimmableStoryboard.StoryboardReplacesBackground.BindTo(storyboardReplacesBackground);


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/discussions/17975. Feels pretty good to me, and probably how it should have been implemented from the start.

https://user-images.githubusercontent.com/191335/165212538-f4e21f9a-4f44-4862-8212-47e3713f3ed8.mp4


