### PR TITLE
Add first run screen for importing from previous installation

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
 
-        [Resolved(canBeNull: true)]
+        [Resolved(canBeNull: true)] // Can't really be null but required to handle potential of disposal before DI completes.
         private DrawableHitObject? drawableObject { get; set; }
 
         [Resolved]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenImportFromStable.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenImportFromStable.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Screens;
+using osu.Framework.Utils;
+using osu.Game.Database;
+using osu.Game.Overlays;
+using osu.Game.Overlays.FirstRunSetup;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneFirstRunScreenImportFromStable : OsuManualInputManagerTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        private readonly Mock<LegacyImportManager> legacyImportManager = new Mock<LegacyImportManager>();
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            legacyImportManager.Setup(m => m.GetImportCount(It.IsAny<StableContent>(), It.IsAny<CancellationToken>())).Returns(() => Task.FromResult(RNG.Next(0, 256)));
+
+            Dependencies.CacheAs(legacyImportManager.Object);
+        }
+
+        public TestSceneFirstRunScreenImportFromStable()
+        {
+            AddStep("load screen", () =>
+            {
+                Child = new PopoverContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new ScreenStack(new ScreenImportFromStable())
+                    }
+                };
+            });
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Database;
 using osu.Game.Online;
@@ -89,6 +91,8 @@ namespace osu.Game.Beatmaps.Drawables
 
         private void queueDownloads(string[] sourceFilenames, int? limit = null)
         {
+            Debug.Assert(LoadState == LoadState.NotLoaded);
+
             try
             {
                 // Matches osu-stable, in order to provide new users with roughly the same randomised selection of bundled beatmaps.

--- a/osu.Game/Collections/CollectionManager.cs
+++ b/osu.Game/Collections/CollectionManager.cs
@@ -111,6 +111,18 @@ namespace osu.Game.Collections
 
         public Action<Notification> PostNotification { protected get; set; }
 
+        public Task<int> GetAvailableCount(StableStorage stableStorage)
+        {
+            if (!stableStorage.Exists(database_name))
+                return Task.FromResult(0);
+
+            return Task.Run(() =>
+            {
+                using (var stream = stableStorage.GetStream(database_name))
+                    return readCollections(stream).Count;
+            });
+        }
+
         /// <summary>
         /// This is a temporary method and will likely be replaced by a full-fledged (and more correctly placed) migration process in the future.
         /// </summary>

--- a/osu.Game/Database/LegacyImportManager.cs
+++ b/osu.Game/Database/LegacyImportManager.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Database
 
         public bool SupportsImportFromStable => RuntimeInfo.IsDesktop;
 
+        public void UpdateStorage(string stablePath) => cachedStorage = new StableStorage(stablePath, desktopGameHost);
+
         public async Task<int> GetImportCount(StableContent content, CancellationToken cancellationToken)
         {
             var stableStorage = GetCurrentStableStorage();
@@ -91,7 +93,8 @@ namespace osu.Game.Database
                 Schedule(() => dialogOverlay.Push(new StableDirectoryLocationDialog(taskCompletionSource)));
                 string stablePath = await taskCompletionSource.Task.ConfigureAwait(false);
 
-                stableStorage = cachedStorage = new StableStorage(stablePath, desktopGameHost);
+                UpdateStorage(stablePath);
+                stableStorage = GetCurrentStableStorage();
             }
 
             var importTasks = new List<Task>();

--- a/osu.Game/Database/LegacyImportManager.cs
+++ b/osu.Game/Database/LegacyImportManager.cs
@@ -37,13 +37,13 @@ namespace osu.Game.Database
         [Resolved]
         private CollectionManager collections { get; set; }
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
 
         [Resolved]
         private IDialogOverlay dialogOverlay { get; set; }
 
-        [Resolved(CanBeNull = true)]
+        [Resolved(canBeNull: true)]
         private DesktopGameHost desktopGameHost { get; set; }
 
         private StableStorage cachedStorage;
@@ -52,7 +52,7 @@ namespace osu.Game.Database
 
         public void UpdateStorage(string stablePath) => cachedStorage = new StableStorage(stablePath, desktopGameHost);
 
-        public async Task<int> GetImportCount(StableContent content, CancellationToken cancellationToken)
+        public virtual async Task<int> GetImportCount(StableContent content, CancellationToken cancellationToken)
         {
             var stableStorage = GetCurrentStableStorage();
 
@@ -120,7 +120,7 @@ namespace osu.Game.Database
             if (cachedStorage != null)
                 return cachedStorage;
 
-            var stableStorage = game.GetStorageForStableInstall();
+            var stableStorage = game?.GetStorageForStableInstall();
             if (stableStorage != null)
                 return cachedStorage = stableStorage;
 

--- a/osu.Game/Database/LegacyImportManager.cs
+++ b/osu.Game/Database/LegacyImportManager.cs
@@ -49,6 +49,29 @@ namespace osu.Game.Database
 
         public bool SupportsImportFromStable => RuntimeInfo.IsDesktop;
 
+        public async Task<int> GetImportCount(StableContent content)
+        {
+            var stableStorage = await getStableStorage().ConfigureAwait(false);
+
+            switch (content)
+            {
+                case StableContent.Beatmaps:
+                    return await new LegacyBeatmapImporter(beatmaps).GetAvailableCount(stableStorage);
+
+                case StableContent.Skins:
+                    return await new LegacySkinImporter(skins).GetAvailableCount(stableStorage);
+
+                case StableContent.Collections:
+                    return await collections.GetAvailableCount(stableStorage);
+
+                case StableContent.Scores:
+                    return await new LegacyScoreImporter(scores).GetAvailableCount(stableStorage);
+
+                default:
+                    throw new ArgumentException($"Only one {nameof(StableContent)} flag should be specified.");
+            }
+        }
+
         public async Task ImportFromStableAsync(StableContent content)
         {
             var stableStorage = await getStableStorage().ConfigureAwait(false);

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Database
             Importer = importer;
         }
 
+        public Task<int> GetAvailableCount(StableStorage stableStorage) => Task.Run(() => GetStableImportPaths(stableStorage).Count());
+
         public Task ImportFromStableAsync(StableStorage stableStorage)
         {
             var storage = PrepareStableStorage(stableStorage);

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -24,8 +24,14 @@ namespace osu.Game.Database
         /// <summary>
         /// Select paths to import from stable where all paths should be absolute. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
-        protected virtual IEnumerable<string> GetStableImportPaths(Storage storage) => storage.GetDirectories(ImportFromStablePath)
-                                                                                              .Select(path => storage.GetFullPath(path));
+        protected virtual IEnumerable<string> GetStableImportPaths(Storage storage)
+        {
+            if (!storage.ExistsDirectory(ImportFromStablePath))
+                return Enumerable.Empty<string>();
+
+            return storage.GetDirectories(ImportFromStablePath)
+                          .Select(path => storage.GetFullPath(path));
+        }
 
         protected readonly IModelImporter<TModel> Importer;
 

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Database
             Importer = importer;
         }
 
-        public Task<int> GetAvailableCount(StableStorage stableStorage) => Task.Run(() => GetStableImportPaths(stableStorage).Count());
+        public Task<int> GetAvailableCount(StableStorage stableStorage) => Task.Run(() => GetStableImportPaths(PrepareStableStorage(stableStorage)).Count());
 
         public Task ImportFromStableAsync(StableStorage stableStorage)
         {

--- a/osu.Game/Database/LegacyScoreImporter.cs
+++ b/osu.Game/Database/LegacyScoreImporter.cs
@@ -15,8 +15,14 @@ namespace osu.Game.Database
         protected override string ImportFromStablePath => Path.Combine("Data", "r");
 
         protected override IEnumerable<string> GetStableImportPaths(Storage storage)
-            => storage.GetFiles(ImportFromStablePath).Where(p => Importer.HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
-                      .Select(path => storage.GetFullPath(path));
+        {
+            if (!storage.ExistsDirectory(ImportFromStablePath))
+                return Enumerable.Empty<string>();
+
+            return storage.GetFiles(ImportFromStablePath)
+                          .Where(p => Importer.HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
+                          .Select(path => storage.GetFullPath(path));
+        }
 
         public LegacyScoreImporter(IModelImporter<ScoreInfo> importer)
             : base(importer)

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Graphics.UserInterfaceV2
@@ -25,7 +26,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             set => Component.ReadOnly = value;
         }
 
-        public string PlaceholderText
+        public LocalisableString PlaceholderText
         {
             set => Component.PlaceholderText = value;
         }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -44,8 +45,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         internal class Background : CompositeDrawable
         {
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            [BackgroundDependencyLoader(true)]
+            private void load(OverlayColourProvider overlayColourProvider, OsuColour colours)
             {
                 RelativeSizeAxes = Axes.Both;
 
@@ -54,7 +55,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                 InternalChild = new Box
                 {
-                    Colour = colours.GreySeaFoamDarker,
+                    Colour = overlayColourProvider?.Background5 ?? colours.GreySeaFoamDarker,
                     RelativeSizeAxes = Axes.Both,
                 };
             }

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -69,6 +69,26 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString SelectAll => new TranslatableString(getKey(@"select_all"), @"Select All");
 
+        /// <summary>
+        /// "Beatmaps"
+        /// </summary>
+        public static LocalisableString Beatmaps => new TranslatableString(getKey(@"beatmaps"), @"Beatmaps");
+
+        /// <summary>
+        /// "Scores"
+        /// </summary>
+        public static LocalisableString Scores => new TranslatableString(getKey(@"scores"), @"Scores");
+
+        /// <summary>
+        /// "Skins"
+        /// </summary>
+        public static LocalisableString Skins => new TranslatableString(getKey(@"skins"), @"Skins");
+
+        /// <summary>
+        /// "Collections"
+        /// </summary>
+        public static LocalisableString Collections => new TranslatableString(getKey(@"collections"), @"Collections");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
+++ b/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class FirstRunOverlayImportFromStableScreenStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ScreenImportFromStable";
+
+        /// <summary>
+        /// "Import"
+        /// </summary>
+        public static LocalisableString Header => new TranslatableString(getKey(@"header"), @"Import");
+
+        /// <summary>
+        /// "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation."
+        /// </summary>
+        public static LocalisableString Description => new TranslatableString(getKey(@"description"),
+            @"If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation.");
+
+        /// <summary>
+        /// "previous osu! install"
+        /// </summary>
+        public static LocalisableString LocateDirectoryLabel => new TranslatableString(getKey(@"locate_directory_label"), @"previous osu! install");
+
+        /// <summary>
+        /// "Click to locate a previous osu! install"
+        /// </summary>
+        public static LocalisableString LocateDirectoryPlaceholder => new TranslatableString(getKey(@"locate_directory_placeholder"), @"Click to locate a previous osu! install");
+
+        /// <summary>
+        /// "Import content from previous version"
+        /// </summary>
+        public static LocalisableString ImportButton => new TranslatableString(getKey(@"import_button"), @"Import content from previous version");
+
+        /// <summary>
+        /// "Your import will continue in the background. Check on its progress in the notifications sidebar!"
+        /// </summary>
+        public static LocalisableString ImportInProgress =>
+            new TranslatableString(getKey(@"import_in_progress"), @"Your import will continue in the background. Check on its progress in the notifications sidebar!");
+
+        /// <summary>
+        /// "calculating..."
+        /// </summary>
+        public static LocalisableString Calculating => new TranslatableString(getKey(@"calculating"), @"calculating...");
+
+        /// <summary>
+        /// "{0} items"
+        /// </summary>
+        public static LocalisableString Items(int arg0) => new TranslatableString(getKey(@"items"), @"{0} item(s)", arg0);
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
+++ b/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
@@ -74,16 +74,6 @@ We recommend you give the new defaults a try, but if you'd like to have things f
         /// </summary>
         public static LocalisableString ClassicDefaults => new TranslatableString(getKey(@"classic_defaults"), @"Classic defaults");
 
-        /// <summary>
-        /// "Welcome"
-        /// </summary>
-        public static LocalisableString ImportTitle => new TranslatableString(getKey(@"import_title"), @"Import");
-
-        /// <summary>
-        /// "Import content from previous version"
-        /// </summary>
-        public static LocalisableString ImportContentFromPreviousVersion => new TranslatableString(getKey(@"import_content_from_previous_version"), @"Import content from previous version");
-
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
+++ b/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
@@ -74,6 +74,16 @@ We recommend you give the new defaults a try, but if you'd like to have things f
         /// </summary>
         public static LocalisableString ClassicDefaults => new TranslatableString(getKey(@"classic_defaults"), @"Classic defaults");
 
+        /// <summary>
+        /// "Welcome"
+        /// </summary>
+        public static LocalisableString ImportTitle => new TranslatableString(getKey(@"import_title"), @"Import");
+
+        /// <summary>
+        /// "Import content from stable"
+        /// </summary>
+        public static LocalisableString ImportContentFromStable => new TranslatableString(getKey(@"import_content_from_stable"), @"Import content from osu!(stable)");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
+++ b/osu.Game/Localisation/FirstRunSetupOverlayStrings.cs
@@ -80,9 +80,9 @@ We recommend you give the new defaults a try, but if you'd like to have things f
         public static LocalisableString ImportTitle => new TranslatableString(getKey(@"import_title"), @"Import");
 
         /// <summary>
-        /// "Import content from stable"
+        /// "Import content from previous version"
         /// </summary>
-        public static LocalisableString ImportContentFromStable => new TranslatableString(getKey(@"import_content_from_stable"), @"Import content from osu!(stable)");
+        public static LocalisableString ImportContentFromPreviousVersion => new TranslatableString(getKey(@"import_content_from_previous_version"), @"Import content from previous version");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
+++ b/osu.Game/Overlays/FirstRunSetup/FirstRunSetupScreen.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Overlays.FirstRunSetup
 
         protected const float CONTENT_FONT_SIZE = 16;
 
+        protected const float CONTENT_PADDING = 30;
+
         protected const float HEADER_FONT_SIZE = 24;
 
         [Resolved]
@@ -41,7 +43,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Padding = new MarginPadding { Horizontal = 30 },
+                        Padding = new MarginPadding { Horizontal = CONTENT_PADDING },
                         Children = new Drawable[]
                         {
                             new OsuSpriteText

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Overlays.FirstRunSetup
     public class ScreenBeatmaps : FirstRunSetupScreen
     {
         private ProgressRoundedButton downloadBundledButton = null!;
-        private ProgressRoundedButton importBeatmapsButton = null!;
         private ProgressRoundedButton downloadTutorialButton = null!;
 
         private OsuTextFlowContainer currentlyLoadedBeatmaps = null!;
@@ -41,8 +40,8 @@ namespace osu.Game.Overlays.FirstRunSetup
 
         private IDisposable? beatmapSubscription;
 
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(LegacyImportManager? legacyImportManager)
+        [BackgroundDependencyLoader]
+        private void load()
         {
             Vector2 buttonSize = new Vector2(400, 50);
 
@@ -102,35 +101,6 @@ namespace osu.Game.Overlays.FirstRunSetup
                     BackgroundColour = colours.Blue3,
                     Text = FirstRunSetupBeatmapScreenStrings.BundledButton,
                     Action = downloadBundled
-                },
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
-                {
-                    Colour = OverlayColourProvider.Content1,
-                    Text = "If you have an existing osu! install, you can also choose to import your existing beatmap collection.",
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y
-                },
-                importBeatmapsButton = new ProgressRoundedButton
-                {
-                    Size = buttonSize,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    BackgroundColour = colours.Blue3,
-                    Text = MaintenanceSettingsStrings.ImportBeatmapsFromStable,
-                    Action = () =>
-                    {
-                        importBeatmapsButton.Enabled.Value = false;
-                        legacyImportManager?.ImportFromStableAsync(StableContent.Beatmaps).ContinueWith(t => Schedule(() =>
-                        {
-                            if (t.IsCompletedSuccessfully)
-                                importBeatmapsButton.Complete();
-                            else
-                            {
-                                importBeatmapsButton.Enabled.Value = true;
-                                importBeatmapsButton.Abort();
-                            }
-                        }));
-                    }
                 },
                 new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Settings;
+using osuTK;
+
+namespace osu.Game.Overlays.FirstRunSetup
+{
+    [LocalisableDescription(typeof(FirstRunSetupOverlayStrings), nameof(FirstRunSetupOverlayStrings.ImportTitle))]
+    public class ScreenImportFromStable : FirstRunSetupScreen
+    {
+        private ProgressRoundedButton importButton = null!;
+
+        private SettingsCheckbox checkboxSkins = null!;
+        private SettingsCheckbox checkboxBeatmaps = null!;
+        private SettingsCheckbox checkboxScores = null!;
+        private SettingsCheckbox checkboxCollections = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private LegacyImportManager? legacyImportManager { get; set; }
+
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load()
+        {
+            Vector2 buttonSize = new Vector2(400, 50);
+
+            Content.Children = new Drawable[]
+            {
+                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
+                {
+                    Colour = OverlayColourProvider.Content1,
+                    Text =
+                        "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation.",
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y
+                },
+                checkboxBeatmaps = new SettingsCheckbox
+                {
+                    LabelText = "Beatmaps",
+                    Current = { Value = true }
+                },
+                checkboxScores = new SettingsCheckbox
+                {
+                    LabelText = "Scores",
+                    Current = { Value = true }
+                },
+                checkboxSkins = new SettingsCheckbox
+                {
+                    LabelText = "Skins",
+                    Current = { Value = true }
+                },
+                checkboxCollections = new SettingsCheckbox
+                {
+                    LabelText = "Collections",
+                    Current = { Value = true }
+                },
+                importButton = new ProgressRoundedButton
+                {
+                    Size = buttonSize,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    BackgroundColour = colours.Blue3,
+                    Text = FirstRunSetupOverlayStrings.ImportContentFromStable,
+                    Action = runImport
+                },
+            };
+        }
+
+        private void runImport()
+        {
+            importButton.Enabled.Value = false;
+
+            StableContent importableContent = 0;
+
+            if (checkboxBeatmaps.Current.Value) importableContent |= StableContent.Beatmaps;
+            if (checkboxScores.Current.Value) importableContent |= StableContent.Scores;
+            if (checkboxSkins.Current.Value) importableContent |= StableContent.Skins;
+            if (checkboxCollections.Current.Value) importableContent |= StableContent.Collections;
+
+            legacyImportManager?.ImportFromStableAsync(importableContent)
+                               .ContinueWith(t => Schedule(() =>
+                               {
+                                   if (t.IsCompletedSuccessfully)
+                                       importButton.Complete();
+                                   else
+                                   {
+                                       importButton.Enabled.Value = true;
+                                       importButton.Abort();
+                                   }
+                               }));
+        }
+    }
+}

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -10,6 +12,7 @@ using osu.Framework.Localisation;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osuTK;
@@ -26,11 +29,15 @@ namespace osu.Game.Overlays.FirstRunSetup
         private SettingsCheckbox checkboxScores = null!;
         private SettingsCheckbox checkboxCollections = null!;
 
+        private OsuTextFlowContainer currentStablePath = null!;
+
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
         [Resolved]
         private LegacyImportManager legacyImportManager { get; set; } = null!;
+
+        private CancellationTokenSource? stablePathUpdateCancellation;
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load()
@@ -46,6 +53,21 @@ namespace osu.Game.Overlays.FirstRunSetup
                         "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation.",
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y
+                },
+                currentStablePath = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: HEADER_FONT_SIZE, weight: FontWeight.SemiBold))
+                {
+                    Colour = OverlayColourProvider.Content2,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                },
+                new RoundedButton
+                {
+                    Size = buttonSize,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    BackgroundColour = colours.Blue3,
+                    Text = "Locate osu!(stable) install",
+                    Action = locateStable,
                 },
                 checkboxBeatmaps = new SettingsCheckbox
                 {
@@ -78,10 +100,65 @@ namespace osu.Game.Overlays.FirstRunSetup
                 },
             };
 
-            legacyImportManager.GetImportCount(StableContent.Beatmaps).ContinueWith(task => Schedule(() => checkboxBeatmaps.LabelText += $" ({task.GetResultSafely()} items)"));
-            legacyImportManager.GetImportCount(StableContent.Scores).ContinueWith(task => Schedule(() => checkboxScores.LabelText += $" ({task.GetResultSafely()} items)"));
-            legacyImportManager.GetImportCount(StableContent.Skins).ContinueWith(task => Schedule(() => checkboxSkins.LabelText += $" ({task.GetResultSafely()} items)"));
-            legacyImportManager.GetImportCount(StableContent.Collections).ContinueWith(task => Schedule(() => checkboxCollections.LabelText += $" ({task.GetResultSafely()} items)"));
+            updateStablePath();
+        }
+
+        private void locateStable()
+        {
+            legacyImportManager.ImportFromStableAsync(0).ContinueWith(task =>
+            {
+                Schedule(updateStablePath);
+            });
+        }
+
+        private void updateStablePath()
+        {
+            stablePathUpdateCancellation?.Cancel();
+
+            var storage = legacyImportManager.GetCurrentStableStorage();
+
+            if (storage == null)
+            {
+                foreach (var c in Content.Children.OfType<SettingsCheckbox>())
+                    c.Current.Disabled = true;
+                currentStablePath.Text = "No installation found";
+                return;
+            }
+
+            foreach (var c in Content.Children.OfType<SettingsCheckbox>())
+                c.Current.Disabled = false;
+
+            currentStablePath.Text = storage.GetFullPath(string.Empty);
+            stablePathUpdateCancellation = new CancellationTokenSource();
+
+            legacyImportManager.GetImportCount(StableContent.Beatmaps, stablePathUpdateCancellation.Token).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsCanceled)
+                    return;
+
+                checkboxBeatmaps.LabelText = $"Beatmaps ({task.GetResultSafely()} items)";
+            }));
+            legacyImportManager.GetImportCount(StableContent.Scores, stablePathUpdateCancellation.Token).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsCanceled)
+                    return;
+
+                checkboxScores.LabelText = $"Scores ({task.GetResultSafely()} items)";
+            }));
+            legacyImportManager.GetImportCount(StableContent.Skins, stablePathUpdateCancellation.Token).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsCanceled)
+                    return;
+
+                checkboxSkins.LabelText = $"Skins ({task.GetResultSafely()} items)";
+            }));
+            legacyImportManager.GetImportCount(StableContent.Collections, stablePathUpdateCancellation.Token).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsCanceled)
+                    return;
+
+                checkboxCollections.LabelText = $"Collections ({task.GetResultSafely()} items)";
+            }));
         }
 
         private void runImport()
