### PR TITLE
Fix popup dialog potentially not clicking last button when dismissed

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
@@ -501,6 +502,22 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("Release escape", () => InputManager.ReleaseKey(Key.Escape));
             AddUntilStep("Wait for game exit", () => Game.ScreenStack.CurrentScreen == null);
             AddStep("test dispose doesn't crash", () => Game.Dispose());
+        }
+
+        [Test]
+        public void TestRapidBackButtonExit()
+        {
+            AddStep("set hold delay to 0", () => Game.LocalConfig.SetValue(OsuSetting.UIHoldActivationDelay, 0.0));
+
+            AddStep("press escape twice rapidly", () =>
+            {
+                InputManager.Key(Key.Escape);
+                InputManager.Key(Key.Escape);
+            });
+
+            pushEscape();
+
+            AddAssert("exit dialog is shown", () => Game.Dependencies.Get<IDialogOverlay>().CurrentDialog != null);
         }
 
         private Func<Player> playToResults()

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -100,10 +100,6 @@ namespace osu.Game.Overlays.Dialog
             }
         }
 
-        // We always want dialogs to show their appear animation, so we request they start hidden.
-        // Normally this would not be required, but is here due to the manual Show() call that occurs before LoadComplete().
-        protected override bool StartHidden => true;
-
         protected PopupDialog()
         {
             RelativeSizeAxes = Axes.Both;
@@ -272,7 +268,7 @@ namespace osu.Game.Overlays.Dialog
 
         protected override void PopOut()
         {
-            if (!actionInvoked && content.IsPresent)
+            if (!actionInvoked)
                 // In the case a user did not choose an action before a hide was triggered, press the last button.
                 // This is presumed to always be a sane default "cancel" action.
                 buttonsContainer.Last().TriggerClick();


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/17526.

This PR removes things I'm not sure about. `content.IsPresent` was added in https://github.com/ppy/osu/pull/6825 to fix a visual bug, but removing it now doesn't seem to regress. The `StartHidden` override also needs to be removed to make it work, and it still looks the same, even though the comment says otherwise.