### PR TITLE
Remove `TriangleButton` usage in editor

### DIFF
--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens.Edit.Timing
     {
         private LabelledTextBox textBox;
 
-        private TriangleButton button;
+        private OsuButton button;
 
         [Resolved]
         protected Bindable<ControlPointGroup> SelectedGroup { get; private set; }
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Edit.Timing
                         {
                             Label = "Time"
                         },
-                        button = new TriangleButton
+                        button = new RoundedButton
                         {
                             Text = "Use current time",
                             RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -100,7 +101,7 @@ namespace osu.Game.Screens.Edit.Timing
                         Spacing = new Vector2(5),
                         Children = new Drawable[]
                         {
-                            deleteButton = new OsuButton
+                            deleteButton = new RoundedButton
                             {
                                 Text = "-",
                                 Size = new Vector2(30, 30),
@@ -108,7 +109,7 @@ namespace osu.Game.Screens.Edit.Timing
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,
                             },
-                            new OsuButton
+                            new RoundedButton
                             {
                                 Text = "+ Add at current time",
                                 Action = addNew,

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Edit.Verify
                     Margin = new MarginPadding(20),
                     Children = new Drawable[]
                     {
-                        new TriangleButton
+                        new RoundedButton
                         {
                             Text = "Refresh",
                             Action = refresh,


### PR DESCRIPTION
As I move the editor forward towards the new design direction, having these buttons with incorrect corner radius was an eyesore.

Going forwards, all `RoundedButton`s will have triangles, so eventually the visual look will be similar.