### PR TITLE
Fix tournament user stat population potentially using wrong ruleset

### DIFF
--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -259,7 +259,7 @@ namespace osu.Game.Tournament
 
         public void PopulateUser(APIUser user, Action success = null, Action failure = null, bool immediate = false)
         {
-            var req = new GetUserRequest(user.Id, Ruleset.Value);
+            var req = new GetUserRequest(user.Id, ladder.Ruleset.Value);
 
             if (immediate)
             {


### PR DESCRIPTION
`OsuGameBase.Ruleset` is bound [late](https://github.com/ppy/osu/blob/7d0470794bcd454d3a93954ec4fe3415933627ef/osu.Game.Tournament/TournamentGameBase.cs#L169) so we must use the ladder one during user retrieval.

Closes https://github.com/ppy/osu/issues/18363.