### PR TITLE
Fix footer random button autosizing to text length

### DIFF
--- a/osu.Game/Screens/Select/FooterButtonRandom.cs
+++ b/osu.Game/Screens/Select/FooterButtonRandom.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -19,6 +20,9 @@ namespace osu.Game.Screens.Select
         public Action NextRandom { get; set; }
         public Action PreviousRandom { get; set; }
 
+        private Container persistentText;
+        private OsuSpriteText randomSpriteText;
+        private OsuSpriteText rewindSpriteText;
         private bool rewindSearch;
 
         [BackgroundDependencyLoader]
@@ -26,7 +30,32 @@ namespace osu.Game.Screens.Select
         {
             SelectedColour = colours.Green;
             DeselectedColour = SelectedColour.Opacity(0.5f);
-            updateText();
+
+            TextContainer.Add(persistentText = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AlwaysPresent = true,
+                AutoSizeAxes = Axes.Both,
+                Children = new[]
+                {
+                    randomSpriteText = new OsuSpriteText
+                    {
+                        AlwaysPresent = true,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Text = "random",
+                    },
+                    rewindSpriteText = new OsuSpriteText
+                    {
+                        AlwaysPresent = true,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Text = "rewind",
+                        Alpha = 0f,
+                    }
+                }
+            });
 
             Action = () =>
             {
@@ -34,22 +63,22 @@ namespace osu.Game.Screens.Select
                 {
                     const double fade_time = 500;
 
-                    OsuSpriteText rewindSpriteText;
+                    OsuSpriteText fallingRewind;
 
-                    TextContainer.Add(rewindSpriteText = new OsuSpriteText
+                    TextContainer.Add(fallingRewind = new OsuSpriteText
                     {
                         Alpha = 0,
-                        Text = @"rewind",
+                        Text = rewindSpriteText.Text,
                         AlwaysPresent = true, // make sure the button is sized large enough to always show this
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                     });
 
-                    rewindSpriteText.FadeOutFromOne(fade_time, Easing.In);
-                    rewindSpriteText.MoveTo(Vector2.Zero).MoveTo(new Vector2(0, 10), fade_time, Easing.In);
-                    rewindSpriteText.Expire();
+                    fallingRewind.FadeOutFromOne(fade_time, Easing.In);
+                    fallingRewind.MoveTo(Vector2.Zero).MoveTo(new Vector2(0, 10), fade_time, Easing.In);
+                    fallingRewind.Expire();
 
-                    SpriteText.FadeInFromZero(fade_time, Easing.In);
+                    persistentText.FadeInFromZero(fade_time, Easing.In);
 
                     PreviousRandom.Invoke();
                 }
@@ -119,6 +148,10 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private void updateText(bool rewind = false) => Text = rewind ? "rewind" : "random";
+        private void updateText(bool rewind = false)
+        {
+            randomSpriteText.Alpha = rewind ? 0 : 1;
+            rewindSpriteText.Alpha = rewind ? 1 : 0;
+        }
     }
 }


### PR DESCRIPTION
- Closes #18040 

Was happening due to the text update logic actually updating the text directly, which is what the button depends on for its size.

Changed to separate sprite texts for "random" and "rewind", to let the button autosize to the largest size. This also allows for adding animation when transitioning between the two, but I can't find a good one to add in this PR (open for suggestions).

https://user-images.githubusercontent.com/22781491/166234703-c20e3bd1-70c8-4d4a-aa41-324070a63c47.mp4

Not 100% sure on the excessive use of `AlwaysPresent`, but can't really see any other option.