### PR TITLE
Add basic localisation strings for new mod select

### DIFF
--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -59,6 +59,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Importing => new TranslatableString(getKey(@"importing"), @"Importing...");
 
+        /// <summary>
+        /// "Deselect All"
+        /// </summary>
+        public static LocalisableString DeselectAll => new TranslatableString(getKey(@"deselect_all"), @"Deselect All");
+
+        /// <summary>
+        /// "Select All"
+        /// </summary>
+        public static LocalisableString SelectAll => new TranslatableString(getKey(@"select_all"), @"Select All");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/DifficultyMultiplierDisplayStrings.cs
+++ b/osu.Game/Localisation/DifficultyMultiplierDisplayStrings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class DifficultyMultiplierDisplayStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.DifficultyMultiplierDisplay";
+
+        /// <summary>
+        /// "Difficulty Multiplier"
+        /// </summary>
+        public static LocalisableString DifficultyMultiplier => new TranslatableString(getKey(@"difficulty_multiplier"), @"Difficulty Multiplier");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/ModSelectScreenStrings.cs
+++ b/osu.Game/Localisation/ModSelectScreenStrings.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ModSelectScreenStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ModSelectScreen";
+
+        /// <summary>
+        /// "Mod Select"
+        /// </summary>
+        public static LocalisableString ModSelectTitle => new TranslatableString(getKey(@"mod_select_title"), @"Mod Select");
+
+        /// <summary>
+        /// "Mods provide different ways to enjoy gameplay. Some have an effect on the score you can achieve during ranked play. Others are just for fun."
+        /// </summary>
+        public static LocalisableString ModSelectDescription => new TranslatableString(getKey(@"mod_select_description"), @"Mods provide different ways to enjoy gameplay. Some have an effect on the score you can achieve during ranked play. Others are just for fun.");
+
+        /// <summary>
+        /// "Mod Customisation"
+        /// </summary>
+        public static LocalisableString ModCustomisation => new TranslatableString(getKey(@"mod_customisation"), @"Mod Customisation");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Mods;
 using osuTK;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -99,7 +100,7 @@ namespace osu.Game.Overlays.Mods
                                             Origin = Anchor.Centre,
                                             Margin = new MarginPadding { Horizontal = 18 },
                                             Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                            Text = "Difficulty Multiplier",
+                                            Text = DifficultyMultiplierDisplayStrings.DifficultyMultiplier,
                                             Font = OsuFont.Default.With(size: 17, weight: FontWeight.SemiBold)
                                         }
                                     }

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
 using osuTK;
@@ -220,7 +222,6 @@ namespace osu.Game.Overlays.Mods
                     Origin = Anchor.CentreLeft,
                     Scale = new Vector2(0.8f),
                     RelativeSizeAxes = Axes.X,
-                    LabelText = "Enable All",
                     Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)
                 });
                 panelFlow.Padding = new MarginPadding
@@ -263,6 +264,19 @@ namespace osu.Game.Overlays.Mods
 
             contentContainer.BorderColour = ColourInfo.GradientVertical(colourProvider.Background4, colourProvider.Background3);
             contentBackground.Colour = colourProvider.Background4;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            toggleAllCheckbox?.Current.BindValueChanged(_ => updateToggleAllText(), true);
+        }
+
+        private void updateToggleAllText()
+        {
+            Debug.Assert(toggleAllCheckbox != null);
+            toggleAllCheckbox.LabelText = toggleAllCheckbox.Current.Value ? CommonStrings.DeselectAll : CommonStrings.SelectAll;
         }
 
         private void updateLocalAvailableMods()

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -23,6 +23,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 using osuTK.Input;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -58,12 +59,12 @@ namespace osu.Game.Overlays.Mods
         {
             customisationButton = new ShearedToggleButton(200)
             {
-                Text = "Mod Customisation",
+                Text = ModSelectScreenStrings.ModCustomisation,
                 Active = { BindTarget = customisationVisible }
             },
             new ShearedButton(200)
             {
-                Text = "Deselect All",
+                Text = CommonStrings.DeselectAll,
                 Action = DeselectAll
             }
         };
@@ -80,8 +81,8 @@ namespace osu.Game.Overlays.Mods
         [BackgroundDependencyLoader]
         private void load()
         {
-            Header.Title = "Mod Select";
-            Header.Description = "Mods provide different ways to enjoy gameplay. Some have an effect on the score you can achieve during ranked play. Others are just for fun.";
+            Header.Title = ModSelectScreenStrings.ModSelectTitle;
+            Header.Description = ModSelectScreenStrings.ModSelectDescription;
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -8,6 +8,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osuTK.Input;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.OnlinePlay
 {
@@ -34,14 +35,14 @@ namespace osu.Game.Screens.OnlinePlay
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,
-                Text = "Select All",
+                Text = CommonStrings.SelectAll,
                 Action = SelectAll
             },
             new ShearedButton(200)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,
-                Text = "Deselect All",
+                Text = CommonStrings.DeselectAll,
                 Action = DeselectAll
             }
         };


### PR DESCRIPTION
- [x] Depends on #18130 (because strings are added for the new buttons, too).

This encompasses just the basic strings that can be extracted quickly. Localising the entire mod machinery will be *considerably* more work (enum translations, translations of mod names, descriptions, settings). I'm willing to look into that eventually, but it's not really required for parity.

Unsure about putting "Select/Deselect All" in that particular casing into common strings, but it seems general enough...?