### PR TITLE
Fix `HealthProcessor` fail conditions not handling multiple invocations

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSuddenDeath.cs
@@ -9,6 +9,10 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModSuddenDeath : ModSuddenDeath
     {
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModAutopilot)).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
+        {
+            typeof(OsuModAutopilot),
+            typeof(OsuModTarget),
+        }).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTarget.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTarget.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => @"Practice keeping up with the beat of the song.";
         public override double ScoreMultiplier => 1;
 
-        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles) };
+        public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSuddenDeath) };
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> Seed { get; } = new Bindable<int?>

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -161,6 +161,43 @@ namespace osu.Game.Tests.Gameplay
         }
 
         [Test]
+        public void TestFailConditions()
+        {
+            var beatmap = createBeatmap(0, 1000);
+            createProcessor(beatmap);
+
+            AddStep("setup fail conditions", () => processor.FailConditions += ((_, result) => result.Type == HitResult.Miss));
+
+            AddStep("apply perfect hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Perfect }));
+            AddAssert("not failed", () => !processor.HasFailed);
+            AddStep("apply miss hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Miss }));
+            AddAssert("failed", () => processor.HasFailed);
+        }
+
+        [Test]
+        public void TestMultipleFailConditions([Values] bool applyFirstCondition)
+        {
+            var beatmap = createBeatmap(0, 1000);
+            createProcessor(beatmap);
+
+            AddStep("setup multiple fail conditions", () =>
+            {
+                processor.FailConditions += ((_, result) => result.Type == HitResult.Miss);
+                processor.FailConditions += ((_, result) => result.Type == HitResult.Meh);
+            });
+
+            AddStep("apply perfect hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Perfect }));
+            AddAssert("not failed", () => !processor.HasFailed);
+
+            if (applyFirstCondition)
+                AddStep("apply miss hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Miss }));
+            else
+                AddStep("apply meh hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Meh }));
+
+            AddAssert("failed", () => processor.HasFailed);
+        }
+
+        [Test]
         public void TestBonusObjectsExcludedFromDrain()
         {
             var beatmap = new Beatmap

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Tests.Gameplay
             AddStep("apply perfect hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Perfect }));
             AddAssert("not failed", () => !processor.HasFailed);
 
-            AddStep($"apply {resultApplied.ToString().ToLower()} hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Miss }));
+            AddStep($"apply {resultApplied.ToString().ToLower()} hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = resultApplied }));
             AddAssert("failed", () => processor.HasFailed);
         }
 

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -174,8 +174,9 @@ namespace osu.Game.Tests.Gameplay
             AddAssert("failed", () => processor.HasFailed);
         }
 
-        [Test]
-        public void TestMultipleFailConditions([Values] bool applyFirstCondition)
+        [TestCase(HitResult.Miss)]
+        [TestCase(HitResult.Meh)]
+        public void TestMultipleFailConditions(HitResult resultApplied)
         {
             var beatmap = createBeatmap(0, 1000);
             createProcessor(beatmap);
@@ -189,11 +190,7 @@ namespace osu.Game.Tests.Gameplay
             AddStep("apply perfect hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Perfect }));
             AddAssert("not failed", () => !processor.HasFailed);
 
-            if (applyFirstCondition)
-                AddStep("apply miss hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Miss }));
-            else
-                AddStep("apply meh hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Meh }));
-
+            AddStep($"apply {resultApplied.ToString().ToLower()} hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Miss }));
             AddAssert("failed", () => processor.HasFailed);
         }
 

--- a/osu.Game/Rulesets/Scoring/HealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/HealthProcessor.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Scoring
 
             Health.Value += GetHealthIncreaseFor(result);
 
-            if (meetsFailConditions(result))
+            if (meetsAnyFailCondition(result))
             {
                 if (Failed?.Invoke() != false)
                     HasFailed = true;
@@ -70,10 +70,10 @@ namespace osu.Game.Rulesets.Scoring
         protected virtual bool DefaultFailCondition => Precision.AlmostBigger(Health.MinValue, Health.Value);
 
         /// <summary>
-        /// Whether the current state of <see cref="HealthProcessor"/> or the provided <paramref name="result"/> meets the fail conditions.
+        /// Whether the current state of <see cref="HealthProcessor"/> or the provided <paramref name="result"/> meets any fail condition.
         /// </summary>
         /// <param name="result">The judgement result.</param>
-        private bool meetsFailConditions(JudgementResult result)
+        private bool meetsAnyFailCondition(JudgementResult result)
         {
             if (DefaultFailCondition)
                 return true;

--- a/osu.Game/Rulesets/Scoring/HealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/HealthProcessor.cs
@@ -43,11 +43,11 @@ namespace osu.Game.Rulesets.Scoring
 
             Health.Value += GetHealthIncreaseFor(result);
 
-            if (!DefaultFailCondition && FailConditions?.Invoke(this, result) != true)
-                return;
-
-            if (Failed?.Invoke() != false)
-                HasFailed = true;
+            if (meetsFailConditions(result))
+            {
+                if (Failed?.Invoke() != false)
+                    HasFailed = true;
+            }
         }
 
         protected override void RevertResultInternal(JudgementResult result)
@@ -68,6 +68,28 @@ namespace osu.Game.Rulesets.Scoring
         /// The default conditions for failing.
         /// </summary>
         protected virtual bool DefaultFailCondition => Precision.AlmostBigger(Health.MinValue, Health.Value);
+
+        /// <summary>
+        /// Whether the current state of <see cref="HealthProcessor"/> or the provided <paramref name="result"/> meets the fail conditions.
+        /// </summary>
+        /// <param name="result">The judgement result.</param>
+        private bool meetsFailConditions(JudgementResult result)
+        {
+            if (DefaultFailCondition)
+                return true;
+
+            if (FailConditions != null)
+            {
+                foreach (var condition in FailConditions.GetInvocationList())
+                {
+                    bool conditionResult = (bool)condition.Method.Invoke(condition.Target, new object[] { this, result });
+                    if (conditionResult)
+                        return true;
+                }
+            }
+
+            return false;
+        }
 
         protected override void Reset(bool storeResults)
         {


### PR DESCRIPTION
- Closes #17987 

As described in https://github.com/ppy/osu/issues/17987#issuecomment-1110093768, currently invoking `FailConditions` which has multiple subscribers returns the result of the last one, discarding the rest.

Fortunately, multicast delegates provide [`GetInvocationsList`](https://docs.microsoft.com/en-us/dotnet/api/system.delegate.getinvocationlist?view=net-6.0#definition) which allows for iterating through every subscriber and invoking it separately.