### PR TITLE
Rename remaining references to "mod select screen" nomenclature

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
@@ -17,7 +17,7 @@ using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    public class TestSceneFreeModSelectScreen : MultiplayerTestScene
+    public class TestSceneFreeModSelectOverlay : MultiplayerTestScene
     {
         private FreeModSelectOverlay freeModSelectOverlay;
         private readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>();

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -24,7 +24,7 @@ using osuTK.Input;
 namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public class TestSceneModSelectScreen : OsuManualInputManagerTestScene
+    public class TestSceneModSelectOverlay : OsuManualInputManagerTestScene
     {
         [Resolved]
         private RulesetStore rulesetStore { get; set; }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -222,7 +222,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestSettingsNotCrossPolluting()
         {
             Bindable<IReadOnlyList<Mod>> selectedMods2 = null;
-            ModSelectOverlay modSelectScreen2 = null;
+            ModSelectOverlay modSelectOverlay2 = null;
 
             createScreen();
             AddStep("select diff adjust", () => SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust() });
@@ -235,7 +235,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("create second overlay", () =>
             {
-                Add(modSelectScreen2 = new UserModSelectOverlay().With(d =>
+                Add(modSelectOverlay2 = new UserModSelectOverlay().With(d =>
                 {
                     d.Origin = Anchor.TopCentre;
                     d.Anchor = Anchor.TopCentre;
@@ -243,7 +243,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 }));
             });
 
-            AddStep("show", () => modSelectScreen2.Show());
+            AddStep("show", () => modSelectOverlay2.Show());
 
             AddAssert("ensure first is unchanged", () => SelectedMods.Value.OfType<OsuModDifficultyAdjust>().Single().CircleSize.Value == 8);
             AddAssert("ensure second is default", () => selectedMods2.Value.OfType<OsuModDifficultyAdjust>().Single().CircleSize.Value == null);

--- a/osu.Game/Localisation/ModSelectOverlayStrings.cs
+++ b/osu.Game/Localisation/ModSelectOverlayStrings.cs
@@ -5,9 +5,9 @@ using osu.Framework.Localisation;
 
 namespace osu.Game.Localisation
 {
-    public static class ModSelectScreenStrings
+    public static class ModSelectOverlayStrings
     {
-        private const string prefix = @"osu.Game.Resources.Localisation.ModSelectScreen";
+        private const string prefix = @"osu.Game.Resources.Localisation.ModSelectOverlay";
 
         /// <summary>
         /// "Mod Select"

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Overlays.Mods
             State.BindValueChanged(_ => samplePlaybackDisabled.Value = State.Value == Visibility.Hidden, true);
 
             // This is an optimisation to prevent refreshing the available settings controls when it can be
-            // reasonably assumed that the settings panel is never to be displayed (e.g. FreeModSelectScreen).
+            // reasonably assumed that the settings panel is never to be displayed (e.g. FreeModSelectOverlay).
             if (customisationButton != null)
                 ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -84,8 +84,8 @@ namespace osu.Game.Overlays.Mods
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            Header.Title = ModSelectScreenStrings.ModSelectTitle;
-            Header.Description = ModSelectScreenStrings.ModSelectDescription;
+            Header.Title = ModSelectOverlayStrings.ModSelectTitle;
+            Header.Description = ModSelectOverlayStrings.ModSelectDescription;
 
             AddRange(new Drawable[]
             {
@@ -262,7 +262,7 @@ namespace osu.Game.Overlays.Mods
             {
                 customisationButton = new ShearedToggleButton(BUTTON_WIDTH)
                 {
-                    Text = ModSelectScreenStrings.ModCustomisation,
+                    Text = ModSelectOverlayStrings.ModCustomisation,
                     Active = { BindTarget = customisationVisible }
                 },
                 new ShearedButton(BUTTON_WIDTH)


### PR DESCRIPTION
This wasn't intentionally split from https://github.com/ppy/osu/pull/18215, I just leaned way too heavily on rider's "rename related symbols" feature... There should be no more now though, touch wood, I grepped.

Moderately important to get this in before the new generation of resx files for localisations, as localisation keys are touched here too.