### PR TITLE
Bring sentry usage up-to-date

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneOsuGame.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneOsuGame.cs
@@ -23,7 +23,6 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Menu;
 using osu.Game.Skinning;
-using osu.Game.Utils;
 
 namespace osu.Game.Tests.Visual.Navigation
 {
@@ -33,7 +32,6 @@ namespace osu.Game.Tests.Visual.Navigation
         private IReadOnlyList<Type> requiredGameDependencies => new[]
         {
             typeof(OsuGame),
-            typeof(SentryLogger),
             typeof(OsuLogo),
             typeof(IdleTracker),
             typeof(OnScreenDisplay),

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -258,6 +258,8 @@ namespace osu.Game
         {
             dependencies.CacheAs(this);
 
+            SentryLogger.AttachUser(API.LocalUser);
+
             dependencies.Cache(osuLogo = new OsuLogo { Alpha = 0 });
 
             // bind config int to database RulesetInfo

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -258,8 +258,6 @@ namespace osu.Game
         {
             dependencies.CacheAs(this);
 
-            dependencies.Cache(SentryLogger);
-
             dependencies.Cache(osuLogo = new OsuLogo { Alpha = 0 });
 
             // bind config int to database RulesetInfo

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -125,7 +125,7 @@ namespace osu.Game
 
         protected MusicController MusicController { get; private set; }
 
-        protected internal IAPIProvider API { get; protected set; }
+        protected IAPIProvider API { get; set; }
 
         protected Storage Storage { get; set; }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -125,7 +125,7 @@ namespace osu.Game
 
         protected MusicController MusicController { get; private set; }
 
-        protected IAPIProvider API { get; set; }
+        protected internal IAPIProvider API { get; protected set; }
 
         protected Storage Storage { get; set; }
 

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -50,10 +50,35 @@ namespace osu.Game.Utils
                 if (lastException != null && lastException.Message == exception.Message && exception.StackTrace.StartsWith(lastException.StackTrace, StringComparison.Ordinal)) return;
 
                 lastException = exception;
-                sentry.CaptureEvent(new SentryEvent(exception) { Message = entry.Message }, sentryScope);
+                sentry.CaptureEvent(new SentryEvent(exception)
+                {
+                    Message = entry.Message,
+                    Level = getSentryLevel(entry.Level),
+                }, sentryScope);
             }
             else
                 sentryScope.AddBreadcrumb(DateTimeOffset.Now, entry.Message, entry.Target.ToString(), "navigation");
+        }
+
+        private SentryLevel? getSentryLevel(LogLevel entryLevel)
+        {
+            switch (entryLevel)
+            {
+                case LogLevel.Debug:
+                    return SentryLevel.Debug;
+
+                case LogLevel.Verbose:
+                    return SentryLevel.Info;
+
+                case LogLevel.Important:
+                    return SentryLevel.Warning;
+
+                case LogLevel.Error:
+                    return SentryLevel.Error;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entryLevel), entryLevel, null);
+            }
         }
 
         private bool shouldSubmitException(Exception exception)

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -41,6 +41,8 @@ namespace osu.Game.Utils
             Logger.NewEntry += processLogEntry;
         }
 
+        ~SentryLogger() => Dispose(false);
+
         public void AttachUser(IBindable<APIUser> user)
         {
             Debug.Assert(localUser == null);

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -20,8 +20,6 @@ namespace osu.Game.Utils
     /// </summary>
     public class SentryLogger : IDisposable
     {
-        private Exception? lastException;
-
         private IBindable<APIUser>? localUser;
 
         private readonly IDisposable? sentrySession;
@@ -68,11 +66,6 @@ namespace osu.Game.Utils
             if (exception != null)
             {
                 if (!shouldSubmitException(exception)) return;
-
-                // since we let unhandled exceptions go ignored at times, we want to ensure they don't get submitted on subsequent reports.
-                if (lastException != null && lastException.Message == exception.Message && exception.StackTrace.StartsWith(lastException.StackTrace, StringComparison.Ordinal)) return;
-
-                lastException = exception;
 
                 // framework does some weird exception redirection which means sentry does not see unhandled exceptions using its automatic methods.
                 // but all unhandled exceptions still arrive via this pathway. we just need to mark them as unhandled for tagging purposes.

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Utils
             var options = new SentryOptions
             {
                 Dsn = "https://ad9f78529cef40ac874afb95a9aca04e@sentry.ppy.sh/2",
+                AutoSessionTracking = true,
+                IsEnvironmentUser = false,
                 Release = game.Version
             };
 

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -95,10 +95,31 @@ namespace osu.Game.Utils
                 });
             }
             else
