### PR TITLE
Wrap `BeatmapOnlineLookupQueue` cache request in a task

### DIFF
--- a/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Beatmaps
                 }
             };
 
-            cacheDownloadRequest.PerformAsync();
+            Task.Run(() => cacheDownloadRequest.PerformAsync());
         }
 
         private bool checkLocalCache(BeatmapSetInfo set, BeatmapInfo beatmapInfo)


### PR DESCRIPTION
Was causing an inspection to pop up when having a local framework checkout (no idea why), but should probably be wrapped in a `Task` rather than running it like that.

<img width="1032" alt="CleanShot 2022-05-05 at 12 40 15@2x" src="https://user-images.githubusercontent.com/22781491/166898519-4e028eb1-fb56-4e4b-8244-be80ccdd7d6d.png">

This might mean that we have usages elsewhere which still perform async calls but without a `Task.Run` wrapped around them.