### PR TITLE
Add waveform comparison view to editor timing screen

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.513.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.521.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.525.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics;

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -24,8 +24,8 @@ namespace osu.Game.Screens.Edit.Timing
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
-            Height = 200;
             RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
 
             CornerRadius = LabelledDrawable<Drawable>.CORNER_RADIUS;
             Masking = true;
@@ -39,20 +39,44 @@ namespace osu.Game.Screens.Edit.Timing
                 },
                 new GridContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     RowDimensions = new[]
                     {
-                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute, 200),
                         new Dimension(GridSizeMode.Absolute, 60),
                     },
                     Content = new[]
                     {
                         new Drawable[]
                         {
-                            new MetronomeDisplay
+                            new Container
                             {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
+                                RelativeSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    new GridContainer
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        ColumnDimensions = new[]
+                                        {
+                                            new Dimension(GridSizeMode.AutoSize),
+                                            new Dimension()
+                                        },
+                                        Content = new[]
+                                        {
+                                            new Drawable[]
+                                            {
+                                                new MetronomeDisplay
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                },
+                                                new WaveformComparisonDisplay(),
+                                            }
+                                        },
+                                    }
+                                }
                             }
                         },
                         new Drawable[]

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Timing
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
         [Resolved]
-        private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
+        private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
 
         [Resolved]
         private EditorClock editorClock { get; set; } = null!;
@@ -45,6 +45,8 @@ namespace osu.Game.Screens.Edit.Timing
         private TimingControlPoint timingPoint = TimingControlPoint.DEFAULT;
 
         private int lastDisplayedBeatIndex;
+
+        private double offsetZeroTime => selectedGroup.Value?.Time ?? 0;
 
         public WaveformComparisonDisplay()
         {
@@ -93,10 +95,10 @@ namespace osu.Game.Screens.Edit.Timing
             beatLength.BindValueChanged(_ => showFrom(lastDisplayedBeatIndex), true);
         }
 
