### PR TITLE
Darken background colour in "setup" and "verify" screens

### DIFF
--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Edit.Setup
 
             Add(new Box
             {
-                Colour = colourProvider.Background2,
+                Colour = colourProvider.Background3,
                 RelativeSizeAxes = Axes.Both,
             });
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Edit.Verify
             {
                 new Box
                 {
-                    Colour = colours.Background2,
+                    Colour = colours.Background3,
                     RelativeSizeAxes = Axes.Both,
                 },
                 new OsuScrollContainer


### PR DESCRIPTION
Matches design, and also mashes pretty well in setup screen with the background colour used for labelled components (right now it feels as if the labelled components are too dark).

| before (B2) | after (B3) |
|-------------|------------|
| <img width="1708" alt="CleanShot 2022-05-28 at 02 12 23@2x" src="https://user-images.githubusercontent.com/22781491/170799204-521465d4-4d4c-4260-8bfc-7c3927023309.png"> | <img width="1708" alt="CleanShot 2022-05-28 at 02 14 43@2x" src="https://user-images.githubusercontent.com/22781491/170799312-c21d3666-87b3-4d52-b331-e08cca2a5ec7.png"> |
| <img width="1708" alt="CleanShot 2022-05-28 at 02 13 06@2x" src="https://user-images.githubusercontent.com/22781491/170799223-104d1bf9-37d2-4e23-bd71-28ef0848417c.png"> | <img width="1708" alt="CleanShot 2022-05-28 at 02 16 17@2x" src="https://user-images.githubusercontent.com/22781491/170799406-d229c86c-20d4-4060-9754-8e6ddc6e3b4e.png"> |

(verify section still looks messed up, but I think darkening the background in a similar manner to timing screen might work better)