### PR TITLE
Fix Inconsistent playlist/multiplayer creation dropdowns

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -197,26 +197,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                                 },
                                                                 new Section("Queue mode")
                                                                 {
-                                                                    Child = new Container
+                                                                    Child = QueueModeDropdown = new OsuEnumDropdown<QueueMode>
                                                                     {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        Height = 40,
-                                                                        Child = QueueModeDropdown = new OsuEnumDropdown<QueueMode>
-                                                                        {
-                                                                            RelativeSizeAxes = Axes.X
-                                                                        }
+                                                                        RelativeSizeAxes = Axes.X
                                                                     }
                                                                 },
                                                                 new Section("Auto start")
                                                                 {
-                                                                    Child = new Container
+                                                                    Child = startModeDropdown = new OsuEnumDropdown<StartMode>
                                                                     {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        Height = 40,
-                                                                        Child = startModeDropdown = new OsuEnumDropdown<StartMode>
-                                                                        {
-                                                                            RelativeSizeAxes = Axes.X
-                                                                        }
+                                                                        RelativeSizeAxes = Axes.X
                                                                     }
                                                                 }
                                                             },


### PR DESCRIPTION
Closes #18162

This fixes the Queue Mode and Auto Start dropdowns not pushing the contents bellow

I've removed the container around the dropdown so it doesnt prevent the dropdowns from pushing the content bellow.

Also as mentioned in #18162 the Auto Start dropdown moves the Select Beatmap button off the screen as shown in the images provided here.

| Auto Start not selected | Auto Start selected |
| --- | --- |
| ![NotSelected](https://user-images.githubusercontent.com/90214642/168447339-c3c96078-1d12-4095-b781-4dfbbfce8ea9.PNG) | ![Selected](https://user-images.githubusercontent.com/90214642/168447343-c5a2bf81-b539-4cb9-a963-dac3f61a146e.PNG) |

Altough unless this is gonna be an issue then i've encountered no further problems.