### PR TITLE
Close new design's mod customisation area on escape press before exiting 

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -164,11 +164,19 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
             assertCustomisationToggleState(disabled: false, active: true);
 
-            AddStep("dismiss mod customisation", () =>
+            AddStep("dismiss mod customisation via mouse", () =>
             {
                 InputManager.MoveMouseTo(modSelectScreen.ChildrenOfType<ShearedToggleButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
+            assertCustomisationToggleState(disabled: false, active: false);
+
+            AddStep("reset mods", () => SelectedMods.SetDefault());
+            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            assertCustomisationToggleState(disabled: false, active: true);
+
+            AddStep("dismiss mod customisation via keyboard", () => InputManager.Key(Key.Escape));
+            assertCustomisationToggleState(disabled: false, active: false);
 
             AddStep("append another mod not requiring config", () => SelectedMods.Value = SelectedMods.Value.Append(new OsuModFlashlight()).ToArray());
             assertCustomisationToggleState(disabled: false, active: false);

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -18,6 +18,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 using osuTK.Input;
@@ -313,6 +314,17 @@ namespace osu.Game.Overlays.Mods
                       .MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint)
                       .FadeOut(fade_out_duration, Easing.OutQuint);
             }
+        }
+
+        public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Action == GlobalAction.Back && customisationVisible.Value)
+            {
+                customisationVisible.Value = false;
+                return true;
+            }
+
+            return base.OnPressed(e);
         }
 
         internal class ColumnScrollContainer : OsuScrollContainer<ColumnFlowContainer>

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Overlays.Mods
             foreach (var mod in SelectedMods.Value)
             {
                 anyCustomisableMod |= mod.GetSettingsSourceProperties().Any();
-                anyModWithRequiredCustomisationAdded |= !valueChangedEvent.OldValue.Contains(mod) && mod.RequiresConfiguration;
+                anyModWithRequiredCustomisationAdded |= valueChangedEvent.OldValue.All(m => m.GetType() != mod.GetType()) && mod.RequiresConfiguration;
             }
 
             if (anyCustomisableMod)


### PR DESCRIPTION
Something I noticed when testing my integration branch of the new mod select (#16917). To see what I mean:

1. Open the test scene
2. Select a mod with customisation settings, then open the customisation area
3. Press Escape

Current master does this:

https://user-images.githubusercontent.com/20418176/166979118-97e46e35-2547-4ea3-9032-f1b7d058e871.mp4

which feels pretty wrong (the customisation area is kept open as the mod overlay pops out, and remains open as the whole overlay is toggled). This PR changes the behaviour to the following:

https://user-images.githubusercontent.com/20418176/166979237-d531edd7-af69-44ee-b4dd-259bd070fe84.mp4

i.e. the first Esc press dismisses the customisation area, and the second pops out the entire overlay. I also considered automatically hiding on popout in order to require only one Esc press, but it felt pretty wrong, but will change to that if there are strong feelings about it.

Of note, 2cc56a4b19348b2b80ca4e4521a37e56a4bc0011 is a drive-by fix to a bug in the customisation toggle logic that caused the test modified here to fail when ran in the test browser on master. I don't actually know the immediate cause of the bug, but it is obviously something to do with the ~~insane~~ mod reference management logic that I touched on [in the previous pull](https://github.com/ppy/osu/pull/18081), and the fix is known (by switching to check type equality rather than reference equality via `.Contains()`), so I didn't bother root-causing it.