### PR TITLE
Hide empty columns on new mod select design

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -451,6 +451,36 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("mod select hidden", () => modSelectScreen.State.Value == Visibility.Hidden);
         }
 
+        [Test]
+        public void TestColumnHiding()
+        {
+            AddStep("create screen", () => Child = modSelectScreen = new UserModSelectScreen
+            {
+                RelativeSizeAxes = Axes.Both,
+                State = { Value = Visibility.Visible },
+                SelectedMods = { BindTarget = SelectedMods },
+                IsValidMod = mod => mod.Type == ModType.DifficultyIncrease || mod.Type == ModType.Conversion
+            });
+            waitForColumnLoad();
+            changeRuleset(0);
+
+            AddAssert("two columns visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 2);
+
+            AddStep("unset filter", () => modSelectScreen.IsValidMod = _ => true);
+            AddAssert("all columns visible", () => this.ChildrenOfType<ModColumn>().All(col => col.IsPresent));
+
+            AddStep("filter out everything", () => modSelectScreen.IsValidMod = _ => false);
+            AddAssert("no columns visible", () => this.ChildrenOfType<ModColumn>().All(col => !col.IsPresent));
+
+            AddStep("hide", () => modSelectScreen.Hide());
+            AddStep("set filter for 3 columns", () => modSelectScreen.IsValidMod = mod => mod.Type == ModType.DifficultyReduction
+                                                                                          || mod.Type == ModType.Automation
+                                                                                          || mod.Type == ModType.Conversion);
+
+            AddStep("show", () => modSelectScreen.Show());
+            AddUntilStep("3 columns visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 3);
+        }
+
         private void waitForColumnLoad() => AddUntilStep("all column content loaded",
             () => modSelectScreen.ChildrenOfType<ModColumn>().Any() && modSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
 

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -55,7 +55,17 @@ namespace osu.Game.Overlays.Mods
             }
         }
 
+        /// <summary>
+        /// Determines whether this column should accept user input.
+        /// </summary>
         public Bindable<bool> Active = new BindableBool(true);
+
+        private readonly Bindable<bool> allFiltered = new BindableBool();
+
+        /// <summary>
+        /// True if all of the panels in this column have been filtered out by the current <see cref="Filter"/>.
+        /// </summary>
+        public IBindable<bool> AllFiltered => allFiltered;
 
         /// <summary>
         /// List of mods marked as selected in this column.
@@ -338,6 +348,9 @@ namespace osu.Game.Overlays.Mods
                 panel.Active.Value = SelectedMods.Contains(panel.Mod);
                 panel.ApplyFilter(Filter);
             }
+
+            allFiltered.Value = panelFlow.All(panel => panel.Filtered.Value);
+            Alpha = allFiltered.Value ? 0 : 1;
 
             if (toggleAllCheckbox != null && !SelectionAnimationRunning)
             {

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -350,7 +350,6 @@ namespace osu.Game.Overlays.Mods
             }
 
             allFiltered.Value = panelFlow.All(panel => panel.Filtered.Value);
-            Alpha = allFiltered.Value ? 0 : 1;
 
             if (toggleAllCheckbox != null && !SelectionAnimationRunning)
             {

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -580,17 +580,20 @@ namespace osu.Game.Overlays.Mods
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                Active.BindValueChanged(_ => updateDim(), true);
+                Active.BindValueChanged(_ => updateState());
+                Column.AllFiltered.BindValueChanged(_ => updateState(), true);
                 FinishTransforms();
             }
 
             protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate || Column.SelectionAnimationRunning;
 
-            private void updateDim()
+            private void updateState()
             {
                 Colour4 targetColour;
 
-                if (Active.Value)
+                Column.Alpha = Column.AllFiltered.Value ? 0 : 1;
+
+                if (Column.Active.Value)
                     targetColour = Colour4.White;
                 else
                     targetColour = IsHovered ? colours.GrayC : colours.Gray8;
@@ -609,14 +612,14 @@ namespace osu.Game.Overlays.Mods
             protected override bool OnHover(HoverEvent e)
             {
                 base.OnHover(e);
-                updateDim();
+                updateState();
                 return Active.Value;
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
                 base.OnHoverLost(e);
-                updateDim();
+                updateState();
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -129,7 +129,6 @@ namespace osu.Game.Overlays.Mods
                                 Shear = new Vector2(SHEAR, 0),
                                 RelativeSizeAxes = Axes.Y,
                                 AutoSizeAxes = Axes.X,
-                                Spacing = new Vector2(10, 0),
                                 Margin = new MarginPadding { Horizontal = 70 },
                                 Children = new[]
                                 {
@@ -237,12 +236,21 @@ namespace osu.Game.Overlays.Mods
         }
 
         private ColumnDimContainer createModColumnContent(ModType modType, Key[]? toggleKeys = null)
-            => new ColumnDimContainer(CreateModColumn(modType, toggleKeys).With(column => column.Filter = IsValidMod))
+        {
+            var column = CreateModColumn(modType, toggleKeys).With(column =>
+            {
+                column.Filter = IsValidMod;
+                // spacing applied here rather than via `columnFlow.Spacing` to avoid uneven gaps when some of the columns are hidden.
+                column.Margin = new MarginPadding { Right = 10 };
+            });
+
+            return new ColumnDimContainer(column)
             {
                 AutoSizeAxes = Axes.X,
                 RelativeSizeAxes = Axes.Y,
-                RequestScroll = column => columnScroll.ScrollIntoView(column, extraScroll: 140),
+                RequestScroll = col => columnScroll.ScrollIntoView(col, extraScroll: 140),
             };
+        }
 
         private ShearedButton[] createDefaultFooterButtons()
             => new[]


### PR DESCRIPTION
Closes #18154.

https://user-images.githubusercontent.com/20418176/167300827-ac083d43-c168-483e-a458-828939686c65.mp4

This immediately exposes more issues, most of which are mentioned [in this discord conversation](https://discord.com/channels/188630481301012481/188630652340404224/972854220292251678), but I'm PRing at least for discussion/so that it can be tweaked with further.

As for the code itself, the most annoying part was preserving the pop in/out animations wherein columns fly in from alternate directions. I have managed to salvage it, but I'm not sure if the end result is legible.