### PR TITLE
Remove leftover border thickness spec in mod settings area

### DIFF
--- a/osu.Game/Overlays/Mods/ModSettingsArea.cs
+++ b/osu.Game/Overlays/Mods/ModSettingsArea.cs
@@ -44,7 +44,6 @@ namespace osu.Game.Overlays.Mods
             {
                 RelativeSizeAxes = Axes.Both,
                 Masking = true,
-                BorderThickness = 2,
                 Children = new Drawable[]
                 {
                     background = new Box


### PR DESCRIPTION
#16917, continued.

This spec was never supposed to be there, it was a vestige of a previous design iteration that went by unnoticed. Border colour defaults to black which doesn't help notice it in this case.

| before | after |
| :-: | :-: |
| ![image](https://user-images.githubusercontent.com/20418176/167143897-2d3c895b-d3af-4368-aa07-3d760a2ea82d.png) | ![image](https://user-images.githubusercontent.com/20418176/167144510-5c789af0-f8e1-4bfc-8051-1aea5a1c24a7.png) |

(images above best viewed by opening in separate tabs and tabbing back and forth between them)