-                SentrySdk.AddBreadcrumb(entry.Message, entry.Target.ToString(), "navigation");
+                SentrySdk.AddBreadcrumb(entry.Message, entry.Target.ToString(), "navigation", level: getBreadcrumbLevel(entry.Level));
         }
 
-        private SentryLevel? getSentryLevel(LogLevel entryLevel)
+        private BreadcrumbLevel getBreadcrumbLevel(LogLevel entryLevel)
+        {
+            switch (entryLevel)
+            {
+                case LogLevel.Debug:
+                    return BreadcrumbLevel.Debug;
+
+                case LogLevel.Verbose:
+                    return BreadcrumbLevel.Info;
+
+                case LogLevel.Important:
+                    return BreadcrumbLevel.Warning;
+
+                case LogLevel.Error:
+                    return BreadcrumbLevel.Error;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entryLevel), entryLevel, null);
+            }
+        }
+
+        private SentryLevel getSentryLevel(LogLevel entryLevel)
         {
             switch (entryLevel)
             {


### PR DESCRIPTION
This fixes multiple issues with our existing sentry usage.

- Fixes unhandled/unobserved not being communicated to sentry (216c68e6d0 / c6112b3ae7)
- Remove sentry logger debounce (363643a16d)
  - This is probably going to result in a high quantity of exceptions, but I think this is fine. We can add rules as we go to not log certain exception types.
- Update sentry SDK usage in line with more recent specifications (9734d778f4)
- Attaches user metadata to sentry (3338bffce3)
- Adds better mapping of verbosity (6a49eb6875 / 09c21cde8c)
- Enables session tracking

Example exceptions can be seen here: https://sentry.ppy.sh/organizations/ppy/issues/?groupStatsPeriod=auto&project=2&query=firstRelease%3A%22local+debug%22&sort=freq&statsPeriod=90d (this is an internal link and will only work for @smoogipoo for now).

![Safari 2022-05-10 at 07 17 52](https://user-images.githubusercontent.com/191335/167571332-79ee5704-8e1b-4899-98da-fa125fa426ce.png)

![Safari 2022-05-10 at 07 18 33](https://user-images.githubusercontent.com/191335/167571512-54b1577f-5cf3-4b45-8205-e69f352f95ce.png)


Diff used for testing:

```diff
diff --git a/osu.Desktop/Program.cs b/osu.Desktop/Program.cs
index eb9045d9ce..66c5e2dcdb 100644
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -132,7 +132,7 @@ private static void setupSquirrel()
             });
         }
 
-        private static int allowableExceptions = DebugUtils.IsDebugBuild ? 0 : 1;
+        private static int allowableExceptions = DebugUtils.IsDebugBuild ? 1 : 1;
 
         /// <summary>
         /// Allow a maximum of one unhandled exception, per second of execution.
diff --git a/osu.Game/OsuGame.cs b/osu.Game/OsuGame.cs
index b8abef38a8..5eae773745 100644
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -9,6 +9,7 @@
 using System.Threading.Tasks;
 using Humanizer;
 using JetBrains.Annotations;
+using NUnit.Framework.Internal;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -56,6 +57,7 @@
 using osu.Game.Users;
 using osu.Game.Utils;
 using osuTK.Graphics;
+using Logger = osu.Framework.Logging.Logger;
 
 namespace osu.Game
 {
@@ -1091,8 +1093,8 @@ public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
             switch (e.Action)
             {
                 case GlobalAction.ToggleSkinEditor:
-                    skinEditor.ToggleVisibility();
-                    return true;
+                    Task.Run(() => throw new Exception("this is an unobserved exception"));
+                    throw new Exception("this is a normal exception");
 
                 case GlobalAction.ResetInputSettings:
                     Host.ResetInputHandlers();
diff --git a/osu.Game/Utils/SentryLogger.cs b/osu.Game/Utils/SentryLogger.cs
index ad4bcf6274..91c6bad313 100644
--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -29,8 +29,8 @@ public SentryLogger(OsuGame game)
             sentrySession = SentrySdk.Init(options =>
             {
                 // Not setting the dsn will completely disable sentry.
-                if (game.IsDeployedBuild)
-                    options.Dsn = "https://ad9f78529cef40ac874afb95a9aca04e@sentry.ppy.sh/2";
+                //if (game.IsDeployedBuild)
+                options.Dsn = "https://ad9f78529cef40ac874afb95a9aca04e@sentry.ppy.sh/2";
 
                 options.AutoSessionTracking = true;
                 options.IsEnvironmentUser = false;

```