### PR TITLE
Fix dropdown items' background being the wrong colour on first hover

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -184,14 +184,12 @@ namespace osu.Game.Graphics.UserInterface
 
                 protected override void UpdateBackgroundColour()
                 {
-                    if (!IsPreSelected && !IsSelected)
-                    {
-                        Background.FadeOut(600, Easing.OutQuint);
-                        return;
-                    }
-
-                    Background.FadeIn(100, Easing.OutQuint);
                     Background.FadeColour(IsPreSelected ? BackgroundColourHover : BackgroundColourSelected, 100, Easing.OutQuint);
+
+                    if (IsPreSelected || IsSelected)
+                        Background.FadeIn(100, Easing.OutQuint);
+                    else
+                        Background.FadeOut(600, Easing.OutQuint);
                 }
 
                 protected override void UpdateForegroundColour()


### PR DESCRIPTION
Turns out to be an osu!-side issue. The colour transform was being shortcutted for the non-displayed case, which meant it was not in a good state in time for the first hover.

Closes https://github.com/ppy/osu/issues/18163#issuecomment-1120747301