### PR TITLE
Improve first run overlay layout (and switch on)

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
@@ -74,7 +74,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        [Ignore("Enable when first run setup is being displayed on first run.")]
         public void TestDoesntOpenOnSecondRun()
         {
             AddStep("set first run", () => LocalConfig.SetValue(OsuSetting.ShowFirstRunSetup, true));

--- a/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
+++ b/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
@@ -19,13 +19,16 @@ namespace osu.Game.Overlays.FirstRunSetup
 
         protected FillFlowContainer Content { get; private set; }
 
+        protected const float CONTENT_FONT_SIZE = 16;
+
+        protected const float HEADER_FONT_SIZE = 24;
+
         [Resolved]
         protected OverlayColourProvider OverlayColourProvider { get; private set; }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            const float header_size = 40;
             const float spacing = 20;
 
             InternalChildren = new Drawable[]
@@ -44,12 +47,12 @@ namespace osu.Game.Overlays.FirstRunSetup
                             new OsuSpriteText
                             {
                                 Text = this.GetLocalisableDescription(),
-                                Font = OsuFont.Default.With(size: header_size),
+                                Font = OsuFont.TorusAlternate.With(size: HEADER_FONT_SIZE),
                                 Colour = OverlayColourProvider.Light1,
                             },
                             Content = new FillFlowContainer
                             {
-                                Y = header_size + spacing,
+                                Y = HEADER_FONT_SIZE + spacing,
                                 Spacing = new Vector2(spacing),
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
+++ b/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             base.OnEntering(e);
             this
-                .FadeInFromZero(500)
+                .FadeInFromZero(100)
                 .MoveToX(offset)
                 .MoveToX(0, 500, Easing.OutQuint);
         }
@@ -77,7 +77,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             base.OnResuming(e);
             this
-                .FadeInFromZero(500)
+                .FadeInFromZero(100)
                 .MoveToX(0, 500, Easing.OutQuint);
         }
 

--- a/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
+++ b/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
@@ -33,23 +33,29 @@ namespace osu.Game.Overlays.FirstRunSetup
                 new OsuScrollContainer(Direction.Vertical)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    ScrollbarOverlapsContent = false,
