### PR TITLE
Fix distance snapping grid providing incorrect time values for non-1.0x spacing

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
 
             AddStep("move mouse outside grid", () => InputManager.MoveMouseTo(grid.ToScreenSpace(grid_position + new Vector2(beat_length, 0) * 3f)));
-            assertSnappedDistance(beat_length * 2);
+            assertSnappedDistance(beat_length);
         }
 
         private void assertSnappedDistance(float expectedDistance) => AddAssert($"snap distance = {expectedDistance}", () =>

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [TestCase(0.5f)]
         public void TestDistanceSpacing(float multiplier)
         {
-            AddStep($"set beat divisor = {multiplier}", () => snapProvider.DistanceSpacingMultiplier.Value = multiplier);
+            AddStep($"set distance spacing = {multiplier}", () => snapProvider.DistanceSpacingMultiplier.Value = multiplier);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Cached(typeof(IDistanceSnapProvider))]
         private readonly SnapProvider snapProvider = new SnapProvider();
 
-        private TestOsuDistanceSnapGrid grid;
+        private OsuDistanceSnapGrid grid;
 
         public TestSceneOsuDistanceSnapGrid()
         {
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.SlateGray
                 },
-                grid = new TestOsuDistanceSnapGrid(new HitCircle { Position = grid_position }),
+                grid = new OsuDistanceSnapGrid(new HitCircle { Position = grid_position }),
                 new SnappingCursorContainer { GetSnapPosition = v => grid.GetSnappedPosition(grid.ToLocalSpace(v)).position }
             };
         });
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4.SlateGray
                     },
-                    grid = new TestOsuDistanceSnapGrid(new HitCircle { Position = grid_position }, new HitCircle { StartTime = 200 }),
+                    grid = new OsuDistanceSnapGrid(new HitCircle { Position = grid_position }, new HitCircle { StartTime = 200 }),
                     new SnappingCursorContainer { GetSnapPosition = v => grid.GetSnappedPosition(grid.ToLocalSpace(v)).position }
                 };
             });
@@ -167,16 +167,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             private void updatePosition(Vector2 screenSpacePosition)
             {
                 cursor.Position = GetSnapPosition.Invoke(screenSpacePosition);
-            }
-        }
-
-        private class TestOsuDistanceSnapGrid : OsuDistanceSnapGrid
-        {
-            public new float DistanceSpacing => base.DistanceSpacing;
-
-            public TestOsuDistanceSnapGrid(OsuHitObject hitObject, OsuHitObject nextHitObject = null)
-                : base(hitObject, nextHitObject)
-            {
             }
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -82,6 +82,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep($"set beat divisor = {divisor}", () => beatDivisor.Value = divisor);
         }
 
+        [TestCase(1.0f)]
+        [TestCase(2.0f)]
+        [TestCase(0.5f)]
+        public void TestDistanceSpacing(float multiplier)
+        {
+            AddStep($"set beat divisor = {multiplier}", () => snapProvider.DistanceSpacingMultiplier.Value = multiplier);
+        }
+
         [Test]
         public void TestCursorInCentre()
         {
@@ -177,7 +185,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition) => new SnapResult(screenSpacePosition, 0);
 
