### PR TITLE
Move UI scale setup to the beginning of the first run setup

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             AddStep("step to next", () => overlay.NextButton.TriggerClick());
 
-            AddAssert("is at known screen", () => overlay.CurrentScreen is ScreenBeatmaps);
+            AddAssert("is at known screen", () => overlay.CurrentScreen is ScreenUIScale);
 
             AddStep("hide", () => overlay.Hide());
             AddAssert("overlay hidden", () => overlay.State.Value == Visibility.Hidden);
@@ -195,7 +195,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("run notification action", () => lastNotification.Activated());
 
             AddAssert("overlay shown", () => overlay.State.Value == Visibility.Visible);
-            AddAssert("is resumed", () => overlay.CurrentScreen is ScreenBeatmaps);
+            AddAssert("is resumed", () => overlay.CurrentScreen is ScreenUIScale);
         }
 
         // interface mocks break hot reload, mocking this stub implementation instead works around it.

--- a/osu.Game/Overlays/FirstRunSetupOverlay.cs
+++ b/osu.Game/Overlays/FirstRunSetupOverlay.cs
@@ -76,10 +76,10 @@ namespace osu.Game.Overlays
         private void load(OsuColour colours, LegacyImportManager? legacyImportManager)
         {
             steps.Add(typeof(ScreenWelcome));
+            steps.Add(typeof(ScreenUIScale));
             steps.Add(typeof(ScreenBeatmaps));
             if (legacyImportManager?.SupportsImportFromStable == true)
                 steps.Add(typeof(ScreenImportFromStable));
-            steps.Add(typeof(ScreenUIScale));
             steps.Add(typeof(ScreenBehaviour));
 
             Header.Title = FirstRunSetupOverlayStrings.FirstRunSetupTitle;


### PR DESCRIPTION
As discussed. In the future I could see us also using a predetermined UI scale on startup based on device / DPI.

---

When running on a device where the default UI scale is too large or small, this would be the first setting you want to change, so now it is shown first.