### PR TITLE
Fix unobserved exceptions in `TestSceneStatisticsPanel` due to unimplemented beatmap converter

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -13,6 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Rulesets.Osu.Objects;
@@ -114,10 +116,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 throw new NotImplementedException();
             }
 
-            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap)
-            {
-                throw new NotImplementedException();
-            }
+            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new TestBeatmapConverter(beatmap);
 
             public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap)
             {
@@ -151,6 +150,24 @@ namespace osu.Game.Tests.Visual.Ranking
                     }
                 }
             };
+
+            private class TestBeatmapConverter : IBeatmapConverter
+            {
+#pragma warning disable CS0067 // The event is never used
+                public event Action<HitObject, IEnumerable<HitObject>> ObjectConverted;
+#pragma warning restore CS0067
+
+                public IBeatmap Beatmap { get; }
+
+                public TestBeatmapConverter(IBeatmap beatmap)
+                {
+                    Beatmap = beatmap;
+                }
+
+                public bool CanConvert() => true;
+
+                public IBeatmap Convert(CancellationToken cancellationToken = default) => Beatmap.Clone();
+            }
         }
 
         private class TestRulesetAllStatsRequireHitEvents : TestRuleset


### PR DESCRIPTION
`TestSceneStatisticsPanel` intends to check the operation of statistics panels using dummy ruleset classes. However, `StatisticsPanel` relies on being able to retrieve the playable beatmap:

https://github.com/ppy/osu/blob/62266c72eab593476b1c4039bb717d714632fc88/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs#L84-L88

which requires a converter. One was not provided by the dummy rulesets, therefore the retrieval would fail with an unobserved exception.

To fix, add a barebones converter implementation that is enough for the test to pass.