@@ -95,7 +172,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             if (checkboxSkins.Current.Value) importableContent |= StableContent.Skins;
             if (checkboxCollections.Current.Value) importableContent |= StableContent.Collections;
 
-            legacyImportManager.ImportFromStableAsync(importableContent)
+            legacyImportManager.ImportFromStableAsync(importableContent, false)
                                .ContinueWith(t => Schedule(() =>
                                {
                                    if (t.IsCompletedSuccessfully)

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -211,14 +211,14 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             private void onDirectorySelected(ValueChangedEvent<DirectoryInfo> directory)
             {
-                if (directory.NewValue == null || directory.OldValue == null)
+                if (directory.NewValue == null)
                 {
                     Current.Value = string.Empty;
                     return;
                 }
 
                 // DirectorySelectors can trigger a noop value changed, but `DirectoryInfo` equality doesn't catch this.
-                if (directory.OldValue.FullName == directory.NewValue.FullName)
+                if (directory.OldValue?.FullName == directory.NewValue.FullName)
                     return;
 
                 if (directory.NewValue?.GetFiles(@"osu!.*.cfg").Any() ?? false)

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -27,7 +27,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.FirstRunSetup
 {
-    [LocalisableDescription(typeof(FirstRunSetupOverlayStrings), nameof(FirstRunSetupOverlayStrings.ImportTitle))]
+    [LocalisableDescription(typeof(FirstRunOverlayImportFromStableScreenStrings), nameof(FirstRunOverlayImportFromStableScreenStrings.Header))]
     public class ScreenImportFromStable : FirstRunSetupScreen
     {
         private static readonly Vector2 button_size = new Vector2(400, 50);
@@ -51,15 +51,14 @@ namespace osu.Game.Overlays.FirstRunSetup
                 new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
-                    Text =
-                        "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation.",
+                    Text = FirstRunOverlayImportFromStableScreenStrings.Description,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y
                 },
                 stableLocatorTextBox = new StableLocatorLabelledTextBox
                 {
-                    Label = "previous osu! install",
-                    PlaceholderText = "Click to locate a previous osu! install"
+                    Label = FirstRunOverlayImportFromStableScreenStrings.LocateDirectoryLabel,
+                    PlaceholderText = FirstRunOverlayImportFromStableScreenStrings.LocateDirectoryPlaceholder
                 },
                 new ImportCheckbox("Beatmaps", StableContent.Beatmaps),
                 new ImportCheckbox("Scores", StableContent.Scores),
@@ -70,14 +69,13 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Size = button_size,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Text = FirstRunSetupOverlayStrings.ImportContentFromPreviousVersion,
+                    Text = FirstRunOverlayImportFromStableScreenStrings.ImportButton,
                     Action = runImport
                 },
                 progressText = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
-                    Text =
-                        "Your import will continue in the background. Check on its progress in the notifications sidebar!",
+                    Text = FirstRunOverlayImportFromStableScreenStrings.ImportInProgress,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Alpha = 0,
@@ -168,7 +166,7 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             public void UpdateCount()
             {
-                LabelText = LocalisableString.Interpolate($"{title} (calculating...)");
+                LabelText = LocalisableString.Interpolate($"{title} ({FirstRunOverlayImportFromStableScreenStrings.Calculating})");
 
                 countUpdateCancellation?.Cancel();
                 countUpdateCancellation = new CancellationTokenSource();
@@ -178,7 +176,9 @@ namespace osu.Game.Overlays.FirstRunSetup
                     if (task.IsCanceled)
                         return;
 
-                    LabelText = LocalisableString.Interpolate($"{title} ({task.GetResultSafely()} items)");
+                    int count = task.GetResultSafely();
+
+                    LabelText = LocalisableString.Interpolate($"{title} ({FirstRunOverlayImportFromStableScreenStrings.Items(count)})");
                 }));
             }
         }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Database;
