### PR TITLE
Add keybind for handling distance spacing scrolls in editor

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.EditorFlipHorizontally),
             new KeyBinding(new[] { InputKey.Control, InputKey.J }, GlobalAction.EditorFlipVertically),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt }, GlobalAction.EditorDistanceSpacing),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -301,5 +302,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorFlipVertically))]
         EditorFlipVertically,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDistanceSpacing))]
+        EditorDistanceSpacing,
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -79,7 +79,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.EditorFlipHorizontally),
             new KeyBinding(new[] { InputKey.Control, InputKey.J }, GlobalAction.EditorFlipVertically),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Alt }, GlobalAction.EditorDistanceSpacing),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelDown }, GlobalAction.EditorDecreaseDistanceSpacing),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelUp }, GlobalAction.EditorIncreaseDistanceSpacing),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -303,7 +304,10 @@ namespace osu.Game.Input.Bindings
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorFlipVertically))]
         EditorFlipVertically,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDistanceSpacing))]
-        EditorDistanceSpacing,
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorIncreaseDistanceSpacing))]
+        EditorIncreaseDistanceSpacing,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDecreaseDistanceSpacing))]
+        EditorDecreaseDistanceSpacing,
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -240,6 +240,11 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorFlipVertically => new TranslatableString(getKey(@"editor_flip_vertically"), @"Flip selection vertically");
 
         /// <summary>
+        /// "Distance grid spacing (hold)"
+        /// </summary>
+        public static LocalisableString EditorDistanceSpacing => new TranslatableString(getKey(@"editor_distance_spacing"), @"Distance grid spacing (hold)");
+
+        /// <summary>
         /// "Toggle skin editor"
         /// </summary>
         public static LocalisableString ToggleSkinEditor => new TranslatableString(getKey(@"toggle_skin_editor"), @"Toggle skin editor");

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -240,9 +240,14 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorFlipVertically => new TranslatableString(getKey(@"editor_flip_vertically"), @"Flip selection vertically");
 
         /// <summary>
-        /// "Distance grid spacing (hold)"
+        /// "Increase distance grid spacing"
         /// </summary>
-        public static LocalisableString EditorDistanceSpacing => new TranslatableString(getKey(@"editor_distance_spacing"), @"Distance grid spacing (hold)");
+        public static LocalisableString EditorIncreaseDistanceSpacing => new TranslatableString(getKey(@"editor_increase_distance_spacing"), @"Increase distance grid spacing");
+
+        /// <summary>
+        /// "Decrease distance grid spacing"
+        /// </summary>
+        public static LocalisableString EditorDecreaseDistanceSpacing => new TranslatableString(getKey(@"editor_decrease_distance_spacing"), @"Decrease distance grid spacing");
 
         /// <summary>
         /// "Toggle skin editor"

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -240,14 +240,14 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorFlipVertically => new TranslatableString(getKey(@"editor_flip_vertically"), @"Flip selection vertically");
 
         /// <summary>
-        /// "Increase distance grid spacing"
+        /// "Increase distance spacing"
         /// </summary>
-        public static LocalisableString EditorIncreaseDistanceSpacing => new TranslatableString(getKey(@"editor_increase_distance_spacing"), @"Increase distance grid spacing");
+        public static LocalisableString EditorIncreaseDistanceSpacing => new TranslatableString(getKey(@"editor_increase_distance_spacing"), @"Increase distance spacing");
 
         /// <summary>
-        /// "Decrease distance grid spacing"
+        /// "Decrease distance spacing"
         /// </summary>
-        public static LocalisableString EditorDecreaseDistanceSpacing => new TranslatableString(getKey(@"editor_decrease_distance_spacing"), @"Decrease distance grid spacing");
+        public static LocalisableString EditorDecreaseDistanceSpacing => new TranslatableString(getKey(@"editor_decrease_distance_spacing"), @"Decrease distance spacing");
 
         /// <summary>
         /// "Toggle skin editor"

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Edit
             {
                 case GlobalAction.EditorIncreaseDistanceSpacing:
                 case GlobalAction.EditorDecreaseDistanceSpacing:
-                    return adjustDistanceSpacing(e.Action, e.IsPrecise ? 0.01f : 0.1f);
+                    return adjustDistanceSpacing(e.Action, e.ScrollAmount * (e.IsPrecise ? 0.01f : 0.1f));
             }
 
             return false;

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -4,9 +4,11 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Rulesets.Objects;
 using osuTK;
@@ -18,7 +20,7 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     /// <typeparam name="TObject">The base type of supported objects.</typeparam>
     [Cached(typeof(IDistanceSnapProvider))]
