### PR TITLE
Fix metronome speed not adjusted on different playback rates

### DIFF
--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
@@ -27,6 +28,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         private Drawable weight;
         private Drawable stick;
+
+        private IAdjustableClock metronomeClock;
 
         [Resolved]
         private OverlayColourProvider overlayColourProvider { get; set; }
@@ -192,6 +195,8 @@ namespace osu.Game.Screens.Edit.Timing
                     Y = -3,
                 },
             };
+
+            Clock = new FramedClock(metronomeClock = new StopwatchClock(true));
         }
 
         private double beatLength;
@@ -215,6 +220,8 @@ namespace osu.Game.Screens.Edit.Timing
 
             if (BeatSyncSource.ControlPoints == null || BeatSyncSource.Clock == null)
                 return;
+
+            metronomeClock.Rate = IsBeatSyncedWithTrack ? BeatSyncSource.Clock.Rate : 1;
 
             timingPoint = BeatSyncSource.ControlPoints.TimingPointAt(BeatSyncSource.Clock.CurrentTime);
 

--- a/osu.Game/Tests/Visual/EditorClockTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorClockTestScene.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
@@ -24,6 +25,8 @@ namespace osu.Game.Tests.Visual
         [Cached]
         protected new readonly EditorClock Clock;
 
+        private readonly Bindable<double> frequencyAdjustment = new BindableDouble(1);
+
         protected virtual bool ScrollUsingMouseWheel => true;
 
         protected EditorClockTestScene()
@@ -44,14 +47,21 @@ namespace osu.Game.Tests.Visual
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             Beatmap.BindValueChanged(beatmapChanged, true);
+
+            AddSliderStep("editor clock rate", 0.0, 2.0, 1.0, v => frequencyAdjustment.Value = v);
         }
 
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> e)
         {
+            e.OldValue?.Track.RemoveAdjustment(AdjustableProperty.Frequency, frequencyAdjustment);
+
             Clock.Beatmap = e.NewValue.Beatmap;
             Clock.ChangeSource(e.NewValue.Track);
             Clock.ProcessFrame();
+
+            e.NewValue.Track.AddAdjustment(AdjustableProperty.Frequency, frequencyAdjustment);
         }
 
         protected override void Update()


### PR DESCRIPTION
- Closes #18365 

Since the metronome needs to maintain its own clock away from the track, this is resolved by coupling the metronome clock's rate with the track only when running (i.e. when `IsBeatSyncedWithTrack = true`)