### PR TITLE
Fix catch editor juice stream and banana shower not shown in timeline while placement is waiting

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
@@ -18,13 +18,18 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             InternalChild = outline = new TimeSpanOutline();
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            BeginPlacement();
+        }
+
         protected override void Update()
         {
             base.Update();
 
             outline.UpdateFrom(HitObjectContainer, HitObject);
-
-            BeginPlacement();
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             base.Update();
 
             outline.UpdateFrom(HitObjectContainer, HitObject);
+
+            BeginPlacement();
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamPlacementBlueprint.cs
@@ -47,6 +47,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             base.LoadComplete();
 
             inputManager = GetContainingInputManager();
+
+            BeginPlacement();
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)


### PR DESCRIPTION
Note: I found an unrelated issue that banana shower placement blueprint is bugged due to negative length.