### PR TITLE
Update beat snap divisor control to be more in line with new designs

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Database;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Screens.Edit;
@@ -45,6 +46,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                     {
                         (typeof(EditorBeatmap), editorBeatmap),
                         (typeof(IBeatSnapProvider), editorBeatmap),
+                        (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Green)),
                     },
                     Child = new ComposeScreen { State = { Value = Visibility.Visible } },
                 };

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Editing
         private BindableBeatDivisor bindableBeatDivisor;
 
         private SliderBar<int> tickSliderBar => beatDivisorControl.ChildrenOfType<SliderBar<int>>().Single();
-        private EquilateralTriangle tickMarkerHead => tickSliderBar.ChildrenOfType<EquilateralTriangle>().Single();
+        private Triangle tickMarkerHead => tickSliderBar.ChildrenOfType<Triangle>().Single();
 
         [Cached]
         private readonly OverlayColourProvider overlayColour = new OverlayColourProvider(OverlayColourScheme.Green);

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -5,11 +5,13 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
+using osu.Game.Overlays;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
@@ -24,6 +26,9 @@ namespace osu.Game.Tests.Visual.Editing
 
         private SliderBar<int> tickSliderBar => beatDivisorControl.ChildrenOfType<SliderBar<int>>().Single();
         private EquilateralTriangle tickMarkerHead => tickSliderBar.ChildrenOfType<EquilateralTriangle>().Single();
