### PR TITLE
Disallow multi-spectator player clocks from being started/stopped externally

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
@@ -34,6 +34,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         public void Stop() => IsRunning = false;
 
+        void IAdjustableClock.Start()
+        {
+            // Our running state should only be managed by an ISyncManager, ignore calls from external sources.
+        }
+
+        void IAdjustableClock.Stop()
+        {
+            // Our running state should only be managed by an ISyncManager, ignore calls from external sources.
+        }
+
         public bool Seek(double position)
         {
             CurrentTime = position;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
@@ -144,6 +144,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 // Make sure the player clock is running if it can.
                 if (!clock.WaitingOnFrames.Value)
                     clock.Start();
+                else
+                    clock.Stop();
 
                 if (clock.IsCatchingUp)
                 {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
@@ -12,6 +12,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
     public interface ISpectatorPlayerClock : IFrameBasedClock, IAdjustableClock
     {
         /// <summary>
+        /// Starts this <see cref="ISpectatorPlayerClock"/>.
+        /// </summary>
+        new void Start();
+
+        /// <summary>
+        /// Stops this <see cref="ISpectatorPlayerClock"/>.
+        /// </summary>
+        new void Stop();
+
+        /// <summary>
         /// Whether this clock is waiting on frames to continue playback.
         /// </summary>
         Bindable<bool> WaitingOnFrames { get; }


### PR DESCRIPTION
- Alternative to / closes https://github.com/ppy/osu/pull/18245

This resolves the issue alternatively by never allowing `CatchUpSpectatorPlayerClock`s to be started/stopped externally, as they're supposed to be managed by `CatchUpSyncManager` solely.

Note that this PR also bundles a change in `CatchUpSyncManager` for stopping the clock when `WaitingForFrames = true`, as that was [something that `Player` would manage](https://github.com/ppy/osu/blob/cbd1169495a283d4d439cfc16edd856b23304f9e/osu.Game/Screens/Play/Player.cs#L303-L309), but now that the clock's running state is completely decoupled from player, we'll have to do it at `CatchUpSyncManager` ourselves.

Another idea I had in mind is to define a new `TrackingMaster` boolean next to `IsRunning` for whether the clock should be progressing to reach master, so that the clock can still be started/stopped externally as desired, without affecting whether it should follow master (only `CatchUpSyncManager` would decide that).

Going to recommend testing multi-spectator with this PR in various ways, in case I failed to notice one case where disallowing this clock from being stopped externally breaks it.

Note that `TestMostInSyncUserIsAudioSource` may start failing when running the full test scene in headless with this PR, and it's not entirely this PR's fault. See https://github.com/ppy/osu/issues/18352.