### PR TITLE
Remove placeholder UI pieces to avoid user confusion

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -31,7 +31,9 @@ namespace osu.Game.Overlays.Profile
             User.ValueChanged += e => updateDisplay(e.NewValue);
 
             TabControl.AddItem(LayoutStrings.HeaderUsersShow);
-            TabControl.AddItem(LayoutStrings.HeaderUsersModding);
+
+            // todo: pending implementation.
+            // TabControl.AddItem(LayoutStrings.HeaderUsersModding);
 
             centreHeaderContainer.DetailsVisible.BindValueChanged(visible => detailHeaderContainer.Expanded = visible.NewValue, true);
         }

--- a/osu.Game/Screens/Select/Filter/SortMode.cs
+++ b/osu.Game/Screens/Select/Filter/SortMode.cs
@@ -27,8 +27,9 @@ namespace osu.Game.Screens.Select.Filter
         [LocalisableDescription(typeof(SortStrings), nameof(SortStrings.ArtistTracksLength))]
         Length,
 
-        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchFiltersRank))]
-        RankAchieved,
+        // todo: pending support (https://github.com/ppy/osu/issues/4917)
+        // [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchFiltersRank))]
+        // RankAchieved,
 
         [LocalisableDescription(typeof(BeatmapsetsStrings), nameof(BeatmapsetsStrings.ShowInfoSource))]
         Source,


### PR DESCRIPTION
Since a user recently reported in https://github.com/ppy/osu/issues/18015 that the rank achieved sorting mode was "not working" while it was a placeholder, it's better to just remove them from the game for the time being.

I've navigated through and I haven't seen anything other than:
 - "Rank Achieved" sorting mode, which is not supported yet and tracked under https://github.com/ppy/osu/issues/4917
 - "Modding" tab in user profile, which is not implemented yet.