### PR TITLE
Display toast notification on editor distance spacing changes

### DIFF
--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Edit
         private ExpandableSlider<double, SizeSlider<double>> distanceSpacingSlider;
         private bool distanceSpacingScrollActive;
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
 
         protected DistancedHitObjectComposer(Ruleset ruleset)
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Edit
                     distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({v.NewValue:0.##x})";
 
                     if (v.NewValue != v.OldValue)
-                        onScreenDisplay.Display(new DistanceSpacingToast(v.NewValue.ToLocalisableString(@"0.##x")));
+                        onScreenDisplay?.Display(new DistanceSpacingToast(v.NewValue.ToLocalisableString(@"0.##x")));
 
                     EditorBeatmap.BeatmapInfo.DistanceSpacing = v.NewValue;
                 }, true);

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -3,12 +3,16 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
+using osu.Game.Overlays;
+using osu.Game.Overlays.OSD;
 using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Rulesets.Objects;
 using osuTK;
@@ -36,6 +40,9 @@ namespace osu.Game.Rulesets.Edit
 
         private ExpandableSlider<double, SizeSlider<double>> distanceSpacingSlider;
         private bool distanceSpacingScrollActive;
+
+        [Resolved]
+        private OnScreenDisplay onScreenDisplay { get; set; }
 
         protected DistancedHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -72,6 +79,10 @@ namespace osu.Game.Rulesets.Edit
                 {
                     distanceSpacingSlider.ContractedLabelText = $"D. S. ({v.NewValue:0.##x})";
                     distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({v.NewValue:0.##x})";
+
+                    if (v.NewValue != v.OldValue)
+                        onScreenDisplay.Display(new DistanceSpacingToast(v.NewValue.ToLocalisableString(@"0.##x")));
+
                     EditorBeatmap.BeatmapInfo.DistanceSpacing = v.NewValue;
                 }, true);
             }
@@ -81,7 +92,6 @@ namespace osu.Game.Rulesets.Edit
         {
             if (!DistanceSpacingMultiplier.Disabled && e.Action == GlobalAction.EditorDistanceSpacing)
             {
-                RightSideToolboxContainer.Expanded.Value = true;
                 distanceSpacingScrollActive = true;
                 return true;
             }
@@ -92,10 +102,7 @@ namespace osu.Game.Rulesets.Edit
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
             if (!DistanceSpacingMultiplier.Disabled && e.Action == GlobalAction.EditorDistanceSpacing)
-            {
-                RightSideToolboxContainer.Expanded.Value = false;
                 distanceSpacingScrollActive = false;
-            }
         }
 
         protected override bool OnScroll(ScrollEvent e)
@@ -158,6 +165,14 @@ namespace osu.Game.Rulesets.Edit
                 Padding = new MarginPadding { Left = 10 };
 
                 FillFlow.Spacing = new Vector2(10);
+            }
+        }
+
+        private class DistanceSpacingToast : Toast
+        {
+            public DistanceSpacingToast(LocalisableString value)
+                : base("Distance Spacing", value, string.Empty)
+            {
             }
         }
     }

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -76,15 +76,15 @@ namespace osu.Game.Rulesets.Edit
             if (!DistanceSpacingMultiplier.Disabled)
             {
                 DistanceSpacingMultiplier.Value = EditorBeatmap.BeatmapInfo.DistanceSpacing;
-                DistanceSpacingMultiplier.BindValueChanged(v =>
+                DistanceSpacingMultiplier.BindValueChanged(multiplier =>
                 {
-                    distanceSpacingSlider.ContractedLabelText = $"D. S. ({v.NewValue:0.##x})";
-                    distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({v.NewValue:0.##x})";
+                    distanceSpacingSlider.ContractedLabelText = $"D. S. ({multiplier.NewValue:0.##x})";
+                    distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({multiplier.NewValue:0.##x})";
 
-                    if (v.NewValue != v.OldValue)
-                        onScreenDisplay?.Display(new DistanceSpacingToast(v.NewValue.ToLocalisableString(@"0.##x"), v));
+                    if (multiplier.NewValue != multiplier.OldValue)
+                        onScreenDisplay?.Display(new DistanceSpacingToast(multiplier.NewValue.ToLocalisableString(@"0.##x"), multiplier));
 
-                    EditorBeatmap.BeatmapInfo.DistanceSpacing = v.NewValue;
+                    EditorBeatmap.BeatmapInfo.DistanceSpacing = multiplier.NewValue;
                 }, true);
             }
         }

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Edit
             [BackgroundDependencyLoader]
             private void load(OsuConfigManager config)
             {
-                ShortcutText.Text = config.LookupKeyBindings(getAction(change));
+                ShortcutText.Text = config.LookupKeyBindings(getAction(change)).ToUpper();
             }
 
             private static GlobalAction getAction(ValueChangedEvent<double> change) => change.NewValue - change.OldValue > 0

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -3,11 +3,13 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
@@ -80,7 +82,7 @@ namespace osu.Game.Rulesets.Edit
                     distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({v.NewValue:0.##x})";
 
                     if (v.NewValue != v.OldValue)
-                        onScreenDisplay?.Display(new DistanceSpacingToast(v.NewValue.ToLocalisableString(@"0.##x")));
+                        onScreenDisplay?.Display(new DistanceSpacingToast(v.NewValue.ToLocalisableString(@"0.##x"), v));
 
                     EditorBeatmap.BeatmapInfo.DistanceSpacing = v.NewValue;
                 }, true);
@@ -182,10 +184,23 @@ namespace osu.Game.Rulesets.Edit
 
         private class DistanceSpacingToast : Toast
         {
-            public DistanceSpacingToast(LocalisableString value)
-                : base("Distance Spacing", value, string.Empty)
+            private readonly ValueChangedEvent<double> change;
+
+            public DistanceSpacingToast(LocalisableString value, ValueChangedEvent<double> change)
+                : base(getAction(change).GetLocalisableDescription(), value, string.Empty)
             {
+                this.change = change;
             }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuConfigManager config)
+            {
+                ShortcutText.Text = config.LookupKeyBindings(getAction(change));
+            }
+
+            private static GlobalAction getAction(ValueChangedEvent<double> change) => change.NewValue - change.OldValue > 0
+                ? GlobalAction.EditorIncreaseDistanceSpacing
+                : GlobalAction.EditorDecreaseDistanceSpacing;
         }
     }
 }


### PR DESCRIPTION
- [x] Depends on #18070

Fulfills the second part of https://github.com/ppy/osu/pull/16576#issuecomment-1115067772, for better visibility of the distance spacing value to the mapper (also no longer expands the setting when pressing the hotkey, given that it's main purpose is to show that the spacing is going to be changed).

PR'd separately as I'm not 100% sure on the direction taken UI-wise, maybe good enough for now?