### PR TITLE
Improve displayed text on first run setup back/next buttons

### DIFF
--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Localisation
         public static LocalisableString Back => new TranslatableString(getKey(@"back"), @"Back");
 
         /// <summary>
+        /// "Next"
+        /// </summary>
+        public static LocalisableString Next => new TranslatableString(getKey(@"next"), @"Next");
+
+        /// <summary>
         /// "Finish"
         /// </summary>
         public static LocalisableString Finish => new TranslatableString(getKey(@"finish"), @"Finish");

--- a/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
+++ b/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
@@ -48,11 +48,6 @@ osu! is a very configurable game, and diving straight into the settings can some
         /// </summary>
         public static LocalisableString UIScaleDescription => new TranslatableString(getKey(@"ui_scale_description"), @"The size of the osu! user interface can be adjusted to your liking.");
 
-        /// <summary>
-        /// "Next ({0})"
-        /// </summary>
-        public static LocalisableString Next(LocalisableString nextStepDescription) => new TranslatableString(getKey(@"next"), @"Next ({0})", nextStepDescription);
-
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -304,12 +304,15 @@ namespace osu.Game.Overlays
             BackButton.Enabled.Value = currentStepIndex > 0;
             NextButton.Enabled.Value = currentStepIndex != null;
 
-            if (currentStepIndex != null)
-            {
-                NextButton.Text = currentStepIndex + 1 < steps.Length
-                    ? FirstRunSetupOverlayStrings.Next(steps[currentStepIndex.Value + 1].Description)
-                    : CommonStrings.Finish;
-            }
+            if (currentStepIndex == null)
+                return;
+
+            if (currentStepIndex == 0)
+                NextButton.Text = FirstRunSetupOverlayStrings.GetStarted;
+            else if (currentStepIndex < steps.Length - 1)
+                NextButton.Text = FirstRunSetupOverlayStrings.Next(steps[currentStepIndex.Value + 1].Description);
+            else
+                NextButton.Text = CommonStrings.Finish;
         }
 
         private class FirstRunStep

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays
                     {
                         BackButton = new DangerousTriangleButton
                         {
-                            Width = 200,
+                            Width = 300,
                             Text = CommonStrings.Back,
                             Action = showPreviousStep,
                             Enabled = { Value = false },
@@ -307,12 +307,22 @@ namespace osu.Game.Overlays
             if (currentStepIndex == null)
                 return;
 
-            if (currentStepIndex == 0)
+            bool isFirstStep = currentStepIndex == 0;
+            bool isLastStep = currentStepIndex == steps.Length - 1;
+
+            if (isFirstStep)
+            {
+                BackButton.Text = CommonStrings.Back;
                 NextButton.Text = FirstRunSetupOverlayStrings.GetStarted;
-            else if (currentStepIndex < steps.Length - 1)
-                NextButton.Text = new TranslatableString(@"_", @"{0} ({1})", CommonStrings.Next, steps[currentStepIndex.Value + 1].Description);
+            }
             else
-                NextButton.Text = CommonStrings.Finish;
+            {
+                BackButton.Text = new TranslatableString(@"_", @"{0} ({1})", CommonStrings.Back, steps[currentStepIndex.Value - 1].Description);
+
+                NextButton.Text = isLastStep
+                    ? CommonStrings.Finish
+                    : new TranslatableString(@"_", @"{0} ({1})", CommonStrings.Next, steps[currentStepIndex.Value + 1].Description);
+            }
         }
 
         private class FirstRunStep

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Overlays
             if (currentStepIndex == 0)
                 NextButton.Text = FirstRunSetupOverlayStrings.GetStarted;
             else if (currentStepIndex < steps.Length - 1)
-                NextButton.Text = FirstRunSetupOverlayStrings.Next(steps[currentStepIndex.Value + 1].Description);
+                NextButton.Text = new TranslatableString(@"_", @"{0} ({1})", CommonStrings.Next, steps[currentStepIndex.Value + 1].Description);
             else
                 NextButton.Text = CommonStrings.Finish;
         }


### PR DESCRIPTION
Also moves "next" to common strings now that I know how to interpolate it properly.