### PR TITLE
Fix some missing/incorrect UI SFX

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SwitchButton.cs
@@ -4,6 +4,8 @@
 #nullable enable
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -30,6 +32,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private Color4 enabledColour;
         private Color4 disabledColour;
+
+        private Sample? sampleChecked;
+        private Sample? sampleUnchecked;
 
         public SwitchButton()
         {
@@ -70,13 +75,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OverlayColourProvider? colourProvider, OsuColour colours)
+        private void load(OverlayColourProvider? colourProvider, OsuColour colours, AudioManager audio)
         {
             enabledColour = colourProvider?.Highlight1 ?? colours.BlueDark;
             disabledColour = colourProvider?.Background3 ?? colours.Gray3;
 
             switchContainer.Colour = enabledColour;
             fill.Colour = disabledColour;
+
+            sampleChecked = audio.Samples.Get(@"UI/check-on");
+            sampleUnchecked = audio.Samples.Get(@"UI/check-off");
         }
 
         protected override void LoadComplete()
@@ -105,6 +113,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             updateBorder();
             base.OnHoverLost(e);
+        }
+
+        protected override void OnUserChange(bool value)
+        {
+            base.OnUserChange(value);
+
+            if (value)
+                sampleChecked?.Play();
+            else
+                sampleUnchecked?.Play();
         }
 
         private void updateBorder()

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingCardSizeTabControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingCardSizeTabControl.cs
@@ -72,7 +72,8 @@ namespace osu.Game.Overlays.BeatmapListing
                             Size = new Vector2(12),
                             Icon = getIconForCardSize(Value)
                         }
-                    }
+                    },
+                    new HoverClickSounds(HoverSampleSet.TabSelect)
                 };
             }
 

--- a/osu.Game/Overlays/OverlaySortTabControl.cs
+++ b/osu.Game/Overlays/OverlaySortTabControl.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Overlays
                     }
                 });
 
-                AddInternal(new HoverClickSounds());
+                AddInternal(new HoverClickSounds(HoverSampleSet.TabSelect));
             }
 
             protected override void LoadComplete()


### PR DESCRIPTION
Adds SFX for the `SwitchButton` checkbox (that doesn't derive from `OsuCheckbox` for whatever reason) and fixes incorrect/missing sample being played for some `TabControl`s