### PR TITLE
Restructure data flow in mod select overlay

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Tests.Mods;
 using osuTK;
 using osuTK.Input;
 
@@ -479,6 +480,21 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("show", () => modSelectOverlay.Show());
             AddUntilStep("3 columns visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 3);
+        }
+
+        [Test]
+        public void TestColumnHidingOnRulesetChange()
+        {
+            createScreen();
+
+            changeRuleset(0);
+            AddAssert("5 columns visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 5);
+
+            AddStep("change to ruleset without all mod types", () => Ruleset.Value = TestCustomisableModRuleset.CreateTestRulesetInfo());
+            AddUntilStep("1 column visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 1);
+
+            changeRuleset(0);
+            AddAssert("5 columns visible", () => this.ChildrenOfType<ModColumn>().Count(col => col.IsPresent) == 5);
         }
 
         private void waitForColumnLoad() => AddUntilStep("all column content loaded",

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
@@ -19,6 +19,11 @@ namespace osu.Game.Overlays.Mods
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; }
 
+        public IncompatibilityDisplayingModPanel(ModState modState)
+            : base(modState)
+        {
+        }
+
         public IncompatibilityDisplayingModPanel(Mod mod)
             : base(mod)
         {

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -296,8 +296,8 @@ namespace osu.Game.Overlays.Mods
 
             if (toggleAllCheckbox != null && !SelectionAnimationRunning)
             {
-                toggleAllCheckbox.Alpha = panelFlow.Any(panel => !panel.Filtered.Value) ? 1 : 0;
-                toggleAllCheckbox.Current.Value = panelFlow.Where(panel => !panel.Filtered.Value).All(panel => panel.Active.Value);
+                toggleAllCheckbox.Alpha = availableMods.Any(panel => !panel.Filtered.Value) ? 1 : 0;
+                toggleAllCheckbox.Current.Value = availableMods.Where(panel => !panel.Filtered.Value).All(panel => panel.Active.Value);
             }
         }
 
@@ -342,7 +342,7 @@ namespace osu.Game.Overlays.Mods
         {
             pendingSelectionOperations.Clear();
 
-            foreach (var button in panelFlow.Where(b => !b.Active.Value && !b.Filtered.Value))
+            foreach (var button in availableMods.Where(b => !b.Active.Value && !b.Filtered.Value))
                 pendingSelectionOperations.Enqueue(() => button.Active.Value = true);
         }
 
@@ -353,7 +353,7 @@ namespace osu.Game.Overlays.Mods
         {
             pendingSelectionOperations.Clear();
 
-            foreach (var button in panelFlow.Where(b => b.Active.Value && !b.Filtered.Value))
+            foreach (var button in availableMods.Where(b => b.Active.Value && !b.Filtered.Value))
                 pendingSelectionOperations.Enqueue(() => button.Active.Value = false);
         }
 

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -49,7 +49,9 @@ namespace osu.Game.Overlays.Mods
                 Debug.Assert(value.All(mod => mod.Mod.Type == ModType));
 
                 availableMods = value;
-                asyncLoadPanels();
+
+                if (IsLoaded)
+                    asyncLoadPanels();
             }
         }
 
@@ -249,6 +251,7 @@ namespace osu.Game.Overlays.Mods
             base.LoadComplete();
 
             toggleAllCheckbox?.Current.BindValueChanged(_ => updateToggleAllText(), true);
+            asyncLoadPanels();
         }
 
         private void updateToggleAllText()

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -64,13 +64,6 @@ namespace osu.Game.Overlays.Mods
         }
 
         /// <summary>
-        /// A function determining whether each mod in the column should be displayed.
-        /// A return value of <see langword="true"/> means that the mod is not filtered and therefore its corresponding panel should be displayed.
-        /// A return value of <see langword="false"/> means that the mod is filtered out and therefore its corresponding panel should be hidden.
-        /// </summary>
-        public Func<Mod, bool>? Filter { get; set; } // TODO: remove later
-
-        /// <summary>
         /// Determines whether this column should accept user input.
         /// </summary>
         public Bindable<bool> Active = new BindableBool(true);

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -50,6 +50,14 @@ namespace osu.Game.Overlays.Mods
 
                 availableMods = value;
 
+                foreach (var mod in availableMods)
+                {
+                    mod.Active.BindValueChanged(_ => updateState());
+                    mod.Filtered.BindValueChanged(_ => updateState());
+                }
+
+                updateState();
+
                 if (IsLoaded)
                     asyncLoadPanels();
             }

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -57,9 +57,9 @@ namespace osu.Game.Overlays.Mods
         private Sample? sampleOff;
         private Sample? sampleOn;
 
