### PR TITLE
Add back select/deselect all mods buttons to new mod select design

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
@@ -1,19 +1,32 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneFreeModSelectScreen : MultiplayerTestScene
     {
         private FreeModSelectScreen freeModSelectScreen;
+        private readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>();
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGameBase osuGameBase)
+        {
+            availableMods.BindTo(osuGameBase.AvailableMods);
+        }
 
         [Test]
         public void TestFreeModSelect()
@@ -42,6 +55,26 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("customisation area not expanded", () => this.ChildrenOfType<ModSettingsArea>().Single().Height == 0);
         }
 
+        [Test]
+        public void TestSelectDeselectAll()
+        {
+            createFreeModSelect();
+
+            AddStep("click select all button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("all mods selected", assertAllAvailableModsSelected);
+
+            AddStep("click deselect all button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("all mods deselected", () => !freeModSelectScreen.SelectedMods.Value.Any());
+        }
+
         private void createFreeModSelect()
         {
             AddStep("create free mod select screen", () => Child = freeModSelectScreen = new FreeModSelectScreen
@@ -51,6 +84,22 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("all column content loaded",
                 () => freeModSelectScreen.ChildrenOfType<ModColumn>().Any()
                       && freeModSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
+        }
+
+        private bool assertAllAvailableModsSelected()
+        {
+            var allAvailableMods = availableMods.Value
+                                                .SelectMany(pair => pair.Value)
+                                                .Where(mod => mod.UserPlayable && mod.HasImplementation)
+                                                .ToList();
+
+            foreach (var availableMod in allAvailableMods)
+            {
+                if (freeModSelectScreen.SelectedMods.Value.All(selectedMod => selectedMod.GetType() != availableMod.GetType()))
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -415,6 +415,23 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("unimplemented mod panel is filtered", () => getPanelForMod(typeof(TestUnimplementedMod)).Filtered.Value);
         }
 
+        [Test]
+        public void TestDeselectAllViaButton()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("select DT + HD", () => SelectedMods.Value = new Mod[] { new OsuModDoubleTime(), new OsuModHidden() });
+            AddAssert("DT + HD selected", () => modSelectScreen.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
+
+            AddStep("click deselect all button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("all mods deselected", () => !SelectedMods.Value.Any());
+        }
+
         private void waitForColumnLoad() => AddUntilStep("all column content loaded",
             () => modSelectScreen.ChildrenOfType<ModColumn>().Any() && modSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
 

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -275,35 +275,48 @@ namespace osu.Game.Overlays.Mods
                 return;
 
             localAvailableMods = newMods;
-            loadPanels();
+
+            if (!IsLoaded)
+                // if we're coming from BDL, perform the first load synchronously to make sure everything is in place as early as possible.
+                onPanelsLoaded(createPanels());
+            else
+                asyncLoadPanels();
         }
 
         private CancellationTokenSource? cancellationTokenSource;
 
-        private void loadPanels()
+        private void asyncLoadPanels()
         {
             cancellationTokenSource?.Cancel();
 
-            var panels = localAvailableMods.Select(mod => CreateModPanel(mod).With(panel => panel.Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)));
+            var panels = createPanels();
 
             Task? loadTask;
 
-            latestLoadTask = loadTask = LoadComponentsAsync(panels, loaded =>
-            {
-                panelFlow.ChildrenEnumerable = loaded;
-
-                updateState();
-
-                foreach (var panel in panelFlow)
-                {
-                    panel.Active.BindValueChanged(_ => panelStateChanged(panel));
-                }
-            }, (cancellationTokenSource = new CancellationTokenSource()).Token);
+            latestLoadTask = loadTask = LoadComponentsAsync(panels, onPanelsLoaded, (cancellationTokenSource = new CancellationTokenSource()).Token);
             loadTask.ContinueWith(_ =>
             {
                 if (loadTask == latestLoadTask)
                     latestLoadTask = null;
             });
+        }
+
+        private IEnumerable<ModPanel> createPanels()
+        {
+            var panels = localAvailableMods.Select(mod => CreateModPanel(mod).With(panel => panel.Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)));
+            return panels;
+        }
+
+        private void onPanelsLoaded(IEnumerable<ModPanel> loaded)
+        {
+            panelFlow.ChildrenEnumerable = loaded;
+
+            updateState();
+
+            foreach (var panel in panelFlow)
+            {
+                panel.Active.BindValueChanged(_ => panelStateChanged(panel));
+            }
         }
 
         private void updateState()

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Overlays.Mods
                 return;
 
             localAvailableMods = newMods;
-            Scheduler.AddOnce(loadPanels);
+            loadPanels();
         }
 
         private CancellationTokenSource? cancellationTokenSource;

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -399,7 +399,7 @@ namespace osu.Game.Overlays.Mods
 
         private readonly Queue<Action> pendingSelectionOperations = new Queue<Action>();
 
-        protected bool SelectionAnimationRunning => pendingSelectionOperations.Count > 0;
+        internal bool SelectionAnimationRunning => pendingSelectionOperations.Count > 0;
 
         protected override void Update()
         {

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -48,16 +48,25 @@ namespace osu.Game.Overlays.Mods
         }
 
         /// <summary>
-        /// Whether configurable <see cref="Mod"/>s can be configured by the local user.
-        /// </summary>
-        protected virtual bool AllowCustomisation => true;
-
-        /// <summary>
         /// Whether the total score multiplier calculated from the current selected set of mods should be shown.
         /// </summary>
         protected virtual bool ShowTotalMultiplier => true;
 
         protected virtual ModColumn CreateModColumn(ModType modType, Key[]? toggleKeys = null) => new ModColumn(modType, false, toggleKeys);
+
+        protected virtual Drawable[] CreateFooterButtons() => new Drawable[]
+        {
+            customisationButton = new ShearedToggleButton(200)
+            {
+                Text = "Mod Customisation",
+                Active = { BindTarget = customisationVisible }
+            },
+            new ShearedButton(200)
+            {
+                Text = "Deselect All",
+                Action = DeselectAll
+            }
+        };
 
         private readonly BindableBool customisationVisible = new BindableBool();
 
@@ -65,6 +74,7 @@ namespace osu.Game.Overlays.Mods
         private ModSettingsArea modSettingsArea = null!;
         private ColumnScrollContainer columnScroll = null!;
         private ColumnFlowContainer columnFlow = null!;
+        private ShearedToggleButton? customisationButton;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -146,22 +156,21 @@ namespace osu.Game.Overlays.Mods
                 });
             }
 
