### PR TITLE
Fix user-contracted toolbox groups in editor incorrectly expanding on hover

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
@@ -99,15 +99,15 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         /// <summary>
-        /// Tests expanding a container will expand underlying groups if contracted.
+        /// Tests expanding a container will not expand underlying groups if they were manually contracted by the user.
         /// </summary>
         [Test]
-        public void TestExpandingContainerExpandsContractedGroup()
+        public void TestExpandingContainerDoesNotExpandContractedGroup()
         {
             AddStep("contract group", () => toolboxGroup.Expanded.Value = false);
 
             AddStep("expand container", () => container.Expanded.Value = true);
-            AddAssert("group expanded", () => toolboxGroup.Expanded.Value);
+            AddAssert("group not expanded", () => !toolboxGroup.Expanded.Value);
             AddAssert("controls expanded", () => slider1.Expanded.Value && slider2.Expanded.Value);
 
             AddStep("contract container", () => container.Expanded.Value = false);

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -117,32 +117,17 @@ namespace osu.Game.Overlays
             };
         }
 
-        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
         {
-            if (invalidation.HasFlagFast(Invalidation.DrawSize))
-                headerTextVisibilityCache.Invalidate();
-
-            return base.OnInvalidate(invalidation, source);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (!headerTextVisibilityCache.IsValid)
-                // These toolbox grouped may be contracted to only show icons.
-                // For now, let's hide the header to avoid text truncation weirdness in such cases.
-                headerText.FadeTo(headerText.DrawWidth < DrawWidth ? 1 : 0, 150, Easing.OutQuint);
+            expandedColour = colours.Yellow;
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            Expanded.BindValueChanged(v =>
-            {
-                Scheduler.AddOnce(updateExpandedState);
-            }, true);
+            Expanded.BindValueChanged(updateExpandedState, true);
 
             this.Delay(600).Schedule(updateFadeState);
         }
@@ -159,15 +144,27 @@ namespace osu.Game.Overlays
             base.OnHoverLost(e);
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        protected override void Update()
         {
-            expandedColour = colours.Yellow;
+            base.Update();
+
+            if (!headerTextVisibilityCache.IsValid)
+                // These toolbox grouped may be contracted to only show icons.
+                // For now, let's hide the header to avoid text truncation weirdness in such cases.
+                headerText.FadeTo(headerText.DrawWidth < DrawWidth ? 1 : 0, 150, Easing.OutQuint);
         }
 
-        private void updateExpandedState()
+        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
         {
-            if (Expanded.Value)
+            if (invalidation.HasFlagFast(Invalidation.DrawSize))
+                headerTextVisibilityCache.Invalidate();
+
+            return base.OnInvalidate(invalidation, source);
+        }
+
+        private void updateExpandedState(ValueChangedEvent<bool> expanded)
+        {
+            if (expanded.NewValue)
                 content.AutoSizeAxes = Axes.Y;
             else
             {
@@ -175,7 +172,7 @@ namespace osu.Game.Overlays
                 content.ResizeHeightTo(0, transition_duration, Easing.OutQuint);
             }
 
-            button.FadeColour(Expanded.Value ? expandedColour : Color4.White, 200, Easing.InOutQuint);
+            button.FadeColour(expanded.NewValue ? expandedColour : Color4.White, 200, Easing.InOutQuint);
         }
 
         private void updateFadeState()

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Overlays
         private readonly Cached headerTextVisibilityCache = new Cached();
 
         private readonly FillFlowContainer content;
-        private readonly IconButton button;
 
         public BindableBool Expanded { get; } = new BindableBool(true);
 
@@ -87,7 +86,7 @@ namespace osu.Game.Overlays
                                     Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 17),
                                     Padding = new MarginPadding { Left = 10, Right = 30 },
                                 },
-                                button = new IconButton
+                                new IconButton
                                 {
                                     Origin = Anchor.Centre,
                                     Anchor = Anchor.CentreRight,

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Extensions.EnumExtensions;

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -141,10 +141,6 @@ namespace osu.Game.Overlays
 
             Expanded.BindValueChanged(v =>
             {
-                // clearing transforms can break autosizing, see: https://github.com/ppy/osu-framework/issues/5064
-                if (v.NewValue != v.OldValue)
-                    content.ClearTransforms();
-
                 Scheduler.AddOnce(updateExpandedState);
             }, true);
 

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -39,9 +39,9 @@ namespace osu.Game.Overlays
 
         public BindableBool Expanded { get; } = new BindableBool(true);
 
-        private Color4 expandedColour;
-
         private readonly OsuSpriteText headerText;
+
+        private readonly Container headerContent;
 
         /// <summary>
         /// Create a new instance.
@@ -71,7 +71,7 @@ namespace osu.Game.Overlays
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        new Container
+                        headerContent = new Container
                         {
                             Name = @"Header",
                             Origin = Anchor.TopCentre,
@@ -115,12 +115,6 @@ namespace osu.Game.Overlays
                     }
                 },
             };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            expandedColour = colours.Yellow;
         }
 
         protected override void LoadComplete()
@@ -172,7 +166,7 @@ namespace osu.Game.Overlays
                 content.ResizeHeightTo(0, transition_duration, Easing.OutQuint);
             }
 
-            button.FadeColour(expanded.NewValue ? expandedColour : Color4.White, 200, Easing.InOutQuint);
+            headerContent.FadeColour(expanded.NewValue ? Color4.White : OsuColour.Gray(0.5f), 200, Easing.OutQuint);
         }
 
         private void updateFadeState()


### PR DESCRIPTION
This made it nigh-impossible to actually set the state to expanded after contracting once, due to how the `Expanded` flag was being managed internally. It also made little sense from a UX perspective - if a user has chosen to hide a toolbox they wouldn't want it to forcefuly expand on hover.

I also changed colour denoting expanded state to be gray rather than yellow, as I found the yellow colour very non-descript in this case. Gray seems to work better?