### PR TITLE
Display Announce type channels separately in new chat overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     leaveText.Text = $"OnRequestLeave: {channel.Name}";
                     leaveText.FadeOutFromOne(1000, Easing.InQuint);
-                    selected.Value = null;
+                    selected.Value = channelList.ChannelListingChannel;
                     channelList.RemoveChannel(channel);
                 };
 
@@ -111,6 +111,12 @@ namespace osu.Game.Tests.Visual.Online
             {
                 for (int i = 0; i < 10; i++)
                     channelList.AddChannel(createRandomPrivateChannel());
+            });
+
+            AddStep("Add Announce Channels", () =>
+            {
+                for (int i = 0; i < 2; i++)
+                    channelList.AddChannel(createRandomAnnounceChannel());
             });
         }
 
@@ -169,6 +175,17 @@ namespace osu.Game.Tests.Visual.Online
                 Id = id,
                 Username = $"test user {id}",
             });
+        }
+
+        private Channel createRandomAnnounceChannel()
+        {
+            int id = RNG.Next(0, 10000);
+            return new Channel
+            {
+                Name = $"Announce {id}",
+                Type = ChannelType.Announce,
+                Id = id,
+            };
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
@@ -452,6 +452,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestKeyboardNextChannel()
         {
+            Channel announceChannel = createAnnounceChannel();
             Channel pmChannel1 = createPrivateChannel();
             Channel pmChannel2 = createPrivateChannel();
 
@@ -461,6 +462,7 @@ namespace osu.Game.Tests.Visual.Online
                 channelManager.JoinChannel(testChannel2);
                 channelManager.JoinChannel(pmChannel1);
                 channelManager.JoinChannel(pmChannel2);
+                channelManager.JoinChannel(announceChannel);
                 chatOverlay.Show();
             });
 
@@ -474,6 +476,9 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep("Press document next keys", () => InputManager.Keys(PlatformAction.DocumentNext));
             AddAssert("PM Channel 2 displayed", () => channelIsVisible && currentDrawableChannel.Channel == pmChannel2);
+
+            AddStep("Press document next keys", () => InputManager.Keys(PlatformAction.DocumentNext));
+            AddAssert("Announce channel displayed", () => channelIsVisible && currentDrawableChannel.Channel == announceChannel);
 
             AddStep("Press document next keys", () => InputManager.Keys(PlatformAction.DocumentNext));
             AddAssert("Channel 1 displayed", () => channelIsVisible && currentDrawableChannel.Channel == testChannel1);
@@ -537,6 +542,17 @@ namespace osu.Game.Tests.Visual.Online
                 Id = id,
                 Username = $"test user {id}",
             });
+        }
+
+        private Channel createAnnounceChannel()
+        {
+            int id = RNG.Next(0, 10000);
+            return new Channel
+            {
+                Name = $"Announce {id}",
+                Type = ChannelType.Announce,
+                Id = id,
+            };
         }
 
         private class TestChatOverlayV2 : ChatOverlayV2

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -26,8 +26,8 @@ namespace osu.Game.Overlays.Chat.ChannelList
         public Action<Channel>? OnRequestSelect;
         public Action<Channel>? OnRequestLeave;
 
-        public IEnumerable<Channel> Channels => groupFlow.Children.Where(child => child is ChannelGroup)
-                                                         .Cast<ChannelGroup>()
+        public IEnumerable<Channel> Channels => groupFlow.Children
+                                                         .OfType<ChannelGroup>()
                                                          .SelectMany(channelGroup => channelGroup.ItemFlow)
                                                          .Select(item => item.Channel);
 

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -26,13 +26,16 @@ namespace osu.Game.Overlays.Chat.ChannelList
         public Action<Channel>? OnRequestSelect;
         public Action<Channel>? OnRequestLeave;
 
-        public IEnumerable<Channel> Channels => publicChannelFlow.Channels.Concat(privateChannelFlow.Channels);
+        public IEnumerable<Channel> Channels =>
+            announceChannelFlow.Channels.Concat(publicChannelFlow.Channels).Concat(privateChannelFlow.Channels);
 
         public readonly ChannelListing.ChannelListingChannel ChannelListingChannel = new ChannelListing.ChannelListingChannel();
 
         private readonly Dictionary<Channel, ChannelListItem> channelMap = new Dictionary<Channel, ChannelListItem>();
 
         private OsuScrollContainer scroll = null!;
+        private ChannelListLabel announceChannelLabel = null!;
+        private ChannelListItemFlow announceChannelFlow = null!;
         private ChannelListItemFlow publicChannelFlow = null!;
         private ChannelListItemFlow privateChannelFlow = null!;
         private ChannelListItem selector = null!;
