### PR TITLE
Fix mod panel samples playing when using autoplay shortcut

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySamplePlayback.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Game.Audio;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects.Drawables;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableSound.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableSound.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Testing;
 using osu.Game.Audio;
-using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 
 namespace osu.Game.Tests.Visual.Gameplay

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableSound.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableSound.cs
@@ -130,7 +130,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Cached(typeof(ISkinSource))]
-        [Cached(typeof(ISamplePlaybackDisabler))]
         private class TestSkinSourceContainer : Container, ISkinSource, ISamplePlaybackDisabler
         {
             [Resolved]

--- a/osu.Game/Audio/ISamplePlaybackDisabler.cs
+++ b/osu.Game/Audio/ISamplePlaybackDisabler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Skinning;
 
@@ -10,6 +11,7 @@ namespace osu.Game.Audio
     /// Allows a component to disable sample playback dynamically as required.
     /// Automatically handled by <see cref="PausableSkinnableSound"/>.
     /// </summary>
+    [Cached]
     public interface ISamplePlaybackDisabler
     {
         /// <summary>

--- a/osu.Game/Audio/ISamplePlaybackDisabler.cs
+++ b/osu.Game/Audio/ISamplePlaybackDisabler.cs
@@ -4,11 +4,11 @@
 using osu.Framework.Bindables;
 using osu.Game.Skinning;
 
-namespace osu.Game.Screens.Play
+namespace osu.Game.Audio
 {
     /// <summary>
     /// Allows a component to disable sample playback dynamically as required.
-    /// Handled by <see cref="PausableSkinnableSound"/>.
+    /// Automatically handled by <see cref="PausableSkinnableSound"/>.
     /// </summary>
     public interface ISamplePlaybackDisabler
     {

--- a/osu.Game/Audio/ISamplePlaybackDisabler.cs
+++ b/osu.Game/Audio/ISamplePlaybackDisabler.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Audio
     /// <summary>
     /// Allows a component to disable sample playback dynamically as required.
     /// Automatically handled by <see cref="PausableSkinnableSound"/>.
+    /// May also be manually handled locally to particular components.
     /// </summary>
     [Cached]
     public interface ISamplePlaybackDisabler

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -15,6 +15,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Layout;
 using osu.Framework.Lists;
 using osu.Framework.Utils;
+using osu.Game.Audio;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -27,7 +28,7 @@ using osuTK.Input;
 
 namespace osu.Game.Overlays.Mods
 {
-    public abstract class ModSelectScreen : ShearedOverlayContainer
+    public abstract class ModSelectScreen : ShearedOverlayContainer, ISamplePlaybackDisabler
     {
         protected const int BUTTON_WIDTH = 200;
 
@@ -187,6 +188,8 @@ namespace osu.Game.Overlays.Mods
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            State.BindValueChanged(_ => samplePlaybackDisabled.Value = State.Value == Visibility.Hidden, true);
 
             ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
 
@@ -427,6 +430,13 @@ namespace osu.Game.Overlays.Mods
                 backButton.TriggerClick();
             }
         }
+
+        #endregion
+
+        #region Sample playback control
+
+        private readonly Bindable<bool> samplePlaybackDisabled = new BindableBool(true);
+        IBindable<bool> ISamplePlaybackDisabler.SamplePlaybackDisabled => samplePlaybackDisabled;
 
         #endregion
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -19,6 +19,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -51,7 +51,6 @@ using osuTK.Input;
 namespace osu.Game.Screens.Edit
 {
     [Cached(typeof(IBeatSnapProvider))]
-    [Cached(typeof(ISamplePlaybackDisabler))]
     [Cached]
     public class Editor : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, IKeyBindingHandler<PlatformAction>, IBeatSnapProvider, ISamplePlaybackDisabler
     {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -16,6 +16,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -38,7 +38,6 @@ using osuTK.Graphics;
 namespace osu.Game.Screens.Play
 {
     [Cached]
-    [Cached(typeof(ISamplePlaybackDisabler))]
     public abstract class Player : ScreenWithBeatmapBackground, ISamplePlaybackDisabler, ILocalUserPlayInfo
     {
         /// <summary>

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -8,7 +8,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Threading;
 using osu.Game.Audio;
-using osu.Game.Screens.Play;
 
 namespace osu.Game.Skinning
 {


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/20418176/167288981-fea9d514-7c3f-4411-8fdf-fa07143d4580.mp4

After:

https://user-images.githubusercontent.com/20418176/167288994-d3a6e57f-b71f-4aa5-8bbc-3d9e0e8989aa.mp4

The old overlay didn't have this issue, because... [it managed sound playback for each button on the level of the entire overlay rather than in the buttons](https://github.com/ppy/osu/blob/4199bab1f1a73c9fecd2227b5d78b6cf46782832/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L472-L491). Cool.

As for the solution, I hijacked `ISamplePlaybackDisabler` from player/editor, moved it to a more general namespace, and applied it manually to the overlay. Not sure if solution is agreeable.

No tests because samples are annoying to test. But this can be tested in the test browser, too, by some manual clicking of test steps (repro scenario: create overlay, hide overlay, set mods externally - samples will play on master and won't play on this branch).