### PR TITLE
Fix timeline not handling mouse down events

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -270,12 +270,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             if (base.OnMouseDown(e))
-            {
                 beginUserDrag();
-                return true;
-            }
 
-            return false;
+            return true;
         }
 
         protected override void OnMouseUp(MouseUpEvent e)


### PR DESCRIPTION
As reported in [discord](https://discord.com/channels/188630481301012481/188630652340404224/973830418468065301). Yet another case of the regression from https://github.com/ppy/osu-framework/pull/5118 regarding removing `ScrollContainer.OnMouseDown() => true` which was a wrong return value.