### PR TITLE
Fix per-hit object slider velocity ignored in osu!catch

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -431,9 +431,10 @@ namespace osu.Game.Beatmaps.Formats
                 OmitFirstBarLine = omitFirstBarSignature,
             };
 
-            bool isOsuRuleset = beatmap.BeatmapInfo.Ruleset.OnlineID == 0;
-            // scrolling rulesets use effect points rather than difficulty points for scroll speed adjustments.
-            if (!isOsuRuleset)
+            int onlineRulesetID = beatmap.BeatmapInfo.Ruleset.OnlineID;
+
+            // osu!taiko and osu!mania use effect points rather than difficulty points for scroll speed adjustments.
+            if (onlineRulesetID == 1 || onlineRulesetID == 3)
                 effectPoint.ScrollSpeed = speedMultiplier;
 
             addControlPoint(time, effectPoint, timingChange);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -183,15 +183,15 @@ namespace osu.Game.Beatmaps.Formats
             SampleControlPoint lastRelevantSamplePoint = null;
             DifficultyControlPoint lastRelevantDifficultyPoint = null;
 
-            bool isOsuRuleset = onlineRulesetID == 0;
+            // In osu!taiko and osu!mania, a scroll speed is stored as "slider velocity" in legacy formats.
+            // In that case, a scrolling speed change is a global effect and per-hit object difficulty control points are ignored.
+            bool scrollSpeedEncodedAsSliderVelocity = onlineRulesetID == 1 || onlineRulesetID == 3;
 
             // iterate over hitobjects and pull out all required sample and difficulty changes
             extractDifficultyControlPoints(beatmap.HitObjects);
             extractSampleControlPoints(beatmap.HitObjects);
 
-            // handle scroll speed, which is stored as "slider velocity" in legacy formats.
-            // this is relevant for scrolling ruleset beatmaps.
-            if (!isOsuRuleset)
+            if (scrollSpeedEncodedAsSliderVelocity)
             {
                 foreach (var point in legacyControlPoints.EffectPoints)
                     legacyControlPoints.Add(point.Time, new DifficultyControlPoint { SliderVelocity = point.ScrollSpeed });
@@ -242,7 +242,7 @@ namespace osu.Game.Beatmaps.Formats
 
             IEnumerable<DifficultyControlPoint> collectDifficultyControlPoints(IEnumerable<HitObject> hitObjects)
             {
-                if (!isOsuRuleset)
+                if (scrollSpeedEncodedAsSliderVelocity)
                     yield break;
 
                 foreach (var hitObject in hitObjects)


### PR DESCRIPTION
Fix #16433 (without addressing the scrolling speed change encoding in taiko and mania).
The condition should be only applied to taiko and mania, but was applied to catch (there is no such thing as a scroll speed change).