### PR TITLE
Remove redundant installation of `libavformat` in Linux CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,15 +78,6 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
-      # FIXME: libavformat is not included in Ubuntu. Let's fix that.
-      # https://github.com/ppy/osu-framework/issues/4349
-      # Remove this once https://github.com/actions/virtual-environments/issues/3306 has been resolved.
-      - name: Install libavformat-dev
-        if: ${{matrix.os.fullname == 'ubuntu-latest'}}
-        run: |
-         sudo apt-get update && \
-         sudo apt-get -y install libavformat-dev
-
       - name: Compile
         run: dotnet build -c Debug -warnaserror osu.Desktop.slnf
 


### PR DESCRIPTION
Linux `libavformat` native libraries are now packaged with framework.