### PR TITLE
Fix song select potentially displaying BPM range with equal min/max values

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using NUnit.Framework;
@@ -127,6 +126,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("check info labels count", () => infoWedge.Info.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Count() == expectedCount);
         }
 
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("reset mods", () => SelectedMods.SetDefault());
+        }
+
         [Test]
         public void TestNullBeatmap()
         {
@@ -147,24 +152,43 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestBPMUpdates()
         {
-            const float bpm = 120;
+            const double bpm = 120;
             IBeatmap beatmap = createTestBeatmap(new OsuRuleset().RulesetInfo);
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 60 * 1000 / bpm });
 
             OsuModDoubleTime doubleTime = null;
 
             selectBeatmap(beatmap);
-            checkDisplayedBPM(bpm);
+            checkDisplayedBPM($"{bpm}");
 
             AddStep("select DT", () => SelectedMods.Value = new[] { doubleTime = new OsuModDoubleTime() });
-            checkDisplayedBPM(bpm * 1.5f);
+            checkDisplayedBPM($"{bpm * 1.5f}");
 
             AddStep("change DT rate", () => doubleTime.SpeedChange.Value = 2);
-            checkDisplayedBPM(bpm * 2);
+            checkDisplayedBPM($"{bpm * 2}");
+        }
 
-            void checkDisplayedBPM(float target) =>
-                AddUntilStep($"displayed bpm is {target}", () => this.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Any(
-                    label => label.Statistic.Name == "BPM" && label.Statistic.Content == target.ToString(CultureInfo.InvariantCulture)));
+        [TestCase(120, 125, "120-125 (mostly 120)")]
+        [TestCase(120, 120.6, "120-121 (mostly 120)")]
+        [TestCase(120, 120.4, "120")]
+        public void TestVaryingBPM(double commonBpm, double otherBpm, string expectedDisplay)
+        {
+            IBeatmap beatmap = createTestBeatmap(new OsuRuleset().RulesetInfo);
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 60 * 1000 / commonBpm });
+            beatmap.ControlPointInfo.Add(100, new TimingControlPoint { BeatLength = 60 * 1000 / otherBpm });
+            beatmap.ControlPointInfo.Add(200, new TimingControlPoint { BeatLength = 60 * 1000 / commonBpm });
+
+            selectBeatmap(beatmap);
+            checkDisplayedBPM(expectedDisplay);
+        }
+
+        private void checkDisplayedBPM(string target)
+        {
+            AddUntilStep($"displayed bpm is {target}", () =>
+            {
+                var label = this.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == "BPM");
+                return label.Statistic.Content == target;
+            });
         }
 
         private void setRuleset(RulesetInfo rulesetInfo)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -168,15 +168,20 @@ namespace osu.Game.Tests.Visual.SongSelect
             checkDisplayedBPM($"{bpm * 2}");
         }
 
-        [TestCase(120, 125, "120-125 (mostly 120)")]
-        [TestCase(120, 120.6, "120-121 (mostly 120)")]
-        [TestCase(120, 120.4, "120")]
-        public void TestVaryingBPM(double commonBpm, double otherBpm, string expectedDisplay)
+        [TestCase(120, 125, null, "120-125 (mostly 120)")]
+        [TestCase(120, 120.6, null, "120-121 (mostly 120)")]
+        [TestCase(120, 120.4, null, "120")]
+        [TestCase(120, 120.6, "DT", "180-182 (mostly 180)")]
+        [TestCase(120, 120.4, "DT", "180")]
+        public void TestVaryingBPM(double commonBpm, double otherBpm, string mod, string expectedDisplay)
         {
             IBeatmap beatmap = createTestBeatmap(new OsuRuleset().RulesetInfo);
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 60 * 1000 / commonBpm });
             beatmap.ControlPointInfo.Add(100, new TimingControlPoint { BeatLength = 60 * 1000 / otherBpm });
             beatmap.ControlPointInfo.Add(200, new TimingControlPoint { BeatLength = 60 * 1000 / commonBpm });
