### PR TITLE
Update overlay ruleset selector inline with osu-web design

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneProfileRulesetSelector.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneProfileRulesetSelector.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual.Online
     public class TestSceneProfileRulesetSelector : OsuTestScene
     {
         [Cached]
-        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
 
         public TestSceneProfileRulesetSelector()
         {
@@ -37,9 +37,9 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("set mania as default", () => selector.SetDefaultRuleset(new ManiaRuleset().RulesetInfo));
 
             AddStep("User with osu as default", () => user.Value = new APIUser { Id = 0, PlayMode = "osu" });
-            AddStep("User with taiko as default", () => user.Value = new APIUser { Id = 2, PlayMode = "taiko" });
-            AddStep("User with catch as default", () => user.Value = new APIUser { Id = 3, PlayMode = "fruits" });
-            AddStep("User with mania as default", () => user.Value = new APIUser { Id = 1, PlayMode = "mania" });
+            AddStep("User with taiko as default", () => user.Value = new APIUser { Id = 1, PlayMode = "taiko" });
+            AddStep("User with catch as default", () => user.Value = new APIUser { Id = 2, PlayMode = "fruits" });
+            AddStep("User with mania as default", () => user.Value = new APIUser { Id = 3, PlayMode = "mania" });
             AddStep("null user", () => user.Value = null);
         }
     }

--- a/osu.Game.Tests/Visual/Online/TestSceneProfileRulesetSelector.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneProfileRulesetSelector.cs
@@ -32,14 +32,14 @@ namespace osu.Game.Tests.Visual.Online
             };
 
             AddStep("set osu! as default", () => selector.SetDefaultRuleset(new OsuRuleset().RulesetInfo));
-            AddStep("set mania as default", () => selector.SetDefaultRuleset(new ManiaRuleset().RulesetInfo));
             AddStep("set taiko as default", () => selector.SetDefaultRuleset(new TaikoRuleset().RulesetInfo));
             AddStep("set catch as default", () => selector.SetDefaultRuleset(new CatchRuleset().RulesetInfo));
+            AddStep("set mania as default", () => selector.SetDefaultRuleset(new ManiaRuleset().RulesetInfo));
 
-            AddStep("User with osu as default", () => user.Value = new APIUser { PlayMode = "osu" });
-            AddStep("User with mania as default", () => user.Value = new APIUser { PlayMode = "mania" });
-            AddStep("User with taiko as default", () => user.Value = new APIUser { PlayMode = "taiko" });
-            AddStep("User with catch as default", () => user.Value = new APIUser { PlayMode = "fruits" });
+            AddStep("User with osu as default", () => user.Value = new APIUser { Id = 0, PlayMode = "osu" });
+            AddStep("User with taiko as default", () => user.Value = new APIUser { Id = 2, PlayMode = "taiko" });
+            AddStep("User with catch as default", () => user.Value = new APIUser { Id = 3, PlayMode = "fruits" });
+            AddStep("User with mania as default", () => user.Value = new APIUser { Id = 1, PlayMode = "mania" });
             AddStep("null user", () => user.Value = null);
         }
     }

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -5,14 +5,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using osuTK.Graphics;
 using osuTK;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays
 {
@@ -26,7 +24,7 @@ namespace osu.Game.Overlays
             set
             {
                 accentColour = value;
-                text.FadeColour(value, 120, Easing.OutQuint);
+                icon.FadeColour(value, 120, Easing.OutQuint);
             }
         }
 
@@ -35,7 +33,7 @@ namespace osu.Game.Overlays
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; }
 
-        private readonly OsuSpriteText text;
+        private readonly Drawable icon;
 
         public OverlayRulesetTabItem(RulesetInfo value)
             : base(value)
@@ -48,15 +46,14 @@ namespace osu.Game.Overlays
                 {
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
-                    Spacing = new Vector2(3, 0),
-                    Child = text = new OsuSpriteText
+                    Spacing = new Vector2(5f, 0),
+                    Child = icon = new ConstrainedIconContainer
                     {
-                        Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
-                        Text = value.Name,
-                        Font = OsuFont.GetFont(size: 14),
-                        ShadowColour = Color4.Black.Opacity(0.75f)
-                    }
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(20f),
+                        Icon = value.CreateInstance().CreateIcon(),
+                    },
                 },
                 new HoverClickSounds()
             });
