### PR TITLE
Fix wrong sizing of editor timeline ticks

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                         Vector2 size = Vector2.One;
 
-                        if (indexInBar != 1)
+                        if (indexInBar != 0)
                             size = BindableBeatDivisor.GetSize(divisor);
 
                         var line = getNextUsableLine();


### PR DESCRIPTION
Closes #18464

Before:

![image](https://user-images.githubusercontent.com/20418176/170885660-d8c81247-c016-491d-b56f-c7c331247404.png)

After:

![image](https://user-images.githubusercontent.com/20418176/170885693-191c035b-4f85-465a-9539-db3b1bccc537.png)

Regressed in #18393, which should be obvious [after about five seconds of looking at what changed in `TimelineTickDisplay` there](https://github.com/ppy/osu/pull/18393/files#diff-d20978ec30bd94d4732703aae7bce63bdf016cdae2819419466df8d0a797d30d) - note the `indexInBar` checks before and after. Pretty embarrassing one this on my behalf, I could have sworn I checked that the values were unchanged, but apparently missed the bogus condition.

No tests because I don't realistically expect this to regress again. Can add if it's deemed required.