### PR TITLE
Fix mod panels not ignoring super key presses

### DIFF
--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -441,7 +441,7 @@ namespace osu.Game.Overlays.Mods
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (e.ControlPressed || e.AltPressed) return false;
+            if (e.ControlPressed || e.AltPressed || e.SuperPressed) return false;
             if (toggleKeys == null) return false;
 
             int index = Array.IndexOf(toggleKeys, e.Key);


### PR DESCRIPTION
Most other usages have this included. Noticed that the panel was changing state when exiting the game using cmd-w.

Would probably be nice to have an exposed `HasAnyModifierPressed` helper property.