### PR TITLE
Fix `WaveformTestBeatmap`s potentially providing disposed track

### DIFF
--- a/osu.Game.Tests/WaveformTestBeatmap.cs
+++ b/osu.Game.Tests/WaveformTestBeatmap.cs
@@ -59,6 +59,13 @@ namespace osu.Game.Tests
 
         protected override Track GetBeatmapTrack() => trackStore.Get(firstAudioFile);
 
+        public override bool TryTransferTrack(WorkingBeatmap target)
+        {
+            // Our track comes from a local track store that's disposed on finalizer,
+            // therefore it's unsafe to transfer it to another working beatmap.
+            return false;
+        }
+
         private string firstAudioFile
         {
             get

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -133,10 +133,10 @@ namespace osu.Game.Beatmaps
         /// <returns>Whether the track has been transferred to the <paramref name="target"/>.</returns>
         public virtual bool TryTransferTrack([NotNull] WorkingBeatmap target)
         {
-            if (BeatmapInfo?.AudioEquals(target.BeatmapInfo) != true || track.IsDummyDevice)
+            if (BeatmapInfo?.AudioEquals(target.BeatmapInfo) != true || Track.IsDummyDevice)
                 return false;
 
-            target.track = track;
+            target.track = Track;
             return true;
         }
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Beatmaps
         /// Used as an optimisation to avoid reload / track swap across difficulties in the same beatmap set.
         /// </summary>
         /// <param name="target">The target working beatmap to transfer this track to.</param>
-        /// <returns>Whether the track is valid and has been transferred to this working beatmap.</returns>
+        /// <returns>Whether the track has been transferred to the <paramref name="target"/>.</returns>
         public virtual bool TryTransferTrack([NotNull] WorkingBeatmap target)
         {
             if (BeatmapInfo?.AudioEquals(target.BeatmapInfo) != true)

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Beatmaps
         /// <returns>Whether the track has been transferred to the <paramref name="target"/>.</returns>
         public virtual bool TryTransferTrack([NotNull] WorkingBeatmap target)
         {
-            if (BeatmapInfo?.AudioEquals(target.BeatmapInfo) != true)
+            if (BeatmapInfo?.AudioEquals(target.BeatmapInfo) != true || track.IsDummyDevice)
                 return false;
 
             target.track = track;

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -126,11 +126,19 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Transfer a valid audio track into this working beatmap. Used as an optimisation to avoid reload / track swap
-        /// across difficulties in the same beatmap set.
+        /// Attempts to transfer the audio track to a target working beatmap, if valid for transferring.
+        /// Used as an optimisation to avoid reload / track swap across difficulties in the same beatmap set.
         /// </summary>
-        /// <param name="track">The track to transfer.</param>
-        public void TransferTrack([NotNull] Track track) => this.track = track ?? throw new ArgumentNullException(nameof(track));
+        /// <param name="target">The target working beatmap to transfer this track to.</param>
+        /// <returns>Whether the track is valid and has been transferred to this working beatmap.</returns>
+        public virtual bool TryTransferTrack([NotNull] WorkingBeatmap target)
+        {
+            if (BeatmapInfo?.AudioEquals(target.BeatmapInfo) != true)
+                return false;
+
+            target.track = track;
+            return true;
+        }
 
         /// <summary>
         /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Overlays
 
             TrackChangeDirection direction = TrackChangeDirection.None;
 
-            bool audioEquals = newWorking?.BeatmapInfo?.AudioEquals(current?.BeatmapInfo) ?? false;
+            bool audioEquals = newWorking?.BeatmapInfo?.AudioEquals(current?.BeatmapInfo) == true;
 
             if (current != null)
             {

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -290,15 +290,8 @@ namespace osu.Game.Overlays
 
             current = newWorking;
 
-            if (!audioEquals || CurrentTrack.IsDummyDevice)
-            {
+            if (lastWorking == null || !lastWorking.TryTransferTrack(current))
                 changeTrack();
-            }
-            else
-            {
-                // transfer still valid track to new working beatmap
-                current.TransferTrack(lastWorking.Track);
-            }
 
             TrackChanged?.Invoke(current, direction);
 

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -373,6 +373,13 @@ namespace osu.Game.Tests.Visual
 
             protected override Track GetBeatmapTrack() => track;
 
+            public override bool TryTransferTrack(WorkingBeatmap target)
+            {
+                // Our track comes from a local track store that's disposed on finalizer,
+                // therefore it's unsafe to transfer it to another working beatmap.
+                return false;
+            }
+
             public class TrackVirtualStore : AudioCollectionManager<Track>, ITrackStore
             {
                 private readonly IFrameBasedClock referenceClock;


### PR DESCRIPTION
This was noticed by @peppy in [`TestSceneTapTimingControl` in this branch](https://github.com/ppy/osu/blob/b09931327e0562ece51c2120a25cf94ea779218d/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs) by re-running the test scene at least once, resulting in an `ObjectDisposedException` due to the test scene operating on a disposed track.

Reason why this happens boils down to the track-transferring logic in `MusicController`, in which working beatmaps with identical audio files can have the same track from the last selected beatmap.

In `WaveformTestBeatmap`s, the track is retrieved using a local track store that's disposed on a finaliser. Which means it's not safe to transfer that track to another working beatmap, as the track will be disposed once the previous one is dismissed and finalised by GC.

`ClockBackedTestWorkingBeatmap` should be affected by this as well, but `MusicController` handles that by not allowing to transfer virtual tracks (using the `Track.IsDummyDevice` property).

This PR refactors the track-transferring logic to allow for both `WaveformTestBeatmap` and `ClockBackedTestWorkingBeatmap` to explicitly disallow transferring tracks, and remove the necessity of a `Track.IsDummyDevice` conditional (as it doesn't make sense on face value, until you find the context behind it which is being retrieved by local track stores disposed on finaliser).