### PR TITLE
Fix mods wrongly adding audio adjustments after being toggled off

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -482,7 +482,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestCorrectAudioAdjustmentDeapplication()
+        public void TestCorrectAudioAdjustmentAfterPitchAdjustChange()
         {
             createScreen();
             changeRuleset(0);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectScreen.cs
@@ -481,6 +481,38 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("3 columns visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 3);
         }
 
+        [Test]
+        public void TestCorrectAudioAdjustmentDeapplication()
+        {
+            createScreen();
+            changeRuleset(0);
+
+            AddStep("allow track adjustments", () => MusicController.AllowTrackAdjustments = true);
+
+            AddStep("set wind up", () => modSelectScreen.SelectedMods.Value = new[] { new ModWindUp() });
+            AddStep("open customisation menu", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedToggleButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("frequency above 1", () => MusicController.CurrentTrack.AggregateFrequency.Value > 1);
+            AddAssert("tempo is 1", () => MusicController.CurrentTrack.AggregateTempo.Value == 1);
+
+            AddStep("turn off pitch adjustment", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<SettingsCheckbox>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("frequency is 1", () => MusicController.CurrentTrack.AggregateFrequency.Value == 1);
+            AddAssert("tempo above 1", () => MusicController.CurrentTrack.AggregateTempo.Value > 1);
+
+            AddStep("reset mods", () => modSelectScreen.SelectedMods.SetDefault());
+            AddAssert("frequency is 1", () => MusicController.CurrentTrack.AggregateFrequency.Value == 1);
+            AddAssert("tempo is 1", () => MusicController.CurrentTrack.AggregateTempo.Value == 1);
+
+            AddStep("disallow track adjustments", () => MusicController.AllowTrackAdjustments = false);
+        }
+
         private void waitForColumnLoad() => AddUntilStep("all column content loaded",
             () => modSelectScreen.ChildrenOfType<ModColumn>().Any() && modSelectScreen.ChildrenOfType<ModColumn>().All(column => column.IsLoaded && column.ItemsLoaded));
 

--- a/osu.Game/Rulesets/Mods/IApplicableToTrack.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToTrack.cs
@@ -10,6 +10,13 @@ namespace osu.Game.Rulesets.Mods
     /// </summary>
     public interface IApplicableToTrack : IApplicableMod
     {
+        /// <summary>
+        /// Use this method to apply any adjustments applicable for this mod to the supplied <paramref name="track"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method is the only valid point at which adjustments can be added safely.
+        /// Storing the supplied <paramref name="track"/> reference and adding adjustments at a later date is not supported and will lead to incorrect operation.
+        /// </remarks>
         void ApplyToTrack(ITrack track);
     }
 }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -46,6 +46,20 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.01,
         };
 
+        private readonly BindableNumber<double> frequencyAdjustment = new BindableDouble
+        {
+            Default = 1,
+            Value = 1,
+            Precision = 0.01
+        };
+
+        private readonly BindableNumber<double> tempoAdjustment = new BindableDouble
+        {
+            Default = 1,
+            Value = 1,
+            Precision = 0.01
+        };
+
         private ITrack track;
 
         protected ModTimeRamp()
@@ -57,7 +71,11 @@ namespace osu.Game.Rulesets.Mods
 
         public void ApplyToTrack(ITrack track)
         {
+            // stored only for the purpose of accessing track.CurrentTime.
             this.track = track;
+
+            track.AddAdjustment(AdjustableProperty.Frequency, frequencyAdjustment);
+            track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjustment);
 
             FinalRate.TriggerChange();
             AdjustPitch.TriggerChange();
@@ -100,13 +118,13 @@ namespace osu.Game.Rulesets.Mods
 
         private void applyPitchAdjustment(ValueChangedEvent<bool> adjustPitchSetting)
         {
-            // remove existing old adjustment
-            track?.RemoveAdjustment(adjustmentForPitchSetting(adjustPitchSetting.OldValue), SpeedChange);
+            adjustmentForPitchSetting(adjustPitchSetting.OldValue).UnbindFrom(SpeedChange);
+            adjustmentForPitchSetting(adjustPitchSetting.OldValue).SetDefault();
 
-            track?.AddAdjustment(adjustmentForPitchSetting(adjustPitchSetting.NewValue), SpeedChange);
+            adjustmentForPitchSetting(adjustPitchSetting.NewValue).BindTo(SpeedChange);
         }
 
-        private AdjustableProperty adjustmentForPitchSetting(bool adjustPitchSettingValue)
-            => adjustPitchSettingValue ? AdjustableProperty.Frequency : AdjustableProperty.Tempo;
+        private BindableNumber<double> adjustmentForPitchSetting(bool adjustPitchSettingValue)
+            => adjustPitchSettingValue ? frequencyAdjustment : tempoAdjustment;
     }
 }


