### PR TITLE
Adjust difficulty multiplier pop in/out transition on mod overlay

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -428,7 +428,6 @@ namespace osu.Game.Overlays.Mods
             base.PopIn();
 
             multiplierDisplay?
-                .Delay(fade_in_duration / 5)
                 .FadeIn(fade_in_duration, Easing.OutQuint)
                 .MoveToY(0, fade_in_duration, Easing.OutQuint);
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -428,9 +428,9 @@ namespace osu.Game.Overlays.Mods
             base.PopIn();
 
             multiplierDisplay?
-                .Delay(fade_in_duration * 0.65f)
-                .FadeIn(fade_in_duration / 2, Easing.OutQuint)
-                .ScaleTo(1, fade_in_duration, Easing.OutElastic);
+                .Delay(fade_in_duration / 5)
+                .FadeIn(fade_in_duration, Easing.OutQuint)
+                .MoveToY(0, fade_in_duration, Easing.OutQuint);
 
             int nonFilteredColumnCount = 0;
 
@@ -465,7 +465,7 @@ namespace osu.Game.Overlays.Mods
 
             multiplierDisplay?
                 .FadeOut(fade_out_duration / 2, Easing.OutQuint)
-                .ScaleTo(0.75f, fade_out_duration, Easing.OutQuint);
+                .MoveToY(-distance, fade_out_duration / 2, Easing.OutQuint);
 
             int nonFilteredColumnCount = 0;
 


### PR DESCRIPTION
The previous transition was supposed to be a center-anchored elastic scale-in, but this didn't work as intended - because the multiplier ended up inside of an auto-sized right-aligned container, the animation itself would end up being anchored right.

Attempts to remove the scale transition resulted in a rather jarring-looking result, so swap out the elastic scale-in for a sweep-in effect from the top, to match the header and avoid introducing too many directions of movement.

https://user-images.githubusercontent.com/20418176/168489095-1eb5f5b7-f32c-43dd-9481-21d2f6552f91.mp4

Delay and duration values tweaked "to taste" - can be adjusted further if there is an alternative set of values that feels better.