### PR TITLE
Fix toggling mods after exiting first run setup overlay at UI scale step causing stack overflow

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -19,6 +20,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Select;
@@ -130,6 +132,10 @@ namespace osu.Game.Overlays.FirstRunSetup
             [Cached]
             [Cached(typeof(IBindable<WorkingBeatmap>))]
             protected Bindable<WorkingBeatmap> Beatmap { get; private set; } = new Bindable<WorkingBeatmap>();
+
+            [Cached]
+            [Cached(typeof(IBindable<IReadOnlyList<Mod>>))]
+            protected Bindable<IReadOnlyList<Mod>> SelectedMods { get; private set; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
             public override bool HandlePositionalInput => false;
             public override bool HandleNonPositionalInput => false;


### PR DESCRIPTION
Fixes scenario wherein entering the first run setup overlay, exiting at the "UI scale" step (which shows a song select), then moving to actual song select and trying to select a mod would lead to a crash.

The crash was caused by two simultaneously active mod screen instances which shared a single global mods bindable attempting to swap the global mod bindable's mod instances for ones they owned. This logic - while generally problematic and hard to maintain - was fixing several issues with mod reference management and setting copying, so I'm letting it live another day.

If you're wondering why this worked on the old design - it was because of what I want to call "undefined behaviour". What would happen with the old design was:

* User clicks button on overlay A
* Overlay A sets global mods
* Overlay B detects change in global mods
* Overlay B [replaces global mods with its own mod instances](https://github.com/ppy/osu/blob/3bb22dece6c4bb3386c4cd7b13aaba9535a24b49/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L511)
* Overlay A detects change in global mods
* Mod buttons of overlay A [determine that all mods that need to be selected already are selected and do nothing](https://github.com/ppy/osu/blob/3bb22dece6c4bb3386c4cd7b13aaba9535a24b49/osu.Game/Overlays/Mods/ModButton.cs#L54)

This change will mean that the song select preview on the "UI scale" step will not receive the same mods that the actual game has enabled. That said, it already doesn't use the same beatmap or ruleset, so this looks fine to break.

I won't lie, this is a "give up" sort of solution, but I do not have better ideas for the time being. PRing now so this doesn't have to get hotfixed if a build happens anytime soon.