### PR TITLE
Package .json files in nupkg output

### DIFF
--- a/osu.Desktop/osu.nuspec
+++ b/osu.Desktop/osu.nuspec
@@ -18,5 +18,6 @@
       <file src="**.exe" target="lib\net45\" exclude="**vshost**"/>
       <file src="**.dll" target="lib\net45\"/>
       <file src="**.config" target="lib\net45\"/>
+      <file src="**.json" target="lib\net45\"/>
     </files>
 </package>


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/issues/18318#issuecomment-1129481956

It isn't really required for us, but might as well have it I suppose?

This `.nuspec` file is kinda dodgy and only seems to work because osu-deploy is using `nuget.exe` as opposed to `dotnet pack`, so I'm following existing examples without changing the things that look glaringly wrong.

Note: I can't get `dotnet pack` to work favourably at all, so not investigating that for now.

Testing with:
```sh
cd osu.Desktop
rm -r out
dotnet publish -c:Release -r:win-x64 -o out
nuget pack osu.nuspec -BasePath out
```