### PR TITLE
Port test coverage from old mod select overlay to new design

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -2,17 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osuTK.Input;
 
@@ -169,6 +173,206 @@ namespace osu.Game.Tests.Visual.UserInterface
             assertCustomisationToggleState(disabled: true, active: false); // config was dismissed without explicit user action.
         }
 
+        /// <summary>
+        /// Ensure that two mod overlays are not cross polluting via central settings instances.
+        /// </summary>
+        [Test]
+        public void TestSettingsNotCrossPolluting()
+        {
+            Bindable<IReadOnlyList<Mod>> selectedMods2 = null;
+            ModSelectScreen modSelectScreen2 = null;
+
+            createScreen();
+            AddStep("select diff adjust", () => SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust() });
+
+            AddStep("set setting", () => modSelectScreen.ChildrenOfType<SettingsSlider<float>>().First().Current.Value = 8);
+
+            AddAssert("ensure setting is propagated", () => SelectedMods.Value.OfType<OsuModDifficultyAdjust>().Single().CircleSize.Value == 8);
+
+            AddStep("create second bindable", () => selectedMods2 = new Bindable<IReadOnlyList<Mod>>(new Mod[] { new OsuModDifficultyAdjust() }));
+
+            AddStep("create second overlay", () =>
+            {
+                Add(modSelectScreen2 = new UserModSelectScreen().With(d =>
+                {
+                    d.Origin = Anchor.TopCentre;
+                    d.Anchor = Anchor.TopCentre;
+                    d.SelectedMods.BindTarget = selectedMods2;
+                }));
+            });
+
+            AddStep("show", () => modSelectScreen2.Show());
+
+            AddAssert("ensure first is unchanged", () => SelectedMods.Value.OfType<OsuModDifficultyAdjust>().Single().CircleSize.Value == 8);
+            AddAssert("ensure second is default", () => selectedMods2.Value.OfType<OsuModDifficultyAdjust>().Single().CircleSize.Value == null);
+        }
+
+        [Test]
+        public void TestSettingsResetOnDeselection()
+        {
+            var osuModDoubleTime = new OsuModDoubleTime { SpeedChange = { Value = 1.2 } };
+
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("set dt mod with custom rate", () => { SelectedMods.Value = new[] { osuModDoubleTime }; });
+
+            AddAssert("selected mod matches", () => (SelectedMods.Value.Single() as OsuModDoubleTime)?.SpeedChange.Value == 1.2);
+
+            AddStep("deselect", () => getPanelForMod(typeof(OsuModDoubleTime)).TriggerClick());
+            AddAssert("selected mods empty", () => SelectedMods.Value.Count == 0);
+
+            AddStep("reselect", () => getPanelForMod(typeof(OsuModDoubleTime)).TriggerClick());
+            AddAssert("selected mod has default value", () => (SelectedMods.Value.Single() as OsuModDoubleTime)?.SpeedChange.IsDefault == true);
+        }
+
+        [Test]
+        public void TestAnimationFlushOnClose()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("Select all fun mods", () =>
+            {
+                modSelectScreen.ChildrenOfType<ModColumn>()
+                               .Single(c => c.ModType == ModType.DifficultyIncrease)
+                               .SelectAll();
+            });
+
+            AddUntilStep("many mods selected", () => SelectedMods.Value.Count >= 5);
+
+            AddStep("trigger deselect and close overlay", () =>
+            {
+                modSelectScreen.ChildrenOfType<ModColumn>()
+                               .Single(c => c.ModType == ModType.DifficultyIncrease)
+                               .DeselectAll();
+
+                modSelectScreen.Hide();
+            });
+
+            AddAssert("all mods deselected", () => SelectedMods.Value.Count == 0);
+        }
+
+        [Test]
+        public void TestRulesetChanges()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            var noFailMod = new OsuRuleset().GetModsFor(ModType.DifficultyReduction).FirstOrDefault(m => m is OsuModNoFail);
+
+            AddStep("set mods externally", () => { SelectedMods.Value = new[] { noFailMod }; });
+
+            changeRuleset(0);
+
+            AddAssert("ensure mods still selected", () => SelectedMods.Value.SingleOrDefault(m => m is OsuModNoFail) != null);
+
+            changeRuleset(3);
+
+            AddAssert("ensure mods not selected", () => SelectedMods.Value.Count == 0);
+
+            changeRuleset(0);
+
+            AddAssert("ensure mods not selected", () => SelectedMods.Value.Count == 0);
+        }
+
+        [Test]
+        public void TestExternallySetCustomizedMod()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("set customized mod externally", () => SelectedMods.Value = new[] { new OsuModDoubleTime { SpeedChange = { Value = 1.01 } } });
+
+            AddAssert("ensure button is selected and customized accordingly", () =>
+            {
+                var button = getPanelForMod(SelectedMods.Value.Single().GetType());
+                return ((OsuModDoubleTime)button.Mod).SpeedChange.Value == 1.01;
+            });
+        }
+
+        [Test]
+        public void TestSettingsAreRetainedOnReload()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("set customized mod externally", () => SelectedMods.Value = new[] { new OsuModDoubleTime { SpeedChange = { Value = 1.01 } } });
+            AddAssert("setting remains", () => (SelectedMods.Value.SingleOrDefault() as OsuModDoubleTime)?.SpeedChange.Value == 1.01);
+
+            createScreen();
+            AddAssert("setting remains", () => (SelectedMods.Value.SingleOrDefault() as OsuModDoubleTime)?.SpeedChange.Value == 1.01);
+        }
+
+        [Test]
+        public void TestExternallySetModIsReplacedByOverlayInstance()
+        {
+            Mod external = new OsuModDoubleTime();
+            Mod overlayButtonMod = null;
+
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("set mod externally", () => { SelectedMods.Value = new[] { external }; });
+
+            AddAssert("ensure button is selected", () =>
+            {
+                var button = getPanelForMod(SelectedMods.Value.Single().GetType());
+                overlayButtonMod = button.Mod;
+                return button.Active.Value;
+            });
+
+            // Right now, when an external change occurs, the ModSelectOverlay will replace the global instance with its own
+            AddAssert("mod instance doesn't match", () => external != overlayButtonMod);
+
+            AddAssert("one mod present in global selected", () => SelectedMods.Value.Count == 1);
+            AddAssert("globally selected matches button's mod instance", () => SelectedMods.Value.Contains(overlayButtonMod));
+            AddAssert("globally selected doesn't contain original external change", () => !SelectedMods.Value.Contains(external));
+        }
+
+        [Test]
+        public void TestChangeIsValidChangesButtonVisibility()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddAssert("double time visible", () => modSelectScreen.ChildrenOfType<ModPanel>().Where(panel => panel.Mod is OsuModDoubleTime).Any(panel => !panel.Filtered.Value));
+
+            AddStep("make double time invalid", () => modSelectScreen.IsValidMod = m => !(m is OsuModDoubleTime));
+            AddUntilStep("double time not visible", () => modSelectScreen.ChildrenOfType<ModPanel>().Where(panel => panel.Mod is OsuModDoubleTime).All(panel => panel.Filtered.Value));
+            AddAssert("nightcore still visible", () => modSelectScreen.ChildrenOfType<ModPanel>().Where(panel => panel.Mod is OsuModNightcore).Any(panel => !panel.Filtered.Value));
+
+            AddStep("make double time valid again", () => modSelectScreen.IsValidMod = m => true);
+            AddUntilStep("double time visible", () => modSelectScreen.ChildrenOfType<ModPanel>().Where(panel => panel.Mod is OsuModDoubleTime).Any(panel => !panel.Filtered.Value));
+            AddAssert("nightcore still visible", () => modSelectScreen.ChildrenOfType<ModPanel>().Where(b => b.Mod is OsuModNightcore).Any(panel => !panel.Filtered.Value));
+        }
+
+        [Test]
+        public void TestChangeIsValidPreservesSelection()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("select DT + HD", () => SelectedMods.Value = new Mod[] { new OsuModDoubleTime(), new OsuModHidden() });
+            AddAssert("DT + HD selected", () => modSelectScreen.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
+
+            AddStep("make NF invalid", () => modSelectScreen.IsValidMod = m => !(m is ModNoFail));
+            AddAssert("DT + HD still selected", () => modSelectScreen.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
+        }
+
+        [Test]
+        public void TestUnimplementedModIsUnselectable()
+        {
+            var testRuleset = new TestUnimplementedModOsuRuleset();
+
+            createScreen();
+
+            AddStep("set ruleset", () => Ruleset.Value = testRuleset.RulesetInfo);
+            waitForColumnLoad();
+
+            AddAssert("unimplemented mod panel is filtered", () => getPanelForMod(typeof(TestUnimplementedMod)).Filtered.Value);
+        }
+
         private void waitForColumnLoad() => AddUntilStep("all column content loaded",
             () => modSelectScreen.ChildrenOfType<ModColumn>().Any() && modSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
 
@@ -188,5 +392,26 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private ModPanel getPanelForMod(Type modType)
             => modSelectScreen.ChildrenOfType<ModPanel>().Single(panel => panel.Mod.GetType() == modType);
+
+        private class TestUnimplementedMod : Mod
+        {
+            public override string Name => "Unimplemented mod";
+            public override string Acronym => "UM";
+            public override string Description => "A mod that is not implemented.";
+            public override double ScoreMultiplier => 1;
+            public override ModType Type => ModType.Conversion;
+        }
+
+        private class TestUnimplementedModOsuRuleset : OsuRuleset
+        {
+            public override string ShortName => "unimplemented";
+
+            public override IEnumerable<Mod> GetModsFor(ModType type)
+            {
+                if (type == ModType.Conversion) return base.GetModsFor(type).Concat(new[] { new TestUnimplementedMod() });
+
+                return base.GetModsFor(type);
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -104,17 +104,25 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("activate DT", () => getPanelForMod(typeof(OsuModDoubleTime)).TriggerClick());
             AddAssert("DT active", () => SelectedMods.Value.Single().GetType() == typeof(OsuModDoubleTime));
+            AddAssert("DT panel active", () => getPanelForMod(typeof(OsuModDoubleTime)).Active.Value);
 
             AddStep("activate NC", () => getPanelForMod(typeof(OsuModNightcore)).TriggerClick());
             AddAssert("only NC active", () => SelectedMods.Value.Single().GetType() == typeof(OsuModNightcore));
+            AddAssert("DT panel not active", () => !getPanelForMod(typeof(OsuModDoubleTime)).Active.Value);
+            AddAssert("NC panel active", () => getPanelForMod(typeof(OsuModNightcore)).Active.Value);
 
             AddStep("activate HR", () => getPanelForMod(typeof(OsuModHardRock)).TriggerClick());
             AddAssert("NC+HR active", () => SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModNightcore))
                                             && SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModHardRock)));
