### PR TITLE
Fix multiplayer spectator occasionally freezing at start again

### DIFF
--- a/osu.Game.Tests/OnlinePlay/TestSceneCatchUpSyncManager.cs
+++ b/osu.Game.Tests/OnlinePlay/TestSceneCatchUpSyncManager.cs
@@ -186,6 +186,10 @@ namespace osu.Game.Tests.OnlinePlay
             public double FramesPerSecond => 0;
 
             public FrameTimeInfo TimeInfo => default;
+
+            public void MarkReady()
+            {
+            }
         }
 
         private class TestManualClock : ManualClock, IAdjustableClock

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -15,13 +16,14 @@ using osu.Game.Configuration;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
-using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.PlayerSettings;
+using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps.IO;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -349,14 +351,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         /// <summary>
-        /// Tests spectating with a beatmap that has a high lead-in value.
+        /// Tests spectating with a beatmap that has a high <see cref="BeatmapInfo.AudioLeadIn"/> value.
         /// </summary>
         [Test]
-        public void TestLeadIn()
+        public void TestAudioLeadIn() => testLeadIn(b => b.BeatmapInfo.AudioLeadIn = 2000);
+
+        /// <summary>
+        /// Tests spectating with a beatmap that has a storyboard element with a negative start time (i.e. intro storyboard element).
+        /// </summary>
+        [Test]
+        public void TestIntroStoryboardElement() => testLeadIn(b =>
+        {
+            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            sprite.TimelineGroup.Alpha.Add(Easing.None, -2000, 0, 0, 1);
+            b.Storyboard.GetLayer("Background").Add(sprite);
+        });
+
+        private void testLeadIn(Action<WorkingBeatmap> applyToBeatmap = null)
         {
             start(PLAYER_1_ID);
 
-            loadSpectateScreen(false, 2000);
+            loadSpectateScreen(false, applyToBeatmap);
 
             // to ensure negative gameplay start time does not affect spectator, send frames exactly after StartGameplay().
             // (similar to real spectating sessions in which the first frames get sent between StartGameplay() and player load complete)
@@ -370,14 +385,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             assertRunning(PLAYER_1_ID);
         }
 
-        private void loadSpectateScreen(bool waitForPlayerLoad = true, double? leadIn = null)
+        private void loadSpectateScreen(bool waitForPlayerLoad = true, Action<WorkingBeatmap> applyToBeatmap = null)
         {
-            AddStep(!leadIn.HasValue ? "load screen" : $"load screen (lead-in = {leadIn}ms)", () =>
+            AddStep("load screen", () =>
             {
                 Beatmap.Value = beatmapManager.GetWorkingBeatmap(importedBeatmap);
                 Ruleset.Value = importedBeatmap.Ruleset;
 
-                LoadScreen(spectatorScreen = new TestMultiSpectatorScreen(SelectedRoom.Value, playingUsers.ToArray(), leadIn));
+                applyToBeatmap?.Invoke(Beatmap.Value);
+
+                LoadScreen(spectatorScreen = new MultiSpectatorScreen(SelectedRoom.Value, playingUsers.ToArray()));
             });
 
             AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded && (!waitForPlayerLoad || spectatorScreen.AllPlayersLoaded));
@@ -460,22 +477,5 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private GameplayLeaderboardScore getLeaderboardScore(int userId) => spectatorScreen.ChildrenOfType<GameplayLeaderboardScore>().Single(s => s.User?.Id == userId);
 
         private int[] getPlayerIds(int count) => Enumerable.Range(PLAYER_1_ID, count).ToArray();
-
-        private class TestMultiSpectatorScreen : MultiSpectatorScreen
-        {
-            private readonly double? leadIn;
-
-            public TestMultiSpectatorScreen(Room room, MultiplayerRoomUser[] users, double? leadIn = null)
-                : base(room, users)
-            {
-                this.leadIn = leadIn;
-            }
-
-            protected override MasterGameplayClockContainer CreateMasterGameplayClockContainer(WorkingBeatmap beatmap)
-            {
-                beatmap.BeatmapInfo.AudioLeadIn = leadIn ?? 0;
-                return base.CreateMasterGameplayClockContainer(beatmap);
-            }
-        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
@@ -28,9 +28,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         public bool IsRunning { get; private set; }
 
+        private bool isReady;
+
         public void Reset() => CurrentTime = 0;
 
-        public void Start() => IsRunning = true;
+        public void Start()
+        {
+            if (!isReady)
+                throw new InvalidOperationException(@"Attempting to start spectator clock while not ready for use yet.");
+
+            IsRunning = true;
+        }
 
         public void Stop() => IsRunning = false;
 
@@ -80,6 +88,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         public double FramesPerSecond { get; private set; }
 
         public FrameTimeInfo TimeInfo => new FrameTimeInfo { Elapsed = ElapsedFrameTime, Current = CurrentTime };
+
+        public void MarkReady() => isReady = true;
 
         public Bindable<bool> WaitingOnFrames { get; } = new Bindable<bool>(true);
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Logging;
 using osu.Framework.Timing;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
@@ -76,14 +75,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
                 // Ensure all player clocks are stopped until the start succeeds.
                 foreach (var clock in playerClocks)
-                {
-                    if (clock.IsRunning)
-                    {
-                        Logger.Log($"{GetType().Name}.Update(): Found running clock while sync manager is stopped, stopping clock.");
-                        clock.Stop();
-                    }
-                }
-
+                    clock.Stop();
                 return;
             }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Framework.Timing;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
@@ -75,7 +76,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
                 // Ensure all player clocks are stopped until the start succeeds.
                 foreach (var clock in playerClocks)
-                    clock.Stop();
+                {
+                    if (clock.IsRunning)
+                    {
+                        Logger.Log($"{GetType().Name}.Update(): Found running clock while sync manager is stopped, stopping clock.");
+                        clock.Stop();
+                    }
+                }
+
                 return;
             }
 