-                    Children = new Drawable[]
+                    Masking = false,
+                    Child = new Container
                     {
-                        new OsuSpriteText
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding { Horizontal = 30 },
+                        Children = new Drawable[]
                         {
-                            Text = this.GetLocalisableDescription(),
-                            Font = OsuFont.Default.With(size: header_size),
-                            Colour = OverlayColourProvider.Light1,
+                            new OsuSpriteText
+                            {
+                                Text = this.GetLocalisableDescription(),
+                                Font = OsuFont.Default.With(size: header_size),
+                                Colour = OverlayColourProvider.Light1,
+                            },
+                            Content = new FillFlowContainer
+                            {
+                                Y = header_size + spacing,
+                                Spacing = new Vector2(spacing),
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                            }
                         },
-                        Content = new FillFlowContainer
-                        {
-                            Y = header_size + spacing,
-                            Spacing = new Vector2(spacing),
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Vertical,
-                        }
                     },
                 }
             };

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
@@ -46,11 +46,11 @@ namespace osu.Game.Overlays.FirstRunSetup
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(LegacyImportManager? legacyImportManager)
         {
-            Vector2 buttonSize = new Vector2(500, 60);
+            Vector2 buttonSize = new Vector2(400, 50);
 
             Content.Children = new Drawable[]
             {
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 20))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     Text = FirstRunSetupBeatmapScreenStrings.Description,
@@ -63,7 +63,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Height = 30,
                     Children = new Drawable[]
                     {
-                        currentlyLoadedBeatmaps = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 24, weight: FontWeight.SemiBold))
+                        currentlyLoadedBeatmaps = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: HEADER_FONT_SIZE, weight: FontWeight.SemiBold))
                         {
                             Colour = OverlayColourProvider.Content2,
                             TextAnchor = Anchor.Centre,
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                         },
                     }
                 },
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 20))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     Text = FirstRunSetupBeatmapScreenStrings.TutorialDescription,
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Text = FirstRunSetupBeatmapScreenStrings.TutorialButton,
                     Action = downloadTutorial
                 },
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 20))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     Text = FirstRunSetupBeatmapScreenStrings.BundledDescription,
@@ -105,7 +105,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Text = FirstRunSetupBeatmapScreenStrings.BundledButton,
                     Action = downloadBundled
                 },
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 20))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     Text = "If you have an existing osu! install, you can also choose to import your existing beatmap collection.",
@@ -131,7 +131,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                         }));
                     }
                 },
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 20))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     Text = FirstRunSetupBeatmapScreenStrings.ObtainMoreBeatmaps,

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             Content.Children = new Drawable[]
             {
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 24))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Text = FirstRunSetupOverlayStrings.BehaviourDescription,
                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -9,7 +9,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Settings.Sections;
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         private SearchContainer<SettingsSection> searchContainer;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuColour colours)
         {
             Content.Children = new Drawable[]
             {
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                     {
                         new[]
                         {
-                            new TriangleButton
+                            new RoundedButton
                             {
                                 Anchor = Anchor.TopLeft,
                                 Origin = Anchor.TopLeft,
@@ -59,10 +59,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                                 Action = applyStandard,
                             },
                             Empty(),
-                            new DangerousTriangleButton
+                            new RoundedButton
                             {
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
+                                BackgroundColour = colours.Pink3,
                                 Text = FirstRunSetupOverlayStrings.ClassicDefaults,
                                 RelativeSizeAxes = Axes.X,
                                 Action = applyClassic

--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -125,6 +125,7 @@ namespace osu.Game.Overlays.FirstRunSetup
 
         private class SampleScreenContainer : CompositeDrawable
         {
+            private readonly OsuScreen screen;
             // Minimal isolation from main game.
 
             [Cached]
@@ -144,6 +145,12 @@ namespace osu.Game.Overlays.FirstRunSetup
             public override bool PropagatePositionalInputSubTree => false;
             public override bool PropagateNonPositionalInputSubTree => false;
 
+            public SampleScreenContainer(OsuScreen screen)
+            {
+                this.screen = screen;
+                RelativeSizeAxes = Axes.Both;
+            }
+
             [BackgroundDependencyLoader]
             private void load(AudioManager audio, TextureStore textures, RulesetStore rulesets)
             {
@@ -151,13 +158,8 @@ namespace osu.Game.Overlays.FirstRunSetup
                 Beatmap.Value.LoadTrack();
 
                 Ruleset.Value = rulesets.AvailableRulesets.First();
-            }
 
-            public SampleScreenContainer(Screen screen)
-            {
                 OsuScreenStack stack;
-                RelativeSizeAxes = Axes.Both;
-
                 OsuLogo logo;
 
                 Padding = new MarginPadding(5);
@@ -191,7 +193,8 @@ namespace osu.Game.Overlays.FirstRunSetup
                     },
                 };
 
-                stack.Push(screen);
+                // intentionally load synchronously so it is included in the initial load of the first run screen.
+                stack.PushSynchronously(screen);
             }
         }
     }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Overlays.FirstRunSetup
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
+            const float screen_width = 640;
+
             Content.Children = new Drawable[]
             {
                 new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
@@ -54,7 +56,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     RelativeSizeAxes = Axes.None,
-                    Size = new Vector2(960, 960 / 16f * 9 / 2),
+                    Size = new Vector2(screen_width, screen_width / 16f * 9 / 2),
                     Children = new Drawable[]
                     {
                         new GridContainer

--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             Content.Children = new Drawable[]
             {
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 24))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Text = FirstRunSetupOverlayStrings.UIScaleDescription,
                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             Content.Children = new Drawable[]
             {
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 20))
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Text = FirstRunSetupOverlayStrings.WelcomeDescription,
                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -171,8 +171,7 @@ namespace osu.Game.Overlays
 
             config.BindWith(OsuSetting.ShowFirstRunSetup, showFirstRunSetup);
 
-            // TODO: uncomment when happy with the whole flow.
-            // if (showFirstRunSetup.Value) Show();
+            if (showFirstRunSetup.Value) Show();
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
@@ -304,8 +303,7 @@ namespace osu.Game.Overlays
             }
             else
             {
-                // TODO: uncomment when happy with the whole flow.
-                // showFirstRunSetup.Value = false;
+                showFirstRunSetup.Value = false;
                 currentStepIndex = null;
                 Hide();
             }

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -118,11 +118,7 @@ namespace osu.Game.Overlays
                                         new Container
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            Padding = new MarginPadding
-                                            {
-                                                Vertical = 20,
-                                                Horizontal = 20,
-                                            },
+                                            Padding = new MarginPadding { Vertical = 20 },
                                             Child = screenContent = new Container { RelativeSizeAxes = Axes.Both, },
                                         },
                                     },

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Overlays
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
                     Padding = new MarginPadding { Bottom = 20, },
