### PR TITLE
Update framework

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.422.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.423.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.428.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Extensions/TimeDisplayExtensions.cs
+++ b/osu.Game/Extensions/TimeDisplayExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Humanizer;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -42,12 +43,12 @@ namespace osu.Game.Extensions
         public static LocalisableString ToFormattedDuration(this TimeSpan timeSpan)
         {
             if (timeSpan.TotalDays >= 1)
-                return new LocalisableFormattableString(timeSpan, @"dd\:hh\:mm\:ss");
+                return timeSpan.ToLocalisableString(@"dd\:hh\:mm\:ss");
 
             if (timeSpan.TotalHours >= 1)
-                return new LocalisableFormattableString(timeSpan, @"hh\:mm\:ss");
+                return timeSpan.ToLocalisableString(@"hh\:mm\:ss");
 
-            return new LocalisableFormattableString(timeSpan, @"mm\:ss");
+            return timeSpan.ToLocalisableString(@"mm\:ss");
         }
 
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -131,22 +130,7 @@ namespace osu.Game.Graphics.UserInterface
                 BackgroundColourSelected = SelectionColour
             };
 
-            protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new DropdownScrollContainer(direction);
-
-            // Hotfix for https://github.com/ppy/osu/issues/17961
-            public class DropdownScrollContainer : OsuScrollContainer
-            {
-                public DropdownScrollContainer(Direction direction)
-                    : base(direction)
-                {
-                }
-
-                protected override bool OnMouseDown(MouseDownEvent e)
-                {
-                    base.OnMouseDown(e);
-                    return true;
-                }
-            }
+            protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new OsuScrollContainer(direction);
 
             #region DrawableOsuDropdownMenuItem
 

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -9,7 +9,6 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osuTK;
 
@@ -82,22 +81,7 @@ namespace osu.Game.Graphics.UserInterface
             return new DrawableOsuMenuItem(item);
         }
 
-        protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new OsuMenuScrollContainer(direction);
-
-        // Hotfix for https://github.com/ppy/osu/issues/17961
-        public class OsuMenuScrollContainer : OsuScrollContainer
-        {
-            public OsuMenuScrollContainer(Direction direction)
-                : base(direction)
-            {
-            }
-
-            protected override bool OnMouseDown(MouseDownEvent e)
-            {
-                base.OnMouseDown(e);
-                return true;
-            }
-        }
+        protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new OsuScrollContainer(direction);
 
         protected override Menu CreateSubMenu() => new OsuMenu(Direction.Vertical)
         {

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 maxComboColumn.Text = value.MaxCombo.ToLocalisableString(@"0\x");
 
                 ppColumn.Alpha = value.BeatmapInfo.Status.GrantsPerformancePoints() ? 1 : 0;
-                ppColumn.Text = value.PP?.ToLocalisableString(@"N0");
+                ppColumn.Text = value.PP?.ToLocalisableString(@"N0") ?? default(LocalisableString);
 
                 statisticsColumns.ChildrenEnumerable = value.GetStatisticsForDisplay().Select(createStatisticsColumn);
                 modsColumn.Mods = value.Mods;

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -317,11 +317,11 @@ namespace osu.Game.Overlays
             }
             else
             {
-                BackButton.Text = new TranslatableString(@"_", @"{0} ({1})", CommonStrings.Back, steps[currentStepIndex.Value - 1].Description);
+                BackButton.Text = LocalisableString.Interpolate($@"{CommonStrings.Back} ({steps[currentStepIndex.Value - 1].Description})");
 
                 NextButton.Text = isLastStep
                     ? CommonStrings.Finish
-                    : new TranslatableString(@"_", @"{0} ({1})", CommonStrings.Next, steps[currentStepIndex.Value + 1].Description);
+                    : LocalisableString.Interpolate($@"{CommonStrings.Next} ({steps[currentStepIndex.Value + 1].Description})");
             }
         }
 

--- a/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private void updateProgress(APIUser user)
         {
             levelProgressBar.Length = user?.Statistics?.Level.Progress / 100f ?? 0;
-            levelProgressText.Text = user?.Statistics?.Level.Progress.ToLocalisableString("0'%'");
+            levelProgressText.Text = user?.Statistics?.Level.Progress.ToLocalisableString("0'%'") ?? default(LocalisableString);
         }
     }
 }

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Overlays.Rankings
             startDateColumn.Value = dateToString(response.Spotlight.StartDate);
             endDateColumn.Value = dateToString(response.Spotlight.EndDate);
             mapCountColumn.Value = response.BeatmapSets.Count.ToLocalisableString(@"N0");
-            participantsColumn.Value = response.Spotlight.Participants?.ToLocalisableString(@"N0");
+            participantsColumn.Value = response.Spotlight.Participants?.ToLocalisableString(@"N0") ?? default(LocalisableString);
         }
 
         private LocalisableString dateToString(DateTimeOffset date) => date.ToLocalisableString(@"yyyy-MM-dd");

--- a/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/PerformanceTable.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 
@@ -24,7 +25,7 @@ namespace osu.Game.Overlays.Rankings.Tables
 
         protected override Drawable[] CreateUniqueContent(UserStatistics item) => new Drawable[]
         {
-            new RowText { Text = item.PP?.ToLocalisableString(@"N0"), }
+            new RowText { Text = item.PP?.ToLocalisableString(@"N0") ?? default(LocalisableString), }
         };
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -99,8 +99,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
             {
                 public override LocalisableString TooltipText =>
                     Current.Value == 0
-                        ? new TranslatableString("_", @"{0} ms", base.TooltipText)
-                        : new TranslatableString("_", @"{0} ms {1}", base.TooltipText, getEarlyLateText(Current.Value));
+                        ? LocalisableString.Interpolate($@"{base.TooltipText} ms")
+                        : LocalisableString.Interpolate($@"{base.TooltipText} ms {getEarlyLateText(Current.Value)}");
 
                 private LocalisableString getEarlyLateText(double value)
                 {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.10.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.423.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.428.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.422.0" />
     <PackageReference Include="Sentry" Version="3.14.1" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.423.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.428.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.422.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.423.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.428.0" />
     <PackageReference Include="SharpCompress" Version="0.30.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
This also comes with a change to some of the `GetLocalisableString` use cases, as previously such use cases have been returning `null` values just fine due to `GetLocalisableString` returning `LocalisableFormattableString` (which is a class/reference type), and that `null` value was being wrapped in a `LocalisableString` implicitly, therefore not requiring a fallback string.

Now replaced to fall back to `default(LocalisableString)` instead.