-        public ModPanel(Mod mod)
+        public ModPanel(ModState modState)
         {
-            modState = new ModState(mod);
+            this.modState = modState;
 
             RelativeSizeAxes = Axes.X;
             Height = 42;
@@ -81,7 +81,7 @@ namespace osu.Game.Overlays.Mods
                 SwitchContainer = new Container
                 {
                     RelativeSizeAxes = Axes.Y,
-                    Child = new ModSwitchSmall(mod)
+                    Child = new ModSwitchSmall(Mod)
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -117,7 +117,7 @@ namespace osu.Game.Overlays.Mods
                                 {
                                     new OsuSpriteText
                                     {
-                                        Text = mod.Name,
+                                        Text = Mod.Name,
                                         Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
                                         Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
                                         Margin = new MarginPadding
@@ -127,7 +127,7 @@ namespace osu.Game.Overlays.Mods
                                     },
                                     new OsuSpriteText
                                     {
-                                        Text = mod.Description,
+                                        Text = Mod.Description,
                                         Font = OsuFont.Default.With(size: 12),
                                         RelativeSizeAxes = Axes.X,
                                         Truncate = true,
@@ -141,6 +141,11 @@ namespace osu.Game.Overlays.Mods
             };
 
             Action = Active.Toggle;
+        }
+
+        public ModPanel(Mod mod)
+            : this(new ModState(mod))
+        {
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -28,9 +28,11 @@ namespace osu.Game.Overlays.Mods
 {
     public class ModPanel : OsuClickableContainer
     {
-        public Mod Mod { get; }
-        public BindableBool Active { get; } = new BindableBool();
-        public BindableBool Filtered { get; } = new BindableBool();
+        public Mod Mod => modState.Mod;
+        public BindableBool Active => modState.Active;
+        public BindableBool Filtered => modState.Filtered;
+
+        private readonly ModState modState;
 
         protected readonly Box Background;
         protected readonly Container SwitchContainer;
@@ -57,7 +59,7 @@ namespace osu.Game.Overlays.Mods
 
         public ModPanel(Mod mod)
         {
-            Mod = mod;
+            modState = new ModState(mod);
 
             RelativeSizeAxes = Axes.X;
             Height = 42;

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -192,9 +192,10 @@ namespace osu.Game.Overlays.Mods
 
         protected override void LoadComplete()
         {
-            base.LoadComplete();
-
+            // this is called before base call so that the mod state is populated early, and the transition in `PopIn()` can play out properly.
             availableMods.BindValueChanged(_ => createLocalMods(), true);
+
+            base.LoadComplete();
 
             State.BindValueChanged(_ => samplePlaybackDisabled.Value = State.Value == Visibility.Hidden, true);
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -12,7 +12,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
-using osu.Framework.Lists;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Configuration;
@@ -406,11 +405,6 @@ namespace osu.Game.Overlays.Mods
             var candidateSelection = allLocalAvailableMods.Where(modState => modState.Active.Value)
                                                           .Select(modState => modState.Mod)
                                                           .ToArray();
-
-            // the following guard intends to check cases where we've already replaced potentially-external mod references with our own and avoid endless recursion.
-            // TODO: replace custom comparer with System.Collections.Generic.ReferenceEqualityComparer when fully on .NET 6
-            if (candidateSelection.SequenceEqual(SelectedMods.Value, new FuncEqualityComparer<Mod>(ReferenceEquals)))
-                return;
 
             SelectedMods.Value = ComputeNewModsFromSelection(SelectedMods.Value, candidateSelection);
         }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -369,6 +369,9 @@ namespace osu.Game.Overlays.Mods
 
         private void updateFromExternalSelection()
         {
+            if (externalSelectionUpdateInProgress)
+                return;
+
             externalSelectionUpdateInProgress = true;
 
             var newSelection = new List<Mod>();

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -65,6 +65,7 @@ namespace osu.Game.Overlays.Mods
 
         private readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>();
         private readonly Dictionary<ModType, IReadOnlyList<ModState>> localAvailableMods = new Dictionary<ModType, IReadOnlyList<ModState>>();
+        private IEnumerable<ModState> allLocalAvailableMods => localAvailableMods.SelectMany(pair => pair.Value);
 
         private readonly BindableBool customisationVisible = new BindableBool();
 
@@ -294,7 +295,7 @@ namespace osu.Game.Overlays.Mods
 
         private void filterMods()
         {
-            foreach (var modState in localAvailableMods.Values.SelectMany(m => m))
+            foreach (var modState in allLocalAvailableMods)
                 modState.Filtered.Value = !modState.Mod.HasImplementation || !IsValidMod.Invoke(modState.Mod);
         }
 
@@ -372,7 +373,7 @@ namespace osu.Game.Overlays.Mods
 
             var newSelection = new List<Mod>();
 
-            foreach (var modState in localAvailableMods.SelectMany(pair => pair.Value))
+            foreach (var modState in allLocalAvailableMods)
             {
                 var matchingSelectedMod = SelectedMods.Value.SingleOrDefault(selected => selected.GetType() == modState.Mod.GetType());
 
@@ -399,10 +400,9 @@ namespace osu.Game.Overlays.Mods
             if (externalSelectionUpdateInProgress)
                 return;
 
-            var candidateSelection = localAvailableMods.SelectMany(pair => pair.Value)
-                                                       .Where(modState => modState.Active.Value)
-                                                       .Select(modState => modState.Mod)
-                                                       .ToArray();
+            var candidateSelection = allLocalAvailableMods.Where(modState => modState.Active.Value)
+                                                          .Select(modState => modState.Mod)
+                                                          .ToArray();
 
             // the following guard intends to check cases where we've already replaced potentially-external mod references with our own and avoid endless recursion.
             // TODO: replace custom comparer with System.Collections.Generic.ReferenceEqualityComparer when fully on .NET 6

--- a/osu.Game/Overlays/Mods/ModState.cs
+++ b/osu.Game/Overlays/Mods/ModState.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Overlays.Mods
+{
+    /// <summary>
+    /// Wrapper class used to store the current state of a mod shown on the <see cref="ModSelectOverlay"/>.
+    /// Used primarily to decouple data from drawable logic.
+    /// </summary>
+    public class ModState
+    {
+        /// <summary>
+        /// The mod that whose state this instance describes.
+        /// </summary>
+        public Mod Mod { get; }
+
+        /// <summary>
+        /// Whether the mod is currently selected.
+        /// </summary>
+        public BindableBool Active { get; } = new BindableBool();
+
+        /// <summary>
+        /// Whether the mod is currently filtered out due to not matching imposed criteria.
+        /// </summary>
+        public BindableBool Filtered { get; } = new BindableBool();
+
+        public ModState(Mod mod)
+        {
+            Mod = mod;
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/UserModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/UserModSelectOverlay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays.Mods
             {
             }
 
-            protected override ModPanel CreateModPanel(Mod mod) => new IncompatibilityDisplayingModPanel(mod);
+            protected override ModPanel CreateModPanel(ModState modState) => new IncompatibilityDisplayingModPanel(modState);
         }
     }
 }


### PR DESCRIPTION
This is a request for comment of sorts, that was spurred by [a few](https://discord.com/channels/188630481301012481/188630652340404224/973465348881915924) [comments](https://discord.com/channels/188630481301012481/188630652340404224/973463616756015114) on discord that the data flow in the new mod select overlay was difficult to understand. I'm interested to see if this diff helps anything.

This is a bit of a large one (right at the edge of 500 lines), so I'll try to describe the basic idea of what was done here. The single biggest pain points in my work with this overlay were the following:

* Drawables stored data/state (like what mods a column has, which mods are active, which are filtered out), but also tried to accommodate async loading flows and framework operation order. This led to situations where a data operation wouldn't work right, because there was nowhere to store state to yet as the supporting drawables were possibly not constructed yet.
* The mod reference replacement logic that I keep bringing up. I'll leave it at that, I think everyone's seen the worst of it now.

This pull attempts to address both concerns at once by doing the following:

* State is pulled out of drawables into a pure data class (`ModState`). This data is always constructed synchronously, and changes always propagate instantly. This is a source of truth that then drawable async flows can build onto for more optimised loading in a safer way.
* Mod instances with their associated state are now created by the root overlay, then passed down to the columns, then passed down to the individual panels. This is a change from the old logic that had the mod instances in the columns, leading to weird back-and-forths in the reference replacement logic - all of it happens on the overlay level now.
  * This also allows for implementing filtering only at the mod select level, and paves a way for making further UI adjustments more simple. For instance, I will want to disable the "deselect/select all" buttons in the footer at some point in the future. This would have been much more awkward to achieve with the mod references and state living in the columns.

As a bit of a statement as to how well this _appears_ to be working, this diff fixes #18222 without really trying much to do anything of the sort - most of the code is simply rearranged, but the bug is fixed anyhow (because it was caused by state updates not firing due to being coupled to drawable presence and/or quirks in `LoadComponentsAsync()`). The passing test added in 315c67a316343e8935c61e640aa502c418e887cf supports this.