### PR TITLE
Fix appearance of sheared button borders after click

### DIFF
--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -5,6 +5,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
@@ -68,6 +69,7 @@ namespace osu.Game.Graphics.UserInterface
         private Colour4? lighterColour;
         private Colour4? textColour;
 
+        private readonly Container backgroundLayer;
         private readonly Box flashLayer;
 
         /// <summary>
@@ -85,24 +87,35 @@ namespace osu.Game.Graphics.UserInterface
             Height = 50;
             Padding = new MarginPadding { Horizontal = shear * 50 };
 
-            Content.CornerRadius = 7;
+            const float corner_radius = 7;
+
+            Content.CornerRadius = corner_radius;
             Content.Shear = new Vector2(shear, 0);
             Content.Masking = true;
-            Content.BorderThickness = 2;
             Content.Anchor = Content.Origin = Anchor.Centre;
 
             Children = new Drawable[]
             {
-                background = new Box
+                backgroundLayer = new Container
                 {
-                    RelativeSizeAxes = Axes.Both
-                },
-                text = new OsuSpriteText
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Font = OsuFont.TorusAlternate.With(size: 17),
-                    Shear = new Vector2(-shear, 0)
+                    RelativeSizeAxes = Axes.Both,
+                    CornerRadius = corner_radius,
+                    Masking = true,
+                    BorderThickness = 2,
+                    Children = new Drawable[]
+                    {
+                        background = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        },
+                        text = new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Font = OsuFont.TorusAlternate.With(size: 17),
+                            Shear = new Vector2(-shear, 0)
+                        },
+                    }
                 },
                 flashLayer = new Box
                 {
@@ -186,7 +199,7 @@ namespace osu.Game.Graphics.UserInterface
             }
 
             background.FadeColour(colourDark, 150, Easing.OutQuint);
-            Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(colourDark, colourLight), 150, Easing.OutQuint);
+            backgroundLayer.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(colourDark, colourLight), 150, Easing.OutQuint);
 
             if (!Enabled.Value)
                 colourText = colourText.Opacity(0.6f);


### PR DESCRIPTION
The border would previously get brighter after click, but then dim instantly when the flash layer has fully faded out. The underlying issue there is https://github.com/ppy/osu-framework/issues/5191, but `ShearedButton` was placing the flashing layer incorrectly anyway, as the intent was that it should also apply to the border.

Before:

https://user-images.githubusercontent.com/20418176/169665616-624431a1-498c-4f5b-bf18-3825ce8b4250.mp4

After:

https://user-images.githubusercontent.com/20418176/169665624-037f8693-b3a1-425c-9c6c-15da72ad4d09.mp4