### PR TITLE
Add `enum` to snap method as alternative to multiple nested invocations

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
@@ -89,15 +90,19 @@ namespace osu.Game.Rulesets.Catch.Edit
             new TernaryButton(distanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Ruler })
         });
 
-        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
-            var result = base.FindSnappedPositionAndTime(screenSpacePosition);
+            var result = base.FindSnappedPositionAndTime(screenSpacePosition, snapType);
+
             result.ScreenSpacePosition.X = screenSpacePosition.X;
 
-            if (distanceSnapGrid.IsPresent && distanceSnapGrid.GetSnappedPosition(result.ScreenSpacePosition) is SnapResult snapResult &&
-                Vector2.Distance(snapResult.ScreenSpacePosition, result.ScreenSpacePosition) < distance_snap_radius)
+            if (snapType.HasFlagFast(SnapType.Grids))
             {
-                result = snapResult;
+                if (distanceSnapGrid.IsPresent && distanceSnapGrid.GetSnappedPosition(result.ScreenSpacePosition) is SnapResult snapResult &&
+                    Vector2.Distance(snapResult.ScreenSpacePosition, result.ScreenSpacePosition) < distance_snap_radius)
+                {
+                    result = snapResult;
+                }
             }
 
             return result;

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaBeatSnapGrid.cs
@@ -97,12 +97,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             set => InternalChild = value;
         }
 
-        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override SnapResult FindSnappedPosition(Vector2 screenSpacePosition)
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
             throw new System.NotImplementedException();
         }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -5,7 +5,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Mania.Edit.Blueprints
@@ -52,8 +55,28 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             base.UpdateTimeAndPosition(result);
 
+            var playfield = (Column)result.Playfield;
+
+            // Apply an offset to better align with the visual grid.
+            // This should only be applied during placement, as during selection / drag operations the movement is relative
+            // to the initial point of interaction rather than the grid.
+            switch (playfield.ScrollingInfo.Direction.Value)
+            {
+                case ScrollingDirection.Down:
+                    result.ScreenSpacePosition -= new Vector2(0, getNoteHeight(playfield) / 2);
+                    break;
+
+                case ScrollingDirection.Up:
+                    result.ScreenSpacePosition += new Vector2(0, getNoteHeight(playfield) / 2);
+                    break;
+            }
+
             if (PlacementActive == PlacementState.Waiting)
-                Column = result.Playfield as Column;
+                Column = playfield;
         }
+
+        private float getNoteHeight(Column resultPlayfield) =>
+            resultPlayfield.ToScreenSpace(new Vector2(DefaultNotePiece.NOTE_HEIGHT)).Y -
+            resultPlayfield.ToScreenSpace(Vector2.Zero).Y;
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -55,24 +55,25 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             base.UpdateTimeAndPosition(result);
 
-            var playfield = (Column)result.Playfield;
-
-            // Apply an offset to better align with the visual grid.
-            // This should only be applied during placement, as during selection / drag operations the movement is relative
-            // to the initial point of interaction rather than the grid.
-            switch (playfield.ScrollingInfo.Direction.Value)
+            if (result.Playfield is Column col)
             {
-                case ScrollingDirection.Down:
-                    result.ScreenSpacePosition -= new Vector2(0, getNoteHeight(playfield) / 2);
-                    break;
+                // Apply an offset to better align with the visual grid.
+                // This should only be applied during placement, as during selection / drag operations the movement is relative
+                // to the initial point of interaction rather than the grid.
+                switch (col.ScrollingInfo.Direction.Value)
+                {
+                    case ScrollingDirection.Down:
+                        result.ScreenSpacePosition -= new Vector2(0, getNoteHeight(col) / 2);
+                        break;
 
-                case ScrollingDirection.Up:
-                    result.ScreenSpacePosition += new Vector2(0, getNoteHeight(playfield) / 2);
-                    break;
+                    case ScrollingDirection.Up:
+                        result.ScreenSpacePosition += new Vector2(0, getNoteHeight(col) / 2);
+                        break;
+                }
+
+                if (PlacementActive == PlacementState.Waiting)
+                    Column = col;
             }