-    public abstract class DistancedHitObjectComposer<TObject> : HitObjectComposer<TObject>, IDistanceSnapProvider
+    public abstract class DistancedHitObjectComposer<TObject> : HitObjectComposer<TObject>, IDistanceSnapProvider, IKeyBindingHandler<GlobalAction>
         where TObject : HitObject
     {
         protected Bindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1.0)
@@ -75,21 +77,21 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
-        protected override bool OnKeyDown(KeyDownEvent e)
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (!DistanceSpacingMultiplier.Disabled && e.ControlPressed && e.AltPressed && !e.Repeat)
+            if (!DistanceSpacingMultiplier.Disabled && e.Action == GlobalAction.EditorDistanceSpacing)
             {
                 RightSideToolboxContainer.Expanded.Value = true;
                 distanceSpacingScrollActive = true;
                 return true;
             }
 
-            return base.OnKeyDown(e);
+            return false;
         }
 
-        protected override void OnKeyUp(KeyUpEvent e)
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
-            if (!DistanceSpacingMultiplier.Disabled && distanceSpacingScrollActive && (!e.AltPressed || !e.ControlPressed))
+            if (!DistanceSpacingMultiplier.Disabled && e.Action == GlobalAction.EditorDistanceSpacing)
             {
                 RightSideToolboxContainer.Expanded.Value = false;
                 distanceSpacingScrollActive = false;

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     /// <typeparam name="TObject">The base type of supported objects.</typeparam>
     [Cached(typeof(IDistanceSnapProvider))]
-    public abstract class DistancedHitObjectComposer<TObject> : HitObjectComposer<TObject>, IDistanceSnapProvider, IKeyBindingHandler<GlobalAction>
+    public abstract class DistancedHitObjectComposer<TObject> : HitObjectComposer<TObject>, IDistanceSnapProvider, IScrollBindingHandler<GlobalAction>
         where TObject : HitObject
     {
         protected Bindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1.0)
@@ -35,7 +35,6 @@ namespace osu.Game.Rulesets.Edit
         protected ExpandingToolboxContainer RightSideToolboxContainer { get; private set; }
 
         private ExpandableSlider<double, SizeSlider<double>> distanceSpacingSlider;
-        private bool distanceSpacingScrollActive;
 
         protected DistancedHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -79,11 +78,11 @@ namespace osu.Game.Rulesets.Edit
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (!DistanceSpacingMultiplier.Disabled && e.Action == GlobalAction.EditorDistanceSpacing)
+            switch (e.Action)
             {
-                RightSideToolboxContainer.Expanded.Value = true;
-                distanceSpacingScrollActive = true;
-                return true;
+                case GlobalAction.EditorIncreaseDistanceSpacing:
+                case GlobalAction.EditorDecreaseDistanceSpacing:
+                    return adjustDistanceSpacing(e.Action, 0.1f);
             }
 
             return false;
@@ -91,22 +90,31 @@ namespace osu.Game.Rulesets.Edit
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
-            if (!DistanceSpacingMultiplier.Disabled && e.Action == GlobalAction.EditorDistanceSpacing)
-            {
-                RightSideToolboxContainer.Expanded.Value = false;
-                distanceSpacingScrollActive = false;
-            }
         }
 
-        protected override bool OnScroll(ScrollEvent e)
+        public bool OnScroll(KeyBindingScrollEvent<GlobalAction> e)
         {
-            if (distanceSpacingScrollActive)
+            switch (e.Action)
             {
-                DistanceSpacingMultiplier.Value += e.ScrollDelta.Y * (e.IsPrecise ? 0.01f : 0.1f);
-                return true;
+                case GlobalAction.EditorIncreaseDistanceSpacing:
+                case GlobalAction.EditorDecreaseDistanceSpacing:
+                    return adjustDistanceSpacing(e.Action, e.IsPrecise ? 0.01f : 0.1f);
             }
 
-            return base.OnScroll(e);
+            return false;
+        }
+
+        private bool adjustDistanceSpacing(GlobalAction action, float amount)
+        {
+            if (DistanceSpacingMultiplier.Disabled)
+                return false;
+
+            if (action == GlobalAction.EditorIncreaseDistanceSpacing)
+                DistanceSpacingMultiplier.Value += amount;
+            else if (action == GlobalAction.EditorDecreaseDistanceSpacing)
+                DistanceSpacingMultiplier.Value -= amount;
+
+            return true;
         }
 
         public virtual float GetBeatSnapDistanceAt(HitObject referenceObject)


### PR DESCRIPTION
Allows for customizing the keybind used to scroll through the value of distance spacing, as suggested in https://github.com/ppy/osu/pull/16576#issuecomment-1115067772