### PR TITLE
Don't output beatmap parse failures in a visible manner

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps.Formats
                 }
                 catch (Exception e)
                 {
-                    Logger.Log($"Failed to process line \"{line}\" into \"{output}\": {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                    Logger.Log($"Failed to process line \"{line}\" into \"{output}\": {e.Message}");
                 }
             }
         }


### PR DESCRIPTION
The user can't do much about this. When a user reports a beatmap issue, the logs will still contain this useful information. Should be fine I think.

As mentioned in

https://github.com/ppy/osu/discussions/18426
https://github.com/ppy/osu/issues/750
https://github.com/ppy/osu/issues/18372

etc.