### PR DESCRIPTION
Closes #18178.

First, an explanation why this broke. On master, `ModTimeRamp` stores a reference to the last track supplied on `IApplicableToTrack`:

https://github.com/ppy/osu/blob/5b17e92770e1613d099599b9fc8f758a10b0c479/osu.Game/Rulesets/Mods/ModTimeRamp.cs#L60

It then uses this track reference to access `CurrentTime` (which is not the problem), but also to dynamically add/remove audio adjustments when the "Adjust Pitch" option is toggled (which is the problem):

https://github.com/ppy/osu/blob/5b17e92770e1613d099599b9fc8f758a10b0c479/osu.Game/Rulesets/Mods/ModTimeRamp.cs#L101-L107

It turns out that this only worked correctly on the old overlay due to a particular ordering of operations. With the old mod overlay, the following happened:

* On deselection, `ModButton` [resets settings to defaults first](https://github.com/ppy/osu/blob/5b17e92770e1613d099599b9fc8f758a10b0c479/osu.Game/Overlays/Mods/ModButton.cs#L74-L75)
  * The deselection potentially triggers a change of `AdjustPitch` to defaults, therefore potentially swapping a tempo adjustment for a frequency adjustment
* `ModButton` then [signals that its selection has changed](https://github.com/ppy/osu/blob/5b17e92770e1613d099599b9fc8f758a10b0c479/osu.Game/Overlays/Mods/ModButton.cs#L111), eventually triggering a game-global `SelectedMods` update
* `MusicController` [subscribes to mod changes](https://github.com/ppy/osu/blob/5b17e92770e1613d099599b9fc8f758a10b0c479/osu.Game/Overlays/MusicController.cs#L64) and [resets adjustments](https://github.com/ppy/osu/blob/5b17e92770e1613d099599b9fc8f758a10b0c479/osu.Game/Overlays/MusicController.cs#L64) after all that.

On the new design, the ordering there ends up basically swapped - the adjustments are reset, the mod is reset to defaults after that, which causes an `AdjustPitch` change, which causes a dynamic adjustment to be added and triggers the bug.

Rather than focus on which ordering is correct, I initially resolved to add an `IApplicableToTrack.UnapplyFromTrack()` method, but then figured that this isn't really required so long as mods stop adding adjustments on held references to tracks. Which is what this pull does - `ModTimeRamp` and `ModAdaptiveSpeed` are changed so that they don't apply adjustments to held references to tracks, and ample warning is added to xmldoc to not do this. Unfortunately in `ModTimeRamp` I cannot fully get rid of the reference, as that mod also accesses `ITrack.CurrentTime`.

I know that @frenzibyte was really adamant about [some fool-proof way to add adjustments](https://discord.com/channels/188630481301012481/188630652340404224/973314948144971847) that would make it impossible for this to ever happen, but (a) my brain somehow just stops working when reading any of that proposal, and (b) it doesn't solve the fact that `ModTimeRamp` needs `ITrack` to work, and at the point where you've got a track reference in hand again, you can bug out again.