### PR TITLE
Fix skin editor overlay showing behind mod select overlay

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Game.Overlays.Settings;
@@ -131,6 +132,16 @@ namespace osu.Game.Tests.Visual.Navigation
             switchToGameplayScene();
 
             AddAssert("no mod selected", () => !((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Any());
+        }
+
+        [Test]
+        public void TestModOverlayClosesOnOpeningSkinEditor()
+        {
+            advanceToSongSelect();
+            AddStep("open mod overlay", () => songSelect.ModSelectOverlay.Show());
+
+            openSkinEditor();
+            AddUntilStep("mod overlay closed", () => songSelect.ModSelectOverlay.State.Value == Visibility.Hidden);
         }
 
         private void switchToGameplayScene()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -18,7 +18,7 @@ using static osu.Game.Tests.Visual.Navigation.TestSceneScreenNavigation;
 
 namespace osu.Game.Tests.Visual.Navigation
 {
-    public class TestSceneSkinEditorSceneLibrary : OsuGameTestScene
+    public class TestSceneSkinEditorNavigation : OsuGameTestScene
     {
         private TestPlaySongSelect songSelect;
         private SkinEditor skinEditor => Game.ChildrenOfType<SkinEditor>().FirstOrDefault();

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorSceneLibrary.cs
@@ -20,20 +20,21 @@ namespace osu.Game.Tests.Visual.Navigation
 {
     public class TestSceneSkinEditorSceneLibrary : OsuGameTestScene
     {
-        private SkinEditor skinEditor;
+        private TestPlaySongSelect songSelect;
+        private SkinEditor skinEditor => Game.ChildrenOfType<SkinEditor>().FirstOrDefault();
 
-        public override void SetUpSteps()
+        private void advanceToSongSelect()
         {
-            base.SetUpSteps();
-
-            Screens.Select.SongSelect songSelect = null;
             PushAndConfirm(() => songSelect = new TestPlaySongSelect());
             AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
 
             AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
 
             AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+        }
 
+        private void openSkinEditor()
+        {
             AddStep("open skin editor", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);
@@ -42,13 +43,15 @@ namespace osu.Game.Tests.Visual.Navigation
                 InputManager.ReleaseKey(Key.ControlLeft);
                 InputManager.ReleaseKey(Key.ShiftLeft);
             });
-
-            AddUntilStep("get skin editor", () => (skinEditor = Game.ChildrenOfType<SkinEditor>().FirstOrDefault()) != null);
+            AddUntilStep("skin editor loaded", () => skinEditor != null);
         }
 
         [Test]
         public void TestEditComponentDuringGameplay()
         {
+            advanceToSongSelect();
+            openSkinEditor();
+
             switchToGameplayScene();
 
             BarHitErrorMeter hitErrorMeter = null;
@@ -85,6 +88,8 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestAutoplayCompatibleModsRetainedOnEnteringGameplay()
         {
+            advanceToSongSelect();
+            openSkinEditor();
             AddStep("select DT", () => Game.SelectedMods.Value = new Mod[] { new OsuModDoubleTime() });
 
             switchToGameplayScene();
@@ -95,6 +100,8 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestAutoplayIncompatibleModsRemovedOnEnteringGameplay()
         {
+            advanceToSongSelect();
+            openSkinEditor();
             AddStep("select no fail and spun out", () => Game.SelectedMods.Value = new Mod[] { new OsuModNoFail(), new OsuModSpunOut() });
 
             switchToGameplayScene();
@@ -105,6 +112,8 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestDuplicateAutoplayModRemovedOnEnteringGameplay()
         {
+            advanceToSongSelect();
+            openSkinEditor();
             AddStep("select autoplay", () => Game.SelectedMods.Value = new Mod[] { new OsuModAutoplay() });
 
             switchToGameplayScene();
@@ -115,6 +124,8 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestCinemaModRemovedOnEnteringGameplay()
         {
+            advanceToSongSelect();
+            openSkinEditor();
             AddStep("select cinema", () => Game.SelectedMods.Value = new Mod[] { new OsuModCinema() });
 
             switchToGameplayScene();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -201,6 +201,10 @@ namespace osu.Game
 
             externalOverlays.Add(overlayContainer);
             overlayContent.Add(overlayContainer);
+
+            if (overlayContainer is OsuFocusedOverlayContainer focusedOverlayContainer)
+                focusedOverlays.Add(focusedOverlayContainer);
+
             return new InvokeOnDisposal(() => unregisterBlockingOverlay(overlayContainer));
         }
 
@@ -223,6 +227,10 @@ namespace osu.Game
         private void unregisterBlockingOverlay(OverlayContainer overlayContainer)
         {
             externalOverlays.Remove(overlayContainer);
+
+            if (overlayContainer is OsuFocusedOverlayContainer focusedOverlayContainer)
+                focusedOverlays.Remove(focusedOverlayContainer);
+
             overlayContainer.Expire();
         }
 


### PR DESCRIPTION
As pointed out [on discord](https://discord.com/channels/188630481301012481/188630652340404224/972573142381903912).

Fixed by closing the overlay when skin editor was entered. This was already kind of supposed to happen, but there was a gap in the blocking overlay registration logic (wasn't adding to `focusedOverlays` if the overlay was applicable).

Before:

https://user-images.githubusercontent.com/20418176/167271591-afa7a7fd-37ea-40ce-82d2-b68c85fdffa7.mp4

After:

https://user-images.githubusercontent.com/20418176/167271593-c3c2adfa-5d7e-4f53-84c6-66ccd057a3b7.mp4

I think this makes more sense anyways. The mod overlay is so huge and takes so much space that it is nearly its own screen at this point.

I hijacked `TestSceneSkinEditorSceneLibrary` and generalised it a touch for the test. Seemed a bit specific anyhow.