### PR TITLE
Use correct translation for "Accuracy" label in break overlay

### DIFF
--- a/osu.Game/Screens/Play/Break/BreakInfo.cs
+++ b/osu.Game/Screens/Play/Break/BreakInfo.cs
@@ -43,8 +43,7 @@ namespace osu.Game.Screens.Play.Break
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            AccuracyDisplay = new PercentageBreakInfoLine(BeatmapsetsStrings.ShowStatsAccuracy),
-
+                            AccuracyDisplay = new PercentageBreakInfoLine(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy),
                             // See https://github.com/ppy/osu/discussions/15185
                             // RankDisplay = new BreakInfoLine<int>("Rank"),
                             GradeDisplay = new BreakInfoLine<ScoreRank>("Grade"),


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/17986

The one previously used was the beatmap OD string, which has been renamed to "Accuracy". This is different from the score accuracy as noted in https://github.com/ppy/osu/discussions/17986.