### PR TITLE
Adjust HP drain and recoveries to closer match osu-stable

### DIFF
--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Judgements
                     return -DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.Meh:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.05;
 
                 case HitResult.Ok:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.5;

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Judgements
                     return -DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.Miss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 2;
 
                 case HitResult.Meh:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.05;

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -27,17 +27,17 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The minimum health target at an HP drain rate of 0.
         /// </summary>
-        private const double min_health_target = 0.95;
+        private const double min_health_target = 0.99;
 
         /// <summary>
         /// The minimum health target at an HP drain rate of 5.
         /// </summary>
-        private const double mid_health_target = 0.70;
+        private const double mid_health_target = 0.9;
 
         /// <summary>
         /// The minimum health target at an HP drain rate of 10.
         /// </summary>
-        private const double max_health_target = 0.30;
+        private const double max_health_target = 0.4;
 
         private IBeatmap beatmap;
 


### PR DESCRIPTION
- Supersedes / closes https://github.com/ppy/osu/pull/15029
- Aims to resolve https://github.com/ppy/osu/issues/7975

I've gone through the osu-stable implementation once again and found a few areas of improvement.

My testing was mostly done on https://osu.ppy.sh/beatmapsets/268431#osu/611157. I don't have comparisons because they're kinda hard to make and there's still differences (see my conclusions).

## Minimum health targets were incorrect

The original values weren't taken from stable, but rather "what feels ok". As it turns out, all of osu+catch+mania use the same HP targets, albeit mania doesn't have HP drain.  

Of particular importance, stable has 3 target values:
```
lowest-hp-ever: [ 97.5% 80% 30% ]
lowest-hp-combo-end: [ 99% 85% 40%]
lowest-hp-end: [ 99% 90% 40% ]
```
These values are checked at different points in the calculation to make sure the HP doesn't fall below it. Since lazer doesn't have geki/katsu, the second row wasn't considered, and I've decided to go with the `hp-end` values from above purely because they feel a little bit better in actual gameplay.

## Adjusted HP increases to line up better

From the very start of implementation of HP drain, lazer's `Meh` judgements decreased HP. I can't find any reason for this, so I take it as my misunderstanding at the time that 50s decrease HP in stable, but this is not the case.

Additionally, misses are also quite harsh on stable and quite lenient on lazer. I've tried to make misses a little bit more harsh while hopefully not impacting lower-HP values too much.

The following is a table of stable vs lazer HP increases as percentages of total HP for each hit result. A linear interpolation of the HP difficulty value is indicated in cells containing multiple values within brackets.

| result  | stable | stable (HP7) | lazer (master) | lazer (new) |
| --- | --- | --- | --- | --- |
| great | 3% | 3% | 5% | 5% |
| ok | [ 8.8% 1.1% 1.1% ] | 1.1% | 2.5% | 2.5% |
| meh | [ 1.6% 0.2% 0.2% ] | 0.2% | -0.25% | 0.25% ⬆ |
| miss | [ -3% -12.5% -20% ] | -15.5% | -5% | -10% ⬇ |
| l_tick_hit | 1.5%\* | 1.5%\* | 5% | 5% |
| l_tick_miss | [ -2% -7.5% -14% ] | -10.1% | -5% | -5% |

\* repeats give 2% HP but lazer doesn't differentiate

Note: The above are the base values pre-hp-multiplier (determined as part of osu-stable's HP drain algorithm). I don't think this multiplier makes much of a difference in practice.

## Conclusion

It's still not perfect and definitely doesn't match osu-stable, but feels better at higher HP values. I'm still interested in trying to keep it simple before resorting to outright porting osu-stable's implementation across; interpolation, multipliers, and all.