### PR TITLE
Fix some more chat tests failing intermittently

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlayV2.cs
@@ -404,22 +404,22 @@ namespace osu.Game.Tests.Visual.Online
             });
             AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
-            AddAssert("Channel 1 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Loading);
+            AddUntilStep("Channel 1 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Loading);
 
             AddStep("Join channel 2", () => channelManager.JoinChannel(testChannel2));
             AddStep("Select channel 2", () => clickDrawable(getChannelListItem(testChannel2)));
-            AddAssert("Channel 2 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel2).LoadState == LoadState.Loading);
+            AddUntilStep("Channel 2 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel2).LoadState == LoadState.Loading);
 
             AddStep("Finish channel 1 load", () => chatOverlay.GetSlowLoadingChannel(testChannel1).LoadEvent.Set());
-            AddAssert("Channel 1 ready", () => chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Ready);
+            AddUntilStep("Channel 1 ready", () => chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Ready);
             AddAssert("Channel 1 not displayed", () => !channelIsVisible);
 
             AddStep("Finish channel 2 load", () => chatOverlay.GetSlowLoadingChannel(testChannel2).LoadEvent.Set());
-            AddAssert("Channel 2 loaded", () => chatOverlay.GetSlowLoadingChannel(testChannel2).IsLoaded);
+            AddUntilStep("Channel 2 loaded", () => chatOverlay.GetSlowLoadingChannel(testChannel2).IsLoaded);
             waitForChannel2Visible();
 
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
-            AddAssert("Channel 1 loaded", () => chatOverlay.GetSlowLoadingChannel(testChannel1).IsLoaded);
+            AddUntilStep("Channel 1 loaded", () => chatOverlay.GetSlowLoadingChannel(testChannel1).IsLoaded);
             waitForChannel1Visible();
         }
 


### PR DESCRIPTION
```
TearDown : osu.Framework.Testing.Drawables.Steps.AssertButton+TracedException : Channel 1 ready
--TearDown
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Platform.GameHost.UpdateFrame()
   at osu.Framework.Threading.GameThread.processFrame()
   at osu.Framework.Threading.GameThread.RunSingleFrame()
   at osu.Framework.Threading.GameThread.<createThread>g__runWork|66_0()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

-----

One or more child tests had errors
  Exception doesn't have a stacktrace

[runtime] 2022-05-29 19:29:09 [verbose]: 💨 Class: TestSceneChatOverlayV2
[runtime] 2022-05-29 19:29:09 [verbose]: 🔶 Test:  TestSlowLoadingChannel
[runtime] 2022-05-29 19:29:09 [verbose]: Chat is now polling every 60000 ms
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #1 Setup request handler
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #2 Add test channels
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #3 Show overlay (slow-loading)
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #4 Join channel 1
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #5 Select channel 1
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #6 Channel 1 loading
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #7 Join channel 2
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #8 Select channel 2
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #9 Channel 2 loading
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #10 Finish channel 1 load
[runtime] 2022-05-29 19:29:09 [verbose]: 🔸 Step #11 Channel 1 ready
[runtime] 2022-05-29 19:29:09 [verbose]: 💥 Failed
[runtime] 2022-05-29 19:29:09 [verbose]: ⏳ Currently loading components (2)
[runtime] 2022-05-29 19:29:09 [verbose]: TestSceneChatOverlayV2+SlowLoadingDrawableChannel
[runtime] 2022-05-29 19:29:09 [verbose]: - thread: ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2022-05-29 19:29:09 [verbose]: - state:  Loading
[runtime] 2022-05-29 19:29:09 [verbose]: TestSceneChatOverlayV2+SlowLoadingDrawableChannel
[runtime] 2022-05-29 19:29:09 [verbose]: - thread: ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2022-05-29 19:29:09 [verbose]: - state:  Ready
[runtime] 2022-05-29 19:29:09 [verbose]: 🧵 Task schedulers
[runtime] 2022-05-29 19:29:09 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:1 pending:0
[runtime] 2022-05-29 19:29:09 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-05-29 19:29:09 [verbose]: 🎱 Thread pool
[runtime] 2022-05-29 19:29:09 [verbose]: worker:          min 32     max 32,767 available 32,765
[runtime] 2022-05-29 19:29:09 [verbose]: completion:      min 32     max 1,000  available 1,000

```