+
+            if (mod != null)
+                AddStep($"select {mod}", () => SelectedMods.Value = new[] { Ruleset.Value.CreateInstance().CreateModFromAcronym(mod) });
 
             selectBeatmap(beatmap);
             checkDisplayedBPM(expectedDisplay);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddUntilStep($"displayed bpm is {target}", () =>
             {
-                var label = this.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == "BPM");
+                var label = infoWedge.DisplayedContent.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == "BPM");
                 return label.Statistic.Content == target;
             });
         }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -12,7 +12,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
@@ -416,13 +415,13 @@ namespace osu.Game.Screens.Select
                 foreach (var mod in mods.Value.OfType<IApplicableToRate>())
                     rate = mod.ApplyToRate(0, rate);
 
-                double bpmMax = beatmap.ControlPointInfo.BPMMaximum * rate;
-                double bpmMin = beatmap.ControlPointInfo.BPMMinimum * rate;
-                double mostCommonBPM = 60000 / beatmap.GetMostCommonBeatLength() * rate;
+                int bpmMax = (int)Math.Round(beatmap.ControlPointInfo.BPMMaximum * rate);
+                int bpmMin = (int)Math.Round(beatmap.ControlPointInfo.BPMMinimum * rate);
+                int mostCommonBPM = (int)Math.Round(60000 / beatmap.GetMostCommonBeatLength() * rate);
 
-                string labelText = Precision.AlmostEquals(bpmMin, bpmMax)
-                    ? $"{bpmMin:0}"
-                    : $"{bpmMin:0}-{bpmMax:0} (mostly {mostCommonBPM:0})";
+                string labelText = bpmMin == bpmMax
+                    ? $"{bpmMin}"
+                    : $"{bpmMin}-{bpmMax} (mostly {mostCommonBPM})";
 
                 bpmLabelContainer.Child = new InfoLabel(new BeatmapStatistic
                 {

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -415,9 +415,9 @@ namespace osu.Game.Screens.Select
                 foreach (var mod in mods.Value.OfType<IApplicableToRate>())
                     rate = mod.ApplyToRate(0, rate);
 
-                int bpmMax = (int)Math.Round(beatmap.ControlPointInfo.BPMMaximum * rate);
-                int bpmMin = (int)Math.Round(beatmap.ControlPointInfo.BPMMinimum * rate);
-                int mostCommonBPM = (int)Math.Round(60000 / beatmap.GetMostCommonBeatLength() * rate);
+                int bpmMax = (int)Math.Round(Math.Round(beatmap.ControlPointInfo.BPMMaximum) * rate);
+                int bpmMin = (int)Math.Round(Math.Round(beatmap.ControlPointInfo.BPMMinimum) * rate);
+                int mostCommonBPM = (int)Math.Round(Math.Round(60000 / beatmap.GetMostCommonBeatLength()) * rate);
 
                 string labelText = bpmMin == bpmMax
                     ? $"{bpmMin}"


### PR DESCRIPTION
- Closes #18342 

The wedge determines whether to display a range or a singular value using `Precision.AlmostEquals(..., 0.001f)`, which isn't correct given that the BPMs are rounded and can be equal in integral form but different in decimals. 

Therefore the BPMs are rounded first, then casted to integers and compared to each other.

While at it, I've also included a change that avoids cases like 120 BPM formed by `120 - 120.4` turn into 180-181 BPM when DT is enabled, instead of staying singular at 180 BPM.

However, that... involved rounding twice to achieve expectations, first rounding the decimal BPM value to integral (e.g. `120.6` -> `121`), then rounding the rounded BPM with the decimal rate applied to it (e.g. `121 * 1.5` -> `181.5` -> `182`).

Can consider reverting if the rate should be applied to the decimal BPM directly and let cases like the one mentioned above (`120` -> `180-181`) to remain as-is.