### PR TITLE
Handle beat divisor input on mouse down, rather than mouse up

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -453,6 +453,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             protected override bool OnMouseDown(MouseDownEvent e)
             {
                 marker.Active = true;
+                handleMouseInput(e.ScreenSpaceMousePosition);
                 return base.OnMouseDown(e);
             }
 


### PR DESCRIPTION
It felt way too unresponsive previously due to the drag start delay. This is the kind of control where you expect immediate feedback as it already has some sane snapping logic that avoids accidentally "dragging" on tablet/touch.