### PR TITLE
Fix beatmap badge colours not updated inline with recent changes

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -197,10 +197,10 @@ namespace osu.Game.Graphics
             switch (roomCategory)
             {
                 case RoomCategory.Spotlight:
-                    return Green2;
+                    return SpotlightColour;
 
                 case RoomCategory.FeaturedArtist:
-                    return Blue2;
+                    return FeaturedArtistColour;
 
                 default:
                     return null;
@@ -379,5 +379,8 @@ namespace osu.Game.Graphics
         public readonly Color4 ChatBlue = Color4Extensions.FromHex(@"17292e");
 
         public readonly Color4 ContextMenuGray = Color4Extensions.FromHex(@"223034");
+
+        public Color4 SpotlightColour => Green2;
+        public Color4 FeaturedArtistColour => Blue2;
     }
 }

--- a/osu.Game/Overlays/BeatmapSet/FeaturedArtistBeatmapBadge.cs
+++ b/osu.Game/Overlays/BeatmapSet/FeaturedArtistBeatmapBadge.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private void load(OsuColour colours)
         {
             BadgeText = BeatmapsetsStrings.FeaturedArtistBadgeLabel;
-            BadgeColour = colours.Blue1;
+            BadgeColour = colours.FeaturedArtistColour;
             // todo: add linking support to allow redirecting featured artist badge to corresponding track.
         }
     }

--- a/osu.Game/Overlays/BeatmapSet/SpotlightBeatmapBadge.cs
+++ b/osu.Game/Overlays/BeatmapSet/SpotlightBeatmapBadge.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private void load(OsuColour colours)
         {
             BadgeText = BeatmapsetsStrings.SpotlightBadgeLabel;
-            BadgeColour = colours.Pink1;
+            BadgeColour = colours.SpotlightColour;
             // todo: add linking support to allow redirecting spotlight badge to https://osu.ppy.sh/wiki/en/Beatmap_Spotlights.
         }
     }


### PR DESCRIPTION
Spotlight colour has changed to green in #18437, but that change only happened in room category, leaving the spotlight beatmap badge colour unchanged.

There's also a "hover" colour according to https://github.com/ppy/osu-web/pull/8957, but that's for opening links within the badge, and that's not supported here yet.