@@ -28,8 +29,8 @@ namespace osu.Game.Overlays.FirstRunSetup
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        [Resolved(canBeNull: true)]
-        private LegacyImportManager? legacyImportManager { get; set; }
+        [Resolved]
+        private LegacyImportManager legacyImportManager { get; set; } = null!;
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load()
@@ -76,6 +77,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Action = runImport
                 },
             };
+
+            legacyImportManager.GetImportCount(StableContent.Beatmaps).ContinueWith(task => Schedule(() => checkboxBeatmaps.LabelText += $" ({task.GetResultSafely()} items)"));
+            legacyImportManager.GetImportCount(StableContent.Scores).ContinueWith(task => Schedule(() => checkboxScores.LabelText += $" ({task.GetResultSafely()} items)"));
+            legacyImportManager.GetImportCount(StableContent.Skins).ContinueWith(task => Schedule(() => checkboxSkins.LabelText += $" ({task.GetResultSafely()} items)"));
+            legacyImportManager.GetImportCount(StableContent.Collections).ContinueWith(task => Schedule(() => checkboxCollections.LabelText += $" ({task.GetResultSafely()} items)"));
         }
 
         private void runImport()
@@ -89,7 +95,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             if (checkboxSkins.Current.Value) importableContent |= StableContent.Skins;
             if (checkboxCollections.Current.Value) importableContent |= StableContent.Collections;
 
