### PR TITLE
Consider current culture while searching in settings

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 
@@ -39,7 +40,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateCornerRadius() => Content.CornerRadius = DrawHeight / 2;
 
-        public virtual IEnumerable<string> FilterTerms => new[] { Text.ToString() };
+        [Resolved]
+        private LocalisationManager localisation { get; set; }
+
+        public virtual IEnumerable<string> FilterTerms => new[] { localisation.GetLocalisedBindableString(Text).Value };
 
         public bool MatchingFilter
         {

--- a/osu.Game/Overlays/Settings/SettingsButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsButton.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
@@ -20,13 +21,15 @@ namespace osu.Game.Overlays.Settings
 
         public LocalisableString TooltipText { get; set; }
 
+        [Resolved]
+        private LocalisationManager localisation { get; set; }
+
         public override IEnumerable<string> FilterTerms
         {
             get
             {
                 if (TooltipText != default)
-                    // TODO: this won't work as intended once the tooltip text is translated.
-                    return base.FilterTerms.Append(TooltipText.ToString());
+                    return base.FilterTerms.Append(localisation.GetLocalisedBindableString(TooltipText).Value);
 
                 return base.FilterTerms;
             }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -98,13 +98,17 @@ namespace osu.Game.Overlays.Settings
             set => controlWithCurrent.Current = value;
         }
 
+        [Resolved]
+        private LocalisationManager localisation { get; set; }
+
         public virtual IEnumerable<string> FilterTerms
         {
             get
             {
                 var keywords = new List<string>(Keywords ?? Array.Empty<string>())
                 {
-                    LabelText.ToString()
+                    localisation.GetLocalisedBindableString(LabelText).Value,
+                    localisation.GetLocalisedBindableString(TooltipText).Value
                 };
 
                 if (HasClassicDefault)

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -32,7 +32,11 @@ namespace osu.Game.Overlays.Settings
         public abstract LocalisableString Header { get; }
 
         public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
-        public virtual IEnumerable<string> FilterTerms => new[] { Header.ToString() };
+
+        [Resolved]
+        private LocalisationManager localisation { get; set; }
+
+        public virtual IEnumerable<string> FilterTerms => new[] { localisation.GetLocalisedBindableString(Header).Value };
 
         public const int ITEM_SPACING = 14;
 

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -25,11 +25,12 @@ namespace osu.Game.Overlays.Settings
 
         public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
 
+        [Resolved]
+        private LocalisationManager localisation { get; set; }
+
         // FilterTerms should contains both original string and localised string for user to search.
-        // Since LocalisableString is unable to get original string at this time (2021-08-14),
-        // only call .ToString() to use localised one.
         // TODO: Update here when FilterTerms accept LocalisableString.
-        public virtual IEnumerable<string> FilterTerms => new[] { Header.ToString() };
+        public virtual IEnumerable<string> FilterTerms => new[] { localisation.GetLocalisedBindableString(Header).Value };
 
         public bool MatchingFilter
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/14802
- [x] Depends on https://github.com/ppy/osu-framework/pull/5174

Search in settings only searches in english terms because their FilterTerms use LocalisedString.ToString(), which passes the default value (english, which is then used by framework's SearchContainer to make matches). 

My solution is using LocalisationManager to pass the string in it's appropiate culture, however I'm not sure if creating a new LocalisationManager for each element that needs it is efficient, so any suggestions would be appreciated.