### PR TITLE
Add challenge mods

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -109,6 +109,9 @@ namespace osu.Game.Rulesets.Catch
                         new MultiMod(new CatchModDoubleTime(), new CatchModNightcore()),
                         new CatchModHidden(),
                         new CatchModFlashlight(),
+                        new CatchModAccuracyChallenge(),
+                        new CatchModHealthChallenge(),
+                        new CatchModJudgementChallenge(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Catch/Mods/CatchModAccuracyChallenge.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModAccuracyChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public class CatchModAccuracyChallenge : ModAccuracyChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHealthChallenge.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHealthChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public class CatchModHealthChallenge : ModHealthChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Scoring;
+
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public class CatchModJudgementChallenge : ModJudgementChallenge
+    {
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+
+        public CatchModJudgementChallenge()
+        {
+            hitResultsMaximumCount[HitResult.Miss] = MaxMiss;
+            hitResultsMaximumCount[HitResult.Meh] = MaxMeh;
+            hitResultsMaximumCount[HitResult.Ok] = MaxOk;
+            hitResultsMaximumCount[HitResult.Good] = MaxGood;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
@@ -20,21 +20,21 @@ namespace osu.Game.Rulesets.Catch.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
@@ -20,21 +20,21 @@ namespace osu.Game.Rulesets.Catch.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModJudgementChallenge.cs
@@ -5,44 +5,52 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Overlays.Settings;
 
 
 namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModJudgementChallenge : ModJudgementChallenge
     {
-        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMiss { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMeh { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxOk { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxGood { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
-        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+        protected override IDictionary<HitResult, BindableNumber<int>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, BindableNumber<int>> hitResultsMaximumCount = new Dictionary<HitResult, BindableNumber<int>>();
 
         public CatchModJudgementChallenge()
         {

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -222,6 +222,9 @@ namespace osu.Game.Rulesets.Mania
                         new MultiMod(new ManiaModDoubleTime(), new ManiaModNightcore()),
                         new MultiMod(new ManiaModFadeIn(), new ManiaModHidden()),
                         new ManiaModFlashlight(),
+                        new ManiaModAccuracyChallenge(),
+                        new ManiaModHealthChallenge(),
+                        new ManiaModJudgementChallenge(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModAccuracyChallenge.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModAccuracyChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModAccuracyChallenge : ModAccuracyChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHealthChallenge.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHealthChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModHealthChallenge : ModHealthChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Scoring;
+
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModJudgementChallenge : ModJudgementChallenge
+    {
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum greats", "Maximum number of greats before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxGreat { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+
+        public ManiaModJudgementChallenge()
+        {
+            hitResultsMaximumCount[HitResult.Miss] = MaxMiss;
+            hitResultsMaximumCount[HitResult.Meh] = MaxMeh;
+            hitResultsMaximumCount[HitResult.Ok] = MaxOk;
+            hitResultsMaximumCount[HitResult.Good] = MaxGood;
+            hitResultsMaximumCount[HitResult.Great] = MaxGreat;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
@@ -20,28 +20,28 @@ namespace osu.Game.Rulesets.Mania.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum greats", "Maximum number of \"great\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"great\" hits", "Maximum number of \"great\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGreat { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
@@ -5,51 +5,61 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Overlays.Settings;
 
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModJudgementChallenge : ModJudgementChallenge
     {
-        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMiss { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMeh { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxOk { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxGood { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"great\" hits", "Maximum number of \"great\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxGreat { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"great\" hits", "Maximum number of \"great\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxGreat { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
-        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+        protected override IDictionary<HitResult, BindableNumber<int>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, BindableNumber<int>> hitResultsMaximumCount = new Dictionary<HitResult, BindableNumber<int>>();
 
         public ManiaModJudgementChallenge()
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModJudgementChallenge.cs
@@ -20,28 +20,28 @@ namespace osu.Game.Rulesets.Mania.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum greats", "Maximum number of greats before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum greats", "Maximum number of \"great\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGreat { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAccuracyChallenge.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAccuracyChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModAccuracyChallenge : ModAccuracyChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHealthChallenge.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHealthChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModHealthChallenge : ModHealthChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
@@ -20,21 +20,21 @@ namespace osu.Game.Rulesets.Osu.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
@@ -5,44 +5,52 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Overlays.Settings;
 
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModJudgementChallenge : ModJudgementChallenge
     {
-        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMiss { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMeh { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxOk { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxGood { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
-        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+        protected override IDictionary<HitResult, BindableNumber<int>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, BindableNumber<int>> hitResultsMaximumCount = new Dictionary<HitResult, BindableNumber<int>>();
 
         public OsuModJudgementChallenge()
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Scoring;
+
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModJudgementChallenge : ModJudgementChallenge
+    {
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+
+        public OsuModJudgementChallenge()
+        {
+            hitResultsMaximumCount[HitResult.Miss] = MaxMiss;
+            hitResultsMaximumCount[HitResult.Meh] = MaxMeh;
+            hitResultsMaximumCount[HitResult.Ok] = MaxOk;
+            hitResultsMaximumCount[HitResult.Good] = MaxGood;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModJudgementChallenge.cs
@@ -20,21 +20,21 @@ namespace osu.Game.Rulesets.Osu.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -159,7 +159,10 @@ namespace osu.Game.Rulesets.Osu
                         new MultiMod(new OsuModDoubleTime(), new OsuModNightcore()),
                         new OsuModHidden(),
                         new MultiMod(new OsuModFlashlight(), new OsuModBlinds()),
-                        new OsuModStrictTracking()
+                        new OsuModStrictTracking(),
+                        new OsuModAccuracyChallenge(),
+                        new OsuModHealthChallenge(),
+                        new OsuModJudgementChallenge(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAccuracyChallenge.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAccuracyChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public class TaikoModAccuracyChallenge : ModAccuracyChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHealthChallenge.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHealthChallenge.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public class TaikoModHealthChallenge : ModHealthChallenge
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Scoring;
+
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public class TaikoModJudgementChallenge : ModJudgementChallenge
+    {
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+
+        public TaikoModJudgementChallenge()
+        {
+            hitResultsMaximumCount[HitResult.Miss] = MaxMiss;
+            hitResultsMaximumCount[HitResult.Meh] = MaxMeh;
+            hitResultsMaximumCount[HitResult.Ok] = MaxOk;
+            hitResultsMaximumCount[HitResult.Good] = MaxGood;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
@@ -20,21 +20,21 @@ namespace osu.Game.Rulesets.Taiko.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
@@ -5,44 +5,52 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Overlays.Settings;
 
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModJudgementChallenge : ModJudgementChallenge
     {
-        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMiss { get; } = new Bindable<int?>
+        [SettingSource("Maximum misses", "Maximum number of misses before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMiss { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"meh\" hits", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxMeh { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxOk { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"ok\" hits", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxOk { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> MaxGood { get; } = new Bindable<int?>
+        [SettingSource("Maximum \"good\" hits", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsSlider<int, JudgementMaxSlider>))]
+        public BindableNumber<int> MaxGood { get; } = new BindableInt
         {
-            Default = null,
-            Value = null
+            Default = 26,
+            Value = 26,
+            MinValue = 0,
+            MaxValue = 26
         };
 
-        protected override IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts => hitResultsMaximumCount;
-        private Dictionary<HitResult, Bindable<int?>> hitResultsMaximumCount = new Dictionary<HitResult, Bindable<int?>>();
+        protected override IDictionary<HitResult, BindableNumber<int>> HitResultMaximumCounts => hitResultsMaximumCount;
+        private Dictionary<HitResult, BindableNumber<int>> hitResultsMaximumCount = new Dictionary<HitResult, BindableNumber<int>>();
 
         public TaikoModJudgementChallenge()
         {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModJudgementChallenge.cs
@@ -20,21 +20,21 @@ namespace osu.Game.Rulesets.Taiko.Mods
             Value = null
         };
 
-        [SettingSource("Maximum mehs", "Maximum number of mehs before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum mehs", "Maximum number of \"meh\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxMeh { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum oks", "Maximum number of oks before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum oks", "Maximum number of \"ok\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxOk { get; } = new Bindable<int?>
         {
             Default = null,
             Value = null
         };
 
-        [SettingSource("Maximum goods", "Maximum number of goods before fail.", SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum goods", "Maximum number of \"good\" hits before fail.", SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxGood { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -128,6 +128,9 @@ namespace osu.Game.Rulesets.Taiko
                         new MultiMod(new TaikoModDoubleTime(), new TaikoModNightcore()),
                         new TaikoModHidden(),
                         new TaikoModFlashlight(),
+                        new TaikoModAccuracyChallenge(),
+                        new TaikoModHealthChallenge(),
+                        new TaikoModJudgementChallenge(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Judgements;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModAccuracyChallenge : ModChallenge
+    {
+        public override string Name => "Accuracy Challenge";
+        public override string Acronym => "AC";
+        public override IconUsage? Icon => FontAwesome.Solid.Calculator;
+        public override string Description => "Fail the beatmap if your accuracy goes below a specified value.";
+
+        [SettingSource("Minimum accuracy", "Fail map if your accuracy goes under this value.")]
+        public BindableNumber<double> MinimumAccuracy { get; } = new BindableDouble
+        {
+            MinValue = 0,
+            MaxValue = 100,
+            Default = 90,
+            Value = 90,
+            Precision = 0.01,
+        };
+
+        private double baseScore;
+        private double maxBaseScore;
+        private double accuracy => maxBaseScore > 0 ? baseScore / maxBaseScore : 1;
+
+        protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
+        {
+            incrementInternalScoresFromJudgementResult(result);
+            if (!AllowChallengeFailureAtHitObject(result.HitObject))
+                return false;
+            return accuracy < MinimumAccuracy.Value / 100;
+        }
+
+        private void incrementInternalScoresFromJudgementResult(JudgementResult result)
+        {
+            if (!result.Type.IsScorable() || result.Type.IsBonus())
+                return;
+            baseScore += result.Type.IsHit() ? result.Judgement.NumericResultFor(result) : 0;
+            maxBaseScore += result.Judgement.MaxNumericResult;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Rulesets.Mods
             incrementInternalScoresFromJudgementResult(result);
             if (!AllowChallengeFailureAtHitObject(result.HitObject))
                 return false;
+
             return accuracy < MinimumAccuracy.Value / 100;
         }
 
@@ -42,6 +43,7 @@ namespace osu.Game.Rulesets.Mods
         {
             if (!result.Type.IsScorable() || result.Type.IsBonus())
                 return;
+
             baseScore += result.Type.IsHit() ? result.Judgement.NumericResultFor(result) : 0;
             maxBaseScore += result.Judgement.MaxNumericResult;
         }

--- a/osu.Game/Rulesets/Mods/ModChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModChallenge.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Mods
         {
             Continuously,
             AtBreak,
-            AtEnd, // doesn't make sense to be compatible with `ModEasyWithExtraLives` if you're checking the last hitobject
+            AtEnd,
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModChallenge.cs
@@ -40,12 +40,14 @@ namespace osu.Game.Rulesets.Mods
                     for (int i = 0; i < beatmap.HitObjects.Count - 1; i++)
                     {
                         double inBetweenTime = (beatmap.HitObjects.ElementAtOrDefault(i).GetEndTime() + beatmap.HitObjects.ElementAtOrDefault(i + 1).StartTime) / 2;
+
                         foreach (BreakPeriod breakPeriod in beatmap.Breaks)
                         {
                             if (breakPeriod.Contains(inBetweenTime))
                                 HitObjectsBeforeBreaks.Add(beatmap.HitObjects.ElementAtOrDefault(i));
                         }
                     }
+
                     break;
             }
         }
@@ -61,14 +63,18 @@ namespace osu.Game.Rulesets.Mods
             switch (CheckingInterval.Value)
             {
                 case ChallengeCheckInterval.AtBreak:
-                    if (!HitObjectsBeforeBreaks.Contains(hitObject)) return false;
+                    if (!HitObjectsBeforeBreaks.Contains(hitObject))
+                        return false;
+
                     break;
 
                 case ChallengeCheckInterval.AtEnd:
                     if (hitObject != LastHitObjectInBeatmap)
                         return false;
+
                     break;
             }
+
             return true;
         }
 

--- a/osu.Game/Rulesets/Mods/ModChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModChallenge.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps.Timing;
 using osu.Game.Scoring;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
+using System.ComponentModel;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -83,15 +84,20 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         /// <param name="judgement">The judgement to check.</param>
         /// <returns>Whether the judgement is the best it can possibly be.</returns>
-        protected bool JudgementIsFlawed(JudgementResult judgement)
+        protected bool IsImperfectJudgement(JudgementResult judgement)
         {
             return !(judgement.Type == judgement.Judgement.MaxResult || judgement.Type == HitResult.LargeTickHit) && judgement.Type.AffectsCombo();
         }
 
         public enum ChallengeCheckInterval
         {
+            [Description(@"Continously")]
             Continuously,
+
+            [Description(@"At break")]
             AtBreak,
+
+            [Description(@"At end")]
             AtEnd,
         }
     }

--- a/osu.Game/Rulesets/Mods/ModChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModChallenge.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Objects;
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModChallenge : ModFailCondition, IApplicableToBeatmap
+    {
+        public override ModType Type => ModType.DifficultyIncrease;
+        public override double ScoreMultiplier => 1;
+        public override bool RequiresConfiguration => true;
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModPerfect)).Append(typeof(ModEasyWithExtraLives)).ToArray();
+
+        [SettingSource("Checking interval", "When conditions will be checked.")]
+        public Bindable<ChallengeCheckInterval> CheckingInterval { get; } = new Bindable<ChallengeCheckInterval>();
+
+        protected readonly List<HitObject> HitObjectsBeforeBreaks = new List<HitObject>();
+        protected HitObject LastHitObjectInBeatmap;
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            switch (CheckingInterval.Value)
+            {
+                case ChallengeCheckInterval.AtEnd:
+                    LastHitObjectInBeatmap = beatmap.HitObjects.LastOrDefault();
+                    break;
+
+                case ChallengeCheckInterval.AtBreak:
+                    for (int i = 0; i < beatmap.HitObjects.Count - 1; i++)
+                    {
+                        double inBetweenTime = (beatmap.HitObjects.ElementAtOrDefault(i).GetEndTime() + beatmap.HitObjects.ElementAtOrDefault(i + 1).StartTime) / 2;
+                        foreach (BreakPeriod breakPeriod in beatmap.Breaks)
+                        {
+                            if (breakPeriod.Contains(inBetweenTime))
+                                HitObjectsBeforeBreaks.Add(beatmap.HitObjects.ElementAtOrDefault(i));
+                        }
+                    }
+                    break;
+            }
+        }
+
+        public virtual ScoreRank AdjustRank(ScoreRank rank, double accuracy) => rank;
+
+        /// <summary>
+        /// Check whether the <see cref="CheckingInterval"/> allows for a challenge-induced failure to take place at this <see cref="HitObject"/>.
+        /// </summary>
+        /// <returns>Whether a challenge-induced failure is allowed to take place.</returns>
+        protected bool AllowChallengeFailureAtHitObject(HitObject hitObject)
+        {
+            switch (CheckingInterval.Value)
+            {
+                case ChallengeCheckInterval.AtBreak:
+                    if (!HitObjectsBeforeBreaks.Contains(hitObject)) return false;
+                    break;
+
+                case ChallengeCheckInterval.AtEnd:
+                    if (hitObject != LastHitObjectInBeatmap)
+                        return false;
+                    break;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the <see cref="JudgementResult"/> is anything less than the best it can possibly be.
+        /// </summary>
+        /// <param name="judgement">The judgement to check.</param>
+        /// <returns>Whether the judgement is the best it can possibly be.</returns>
+        protected bool JudgementIsFlawed(JudgementResult judgement)
+        {
+            return !(judgement.Type == judgement.Judgement.MaxResult || judgement.Type == HitResult.LargeTickHit) && judgement.Type.AffectsCombo();
+        }
+
+        public enum ChallengeCheckInterval
+        {
+            Continuously,
+            AtBreak,
+            AtEnd, // doesn't make sense to be compatible with `ModEasyWithExtraLives` if you're checking the last hitobject
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModEasyWithExtraLives.cs
+++ b/osu.Game/Rulesets/Mods/ModEasyWithExtraLives.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using Humanizer;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
@@ -19,6 +21,7 @@ namespace osu.Game.Rulesets.Mods
         };
 
         public override string SettingDescription => Retries.IsDefault ? string.Empty : $"{"lives".ToQuantity(Retries.Value)}";
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModChallenge)).ToArray();
 
         private int retries;
 

--- a/osu.Game/Rulesets/Mods/ModHealthChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModHealthChallenge.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Rulesets.Mods
 
         private bool playIsPerfect = true;
 
-
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
         {
             if (JudgementIsFlawed(result))

--- a/osu.Game/Rulesets/Mods/ModHealthChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModHealthChallenge.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Judgements;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModHealthChallenge : ModChallenge
+    {
+        public override string Name => "Health Challenge";
+        public override string Acronym => "HC";
+        public override IconUsage? Icon => FontAwesome.Solid.Heartbeat;
+        public override string Description => "Fail the beatmap if your health goes below a specified value.";
+
+        [SettingSource("Minimum health", "Fail map if your health goes under this value.")]
+        public BindableNumber<double> MinimumHealth { get; } = new BindableDouble
+        {
+            MinValue = 0,
+            MaxValue = 100,
+            Default = 75,
+            Value = 75,
+            Precision = 0.1,
+        };
+
+        private bool playIsPerfect = true;
+
+
+        protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
+        {
+            if (JudgementIsFlawed(result))
+                playIsPerfect = false;
+            if (!AllowChallengeFailureAtHitObject(result.HitObject))
+                return false;
+
+            if (CheckingInterval.Value == ChallengeCheckInterval.Continuously)
+                return healthProcessor.Health.Value < MinimumHealth.Value / 100 && JudgementIsFlawed(result);
+
+            return healthProcessor.Health.Value < MinimumHealth.Value && !playIsPerfect;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModHealthChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModHealthChallenge.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Rulesets.Mods
 
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
         {
-            if (JudgementIsFlawed(result))
+            if (IsImperfectJudgement(result))
                 playIsPerfect = false;
             if (!AllowChallengeFailureAtHitObject(result.HitObject))
                 return false;
 
             if (CheckingInterval.Value == ChallengeCheckInterval.Continuously)
-                return healthProcessor.Health.Value < MinimumHealth.Value / 100 && JudgementIsFlawed(result);
+                return healthProcessor.Health.Value < MinimumHealth.Value / 100 && IsImperfectJudgement(result);
 
             return healthProcessor.Health.Value < MinimumHealth.Value && !playIsPerfect;
         }

--- a/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Rulesets.Mods
         /// Intended to be used with mod <see cref="SettingSourceAttribute"/> bindables.
         /// </summary>
         protected abstract IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts { get; }
+
         private readonly Dictionary<HitResult, int> hitResultCounts = new Dictionary<HitResult, int>();
         private int nonBestCount = 0;
 

--- a/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Judgements;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModJudgementChallenge : ModChallenge
+    {
+        public override string Name => "Judgement Challenge";
+        public override string Acronym => "JC";
+        public override IconUsage? Icon => FontAwesome.Solid.Gavel;
+        public override string Description => "Fail the beatmap if your judgements go above specified values.";
+
+        [SettingSource("Maximum non-best judgements", "Maximum number of non-best judgements before fail (disregards judgement type).", 1, SettingControlType = typeof(SettingsNumberBox))]
+        public Bindable<int?> MaxNonBest { get; } = new Bindable<int?>
+        {
+            Default = null,
+            Value = null
+        };
+
+        /// <summary>
+        /// The maximum allowable number of each type <see cref="HitResult"/> for the challenge.
+        /// Intended to be used with mod <see cref="SettingSourceAttribute"/> bindables.
+        /// </summary>
+        protected abstract IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts { get; }
+        private readonly Dictionary<HitResult, int> hitResultCounts = new Dictionary<HitResult, int>();
+        private int nonBestCount = 0;
+
+        protected ModJudgementChallenge()
+        {
+            foreach (HitResult key in Enum.GetValues(typeof(HitResult)).Cast<HitResult>())
+                hitResultCounts.Add(key, 0);
+        }
+
+        protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
+        {
+            hitResultCounts[result.Type] += 1;
+            nonBestCount += JudgementIsFlawed(result) ? 1 : 0;
+
+            if (!AllowChallengeFailureAtHitObject(result.HitObject))
+                return false;
+
+            if (nonBestCount > MaxNonBest.Value)
+                return true;
+
+            foreach (var (key, value) in HitResultMaximumCounts)
+                if (hitResultCounts[key] > value.Value)
+                    return true;
+
+            return false;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => FontAwesome.Solid.Gavel;
         public override string Description => "Fail the beatmap if your judgements go above specified values.";
 
-        [SettingSource("Maximum non-best judgements", "Maximum number of non-best judgements before fail (disregards judgement type).", 1, SettingControlType = typeof(SettingsNumberBox))]
+        [SettingSource("Maximum non-best judgements", "Maximum number of non-best judgements before fail (disregards judgement type).", 1)]
         public Bindable<int?> MaxNonBest { get; } = new Bindable<int?>
         {
             Default = null,
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Mods
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
         {
             hitResultCounts[result.Type] += 1;
-            nonBestCount += JudgementIsFlawed(result) ? 1 : 0;
+            nonBestCount += IsImperfectJudgement(result) ? 1 : 0;
 
             if (!AllowChallengeFailureAtHitObject(result.HitObject))
                 return false;

--- a/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => FontAwesome.Solid.Gavel;
         public override string Description => "Fail the beatmap if your judgements go above specified values.";
 
-        [SettingSource("Maximum non-best judgements", "Maximum number of non-best judgements before fail (disregards judgement type).", 1)]
+        [SettingSource("Maximum non-best judgements", "Maximum number of non-best judgements before fail (disregards judgement type).", 1, SettingControlType = typeof(SettingsNumberBox))]
         public Bindable<int?> MaxNonBest { get; } = new Bindable<int?>
         {
             Default = null,

--- a/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModJudgementChallenge.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Mods
         protected abstract IDictionary<HitResult, Bindable<int?>> HitResultMaximumCounts { get; }
 
         private readonly Dictionary<HitResult, int> hitResultCounts = new Dictionary<HitResult, int>();
-        private int nonBestCount = 0;
+        private int nonBestCount;
 
         protected ModJudgementChallenge()
         {


### PR DESCRIPTION
Previously discussed in #13120.

This collection of mods adds additional failure conditions to gameplay based on accuracy, health, and judgement counts.

Accuracy Challenge
- Triggers a failure if accuracy goes below a set threshold, defaults to 90%.

Health Challenge
- Triggers a failure if health goes below a set threshold, defaults to 75%.
- Will not trigger a failure if health is below the threshold but the `JudgementResult` if the current hit object is the best it could possibly be. This is to avoid impossible-to-win scenarios.

Judgement Challenge
- Triggers a failure if judgement counts go above set values, never triggers by default.
- Includes settings for each possible basic judgement type as well as any non-best judgement.

All challenges can be set to check challenge conditions continuously, at breaks, or at the end of a beatmap.

`ModJudgementChallenge` currently requires ruleset implementations to have their own threshold settings. This was done to allow for custom ruleset agnosticism, but it adds a significant amount of redundancy. If reducing redundancy takes priority, we could add settings for miss through good judgements to `ModJudgementChallenge` and have the mania implementation add its own great setting.

https://user-images.githubusercontent.com/47010459/169851980-e321874c-03e0-4647-aa9d-05bd14f919df.mp4