### PR TITLE
Use pooled memory for memory copies performed by `ZipArchiveReader`

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.527.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.529.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.530.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/IO/Archives/ZipArchiveReader.cs
+++ b/osu.Game/IO/Archives/ZipArchiveReader.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Toolkit.HighPerformance;
+using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
 using SharpCompress.Archives.Zip;
+using SixLabors.ImageSharp.Memory;
 
 namespace osu.Game.IO.Archives
 {
@@ -27,15 +31,12 @@ namespace osu.Game.IO.Archives
             if (entry == null)
                 throw new FileNotFoundException();
 
-            // allow seeking
-            MemoryStream copy = new MemoryStream();
+            var owner = MemoryAllocator.Default.Allocate<byte>((int)entry.Size);
 
             using (Stream s = entry.OpenEntryStream())
-                s.CopyTo(copy);
+                s.ReadToFill(owner.Memory.Span);
 
-            copy.Position = 0;
-
-            return copy;
+            return new MemoryOwnerMemoryStream(owner);
         }
 
         public override void Dispose()
@@ -45,5 +46,48 @@ namespace osu.Game.IO.Archives
         }
 
         public override IEnumerable<string> Filenames => archive.Entries.Select(e => e.Key).ExcludeSystemFileNames();
+
+        private class MemoryOwnerMemoryStream : Stream
+        {
+            private readonly IMemoryOwner<byte> owner;
+            private readonly Stream stream;
+
+            public MemoryOwnerMemoryStream(IMemoryOwner<byte> owner)
+            {
+                this.owner = owner;
+
+                stream = owner.Memory.AsStream();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                owner?.Dispose();
+                base.Dispose(disposing);
+            }
+
+            public override void Flush() => stream.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) => stream.Read(buffer, offset, count);
+
+            public override long Seek(long offset, SeekOrigin origin) => stream.Seek(offset, origin);
+
+            public override void SetLength(long value) => stream.SetLength(value);
+
+            public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
+
+            public override bool CanRead => stream.CanRead;
+
+            public override bool CanSeek => stream.CanSeek;
+
+            public override bool CanWrite => stream.CanWrite;
+
+            public override long Length => stream.Length;
+
+            public override long Position
+            {
+                get => stream.Position;
+                set => stream.Position = value;
+            }
+        }
     }
 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.11.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.529.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.530.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.527.0" />
     <PackageReference Include="Sentry" Version="3.17.1" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="ppy.LocalisationAnalyser" Version="2022.417.0">
       <PrivateAssets>all</PrivateAssets>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.529.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.530.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.527.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.529.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.530.0" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Testing with navigation test namespace

Before:

![Parallels Desktop 2022-05-30 at 11 30 19](https://user-images.githubusercontent.com/191335/170983353-9dc2b5a5-6ca3-4e20-971c-0c4b3b01fde9.png)

After:

![Parallels Desktop 2022-05-30 at 11 30 12](https://user-images.githubusercontent.com/191335/170983330-d1d2ee83-1bb2-4805-a5e4-d29b479c6ce9.png)

Longer runtime is due to rider doing analysis, important part is memory stats.

Also bumps framework.