### PR TITLE
Handle server shutdown messages in room creation and spectator initialisation

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Online
 {
     public class HubClientConnector : IHubClientConnector
     {
+        public const string SERVER_SHUTDOWN_MESSAGE = "Server is shutting down.";
+
         /// <summary>
         /// Invoked whenever a new hub connection is built, to configure it before it's started.
         /// </summary>

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -64,20 +64,28 @@ namespace osu.Game.Online
             this.preferMessagePack = preferMessagePack;
 
             apiState.BindTo(api.State);
-            apiState.BindValueChanged(state =>
-            {
-                switch (state.NewValue)
-                {
-                    case APIState.Failing:
-                    case APIState.Offline:
-                        Task.Run(() => disconnect(true));
-                        break;
+            apiState.BindValueChanged(state => connectIfPossible(), true);
+        }
 
-                    case APIState.Online:
-                        Task.Run(connect);
-                        break;
-                }
-            }, true);
+        public void Reconnect()
+        {
+            Logger.Log($"{clientName} reconnecting...", LoggingTarget.Network);
+            Task.Run(connectIfPossible);
+        }
+
+        private void connectIfPossible()
+        {
+            switch (apiState.Value)
+            {
+                case APIState.Failing:
+                case APIState.Offline:
+                    Task.Run(() => disconnect(true));
+                    break;
+
+                case APIState.Online:
+                    Task.Run(connect);
+                    break;
+            }
         }
 
         private async Task connect()

--- a/osu.Game/Online/IHubClientConnector.cs
+++ b/osu.Game/Online/IHubClientConnector.cs
@@ -30,5 +30,10 @@ namespace osu.Game.Online
         /// Invoked whenever a new hub connection is built, to configure it before it's started.
         /// </summary>
         public Action<HubConnection>? ConfigureConnection { get; set; }
+
+        /// <summary>
+        /// Reconnect if already connected.
+        /// </summary>
+        void Reconnect();
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClientExtensions.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClientExtensions.cs
@@ -25,12 +25,7 @@ namespace osu.Game.Online.Multiplayer
 
                     Debug.Assert(exception != null);
 
-                    string message = exception is HubException
-                        // HubExceptions arrive with additional message context added, but we want to display the human readable message:
-                        // "An unexpected error occurred invoking 'AddPlaylistItem' on the server.InvalidStateException: Can't enqueue more than 3 items at once."
-                        // We generally use the message field for a user-parseable error (eventually to be replaced), so drop the first part for now.
-                        ? exception.Message.Substring(exception.Message.IndexOf(':') + 1).Trim()
-                        : exception.Message;
+                    string message = exception.GetHubExceptionMessage() ?? exception.Message;
 
                     Logger.Log(message, level: LogLevel.Important);
                     onError?.Invoke(exception);
@@ -40,5 +35,16 @@ namespace osu.Game.Online.Multiplayer
                     onSuccess?.Invoke();
                 }
             });
+
+        public static string? GetHubExceptionMessage(this Exception exception)
+        {
+            if (exception is HubException hubException)
+                // HubExceptions arrive with additional message context added, but we want to display the human readable message:
+                // "An unexpected error occurred invoking 'AddPlaylistItem' on the server.InvalidStateException: Can't enqueue more than 3 items at once."
+                // We generally use the message field for a user-parseable error (eventually to be replaced), so drop the first part for now.
+                return hubException.Message.Substring(exception.Message.IndexOf(':') + 1).Trim();
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Partner PR to ppy/osu-server-spectator#133.

Forcing a reconnect will allow the client to (hopefully) connect to a fresh server instance where it is more welcome.