### PR TITLE
Fix duration is negative while placing banana shower in catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneBananaShowerPlacementBlueprint.cs
@@ -55,7 +55,10 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
 
             AddMoveStep(end_time, 0);
             AddClickStep(MouseButton.Left);
+
             AddMoveStep(start_time, 0);
+            AddAssert("duration is positive", () => ((BananaShower)CurrentBlueprint.HitObject).Duration > 0);
+
             AddClickStep(MouseButton.Right);
             AddAssert("start time is correct", () => Precision.AlmostEquals(LastObject.HitObject.StartTime, start_time));
             AddAssert("end time is correct", () => Precision.AlmostEquals(LastObject.HitObject.GetEndTime(), end_time));

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Catch.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Catch.Objects;
@@ -12,6 +13,9 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
     public class BananaShowerPlacementBlueprint : CatchPlacementBlueprint<BananaShower>
     {
         private readonly TimeSpanOutline outline;
+
+        private double placementStartTime;
+        private double placementEndTime;
 
         public BananaShowerPlacementBlueprint()
         {
@@ -38,13 +42,6 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
                 case PlacementState.Active:
                     if (e.Button != MouseButton.Right) break;
 
-                    // If the duration is negative, swap the start and the end time to make the duration positive.
-                    if (HitObject.Duration < 0)
-                    {
-                        HitObject.StartTime = HitObject.EndTime;
-                        HitObject.Duration = -HitObject.Duration;
-                    }
-
                     EndPlacement(HitObject.Duration > 0);
                     return true;
             }
@@ -61,13 +58,16 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             switch (PlacementActive)
             {
                 case PlacementState.Waiting:
-                    HitObject.StartTime = time;
+                    placementStartTime = placementEndTime = time;
                     break;
 
                 case PlacementState.Active:
-                    HitObject.EndTime = time;
+                    placementEndTime = time;
                     break;
             }
+
+            HitObject.StartTime = Math.Min(placementStartTime, placementEndTime);
+            HitObject.EndTime = Math.Max(placementStartTime, placementEndTime);
         }
     }
 }


### PR DESCRIPTION
Timeline blueprint was glitched when the hit object has negative duration.
Negative duration is unwanted anyways so placement implementation is fixed instead of supporting it in the timeline blueprint.