### PR TITLE
Reduce sorting worst-case time complexity in difficulty calculation

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -38,7 +38,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double difficulty = 0;
             double weight = 1;
 
-            List<double> strains = GetCurrentStrainPeaks().OrderByDescending(d => d).ToList();
+            // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+            // These sections will not contribute to the difficulty.
+            var peaks = GetCurrentStrainPeaks().Where(p => p > 0);
+
+            List<double> strains = peaks.OrderByDescending(d => d).ToList();
 
             // We are reducing the highest strains first to account for extreme difficulty spikes
             for (int i = 0; i < Math.Min(strains.Count, ReducedSectionCount); i++)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -141,7 +141,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 double colourPeak = colourPeaks[i] * colour_skill_multiplier;
                 double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier;
                 double staminaPeak = (staminaRightPeaks[i] + staminaLeftPeaks[i]) * stamina_skill_multiplier * staminaPenalty;
-                peaks.Add(norm(2, colourPeak, rhythmPeak, staminaPeak));
+
+                double peak = norm(2, colourPeak, rhythmPeak, staminaPeak);
+
+                // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+                // These sections will not contribute to the difficulty.
+                if (peak > 0)
+                    peaks.Add(peak);
             }
 
             double difficulty = 0;

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -65,6 +65,10 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         private void saveCurrentPeak()
         {
+            // Ignore sections with 0 strain to avoid edge cases of long maps with a lot of spacing between objects (e.g. /b/2351871).
+            if (currentSectionPeak == 0)
+                return;
+
             strainPeaks.Add(currentSectionPeak);
         }
 

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -65,10 +65,6 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         private void saveCurrentPeak()
         {
-            // Ignore sections with 0 strain to avoid edge cases of long maps with a lot of spacing between objects (e.g. /b/2351871).
-            if (currentSectionPeak == 0)
-                return;
-
             strainPeaks.Add(currentSectionPeak);
         }
 
@@ -104,9 +100,13 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             double difficulty = 0;
             double weight = 1;
 
+            // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+            // These sections will not contribute to the difficulty.
+            var peaks = GetCurrentStrainPeaks().Where(p => p > 0);
+
             // Difficulty is the weighted sum of the highest strains from every section.
             // We're sorting from highest to lowest strain.
-            foreach (double strain in GetCurrentStrainPeaks().OrderByDescending(d => d))
+            foreach (double strain in peaks.OrderByDescending(d => d))
             {
                 difficulty += strain * weight;
                 weight *= DecayWeight;


### PR DESCRIPTION
I noticed an edge case in beatmaps from the set https://osu.ppy.sh/beatmapsets/1124068 where there's lots of spacing between hitobjects leading to many sections of 0 strain. These culminate in what looks like the worst-case O(n^2) time complexity of the quicksort algorithm used in `OrderByDescending`.

https://github.com/ppy/osu/blob/04fb0f5e63d6dffbd2f3eba239b65ab6b698763d/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs#L36-L59

0 strain is an edge case which we can simply discard, as `OrderByDescending()` will always put these at the end of the list and will not contribute to any calculations from there on.

The following profiles should be self explanatory, taken over the entire runtime duration of `/b/2351871`:

Before:
![](https://user-images.githubusercontent.com/1329837/166410895-94c99346-bebd-4151-ba8f-b6dc54baa9d7.png)

After:
![](https://user-images.githubusercontent.com/1329837/166410931-f35ca2fb-568e-4c72-bee3-2849aafccb8e.png)

We may want to backport this change to release-diffcalc, unsure yet. Blocking while I run an SR test across all ranked beatmaps to confirm my intuitions are correct.