### PR TITLE
Fix context menu no longer opening for hitobjects in timeline

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineHitObjectBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineHitObjectBlueprint.cs
@@ -4,7 +4,9 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
@@ -17,6 +19,28 @@ namespace osu.Game.Tests.Visual.Editing
     public class TestSceneTimelineHitObjectBlueprint : TimelineTestScene
     {
         public override Drawable CreateTestComponent() => new TimelineBlueprintContainer(Composer);
+
+        [Test]
+        public void TestContextMenu()
+        {
+            TimelineHitObjectBlueprint blueprint = null;
+
+            AddStep("add object", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.Add(new HitCircle { StartTime = 3000 });
+            });
+
+            AddStep("click object", () =>
+            {
+                blueprint = this.ChildrenOfType<TimelineHitObjectBlueprint>().Single();
+                InputManager.MoveMouseTo(blueprint);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+            AddAssert("context menu open", () => this.ChildrenOfType<OsuContextMenu>().SingleOrDefault()?.State == MenuState.Open);
+        }
 
         [Test]
         public void TestDisallowZeroDurationObjects()

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineHitObjectBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineHitObjectBlueprint.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestContextMenu()
         {
-            TimelineHitObjectBlueprint blueprint = null;
+            TimelineHitObjectBlueprint blueprint;
 
             AddStep("add object", () =>
             {

--- a/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
+++ b/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit;
@@ -38,25 +39,29 @@ namespace osu.Game.Tests.Visual.Editing
 
             Composer = playable.BeatmapInfo.Ruleset.CreateInstance().CreateHitObjectComposer().With(d => d.Alpha = 0);
 
-            AddRange(new Drawable[]
+            Add(new OsuContextMenuContainer
             {
-                EditorBeatmap,
-                Composer,
-                new FillFlowContainer
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 5),
-                    Children = new Drawable[]
+                    EditorBeatmap,
+                    Composer,
+                    new FillFlowContainer
                     {
-                        new StartStopButton(),
-                        new AudioVisualiser(),
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(0, 5),
+                        Children = new Drawable[]
+                        {
+                            new StartStopButton(),
+                            new AudioVisualiser(),
+                        }
+                    },
+                    TimelineArea = new TimelineArea(CreateTestComponent())
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
                     }
-                },
-                TimelineArea = new TimelineArea(CreateTestComponent())
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
                 }
             });
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -16,6 +16,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
@@ -273,7 +274,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             if (base.OnMouseDown(e))
                 beginUserDrag();
 
-            return true;
+            // handling right button as well breaks context menus inside the timeline, only handle left button for now.
+            return e.Button == MouseButton.Left;
         }
 
         protected override void OnMouseUp(MouseUpEvent e)


### PR DESCRIPTION
- Closes #18470 

Working around this for now, since figuring out a proper solution would probably not be that easy.