### PR TITLE
🔧 Add prefix to Sentry release name

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -23,4 +23,4 @@ jobs:
           SENTRY_URL: https://sentry.ppy.sh/
         with:
           environment: production
-          version: ${{ github.ref }}
+          version: osu/${{ github.ref_name }}

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -48,9 +48,8 @@ namespace osu.Game.Utils
 
                 options.AutoSessionTracking = true;
                 options.IsEnvironmentUser = false;
-                // The reported release needs to match release tags on github in order for sentry
-                // to automatically associate and track against releases.
-                options.Release = game.Version.Replace($@"-{OsuGameBase.BUILD_SUFFIX}", string.Empty);
+                // The reported release needs to match version as reported to Sentry in .github/workflows/sentry-release.yml
+                options.Release = $"osu/{game.Version.Replace($@"-{OsuGameBase.BUILD_SUFFIX}", string.Empty)}";
             });
 
             Logger.NewEntry += processLogEntry;


### PR DESCRIPTION
Sentry releases are actually org-wide rather than project-wide, so we need to prefix release names by a slug unique to each project.