### PR TITLE
🚑 Fix use of illegal character in Sentry's release name scheme

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -23,4 +23,4 @@ jobs:
           SENTRY_URL: https://sentry.ppy.sh/
         with:
           environment: production
-          version: osu/${{ github.ref_name }}
+          version: osu@${{ github.ref_name }}

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Utils
                 options.AutoSessionTracking = true;
                 options.IsEnvironmentUser = false;
                 // The reported release needs to match version as reported to Sentry in .github/workflows/sentry-release.yml
-                options.Release = $"osu/{game.Version.Replace($@"-{OsuGameBase.BUILD_SUFFIX}", string.Empty)}";
+                options.Release = $"osu@{game.Version.Replace($@"-{OsuGameBase.BUILD_SUFFIX}", string.Empty)}";
             });
 
             Logger.NewEntry += processLogEntry;


### PR DESCRIPTION
Had accidentally discarded @ instead of /, my head hurts.