### PR TITLE
Fix editor verify settings looking cramped up due to small width

### DIFF
--- a/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
+++ b/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Edit.Verify
                     ColumnDimensions = new[]
                     {
                         new Dimension(),
-                        new Dimension(GridSizeMode.Absolute, 225),
+                        new Dimension(GridSizeMode.Absolute, 250),
                     },
                     Content = new[]
                     {

--- a/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
+++ b/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Edit.Verify
                     ColumnDimensions = new[]
                     {
                         new Dimension(),
-                        new Dimension(GridSizeMode.Absolute, 200),
+                        new Dimension(GridSizeMode.Absolute, 225),
                     },
                     Content = new[]
                     {


### PR DESCRIPTION
| before (200px) | after (225px) |
|--------|-------|
| <img width="379" alt="CleanShot 2022-05-28 at 03 11 26@2x" src="https://user-images.githubusercontent.com/22781491/170801943-9c03ae35-bfb3-4c2b-84dd-2445f6bbf0e3.png"> | <img width="379" alt="CleanShot 2022-05-28 at 03 09 28@2x" src="https://user-images.githubusercontent.com/22781491/170801885-38d794d4-5e63-429b-ba88-b5627b875eab.png"> |

Initially had it at 250px, but that felt too much... maybe better?

<img width="379" src="https://user-images.githubusercontent.com/22781491/170802025-7b7beba0-8783-4d98-b56e-f993b65e1ecd.png">