### PR TITLE
Revert realm to previous release to fix iOS crashes

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -56,6 +56,6 @@
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->
-    <PackageReference Include="Realm" Version="10.12.0" />
+    <PackageReference Include="Realm" Version="10.11.2" />
   </ItemGroup>
 </Project>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Realm" Version="10.12.0" />
+    <PackageReference Include="Realm" Version="10.11.2" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.511.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.513.0" />
     <PackageReference Include="Sentry" Version="3.17.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -89,6 +89,6 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2022.429.0" ExcludeAssets="all" />
-    <PackageReference Include="Realm" Version="10.12.0" />
+    <PackageReference Include="Realm" Version="10.11.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
See https://github.com/realm/realm-dotnet/issues/2929. As noticed in thousands crash logs on sentry (https://sentry.ppy.sh/organizations/ppy/issues/1175/?project=2&query=is%3Aunresolved), and the reason we pulled the latest testflight release.

I've tested that this revert does not break database compatibility, but recommend reviewer also double-checks this. Generally rolling back realm releases is not something we'd want to do, but this particular one was focused on only breaking the thing we're reverting for (https://github.com/realm/realm-dotnet/releases/tag/10.12.0).