### PR TITLE
Update row attribute background colour to fit screen

### DIFF
--- a/osu.Game/Screens/Edit/Timing/RowAttribute.cs
+++ b/osu.Game/Screens/Edit/Timing/RowAttribute.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         private readonly string label;
 
+        protected Drawable Background { get; private set; }
+
         protected FillFlowContainer Content { get; private set; }
 
         public RowAttribute(ControlPoint point, string label)
@@ -41,11 +43,11 @@ namespace osu.Game.Screens.Edit.Timing
             Masking = true;
             CornerRadius = 3;
 
-            InternalChildren = new Drawable[]
+            InternalChildren = new[]
             {
-                new Box
+                Background = new Box
                 {
-                    Colour = overlayColours.Background4,
+                    Colour = overlayColours.Background5,
                     RelativeSizeAxes = Axes.Both,
                 },
                 Content = new FillFlowContainer

--- a/osu.Game/Screens/Edit/Timing/RowAttributes/TimingRowAttribute.cs
+++ b/osu.Game/Screens/Edit/Timing/RowAttributes/TimingRowAttribute.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Edit.Timing.RowAttributes
 {
@@ -24,9 +25,11 @@ namespace osu.Game.Screens.Edit.Timing.RowAttributes
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OverlayColourProvider colourProvider)
         {
             Content.Add(text = new AttributeText(Point));
+
+            Background.Colour = colourProvider.Background4;
 
             timeSignature.BindValueChanged(_ => updateText());
             beatLength.BindValueChanged(_ => updateText(), true);


### PR DESCRIPTION
The current background colour doesn't match with the new design of the screen, which has B4 on the area for "effect" points. Updated to match design, though I'm not sure about the way it's done (manually specifying background colour based on attribute type).

| before | after |
|--------|-------|
| <img width="691" alt="CleanShot 2022-05-28 at 02 24 36@2x" src="https://user-images.githubusercontent.com/22781491/170799824-1e26c1e5-8256-4880-ad98-3edebae0cb64.png"> | <img width="691" alt="CleanShot 2022-05-28 at 02 25 35@2x" src="https://user-images.githubusercontent.com/22781491/170799850-1ed16f67-ba63-4d97-bbb8-87f4ab7580d3.png"> |

Note that hovering over the row has an equal background colour on both sides of the screen, which looks pretty weird, but I'm not sure how that one can be fixed without refactoring the "row background" component in `EditorTable`.