### PR TITLE
Fix realm refetch operations potentially being unsafe

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -348,6 +348,26 @@ namespace osu.Game.Database
         /// Write changes to realm.
         /// </summary>
         /// <param name="action">The work to run.</param>
+        public T Write<T>(Func<Realm, T> action)
+        {
+            if (ThreadSafety.IsUpdateThread)
+            {
+                total_writes_update.Value++;
+                return Realm.Write(action);
+            }
+            else
+            {
+                total_writes_async.Value++;
+
+                using (var realm = getRealmInstance())
+                    return realm.Write(action);
+            }
+        }
+
+        /// <summary>
+        /// Write changes to realm.
+        /// </summary>
+        /// <param name="action">The work to run.</param>
         public void Write(Action<Realm> action)
         {
             if (ThreadSafety.IsUpdateThread)

--- a/osu.Game/Stores/RealmArchiveModelManager.cs
+++ b/osu.Game/Stores/RealmArchiveModelManager.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Stores
                 // (ie. if an async import finished very recently).
                 Realm.Realm.Write(realm =>
                 {
-                    var managed = Realm.Realm.Find<TModel>(item.ID);
+                    var managed = realm.Find<TModel>(item.ID);
                     operation(managed);
 
                     item.Files.Clear();

--- a/osu.Game/Stores/RealmArchiveModelManager.cs
+++ b/osu.Game/Stores/RealmArchiveModelManager.cs
@@ -45,11 +45,16 @@ namespace osu.Game.Stores
             // This method should be removed as soon as all the surrounding pieces support non-detached operations.
             if (!item.IsManaged)
             {
-                var managed = Realm.Realm.Find<TModel>(item.ID);
-                managed.Realm.Write(() => operation(managed));
+                // Importantly, begin the realm write *before* re-fetching, else the update realm may not be in a consistent state
+                // (ie. if an async import finished very recently).
+                Realm.Realm.Write(realm =>
+                {
+                    var managed = Realm.Realm.Find<TModel>(item.ID);
+                    operation(managed);
 
-                item.Files.Clear();
-                item.Files.AddRange(managed.Files.Detach());
+                    item.Files.Clear();
+                    item.Files.AddRange(managed.Files.Detach());
+                });
             }
             else
                 operation(item);
@@ -165,7 +170,9 @@ namespace osu.Game.Stores
 
         public bool Delete(TModel item)
         {
-            return Realm.Run(realm =>
+            // Importantly, begin the realm write *before* re-fetching, else the update realm may not be in a consistent state
+            // (ie. if an async import finished very recently).
+            return Realm.Write(realm =>
             {
                 if (!item.IsManaged)
                     item = realm.Find<TModel>(item.ID);
@@ -173,14 +180,16 @@ namespace osu.Game.Stores
                 if (item?.DeletePending != false)
                     return false;
 
-                realm.Write(r => item.DeletePending = true);
+                item.DeletePending = true;
                 return true;
             });
         }
 
         public void Undelete(TModel item)
         {
-            Realm.Run(realm =>
+            // Importantly, begin the realm write *before* re-fetching, else the update realm may not be in a consistent state
+            // (ie. if an async import finished very recently).
+            Realm.Write(realm =>
             {
                 if (!item.IsManaged)
                     item = realm.Find<TModel>(item.ID);
@@ -188,7 +197,7 @@ namespace osu.Game.Stores
                 if (item?.DeletePending != true)
                     return;
 
-                realm.Write(r => item.DeletePending = false);
+                item.DeletePending = false;
             });
         }
 


### PR DESCRIPTION
As seen in test failure https://github.com/ppy/osu/runs/6357384721?check_suite_focus=true.

To summarise, if an import and subsequent detach both occur on an async thread, but the detached result is immediately used on the main thread, a refetch will fail as the update realm has not had a chance to refresh yet. Starting the write operation before a potential refresh fixes this.