### PR TITLE
Fix buttons no longer coloured using `OverlayColourProvider`

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
@@ -1,78 +1,40 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
-using osuTK;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public class TestSceneRoundedButton : OsuTestScene
+    public class TestSceneRoundedButton : ThemeComparisonTestScene
     {
-        [Test]
-        public void TestBasic()
+        private readonly BindableBool enabled = new BindableBool(true);
+
+        protected override Drawable CreateContent() => new RoundedButton
         {
-            RoundedButton button = null;
+            Width = 400,
+            Text = "Test button",
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Enabled = { BindTarget = enabled },
+        };
 
-            AddStep("create button", () => Child = new Container
-            {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
-                {
-                    button = new RoundedButton
-                    {
-                        Width = 400,
-                        Text = "Test Button",
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Action = () => { }
-                    }
-                }
-            });
-
-            AddToggleStep("toggle disabled", disabled => button.Action = disabled ? (Action)null : () => { });
+        [Test]
+        public void TestDisabled()
+        {
+            AddToggleStep("toggle disabled", disabled => enabled.Value = !disabled);
         }
 
         [Test]
-        public void TestOverlay()
+        public void TestBackgroundColour()
         {
-            IEnumerable<OverlayColourScheme> schemes = Enum.GetValues(typeof(OverlayColourScheme)).Cast<OverlayColourScheme>();
-
-            AddStep("create buttons", () =>
-            {
-                Child = new FillFlowContainer
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(5f),
-                    ChildrenEnumerable = schemes.Select(c => new DependencyProvidingContainer
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        CachedDependencies = new (Type, object)[] { (typeof(OverlayColourProvider), new OverlayColourProvider(c)) },
-                        Child = new RoundedButton
-                        {
-                            Width = 400,
-                            Text = $"Test {c}",
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Action = () => { },
-                        }
-                    }),
-                };
-            });
-
-            AddAssert("first button has correct colour", () => this.ChildrenOfType<RoundedButton>().First().BackgroundColour == new OverlayColourProvider(schemes.First()).Highlight1);
-            AddToggleStep("toggle disabled", disabled => this.ChildrenOfType<RoundedButton>().ForEach(b => b.Action = disabled ? (Action)null : () => { }));
+            AddStep("set red scheme", () => CreateThemedContent(OverlayColourScheme.Red));
+            AddAssert("first button has correct colour", () => Cell(0, 1).ChildrenOfType<RoundedButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Highlight1);
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
@@ -2,11 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -22,15 +27,10 @@ namespace osu.Game.Tests.Visual.UserInterface
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Colour4.DarkGray
-                    },
                     button = new RoundedButton
                     {
                         Width = 400,
-                        Text = "Test button",
+                        Text = "Test Button",
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Action = () => { }
@@ -39,6 +39,40 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddToggleStep("toggle disabled", disabled => button.Action = disabled ? (Action)null : () => { });
+        }
+
+        [Test]
+        public void TestOverlay()
+        {
+            IEnumerable<OverlayColourScheme> schemes = Enum.GetValues(typeof(OverlayColourScheme)).Cast<OverlayColourScheme>();
+
+            AddStep("create buttons", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(5f),
+                    ChildrenEnumerable = schemes.Select(c => new DependencyProvidingContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        CachedDependencies = new (Type, object)[] { (typeof(OverlayColourProvider), new OverlayColourProvider(c)) },
+                        Child = new RoundedButton
+                        {
+                            Width = 400,
+                            Text = $"Test {c}",
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Action = () => { },
+                        }
+                    }),
+                };
+            });
+
+            AddAssert("first button has correct colour", () => this.ChildrenOfType<RoundedButton>().First().BackgroundColour == new OverlayColourProvider(schemes.First()).Highlight1);
+            AddToggleStep("toggle disabled", disabled => this.ChildrenOfType<RoundedButton>().ForEach(b => b.Action = disabled ? (Action)null : () => { }));
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -33,13 +32,33 @@ namespace osu.Game.Graphics.UserInterface
 
         private Color4? backgroundColour;
 
