### PR TITLE
Add drawable channel caching to new chat overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
@@ -365,18 +365,18 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
-        public void TextBoxRetainsFocus()
+        public void TestTextBoxRetainsFocus()
         {
             AddStep("Show overlay", () => chatOverlay.Show());
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
             AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
+            AddStep("Click drawable channel", () => clickDrawable(currentDrawableChannel));
+            AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
             AddStep("Click selector", () => clickDrawable(chatOverlay.ChildrenOfType<ChannelListSelector>().Single()));
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
             AddStep("Click listing", () => clickDrawable(chatOverlay.ChildrenOfType<ChannelListing>().Single()));
-            AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
-            AddStep("Click drawable channel", () => clickDrawable(currentDrawableChannel));
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
             AddStep("Click channel list", () => clickDrawable(chatOverlay.ChildrenOfType<ChannelList>().Single()));
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -31,7 +33,7 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public class TestSceneChatOverlayV2 : OsuManualInputManagerTestScene
     {
-        private ChatOverlayV2 chatOverlay;
+        private TestChatOverlayV2 chatOverlay;
         private ChannelManager channelManager;
 
         private APIUser testUser;
@@ -61,7 +63,7 @@ namespace osu.Game.Tests.Visual.Online
                 Children = new Drawable[]
                 {
                     channelManager,
-                    chatOverlay = new ChatOverlayV2 { RelativeSizeAxes = Axes.Both },
+                    chatOverlay = new TestChatOverlayV2 { RelativeSizeAxes = Axes.Both },
                 },
             };
         });
@@ -386,6 +388,34 @@ namespace osu.Game.Tests.Visual.Online
             AddAssert("TextBox is not focused", () => InputManager.FocusedDrawable == null);
         }
 
+        [Test]
+        public void TestSlowLoadingChannel()
+        {
+            AddStep("Show overlay (slow-loading)", () =>
+            {
+                chatOverlay.Show();
+                chatOverlay.SlowLoading = true;
+            });
+            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            AddAssert("Channel 1 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Loading);
+
+            AddStep("Join channel 2", () => channelManager.JoinChannel(testChannel2));
+            AddStep("Select channel 2", () => clickDrawable(getChannelListItem(testChannel2)));
+            AddAssert("Channel 2 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel2).LoadState == LoadState.Loading);
+
+            AddStep("Finish channel 1 load", () => chatOverlay.GetSlowLoadingChannel(testChannel1).LoadEvent.Set());
+            AddAssert("Channel 1 ready", () => chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Ready);
+            AddAssert("Channel 1 not displayed", () => !channelIsVisible);
+
+            AddStep("Finish channel 2 load", () => chatOverlay.GetSlowLoadingChannel(testChannel2).LoadEvent.Set());
+            AddAssert("Channel 2 loaded", () => chatOverlay.GetSlowLoadingChannel(testChannel2).IsLoaded);
+            AddAssert("Channel 2 displayed", () => channelIsVisible && currentDrawableChannel.Channel == testChannel2);
+
+            AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
+            AddAssert("Channel 1 loaded", () => chatOverlay.GetSlowLoadingChannel(testChannel1).IsLoaded);
+            AddAssert("Channel 1 displayed", () => channelIsVisible && currentDrawableChannel.Channel == testChannel1);
+        }
+
         private bool listingIsVisible =>
             chatOverlay.ChildrenOfType<ChannelListing>().Single().State.Value == Visibility.Visible;
 
@@ -432,5 +462,35 @@ namespace osu.Game.Tests.Visual.Online
             Topic = $"We talk about the number {id} here",
             Type = ChannelType.Public,
         };
+
+        private class TestChatOverlayV2 : ChatOverlayV2
+        {
+            public bool SlowLoading { get; set; }
+
+            public SlowLoadingDrawableChannel GetSlowLoadingChannel(Channel channel) => DrawableChannels.OfType<SlowLoadingDrawableChannel>().Single(c => c.Channel == channel);
+
+            protected override ChatOverlayDrawableChannel CreateDrawableChannel(Channel newChannel)
+            {
+                return SlowLoading
+                    ? new SlowLoadingDrawableChannel(newChannel)
+                    : new ChatOverlayDrawableChannel(newChannel);
+            }
+        }
+
+        private class SlowLoadingDrawableChannel : ChatOverlayDrawableChannel
+        {
+            public readonly ManualResetEventSlim LoadEvent = new ManualResetEventSlim();
+
+            public SlowLoadingDrawableChannel([NotNull] Channel channel)
+                : base(channel)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                LoadEvent.Wait(10000);
+            }
+        }
     }
 }

