### PR TITLE
Add sentry tags for operating system and processor count

### DIFF
--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
@@ -160,6 +161,8 @@ namespace osu.Game.Utils
                     };
 
                     scope.SetTag(@"ruleset", ruleset.ShortName);
+                    scope.SetTag(@"os", $"{RuntimeInfo.OS} ({Environment.OSVersion})");
+                    scope.SetTag(@"processor count", Environment.ProcessorCount.ToString());
                 });
             }
             else


### PR DESCRIPTION
These would usually be in the log header, but right now that's not conveyed. An example use case would be better understanding https://sentry.ppy.sh/organizations/ppy/issues/846/, where we currently don't know whether it is a desktop or mobile OS.

Example: https://sentry.ppy.sh/organizations/ppy/issues/1172

![Safari 2022-05-17 at 03 52 44](https://user-images.githubusercontent.com/191335/168725467-c4838a24-0fdf-4b87-abd2-8254ec5a0a61.png)

