### PR TITLE
Improve flow of adding new control points at timing screen

### DIFF
--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -160,11 +160,7 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         foreach (var controlPoint in selected.ControlPoints)
                         {
-                            if (Activator.CreateInstance(controlPoint.GetType()) is ControlPoint copy)
-                            {
-                                copy.CopyFrom(controlPoint);
-                                group.Add(copy);
-                            }
+                            group.Add(controlPoint.DeepClone());
                         }
                     }
                 }

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -150,6 +151,23 @@ namespace osu.Game.Screens.Edit.Timing
 
                 if (isFirstControlPoint)
                     group.Add(new TimingControlPoint());
+                else
+                {
+                    // Try and create matching types from the currently selected control point.
+                    var selected = selectedGroup.Value;
+
+                    if (selected != null)
+                    {
+                        foreach (var controlPoint in selected.ControlPoints)
+                        {
+                            if (Activator.CreateInstance(controlPoint.GetType()) is ControlPoint copy)
+                            {
+                                copy.CopyFrom(controlPoint);
+                                group.Add(copy);
+                            }
+                        }
+                    }
+                }
 
                 selectedGroup.Value = group;
             }

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -144,7 +144,14 @@ namespace osu.Game.Screens.Edit.Timing
 
             private void addNew()
             {
-                selectedGroup.Value = Beatmap.ControlPointInfo.GroupAt(clock.CurrentTime, true);
+                bool isFirstControlPoint = !Beatmap.ControlPointInfo.TimingPoints.Any();
+
+                var group = Beatmap.ControlPointInfo.GroupAt(clock.CurrentTime, true);
+
+                if (isFirstControlPoint)
+                    group.Add(new TimingControlPoint());
+
+                selectedGroup.Value = group;
             }
         }
     }


### PR DESCRIPTION
- Copy attribute types from currently selected control point to new placements
- Automatically make first control point added to beatmap have timing data

https://user-images.githubusercontent.com/191335/171177632-f284f7e0-8e85-442d-963e-9346e283117a.mp4