-
-            if (PlacementActive == PlacementState.Waiting)
-                Column = playfield;
         }
 
         private float getNoteHeight(Column resultPlayfield) =>

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -56,9 +56,9 @@ namespace osu.Game.Rulesets.Mania.Edit
         protected override Playfield PlayfieldAtScreenSpacePosition(Vector2 screenSpacePosition) =>
             Playfield.GetColumnByPosition(screenSpacePosition);
 
-        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
-            var result = base.FindSnappedPositionAndTime(screenSpacePosition);
+            var result = base.FindSnappedPositionAndTime(screenSpacePosition, snapType);
 
             switch (ScrollingInfo.Direction.Value)
             {

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Edit.Tools;
-using osu.Game.Rulesets.Mania.Objects;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Input;
-using osu.Game.Rulesets.Mania.Skinning.Default;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -55,28 +54,6 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         protected override Playfield PlayfieldAtScreenSpacePosition(Vector2 screenSpacePosition) =>
             Playfield.GetColumnByPosition(screenSpacePosition);
-
-        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
-        {
-            var result = base.FindSnappedPositionAndTime(screenSpacePosition, snapType);
-
-            switch (ScrollingInfo.Direction.Value)
-            {
-                case ScrollingDirection.Down:
-                    result.ScreenSpacePosition -= new Vector2(0, getNoteHeight() / 2);
-                    break;
-
-                case ScrollingDirection.Up:
-                    result.ScreenSpacePosition += new Vector2(0, getNoteHeight() / 2);
-                    break;
-            }
-
-            return result;
-        }
-
-        private float getNoteHeight() =>
-            Playfield.GetColumn(0).ToScreenSpace(new Vector2(DefaultNotePiece.NOTE_HEIGHT)).Y -
-            Playfield.GetColumn(0).ToScreenSpace(Vector2.Zero).Y;
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
         {

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -185,10 +185,7 @@ namespace osu.Game.Tests.Visual.Editing
 
         private class SnapProvider : IDistanceSnapProvider
         {
-            public SnapResult FindSnappedPosition(Vector2 screenSpacePosition) =>
-                new SnapResult(screenSpacePosition, null);
-
-            public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition) => new SnapResult(screenSpacePosition, 0);
+            public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.Grids) => new SnapResult(screenSpacePosition, 0);
 
             public Bindable<double> DistanceSpacingMultiplier { get; } = new BindableDouble(1);
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -361,20 +362,23 @@ namespace osu.Game.Rulesets.Edit
         /// <returns>The most relevant <see cref="Playfield"/>.</returns>
         protected virtual Playfield PlayfieldAtScreenSpacePosition(Vector2 screenSpacePosition) => drawableRulesetWrapper.Playfield;
 
-        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
             var playfield = PlayfieldAtScreenSpacePosition(screenSpacePosition);
             double? targetTime = null;
 
-            if (playfield is ScrollingPlayfield scrollingPlayfield)
+            if (snapType.HasFlagFast(SnapType.Grids))
             {
-                targetTime = scrollingPlayfield.TimeAtScreenSpacePosition(screenSpacePosition);
+                if (playfield is ScrollingPlayfield scrollingPlayfield)
+                {
+                    targetTime = scrollingPlayfield.TimeAtScreenSpacePosition(screenSpacePosition);
 
-                // apply beat snapping
-                targetTime = BeatSnapProvider.SnapTime(targetTime.Value);
+                    // apply beat snapping
+                    targetTime = BeatSnapProvider.SnapTime(targetTime.Value);
 
-                // convert back to screen space
-                screenSpacePosition = scrollingPlayfield.ScreenSpacePositionAtTime(targetTime.Value);
+                    // convert back to screen space
+                    screenSpacePosition = scrollingPlayfield.ScreenSpacePositionAtTime(targetTime.Value);
+                }
             }
 
             return new SnapResult(screenSpacePosition, targetTime, playfield);
@@ -414,10 +418,7 @@ namespace osu.Game.Rulesets.Edit
 
         #region IPositionSnapProvider
 
-        public abstract SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition);
-
-        public virtual SnapResult FindSnappedPosition(Vector2 screenSpacePosition) =>
-            new SnapResult(screenSpacePosition, null);
+        public abstract SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All);
 
         #endregion
     }

