### PR TITLE
Fix unobserved exceptions in multiple tests due to constructing `GameplayState` instances with unconverted beatmaps

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -17,11 +17,11 @@ using osu.Framework.Testing.Input;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Configuration;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
+using osu.Game.Tests.Gameplay;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         public TestSceneGameplayCursor()
         {
             var ruleset = new OsuRuleset();
-            gameplayState = new GameplayState(CreateBeatmap(ruleset.RulesetInfo), ruleset, Array.Empty<Mod>());
+            gameplayState = TestGameplayState.Create(ruleset);
 
             AddStep("change background colour", () =>
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Lists;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
@@ -22,7 +21,6 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
-using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -32,18 +30,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Resolved]
         private SkinManager skinManager { get; set; }
-
-        [Cached]
-        private ScoreProcessor scoreProcessor = new ScoreProcessor(new OsuRuleset());
-
-        [Cached(typeof(HealthProcessor))]
-        private HealthProcessor healthProcessor = new DrainingHealthProcessor(0);
-
-        [Cached]
-        private GameplayState gameplayState = new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset());
-
-        [Cached]
-        private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         protected override bool HasCustomSteps => true;
 
@@ -81,11 +67,19 @@ namespace osu.Game.Tests.Visual.Gameplay
             if (expectedComponentsContainer == null)
                 return false;
 
-            var expectedComponentsAdjustmentContainer = new Container
+            var expectedComponentsAdjustmentContainer = new DependencyProvidingContainer
             {
                 Position = actualComponentsContainer.Parent.ToSpaceOfOtherDrawable(actualComponentsContainer.DrawPosition, Content),
                 Size = actualComponentsContainer.DrawSize,
                 Child = expectedComponentsContainer,
+                // proxy the same required dependencies that `actualComponentsContainer` is using.
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(ScoreProcessor), actualComponentsContainer.Dependencies.Get<ScoreProcessor>()),
+                    (typeof(HealthProcessor), actualComponentsContainer.Dependencies.Get<HealthProcessor>()),
+                    (typeof(GameplayState), actualComponentsContainer.Dependencies.Get<GameplayState>()),
+                    (typeof(GameplayClock), actualComponentsContainer.Dependencies.Get<GameplayClock>())
+                },
             };
 
             Add(expectedComponentsAdjustmentContainer);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
-using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Gameplay;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private HealthProcessor healthProcessor = new DrainingHealthProcessor(0);
 
         [Cached]
-        private GameplayState gameplayState = new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset());
+        private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [Cached]
         private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -14,16 +13,15 @@ using osu.Framework.Input.Events;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
+using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Mods;
 using osuTK;
 using osuTK.Graphics;
@@ -41,7 +39,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private TestReplayRecorder recorder;
 
         [Cached]
-        private GameplayState gameplayState = new GameplayState(new Beatmap(), new OsuRuleset(), Array.Empty<Mod>());
+        private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning.Editor;
-using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Gameplay;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private HealthProcessor healthProcessor = new DrainingHealthProcessor(0);
 
         [Cached]
-        private GameplayState gameplayState = new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset());
+        private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [Cached]
         private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
@@ -16,7 +16,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
-using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Gameplay;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private HealthProcessor healthProcessor = new DrainingHealthProcessor(0);
 
         [Cached]
-        private GameplayState gameplayState = new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset());
+        private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [Cached]
         private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -18,8 +18,8 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
-using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Beatmaps.IO;
+using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Visual.Multiplayer;
 using osu.Game.Tests.Visual.Spectator;
 using osuTK;
@@ -259,12 +259,15 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestFinalFramesPurgedBeforeEndingPlay()
         {
-            AddStep("begin playing", () => spectatorClient.BeginPlaying(new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset()), new Score()));
+            AddStep("begin playing", () => spectatorClient.BeginPlaying(TestGameplayState.Create(new OsuRuleset()), new Score()));
 
             AddStep("send frames and finish play", () =>
             {
                 spectatorClient.HandleFrame(new OsuReplayFrame(1000, Vector2.Zero));
-                spectatorClient.EndPlaying(new GameplayState(new TestBeatmap(new OsuRuleset().RulesetInfo), new OsuRuleset()) { HasPassed = true });
+
+                var completedGameplayState = TestGameplayState.Create(new OsuRuleset());
+                completedGameplayState.HasPassed = true;
+                spectatorClient.EndPlaying(completedGameplayState);
             });
 
             // We can't access API because we're an "online" test.

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
@@ -20,13 +20,13 @@ using osu.Game.Online.Spectator;
 using osu.Game.Replays;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