-                    Child = new GridContainer()
+                    Child = new GridContainer
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays
             typeof(ScreenBehaviour),
         };
 
-        private Container stackContainer = null!;
+        private Container screenContent = null!;
 
         private Bindable<OverlayActivation>? overlayActivationMode;
 
@@ -86,36 +86,51 @@ namespace osu.Game.Overlays
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding
+                    Padding = new MarginPadding { Bottom = 20, },
+                    Child = new GridContainer()
                     {
-                        Horizontal = 70 * 1.2f,
-                        Bottom = 20,
-                    },
-                    Child = new InputBlockingContainer
-                    {
-                        Masking = true,
-                        CornerRadius = 14,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
-                        Children = new Drawable[]
+                        ColumnDimensions = new[]
                         {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = ColourProvider.Background6,
-                            },
-                            stackContainer = new Container
-                            {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding
-                                {
-                                    Vertical = 20,
-                                    Horizontal = 70,
-                                },
-                            }
+                            new Dimension(),
+                            new Dimension(minSize: 640, maxSize: 800),
+                            new Dimension(),
                         },
-                    },
+                        Content = new[]
+                        {
+                            new[]
+                            {
+                                Empty(),
+                                new InputBlockingContainer
+                                {
+                                    Masking = true,
+                                    CornerRadius = 14,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = ColourProvider.Background6,
+                                        },
+                                        new Container
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Padding = new MarginPadding
+                                            {
+                                                Vertical = 20,
+                                                Horizontal = 20,
+                                            },
+                                            Child = screenContent = new Container { RelativeSizeAxes = Axes.Both, },
+                                        },
+                                    },
+                                },
+                                Empty(),
+                            },
+                        }
+                    }
                 },
             });
 
@@ -268,7 +283,7 @@ namespace osu.Game.Overlays
         {
             Debug.Assert(currentStepIndex == null);
 
-            stackContainer.Child = stack = new ScreenStack
+            screenContent.Child = stack = new ScreenStack
             {
                 RelativeSizeAxes = Axes.Both,
             };

--- a/osu.Game/Screens/OsuScreenStack.cs
+++ b/osu.Game/Screens/OsuScreenStack.cs
@@ -29,6 +29,13 @@ namespace osu.Game.Screens
             ScreenExited += ScreenChanged;
         }
 
+        public void PushSynchronously(OsuScreen screen)
+        {
+            LoadComponent(screen);
+
+            Push(screen);
+        }
+
         private void screenPushed(IScreen prev, IScreen next)
         {
             if (LoadState < LoadState.Ready)


### PR DESCRIPTION
This is the final sprint towards getting the first run overlay in a state I'm happy to have it enabled. I'm still not 100% happy with the UI scale screen, but it feels that at this point it's going to benefit new users installing lazer more to have it enabled.

Of importance:

- a93c63b2b5 Adds loading spinner when loading screens (and requires a578f7a406 to correctly load the ui scale nested screens as part of the main load operation).
- 63b9e01d38 Fixes behaviour screen using old style buttons
- 61313b69ec Standardise font sizes in first run overlay screens
- bcce9c5e67 Limits the width of first run overlay content (with e5204e565d helping out by moving horizontal padding to content level to better align scrollbar)
- Finally, 9aadc274bf turns on the first run dialog on first run of the game (and re-enables test coverage).

https://user-images.githubusercontent.com/191335/167597388-99027f93-5014-4dc6-9c70-40835a8a0726.mp4


