### PR TITLE
Add automatic control point tracking to the timing screen

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -52,6 +52,8 @@ namespace osu.Game.Tests.Visual.Editing
         public void SetUpSteps()
         {
             AddStep("Stop clock", () => Clock.Stop());
+
+            AddUntilStep("wait for rows to load", () => Child.ChildrenOfType<EffectRowAttribute>().Any());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -1,14 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Timing;
+using osu.Game.Screens.Edit.Timing.RowAttributes;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
@@ -21,6 +25,8 @@ namespace osu.Game.Tests.Visual.Editing
 
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
+        private TimingScreen timingScreen;
 
         protected override bool ScrollUsingMouseWheel => false;
 
@@ -36,10 +42,50 @@ namespace osu.Game.Tests.Visual.Editing
             Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
             Beatmap.Disabled = true;
 
-            Child = new TimingScreen
+            Child = timingScreen = new TimingScreen
             {
                 State = { Value = Visibility.Visible },
             };
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("Stop clock", () => Clock.Stop());
+        }
+
+        [Test]
+        public void TestTrackingCurrentTimeWhileRunning()
+        {
+            AddStep("Select first effect point", () =>
+            {
+                InputManager.MoveMouseTo(Child.ChildrenOfType<EffectRowAttribute>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 54670);
+            AddUntilStep("Ensure seeked to correct time", () => Clock.CurrentTimeAccurate == 54670);
+
+            AddStep("Seek to just before next point", () => Clock.Seek(69000));
+            AddStep("Start clock", () => Clock.Start());
+
+            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 69670);
+        }
+
+        [Test]
+        public void TestTrackingCurrentTimeWhilePaused()
+        {
+            AddStep("Select first effect point", () =>
+            {
+                InputManager.MoveMouseTo(Child.ChildrenOfType<EffectRowAttribute>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 54670);
+            AddUntilStep("Ensure seeked to correct time", () => Clock.CurrentTimeAccurate == 54670);
+
+            AddStep("Seek to later", () => Clock.Seek(80000));
+            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 69670);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -61,6 +61,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             selectedGroup.BindValueChanged(group =>
             {
+                // TODO: This should scroll the selected row into view.
                 foreach (var b in BackgroundFlow) b.Selected = b.Item == group.NewValue;
             }, true);
         }

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -31,18 +31,33 @@ namespace osu.Game.Screens.Edit.Timing
             });
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            kiai.Current.BindValueChanged(_ => saveChanges());
+            omitBarLine.Current.BindValueChanged(_ => saveChanges());
+            scrollSpeedSlider.Current.BindValueChanged(_ => saveChanges());
+
+            void saveChanges()
+            {
+                if (!isRebinding) ChangeHandler?.SaveState();
+            }
+        }
+
+        private bool isRebinding;
+
         protected override void OnControlPointChanged(ValueChangedEvent<EffectControlPoint> point)
         {
             if (point.NewValue != null)
             {
+                isRebinding = true;
+
                 kiai.Current = point.NewValue.KiaiModeBindable;
-                kiai.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
-
                 omitBarLine.Current = point.NewValue.OmitFirstBarLineBindable;
-                omitBarLine.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
-
                 scrollSpeedSlider.Current = point.NewValue.ScrollSpeedBindable;
-                scrollSpeedSlider.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
+
+                isRebinding = false;
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -158,9 +158,12 @@ namespace osu.Game.Screens.Edit.Timing
                     // To improve the efficiency of this in the future, we should reconsider the overall structure of ControlPointInfo.
 
                     // Find the next group which has the same type as the selected one.
-                    selectedGroup.Value = Beatmap.ControlPointInfo.Groups
-                                                 .Where(g => g.ControlPoints.Any(cp => cp.GetType() == selectedPointType))
-                                                 .LastOrDefault(g => g.Time <= clock.CurrentTimeAccurate);
+                    var found = Beatmap.ControlPointInfo.Groups
+                                       .Where(g => g.ControlPoints.Any(cp => cp.GetType() == selectedPointType))
+                                       .LastOrDefault(g => g.Time <= clock.CurrentTimeAccurate);
+
+                    if (found != null)
+                        selectedGroup.Value = found;
                 }
             }
 

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -156,35 +156,11 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     // We don't have an efficient way of looking up groups currently, only individual point types.
                     // To improve the efficiency of this in the future, we should reconsider the overall structure of ControlPointInfo.
