### PR TITLE
Add the ability to lock the waveform display to a specific time location

### DIFF
--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Edit.Timing
             controlPointGroups.BindTo(editorBeatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((_, __) => updateTimingGroup());
 
-            beatLength.BindValueChanged(_ => regenerateDisplay(), true);
+            beatLength.BindValueChanged(_ => regenerateDisplay(true), true);
 
             displayLocked.BindValueChanged(locked =>
             {
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 // The offset of the selected point may have changed.
                 // This handles the case the user has locked the view and expects the display to update with this change.
-                showFromTime(displayedTime + (newStartTime.Value - selectedGroupStartTime));
+                showFromTime(displayedTime + (newStartTime.Value - selectedGroupStartTime), true);
             }
 
             var nextGroup = editorBeatmap.ControlPointInfo.TimingPoints
@@ -174,18 +174,18 @@ namespace osu.Game.Screens.Edit.Timing
         }
 
         private void showFromBeat(int beatIndex) =>
-            showFromTime(selectedGroupStartTime + beatIndex * timingPoint.BeatLength);
+            showFromTime(selectedGroupStartTime + beatIndex * timingPoint.BeatLength, false);
 
-        private void showFromTime(double time)
+        private void showFromTime(double time, bool animated)
         {
             if (displayedTime == time)
                 return;
 
             displayedTime = time;
-            regenerateDisplay();
+            regenerateDisplay(animated);
         }
 
-        private void regenerateDisplay()
+        private void regenerateDisplay(bool animated)
         {
             double index = (displayedTime - selectedGroupStartTime) / timingPoint.BeatLength;
 
@@ -211,7 +211,7 @@ namespace osu.Game.Screens.Edit.Timing
                 float offset = (float)(time - visible_width / 2) / trackLength * scale;
 
                 row.Alpha = time < selectedGroupStartTime || time > selectedGroupEndTime ? 0.2f : 1;
-                row.WaveformOffset = -offset;
+                row.WaveformOffsetTo(-offset, animated);
                 row.WaveformScale = new Vector2(scale, 1);
                 row.BeatIndex = (int)Math.Floor(index);
 
@@ -314,7 +314,15 @@ namespace osu.Game.Screens.Edit.Timing
 
             public int BeatIndex { set => beatIndexText.Text = value.ToString(); }
             public Vector2 WaveformScale { set => waveformGraph.Scale = value; }
-            public float WaveformOffset { set => waveformGraph.X = value; }
+
+            public void WaveformOffsetTo(float value, bool animated) =>
+                this.TransformTo(nameof(waveformOffset), value, animated ? 300 : 0, Easing.OutQuint);
+
+            private float waveformOffset
+            {
+                get => waveformGraph.X;
+                set => waveformGraph.X = value;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -123,13 +123,7 @@ namespace osu.Game.Screens.Edit.Timing
             beatLength.BindTo(timingPoint.BeatLengthBindable);
 
             double? newStartTime = selectedGroup.Value?.Time;
-
-            if (newStartTime.HasValue && selectedGroupStartTime != newStartTime)
-            {
-                // The offset of the selected point may have changed.
-                // This handles the case the user has locked the view and expects the display to update with this change.
-                showFromTime(displayedTime + (newStartTime.Value - selectedGroupStartTime), true);
-            }
+            double? offsetChange = newStartTime - selectedGroupStartTime;
 
             var nextGroup = editorBeatmap.ControlPointInfo.TimingPoints
                                          .SkipWhile(g => g != tcp)
@@ -138,6 +132,13 @@ namespace osu.Game.Screens.Edit.Timing
 
             selectedGroupStartTime = newStartTime ?? 0;
             selectedGroupEndTime = nextGroup?.Time ?? beatmap.Value.Track.Length;
+
+            if (newStartTime.HasValue && offsetChange.HasValue)
+            {
+                // The offset of the selected point may have changed.
+                // This handles the case the user has locked the view and expects the display to update with this change.
+                showFromTime(displayedTime + offsetChange.Value, true);
+            }
         }
 
         protected override bool OnHover(HoverEvent e) => true;

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -99,7 +99,10 @@ namespace osu.Game.Screens.Edit.Timing
 
             displayLocked.BindValueChanged(locked =>
             {
-                lockedOverlay.FadeTo(locked.NewValue ? 1 : 0, 200, Easing.OutQuint);
+                if (locked.NewValue)
+                    lockedOverlay.Show();
+                else
+                    lockedOverlay.Hide();
             }, true);
         }
 
@@ -268,14 +271,19 @@ namespace osu.Game.Screens.Edit.Timing
                 };
             }
 
-            protected override void LoadComplete()
+            public override void Show()
             {
-                base.LoadComplete();
+                this.FadeIn(100, Easing.OutQuint);
 
                 text
-                    .FadeIn().Then().Delay(500)
-                    .FadeOut().Then().Delay(500)
+                    .FadeIn().Then().Delay(600)
+                    .FadeOut().Then().Delay(600)
                     .Loop();
+            }
+
+            public override void Hide()
+            {
+                this.FadeOut(100, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -112,9 +112,10 @@ namespace osu.Game.Screens.Edit.Timing
             if (tcp == null)
             {
                 timingPoint = new TimingControlPoint();
-                // During movement of a control point's offset, this clause can be hit momentarily.
+                // During movement of a control point's offset, this clause can be hit momentarily,
+                // as moving a control point is implemented by removing it and inserting it at the new time.
                 // We don't want to reset the `selectedGroupStartTime` here as we rely on having the
-                // last value to perform an offset traversal below.
+                // last value to update the waveform display below.
                 selectedGroupEndTime = beatmap.Value.Track.Length;
                 return;
             }


### PR DESCRIPTION
Quite often you will want to be timing using a specific section of the waveform you've identified to have a discernible beat. This allows locking the display to that region while you make further adjustments.

Had to restructure a bit to allow displaying around a time offset, rather than a beat index. This is because the beat index will be changing along with the BPM.

https://user-images.githubusercontent.com/191335/171145067-136e9d0d-7460-4017-a48a-dcc5149c16f2.mp4

This also adds animation to adjustments coming from an external source. The reasoning for this will become more apparent after.. adjustment controls exist. But you can test using the test scene for now.