+            AddAssert("NC panel active", () => getPanelForMod(typeof(OsuModNightcore)).Active.Value);
+            AddAssert("HR panel active", () => getPanelForMod(typeof(OsuModHardRock)).Active.Value);
 
             AddStep("activate MR", () => getPanelForMod(typeof(OsuModMirror)).TriggerClick());
             AddAssert("NC+MR active", () => SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModNightcore))
                                             && SelectedMods.Value.Any(mod => mod.GetType() == typeof(OsuModMirror)));
+            AddAssert("NC panel active", () => getPanelForMod(typeof(OsuModNightcore)).Active.Value);
+            AddAssert("HR panel not active", () => !getPanelForMod(typeof(OsuModHardRock)).Active.Value);
+            AddAssert("MR panel active", () => getPanelForMod(typeof(OsuModMirror)).Active.Value);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -336,8 +336,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("mod instance doesn't match", () => external != overlayButtonMod);
 
             AddAssert("one mod present in global selected", () => SelectedMods.Value.Count == 1);
-            AddAssert("globally selected matches button's mod instance", () => SelectedMods.Value.Contains(overlayButtonMod));
-            AddAssert("globally selected doesn't contain original external change", () => !SelectedMods.Value.Contains(external));
+            AddAssert("globally selected matches button's mod instance", () => SelectedMods.Value.Any(mod => ReferenceEquals(mod, overlayButtonMod)));
+            AddAssert("globally selected doesn't contain original external change", () => !SelectedMods.Value.Any(mod => ReferenceEquals(mod, external)));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 return Precision.AlmostEquals(multiplier, modSelectScreen.ChildrenOfType<DifficultyMultiplierDisplay>().Single().Current.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
+            AddAssert("setting items created", () => modSelectScreen.ChildrenOfType<ISettingsItem>().Any());
         }
 
         [Test]