--- a/osu.Game/Overlays/ChatOverlayV2.cs
+++ b/osu.Game/Overlays/ChatOverlayV2.cs
@@ -242,12 +242,12 @@ namespace osu.Game.Overlays
             {
                 // null channel denotes that we should be showing the listing.
                 currentChannelContainer.Clear(false);
-                channelListing.State.Value = Visibility.Visible;
+                channelListing.Show();
                 textBar.ShowSearch.Value = true;
             }
             else
             {
-                channelListing.State.Value = Visibility.Hidden;
+                channelListing.Hide();
                 textBar.ShowSearch.Value = false;
 
                 if (loadedChannels.ContainsKey(newChannel))
@@ -299,6 +299,7 @@ namespace osu.Game.Overlays
                     foreach (var channel in leftChannels)
                     {
                         channelList.RemoveChannel(channel);
+
                         if (loadedChannels.ContainsKey(channel))
                         {
                             ChatOverlayDrawableChannel loaded = loadedChannels[channel];

--- a/osu.Game/Overlays/ChatOverlayV2.cs
+++ b/osu.Game/Overlays/ChatOverlayV2.cs
@@ -41,6 +41,8 @@ namespace osu.Game.Overlays
 
         private readonly Dictionary<Channel, ChatOverlayDrawableChannel> loadedChannels = new Dictionary<Channel, ChatOverlayDrawableChannel>();
 
+        protected IEnumerable<DrawableChannel> DrawableChannels => loadedChannels.Values;
+
         private readonly BindableFloat chatHeight = new BindableFloat();
         private bool isDraggingTopBar;
         private float dragStartChatHeight;
@@ -260,7 +262,7 @@ namespace osu.Game.Overlays
                     loading.Show();
 
                     // Ensure the drawable channel is stored before async load to prevent double loading
-                    ChatOverlayDrawableChannel drawableChannel = new ChatOverlayDrawableChannel(newChannel);
+                    ChatOverlayDrawableChannel drawableChannel = CreateDrawableChannel(newChannel);
                     loadedChannels.Add(newChannel, drawableChannel);
 
                     LoadComponentAsync(drawableChannel, loadedDrawable =>
@@ -280,6 +282,8 @@ namespace osu.Game.Overlays
                 }
             }
         }
+
+        protected virtual ChatOverlayDrawableChannel CreateDrawableChannel(Channel newChannel) => new ChatOverlayDrawableChannel(newChannel);
 
         private void joinedChannelsChanged(object sender, NotifyCollectionChangedEventArgs args)
         {

--- a/osu.Game/Overlays/ChatOverlayV2.cs
+++ b/osu.Game/Overlays/ChatOverlayV2.cs
@@ -263,18 +263,18 @@ namespace osu.Game.Overlays
                     ChatOverlayDrawableChannel drawableChannel = new ChatOverlayDrawableChannel(newChannel);
                     loadedChannels.Add(newChannel, drawableChannel);
 
-                    LoadComponentAsync(drawableChannel, loaded =>
+                    LoadComponentAsync(drawableChannel, loadedDrawable =>
                     {
                         // Ensure the current channel hasn't changed by the time the load completes
-                        if (currentChannel.Value != newChannel)
+                        if (currentChannel.Value != loadedDrawable.Channel)
                             return;
 
                         // Ensure the cached reference hasn't been removed from leaving the channel
-                        if (!loadedChannels.ContainsKey(newChannel))
+                        if (!loadedChannels.ContainsKey(loadedDrawable.Channel))
                             return;
 
                         currentChannelContainer.Clear(false);
-                        currentChannelContainer.Add(loaded);
+                        currentChannelContainer.Add(loadedDrawable);
                         loading.Hide();
                     });
                 }

--- a/osu.Game/Overlays/ChatOverlayV2.cs
+++ b/osu.Game/Overlays/ChatOverlayV2.cs
@@ -264,6 +264,14 @@ namespace osu.Game.Overlays
 
                     LoadComponentAsync(drawableChannel, loaded =>
                     {
+                        // Ensure the current channel hasn't changed by the time the load completes
+                        if (currentChannel.Value != newChannel)
+                            return;
+
+                        // Ensure the cached reference hasn't been removed from leaving the channel
+                        if (!loadedChannels.ContainsKey(newChannel))
+                            return;
+
                         currentChannelContainer.Clear(false);
                         currentChannelContainer.Add(loaded);
                         loading.Hide();

--- a/osu.Game/Overlays/ChatOverlayV2.cs
+++ b/osu.Game/Overlays/ChatOverlayV2.cs
@@ -241,6 +241,7 @@ namespace osu.Game.Overlays
             if (newChannel == null)
             {
                 // null channel denotes that we should be showing the listing.
+                currentChannelContainer.Clear(false);
                 channelListing.State.Value = Visibility.Visible;
                 textBar.ShowSearch.Value = true;
             }
@@ -298,7 +299,13 @@ namespace osu.Game.Overlays
                     foreach (var channel in leftChannels)
                     {
                         channelList.RemoveChannel(channel);
-                        loadedChannels.Remove(channel);
+                        if (loadedChannels.ContainsKey(channel))
+                        {
+                            ChatOverlayDrawableChannel loaded = loadedChannels[channel];
+                            loadedChannels.Remove(channel);
+                            // DrawableChannel removed from cache must be manually disposed
+                            loaded.Dispose();
+                        }
                     }
 
                     break;


### PR DESCRIPTION
Part of https://github.com/ppy/osu/issues/17001

Re-adds caching behaviour present in old overlay