@@ -110,6 +118,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             bool performStart()
             {
+                foreach (var clock in playerClocks)
+                    clock.MarkReady();
+
                 ReadyToStart?.Invoke();
                 return hasStarted = true;
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
@@ -12,6 +12,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
     public interface ISpectatorPlayerClock : IFrameBasedClock, IAdjustableClock
     {
         /// <summary>
+        /// Marks this clock as ready for use by an <see cref="ISyncManager"/>.
+        /// </summary>
+        void MarkReady();
+
+        /// <summary>
         /// Whether this clock is waiting on frames to continue playback.
         /// </summary>
         Bindable<bool> WaitingOnFrames { get; }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorPlayer.cs
@@ -57,6 +57,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
             }
 
+            public override void Reset(bool startClock = false)
+            {
+                // Similar to below, we also don't want to start clock on reset.
+                // ReSharper disable once RedundantArgumentDefaultValue - removing the "redundant" default value triggers BaseMethodCallWithDefaultParameter
+                base.Reset(false);
+            }
+
             protected override void Update()
             {
                 // The SourceClock here is always a CatchUpSpectatorPlayerClock.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
@@ -163,7 +164,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
             base.LoadComplete();
 
+            Logger.Log($"{GetType().Name}.LoadComplete(): Resetting {nameof(MasterGameplayClockContainer)}.");
             masterClockContainer.Reset();
+
+            Logger.Log($"{GetType().Name}.LoadComplete(): Current master elapsed = {masterClockContainer.GameplayClock.ElapsedFrameTime}.");
 
             syncManager.ReadyToStart += onReadyToStart;
             syncManager.MasterState.BindValueChanged(onMasterStateChanged, true);
@@ -197,7 +201,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                                         .DefaultIfEmpty(0)
                                         .Min();
 
+            Logger.Log($"{GetType().Name}.onReadyToStart(): Setting start time of {nameof(MasterGameplayClockContainer)} to {startTime}ms.");
             masterClockContainer.StartTime = startTime;
+
+            Logger.Log($"{GetType().Name}.onReadyToStart(): Resetting and starting {nameof(MasterGameplayClockContainer)}.");
             masterClockContainer.Reset(true);
 
             // Although the clock has been started, this flag is set to allow for later synchronisation state changes to also be able to start it.
@@ -210,11 +217,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
                 case MasterClockState.Synchronised:
                     if (canStartMasterClock)
+                    {
+                        Logger.Log($"{GetType().Name}.onMasterStateChanged(): Master clock synchronised, starting master.");
                         masterClockContainer.Start();
+                    }
 
                     break;
 
                 case MasterClockState.TooFarAhead:
+                    Logger.Log($"{GetType().Name}.onMasterStateChanged(): Master clock too far ahead, stopping master.");
                     masterClockContainer.Stop();
                     break;
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -8,7 +8,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
@@ -164,10 +163,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
             base.LoadComplete();
 
-            Logger.Log($"{GetType().Name}.LoadComplete(): Resetting {nameof(MasterGameplayClockContainer)}.");
             masterClockContainer.Reset();
-
-            Logger.Log($"{GetType().Name}.LoadComplete(): Current master elapsed = {masterClockContainer.GameplayClock.ElapsedFrameTime}.");
 
             syncManager.ReadyToStart += onReadyToStart;
             syncManager.MasterState.BindValueChanged(onMasterStateChanged, true);
@@ -201,10 +197,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                                         .DefaultIfEmpty(0)
                                         .Min();
 
-            Logger.Log($"{GetType().Name}.onReadyToStart(): Setting start time of {nameof(MasterGameplayClockContainer)} to {startTime}ms.");
             masterClockContainer.StartTime = startTime;
-
-            Logger.Log($"{GetType().Name}.onReadyToStart(): Resetting and starting {nameof(MasterGameplayClockContainer)}.");
             masterClockContainer.Reset(true);
 
             // Although the clock has been started, this flag is set to allow for later synchronisation state changes to also be able to start it.
@@ -217,15 +210,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
                 case MasterClockState.Synchronised:
                     if (canStartMasterClock)
-                    {
-                        Logger.Log($"{GetType().Name}.onMasterStateChanged(): Master clock synchronised, starting master.");
                         masterClockContainer.Start();
-                    }
 
                     break;
 
                 case MasterClockState.TooFarAhead:
-                    Logger.Log($"{GetType().Name}.onMasterStateChanged(): Master clock too far ahead, stopping master.");
                     masterClockContainer.Stop();
                     break;
             }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Play
         /// Resets this <see cref="GameplayClockContainer"/> and the source to an initial state ready for gameplay.
         /// </summary>
         /// <param name="startClock">Whether to start the clock immediately, if not already started.</param>
-        public void Reset(bool startClock = false)
+        public virtual void Reset(bool startClock = false)
         {
             // Manually stop the source in order to not affect the IsPaused state.
             AdjustableSource.Stop();


### PR DESCRIPTION
The multi-spectator freeze-at-start issue has came back again to haunt us... this is a request-for-comment PR.

The regressing PR is https://github.com/ppy/osu/pull/17302 as one might expect, and unfortunately, the test case was fragile enough to not catch such regression and has been false-passing all this time.

The reason why the test case has regressed is, in short, the negative start time was being set using `StartTime`, and the gameplay clock was being reset twice (first in `MultiSpectatorScreen.LoadComplete`, and second in `MasterGameplayClockContainer.LoadComplete`), therefore flushing the `ElapsedFrameTime` back to 0 and make the test case unable to reproduce the issue (because stale `ElaspedFrameTime` is a primary factor in reproducing this fuckery, see (1) in #16713's explaination).

This has been improved in https://github.com/ppy/osu/commit/53e92c0e22aaccd4779c564ee59d7613f87bc145 by pouring the "negative start time" to the audio lead-in field, to receive more realistic results from the test case instead of using a special property.

Now the reason why multi-spectator has regressed is because of `Player.StartGameplay` now actually starting the gameplay clock, which would attempt to do so on the spectator catch-up clocks and bring us all the way back to https://github.com/ppy/osu/pull/16713.

To ensure those clocks never get started again before `CatchUpSyncManager` is ready to start them, I've added a guard in https://github.com/ppy/osu/commit/d0fb8bd3ca14d5964e1bc62ff90f15d5d93c5930. 

The guard may be harsh on users, and could potentially downgrade to an `Important` log that's at least reported to sentry or something? not sure on the direction forward regarding that.