@@ -91,7 +88,6 @@ namespace osu.Game.Overlays
 
         private void updateState()
         {
-            text.Font = text.Font.With(weight: Active.Value ? FontWeight.Bold : FontWeight.Medium);
             AccentColour = Enabled.Value ? getActiveColour() : colourProvider.Foreground1;
         }
 

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Overlays
             Enabled.BindValueChanged(_ => updateState(), true);
         }
 
-        public override bool PropagatePositionalInputSubTree => Enabled.Value && !Active.Value && base.PropagatePositionalInputSubTree;
+        public override bool PropagatePositionalInputSubTree => Enabled.Value && base.PropagatePositionalInputSubTree;
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays
                 {
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
-                    Spacing = new Vector2(5f, 0),
+                    Spacing = new Vector2(4f, 0),
                     Child = icon = new ConstrainedIconContainer
                     {
                         Anchor = Anchor.Centre,

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays
                 {
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
-                    Spacing = new Vector2(4f, 0),
+                    Spacing = new Vector2(4, 0),
                     Child = icon = new ConstrainedIconContainer
                     {
                         Anchor = Anchor.Centre,

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -10,11 +10,13 @@ using osu.Game.Rulesets;
 using osuTK.Graphics;
 using osuTK;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays
 {
-    public class OverlayRulesetTabItem : TabItem<RulesetInfo>
+    public class OverlayRulesetTabItem : TabItem<RulesetInfo>, IHasTooltip
     {
         private Color4 accentColour;
 
@@ -34,6 +36,8 @@ namespace osu.Game.Overlays
         private OverlayColourProvider colourProvider { get; set; }
 
         private readonly Drawable icon;
+
+        public LocalisableString TooltipText => Value.Name;
 
         public OverlayRulesetTabItem(RulesetInfo value)
             : base(value)

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetTabItem.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetTabItem.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
                 isDefault = value;
 
-                icon.FadeTo(isDefault ? 1 : 0, 200, Easing.OutQuint);
+                icon.Alpha = isDefault ? 1 : 0;
             }
         }
 
@@ -47,7 +47,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
                 Alpha = 0,
-                AlwaysPresent = true,
                 Icon = FontAwesome.Solid.Star,
                 Size = new Vector2(12),
             });

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetTabItem.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetTabItem.cs
@@ -2,7 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
@@ -42,14 +45,20 @@ namespace osu.Game.Overlays.Profile.Header.Components
         public ProfileRulesetTabItem(RulesetInfo value)
             : base(value)
         {
-            Add(icon = new SpriteIcon
+            Add(icon = new DefaultRulesetIcon { Alpha = 0 });
+        }
+
+        public class DefaultRulesetIcon : SpriteIcon, IHasTooltip
+        {
+            public LocalisableString TooltipText => UsersStrings.ShowEditDefaultPlaymodeIsDefaultTooltip;
+
+            public DefaultRulesetIcon()
             {
-                Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-                Alpha = 0,
-                Icon = FontAwesome.Solid.Star,
-                Size = new Vector2(12),
-            });
+                Origin = Anchor.Centre;
+                Anchor = Anchor.Centre;
+                Icon = FontAwesome.Solid.Star;
+                Size = new Vector2(12);
+            }
         }
     }
 }


### PR DESCRIPTION
The `BeatmapRulesetSelector` will still be in handy on my beatmap info overlay refactor, and since osu-web has gone with updating the design at their side, figured we may as well.

`TestSceneBeatmapRulesetSelector`:

https://user-images.githubusercontent.com/22781491/165919600-523619d6-37d2-47e9-9e78-2feb4775b792.mp4

`TestSceneProfileRulesetSelector`:

https://user-images.githubusercontent.com/22781491/165919651-9ce989e2-36de-4be2-881b-6f056cf1627a.mp4

`TestSceneBeatmapSetOverlay` & `TestSceneRankingsOverlay` (to show integration):

https://user-images.githubusercontent.com/22781491/165919606-f39d9712-0adb-437e-9d0d-0ddb0ac12b40.mp4

![CleanShot 2022-04-29 at 12 37 12@2x](https://user-images.githubusercontent.com/22781491/165920558-cc058f48-aedb-4e69-954a-21b99c437d01.png)

To clarify on the numbers:
 - The 20px ruleset tab icon size was taken from figma and confirmed with web (used raw, applying 1.4x adjustment makes it look too small relative to the overlays)
 - The 4px spacing between the ruleset icon and the "beatmaps counter" / "default mode star" was taken from web.
 - The spacing between ruleset tabs was left unchanged to match web, but figma has it reduced to 10px instead. I'm presuming web is final on such values, and 10px spacing looks kinda silly when viewed in the game.