### PR TITLE
Fix potential `ObjectDisposedException` on realm notification in `SkinSection`

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.527.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.528.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.529.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Overlays.Settings.Sections
             configBindable.Value = skin.NewValue.ID.ToString();
         }
 
-        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes, Exception error) => Schedule(() =>
+        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes, Exception error)
         {
             // This can only mean that realm is recycling, else we would see the protected skins.
             // Because we are using `Live<>` in this class, we don't need to worry about this scenario too much.
@@ -127,10 +127,13 @@ namespace osu.Game.Overlays.Settings.Sections
                 dropdownItems.Add(skin.ToLive(realm));
             dropdownItems.Insert(protectedCount, random_skin_info);
 
-            skinDropdown.Items = dropdownItems;
+            Schedule(() =>
+            {
+                skinDropdown.Items = dropdownItems;
 
-            updateSelectedSkinFromConfig();
-        });
+                updateSelectedSkinFromConfig();
+            });
+        }
 
         private void updateSelectedSkinFromConfig()
         {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Overlays.Settings.Sections
             configBindable.Value = skin.NewValue.ID.ToString();
         }
 
-        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes, Exception error)
+        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes, Exception error) => Schedule(() =>
         {
             // This can only mean that realm is recycling, else we would see the protected skins.
             // Because we are using `Live<>` in this class, we don't need to worry about this scenario too much.
@@ -130,7 +130,7 @@ namespace osu.Game.Overlays.Settings.Sections
             skinDropdown.Items = dropdownItems;
 
             updateSelectedSkinFromConfig();
-        }
+        });
 
         private void updateSelectedSkinFromConfig()
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.11.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.528.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.529.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.527.0" />
     <PackageReference Include="Sentry" Version="3.17.1" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.528.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.529.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.527.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.528.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.529.0" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
The notification callback was already scheduled, but at a game level. The actual component may have been disposed since.