+        /// <summary>
+        /// Sets a custom background colour to this button, replacing the provided default.
+        /// </summary>
         public Color4 BackgroundColour
         {
-            get => backgroundColour ?? Color4.White;
+            get => backgroundColour ?? defaultBackgroundColour;
             set
             {
                 backgroundColour = value;
                 Background.FadeColour(value);
+            }
+        }
+
+        private Color4 defaultBackgroundColour;
+
+        /// <summary>
+        /// Sets a default background colour to this button.
+        /// </summary>
+        protected Color4 DefaultBackgroundColour
+        {
+            get => defaultBackgroundColour;
+            set
+            {
+                defaultBackgroundColour = value;
+
+                if (backgroundColour == null)
+                    Background.FadeColour(value);
             }
         }
 
@@ -89,8 +108,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            if (backgroundColour == null)
-                BackgroundColour = colours.BlueDark;
+            DefaultBackgroundColour = colours.BlueDark;
         }
 
         protected override void LoadComplete()
@@ -106,10 +124,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (Enabled.Value)
-            {
-                Debug.Assert(backgroundColour != null);
-                Background.FlashColour(backgroundColour.Value.Lighten(0.4f), 200);
-            }
+                Background.FlashColour(BackgroundColour.Lighten(0.4f), 200);
 
             return base.OnClick(e);
         }

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -13,7 +12,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Overlays;
 using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
@@ -88,11 +86,11 @@ namespace osu.Game.Graphics.UserInterface
                 AddInternal(new HoverClickSounds(hoverSounds.Value));
         }
 
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
         {
             if (backgroundColour == null)
-                BackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
+                BackgroundColour = colours.BlueDark;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -12,6 +13,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
@@ -86,11 +88,11 @@ namespace osu.Game.Graphics.UserInterface
                 AddInternal(new HoverClickSounds(hoverSounds.Value));
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
         {
             if (backgroundColour == null)
-                BackgroundColour = colours.BlueDark;
+                BackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -29,8 +28,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
         {
-            if (BackgroundColour == Color4.White)
-                BackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
+            DefaultBackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -2,13 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using JetBrains.Annotations;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -24,13 +20,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 if (IsLoaded)
                     updateCornerRadius();
             }
-        }
-
-        [BackgroundDependencyLoader(true)]
-        private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
-        {
-            if (BackgroundColour == Color4.White)
-                BackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -2,9 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -20,6 +24,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 if (IsLoaded)
                     updateCornerRadius();
             }
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+        {
+            if (BackgroundColour == Color4.White)
+                BackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18182

This has regressed in https://github.com/ppy/osu/pull/18008/commits/b424d20f267b26104eca245cf1f3de926f29849b due to the added conditional which can never be true due to `BackgroundColour` being already assigned by `OsuButton`'s BDL, therefore ignoring the default overlay-based background colour provided by `RoundedButton`.

This is fixed by moving the default background colour specification to `OsuButton`, since there is about only a couple of usages of non-`RoundedButton`, in `BeatmapSetOverlay` and `Editor`, and they don't look quite bad with this change:
| master | PR |
|--------|----|
| <img width="787" src="https://user-images.githubusercontent.com/22781491/167447523-658f12df-85f0-4227-9a42-95f4e7850b49.png"> | <img width="787" alt="CleanShot 2022-05-09 at 18 45 01@2x" src="https://user-images.githubusercontent.com/22781491/167447248-0dcc25d5-63ef-426b-a5fa-057abb2bbece.png"> |
| <img width="787" alt="CleanShot 2022-05-09 at 18 47 28@2x" src="https://user-images.githubusercontent.com/22781491/167447740-c7edf0e1-fd5f-49da-b466-40def781f472.png"> | <img width="768" alt="CleanShot 2022-05-09 at 18 41 58@2x" src="https://user-images.githubusercontent.com/22781491/167447298-e7cded18-728b-4168-af18-6dfb56cd05e7.png"> |

But, this can be fixed alternatively and leaving the specification in `RoundedButton` (4072f4db2ff30d3203863f6b001f5a895b509c9c), but I'm not 100% it's worth the effort if the specification can just be moved above.