### PR TITLE
Fix beatmap info status pill being incorrect on multiple status beatmaps

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -10,6 +10,8 @@ using osu.Game.Rulesets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps.Drawables;
 using osu.Game.Online.API.Requests.Responses;
 using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
 
@@ -101,6 +103,12 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep("show many difficulties", () => overlay.ShowBeatmapSet(createManyDifficultiesBeatmapSet()));
             downloadAssert(true);
+
+            AddAssert("status is loved", () => overlay.ChildrenOfType<BeatmapSetOnlineStatusPill>().Single().Status == BeatmapOnlineStatus.Loved);
+
+            AddStep("go to second beatmap", () => overlay.ChildrenOfType<BeatmapPicker.DifficultySelectorButton>().ElementAt(1).TriggerClick());
+
+            AddAssert("status is graveyard", () => overlay.ChildrenOfType<BeatmapSetOnlineStatusPill>().Single().Status == BeatmapOnlineStatus.Graveyard);
         }
 
         [Test]
@@ -232,6 +240,7 @@ namespace osu.Game.Tests.Visual.Online
                         Fails = Enumerable.Range(1, 100).Select(j => j % 12 - 6).ToArray(),
                         Retries = Enumerable.Range(-2, 100).Select(j => j % 12 - 6).ToArray(),
                     },
+                    Status = i % 2 == 0 ? BeatmapOnlineStatus.Graveyard : BeatmapOnlineStatus.Loved,
                 });
             }
 

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -229,6 +230,8 @@ namespace osu.Game.Overlays.BeatmapSet
             {
                 Details.BeatmapInfo = b.NewValue;
                 externalLink.Link = $@"{api.WebsiteRootUrl}/beatmapsets/{BeatmapSet.Value?.OnlineID}#{b.NewValue?.Ruleset.ShortName}/{b.NewValue?.OnlineID}";
+
+                onlineStatusPill.Status = b.NewValue?.Status ?? BeatmapOnlineStatus.None;
             };
         }
 
@@ -272,7 +275,6 @@ namespace osu.Game.Overlays.BeatmapSet
                     featuredArtist.Alpha = setInfo.NewValue.TrackId != null ? 1 : 0;
 
                     onlineStatusPill.FadeIn(500, Easing.OutQuint);
-                    onlineStatusPill.Status = setInfo.NewValue.Status;
 
                     downloadButtonsContainer.FadeIn(transition_duration);
                     favouriteButton.FadeIn(transition_duration);


### PR DESCRIPTION
For example, loved beatmaps with some difficulties left as graveyard. This matches web.