### PR TITLE
Split `SearchTextBox` implementation for reusability 

### DIFF
--- a/osu.Game/Graphics/UserInterface/BasicSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/BasicSearchTextBox.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class BasicSearchTextBox : SearchTextBox
+    {
+        public BasicSearchTextBox()
+        {
+            Add(new SpriteIcon
+            {
+                Icon = FontAwesome.Solid.Search,
+                Origin = Anchor.CentreRight,
+                Anchor = Anchor.CentreRight,
+                Margin = new MarginPadding { Right = 10 },
+                Size = new Vector2(20),
+            });
+
+            TextFlow.Padding = new MarginPadding { Right = 35 };
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/SearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/SearchTextBox.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Resources.Localisation.Web;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
@@ -18,16 +15,6 @@ namespace osu.Game.Graphics.UserInterface
         public SearchTextBox()
         {
             Height = 35;
-            Add(new SpriteIcon
-            {
-                Icon = FontAwesome.Solid.Search,
-                Origin = Anchor.CentreRight,
-                Anchor = Anchor.CentreRight,
-                Margin = new MarginPadding { Right = 10 },
-                Size = new Vector2(20),
-            });
-
-            TextFlow.Padding = new MarginPadding { Right = 35 };
             PlaceholderText = HomeStrings.SearchPlaceholder;
         }
 

--- a/osu.Game/Graphics/UserInterface/SeekLimitedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/SeekLimitedSearchTextBox.cs
@@ -6,7 +6,7 @@ namespace osu.Game.Graphics.UserInterface
     /// <summary>
     /// A <see cref="SearchTextBox"/> which does not handle left/right arrow keys for seeking.
     /// </summary>
-    public class SeekLimitedSearchTextBox : SearchTextBox
+    public class SeekLimitedSearchTextBox : BasicSearchTextBox
     {
         public override bool HandleLeftRightArrows => false;
     }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public void TakeFocus() => textBox.TakeFocus();
 
-        private class BeatmapSearchTextBox : SearchTextBox
+        private class BeatmapSearchTextBox : BasicSearchTextBox
         {
             /// <summary>
             /// Any time the text box receives key events (even while masked).

--- a/osu.Game/Overlays/Chat/Selection/ChannelSelectionOverlay.cs
+++ b/osu.Game/Overlays/Chat/Selection/ChannelSelectionOverlay.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Overlays.Chat.Selection
             base.PopOut();
         }
 
-        private class HeaderSearchTextBox : SearchTextBox
+        private class HeaderSearchTextBox : BasicSearchTextBox
         {
             [BackgroundDependencyLoader]
             private void load()

--- a/osu.Game/Overlays/Music/FilterControl.cs
+++ b/osu.Game/Overlays/Music/FilterControl.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Music
             Collection = collectionDropdown.Current.Value?.Collection
         };
 
-        public class FilterTextBox : SearchTextBox
+        public class FilterTextBox : BasicSearchTextBox
         {
             protected override bool AllowCommit => true;
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = Header.HEIGHT,
-                            Child = searchTextBox = new SearchTextBox
+                            Child = searchTextBox = new BasicSearchTextBox
                             {
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,


### PR DESCRIPTION
as mentioned in https://github.com/ppy/osu/pull/17915#discussion_r855520259

split current `SearchTextBox` into 2 classes: `SearchTextBox` that handles search textbox behaviors and `BasicSearchTextBox` that contain current design-related implementation (decided to keep default height and placeholder text just for aesthetic purpose for visual tests that loosely depends on `SearchTextBox` like `TestSceneDrawableLoungeRoom`). I am bad at naming things so I copy the osu-framework naming convention for component-basic component implementation naming. No new tests are added since there's no new or changed behavior and it shouldn't break any test cases.


also seems like the current search textbox design was nowhere to be found in the latest design afaik so `BasicSearchTextBox` may be removed in the future. 