### PR TITLE
Fix `SettingsToolboxGroup` not clearing transforms before updating autosize

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
@@ -8,12 +8,12 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.PlayerSettings;
 
-namespace osu.Game.Tests.Visual.Gameplay
+namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public class TestSceneReplaySettingsOverlay : OsuTestScene
+    public class TestSceneSettingsToolboxGroup : OsuTestScene
     {
-        public TestSceneReplaySettingsOverlay()
+        public TestSceneSettingsToolboxGroup()
         {
             ExampleContainer container;
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
@@ -4,12 +4,11 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
-using osu.Game.Screens.Play.HUD;
-using osu.Game.Screens.Play.PlayerSettings;
+using osu.Game.Overlays.Settings;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -17,45 +16,39 @@ namespace osu.Game.Tests.Visual.UserInterface
     [TestFixture]
     public class TestSceneSettingsToolboxGroup : OsuManualInputManagerTestScene
     {
-        public TestSceneSettingsToolboxGroup()
+        private SettingsToolboxGroup group;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
-            ExampleContainer container;
-
-            Add(new PlayerSettingsOverlay
+            Child = group = new SettingsToolboxGroup("example")
             {
-                Anchor = Anchor.TopRight,
-                Origin = Anchor.TopRight,
-                State = { Value = Visibility.Visible }
-            });
-
-            Add(container = new ExampleContainer());
-
-            AddStep(@"Add button", () => container.Add(new TriangleButton
-            {
-                RelativeSizeAxes = Axes.X,
-                Text = @"Button",
-            }));
-
-            AddStep(@"Add checkbox", () => container.Add(new PlayerCheckbox
-            {
-                LabelText = "Checkbox",
-            }));
-
-            AddStep(@"Add textbox", () => container.Add(new FocusedTextBox
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 30,
-                PlaceholderText = "Textbox",
-                HoldFocus = false,
-            }));
-        }
+                Children = new Drawable[]
+                {
+                    new RoundedButton
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Text = @"Button",
+                        Enabled = { Value = true },
+                    },
+                    new OsuCheckbox
+                    {
+                        LabelText = @"Checkbox",
+                    },
+                    new OutlinedTextBox
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 30,
+                        PlaceholderText = @"Textbox",
+                    }
+                },
+            };
+        });
 
         [Test]
         public void TestClickExpandButtonMultipleTimes()
         {
-            SettingsToolboxGroup group = null;
-
-            AddAssert("group expanded by default", () => (group = this.ChildrenOfType<SettingsToolboxGroup>().First()).Expanded.Value);
+            AddAssert("group expanded by default", () => group.Expanded.Value);
             AddStep("click expand button multiple times", () =>
             {
                 InputManager.MoveMouseTo(group.ChildrenOfType<IconButton>().Single());
@@ -64,14 +57,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Scheduler.AddDelayed(() => InputManager.Click(MouseButton.Left), 300);
             });
             AddAssert("group contracted", () => !group.Expanded.Value);
-        }
-
-        private class ExampleContainer : PlayerSettingsGroup
-        {
-            public ExampleContainer()
-                : base("example")
-            {
-            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
@@ -1,17 +1,21 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.PlayerSettings;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public class TestSceneSettingsToolboxGroup : OsuTestScene
+    public class TestSceneSettingsToolboxGroup : OsuManualInputManagerTestScene
     {
         public TestSceneSettingsToolboxGroup()
         {
@@ -44,6 +48,22 @@ namespace osu.Game.Tests.Visual.UserInterface
                 PlaceholderText = "Textbox",
                 HoldFocus = false,
             }));
+        }
+
+        [Test]
+        public void TestClickExpandButtonMultipleTimes()
+        {
+            SettingsToolboxGroup group = null;
+
+            AddAssert("group expanded by default", () => (group = this.ChildrenOfType<SettingsToolboxGroup>().First()).Expanded.Value);
+            AddStep("click expand button multiple times", () =>
+            {
+                InputManager.MoveMouseTo(group.ChildrenOfType<IconButton>().Single());
+                Scheduler.AddDelayed(() => InputManager.Click(MouseButton.Left), 100);
+                Scheduler.AddDelayed(() => InputManager.Click(MouseButton.Left), 200);
+                Scheduler.AddDelayed(() => InputManager.Click(MouseButton.Left), 300);
+            });
+            AddAssert("group contracted", () => !group.Expanded.Value);
         }
 
         private class ExampleContainer : PlayerSettingsGroup

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -156,6 +156,8 @@ namespace osu.Game.Overlays
 
         private void updateExpandedState(ValueChangedEvent<bool> expanded)
         {
+            content.ClearTransforms();
+
             if (expanded.NewValue)
                 content.AutoSizeAxes = Axes.Y;
             else

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -156,6 +156,8 @@ namespace osu.Game.Overlays
 
         private void updateExpandedState(ValueChangedEvent<bool> expanded)
         {
+            // clearing transforms is necessary to avoid a previous height transform
+            // potentially continuing to get processed while content has changed to autosize.
             content.ClearTransforms();
 
             if (expanded.NewValue)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18173

That one is on me for suggesting to remove it and merging the PR as well (should've tested more aggressively...). `ClearTransforms` is required to stop the container from continuing its height resize transform on the `Expanded = false` case when enabling autosize back on `Expanded = true`.