### PR TITLE
Focus textbox upon opening control point popovers

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
@@ -64,6 +65,13 @@ namespace osu.Game.Tests.Visual.Editing
                     }
                 });
             });
+        }
+
+        [Test]
+        public void TestPopoverHasFocus()
+        {
+            clickDifficultyPiece(0);
+            velocityPopoverHasFocus();
         }
 
         [Test]
@@ -131,6 +139,15 @@ namespace osu.Game.Tests.Visual.Editing
 
             InputManager.MoveMouseTo(difficultyPiece);
             InputManager.Click(MouseButton.Left);
+        });
+
+        private void velocityPopoverHasFocus() => AddUntilStep("velocity popover textbox focused", () =>
+        {
+            var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
+            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
+            var textbox = slider?.ChildrenOfType<OsuTextBox>().Single();
+
+            return textbox?.HasFocus == true;
         });
 
         private void velocityPopoverHasSingleValue(double velocity) => AddUntilStep($"velocity popover has {velocity}", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -168,6 +168,7 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void dismissPopover()
         {
+            AddStep("unfocus textbox", () => InputManager.Key(Key.Escape));
             AddStep("dismiss popover", () => InputManager.Key(Key.Escape));
             AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Any(popover => popover.IsPresent));
         }

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -231,6 +231,7 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void dismissPopover()
         {
+            AddStep("unfocus textbox", () => InputManager.Key(Key.Escape));
             AddStep("dismiss popover", () => InputManager.Key(Key.Escape));
             AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Any(popover => popover.IsPresent));
         }

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -173,11 +173,11 @@ namespace osu.Game.Tests.Visual.Editing
             samplePopoverHasSingleBank("normal");
         }
 
-        private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>
+        private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} sample piece", () =>
         {
-            var difficultyPiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
+            var samplePiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
 
-            InputManager.MoveMouseTo(difficultyPiece);
+            InputManager.MoveMouseTo(samplePiece);
             InputManager.Click(MouseButton.Left);
         });
 
@@ -216,7 +216,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void dismissPopover()
         {
             AddStep("dismiss popover", () => InputManager.Key(Key.Escape));
-            AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Any(popover => popover.IsPresent));
+            AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Any(popover => popover.IsPresent));
         }
 
         private void setVolumeViaPopover(int volume) => AddStep($"set volume {volume} via popover", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSamplePointAdjustments.cs
@@ -58,6 +58,13 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestPopoverHasFocus()
+        {
+            clickSamplePiece(0);
+            samplePopoverHasFocus();
+        }
+
+        [Test]
         public void TestSingleSelection()
         {
             clickSamplePiece(0);
@@ -179,6 +186,15 @@ namespace osu.Game.Tests.Visual.Editing
 
             InputManager.MoveMouseTo(samplePiece);
             InputManager.Click(MouseButton.Left);
+        });
+
+        private void samplePopoverHasFocus() => AddUntilStep("sample popover textbox focused", () =>
+        {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
+            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
+            var textbox = slider?.ChildrenOfType<OsuTextBox>().Single();
+
+            return textbox?.HasFocus == true;
         });
 
         private void samplePopoverHasSingleVolume(int volume) => AddUntilStep($"sample popover has volume {volume}", () =>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -122,6 +122,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     beatmap.EndChange();
                 });
             }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                ScheduleAfterChildren(() => GetContainingInputManager().ChangeFocus(sliderVelocitySlider));
+            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -126,6 +126,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 volume.Current.BindValueChanged(val => updateVolumeFor(relevantObjects, val.NewValue));
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                ScheduleAfterChildren(() => GetContainingInputManager().ChangeFocus(volume));
+            }
+
             private static string? getCommonBank(SampleControlPoint[] relevantControlPoints) => relevantControlPoints.Select(point => point.SampleBank).Distinct().Count() == 1 ? relevantControlPoints.First().SampleBank : null;
             private static int? getCommonVolume(SampleControlPoint[] relevantControlPoints) => relevantControlPoints.Select(point => point.SampleVolume).Distinct().Count() == 1 ? (int?)relevantControlPoints.First().SampleVolume : null;
 

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
@@ -105,6 +106,14 @@ namespace osu.Game.Screens.Edit.Timing
             slider.Current.BindValueChanged(val => Current.Value = val.NewValue);
 
             Current.BindValueChanged(_ => updateState(), true);
+        }
+
+        public override bool AcceptsFocus => true;
+
+        protected override void OnFocus(FocusEvent e)
+        {
+            base.OnFocus(e);
+            GetContainingInputManager().ChangeFocus(textBox);
         }
 
         private void updateState()


### PR DESCRIPTION
As mentioned on stream, allows for less steps to entering new values on control points. The scheduling logic follows exactly how `PasswordEntryPopover` does it (and is correct in general, because you want to schedule focusing a child until they're loaded, which happens after `LoadComplete`, therefore requiring a schedule-after-children).

---

To make it easier to adjust control point values on the go, now clicking on the points above/beneath objects will automatically focus the textbox for entering new values.

https://user-images.githubusercontent.com/22781491/167789040-a4da7614-25ae-41ee-b5eb-def963168905.mp4

