### PR TITLE
Fix `DistanceSnapGrid` not applying spacing multiplier appropriately

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Vector2 normalisedDirection = direction * new Vector2(1f / distance);
             Vector2 snappedPosition = StartPosition + normalisedDirection * radialCount * radius;
 
-            return (snappedPosition, StartTime + SnapProvider.GetSnappedDurationFromDistance(ReferenceObject, (snappedPosition - StartPosition).Length));
+            return (snappedPosition, StartTime + GetSnappedDurationFromDistance(ReferenceObject, (snappedPosition - StartPosition).Length));
         }
     }
 }


### PR DESCRIPTION
- Closes #18073 

Was occuring due to the multiplier being applied to the `DistanceSpacing` property only, while everywhere else is unaware of it, and, in return, produce incorrect time/position values.

https://user-images.githubusercontent.com/22781491/166667014-196b3bbe-322e-48fd-bd16-ef28ae259da9.mp4

Haven't added tests as that'll require a bit of more effort, but can look into it tonight/tomorrow if needed.

@peppy please check that this resolves the issues you have with distance snapping, looks to be all correct now.