+using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Mods;
 using osu.Game.Tests.Visual.Spectator;
 using osuTK;
@@ -65,7 +65,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     CachedDependencies = new[]
                     {
                         (typeof(SpectatorClient), (object)(spectatorClient = new TestSpectatorClient())),
-                        (typeof(GameplayState), new GameplayState(new Beatmap(), new OsuRuleset(), Array.Empty<Mod>()))
+                        (typeof(GameplayState), TestGameplayState.Create(new OsuRuleset()))
                     },
                     Children = new Drawable[]
                     {

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -80,16 +81,13 @@ namespace osu.Game.Screens.Play.HUD
                 difficultyCache.GetTimedDifficultyAttributesAsync(gameplayWorkingBeatmap, gameplayState.Ruleset, clonedMods, loadCancellationSource.Token)
                                .ContinueWith(task => Schedule(() =>
                                {
-                                   if (task.Exception != null)
-                                       return;
-
                                    timedAttributes = task.GetResultSafely();
 
                                    IsValid = true;
 
                                    if (lastJudgement != null)
                                        onJudgementChanged(lastJudgement);
-                               }));
+                               }), TaskContinuationOptions.OnlyOnRanToCompletion);
             }
         }
 

--- a/osu.Game/Tests/Gameplay/TestGameplayState.cs
+++ b/osu.Game/Tests/Gameplay/TestGameplayState.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System.Collections.Generic;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Gameplay
+{
+    /// <summary>
+    /// Static class providing a <see cref="Create"/> convenience method to retrieve a correctly-initialised <see cref="GameplayState"/> instance in testing scenarios.
+    /// </summary>
+    public static class TestGameplayState
+    {
+        /// <summary>
+        /// Creates a correctly-initialised <see cref="GameplayState"/> instance for use in testing.
+        /// </summary>
+        public static GameplayState Create(Ruleset ruleset, IReadOnlyList<Mod>? mods = null, Score? score = null)
+        {
+            var beatmap = new TestBeatmap(ruleset.RulesetInfo);
+            var workingBeatmap = new TestWorkingBeatmap(beatmap);
+            var playableBeatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
+
+            return new GameplayState(playableBeatmap, ruleset, mods, score);
+        }
+    }
+}


### PR DESCRIPTION
Many other test failures after the unobserved exception changes stem from the performance points counter, namely this fire-and-forget async call:

https://github.com/ppy/osu/blob/000c152715121b945f0bdb65b9d6edd9718acf7d/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs#L80-L92

These would manifest in the visual test browser prior to https://github.com/ppy/osu/pull/17762, which silenced these failures by manually null-checking `task.Exception` (which technically makes the exception "observed"). The silencing was incorrect and done for test purposes only, so 1641918c515a49530f6c5ce921b40c52b2418463 in this diff reverts that change. Any further failures stemming from that particular code path should be deemed real and be fixed properly.

The root cause is that beatmap instances in `GameplayState` are intended to be post-conversion and default application, but several test scenes were providing unconverted instances.

As for the fix:

- Most scenes manually receive a correctly-populated `GameplayState`, via a new helper method (a8e1c5ba87f53dbe2a30bd81bad67f029dc02234)
- `TestSceneBeatmapFallbacks` is an outlier, because it is a bit unorthodox - one test there intends to check whether two skinnable component containers match in object position, scale, etc., so there is already a `Player` instance in place there, it just was not being supplied to one of the containers correctly. Therefore a more local fix was applied in dcf3d7695484a7bc92b1892a5cf66af5ea0ba208 that proxies `Player` dependencies to the "expected" skinnable component container via a `DependencyProvidingContainer`.