### PR TITLE
Use existing web localisation for chat strings

### DIFF
--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -7,14 +7,17 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat.Listing;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Chat.ChannelList
 {
@@ -57,13 +60,13 @@ namespace osu.Game.Overlays.Chat.ChannelList
                         AutoSizeAxes = Axes.Y,
                         Children = new Drawable[]
                         {
-                            new ChannelListLabel("CHANNELS"),
+                            new ChannelListLabel(ChatStrings.ChannelsListTitlePUBLIC.ToUpper()),
                             publicChannelFlow = new ChannelListItemFlow(),
                             selector = new ChannelListItem(ChannelListingChannel)
                             {
                                 Margin = new MarginPadding { Bottom = 10 },
                             },
-                            new ChannelListLabel("DIRECT MESSAGES"),
+                            new ChannelListLabel(ChatStrings.ChannelsListTitlePM.ToUpper()),
                             privateChannelFlow = new ChannelListItemFlow(),
                         },
                     },
@@ -126,7 +129,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
         private class ChannelListLabel : OsuSpriteText
         {
-            public ChannelListLabel(string label)
+            public ChannelListLabel(LocalisableString label)
             {
                 Text = label;
                 Margin = new MarginPadding { Left = 18, Bottom = 5 };

--- a/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
+++ b/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
 
@@ -58,7 +59,7 @@ namespace osu.Game.Overlays.Chat
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
-                                Text = "osu!chat",
+                                Text = ChatStrings.TitleCompact,
                                 Font = OsuFont.Torus.With(size: 16, weight: FontWeight.SemiBold),
                                 Margin = new MarginPadding { Bottom = 2f },
                             },

--- a/osu.Game/Overlays/Chat/ChatTextBar.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBar.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Chat;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Overlays.Chat
@@ -141,11 +142,11 @@ namespace osu.Game.Overlays.Chat
                 switch (newChannel?.Type)
                 {
                     case ChannelType.Public:
-                        chattingText.Text = $"chatting in {newChannel.Name}";
+                        chattingText.Text = ChatStrings.TalkingIn(newChannel.Name);
                         break;
 
                     case ChannelType.PM:
-                        chattingText.Text = $"chatting with {newChannel.Name}";
+                        chattingText.Text = ChatStrings.TalkingWith(newChannel.Name);
                         break;
 
                     default:

--- a/osu.Game/Overlays/Chat/ChatTextBox.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBox.cs
@@ -5,6 +5,7 @@
 
 using osu.Framework.Bindables;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Chat
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Overlays.Chat
             {
                 bool showSearch = change.NewValue;
 
-                PlaceholderText = showSearch ? "type here to search" : "type here";
+                PlaceholderText = showSearch ? HomeStrings.SearchPlaceholder : ChatStrings.InputPlaceholder;
                 Text = string.Empty;
             }, true);
         }


### PR DESCRIPTION
Differences:
- `osu!chat` -> `chat` (will be removed anyway)
- `chatting in/with` -> `talking in/with`
- `type here to search` -> `type to search`
- `type here` -> `type message...`