-            legacyImportManager?.ImportFromStableAsync(importableContent)
+            legacyImportManager.ImportFromStableAsync(importableContent)
                                .ContinueWith(t => Schedule(() =>
                                {
                                    if (t.IsCompletedSuccessfully)

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             if (storage == null)
             {
-                allowInteraction(false);
+                toggleInteraction(false);
 
                 stableLocatorTextBox.Current.Disabled = false;
                 stableLocatorTextBox.Current.Value = string.Empty;
@@ -104,14 +104,14 @@ namespace osu.Game.Overlays.FirstRunSetup
                 c.UpdateCount();
             }
 
-            allowInteraction(true);
+            toggleInteraction(true);
             stableLocatorTextBox.Current.Value = storage.GetFullPath(string.Empty);
             importButton.Enabled.Value = true;
         }
 
         private void runImport()
         {
-            allowInteraction(false);
+            toggleInteraction(false);
             progressText.FadeIn(1000, Easing.OutQuint);
 
             StableContent importableContent = 0;
@@ -127,13 +127,13 @@ namespace osu.Game.Overlays.FirstRunSetup
                     importButton.Complete();
                 else
                 {
-                    allowInteraction(true);
+                    toggleInteraction(true);
                     importButton.Abort();
                 }
             }));
         }
 