-            FooterContent.Padding = new MarginPadding
+            FooterContent.Child = new FillFlowContainer
             {
-                Vertical = PADDING,
-                Horizontal = 70
-            };
-
-            if (AllowCustomisation)
-            {
-                FooterContent.Add(new ShearedToggleButton(200)
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Horizontal,
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                Padding = new MarginPadding
                 {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Text = "Mod Customisation",
-                    Active = { BindTarget = customisationVisible }
-                });
-            }
+                    Vertical = PADDING,
+                    Horizontal = 70
+                },
+                Spacing = new Vector2(10),
+                Children = CreateFooterButtons()
+            };
         }
 
         private ColumnDimContainer createModColumnContent(ModType modType, Key[]? toggleKeys = null)
@@ -216,7 +225,7 @@ namespace osu.Game.Overlays.Mods
 
         private void updateCustomisation(ValueChangedEvent<IReadOnlyList<Mod>> valueChangedEvent)
         {
-            if (!AllowCustomisation)
+            if (customisationButton == null)
                 return;
 
             bool anyCustomisableMod = false;
@@ -323,6 +332,18 @@ namespace osu.Game.Overlays.Mods
                       .MoveToY(i % 2 == 0 ? -distance : distance, fade_out_duration, Easing.OutQuint)
                       .FadeOut(fade_out_duration, Easing.OutQuint);
             }
+        }
+
+        protected void SelectAll()
+        {
+            foreach (var column in columnFlow.Columns)
+                column.SelectAll();
+        }
+
+        protected void DeselectAll()
+        {
+            foreach (var column in columnFlow.Columns)
+                column.DeselectAll();
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -454,6 +454,8 @@ namespace osu.Game.Overlays.Mods
                 FinishTransforms();
             }
 
+            protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate || Column.SelectionAnimationRunning;
+
             private void updateDim()
             {
                 Colour4 targetColour;

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -145,13 +145,18 @@ namespace osu.Game.Overlays.Mods
                 });
             }
 
