### PR TITLE
Move `OverlayColourProvider` provisioning of `RoundedButton` to `SettingsButton` for now

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
@@ -5,9 +5,12 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -15,14 +18,31 @@ namespace osu.Game.Tests.Visual.UserInterface
     {
         private readonly BindableBool enabled = new BindableBool(true);
 
-        protected override Drawable CreateContent() => new RoundedButton
+        protected override Drawable CreateContent()
         {
-            Width = 400,
-            Text = "Test button",
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            Enabled = { BindTarget = enabled },
-        };
+            return new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new RoundedButton
+                    {
+                        Width = 400,
+                        Text = "Test button",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Enabled = { BindTarget = enabled },
+                    },
+                    new SettingsButton
+                    {
+                        Text = "Test button",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Enabled = { BindTarget = enabled },
+                    },
+                }
+            };
+        }
 
         [Test]
         public void TestDisabled()
@@ -34,7 +54,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestBackgroundColour()
         {
             AddStep("set red scheme", () => CreateThemedContent(OverlayColourScheme.Red));
-            AddAssert("first button has correct colour", () => Cell(0, 1).ChildrenOfType<RoundedButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Highlight1);
+            AddAssert("rounded button has correct colour", () => Cell(0, 1).ChildrenOfType<RoundedButton>().First().BackgroundColour == new OsuColour().Blue3);
+            AddAssert("settings button has correct colour", () => Cell(0, 1).ChildrenOfType<SettingsButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Highlight1);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -2,13 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -27,9 +25,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+        private void load(OsuColour colours)
         {
-            DefaultBackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
+            // According to flyte, buttons are supposed to have explicit colours for now.
+            // Not sure this is the correct direction, but we haven't decided on an `OverlayColourProvider` stand-in yet.
+            // This is a better default. See `SettingsButton` for an override which uses `OverlayColourProvider`.
+            DefaultBackgroundColour = colours.Blue3;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Settings/SettingsButton.cs
+++ b/osu.Game/Overlays/Settings/SettingsButton.cs
@@ -3,9 +3,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Overlays.Settings
@@ -16,6 +19,12 @@ namespace osu.Game.Overlays.Settings
         {
             RelativeSizeAxes = Axes.X;
             Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS };
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+        {
+            DefaultBackgroundColour = overlayColourProvider?.Highlight1 ?? colours.Blue3;
         }
 
         public LocalisableString TooltipText { get; set; }


### PR DESCRIPTION
See inline comment for reasoning.

Basically this makes every `RoundedButton` blue unless using a `SettingsButton` (which will prefer the overlay provider). Not final, but better behaving for now.