-                    IEnumerable<ControlPointGroup> groups = Beatmap.ControlPointInfo.Groups;
-
-                    bool currentTimeBeforeSelectedGroup = clock.CurrentTimeAccurate < selectedGroup.Value.Time;
-
-                    // Decide whether we are searching backwards or forwards.
-                    if (currentTimeBeforeSelectedGroup)
-                        groups = groups.Reverse();
 
                     // Find the next group which has the same type as the selected one.
-                    groups = groups.SkipWhile(g => g != selectedGroup.Value)
-                                   .Skip(1)
-                                   .Where(g => g.ControlPoints.Any(cp => cp.GetType() == selectedPointType));
-
-                    ControlPointGroup newGroup = groups.FirstOrDefault();
-
-                    if (newGroup != null)
-                    {
-                        if (currentTimeBeforeSelectedGroup)
-                        {
-                            // When seeking backwards, the first match from the LINQ query is always what we want.
-                            selectedGroup.Value = newGroup;
-                        }
-                        else
-                        {
-                            // When seeking forwards, we also need to check that the next match is before the current time.
-                            if (newGroup.Time <= clock.CurrentTimeAccurate)
-                                selectedGroup.Value = newGroup;
-                        }
-                    }
+                    selectedGroup.Value = Beatmap.ControlPointInfo.Groups
+                                                 .Where(g => g.ControlPoints.Any(cp => cp.GetType() == selectedPointType))
+                                                 .LastOrDefault(g => g.Time <= clock.CurrentTimeAccurate);
                 }
             }
 

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -28,17 +28,31 @@ namespace osu.Game.Screens.Edit.Timing
             });
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            bpmTextEntry.Current.BindValueChanged(_ => saveChanges());
+            timeSignature.Current.BindValueChanged(_ => saveChanges());
+
+            void saveChanges()
+            {
+                if (!isRebinding) ChangeHandler?.SaveState();
+            }
+        }
+
+        private bool isRebinding;
+
         protected override void OnControlPointChanged(ValueChangedEvent<TimingControlPoint> point)
         {
             if (point.NewValue != null)
             {
-                bpmTextEntry.Current.UnbindEvents();
-                bpmTextEntry.Bindable = point.NewValue.BeatLengthBindable;
-                bpmTextEntry.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
+                isRebinding = true;
 
-                timeSignature.Current.UnbindEvents();
+                bpmTextEntry.Bindable = point.NewValue.BeatLengthBindable;
                 timeSignature.Current = point.NewValue.TimeSignatureBindable;
-                timeSignature.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
+
+                isRebinding = false;
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -32,9 +32,11 @@ namespace osu.Game.Screens.Edit.Timing
         {
             if (point.NewValue != null)
             {
+                bpmTextEntry.Current.UnbindEvents();
                 bpmTextEntry.Bindable = point.NewValue.BeatLengthBindable;
                 bpmTextEntry.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
 
+                timeSignature.Current.UnbindEvents();
                 timeSignature.Current = point.NewValue.TimeSignatureBindable;
                 timeSignature.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
             }


### PR DESCRIPTION
As previously discussed, the new timing controls are displayed in the right-hand area of the timing screen, which tracks the currently selected control point. To make this make more sense, the selected group should be updated as the song progresses.

https://user-images.githubusercontent.com/191335/171104355-5fe304e2-d988-4691-a9c5-1480abf48180.mp4

A bit of follow-up work is required to scroll the selected group into view (the `ScrollContainer` is one level too high to do this easily).