```csharp
Exit code is 134 (Unhandled exception. System.ObjectDisposedException: Children cannot be mutated on a disposed drawable.
Object name: 'Menu+ItemsFlow'.
   at osu.Framework.Graphics.Containers.CompositeDrawable.AddInternal(Drawable drawable) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 580
   at osu.Framework.Graphics.Containers.Container`1.AddInternal(Drawable drawable) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/Container.cs:line 231
   at osu.Framework.Graphics.UserInterface.Menu.Add(MenuItem item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Menu.cs:line 289
   at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.Add(MenuItem item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 356
   at osu.Framework.Graphics.UserInterface.Dropdown`1.addDropdownItem(LocalisableString text, T value) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 114
   at osu.Framework.Graphics.UserInterface.Dropdown`1.setItems(IEnumerable`1 items) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 64
   at osu.Game.Overlays.Settings.SettingsDropdown`1.set_Items(IEnumerable`1 value) in /Users/dean/Projects/osu/osu.Game/Overlays/Settings/SettingsDropdown.cs:line 20
   at osu.Game.Overlays.Settings.Sections.SkinSection.skinsChanged(IRealmCollection`1 sender, ChangeSet changes, Exception error) in /Users/dean/Projects/osu/osu.Game/Overlays/Settings/Sections/SkinSection.cs:line 130
   at Realms.RealmCollectionBase`1.Realms.INotifiable<Realms.NotifiableObjectHandleBase.CollectionChangeSet>.NotifyCallbacks(Nullable`1 changes, Nullable`1 exception)
   at Realms.NotifiableObjectHandleBase.NotifyObjectChanged(IntPtr managedHandle, IntPtr changes, IntPtr exception))

Last runner error: Process /usr/local/share/dotnet/dotnet:50772 exited with code '134': Unhandled exception. System.ObjectDisposedException: Children cannot be mutated on a disposed drawable. Object name: 'Menu+ItemsFlow'. at osu.Framework.Graphics.Containers.CompositeDrawable.AddInternal(Drawable drawable) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 580 at osu.Framework.Graphics.Containers.Container`1.AddInternal(Drawable drawable) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/Container.cs:line 231 at osu.Framework.Graphics.UserInterface.Menu.Add(MenuItem item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Menu.cs:line 289 at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.Add(MenuItem item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 356 at osu.Framework.Graphics.UserInterface.Dropdown`1.addDropdownItem(LocalisableString text, T value) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 114 at osu.Framework.Graphics.UserInterface.Dropdown`1.setItems(IEnumerable`1 items) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 64 at osu.Game.Overlays.Settings.SettingsDropdown`1.set_Items(IEnumerable`1 value) in /Users/dean/Projects/osu/osu.Game/Overlays/Settings/SettingsDropdown.cs:line 20 at osu.Game.Overlays.Settings.Sections.SkinSection.skinsChanged(IRealmCollection`1 sender, ChangeSet changes, Exception error) in /Users/dean/Projects/osu/osu.Game/Overlays/Settings/Sections/SkinSection.cs:line 130 at Realms.RealmCollectionBase`1.Realms.INotifiable<Realms.NotifiableObjectHandleBase.CollectionChangeSet>.NotifyCallbacks(Nullable`1 changes, Nullable`1 exception) at Realms.NotifiableObjectHandleBase.NotifyObjectChanged(IntPtr managedHandle, IntPtr changes, IntPtr exception)

--- EXCEPTION #1/1 [LoggerException]
Message = “
  Process /usr/local/share/dotnet/dotnet:50772 exited with code '134':
  Unhandled exception. System.ObjectDisposedException: Children cannot be mutated on a disposed drawable.
  Object name: 'Menu+ItemsFlow'.
     at osu.Framework.Graphics.Containers.CompositeDrawable.AddInternal(Drawable drawable) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 580
     at osu.Framework.Graphics.Containers.Container`1.AddInternal(Drawable drawable) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/Container.cs:line 231
     at osu.Framework.Graphics.UserInterface.Menu.Add(MenuItem item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Menu.cs:line 289
     at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.Add(MenuItem item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 356
     at osu.Framework.Graphics.UserInterface.Dropdown`1.addDropdownItem(LocalisableString text, T value) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 114
     at osu.Framework.Graphics.UserInterface.Dropdown`1.setItems(IEnumerable`1 items) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 64
     at osu.Game.Overlays.Settings.SettingsDropdown`1.set_Items(IEnumerable`1 value) in /Users/dean/Projects/osu/osu.Game/Overlays/Settings/SettingsDropdown.cs:line 20
     at osu.Game.Overlays.Settings.Sections.SkinSection.skinsChanged(IRealmCollection`1 sender, ChangeSet changes, Exception error) in /Users/dean/Projects/osu/osu.Game/Overlays/Settings/Sections/SkinSection.cs:line 130
     at Realms.RealmCollectionBase`1.Realms.INotifiable<Realms.NotifiableObjectHandleBase.CollectionChangeSet>.NotifyCallbacks(Nullable`1 changes, Nullable`1 exception)
     at Realms.NotifiableObjectHandleBase.NotifyObjectChanged(IntPtr managedHandle, IntPtr changes, IntPtr exception)
”
ExceptionPath = Root
ClassName = JetBrains.Util.LoggerException
HResult = COR_E_APPLICATION=80131600
StackTraceString = “
  at JetBrains.Util.ILoggerEx.LogMessage(ILogger this, LoggingLevel level, String message)
     at JetBrains.Util.ILoggerEx.Error(ILogger this, String message)
     at JetBrains.ReSharper.UnitTestFramework.Execution.TestRunner.TestRunnerRunStrategy.AnalyseProcessCrash(ProcessExitedUnexpectedlyException ex, IUnitTestRun run)
     at JetBrains.ReSharper.UnitTestFramework.Execution.TestRunner.TestRunnerRunStrategy.Run(IUnitTestRun run)
     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
     at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
     at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
     at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)
     at System.Threading.Tasks.Task.TrySetException(Object exceptionObject)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetException(Exception exception, Task`1& taskField)
     at JetBrains.ReSharper.UnitTestFramework.Execution.TestRunner.TestRunnerAgentManager.TestRunnerExecutionAgent.RunTests(CancellationToken cancelCt, CancellationToken abortCt)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
     at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
     at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
     at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)
     at System.Threading.Tasks.Task.TrySetException(Object exceptionObject)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetException(Exception exception, Task`1& taskField)
     at JetBrains.ReSharper.UnitTestFramework.Execution.TestRunner.TestRunnerAgentManager.BoundTestRunnerAgent.RunSafe(Func`1 taskFactory, CancellationToken operationAborted)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
     at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
     at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
     at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)
     at System.Threading.Tasks.Task.TrySetException(Object exceptionObject)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetException(Exception exception, Task`1& taskField)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetException(Exception exception)
     at JetBrains.ReSharper.UnitTestFramework.Common.Extensions.TaskExtensions.ThrowIf[TResult,TException](Task`1 task, WaitHandle waitHandle, Func`1 exceptionFactory)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
     at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
     at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
     at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
     at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
     at System.Threading.Tasks.Task.TwoTaskWhenAnyPromise`1.Invoke(Task completingTask)
     at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
     at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
     at System.Threading.Tasks.TaskCompletionSource`1.TrySetResult(TResult result)
     at JetBrains.ReSharper.UnitTestFramework.Common.Extensions.TaskExtensions.<>c__14`2.<ThrowIf>b__14_0(Object s, Boolean timedOut)
     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Threading.PortableThreadPool.CompleteWait(RegisteredWaitHandle handle, Boolean timedOut)
     at System.Threading.ThreadPoolWorkQueue.Dispatch()
     at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
     at System.Threading.Thread.StartCallback()
”


Last launch log file: /Users/dean/Library/Logs/JetBrains/Rider2022.1/UnitTestLogs/Sessions/2022-05-29-13-39-30-788___40795c7f-2442-46b2-85ce-ee6e3d559344.log

```