### PR TITLE
Add editor track traversal shortcut keys (`Z`-`V`)

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSeeking.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSeeking.cs
@@ -29,6 +29,51 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestSeekToFirst()
+        {
+            pressAndCheckTime(Key.Z, 2170);
+            pressAndCheckTime(Key.Z, 0);
+            pressAndCheckTime(Key.Z, 2170);
+
+            AddAssert("track not running", () => !EditorClock.IsRunning);
+        }
+
+        [Test]
+        public void TestRestart()
+        {
+            pressAndCheckTime(Key.V, 227170);
+
+            AddAssert("track not running", () => !EditorClock.IsRunning);
+
+            AddStep("press X", () => InputManager.Key(Key.X));
+
+            AddAssert("track running", () => EditorClock.IsRunning);
+            AddAssert("time restarted", () => EditorClock.CurrentTime < 100000);
+        }
+
+        [Test]
+        public void TestPauseResume()
+        {
+            AddAssert("track not running", () => !EditorClock.IsRunning);
+
+            AddStep("press C", () => InputManager.Key(Key.C));
+            AddAssert("track running", () => EditorClock.IsRunning);
+
+            AddStep("press C", () => InputManager.Key(Key.C));
+            AddAssert("track not running", () => !EditorClock.IsRunning);
+        }
+
+        [Test]
+        public void TestSeekToLast()
+        {
+            pressAndCheckTime(Key.V, 227170);
+            pressAndCheckTime(Key.V, 229170);
+            pressAndCheckTime(Key.V, 227170);
+
+            AddAssert("track not running", () => !EditorClock.IsRunning);
+        }
+
+        [Test]
         public void TestSnappedSeeking()
         {
             AddStep("seek to 0", () => EditorClock.Seek(0));

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -33,6 +33,7 @@ using osu.Game.Overlays.Notifications;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
@@ -474,6 +475,44 @@ namespace osu.Game.Screens.Edit
 
                 case Key.Right:
                     seek(e, 1);
+                    return true;
+
+                // Track traversal keys.
+                // Matching osu-stable implementations.
+                case Key.Z:
+                    // Seek to first object time, or track start if already there.
+                    double? firstObjectTime = editorBeatmap.HitObjects.FirstOrDefault()?.StartTime;
+
+                    if (firstObjectTime == null || clock.CurrentTime == firstObjectTime)
+                        clock.Seek(0);
+                    else
+                        clock.Seek(firstObjectTime.Value);
+                    return true;
+
+                case Key.X:
+                    // Restart playback from beginning of track.
+                    clock.Seek(0);
+                    clock.Start();
+                    return true;
+
+                case Key.C:
+                    // Pause or resume.
+                    if (clock.IsRunning)
+                        clock.Stop();
+                    else
+                        clock.Start();
+                    return true;
+
+                case Key.V:
+                    // Seek to last object time, or track end if already there.
+                    // Note that in osu-stable subsequent presses when at track end won't return to last object.
+                    // This has intentionally been changed to make it more useful.
+                    double? lastObjectTime = editorBeatmap.HitObjects.LastOrDefault()?.GetEndTime();
+
+                    if (lastObjectTime == null || clock.CurrentTime == lastObjectTime)
+                        clock.Seek(clock.TrackLength);
+                    else
+                        clock.Seek(lastObjectTime.Value);
                     return true;
             }
 


### PR DESCRIPTION
Functionality matches stable. Not adding customisation for now because it would be messy (they are duplicating existing keys for music control in some cases).