### PR TITLE
Add local back button to new mod select design

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectScreen.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("click select all button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().First());
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().ElementAt(1));
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods selected", assertAllAvailableModsSelected);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -432,6 +432,25 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("all mods deselected", () => !SelectedMods.Value.Any());
         }
 
+        [Test]
+        public void TestCloseViaBackButton()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("select difficulty adjust", () => SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust() });
+            assertCustomisationToggleState(disabled: false, active: true);
+            AddAssert("back button disabled", () => !this.ChildrenOfType<ShearedButton>().First().Enabled.Value);
+
+            AddStep("dismiss customisation area", () => InputManager.Key(Key.Escape));
+            AddStep("click back button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("mod select hidden", () => modSelectScreen.State.Value == Visibility.Hidden);
+        }
+
         private void waitForColumnLoad() => AddUntilStep("all column content loaded",
             () => modSelectScreen.ChildrenOfType<ModColumn>().Any() && modSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Overlays.Mods
 {
     public abstract class ModSelectScreen : ShearedOverlayContainer
     {
+        protected const int BUTTON_WIDTH = 200;
+
         protected override OverlayColourScheme ColourScheme => OverlayColourScheme.Green;
 
         [Cached]
@@ -57,12 +59,12 @@ namespace osu.Game.Overlays.Mods
 
         protected virtual IEnumerable<ShearedButton> CreateFooterButtons() => new[]
         {
-            customisationButton = new ShearedToggleButton(200)
+            customisationButton = new ShearedToggleButton(BUTTON_WIDTH)
             {
                 Text = ModSelectScreenStrings.ModCustomisation,
                 Active = { BindTarget = customisationVisible }
             },
-            new ShearedButton(200)
+            new ShearedButton(BUTTON_WIDTH)
             {
                 Text = CommonStrings.DeselectAll,
                 Action = DeselectAll
@@ -171,7 +173,7 @@ namespace osu.Game.Overlays.Mods
                     Horizontal = 70
                 },
                 Spacing = new Vector2(10),
-                ChildrenEnumerable = CreateFooterButtons().Prepend(new ShearedButton(200)
+                ChildrenEnumerable = CreateFooterButtons().Prepend(new ShearedButton(BUTTON_WIDTH)
                 {
                     Text = CommonStrings.Back,
                     Action = Hide,

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Mods
         private FillFlowContainer<ShearedButton> footerButtonFlow = null!;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuColour colours)
         {
             Header.Title = ModSelectScreenStrings.ModSelectTitle;
             Header.Description = ModSelectScreenStrings.ModSelectDescription;
@@ -171,7 +171,13 @@ namespace osu.Game.Overlays.Mods
                     Horizontal = 70
                 },
                 Spacing = new Vector2(10),
-                ChildrenEnumerable = CreateFooterButtons()
+                ChildrenEnumerable = CreateFooterButtons().Prepend(new ShearedButton(200)
+                {
+                    Text = CommonStrings.Back,
+                    Action = Hide,
+                    DarkerColour = colours.Pink2,
+                    LighterColour = colours.Pink1
+                })
             };
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -77,8 +77,10 @@ namespace osu.Game.Overlays.Mods
         private ModSettingsArea modSettingsArea = null!;
         private ColumnScrollContainer columnScroll = null!;
         private ColumnFlowContainer columnFlow = null!;
-        private ShearedToggleButton? customisationButton;
+
         private FillFlowContainer<ShearedButton> footerButtonFlow = null!;
+        private ShearedButton backButton = null!;
+        private ShearedToggleButton? customisationButton;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -173,7 +175,7 @@ namespace osu.Game.Overlays.Mods
                     Horizontal = 70
                 },
                 Spacing = new Vector2(10),
-                ChildrenEnumerable = CreateFooterButtons().Prepend(new ShearedButton(BUTTON_WIDTH)
+                ChildrenEnumerable = CreateFooterButtons().Prepend(backButton = new ShearedButton(BUTTON_WIDTH)
                 {
                     Text = CommonStrings.Back,
                     Action = Hide,
@@ -364,9 +366,12 @@ namespace osu.Game.Overlays.Mods
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (e.Action == GlobalAction.Back && customisationVisible.Value)
+            if (e.Action == GlobalAction.Back)
             {
-                customisationVisible.Value = false;
+                if (customisationVisible.Value)
+                    customisationVisible.Value = false;
+                else
+                    backButton.TriggerClick();
                 return true;
             }
 

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectScreen.cs
@@ -31,14 +31,14 @@ namespace osu.Game.Screens.OnlinePlay
 
         protected override IEnumerable<ShearedButton> CreateFooterButtons() => new[]
         {
-            new ShearedButton(200)
+            new ShearedButton(BUTTON_WIDTH)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,
                 Text = CommonStrings.SelectAll,
                 Action = SelectAll
             },
-            new ShearedButton(200)
+            new ShearedButton(BUTTON_WIDTH)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,


### PR DESCRIPTION
- [x] Depends on #18131 (for mergeability, mostly)

As proposed in #18111.

https://user-images.githubusercontent.com/20418176/167246300-5c72ae33-27dd-4f69-999b-6be66d11dc14.mp4

Generally simple enough. Notably, the back button is disabled while the customisation area is expanded. This was touched on in #18130.