### PR TITLE
Workaround interface mocks in `TestSceneFirstRunSetupOverlay` breaking with hot reload

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using Moq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
@@ -25,9 +27,9 @@ namespace osu.Game.Tests.Visual.UserInterface
     {
         private FirstRunSetupOverlay overlay;
 
-        private readonly Mock<IPerformFromScreenRunner> performer = new Mock<IPerformFromScreenRunner>();
+        private readonly Mock<TestPerformerFromScreenRunner> performer = new Mock<TestPerformerFromScreenRunner>();
 
-        private readonly Mock<INotificationOverlay> notificationOverlay = new Mock<INotificationOverlay>();
+        private readonly Mock<TestNotificationOverlay> notificationOverlay = new Mock<TestNotificationOverlay>();
 
         private Notification lastNotification;
 
@@ -37,8 +39,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         private void load()
         {
             Dependencies.Cache(LocalConfig = new OsuConfigManager(LocalStorage));
-            Dependencies.CacheAs(performer.Object);
-            Dependencies.CacheAs(notificationOverlay.Object);
+            Dependencies.CacheAs<IPerformFromScreenRunner>(performer.Object);
+            Dependencies.CacheAs<INotificationOverlay>(notificationOverlay.Object);
         }
 
         [SetUpSteps]
@@ -195,6 +197,32 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddAssert("overlay shown", () => overlay.State.Value == Visibility.Visible);
             AddAssert("is resumed", () => overlay.CurrentScreen is ScreenBeatmaps);
+        }
+
+        // interface mocks break hot reload, mocking this stub implementation instead works around it.
+        // see: https://github.com/moq/moq4/issues/1252
+        [UsedImplicitly]
+        public class TestNotificationOverlay : INotificationOverlay
+        {
+            public virtual void Post(Notification notification)
+            {
+            }
+
+            public virtual void Hide()
+            {
+            }
+
+            public virtual IBindable<int> UnreadCount => null;
+        }
+
+        // interface mocks break hot reload, mocking this stub implementation instead works around it.
+        // see: https://github.com/moq/moq4/issues/1252
+        [UsedImplicitly]
+        public class TestPerformerFromScreenRunner : IPerformFromScreenRunner
+        {
+            public virtual void PerformFromScreen(Action<IScreen> action, IEnumerable<Type> validScreens = null)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
- Works around https://github.com/moq/moq4/issues/1252

Note that `TestSceneToolbar` and `TestSceneGameplayChatDisplay` are still left broken as we're not 100% sure about this workaround, but it would at least make working on the first-run setup overlay less painful than it is right now.

If we were to stay on this workaround, then we may want to consider moving these "stub classes" to their own files on the test project to not have to duplicate the same on every test scene.