### PR TITLE
Fix slider ball rotation becoming undefined when time is not flowing smoothly

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -195,16 +195,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         public void UpdateProgress(double completionProgress)
         {
-            var newPos = drawableSlider.HitObject.CurvePositionAt(completionProgress);
+            Position = drawableSlider.HitObject.CurvePositionAt(completionProgress);
 
-            var diff = lastPosition.HasValue ? lastPosition.Value - newPos : newPos - drawableSlider.HitObject.CurvePositionAt(completionProgress + 0.01f);
-            if (diff == Vector2.Zero)
+            var diff = lastPosition.HasValue ? lastPosition.Value - Position : Position - drawableSlider.HitObject.CurvePositionAt(completionProgress + 0.01f);
+
+            // Ensure the value is substantially high enough to allow for Atan2 to get a valid angle.
+            if (diff.LengthFast < 0.01f)
                 return;
 
-            Position = newPos;
             ball.Rotation = -90 + (float)(-Math.Atan2(diff.X, diff.Y) * 180 / Math.PI);
-
-            lastPosition = newPos;
+            lastPosition = Position;
         }
 
         private class FollowCircleContainer : CircularContainer


### PR DESCRIPTION
`Atan2` begins to fail when dealing with very very floating point numbers. This occurs when paused in the editor, due to the time transform that smoothly seeks forward.

Before:

https://user-images.githubusercontent.com/191335/168033727-08141923-434a-499b-8478-9649a0902075.mp4

After:

https://user-images.githubusercontent.com/191335/168033624-e63ff635-7213-40ba-b7ed-842c479b1d5b.mp4