--- a/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Rulesets.Edit
 {
     /// <summary>
     /// A snap provider which given a proposed position for a hit object, potentially offers a more correct position and time value inferred from the context of the beatmap.
-    /// Provided values are inferred in an isolated context, without consideration of other nearby hit objects.
     /// </summary>
     [Cached]
     public interface IPositionSnapProvider
@@ -16,18 +15,9 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// Given a position, find a valid time and position snap.
         /// </summary>
-        /// <remarks>
-        /// This call should be equivalent to running <see cref="FindSnappedPosition"/> with any additional logic that can be performed without the time immutability restriction.
-        /// </remarks>
         /// <param name="screenSpacePosition">The screen-space position to be snapped.</param>
+        /// <param name="snapType">The type of snapping to apply.</param>
         /// <returns>The time and position post-snapping.</returns>
-        SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition);
-
-        /// <summary>
-        /// Given a position, find a valid position snap, without changing the time value.
-        /// </summary>
-        /// <param name="screenSpacePosition">The screen-space position to be snapped.</param>
-        /// <returns>The position post-snapping. Time will always be null.</returns>
-        SnapResult FindSnappedPosition(Vector2 screenSpacePosition);
+        SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All);
     }
 }

--- a/osu.Game/Rulesets/Edit/SnapType.cs
+++ b/osu.Game/Rulesets/Edit/SnapType.cs
@@ -8,8 +8,9 @@ namespace osu.Game.Rulesets.Edit
     [Flags]
     public enum SnapType
     {
-        NearbyObjects = 0,
-        Grids = 1,
+        None = 0,
+        NearbyObjects = 1 << 0,
+        Grids = 1 << 1,
         All = NearbyObjects | Grids,
     }
 }

--- a/osu.Game/Rulesets/Edit/SnapType.cs
+++ b/osu.Game/Rulesets/Edit/SnapType.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Edit
+{
+    [Flags]
+    public enum SnapType
+    {
+        NearbyObjects = 0,
+        Grids = 1,
+        All = NearbyObjects | Grids,
+    }
+}

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
         public new ScrollingHitObjectContainer HitObjectContainer => (ScrollingHitObjectContainer)base.HitObjectContainer;
 
         [Resolved]
-        protected IScrollingInfo ScrollingInfo { get; private set; }
+        public IScrollingInfo ScrollingInfo { get; private set; }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -486,7 +486,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     Vector2 originalPosition = movementBlueprintOriginalPositions[i];
                     var testPosition = originalPosition + distanceTravelled;
 
-                    var positionalResult = snapProvider.FindSnappedPosition(testPosition);
+                    var positionalResult = snapProvider.FindSnappedPositionAndTime(testPosition, SnapType.NearbyObjects);
 
                     if (positionalResult.ScreenSpacePosition == testPosition) continue;
 
@@ -505,7 +505,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Vector2 movePosition = movementBlueprintOriginalPositions.First() + distanceTravelled;
 
             // Retrieve a snapped position.
-            var result = snapProvider?.FindSnappedPositionAndTime(movePosition);
+            var result = snapProvider?.FindSnappedPositionAndTime(movePosition, ~SnapType.NearbyObjects);
 
             if (result == null)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -303,10 +303,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </summary>
         public double VisibleRange => track.Length / Zoom;
 
-        public SnapResult FindSnappedPosition(Vector2 screenSpacePosition) =>
-            new SnapResult(screenSpacePosition, null);
-
-        public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition) =>
+        public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All) =>
             new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(screenSpacePosition))));
 
         private double getTimeFromPosition(Vector2 localPosition) =>


### PR DESCRIPTION
As pointed out by @frenzibyte on discord, the previous method naming didn't really match what was being done. Still not sure this is the endgame for making these interactions as clear as possible, but seems like an improvement.

I original had `Beat` as an option in the enum, but it's not used anywhere yet so removed it for siplicity.

f7e055dbfe was required as due to nearby object snap is passing through the same flow and providing a position value, which was being warped and therefore not triggering the "position is equal, no snap occurred" abort at https://github.com/ppy/osu/blob/c0abce918fbacbd57f10a100d04cc1649d8bfb73/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs#L491. It is also more correct in this new location, as it doesn't affect drag operations (where it was previously adding an offset that shouldn't be).

Recommend reviewing each commit individually.