+            FooterContent.Padding = new MarginPadding
+            {
+                Vertical = PADDING,
+                Horizontal = 70
+            };
+
             if (AllowCustomisation)
             {
-                Footer.Add(new ShearedToggleButton(200)
+                FooterContent.Add(new ShearedToggleButton(200)
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
-                    Margin = new MarginPadding { Vertical = PADDING, Left = 70 },
                     Text = "Mod Customisation",
                     Active = { BindTarget = customisationVisible }
                 });

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Mods
 
         protected virtual ModColumn CreateModColumn(ModType modType, Key[]? toggleKeys = null) => new ModColumn(modType, false, toggleKeys);
 
-        protected virtual Drawable[] CreateFooterButtons() => new Drawable[]
+        protected virtual IEnumerable<ShearedButton> CreateFooterButtons() => new[]
         {
             customisationButton = new ShearedToggleButton(200)
             {
@@ -75,6 +75,7 @@ namespace osu.Game.Overlays.Mods
         private ColumnScrollContainer columnScroll = null!;
         private ColumnFlowContainer columnFlow = null!;
         private ShearedToggleButton? customisationButton;
+        private FillFlowContainer<ShearedButton> footerButtonFlow = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -156,7 +157,7 @@ namespace osu.Game.Overlays.Mods
                 });
             }
 
-            FooterContent.Child = new FillFlowContainer
+            FooterContent.Child = footerButtonFlow = new FillFlowContainer<ShearedButton>
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
@@ -169,7 +170,7 @@ namespace osu.Game.Overlays.Mods
                     Horizontal = 70
                 },
                 Spacing = new Vector2(10),
-                Children = CreateFooterButtons()
+                ChildrenEnumerable = CreateFooterButtons()
             };
         }
 
@@ -258,6 +259,12 @@ namespace osu.Game.Overlays.Mods
             const double transition_duration = 300;
 
             MainAreaContent.FadeColour(customisationVisible.Value ? Colour4.Gray : Colour4.White, transition_duration, Easing.InOutCubic);
+
+            foreach (var button in footerButtonFlow)
+            {
+                if (button != customisationButton)
+                    button.Enabled.Value = !customisationVisible.Value;
+            }
 
             float modAreaHeight = customisationVisible.Value ? ModSettingsArea.HEIGHT : 0;
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -95,6 +95,7 @@ namespace osu.Game.Overlays.Mods
                     Padding = new MarginPadding
                     {
                         Top = (ShowTotalMultiplier ? DifficultyMultiplierDisplay.HEIGHT : 0) + PADDING,
+                        Bottom = PADDING
                     },
                     RelativeSizeAxes = Axes.Both,
                     RelativePositionAxes = Axes.Both,

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osuTK.Input;
@@ -10,7 +12,6 @@ namespace osu.Game.Screens.OnlinePlay
 {
     public class FreeModSelectScreen : ModSelectScreen
     {
-        protected override bool AllowCustomisation => false;
         protected override bool ShowTotalMultiplier => false;
 
         public new Func<Mod, bool> IsValidMod
@@ -25,5 +26,23 @@ namespace osu.Game.Screens.OnlinePlay
         }
 
         protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new ModColumn(modType, true, toggleKeys);
+
+        protected override Drawable[] CreateFooterButtons() => new Drawable[]
+        {
+            new ShearedButton(200)
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                Text = "Select All",
+                Action = SelectAll
+            },
+            new ShearedButton(200)
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                Text = "Deselect All",
+                Action = DeselectAll
+            }
+        };
     }
 }

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
@@ -27,7 +28,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new ModColumn(modType, true, toggleKeys);
 
-        protected override Drawable[] CreateFooterButtons() => new Drawable[]
+        protected override IEnumerable<ShearedButton> CreateFooterButtons() => new[]
         {
             new ShearedButton(200)
             {


### PR DESCRIPTION
As mentioned in #18111.

https://user-images.githubusercontent.com/20418176/167244335-dde7131d-4804-4602-b3b7-4a1d4c350bf4.mp4

Highlights:

* 9f96dd47d12db4a4df8ebfa9268eec86907fb886 and 9514a5cef7a6b291056697f1305fa159903103a3: Adjustments to the panel load logic. Goal is to ensure that the first load happens inside BDL rather than is scheduled on first visibility frame as previously; the scheduling + async load were causing the "select all" operation to fail on some columns in tests because the panels weren't physically in place yet at the point of requesting the selection.
* 18e4c3ed0f6659ff7c3dc3b5bb089a7c09c04b80: Fixes an issue wherein after requesting selection/deselection, it wouldn't happen (visually and factually) until the column was scrolled into view.
* 4ff96f82be57186874089d942beb35ee4766a015: UX judgement call; buttons other than the customisation panel are marked dimmed if the panel is active. No good reason for this call rather than the fact that this was the easiest to make happen; making the buttons interactable will take some more jiggling of the click-to-dismiss logic. Note that the requested reintroduction of the back button - which will come as a follow-up - also ties into this (it will also become non-interactable as is, but if it is to be interactable, then what should happen if you press it when the customisation panel is open?)