@@ -49,7 +52,6 @@ namespace osu.Game.Overlays.Chat.ChannelList
                 },
                 scroll = new OsuScrollContainer
                 {
-                    Padding = new MarginPadding { Vertical = 7 },
                     RelativeSizeAxes = Axes.Both,
                     ScrollbarAnchor = Anchor.TopRight,
                     ScrollDistance = 35f,
@@ -60,12 +62,11 @@ namespace osu.Game.Overlays.Chat.ChannelList
                         AutoSizeAxes = Axes.Y,
                         Children = new Drawable[]
                         {
+                            announceChannelLabel = new ChannelListLabel(ChatStrings.ChannelsListTitleANNOUNCE.ToUpper()),
+                            announceChannelFlow = new ChannelListItemFlow(),
                             new ChannelListLabel(ChatStrings.ChannelsListTitlePUBLIC.ToUpper()),
                             publicChannelFlow = new ChannelListItemFlow(),
-                            selector = new ChannelListItem(ChannelListingChannel)
-                            {
-                                Margin = new MarginPadding { Bottom = 10 },
-                            },
+                            selector = new ChannelListItem(ChannelListingChannel),
                             new ChannelListLabel(ChatStrings.ChannelsListTitlePM.ToUpper()),
                             privateChannelFlow = new ChannelListItemFlow(),
                         },
@@ -88,6 +89,8 @@ namespace osu.Game.Overlays.Chat.ChannelList
             ChannelListItemFlow flow = getFlowForChannel(channel);
             channelMap.Add(channel, item);
             flow.Add(item);
+
+            updateVisibility();
         }
 
         public void RemoveChannel(Channel channel)
@@ -100,6 +103,8 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
             channelMap.Remove(channel);
             flow.Remove(item);
+
+            updateVisibility();
         }
 
         public ChannelListItem GetItem(Channel channel)
@@ -122,8 +127,25 @@ namespace osu.Game.Overlays.Chat.ChannelList
                 case ChannelType.PM:
                     return privateChannelFlow;
 
+                case ChannelType.Announce:
+                    return announceChannelFlow;
+
                 default:
                     return publicChannelFlow;
+            }
+        }
+
+        private void updateVisibility()
+        {
+            if (announceChannelFlow.Channels.Count() == 0)
+            {
+                announceChannelLabel.Hide();
+                announceChannelFlow.Hide();
+            }
+            else
+            {
+                announceChannelLabel.Show();
+                announceChannelFlow.Show();
             }
         }
 
@@ -132,7 +154,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
             public ChannelListLabel(LocalisableString label)
             {
                 Text = label;
-                Margin = new MarginPadding { Left = 18, Bottom = 5 };
+                Margin = new MarginPadding { Left = 18, Bottom = 5, Top = 8 };
                 Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold);
             }
         }

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Overlays.Chat.ChannelList
         public Action<Channel>? OnRequestLeave;
 
         public IEnumerable<Channel> Channels => groupFlow.Children.Where(child => child is ChannelGroup)
-                                                                  .Cast<ChannelGroup>()
-                                                                  .SelectMany(channelGroup => channelGroup.ItemFlow)
-                                                                  .Select(item => item.Channel);
+                                                .Cast<ChannelGroup>()
+                                                .SelectMany(channelGroup => channelGroup.ItemFlow)
+                                                .Select(item => item.Channel);
 
         public readonly ChannelListing.ChannelListingChannel ChannelListingChannel = new ChannelListing.ChannelListingChannel();
 
@@ -144,9 +144,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
 
         private class ChannelGroup : FillFlowContainer
         {
-            public FillFlowContainer<ChannelListItem> ItemFlow => flow;
-
-            private readonly FillFlowContainer<ChannelListItem> flow;
+            public readonly FillFlowContainer<ChannelListItem> ItemFlow;
 
             public ChannelGroup(LocalisableString label)
             {
@@ -163,7 +161,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
                         Margin = new MarginPadding { Left = 18, Bottom = 5 },
                         Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold),
                     },
-                    flow = new FillFlowContainer<ChannelListItem>
+                    ItemFlow = new FillFlowContainer<ChannelListItem>
                     {
                         Direction = FillDirection.Vertical,
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Overlays.Chat.ChannelList
         public Action<Channel>? OnRequestLeave;
 
         public IEnumerable<Channel> Channels => groupFlow.Children.Where(child => child is ChannelGroup)
-                                                .Cast<ChannelGroup>()
-                                                .SelectMany(channelGroup => channelGroup.ItemFlow)
-                                                .Select(item => item.Channel);
+                                                         .Cast<ChannelGroup>()
+                                                         .SelectMany(channelGroup => channelGroup.ItemFlow)
+                                                         .Select(item => item.Channel);
 
         public readonly ChannelListing.ChannelListingChannel ChannelListingChannel = new ChannelListing.ChannelListingChannel();
 

--- a/osu.Game/Overlays/Chat/ChatTextBar.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBar.cs
@@ -141,8 +141,8 @@ namespace osu.Game.Overlays.Chat
 
                 switch (newChannel?.Type)
                 {
-                    case ChannelType.Public:
-                        chattingText.Text = ChatStrings.TalkingIn(newChannel.Name);
+                    case null:
+                        chattingText.Text = string.Empty;
                         break;
 
                     case ChannelType.PM:
@@ -150,7 +150,7 @@ namespace osu.Game.Overlays.Chat
                         break;
 
                     default:
-                        chattingText.Text = string.Empty;
+                        chattingText.Text = ChatStrings.TalkingIn(newChannel.Name);
                         break;
                 }
             }, true);


### PR DESCRIPTION
Adds new "ANNOUNCE" section to display at the top of the channel list when user
has joined an announce channel. Hides this section when no announce channels are joined.

![image](https://user-images.githubusercontent.com/8362491/170730718-dc318476-5cb2-4254-8646-656fd989fdc2.png)
