### PR TITLE
Add more context to sentry error reports

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Extensions;
@@ -162,6 +164,20 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f);
             SetDefault(OsuSetting.EditorHitAnimations, false);
+        }
+
+        public IDictionary<OsuSetting, string> GetLoggableState() =>
+            new Dictionary<OsuSetting, string>(ConfigStore.Where(kvp => !keyContainsPrivateInformation(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToString()));
+
+        private static bool keyContainsPrivateInformation(OsuSetting argKey)
+        {
+            switch (argKey)
+            {
+                case OsuSetting.Token:
+                    return true;
+            }
+
+            return false;
         }
 
         public OsuConfigManager(Storage storage)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -56,6 +56,8 @@ using osu.Game.Updater;
 using osu.Game.Users;
 using osu.Game.Utils;
 using osuTK.Graphics;
+using Sentry;
+using Logger = osu.Framework.Logging.Logger;
 
 namespace osu.Game
 {
@@ -1197,6 +1199,15 @@ namespace osu.Game
 
         private void screenChanged(IScreen current, IScreen newScreen)
         {
+            SentrySdk.ConfigureScope(scope =>
+            {
+                scope.Contexts[@"screen stack"] = new
+                {
+                    Current = newScreen.GetType().Name,
+                    Previous = current.GetType().Name,
+                };
+            });
+
             switch (newScreen)
             {
                 case IntroScreen intro:

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -14,6 +14,7 @@ using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -1203,8 +1204,8 @@ namespace osu.Game
             {
                 scope.Contexts[@"screen stack"] = new
                 {
-                    Current = newScreen.GetType().Name,
-                    Previous = current.GetType().Name,
+                    Current = newScreen?.GetType().ReadableName(),
+                    Previous = current?.GetType().ReadableName(),
                 };
             });
 

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -10,6 +10,7 @@ using System.Net;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
@@ -105,6 +106,15 @@ namespace osu.Game.Utils
                         Game = game.Dependencies.Get<OsuConfigManager>().GetLoggableState()
                         // TODO: add framework config here. needs some consideration on how to expose.
                     };
+
+                    var beatmap = game.Dependencies.Get<IBindable<WorkingBeatmap>>().Value.BeatmapInfo;
+
+                    scope.Contexts[@"beatmap"] = new
+                    {
+                        Name = beatmap.ToString(),
+                        beatmap.OnlineID,
+                    };
+
                     scope.Contexts[@"clocks"] = new
                     {
                         Audio = game.Dependencies.Get<MusicController>().CurrentTrack.CurrentTime,

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -11,6 +11,7 @@ using System.Net;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Framework.Statistics;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
@@ -126,6 +127,10 @@ namespace osu.Game.Utils
                             }
                         };
                     });
+
+                    scope.Contexts[@"global statistics"] = GlobalStatistics.GetStatistics()
+                                                                           .GroupBy(s => s.Group)
+                                                                           .ToDictionary(g => g.Key, items => items.ToDictionary(i => i.Name, g => g.DisplayValue));
 
                     scope.Contexts[@"beatmap"] = new
                     {


### PR DESCRIPTION
Adds config, realm, beatmap, clock and global statistics. Should be enough to get by for now. I've gone with the easiest implementation possible, rather than fumbling with trying to get json serialisation working.

- [x] Depends on https://github.com/ppy/osu-framework/pull/5168

Sample report: https://sentry.ppy.sh/organizations/ppy/issues/431/?project=2

![Safari 2022-05-11 at 06 01 51](https://user-images.githubusercontent.com/191335/167779435-55621a26-7053-40b0-abcb-51695659e93c.png)


![Safari 2022-05-11 at 06 01 37](https://user-images.githubusercontent.com/191335/167779400-3a914160-dad0-454d-89ca-a295c347246d.png)


![Safari 2022-05-11 at 06 01 17](https://user-images.githubusercontent.com/191335/167779365-ca44120f-692b-4a75-b7ba-962eef54d079.png)