@@ -82,6 +83,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 return Precision.AlmostEquals(multiplier, modSelectScreen.ChildrenOfType<DifficultyMultiplierDisplay>().Single().Current.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
+            AddAssert("setting items created", () => modSelectScreen.ChildrenOfType<ISettingsItem>().Any());
         }
 
         [Test]

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -435,9 +435,9 @@ namespace osu.Game.Overlays.Mods
         }
 
         /// <summary>
-        /// Play out all remaining animations immediately to leave mods in a good (final) state.
+        /// Run any delayed selections (due to animation) immediately to leave mods in a good (final) state.
         /// </summary>
-        public void FlushAnimation()
+        public void FlushPendingSelections()
         {
             while (pendingSelectionOperations.TryDequeue(out var dequeuedAction))
                 dequeuedAction();

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -309,8 +309,10 @@ namespace osu.Game.Overlays.Mods
             {
                 var matchingSelectedMod = SelectedMods.Value.SingleOrDefault(selected => selected.GetType() == panel.Mod.GetType());
                 panel.Active.Value = matchingSelectedMod != null;
-                if (matchingSelectedMod != null)
+                if (panel.Active.Value)
                     panel.Mod.CopyFrom(matchingSelectedMod);
+                else
+                    panel.Mod.ResetSettingsToDefaults();
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -364,6 +364,15 @@ namespace osu.Game.Overlays.Mods
                 pendingSelectionOperations.Enqueue(() => button.Active.Value = false);
         }
 
+        /// <summary>
+        /// Play out all remaining animations immediately to leave mods in a good (final) state.
+        /// </summary>
+        public void FlushAnimation()
+        {
+            while (pendingSelectionOperations.TryDequeue(out var dequeuedAction))
+                dequeuedAction();
+        }
+
         private class ToggleAllCheckbox : OsuCheckbox
         {
             private Color4 accentColour;

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -296,7 +296,7 @@ namespace osu.Game.Overlays.Mods
         private void updateActiveState()
         {
             foreach (var panel in panelFlow)
-                panel.Active.Value = SelectedMods.Value.Contains(panel.Mod, EqualityComparer<Mod>.Default);
+                panel.Active.Value = SelectedMods.Value.Any(selected => selected.GetType() == panel.Mod.GetType());
         }
 
         #region Bulk select / deselect

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -250,9 +250,9 @@ namespace osu.Game.Overlays.Mods
         protected virtual ModButton CreateModButton(Mod mod) => new ModButton(mod);
 
         /// <summary>
-        /// Play out all remaining animations immediately to leave mods in a good (final) state.
+        /// Run any delayed selections (due to animation) immediately to leave mods in a good (final) state.
         /// </summary>
-        public void FlushAnimation()
+        public void FlushPendingSelections()
         {
             while (pendingSelectionOperations.TryDequeue(out var dequeuedAction))
                 dequeuedAction();

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -369,7 +369,7 @@ namespace osu.Game.Overlays.Mods
 
             foreach (var section in ModSectionsContainer)
             {
-                section.FlushAnimation();
+                section.FlushPendingSelections();
             }
 
             FooterContainer.MoveToX(content_width, WaveContainer.DISAPPEAR_DURATION, Easing.InSine);

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -313,10 +313,12 @@ namespace osu.Game.Overlays.Mods
             {
                 const float distance = 700;
 
-                columnFlow[i].Column
-                             .TopLevelContent
-                             .MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint)
-                             .FadeOut(fade_out_duration, Easing.OutQuint);
+                var column = columnFlow[i].Column;
+
+                column.FlushAnimation();
+                column.TopLevelContent
+                      .MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint)
+                      .FadeOut(fade_out_duration, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Overlays.Mods
         private void updateAvailableMods()
         {
             foreach (var column in columnFlow.Columns)
-                column.Filter = isValidMod;
+                column.Filter = m => m.HasImplementation && isValidMod.Invoke(m);
         }
 
         private void updateCustomisation(ValueChangedEvent<IReadOnlyList<Mod>> valueChangedEvent)

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -308,7 +308,7 @@ namespace osu.Game.Overlays.Mods
 
                 var column = columnFlow[i].Column;
 
-                column.FlushAnimation();
+                column.FlushPendingSelections();
                 column.TopLevelContent
                       .MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint)
                       .FadeOut(fade_out_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Mods/ModSettingsArea.cs
+++ b/osu.Game/Overlays/Mods/ModSettingsArea.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -21,7 +22,7 @@ namespace osu.Game.Overlays.Mods
 {
     public class ModSettingsArea : CompositeDrawable
     {
-        public Bindable<IReadOnlyList<Mod>> SelectedMods { get; } = new Bindable<IReadOnlyList<Mod>>();
+        public Bindable<IReadOnlyList<Mod>> SelectedMods { get; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         public const float HEIGHT = 250;
 
@@ -77,7 +78,7 @@ namespace osu.Game.Overlays.Mods
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            SelectedMods.BindValueChanged(_ => updateMods());
+            SelectedMods.BindValueChanged(_ => updateMods(), true);
         }
 
         private void updateMods()

--- a/osu.Game/Overlays/Mods/UserModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/UserModSelectScreen.cs
@@ -14,9 +14,12 @@ namespace osu.Game.Overlays.Mods
     {
         protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new UserModColumn(modType, false, toggleKeys);
 
-        protected override IReadOnlyList<Mod> ComputeNewModsFromSelection(IEnumerable<Mod> addedMods, IEnumerable<Mod> removedMods)
+        protected override IReadOnlyList<Mod> ComputeNewModsFromSelection(IReadOnlyList<Mod> oldSelection, IReadOnlyList<Mod> newSelection)
         {
-            IEnumerable<Mod> modsAfterRemoval = SelectedMods.Value.Except(removedMods).ToList();
+            var addedMods = newSelection.Except(oldSelection);
+            var removedMods = oldSelection.Except(newSelection);
+
+            IEnumerable<Mod> modsAfterRemoval = newSelection.Except(removedMods).ToList();
 
             // the preference is that all new mods should override potential incompatible old mods.
             // in general that's a bit difficult to compute if more than one mod is added at a time,

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.OnlinePlay
         public new Func<Mod, bool> IsValidMod
         {
             get => base.IsValidMod;
-            set => base.IsValidMod = m => m.HasImplementation && m.UserPlayable && value.Invoke(m);
+            set => base.IsValidMod = m => m.UserPlayable && value.Invoke(m);
         }
 
         public FreeModSelectScreen()


### PR DESCRIPTION
* Continuation of #16917
* Supersedes / closes #17984

This pull ports all test cases from the old design that weren't already applied to the new design, expands existing tests where they were lacking, and contains requisite changes to the new design itself for the tests to pass.

The diff is unfortunately a bit of a wreck. Long story short is, the old mod overlay was *very* particular about the manner in how the mod instances are managed, in order to fix multiple old bugs. At that point my options were to either: blame the tests, check the failure cases, try to reproduce them again with my new design and see if I can fix in an alternative manner, or just go the path of least resistance and to try to jiggle the new design to work. I've gone for number two. It's not great, I know, but I'm not sure how to do better without upending half of everything (and this redesign effort is already nearing on three months since start........)