### PR TITLE
Fix several issues with new mod select reference replacement logic

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
@@ -6,24 +6,19 @@ using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneFreeModSelectScreen : MultiplayerTestScene
     {
+        private FreeModSelectScreen freeModSelectScreen;
+
         [Test]
         public void TestFreeModSelect()
         {
-            FreeModSelectScreen freeModSelectScreen = null;
-
-            AddStep("create free mod select screen", () => Child = freeModSelectScreen = new FreeModSelectScreen
-            {
-                State = { Value = Visibility.Visible }
-            });
-            AddUntilStep("all column content loaded",
-                () => freeModSelectScreen.ChildrenOfType<ModColumn>().Any()
-                      && freeModSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
+            createFreeModSelect();
 
             AddUntilStep("all visible mods are playable",
                 () => this.ChildrenOfType<ModPanel>()
@@ -35,6 +30,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 if (freeModSelectScreen != null)
                     freeModSelectScreen.State.Value = visible ? Visibility.Visible : Visibility.Hidden;
             });
+        }
+
+        [Test]
+        public void TestCustomisationNotAvailable()
+        {
+            createFreeModSelect();
+
+            AddStep("select difficulty adjust", () => freeModSelectScreen.SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            AddWaitStep("wait some", 3);
+            AddAssert("customisation area not expanded", () => this.ChildrenOfType<ModSettingsArea>().Single().Height == 0);
+        }
+
+        private void createFreeModSelect()
+        {
+            AddStep("create free mod select screen", () => Child = freeModSelectScreen = new FreeModSelectScreen
+            {
+                State = { Value = Visibility.Visible }
+            });
+            AddUntilStep("all column content loaded",
+                () => freeModSelectScreen.ChildrenOfType<ModColumn>().Any()
+                      && freeModSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
         }
     }
 }

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -330,14 +330,16 @@ namespace osu.Game.Overlays.Mods
 
         private void panelStateChanged(ModPanel panel)
         {
+            if (externalSelectionUpdateInProgress)
+                return;
+
             var newSelectedMods = panel.Active.Value
                 ? SelectedMods.Append(panel.Mod)
                 : SelectedMods.Except(panel.Mod.Yield());
 
             SelectedMods = newSelectedMods.ToArray();
             updateState();
-            if (!externalSelectionUpdateInProgress)
-                SelectionChangedByUser?.Invoke();
+            SelectionChangedByUser?.Invoke();
         }
 
         /// <summary>

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
+using osu.Framework.Lists;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -264,7 +265,9 @@ namespace osu.Game.Overlays.Mods
         {
             var candidateSelection = columnFlow.Columns.SelectMany(column => column.SelectedMods).ToArray();
 
-            if (candidateSelection.SequenceEqual(SelectedMods.Value))
+            // the following guard intends to check cases where we've already replaced potentially-external mod references with our own and avoid endless recursion.
+            // TODO: replace custom comparer with System.Collections.Generic.ReferenceEqualityComparer when fully on .NET 6
+            if (candidateSelection.SequenceEqual(SelectedMods.Value, new FuncEqualityComparer<Mod>(ReferenceEquals)))
                 return;
 
             SelectedMods.Value = ComputeNewModsFromSelection(SelectedMods.Value, candidateSelection);


### PR DESCRIPTION
This is a "trash fire" sort of diff, split out of stuff I have queued to resolve concerns with #18111. All of it started when I attempted to write a test contained in 380cd1e03619e45ad580356342f99498c0f59592, because I wanted to make sure I didn't break the customisation logic when adding more buttons to the footer. To my surprise, that test was failing on `master` because of the convoluted reference replacement logic.

Commits that follow are fixes to the issues found. In sequence:

* c199b8fcb66fade4234b6e24597d42f4afccc442: This one doesn't strictly fix anything, but is an attempt to clean up some of the state management in `ModColumn`, because I couldn't follow my own code (always a great sign). Previously I attempted to be clever and had three methods updating various aspects of the column to minimise redundant updates, but this wasn't working for readability at all, and therefore all three methods were merged into one `updateState()`.
* 621f7467898e290bdd2d9d9fe3cc4daadd209366: Bug 1. `ModColumn.panelStateChanged()` shouldn't touch `SelectedMods` at all if `externalSelectionUpdateInProgress` is true, because if it is true, then it must have been preceded by a `SetSelection` call, which already ensures that `SelectedMods` is being set to the correct set of local mod references and calls `updateState()` at the end of it to update visuals. This was probably passing tests because tests only exercised the "user" variant in the first place, which has custom incompatibility logic bolted on.
* 8c73ed72078a47eb7f166164cb80e642b5486218: Bug 2. Uncovered by a test failure after fixing bug 1. The `SequenceEqual` call was using `EqualityComparer<Mod>.Default`, which is *not* reference-based because `Mod` implements `IEquatable`. I actually *want* a reference equality check there, because the guard was a protection against stack overflows (to make sure the reference replacement logic doesn't fire more than once).