-            public IBindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1);
+            public Bindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1);
+
+            IBindable<double> IDistanceSnapProvider.DistanceSpacingMultiplier => DistanceSpacingMultiplier;
 
             public float GetBeatSnapDistanceAt(HitObject referenceObject) => (float)beat_length;
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapGrid.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Osu.Edit
     public class OsuDistanceSnapGrid : CircularDistanceSnapGrid
     {
         public OsuDistanceSnapGrid(OsuHitObject hitObject, [CanBeNull] OsuHitObject nextHitObject = null)
-            : base(hitObject, hitObject.StackedEndPosition, hitObject.GetEndTime(), nextHitObject?.StartTime)
+            : base(hitObject, hitObject.StackedEndPosition, hitObject.GetEndTime(), nextHitObject?.StartTime - 1)
         {
             Masking = true;
         }

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddStep($"set distance spacing = {multiplier}", () => snapProvider.DistanceSpacingMultiplier.Value = multiplier);
-            AddAssert("check correct interval count", () => grid.MaxIntervals == (end_time / grid.DistanceBetweenTicks));
+            AddStep("check correct interval count", () => Assert.That((end_time / grid.DistanceBetweenTicks) * multiplier, Is.EqualTo(grid.MaxIntervals)));
         }
 
         private class TestDistanceSnapGrid : DistanceSnapGrid

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Visual.Editing
 
         private class TestDistanceSnapGrid : DistanceSnapGrid
         {
-            public new float DistanceSpacing => base.DistanceSpacing;
+            public new float DistanceBetweenTick => base.DistanceBetweenTick;
 
             public TestDistanceSnapGrid(double? endTime = null)
                 : base(new HitObject(), grid_position, 0, endTime)
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 int indexFromPlacement = 0;
 
-                for (float s = StartPosition.X + DistanceSpacing; s <= DrawWidth && indexFromPlacement < MaxIntervals; s += DistanceSpacing, indexFromPlacement++)
+                for (float s = StartPosition.X + DistanceBetweenTick; s <= DrawWidth && indexFromPlacement < MaxIntervals; s += DistanceBetweenTick, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {
@@ -118,7 +118,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 indexFromPlacement = 0;
 
-                for (float s = StartPosition.X - DistanceSpacing; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceSpacing, indexFromPlacement++)
+                for (float s = StartPosition.X - DistanceBetweenTick; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceBetweenTick, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {
@@ -131,7 +131,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 indexFromPlacement = 0;
 
-                for (float s = StartPosition.Y + DistanceSpacing; s <= DrawHeight && indexFromPlacement < MaxIntervals; s += DistanceSpacing, indexFromPlacement++)
+                for (float s = StartPosition.Y + DistanceBetweenTick; s <= DrawHeight && indexFromPlacement < MaxIntervals; s += DistanceBetweenTick, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 indexFromPlacement = 0;
 
-                for (float s = StartPosition.Y - DistanceSpacing; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceSpacing, indexFromPlacement++)
+                for (float s = StartPosition.Y - DistanceBetweenTick; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceBetweenTick, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Visual.Editing
         public void TestDistanceSpacing(double multiplier)
         {
             AddStep($"set distance spacing = {multiplier}", () => snapProvider.DistanceSpacingMultiplier.Value = multiplier);
-            AddAssert("distance spacing matches multiplier", () => grid.DistanceBetweenTick == beat_snap_distance * multiplier);
+            AddAssert("distance spacing matches multiplier", () => grid.DistanceBetweenTicks == beat_snap_distance * multiplier);
         }
 
         [TestCase(1.0)]
@@ -103,12 +103,12 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddStep($"set distance spacing = {multiplier}", () => snapProvider.DistanceSpacingMultiplier.Value = multiplier);
-            AddAssert("check correct interval count", () => grid.MaxIntervals == (end_time / grid.DistanceBetweenTick));
+            AddAssert("check correct interval count", () => grid.MaxIntervals == (end_time / grid.DistanceBetweenTicks));
         }
 
         private class TestDistanceSnapGrid : DistanceSnapGrid
         {
-            public new float DistanceBetweenTick => base.DistanceBetweenTick;
+            public new float DistanceBetweenTicks => base.DistanceBetweenTicks;
 
             public new int MaxIntervals => base.MaxIntervals;
 
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 int indexFromPlacement = 0;
 
-                for (float s = StartPosition.X + DistanceBetweenTick; s <= DrawWidth && indexFromPlacement < MaxIntervals; s += DistanceBetweenTick, indexFromPlacement++)
+                for (float s = StartPosition.X + DistanceBetweenTicks; s <= DrawWidth && indexFromPlacement < MaxIntervals; s += DistanceBetweenTicks, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {
@@ -141,7 +141,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 indexFromPlacement = 0;
 
-                for (float s = StartPosition.X - DistanceBetweenTick; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceBetweenTick, indexFromPlacement++)
+                for (float s = StartPosition.X - DistanceBetweenTicks; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceBetweenTicks, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {
@@ -154,7 +154,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 indexFromPlacement = 0;
 
-                for (float s = StartPosition.Y + DistanceBetweenTick; s <= DrawHeight && indexFromPlacement < MaxIntervals; s += DistanceBetweenTick, indexFromPlacement++)
+                for (float s = StartPosition.Y + DistanceBetweenTicks; s <= DrawHeight && indexFromPlacement < MaxIntervals; s += DistanceBetweenTicks, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {
@@ -167,7 +167,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                 indexFromPlacement = 0;
 
-                for (float s = StartPosition.Y - DistanceBetweenTick; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceBetweenTick, indexFromPlacement++)
+                for (float s = StartPosition.Y - DistanceBetweenTicks; s >= 0 && indexFromPlacement < MaxIntervals; s -= DistanceBetweenTicks, indexFromPlacement++)
                 {
                     AddInternal(new Circle
                     {

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Edit
     public abstract class DistancedHitObjectComposer<TObject> : HitObjectComposer<TObject>, IDistanceSnapProvider, IScrollBindingHandler<GlobalAction>
         where TObject : HitObject
     {
-        protected Bindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1.0)
+        public Bindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1.0)
         {
             MinValue = 0.1,
             MaxValue = 6.0,

--- a/osu.Game/Rulesets/Edit/IDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IDistanceSnapProvider.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Edit
     {
         /// <summary>
         /// A multiplier which changes the ratio of distance travelled per time unit.
+        /// Importantly, this is provided for manual usage, and not multiplied into any of the methods exposed by this interface.
         /// </summary>
         /// <seealso cref="BeatmapInfo.DistanceSpacing"/>
         IBindable<double> DistanceSpacingMultiplier { get; }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // This grid implementation factors in the user's distance spacing specification,
             // which is usually not considered by an `IDistanceSnapProvider`.
-            float distanceSpacing = (float)DistanceSpacingMultiplier.Value;
+            float distanceSpacingMultiplier = (float)DistanceSpacingMultiplier.Value;
 
             Vector2 travelVector = (position - StartPosition);
 
@@ -84,17 +84,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // When interacting with the resolved snap provider, the distance spacing multiplier should first be removed
             // to allow for snapping at a non-multiplied ratio.
-            float snappedDistance = SnapProvider.FindSnappedDistance(ReferenceObject, travelLength / distanceSpacing);
+            float snappedDistance = SnapProvider.FindSnappedDistance(ReferenceObject, travelLength / distanceSpacingMultiplier);
             double snappedTime = StartTime + SnapProvider.DistanceToDuration(ReferenceObject, snappedDistance);
 
             if (snappedTime > LatestEndTime)
             {
-                snappedDistance = SnapProvider.DurationToDistance(ReferenceObject, LatestEndTime.Value - ReferenceObject.GetEndTime());
+                double tickLength = Beatmap.GetBeatLengthAtTime(StartTime);
+
+                snappedDistance = SnapProvider.DurationToDistance(ReferenceObject, MaxIntervals * tickLength);
                 snappedTime = StartTime + SnapProvider.DistanceToDuration(ReferenceObject, snappedDistance);
             }
 
             // The multiplier can then be reapplied to the final position.
-            Vector2 snappedPosition = StartPosition + travelVector.Normalized() * snappedDistance * distanceSpacing;
+            Vector2 snappedPosition = StartPosition + travelVector.Normalized() * snappedDistance * distanceSpacingMultiplier;
 
             return (snappedPosition, snappedTime);
         }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -87,6 +87,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float snappedDistance = SnapProvider.FindSnappedDistance(ReferenceObject, travelLength / distanceSpacing);
             double snappedTime = StartTime + SnapProvider.DistanceToDuration(ReferenceObject, snappedDistance);
 
+            if (snappedTime > LatestEndTime)
+            {
+                snappedDistance = SnapProvider.DurationToDistance(ReferenceObject, LatestEndTime.Value - ReferenceObject.StartTime);
+            }
+
             // The multiplier can then be reapplied to the final position.
             Vector2 snappedPosition = StartPosition + travelVector.Normalized() * snappedDistance * distanceSpacing;
 

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Vector2 normalisedDirection = direction * new Vector2(1f / distance);
             Vector2 snappedPosition = StartPosition + normalisedDirection * radialCount * radius;
 
-            return (snappedPosition, StartTime + SnapProvider.FindSnappedDuration(ReferenceObject, (snappedPosition - StartPosition).Length));
+            return (snappedPosition, StartTime + SnapProvider.FindSnappedDuration(ReferenceObject, (float)((snappedPosition - StartPosition).Length / DistanceSpacingMultiplier.Value)));
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -30,14 +30,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     Position = StartPosition,
                     Width = crosshair_thickness,
                     EdgeSmoothness = new Vector2(1),
-                    Height = Math.Min(crosshair_max_size, DistanceBetweenTick * 2),
+                    Height = Math.Min(crosshair_max_size, DistanceBetweenTicks * 2),
                 },
                 new Box
                 {
                     Origin = Anchor.Centre,
                     Position = StartPosition,
                     EdgeSmoothness = new Vector2(1),
-                    Width = Math.Min(crosshair_max_size, DistanceBetweenTick * 2),
+                    Width = Math.Min(crosshair_max_size, DistanceBetweenTicks * 2),
                     Height = crosshair_thickness,
                 }
             });
@@ -45,11 +45,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float dx = Math.Max(StartPosition.X, DrawWidth - StartPosition.X);
             float dy = Math.Max(StartPosition.Y, DrawHeight - StartPosition.Y);
             float maxDistance = new Vector2(dx, dy).Length;
-            int requiredCircles = Math.Min(MaxIntervals, (int)(maxDistance / DistanceBetweenTick));
+            int requiredCircles = Math.Min(MaxIntervals, (int)(maxDistance / DistanceBetweenTicks));
 
             for (int i = 0; i < requiredCircles; i++)
             {
-                float radius = (i + 1) * DistanceBetweenTick * 2;
+                float radius = (i + 1) * DistanceBetweenTicks * 2;
 
                 AddInternal(new CircularProgress
                 {
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float travelLength = travelVector.Length;
 
             // FindSnappedDistance will always round down, but we want to potentially round upwards.
-            travelLength += DistanceBetweenTick / 2;
+            travelLength += DistanceBetweenTicks / 2;
 
             // When interacting with the resolved snap provider, the distance spacing multiplier should first be removed
             // to allow for snapping at a non-multiplied ratio.

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -89,7 +89,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (snappedTime > LatestEndTime)
             {
-                snappedDistance = SnapProvider.DurationToDistance(ReferenceObject, LatestEndTime.Value - ReferenceObject.StartTime);
+                snappedDistance = SnapProvider.DurationToDistance(ReferenceObject, LatestEndTime.Value - ReferenceObject.GetEndTime());
+                snappedTime = StartTime + SnapProvider.DistanceToDuration(ReferenceObject, snappedDistance);
             }
 
             // The multiplier can then be reapplied to the final position.

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -30,14 +30,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     Position = StartPosition,
                     Width = crosshair_thickness,
                     EdgeSmoothness = new Vector2(1),
-                    Height = Math.Min(crosshair_max_size, DistanceSpacing * 2),
+                    Height = Math.Min(crosshair_max_size, DistanceBetweenTick * 2),
                 },
                 new Box
                 {
                     Origin = Anchor.Centre,
                     Position = StartPosition,
                     EdgeSmoothness = new Vector2(1),
-                    Width = Math.Min(crosshair_max_size, DistanceSpacing * 2),
+                    Width = Math.Min(crosshair_max_size, DistanceBetweenTick * 2),
                     Height = crosshair_thickness,
                 }
             });
@@ -45,11 +45,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float dx = Math.Max(StartPosition.X, DrawWidth - StartPosition.X);
             float dy = Math.Max(StartPosition.Y, DrawHeight - StartPosition.Y);
             float maxDistance = new Vector2(dx, dy).Length;
-            int requiredCircles = Math.Min(MaxIntervals, (int)(maxDistance / DistanceSpacing));
+            int requiredCircles = Math.Min(MaxIntervals, (int)(maxDistance / DistanceBetweenTick));
 
             for (int i = 0; i < requiredCircles; i++)
             {
-                float radius = (i + 1) * DistanceSpacing * 2;
+                float radius = (i + 1) * DistanceBetweenTick * 2;
 
                 AddInternal(new CircularProgress
                 {
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             float distance = direction.Length;
 
-            float radius = DistanceSpacing;
+            float radius = DistanceBetweenTick;
             int radialCount = Math.Clamp((int)MathF.Round(distance / radius), 1, MaxIntervals);
 
             Vector2 normalisedDirection = direction * new Vector2(1f / distance);

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -49,15 +49,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             for (int i = 0; i < requiredCircles; i++)
             {
-                float radius = (i + 1) * DistanceBetweenTicks * 2;
+                float diameter = (i + 1) * DistanceBetweenTicks * 2;
 
                 AddInternal(new CircularProgress
                 {
                     Origin = Anchor.Centre,
                     Position = StartPosition,
                     Current = { Value = 1 },
-                    Size = new Vector2(radius),
-                    InnerRadius = 4 * 1f / radius,
+                    Size = new Vector2(diameter),
+                    InnerRadius = 4 * 1f / diameter,
                     Colour = GetColourForIndexFromPlacement(i)
                 });
             }

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected IDistanceSnapProvider SnapProvider { get; private set; }
 
         [Resolved]
-        private EditorBeatmap beatmap { get; set; }
+        protected EditorBeatmap Beatmap { get; private set; }
 
         [Resolved]
         private BindableBeatDivisor beatDivisor { get; set; }
@@ -93,16 +93,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updateSpacing()
         {
-            DistanceBetweenTicks = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * DistanceSpacingMultiplier.Value);
+            float distanceSpacingMultiplier = (float)DistanceSpacingMultiplier.Value;
+            float beatSnapDistance = SnapProvider.GetBeatSnapDistanceAt(ReferenceObject);
+
+            DistanceBetweenTicks = beatSnapDistance * distanceSpacingMultiplier;
 
             if (LatestEndTime == null)
                 MaxIntervals = int.MaxValue;
             else
-            {
-                // +1 is added since a snapped hitobject may have its start time slightly less than the snapped time due to floating point errors
-                double maxDuration = LatestEndTime.Value - StartTime + 1;
-                MaxIntervals = (int)(maxDuration / SnapProvider.DistanceToDuration(ReferenceObject, DistanceBetweenTicks));
-            }
+                MaxIntervals = (int)((LatestEndTime.Value - StartTime) / SnapProvider.DistanceToDuration(ReferenceObject, beatSnapDistance));
 
             gridCache.Invalidate();
         }
@@ -138,7 +137,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>The applicable colour.</returns>
         protected ColourInfo GetColourForIndexFromPlacement(int placementIndex)
         {
-            var timingPoint = beatmap.ControlPointInfo.TimingPointAt(StartTime);
+            var timingPoint = Beatmap.ControlPointInfo.TimingPointAt(StartTime);
             double beatLength = timingPoint.BeatLength / beatDivisor.Value;
             int beatIndex = (int)Math.Round((StartTime - timingPoint.Time) / beatLength);
 

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected float DistanceBetweenTick { get; private set; }
 
+        protected IBindable<double> DistanceSpacingMultiplier { get; private set; }
+
         /// <summary>
         /// The maximum number of distance snapping intervals allowed.
         /// </summary>
@@ -52,8 +54,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         [Resolved]
         private BindableBeatDivisor beatDivisor { get; set; }
-
-        private IBindable<double> distanceSpacingMultiplier;
 
         private readonly LayoutValue gridCache = new LayoutValue(Invalidation.RequiredParentSizeToFit);
         private readonly double? endTime;
@@ -86,13 +86,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             beatDivisor.BindValueChanged(_ => updateSpacing());
 
-            distanceSpacingMultiplier = SnapProvider.DistanceSpacingMultiplier.GetBoundCopy();
-            distanceSpacingMultiplier.BindValueChanged(_ => updateSpacing(), true);
+            DistanceSpacingMultiplier = SnapProvider.DistanceSpacingMultiplier.GetBoundCopy();
+            DistanceSpacingMultiplier.BindValueChanged(_ => updateSpacing(), true);
         }
 
         private void updateSpacing()
         {
-            DistanceBetweenTick = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * distanceSpacingMultiplier.Value);
+            DistanceBetweenTick = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * DistanceSpacingMultiplier.Value);
 
             if (endTime == null)
                 MaxIntervals = int.MaxValue;

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// The spacing between each tick of the beat snapping grid.
         /// </summary>
-        protected float DistanceBetweenTick { get; private set; }
+        protected float DistanceBetweenTicks { get; private set; }
 
         protected IBindable<double> DistanceSpacingMultiplier { get; private set; }
 
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         /// <summary>
         /// The position which the grid should start.
-        /// The first beat snapping tick is located at <see cref="StartPosition"/> + <see cref="DistanceBetweenTick"/> away from this point.
+        /// The first beat snapping tick is located at <see cref="StartPosition"/> + <see cref="DistanceBetweenTicks"/> away from this point.
         /// </summary>
         protected readonly Vector2 StartPosition;
 
@@ -93,7 +93,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updateSpacing()
         {
-            DistanceBetweenTick = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * DistanceSpacingMultiplier.Value);
+            DistanceBetweenTicks = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * DistanceSpacingMultiplier.Value);
 
             if (LatestEndTime == null)
                 MaxIntervals = int.MaxValue;
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 // +1 is added since a snapped hitobject may have its start time slightly less than the snapped time due to floating point errors
                 double maxDuration = LatestEndTime.Value - StartTime + 1;
-                MaxIntervals = (int)(maxDuration / SnapProvider.DistanceToDuration(ReferenceObject, DistanceBetweenTick));
+                MaxIntervals = (int)(maxDuration / SnapProvider.DistanceToDuration(ReferenceObject, DistanceBetweenTicks));
             }
 
             gridCache.Invalidate();

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// The spacing between each tick of the beat snapping grid.
         /// </summary>
-        protected float DistanceSpacing { get; private set; }
+        protected float DistanceBetweenTick { get; private set; }
 
         /// <summary>
         /// The maximum number of distance snapping intervals allowed.
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         /// <summary>
         /// The position which the grid should start.
-        /// The first beat snapping tick is located at <see cref="StartPosition"/> + <see cref="DistanceSpacing"/> away from this point.
+        /// The first beat snapping tick is located at <see cref="StartPosition"/> + <see cref="DistanceBetweenTick"/> away from this point.
         /// </summary>
         protected readonly Vector2 StartPosition;
 
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updateSpacing()
         {
-            DistanceSpacing = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * distanceSpacingMultiplier.Value);
+            DistanceBetweenTick = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * distanceSpacingMultiplier.Value);
 
             if (endTime == null)
                 MaxIntervals = int.MaxValue;
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 // +1 is added since a snapped hitobject may have its start time slightly less than the snapped time due to floating point errors
                 double maxDuration = endTime.Value - StartTime + 1;
-                MaxIntervals = (int)(maxDuration / SnapProvider.DistanceToDuration(ReferenceObject, DistanceSpacing));
+                MaxIntervals = (int)(maxDuration / SnapProvider.DistanceToDuration(ReferenceObject, DistanceBetweenTick));
             }
 
             gridCache.Invalidate();

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected readonly double StartTime;
 
+        protected readonly double? LatestEndTime;
+
         [Resolved]
         protected OsuColour Colours { get; private set; }
 
@@ -56,7 +58,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private BindableBeatDivisor beatDivisor { get; set; }
 
         private readonly LayoutValue gridCache = new LayoutValue(Invalidation.RequiredParentSizeToFit);
-        private readonly double? endTime;
 
         protected readonly HitObject ReferenceObject;
 
@@ -70,7 +71,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected DistanceSnapGrid(HitObject referenceObject, Vector2 startPosition, double startTime, double? endTime = null)
         {
             ReferenceObject = referenceObject;
-            this.endTime = endTime;
+            LatestEndTime = endTime;
 
             StartPosition = startPosition;
             StartTime = startTime;
@@ -94,12 +95,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             DistanceBetweenTick = (float)(SnapProvider.GetBeatSnapDistanceAt(ReferenceObject) * DistanceSpacingMultiplier.Value);
 
-            if (endTime == null)
+            if (LatestEndTime == null)
                 MaxIntervals = int.MaxValue;
             else
             {
                 // +1 is added since a snapped hitobject may have its start time slightly less than the snapped time due to floating point errors
-                double maxDuration = endTime.Value - StartTime + 1;
+                double maxDuration = LatestEndTime.Value - StartTime + 1;
                 MaxIntervals = (int)(maxDuration / SnapProvider.DistanceToDuration(ReferenceObject, DistanceBetweenTick));
             }
 


### PR DESCRIPTION
- Alternative to https://github.com/ppy/osu/pull/18092
- Closes https://github.com/ppy/osu/issues/18073

Of note, only 4c884aea5d is required to fix the issue. The majority of the work here was to rewrite the snapping implementation in `CircularDistanceSnapGrid` to use the snap provider, rather than calculate things locally using its own implementation (which felt very ad-hoc).

- [x] Depends on https://github.com/ppy/osu/pull/18100
- [x] Depends on https://github.com/ppy/osu/pull/18101