### PR TITLE
Fix markdown header links displaying smaller than expected

### DIFF
--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownHeading.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownHeading.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Markdig.Syntax;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Sprites;
@@ -64,6 +65,7 @@ namespace osu.Game.Graphics.Containers.Markdown
             }
         }
 
+        [Cached(typeof(IMarkdownTextComponent))]
         private class HeadingTextFlowContainer : OsuMarkdownTextFlowContainer
         {
             public float FontSize;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/18039.