### PR TITLE
Highlight distance snap grid rings that are close to the current time value

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -131,7 +131,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (editorClock == null)
                     return;
 
-                float distanceForCurrentTime = snapProvider.DurationToDistance(referenceObject, editorClock.CurrentTime - referenceObject.GetEndTime());
+                float distanceSpacingMultiplier = (float)snapProvider.DistanceSpacingMultiplier.Value;
+                double timeFromReferencePoint = editorClock.CurrentTime - referenceObject.GetEndTime();
+
+                float distanceForCurrentTime = snapProvider.DurationToDistance(referenceObject, timeFromReferencePoint)
+                                               * distanceSpacingMultiplier;
+
                 float timeBasedAlpha = 1 - Math.Clamp(Math.Abs(distanceForCurrentTime - Size.X / 2) / 30, 0, 1);
 
                 Colour = baseColour.Opacity(Math.Max(baseColour.A, timeBasedAlpha));

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     return;
 
                 float distanceForCurrentTime = snapProvider.DurationToDistance(referenceObject, editorClock.CurrentTime - referenceObject.GetEndTime());
-                float timeBasedAlpha = Math.Clamp(1 - Math.Abs(distanceForCurrentTime - Size.X / 2) / 30, 0, 1);
+                float timeBasedAlpha = 1 - Math.Clamp(Math.Abs(distanceForCurrentTime - Size.X / 2) / 30, 0, 1);
 
                 Colour = baseColour.Opacity(Math.Max(baseColour.A, timeBasedAlpha));
             }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -2,11 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -51,14 +55,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 float diameter = (i + 1) * DistanceBetweenTicks * 2;
 
-                AddInternal(new CircularProgress
+                AddInternal(new Ring(ReferenceObject, GetColourForIndexFromPlacement(i))
                 {
-                    Origin = Anchor.Centre,
                     Position = StartPosition,
-                    Current = { Value = 1 },
+                    Origin = Anchor.Centre,
                     Size = new Vector2(diameter),
                     InnerRadius = 4 * 1f / diameter,
-                    Colour = GetColourForIndexFromPlacement(i)
                 });
             }
         }
@@ -99,6 +101,41 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Vector2 snappedPosition = StartPosition + travelVector.Normalized() * snappedDistance * distanceSpacingMultiplier;
 
             return (snappedPosition, snappedTime);
+        }
+
+        public class Ring : CircularProgress
+        {
+            [Resolved]
+            private IDistanceSnapProvider snapProvider { get; set; }
+
+            [Resolved(canBeNull: true)]
+            private EditorClock editorClock { get; set; }
+
+            private readonly HitObject referenceObject;
+
+            private readonly Color4 baseColour;
+
+            public Ring(HitObject referenceObject, Color4 baseColour)
+            {
+                this.referenceObject = referenceObject;
+
+                Colour = this.baseColour = baseColour;
+
+                Current.Value = 1;
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (editorClock == null)
+                    return;
+
+                float distanceForCurrentTime = snapProvider.DurationToDistance(referenceObject, editorClock.CurrentTime - referenceObject.StartTime);
+                float timeBasedAlpha = Math.Clamp(1 - Math.Abs(distanceForCurrentTime - Size.X / 2) / 30, 0, 1);
+
+                Colour = baseColour.Opacity(Math.Max(baseColour.A, timeBasedAlpha));
+            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return (snappedPosition, snappedTime);
         }
 
-        public class Ring : CircularProgress
+        private class Ring : CircularProgress
         {
             [Resolved]
             private IDistanceSnapProvider snapProvider { get; set; }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (editorClock == null)
                     return;
 
-                float distanceForCurrentTime = snapProvider.DurationToDistance(referenceObject, editorClock.CurrentTime - referenceObject.StartTime);
+                float distanceForCurrentTime = snapProvider.DurationToDistance(referenceObject, editorClock.CurrentTime - referenceObject.GetEndTime());
                 float timeBasedAlpha = Math.Clamp(1 - Math.Abs(distanceForCurrentTime - Size.X / 2) / 30, 0, 1);
 
                 Colour = baseColour.Opacity(Math.Max(baseColour.A, timeBasedAlpha));

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -4,14 +4,15 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -135,7 +136,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="placementIndex">The 0-based beat index from the point of placement.</param>
         /// <returns>The applicable colour.</returns>
-        protected ColourInfo GetColourForIndexFromPlacement(int placementIndex)
+        protected Color4 GetColourForIndexFromPlacement(int placementIndex)
         {
             var timingPoint = Beatmap.ControlPointInfo.TimingPointAt(StartTime);
             double beatLength = timingPoint.BeatLength / beatDivisor.Value;
@@ -144,7 +145,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             var colour = BindableBeatDivisor.GetColourFor(BindableBeatDivisor.GetDivisorForBeatIndex(beatIndex + placementIndex + 1, beatDivisor.Value), Colours);
 
             int repeatIndex = placementIndex / beatDivisor.Value;
-            return ColourInfo.SingleColour(colour).MultiplyAlpha(0.5f / (repeatIndex + 1));
+            return colour.Opacity(0.5f / (repeatIndex + 1));
         }
     }
 }


### PR DESCRIPTION
This is intended to improve the usability of distance snap, especially for mappers coming across from stable (where distance snap is *only* available for the current point-in-time).

By highlighting the grid, it not only shows the correct point of placement if a mapper is looking to get the same behaviour as provided but stable, but should also help users understand exactly what the grid is showing in the first place. This is most noticeable when advancing time while the grid is visible:


https://user-images.githubusercontent.com/191335/167105984-65318479-5f25-4916-afd1-0a88de7e92d6.mp4




- [x] Depends on https://github.com/ppy/osu/pull/18103