### PR TITLE
Improve editor grid rendering

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -59,11 +59,6 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             LayerBelowRuleset.AddRange(new Drawable[]
             {
-                new PlayfieldBorder
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    PlayfieldBorderStyle = { Value = PlayfieldBorderStyle.Corners }
-                },
                 distanceSnapGridContainer = new Container
                 {
                     RelativeSizeAxes = Axes.Both

--- a/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components
@@ -72,25 +73,29 @@ namespace osu.Game.Screens.Edit.Compose.Components
             int index = 0;
             float currentPosition = startPosition;
 
-            while ((endPosition - currentPosition) * Math.Sign(step) > 0)
+            // Make lines the same width independent of display resolution.
+            float lineWidth = DrawWidth / ScreenSpaceDrawQuad.Width;
+
+            while (Precision.AlmostBigger((endPosition - currentPosition) * Math.Sign(step), 0))
             {
                 var gridLine = new Box
                 {
                     Colour = Colour4.White,
                     Alpha = index == 0 ? 0.3f : 0.1f,
-                    EdgeSmoothness = new Vector2(0.2f)
                 };
 
                 if (direction == Direction.Horizontal)
                 {
+                    gridLine.Origin = Anchor.CentreLeft;
                     gridLine.RelativeSizeAxes = Axes.X;
-                    gridLine.Height = 1;
+                    gridLine.Height = lineWidth;
                     gridLine.Y = currentPosition;
                 }
                 else
                 {
+                    gridLine.Origin = Anchor.TopCentre;
                     gridLine.RelativeSizeAxes = Axes.Y;
-                    gridLine.Width = 1;
+                    gridLine.Width = lineWidth;
                     gridLine.X = currentPosition;
                 }
 

--- a/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -76,12 +78,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // Make lines the same width independent of display resolution.
             float lineWidth = DrawWidth / ScreenSpaceDrawQuad.Width;
 
+            List<Box> generatedLines = new List<Box>();
+
             while (Precision.AlmostBigger((endPosition - currentPosition) * Math.Sign(step), 0))
             {
                 var gridLine = new Box
                 {
                     Colour = Colour4.White,
-                    Alpha = index == 0 ? 0.3f : 0.1f,
+                    Alpha = 0.1f,
                 };
 
                 if (direction == Direction.Horizontal)
@@ -99,11 +103,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     gridLine.X = currentPosition;
                 }
 
-                AddInternal(gridLine);
+                generatedLines.Add(gridLine);
 
                 index += 1;
                 currentPosition = startPosition + index * step;
             }
+
+            if (generatedLines.Count == 0)
+                return;
+
+            generatedLines.First().Alpha = 0.3f;
+            generatedLines.Last().Alpha = 0.3f;
+
+            AddRangeInternal(generatedLines);
         }
 
         public Vector2 GetSnappedPosition(Vector2 original)


### PR DESCRIPTION
Before:

![osu Game Tests 2022-05-04 at 04 50 12](https://user-images.githubusercontent.com/191335/166624514-be3ea622-1f62-4a27-955f-8fd39f31c0b4.png)

After:

![osu Game Tests 2022-05-04 at 04 50 00](https://user-images.githubusercontent.com/191335/166624501-82556e0c-7a7b-42bf-95d7-ab214e0aadfa.png)

The newly drawn edges can have a hole at one of the corner points (one pixel) but I'm not interested in fixing that for now. It's probably quite a bit of effort to figure out and not too noticeable without zooming.