### PR TITLE
Disable select/deselect all buttons on mod overlay when they have no effect

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
@@ -9,7 +9,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Testing;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Mods;
@@ -73,23 +72,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             createFreeModSelect();
 
-            AddAssert("select all button enabled", () => this.ChildrenOfType<ShearedButton>().ElementAt(1).Enabled.Value);
+            AddAssert("select all button enabled", () => this.ChildrenOfType<SelectAllModsButton>().Single().Enabled.Value);
 
             AddStep("click select all button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().ElementAt(1));
+                InputManager.MoveMouseTo(this.ChildrenOfType<SelectAllModsButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods selected", assertAllAvailableModsSelected);
-            AddAssert("select all button disabled", () => !this.ChildrenOfType<ShearedButton>().ElementAt(1).Enabled.Value);
+            AddAssert("select all button disabled", () => !this.ChildrenOfType<SelectAllModsButton>().Single().Enabled.Value);
 
             AddStep("click deselect all button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().Last());
+                InputManager.MoveMouseTo(this.ChildrenOfType<DeselectAllModsButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods deselected", () => !freeModSelectOverlay.SelectedMods.Value.Any());
-            AddAssert("select all button enabled", () => this.ChildrenOfType<ShearedButton>().ElementAt(1).Enabled.Value);
+            AddAssert("select all button enabled", () => this.ChildrenOfType<SelectAllModsButton>().Single().Enabled.Value);
         }
 
         private void createFreeModSelect()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
@@ -73,12 +73,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             createFreeModSelect();
 
+            AddAssert("select all button enabled", () => this.ChildrenOfType<ShearedButton>().ElementAt(1).Enabled.Value);
+
             AddStep("click select all button", () =>
             {
                 InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().ElementAt(1));
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods selected", assertAllAvailableModsSelected);
+            AddAssert("select all button disabled", () => !this.ChildrenOfType<ShearedButton>().ElementAt(1).Enabled.Value);
 
             AddStep("click deselect all button", () =>
             {
@@ -86,6 +89,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods deselected", () => !freeModSelectOverlay.SelectedMods.Value.Any());
+            AddAssert("select all button enabled", () => this.ChildrenOfType<ShearedButton>().ElementAt(1).Enabled.Value);
         }
 
         private void createFreeModSelect()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -435,8 +435,11 @@ namespace osu.Game.Tests.Visual.UserInterface
             createScreen();
             changeRuleset(0);
 
+            AddAssert("deselect all button disabled", () => !this.ChildrenOfType<ShearedButton>().Last().Enabled.Value);
+
             AddStep("select DT + HD", () => SelectedMods.Value = new Mod[] { new OsuModDoubleTime(), new OsuModHidden() });
             AddAssert("DT + HD selected", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
+            AddAssert("deselect all button enabled", () => this.ChildrenOfType<ShearedButton>().Last().Enabled.Value);
 
             AddStep("click deselect all button", () =>
             {
@@ -444,6 +447,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods deselected", () => !SelectedMods.Value.Any());
+            AddAssert("deselect all button disabled", () => !this.ChildrenOfType<ShearedButton>().Last().Enabled.Value);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -435,19 +435,19 @@ namespace osu.Game.Tests.Visual.UserInterface
             createScreen();
             changeRuleset(0);
 
-            AddAssert("deselect all button disabled", () => !this.ChildrenOfType<ShearedButton>().Last().Enabled.Value);
+            AddAssert("deselect all button disabled", () => !this.ChildrenOfType<DeselectAllModsButton>().Single().Enabled.Value);
 
             AddStep("select DT + HD", () => SelectedMods.Value = new Mod[] { new OsuModDoubleTime(), new OsuModHidden() });
             AddAssert("DT + HD selected", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value) == 2);
-            AddAssert("deselect all button enabled", () => this.ChildrenOfType<ShearedButton>().Last().Enabled.Value);
+            AddAssert("deselect all button enabled", () => this.ChildrenOfType<DeselectAllModsButton>().Single().Enabled.Value);
 
             AddStep("click deselect all button", () =>
             {
-                InputManager.MoveMouseTo(this.ChildrenOfType<ShearedButton>().Last());
+                InputManager.MoveMouseTo(this.ChildrenOfType<DeselectAllModsButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("all mods deselected", () => !SelectedMods.Value.Any());
-            AddAssert("deselect all button disabled", () => !this.ChildrenOfType<ShearedButton>().Last().Enabled.Value);
+            AddAssert("deselect all button disabled", () => !this.ChildrenOfType<DeselectAllModsButton>().Single().Enabled.Value);
         }
 
         [Test]

--- a/osu.Game/Overlays/Mods/DeselectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/DeselectAllModsButton.cs
@@ -15,11 +15,27 @@ namespace osu.Game.Overlays.Mods
 {
     public class DeselectAllModsButton : ShearedButton, IKeyBindingHandler<GlobalAction>
     {
+        private readonly Bindable<IReadOnlyList<Mod>> selectedMods = new Bindable<IReadOnlyList<Mod>>();
+
         public DeselectAllModsButton(ModSelectOverlay modSelectOverlay)
             : base(ModSelectOverlay.BUTTON_WIDTH)
         {
             Text = CommonStrings.DeselectAll;
             Action = modSelectOverlay.DeselectAll;
+
+            selectedMods.BindTo(modSelectOverlay.SelectedMods);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            selectedMods.BindValueChanged(_ => updateEnabledState(), true);
+        }
+
+        private void updateEnabledState()
+        {
+            Enabled.Value = selectedMods.Value.Any();
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game/Overlays/Mods/DeselectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/DeselectAllModsButton.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class DeselectAllModsButton : ShearedButton, IKeyBindingHandler<GlobalAction>
+    {
+        public DeselectAllModsButton(ModSelectOverlay modSelectOverlay)
+            : base(ModSelectOverlay.BUTTON_WIDTH)
+        {
+            Text = CommonStrings.DeselectAll;
+            Action = modSelectOverlay.DeselectAll;
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat || e.Action != GlobalAction.DeselectAllMods)
+                return false;
+
+            TriggerClick();
+            return true;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Overlays.Mods
         /// <summary>
         /// Select all visible mods in all columns.
         /// </summary>
-        protected void SelectAll()
+        public void SelectAll()
         {
             foreach (var column in columnFlow.Columns)
                 column.SelectAll();

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.Mods
 {
     public abstract class ModSelectOverlay : ShearedOverlayContainer, ISamplePlaybackDisabler
     {
-        protected const int BUTTON_WIDTH = 200;
+        public const int BUTTON_WIDTH = 200;
 
         [Cached]
         public Bindable<IReadOnlyList<Mod>> SelectedMods { get; private set; } = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
@@ -76,11 +76,7 @@ namespace osu.Game.Overlays.Mods
                 };
             }
 
-            yield return deselectAllButton = new ShearedButton(BUTTON_WIDTH)
-            {
-                Text = CommonStrings.DeselectAll,
-                Action = DeselectAll
-            };
+            yield return new DeselectAllModsButton(this);
         }
 
         private readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>();
@@ -98,7 +94,6 @@ namespace osu.Game.Overlays.Mods
         private DifficultyMultiplierDisplay? multiplierDisplay;
 
         private ShearedToggleButton? customisationButton;
-        private ShearedButton? deselectAllButton;
 
         protected ModSelectOverlay(OverlayColourScheme colourScheme = OverlayColourScheme.Green)
             : base(colourScheme)
@@ -256,7 +251,7 @@ namespace osu.Game.Overlays.Mods
         /// <summary>
         /// Deselect all visible mods in all columns.
         /// </summary>
-        protected void DeselectAll()
+        public void DeselectAll()
         {
             foreach (var column in columnFlow.Columns)
                 column.DeselectAll();
@@ -514,10 +509,6 @@ namespace osu.Game.Overlays.Mods
                     hideOverlay(true);
                     return true;
                 }
-
-                case GlobalAction.DeselectAllMods:
-                    deselectAllButton?.TriggerClick();
-                    return true;
             }
 
             return base.OnPressed(e);

--- a/osu.Game/Overlays/Mods/SelectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/SelectAllModsButton.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+using osu.Game.Screens.OnlinePlay;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class SelectAllModsButton : ShearedButton, IKeyBindingHandler<PlatformAction>
+    {
+        public SelectAllModsButton(FreeModSelectOverlay modSelectOverlay)
+            : base(ModSelectOverlay.BUTTON_WIDTH)
+        {
+            Text = CommonStrings.SelectAll;
+            Action = modSelectOverlay.SelectAll;
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+        {
+            if (e.Repeat || e.Action != PlatformAction.SelectAll)
+                return false;
+
+            TriggerClick();
+            return true;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/SelectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/SelectAllModsButton.cs
@@ -1,22 +1,48 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay;
 
 namespace osu.Game.Overlays.Mods
 {
     public class SelectAllModsButton : ShearedButton, IKeyBindingHandler<PlatformAction>
     {
+        private readonly Bindable<IReadOnlyList<Mod>> selectedMods = new Bindable<IReadOnlyList<Mod>>();
+        private readonly Bindable<Dictionary<ModType, IReadOnlyList<ModState>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<ModState>>>();
+
         public SelectAllModsButton(FreeModSelectOverlay modSelectOverlay)
             : base(ModSelectOverlay.BUTTON_WIDTH)
         {
             Text = CommonStrings.SelectAll;
             Action = modSelectOverlay.SelectAll;
+
+            selectedMods.BindTo(modSelectOverlay.SelectedMods);
+            availableMods.BindTo(modSelectOverlay.AvailableMods);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            selectedMods.BindValueChanged(_ => Scheduler.AddOnce(updateEnabledState));
+            availableMods.BindValueChanged(_ => Scheduler.AddOnce(updateEnabledState));
+            updateEnabledState();
+        }
+
+        private void updateEnabledState()
+        {
+            Enabled.Value = availableMods.Value
+                                         .SelectMany(pair => pair.Value)
+                                         .Any(modState => !modState.Active.Value && !modState.Filtered.Value);
         }
 
         public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)

--- a/osu.Game/Screens/OnlinePlay/FreeModSelectOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/FreeModSelectOverlay.cs
@@ -6,18 +6,14 @@ using osu.Game.Overlays;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
-using osu.Framework.Input;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osuTK.Input;
-using osu.Game.Localisation;
 
 namespace osu.Game.Screens.OnlinePlay
 {
-    public class FreeModSelectOverlay : ModSelectOverlay, IKeyBindingHandler<PlatformAction>
+    public class FreeModSelectOverlay : ModSelectOverlay
     {
         protected override bool ShowTotalMultiplier => false;
 
@@ -29,8 +25,6 @@ namespace osu.Game.Screens.OnlinePlay
             set => base.IsValidMod = m => m.UserPlayable && value.Invoke(m);
         }
 
-        private ShearedButton selectAllButton;
-
         public FreeModSelectOverlay()
             : base(OverlayColourScheme.Plum)
         {
@@ -40,31 +34,10 @@ namespace osu.Game.Screens.OnlinePlay
         protected override ModColumn CreateModColumn(ModType modType, Key[] toggleKeys = null) => new ModColumn(modType, true, toggleKeys);
 
         protected override IEnumerable<ShearedButton> CreateFooterButtons() => base.CreateFooterButtons().Prepend(
-            selectAllButton = new ShearedButton(BUTTON_WIDTH)
+            new SelectAllModsButton(this)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,
-                Text = CommonStrings.SelectAll,
-                Action = SelectAll
             });
-
-        public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
-        {
-            if (e.Repeat)
-                return false;
-
-            switch (e.Action)
-            {
-                case PlatformAction.SelectAll:
-                    selectAllButton.TriggerClick();
-                    return true;
-            }
-
-            return false;
-        }
-
-        public void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)
-        {
-        }
     }
 }


### PR DESCRIPTION
Was mentioned offhand as a UX shortcoming that I had on my list to fix.

https://user-images.githubusercontent.com/20418176/170369170-f57a9e9f-615b-49af-8819-26b6e9bf051d.mp4

I ended up splitting the buttons off to separate files because it was starting to feel like there would be too much implementation at the overlay level. I think this cleaned up rather well myself, but interested in seeing whether that opinion holds up to scrutiny.