+
+        [Cached]
+        private readonly OverlayColourProvider overlayColour = new OverlayColourProvider(OverlayColourScheme.Green);
 
         [SetUp]
         public void SetUp() => Schedule(() =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -47,6 +48,7 @@ namespace osu.Game.Tests.Visual.Editing
                     {
                         (typeof(EditorBeatmap), editorBeatmap),
                         (typeof(IBeatSnapProvider), editorBeatmap),
+                        (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Green)),
                     },
                     Child = new ComposeScreen { State = { Value = Visibility.Visible } },
                 };

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineTickDisplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineTickDisplay.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Overlays;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -13,6 +14,9 @@ namespace osu.Game.Tests.Visual.Editing
     public class TestSceneTimelineTickDisplay : TimelineTestScene
     {
         public override Drawable CreateTestComponent() => Empty(); // tick display is implicitly inside the timeline.
+
+        [Cached]
+        private readonly OverlayColourProvider overlayColour = new OverlayColourProvider(OverlayColourScheme.Green);
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit
@@ -97,6 +98,32 @@ namespace osu.Game.Screens.Edit
 
                 default:
                     return Color4.Red;
+            }
+        }
+
+        /// <summary>
+        /// Get a relative display size for the specified divisor.
+        /// </summary>
+        /// <param name="beatDivisor">The beat divisor.</param>
+        /// <returns>A relative size which can be used to display ticks.</returns>
+        public static Vector2 GetSize(int beatDivisor)
+        {
+            switch (beatDivisor)
+            {
+                case 1:
+                case 2:
+                    return new Vector2(0.6f, 0.9f);
+
+                case 3:
+                case 4:
+                    return new Vector2(0.5f, 0.8f);
+
+                case 6:
+                case 8:
+                    return new Vector2(0.4f, 0.7f);
+
+                default:
+                    return new Vector2(0.3f, 0.6f);
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -495,26 +495,22 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 [Resolved]
                 private OverlayColourProvider colourProvider { get; set; }
 
-                private const float size = 10;
-
                 [BackgroundDependencyLoader]
                 private void load()
                 {
                     Colour = colourProvider.Background3;
-                    Anchor = Anchor.TopLeft;
-                    Origin = Anchor.TopCentre;
+                    Anchor = Anchor.BottomLeft;
+                    Origin = Anchor.BottomCentre;
 
-                    Width = size;
-                    RelativeSizeAxes = Axes.Y;
+                    Size = new Vector2(8, 6.5f);
+
                     RelativePositionAxes = Axes.X;
 
                     InternalChildren = new Drawable[]
                     {
-                        new EquilateralTriangle
+                        new Triangle
                         {
-                            Origin = Anchor.BottomCentre,
-                            Anchor = Anchor.BottomCentre,
-                            Height = size,
+                            RelativeSizeAxes = Axes.Both,
                             EdgeSmoothness = new Vector2(1),
                             Colour = Color4.White,
                         }

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -8,9 +8,7 @@ using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
@@ -22,6 +20,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -38,18 +37,17 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             Masking = true;
-            CornerRadius = 5;
 
             InternalChildren = new Drawable[]
             {
                 new Box
                 {
-                    Name = "Gray Background",
+                    Name = "Main background",
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.Gray4
+                    Colour = colourProvider.Background3,
                 },
                 new GridContainer
                 {
@@ -65,9 +63,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
                                 {
                                     new Box
                                     {
-                                        Name = "Black Background",
+                                        Name = "Tick area background",
                                         RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.Black
+                                        Colour = colourProvider.Background5,
                                     },
                                     new TickSliderBar(beatDivisor)
                                     {
@@ -86,7 +84,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                                     new Box
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        Colour = colours.Gray4
+                                        Colour = colourProvider.Background3
                                     },
                                     new Container
                                     {
@@ -139,11 +137,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                                 RelativeSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = colours.Gray4
-                                    },
                                     new Container
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -402,15 +395,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 ClearInternal();
                 CurrentNumber.ValueChanged -= moveMarker;
 
-                foreach (int t in beatDivisor.ValidDivisors.Value.Presets)
+                foreach (int divisor in beatDivisor.ValidDivisors.Value.Presets)
                 {
-                    AddInternal(new Tick
+                    AddInternal(new Tick(divisor)
                     {
-                        Anchor = Anchor.TopLeft,
-                        Origin = Anchor.TopCentre,
-                        RelativePositionAxes = Axes.X,
-                        Colour = BindableBeatDivisor.GetColourFor(t, colours),
-                        X = getMappedPosition(t)
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.Centre,
+                        RelativePositionAxes = Axes.Both,
+                        Colour = BindableBeatDivisor.GetColourFor(divisor, colours),
+                        X = getMappedPosition(divisor),
                     });
                 }
 
@@ -422,7 +415,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             private void moveMarker(ValueChangedEvent<int> divisor)
             {
                 marker.MoveToX(getMappedPosition(divisor.NewValue), 100, Easing.OutQuint);
-                marker.Flash();
             }
 
             protected override void UpdateValue(float value)
@@ -489,29 +481,26 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             private float getMappedPosition(float divisor) => MathF.Pow((divisor - 1) / (beatDivisor.ValidDivisors.Value.Presets.Last() - 1), 0.90f);
 
-            private class Tick : CompositeDrawable
+            private class Tick : Circle
             {
-                public Tick()
+                public Tick(int divisor)
                 {
-                    Size = new Vector2(2.5f, 10);
-
+                    Size = new Vector2(6f, 12) * BindableBeatDivisor.GetSize(divisor);
                     InternalChild = new Box { RelativeSizeAxes = Axes.Both };
-
-                    CornerRadius = 0.5f;
-                    Masking = true;
                 }
             }
 
             private class Marker : CompositeDrawable
             {
-                private Color4 defaultColour;
+                [Resolved]
+                private OverlayColourProvider colourProvider { get; set; }
 
-                private const float size = 7;
+                private const float size = 10;
 
                 [BackgroundDependencyLoader]
-                private void load(OsuColour colours)
+                private void load()
                 {
-                    Colour = defaultColour = colours.Gray4;
+                    Colour = colourProvider.Background3;
                     Anchor = Anchor.TopLeft;
                     Origin = Anchor.TopCentre;
 
@@ -521,15 +510,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                     InternalChildren = new Drawable[]
                     {
-                        new Box
-                        {
-                            Width = 2,
-                            RelativeSizeAxes = Axes.Y,
-                            Origin = Anchor.BottomCentre,
-                            Anchor = Anchor.BottomCentre,
-                            Colour = ColourInfo.GradientVertical(Color4.White.Opacity(0.2f), Color4.White),
-                            Blending = BlendingParameters.Additive,
-                        },
                         new EquilateralTriangle
                         {
                             Origin = Anchor.BottomCentre,
@@ -548,21 +528,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     get => active;
                     set
                     {
-                        this.FadeColour(value ? Color4.White : defaultColour, 500, Easing.OutQuint);
+                        this.FadeColour(value ? colourProvider.Background1 : colourProvider.Background3, 500, Easing.OutQuint);
                         active = value;
                     }
-                }
-
-                public void Flash()
-                {
-                    bool wasActive = active;
-
-                    Active = true;
-
-                    if (wasActive) return;
-
-                    using (BeginDelayedSequence(50))
-                        Active = false;
                 }
             }
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
@@ -132,10 +133,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                         // even though "bar lines" take up the full vertical space, we render them in two pieces because it allows for less anchor/origin churn.
 
+                        Vector2 size = Vector2.One;
+
+                        if (indexInBar != 1)
+                            size = BindableBeatDivisor.GetSize(divisor);
+
                         var line = getNextUsableLine();
                         line.X = xPos;
-                        line.Width = PointVisualisation.MAX_WIDTH * getWidth(indexInBar, divisor);
-                        line.Height = 0.9f * getHeight(indexInBar, divisor);
+                        line.Width = PointVisualisation.MAX_WIDTH * size.X;
+                        line.Height = 0.9f * size.Y;
                         line.Colour = colour;
                     }
 
@@ -167,54 +173,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 point.Show();
 
                 return point;
-            }
-        }
-
-        private static float getWidth(int indexInBar, int divisor)
-        {
-            if (indexInBar == 0)
-                return 1;
-
-            switch (divisor)
-            {
-                case 1:
-                case 2:
-                    return 0.6f;
-
-                case 3:
-                case 4:
-                    return 0.5f;
-
-                case 6:
-                case 8:
-                    return 0.4f;
-
-                default:
-                    return 0.3f;
-            }
-        }
-
-        private static float getHeight(int indexInBar, int divisor)
-        {
-            if (indexInBar == 0)
-                return 1;
-
-            switch (divisor)
-            {
-                case 1:
-                case 2:
-                    return 0.9f;
-
-                case 3:
-                case 4:
-                    return 0.8f;
-
-                case 6:
-                case 8:
-                    return 0.7f;
-
-                default:
-                    return 0.6f;
             }
         }
 


### PR DESCRIPTION
Note that this doesn't match figma 100%. This is just focused on getting it to fit with the surrounding controls for now, proportionally and corner radius-ly.