### PR TITLE
Fix distance snap providing zero-distance snaps incorrectly

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -113,7 +113,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         public void TestCursorInCentre()
         {
             AddStep("move mouse to centre", () => InputManager.MoveMouseTo(grid.ToScreenSpace(grid_position)));
-            assertSnappedDistance(0);
+            assertSnappedDistance(beat_length);
+        }
+
+        [Test]
+        public void TestCursorAlmostInCentre()
+        {
+            AddStep("move mouse to almost centre", () => InputManager.MoveMouseTo(grid.ToScreenSpace(grid_position) + new Vector2(1)));
+            assertSnappedDistance(beat_length);
         }
 
         [Test]

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osuTK;
@@ -76,13 +77,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             Vector2 travelVector = (position - StartPosition);
 
+            // We need a non-zero travel vector in order to find a valid direction.
             if (travelVector == Vector2.Zero)
-                return (StartPosition, StartTime);
+                travelVector = new Vector2(0, -1);
 
             float travelLength = travelVector.Length;
 
             // FindSnappedDistance will always round down, but we want to potentially round upwards.
             travelLength += DistanceBetweenTicks / 2;
+
+            // We never want to snap towards zero.
+            if (travelLength < DistanceBetweenTicks)
+                travelLength = DistanceBetweenTicks;
 
             // When interacting with the resolved snap provider, the distance spacing multiplier should first be removed
             // to allow for snapping at a non-multiplied ratio.

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -7,7 +7,6 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osuTK;


### PR DESCRIPTION
Pointed out in passing by @Walavouchey.

Before:

https://user-images.githubusercontent.com/191335/167991188-a04b80df-b370-44c1-8579-b108babfb21a.mp4

After:

https://user-images.githubusercontent.com/191335/167991249-dc81b023-772f-4878-a4f4-11cd3c8a77b8.mp4

I've also changed the handling of a zero vector to provide a valid snap rather than return the input values. Feels saner? Should not change any actual behaviour since object-stacking-snap takes precedence when placing this close to another object.