### PR TITLE
Add ruleset context to sentry error reports

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1207,6 +1207,8 @@ namespace osu.Game
                     Current = newScreen?.GetType().ReadableName(),
                     Previous = current?.GetType().ReadableName(),
                 };
+
+                scope.SetTag(@"screen", newScreen?.GetType().ReadableName() ?? @"none");
             });
 
             switch (newScreen)

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -127,6 +127,8 @@ namespace osu.Game.Utils
                                 BeatmapSets = realm.All<BeatmapSetInfo>().Count(),
                                 Beatmaps = realm.All<BeatmapInfo>().Count(),
                                 Files = realm.All<RealmFile>().Count(),
+                                Rulesets = realm.All<RulesetInfo>().Count(),
+                                RulesetsAvailable = realm.All<RulesetInfo>().Count(r => r.Available),
                                 Skins = realm.All<SkinInfo>().Count(),
                             }
                         };

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Utils
 
                     scope.Contexts[@"ruleset"] = new
                     {
+                        ruleset.ShortName,
                         ruleset.Name,
                         ruleset.InstantiationInfo,
                         ruleset.OnlineID
@@ -155,6 +156,8 @@ namespace osu.Game.Utils
                         Audio = game.Dependencies.Get<MusicController>().CurrentTrack.CurrentTime,
                         Game = game.Clock.CurrentTime,
                     };
+
+                    scope.SetTag(@"ruleset", ruleset.ShortName);
                 });
             }
             else

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -18,6 +18,7 @@ using osu.Game.Database;
 using osu.Game.Models;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
+using osu.Game.Rulesets;
 using osu.Game.Skinning;
 using Sentry;
 using Sentry.Protocol;
@@ -109,6 +110,7 @@ namespace osu.Game.Utils
                 }, scope =>
                 {
                     var beatmap = game.Dependencies.Get<IBindable<WorkingBeatmap>>().Value.BeatmapInfo;
+                    var ruleset = game.Dependencies.Get<IBindable<RulesetInfo>>().Value;
 
                     scope.Contexts[@"config"] = new
                     {
@@ -137,7 +139,15 @@ namespace osu.Game.Utils
                     scope.Contexts[@"beatmap"] = new
                     {
                         Name = beatmap.ToString(),
+                        Ruleset = beatmap.Ruleset.InstantiationInfo,
                         beatmap.OnlineID,
+                    };
+
+                    scope.Contexts[@"ruleset"] = new
+                    {
+                        ruleset.Name,
+                        ruleset.InstantiationInfo,
+                        ruleset.OnlineID
                     };
 
                     scope.Contexts[@"clocks"] = new


### PR DESCRIPTION
Also adds tags for ruleset's `ShortName` and current screen. Tags work differently from context in that they allow filtering and show the distribution on the right sidebar. These two seem quite helpful in quickly diagnosing an issue.

Example: https://sentry.ppy.sh/organizations/ppy/issues/1053/?project=2&query=is%3Aunresolved

![Safari 2022-05-16 at 07 05 19](https://user-images.githubusercontent.com/191335/168537481-1f834ef1-968e-4135-a372-d4c3f6711a24.png)

![Safari 2022-05-16 at 07 05 56](https://user-images.githubusercontent.com/191335/168537556-8b6b9f39-10d4-464f-9077-c939a80323f4.png)
