### PR TITLE
Workaround bad performance when selecting all freemods

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -192,6 +192,8 @@ namespace osu.Game.Overlays.Mods
 
             State.BindValueChanged(_ => samplePlaybackDisabled.Value = State.Value == Visibility.Hidden, true);
 
+            // This is an optimisation to prevent refreshing the available settings controls when it can be
+            // reasonably assumed that the settings panel is never to be displayed (e.g. FreeModSelectScreen).
             if (customisationButton != null)
                 ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
 

--- a/osu.Game/Overlays/Mods/ModSelectScreen.cs
+++ b/osu.Game/Overlays/Mods/ModSelectScreen.cs
@@ -192,7 +192,8 @@ namespace osu.Game.Overlays.Mods
 
             State.BindValueChanged(_ => samplePlaybackDisabled.Value = State.Value == Visibility.Hidden, true);
 
-            ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
+            if (customisationButton != null)
+                ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
 
             SelectedMods.BindValueChanged(val =>
             {


### PR DESCRIPTION
I noticed that selecting all freemods would bring my osu! to a crawl of sometimes above 100ms frametime. This looks to be caused by the reconstruction of all settings controls whenever a selection changes, as opposed to adding/inserting them along the existing ones.

Since freemods can't be customised anyway (for now?), I've taken the easier route of disabling the settings area binding when the button itself is not displayed (is null). This is a similar check to what's done in other places, so I don't think it's too egregious of a workaround:
https://github.com/ppy/osu/blob/886a4815fa9db9827a0a9475113ffb5e247fdd00/osu.Game/Overlays/Mods/ModSelectScreen.cs#L291-L294