### PR TITLE
Fix multiplayer race condition when starting gameplay

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -149,6 +149,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override void StartGameplay()
         {
+            // We can enter this screen one of two ways:
+            // 1. Via the automatic natural progression of PlayerLoader into Player.
+            //    We'll arrive here in a Loaded state, and we need to let the server know that we're ready to start.
+            // 2. Via the server forcefully starting gameplay because players have been hanging out in PlayerLoader for too long.
+            //    We'll arrive here in a Playing state, and we should neither show the loading spinner nor tell the server that we're ready to start (gameplay has already started).
+
             if (client.LocalUser?.State == MultiplayerUserState.Loaded)
             {
                 // block base call, but let the server know we are ready to start.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -154,10 +154,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             //    We'll arrive here in a Loaded state, and we need to let the server know that we're ready to start.
             // 2. Via the server forcefully starting gameplay because players have been hanging out in PlayerLoader for too long.
             //    We'll arrive here in a Playing state, and we should neither show the loading spinner nor tell the server that we're ready to start (gameplay has already started).
+            //
+            // The base call is blocked here because in both cases gameplay is started only when the server says so via onGameplayStarted().
 
             if (client.LocalUser?.State == MultiplayerUserState.Loaded)
             {
-                // block base call, but let the server know we are ready to start.
                 loadingDisplay.Show();
                 client.ChangeState(MultiplayerUserState.ReadyForGameplay);
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayerLoader.cs
@@ -26,8 +26,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         }
 
         protected override bool ReadyForGameplay =>
-            base.ReadyForGameplay
-            // The server is forcefully starting gameplay.
+            (
+                // The user is ready to enter gameplay.
+                base.ReadyForGameplay
+                // And the server has received the message that we're loaded.
+                && multiplayerClient.LocalUser?.State == MultiplayerUserState.Loaded
+            )
+            // Or the server is forcefully starting gameplay.
             || multiplayerClient.LocalUser?.State == MultiplayerUserState.Playing;
 
         protected override void OnPlayerLoaded()


### PR DESCRIPTION
Since the server is authoritative on all user states, there may/will be a delay between the `Loaded` state being sent and received. The local user state is only updated when it's received. During this delay, if [`Player.StartGameplay()`](https://github.com/ppy/osu/blob/c524b665adba2203b601eefd5f0a59ac749dc433/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs#L150-L158) is triggered then it will not send the `ReadyForGameplay` state.  
This would result in all players waiting for 1 minute (the server's start timeout) before gameplay starts.

The fix I've gone with is to wait for the `Loaded` state to be received before progressing the local user to `Player`.

Can be reproed with:
```diff
diff --git a/osu.Game/Online/Multiplayer/MultiplayerClient.cs b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
index cae675b406..1a8d4aebe6 100644
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -490,8 +490,10 @@ Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
             return Task.CompletedTask;
         }

-        Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
+        async Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
         {
+            await Task.Delay(5000).ConfigureAwait(false);
+
             Scheduler.Add(() =>
             {
                 var user = Room?.Users.SingleOrDefault(u => u.UserID == userId);
@@ -505,8 +507,6 @@ Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)

                 RoomUpdated?.Invoke();
             }, false);
-
-            return Task.CompletedTask;
         }

         Task IMultiplayerClient.MatchUserStateChanged(int userId, MatchUserState state)
```