-        private void selectedGroupChanged(ValueChangedEvent<ControlPointGroup> group)
+        private void selectedGroupChanged(ValueChangedEvent<ControlPointGroup?> group)
         {
             timingPoint = selectedGroup.Value?.ControlPoints.OfType<TimingControlPoint>().FirstOrDefault()
-                          ?? TimingControlPoint.DEFAULT;
+                          ?? new TimingControlPoint();
 
             beatLength.UnbindBindings();
             beatLength.BindTo(timingPoint.BeatLengthBindable);
@@ -120,7 +122,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             if (!IsHovered)
             {
-                int beatOffset = (int)Math.Max(0, ((editorClock.CurrentTime - selectedGroup.Value.Time) / timingPoint.BeatLength));
+                int beatOffset = (int)Math.Max(0, ((editorClock.CurrentTime - offsetZeroTime) / timingPoint.BeatLength));
 
                 showFrom(beatOffset);
             }
@@ -138,7 +140,7 @@ namespace osu.Game.Screens.Edit.Timing
             foreach (var waveform in InternalChildren.OfType<WaveformGraph>())
             {
                 // offset to the required beat index.
-                float offset = (float)(selectedGroup.Value.Time + (beatIndex * timingPoint.BeatLength - (visible_width / 2))) / trackLength * scale;
+                float offset = (float)(offsetZeroTime + (beatIndex * timingPoint.BeatLength - (visible_width / 2))) / trackLength * scale;
 
                 waveform.X = -offset;
                 waveform.Scale = new Vector2(scale, 1);

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -136,14 +136,21 @@ namespace osu.Game.Screens.Edit.Timing
 
             if (!IsHovered)
             {
-                int beatOffset = (int)Math.Floor((editorClock.CurrentTimeAccurate - selectedGroupStartTime) / timingPoint.BeatLength);
+                int currentBeat = (int)Math.Floor((editorClock.CurrentTimeAccurate - selectedGroupStartTime) / timingPoint.BeatLength);
 
-                showFrom(beatOffset);
+                showFrom(currentBeat);
             }
         }
 
         private void showFrom(int beatIndex)
         {
+            if (lastDisplayedBeatIndex == beatIndex)
+                return;
+
+            // Chosen as a pretty usable number across all BPMs.
+            // Optimally we'd want this to scale with the BPM in question, but performing
+            // scaling of the display is both expensive in resampling, and decreases usability
+            // (as it is harder to track the waveform when making realtime adjustments).
             const float visible_width = 300;
 
             float trackLength = (float)beatmap.Value.Track.Length;

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -1,0 +1,152 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    internal class WaveformComparisonDisplay : CompositeDrawable
+    {
+        private const int total_waveforms = 8;
+
+        private OsuSpriteText beatIndexText = null!;
+
+        private readonly BindableNumber<double> beatLength = new BindableDouble();
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+        [Resolved]
+        private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
+
+        [Resolved]
+        private EditorClock editorClock { get; set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private TimingControlPoint timingPoint = TimingControlPoint.DEFAULT;
+
+        private int lastDisplayedBeatIndex;
+
+        public WaveformComparisonDisplay()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            CornerRadius = LabelledDrawable<Drawable>.CORNER_RADIUS;
+            Masking = true;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            for (int i = 0; i < total_waveforms; i++)
+            {
+                AddInternal(new WaveformGraph
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    BaseColour = colourProvider.Colour0,
+                    LowColour = colourProvider.Colour1,
+                    MidColour = colourProvider.Colour2,
+                    HighColour = colourProvider.Colour4,
+                    Waveform = beatmap.Value.Waveform,
+                    Resolution = 1,
+                    RelativePositionAxes = Axes.Both,
+                    Height = 1f / total_waveforms,
+                    Y = (float)i / total_waveforms,
+                });
+            }
+
+            AddInternal(new Circle
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Colour = Color4.White,
+                RelativeSizeAxes = Axes.Y,
+                Width = 3,
+            });
+
+            AddInternal(beatIndexText = new OsuSpriteText
+            {
+                Margin = new MarginPadding(5),
+            });
+
+            selectedGroup.BindValueChanged(selectedGroupChanged, true);
+            beatLength.BindValueChanged(_ => showFrom(lastDisplayedBeatIndex), true);
+        }
+
+        private void selectedGroupChanged(ValueChangedEvent<ControlPointGroup> group)
+        {
+            timingPoint = selectedGroup.Value?.ControlPoints.OfType<TimingControlPoint>().FirstOrDefault()
+                          ?? TimingControlPoint.DEFAULT;
+
+            beatLength.UnbindBindings();
+            beatLength.BindTo(timingPoint.BeatLengthBindable);
+        }
+
+        protected override bool OnHover(HoverEvent e) => true;
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            float trackLength = (float)beatmap.Value.Track.Length;
+            int totalBeatsAvailable = (int)(trackLength / timingPoint.BeatLength);
+
+            Scheduler.AddOnce(showFrom, (int)(e.MousePosition.X / DrawWidth * totalBeatsAvailable));
+
+            return base.OnMouseMove(e);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!IsHovered)
+            {
+                int beatOffset = (int)Math.Max(0, ((editorClock.CurrentTime - selectedGroup.Value.Time) / timingPoint.BeatLength));
+
+                showFrom(beatOffset);
+            }
+        }
+
+        private void showFrom(int beatIndex)
+        {
+            const float visible_width = 300;
+
+            float trackLength = (float)beatmap.Value.Track.Length;
+            float scale = trackLength / visible_width;
+
+            beatIndexText.Text = beatIndex.ToString();
+
+            foreach (var waveform in InternalChildren.OfType<WaveformGraph>())
+            {
+                // offset to the required beat index.
+                float offset = (float)(selectedGroup.Value.Time + (beatIndex * timingPoint.BeatLength - (visible_width / 2))) / trackLength * scale;
+
+                waveform.X = -offset;
+                waveform.Scale = new Vector2(scale, 1);
+
+                beatIndex++;
+            }
+
+            lastDisplayedBeatIndex = beatIndex;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Edit.Timing
         private double selectedGroupStartTime;
         private double selectedGroupEndTime;
 
-        private readonly BindableList<ControlPointGroup> controlPointGroups = new BindableList<ControlPointGroup>();
+        private readonly IBindableList<ControlPointGroup> controlPointGroups = new BindableList<ControlPointGroup>();
 
         public WaveformComparisonDisplay()
         {
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             selectedGroup.BindValueChanged(_ => updateTimingGroup(), true);
 
-            ((IBindableList<ControlPointGroup>)controlPointGroups).BindTo(editorBeatmap.ControlPointInfo.Groups);
+            controlPointGroups.BindTo(editorBeatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((_, __) => updateTimingGroup());
 
             beatLength.BindValueChanged(_ => showFrom(lastDisplayedBeatIndex), true);

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.11.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.521.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.525.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.513.0" />
     <PackageReference Include="Sentry" Version="3.17.1" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.521.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.525.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.513.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.521.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.525.0" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/5197 for performance reasons

---

This is the next step towards a full timing solution. Similar to the metronome, this adds a new visual semi-interactive element which can be used to help understand the timing that is set, but doesn't directly allow mutating the timing yet. Hovering the display will allow scrubbing through the track.

I've tested this with makeshift adjustment controls and confirmed that it is very efficient in helping locate the correct BPM (and offset). Took around 6 seconds each to time a few beatmaps with visual only reference.

As a side note, visual only timing is only good to a certain extent. If you have a play with it, you'll notice that you can find BPM nodes at `bpm / 1.5`, `bpm / 2` etc. where waveforms will look to align but it is not the number you are searching for. This is intended to be one piece of a larger array of tools at a mapper's disposal.

Actual adjustment controls will come as a follow-up effort.

https://user-images.githubusercontent.com/191335/169956666-4f8fd4aa-d020-4c02-abea-eca550d30602.mp4