-        private void allowInteraction(bool allow)
+        private void toggleInteraction(bool allow)
         {
             importButton.Enabled.Value = allow;
             stableLocatorTextBox.Current.Disabled = !allow;

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -188,7 +188,6 @@ namespace osu.Game.Overlays.FirstRunSetup
             [Resolved]
             private LegacyImportManager legacyImportManager { get; set; } = null!;
 
-            // TODO: test
             public IEnumerable<string> HandledExtensions { get; } = new[] { string.Empty };
 
             private readonly Bindable<DirectoryInfo> currentDirectory = new Bindable<DirectoryInfo>();

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -192,14 +192,14 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             private readonly Bindable<DirectoryInfo> currentDirectory = new Bindable<DirectoryInfo>();
 
-            [Resolved]
-            private OsuGameBase game { get; set; } = null!;
+            [Resolved(canBeNull: true)] // Can't really be null but required to handle potential of disposal before DI completes.
+            private OsuGameBase? game { get; set; }
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
 
-                game.RegisterImportHandler(this);
+                game?.RegisterImportHandler(this);
 
                 currentDirectory.BindValueChanged(onDirectorySelected);
 
@@ -242,7 +242,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             protected override void Dispose(bool isDisposing)
             {
                 base.Dispose(isDisposing);
-                game.UnregisterImportHandler(this);
+                game?.UnregisterImportHandler(this);
             }
 
             public override Popover GetPopover() => new DirectoryChooserPopover(currentDirectory);

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Overlays.FirstRunSetup
     [LocalisableDescription(typeof(FirstRunSetupOverlayStrings), nameof(FirstRunSetupOverlayStrings.ImportTitle))]
     public class ScreenImportFromStable : FirstRunSetupScreen
     {
+        private static readonly Vector2 button_size = new Vector2(400, 50);
+
         private ProgressRoundedButton importButton = null!;
         private RoundedButton locateStableButton = null!;
 
@@ -46,8 +48,6 @@ namespace osu.Game.Overlays.FirstRunSetup
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load()
         {
-            Vector2 buttonSize = new Vector2(400, 50);
-
             Content.Children = new Drawable[]
             {
                 new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
@@ -63,14 +63,14 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Colour = OverlayColourProvider.Content2,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
+                    TextAnchor = Anchor.Centre,
                 },
                 locateStableButton = new RoundedButton
                 {
-                    Size = buttonSize,
+                    Size = button_size,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    BackgroundColour = colours.Blue3,
-                    Text = "Locate osu!(stable) install",
+                    Text = "Change location",
                     Action = locateStable,
                 },
                 new ImportCheckbox("Beatmaps", StableContent.Beatmaps),
@@ -79,10 +79,9 @@ namespace osu.Game.Overlays.FirstRunSetup
                 new ImportCheckbox("Collections", StableContent.Collections),
                 importButton = new ProgressRoundedButton
                 {
-                    Size = buttonSize,
+                    Size = button_size,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    BackgroundColour = colours.Blue3,
                     Text = FirstRunSetupOverlayStrings.ImportContentFromStable,
                     Action = runImport
                 },
@@ -112,7 +111,10 @@ namespace osu.Game.Overlays.FirstRunSetup
             {
                 foreach (var c in contentCheckboxes)
                     c.Current.Disabled = true;
+                currentStablePath.FadeColour(colours.Red1, 500, Easing.OutQuint);
                 currentStablePath.Text = "No installation found";
+
+                importButton.Enabled.Value = false;
                 return;
             }
 
@@ -122,8 +124,10 @@ namespace osu.Game.Overlays.FirstRunSetup
                 c.UpdateCount();
             }
 
-            currentStablePath.Text = storage.GetFullPath(string.Empty);
+            currentStablePath.FadeColour(OverlayColourProvider.Content2);
+            currentStablePath.Text = $"Found installation: {storage.GetFullPath(string.Empty)}";
             stablePathUpdateCancellation = new CancellationTokenSource();
+            importButton.Enabled.Value = true;
         }
 
         private void runImport()
@@ -138,13 +142,12 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             legacyImportManager.ImportFromStableAsync(importableContent, false).ContinueWith(t => Schedule(() =>
             {
-                locateStableButton.Enabled.Value = true;
-
                 if (t.IsCompletedSuccessfully)
                     importButton.Complete();
                 else
                 {
                     importButton.Enabled.Value = true;
+                    locateStableButton.Enabled.Value = true;
                     importButton.Abort();
                 }
             }));
@@ -253,9 +256,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                                             {
                                                 Anchor = Anchor.CentreLeft,
                                                 Origin = Anchor.CentreLeft,
-                                                Width = 300,
+                                                RelativeSizeAxes = Axes.X,
+                                                Width = 0.45f,
+                                                Height = button_size.Y,
                                                 Margin = new MarginPadding(10),
-                                                Colour = colours.Pink2,
+                                                BackgroundColour = colours.Pink2,
                                                 Text = CommonStrings.ButtonsCancel,
                                                 Action = this.Exit
                                             },
@@ -263,7 +268,9 @@ namespace osu.Game.Overlays.FirstRunSetup
                                             {
                                                 Anchor = Anchor.CentreRight,
                                                 Origin = Anchor.CentreRight,
-                                                Width = 300,
+                                                RelativeSizeAxes = Axes.X,
+                                                Width = 0.45f,
+                                                Height = button_size.Y,
                                                 Margin = new MarginPadding(10),
                                                 Text = MaintenanceSettingsStrings.SelectDirectory,
                                                 Action = () =>

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -146,6 +146,7 @@ namespace osu.Game.Overlays.FirstRunSetup
 
                 StableContent = stableContent;
 
+                Current.Default = true;
                 Current.Value = true;
 
                 LabelText = title;

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -60,10 +60,10 @@ namespace osu.Game.Overlays.FirstRunSetup
                     Label = FirstRunOverlayImportFromStableScreenStrings.LocateDirectoryLabel,
                     PlaceholderText = FirstRunOverlayImportFromStableScreenStrings.LocateDirectoryPlaceholder
                 },
-                new ImportCheckbox("Beatmaps", StableContent.Beatmaps),
-                new ImportCheckbox("Scores", StableContent.Scores),
-                new ImportCheckbox("Skins", StableContent.Skins),
-                new ImportCheckbox("Collections", StableContent.Collections),
+                new ImportCheckbox(CommonStrings.Beatmaps, StableContent.Beatmaps),
+                new ImportCheckbox(CommonStrings.Scores, StableContent.Scores),
+                new ImportCheckbox(CommonStrings.Skins, StableContent.Skins),
+                new ImportCheckbox(CommonStrings.Collections, StableContent.Collections),
                 importButton = new ProgressRoundedButton
                 {
                     Size = button_size,

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -11,6 +11,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
@@ -88,7 +89,7 @@ namespace osu.Game.Overlays
 
             MainAreaContent.AddRange(new Drawable[]
             {
-                content = new Container
+                content = new PopoverContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             private void updateBankPlaceholderText(IEnumerable<HitObject> objects)
             {
                 string? commonBank = getCommonBank(objects.Select(h => h.SampleControlPoint).ToArray());
-                bank.PlaceholderText = string.IsNullOrEmpty(commonBank) ? "(multiple)" : null;
+                bank.PlaceholderText = string.IsNullOrEmpty(commonBank) ? "(multiple)" : string.Empty;
             }
 
             private void updateVolumeFor(IEnumerable<HitObject> objects, int? newVolume)

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -11,11 +11,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
 using osu.Game.Database;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
 
@@ -24,7 +21,7 @@ namespace osu.Game.Screens.Edit.Setup
     /// <summary>
     /// A labelled textbox which reveals an inline file chooser when clicked.
     /// </summary>
-    internal class FileChooserLabelledTextBox : LabelledTextBox, ICanAcceptFiles, IHasPopover
+    internal class FileChooserLabelledTextBox : LabelledTextBoxWithPopover, ICanAcceptFiles
     {
         private readonly string[] handledExtensions;
 
@@ -39,16 +36,6 @@ namespace osu.Game.Screens.Edit.Setup
         {
             this.handledExtensions = handledExtensions;
         }
-
-        protected override OsuTextBox CreateTextBox() =>
-            new FileChooserOsuTextBox
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.X,
-                CornerRadius = CORNER_RADIUS,
-                OnFocused = this.ShowPopover
-            };
 
         protected override void LoadComplete()
         {
@@ -81,27 +68,7 @@ namespace osu.Game.Screens.Edit.Setup
             game.UnregisterImportHandler(this);
         }
 
-        internal class FileChooserOsuTextBox : OsuTextBox
-        {
-            public Action OnFocused;
-
-            protected override bool OnDragStart(DragStartEvent e)
-            {
-                // This text box is intended to be "read only" without actually specifying that.
-                // As such we don't want to allow the user to select its content with a drag.
-                return false;
-            }
-
-            protected override void OnFocus(FocusEvent e)
-            {
-                OnFocused?.Invoke();
-                base.OnFocus(e);
-
-                GetContainingInputManager().TriggerFocusContention(this);
-            }
-        }
-
-        public Popover GetPopover() => new FileChooserPopover(handledExtensions, currentFile);
+        public override Popover GetPopover() => new FileChooserPopover(handledExtensions, currentFile);
 
         private class FileChooserPopover : OsuPopover
         {

--- a/osu.Game/Screens/Edit/Setup/LabelledTextBoxWithPopover.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledTextBoxWithPopover.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    internal abstract class LabelledTextBoxWithPopover : LabelledTextBox, IHasPopover
+    {
+        public abstract Popover GetPopover();
+
+        protected override OsuTextBox CreateTextBox() =>
+            new PopoverTextBox
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.X,
+                CornerRadius = CORNER_RADIUS,
+                OnFocused = this.ShowPopover
+            };
+
+        internal class PopoverTextBox : OsuTextBox
+        {
+            public Action OnFocused;
+
+            protected override bool OnDragStart(DragStartEvent e)
+            {
+                // This text box is intended to be "read only" without actually specifying that.
+                // As such we don't want to allow the user to select its content with a drag.
+                return false;
+            }
+
+            protected override void OnFocus(FocusEvent e)
+            {
+                OnFocused?.Invoke();
+                base.OnFocus(e);
+
+                GetContainingInputManager().TriggerFocusContention(this);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/LabelledTextBoxWithPopover.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledTextBoxWithPopover.cs
@@ -39,6 +39,9 @@ namespace osu.Game.Screens.Edit.Setup
 
             protected override void OnFocus(FocusEvent e)
             {
+                if (Current.Disabled)
+                    return;
+
                 OnFocused?.Invoke();
                 base.OnFocus(e);
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/18311

One thing to note is that with this change, there are now multiple different methods of importing from stable. If entering song select with no beatmaps, it will show a popup dialog which triggers the older process. There's also buttons in the maintenance settings which do this. I'd like to remove that flow, but I'm still figuring out the correct UX to make this happen.

The difficulty comes from the fact that the first run overlay cannot be displayed on a specific screen currently. Originally I was thinking it should be a `ScreenCarousel` rather than stack, but we don't have that implemented properly so I can't test how well that will work. A more temporary solution may be to "jump" to the correct screen, although this would still require the user to click through the remaining steps after finishing their import task (maybe fine?).

Also I think with this change, we should consider moving the UI scale screen to the beginning of the first run overlay. Rationale is that if the UI is displaying too small or large, going through more complex steps before getting to the part where you can change it is anti-user. We've discussed this in the past so I don't think there will be contention with making this change.

---

This builds on the the existing "import beatmaps" button - which did a kind-of-okay job at importing beatmaps - into a fully fledged screen which allows locating a previous osu! installation and also importing things which aren't beatmaps.

https://user-images.githubusercontent.com/191335/168773274-8df5a461-9216-4640-b3b3-0c85b32f6ff3.mp4
