### PR TITLE
Fix mod panels not hovering correctly after closing customisation area via mouse on new mod select

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -164,7 +165,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
             assertCustomisationToggleState(disabled: false, active: true);
 
-            AddStep("dismiss mod customisation via mouse", () =>
+            AddStep("dismiss mod customisation via toggle", () =>
             {
                 InputManager.MoveMouseTo(modSelectScreen.ChildrenOfType<ShearedToggleButton>().Single());
                 InputManager.Click(MouseButton.Left);
@@ -189,6 +190,29 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("select mod without configuration", () => SelectedMods.Value = new[] { new OsuModAutoplay() });
             assertCustomisationToggleState(disabled: true, active: false); // config was dismissed without explicit user action.
+        }
+
+        [Test]
+        public void TestDismissCustomisationViaDimmedArea()
+        {
+            createScreen();
+            assertCustomisationToggleState(disabled: true, active: false);
+
+            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            assertCustomisationToggleState(disabled: false, active: true);
+
+            AddStep("move mouse to settings area", () => InputManager.MoveMouseTo(this.ChildrenOfType<ModSettingsArea>().Single()));
+            AddStep("move mouse to dimmed area", () =>
+            {
+                InputManager.MoveMouseTo(new Vector2(
+                    modSelectScreen.ScreenSpaceDrawQuad.TopLeft.X,
+                    (modSelectScreen.ScreenSpaceDrawQuad.TopLeft.Y + modSelectScreen.ScreenSpaceDrawQuad.BottomLeft.Y) / 2));
+            });
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            assertCustomisationToggleState(disabled: false, active: false);
+
+            AddStep("move mouse to first mod panel", () => InputManager.MoveMouseTo(modSelectScreen.ChildrenOfType<ModPanel>().First()));
+            AddAssert("first mod panel is hovered", () => modSelectScreen.ChildrenOfType<ModPanel>().First().IsHovered);
         }
 
         /// <summary>

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -464,6 +464,8 @@ namespace osu.Game.Overlays.Mods
 
             public Action? OnClicked { get; set; }
 
+            public override bool HandlePositionalInput => base.HandlePositionalInput && HandleMouse.Value;
+
             protected override bool Handle(UIEvent e)
             {
                 if (!HandleMouse.Value)


### PR DESCRIPTION
Continuation of #16917.

This was pointed out in stream chat.

Before:

https://user-images.githubusercontent.com/20418176/167116168-308857b4-1939-45c2-81fe-2bcfd55d14f5.mp4

Note the lack of hover effects on the panels after the mod area has been closed, and the lack of sounds.

After:

https://user-images.githubusercontent.com/20418176/167116219-9f84d16e-e3f9-4616-8124-f3ddc913dcb0.mp4

Happened due to an edge case in hover handling - if a hovered drawable wants to yield hover because it's going away for whatever reason, it needs to override `HandlePositionalInput` to [be excluded from the input queue on the next frame](https://github.com/ppy/osu-framework/blob/555d10ac512ebd38771ef5fe2441a149d80dcbd2/osu.Framework/Graphics/Drawable.cs#L2555-L2564).