### PR TITLE
Add tap for BPM button

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTapButton.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTapButton.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Screens.Edit.Timing;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneTapButton : OsuManualInputManagerTestScene
+    {
+        private TapButton tapButton;
+
+        [Cached]
+        private readonly OverlayColourProvider overlayColour = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("create button", () =>
+            {
+                Child = tapButton = new TapButton
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(4),
+                };
+            });
+
+            bool pressed = false;
+
+            AddRepeatStep("Press button", () =>
+            {
+                InputManager.MoveMouseTo(tapButton);
+                if (!pressed)
+                    InputManager.PressButton(MouseButton.Left);
+                else
+                    InputManager.ReleaseButton(MouseButton.Left);
+
+                pressed = !pressed;
+            }, 100);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
@@ -11,7 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Timing;
@@ -78,34 +78,6 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestNoop()
-        {
-            AddStep("do nothing", () => { });
-        }
-
-        [Test]
-        public void TestTapThenReset()
-        {
-            AddStep("click tap button", () =>
-            {
-                control.ChildrenOfType<RoundedButton>()
-                       .Last()
-                       .TriggerClick();
-            });
-
-            AddUntilStep("wait for track playing", () => Clock.IsRunning);
-
-            AddStep("click reset button", () =>
-            {
-                control.ChildrenOfType<RoundedButton>()
-                       .First()
-                       .TriggerClick();
-            });
-
-            AddUntilStep("wait for track stopped", () => !Clock.IsRunning);
-        }
-
-        [Test]
         public void TestBasic()
         {
             AddStep("set low bpm", () =>
@@ -115,7 +87,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("click tap button", () =>
             {
-                control.ChildrenOfType<RoundedButton>()
+                control.ChildrenOfType<OsuButton>()
                        .Last()
                        .TriggerClick();
             });
@@ -127,6 +99,28 @@ namespace osu.Game.Tests.Visual.Editing
 
                 editorBeatmap.ControlPointInfo.TimingPoints.First().BeatLength = 60000f / bpm;
             });
+        }
+
+        [Test]
+        public void TestTapThenReset()
+        {
+            AddStep("click tap button", () =>
+            {
+                control.ChildrenOfType<OsuButton>()
+                       .Last()
+                       .TriggerClick();
+            });
+
+            AddUntilStep("wait for track playing", () => Clock.IsRunning);
+
+            AddStep("click reset button", () =>
+            {
+                control.ChildrenOfType<OsuButton>()
+                       .First()
+                       .TriggerClick();
+            });
+
+            AddUntilStep("wait for track stopped", () => !Clock.IsRunning);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
+            new KeyBinding(new[] { InputKey.T }, GlobalAction.EditorTapForBPM),
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.EditorFlipHorizontally),
             new KeyBinding(new[] { InputKey.Control, InputKey.J }, GlobalAction.EditorFlipVertically),
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelDown }, GlobalAction.EditorDecreaseDistanceSpacing),
@@ -322,5 +323,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.DeselectAllMods))]
         DeselectAllMods,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTapForBPM))]
+        EditorTapForBPM,
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -175,6 +175,11 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorTimingMode => new TranslatableString(getKey(@"editor_timing_mode"), @"Timing mode");
 
         /// <summary>
+        /// "Tap for BPM"
+        /// </summary>
+        public static LocalisableString EditorTapForBPM => new TranslatableString(getKey(@"editor_tap_for_bpm"), @"Tap for BPM");
+
+        /// <summary>
         /// "Cycle grid display mode"
         /// </summary>
         public static LocalisableString EditorCycleGridDisplayMode => new TranslatableString(getKey(@"editor_cycle_grid_display_mode"), @"Cycle grid display mode");

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Edit.Timing
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Padding = new MarginPadding(10);
+            Padding = new MarginPadding(10) { Bottom = 0 };
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private OverlayColourProvider overlayColourProvider { get; set; }
 
+        public bool EnableClicking { get; set; } = true;
+
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
@@ -281,6 +283,9 @@ namespace osu.Game.Screens.Edit.Timing
 
                     Schedule(() =>
                     {
+                        if (!EnableClicking)
+                            return;
+
                         var channel = clunk?.GetChannel();
 
                         if (channel != null)

--- a/osu.Game/Screens/Edit/Timing/Section.cs
+++ b/osu.Game/Screens/Edit/Timing/Section.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         Flow = new FillFlowContainer
                         {
-                            Padding = new MarginPadding(20),
+                            Padding = new MarginPadding(10) { Top = 0 },
                             Spacing = new Vector2(20),
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -1,10 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -14,6 +17,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -27,24 +31,27 @@ namespace osu.Game.Screens.Edit.Timing
         public const float SIZE = 100;
 
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
-        private Circle hoverLayer;
+        [Resolved(canBeNull: true)]
+        private Bindable<ControlPointGroup>? selectedGroup { get; set; }
 
-        private CircularContainer innerCircle;
-        private Box innerCircleHighlight;
+        private Circle hoverLayer = null!;
+
+        private CircularContainer innerCircle = null!;
+        private Box innerCircleHighlight = null!;
 
         private int currentLight;
 
-        private Container scaleContainer;
-        private Container lights;
-        private Container lightsGlow;
-        private OsuSpriteText bpmText;
-        private Container textContainer;
+        private Container scaleContainer = null!;
+        private Container lights = null!;
+        private Container lightsGlow = null!;
+        private OsuSpriteText bpmText = null!;
+        private Container textContainer = null!;
 
         private bool grabbedMouseDown;
 
-        private ScheduledDelegate resetDelegate;
+        private ScheduledDelegate? resetDelegate;
 
         private const int light_count = 6;
 
@@ -280,16 +287,24 @@ namespace osu.Game.Screens.Edit.Timing
             double bpm = Math.Round(60000 / ((tapTimings.Last() - tapTimings.First()) / (tapTimings.Count - 1)));
 
             bpmText.Text = $"{bpm} BPM";
+
+            var timingPoint = selectedGroup?.Value.ControlPoints.OfType<TimingControlPoint>().FirstOrDefault();
+
+            if (timingPoint != null)
+            {
+                // Intentionally use the rounded BPM here.
+                timingPoint.BeatLength = 60000 / bpm;
+            }
         }
 
         private class Light : CompositeDrawable
         {
-            public Drawable Glow { get; private set; }
+            public Drawable Glow { get; private set; } = null!;
 
-            private Container fillContent;
+            private Container fillContent = null!;
 
             [Resolved]
-            private OverlayColourProvider colourProvider { get; set; }
+            private OverlayColourProvider colourProvider { get; set; } = null!;
 
             [BackgroundDependencyLoader]
             private void load()

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -62,13 +62,15 @@ namespace osu.Game.Screens.Edit.Timing
 
         private ScheduledDelegate? resetDelegate;
 
-        private const int light_count = 6;
+        private const int light_count = 8;
 
         private const int initial_taps_to_ignore = 4;
 
         private const int max_taps_to_consider = 8;
 
         private const double transition_length = 500;
+
+        private const float angular_light_gap = 0.007f;
 
         private readonly List<double> tapTimings = new List<double>();
 
@@ -185,7 +187,7 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 var light = new Light
                 {
-                    Rotation = i * (360f / light_count)
+                    Rotation = (i + 1) * (360f / light_count) + 360 * angular_light_gap / 2,
                 };
 
                 lights.Add(light);
@@ -336,6 +338,7 @@ namespace osu.Game.Screens.Edit.Timing
                 light.Hide();
 
             tapTimings.Clear();
+            currentLight = 0;
             IsHandlingTapping.Value = false;
         }
 
@@ -357,14 +360,12 @@ namespace osu.Game.Screens.Edit.Timing
 
                 Size = new Vector2(0.98f); // Avoid bleed into masking edge.
 
-                const float angular_gap = 0.007f;
-
                 InternalChildren = new Drawable[]
                 {
                     new CircularProgress
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Current = { Value = 1f / light_count - angular_gap },
+                        Current = { Value = 1f / light_count - angular_light_gap },
                         Colour = colourProvider.Background2,
                     },
                     fillContent = new Container
@@ -377,7 +378,7 @@ namespace osu.Game.Screens.Edit.Timing
                             new CircularProgress
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Current = { Value = 1f / light_count - angular_gap },
+                                Current = { Value = 1f / light_count - angular_light_gap },
                                 Blending = BlendingParameters.Additive
                             },
                             // Please do not try and make sense of this.

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -18,6 +18,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -40,6 +41,9 @@ namespace osu.Game.Screens.Edit.Timing
 
         [Resolved(canBeNull: true)]
         private Bindable<ControlPointGroup>? selectedGroup { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private IBeatSyncProvider? beatSyncSource { get; set; }
 
         private Circle hoverLayer = null!;
 
@@ -299,7 +303,10 @@ namespace osu.Game.Screens.Edit.Timing
                 return;
             }
 
-            double bpm = Math.Round(60000 / ((tapTimings.Last() - tapTimings.Skip(initial_taps_to_ignore).First()) / (tapTimings.Count - initial_taps_to_ignore - 1)));
+            double averageBeatLength = (tapTimings.Last() - tapTimings.Skip(initial_taps_to_ignore).First()) / (tapTimings.Count - initial_taps_to_ignore - 1);
+            double clockRate = beatSyncSource?.Clock?.Rate ?? 1;
+
+            double bpm = Math.Round(60000 / averageBeatLength / clockRate);
 
             bpmText.Text = $"{bpm} BPM";
 

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Edit.Timing
     {
         public const float SIZE = 100;
 
+        public readonly BindableBool IsHandlingTapping = new BindableBool();
+
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
@@ -213,6 +215,7 @@ namespace osu.Game.Screens.Edit.Timing
             const double in_duration = 100;
 
             grabbedMouseDown = true;
+            IsHandlingTapping.Value = true;
 
             handleTap();
 
@@ -269,6 +272,7 @@ namespace osu.Game.Screens.Edit.Timing
                 light.Hide();
 
             tapTimings.Clear();
+            IsHandlingTapping.Value = false;
         }
 
         private void handleTap()

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -275,20 +275,23 @@ namespace osu.Game.Screens.Edit.Timing
             IsHandlingTapping.Value = false;
         }
 
+        private const int initial_taps_to_ignore = 4;
+        private const int max_taps_to_consider = 8;
+
         private void handleTap()
         {
             tapTimings.Add(Clock.CurrentTime);
 
-            if (tapTimings.Count > 8)
+            if (tapTimings.Count > initial_taps_to_ignore + max_taps_to_consider)
                 tapTimings.RemoveAt(0);
 
-            if (tapTimings.Count < 5)
+            if (tapTimings.Count < initial_taps_to_ignore * 2)
             {
                 bpmText.Text = new string('.', tapTimings.Count);
                 return;
             }
 
-            double bpm = Math.Round(60000 / ((tapTimings.Last() - tapTimings.First()) / (tapTimings.Count - 1)));
+            double bpm = Math.Round(60000 / ((tapTimings.Last() - tapTimings.Skip(initial_taps_to_ignore).First()) / (tapTimings.Count - initial_taps_to_ignore - 1)));
 
             bpmText.Text = $"{bpm} BPM";
 

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -68,6 +68,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         private const int max_taps_to_consider = 8;
 
+        private const double transition_length = 500;
+
         private readonly List<double> tapTimings = new List<double>();
 
         [BackgroundDependencyLoader]
@@ -212,15 +214,15 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override bool OnHover(HoverEvent e)
         {
-            hoverLayer.FadeIn(500, Easing.OutQuint);
-            textContainer.FadeColour(textColour, 500, Easing.OutQuint);
+            hoverLayer.FadeIn(transition_length, Easing.OutQuint);
+            textContainer.FadeColour(textColour, transition_length, Easing.OutQuint);
             return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            hoverLayer.FadeOut(500, Easing.OutQuint);
-            textContainer.FadeColour(textColour, 500, Easing.OutQuint);
+            hoverLayer.FadeOut(transition_length, Easing.OutQuint);
+            textContainer.FadeColour(textColour, transition_length, Easing.OutQuint);
             base.OnHoverLost(e);
         }
 
@@ -265,6 +267,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             scaleContainer.ScaleTo(1, out_duration, Easing.OutQuint);
             innerCircle.ScaleTo(1, out_duration, Easing.OutQuint);
+
             innerCircleHighlight.FadeOut(out_duration, Easing.OutQuint);
 
             resetDelegate = Scheduler.AddDelayed(reset, 1000);
@@ -321,9 +324,9 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void reset()
         {
-            bpmText.FadeOut(500, Easing.OutQuint);
+            bpmText.FadeOut(transition_length, Easing.OutQuint);
 
-            using (BeginDelayedSequence(tapTimings.Count > 0 ? 500 : 0))
+            using (BeginDelayedSequence(tapTimings.Count > 0 ? transition_length : 0))
             {
                 Schedule(() => bpmText.Text = "the beat!");
                 bpmText.FadeIn(800, Easing.OutQuint);

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    internal class TapButton : CircularContainer
+    {
+        public const float SIZE = 100;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; }
+
+        private Circle hoverLayer;
+        private CircularContainer innerCircle;
+        private Circle outerCircle;
+
+        private Container scaleContainer;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Size = new Vector2(SIZE);
+
+            const float ring_width = 20;
+            const float light_padding = 3;
+
+            InternalChild = scaleContainer = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    outerCircle = new Circle
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background3
+                    },
+                    new CircularContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Name = "outer masking",
+                        Masking = true,
+                        BorderThickness = light_padding,
+                        BorderColour = colourProvider.Background3,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Colour = Color4.Black,
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0,
+                                AlwaysPresent = true,
+                            },
+                        }
+                    },
+                    innerCircle = new CircularContainer
+                    {
+                        Size = new Vector2(SIZE - ring_width + light_padding),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Masking = true,
+                        BorderThickness = light_padding,
+                        BorderColour = colourProvider.Background3,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Colour = colourProvider.Background2,
+                                RelativeSizeAxes = Axes.Both,
+                                AlwaysPresent = true,
+                            },
+                        }
+                    },
+                    hoverLayer = new Circle
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White.Opacity(0.01f),
+                        Blending = BlendingParameters.Additive,
+                        Alpha = 0,
+                    },
+                }
+            };
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            hoverLayer.FadeIn(500, Easing.OutQuint);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            hoverLayer.FadeOut(500, Easing.OutQuint);
+            base.OnHoverLost(e);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            scaleContainer.ScaleTo(0.98f, 200, Easing.OutQuint);
+            innerCircle.ScaleTo(0.95f, 200, Easing.OutQuint);
+            return base.OnMouseDown(e);
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            scaleContainer.ScaleTo(1, 1200, Easing.OutQuint);
+            innerCircle.ScaleTo(1, 1200, Easing.OutQuint);
+            base.OnMouseUp(e);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -15,18 +15,21 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    internal class TapButton : CircularContainer
+    internal class TapButton : CircularContainer, IKeyBindingHandler<GlobalAction>
     {
         public const float SIZE = 140;
 
@@ -56,6 +59,8 @@ namespace osu.Game.Screens.Edit.Timing
         private ScheduledDelegate? resetDelegate;
 
         private const int light_count = 6;
+
+        private readonly List<double> tapTimings = new List<double>();
 
         [BackgroundDependencyLoader]
         private void load()
@@ -257,7 +262,23 @@ namespace osu.Game.Screens.Edit.Timing
             base.OnMouseUp(e);
         }
 
-        private readonly List<double> tapTimings = new List<double>();
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Action == GlobalAction.EditorTapForBPM && !e.Repeat)
+            {
+                // Direct through mouse handling to achieve animation
+                OnMouseDown(new MouseDownEvent(e.CurrentState, MouseButton.Left));
+                return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+            if (e.Action == GlobalAction.EditorTapForBPM)
+                OnMouseUp(new MouseUpEvent(e.CurrentState, MouseButton.Left));
+        }
 
         private void reset()
         {

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -60,6 +60,10 @@ namespace osu.Game.Screens.Edit.Timing
 
         private const int light_count = 6;
 
+        private const int initial_taps_to_ignore = 4;
+
+        private const int max_taps_to_consider = 8;
+
         private readonly List<double> tapTimings = new List<double>();
 
         [BackgroundDependencyLoader]
@@ -223,10 +227,9 @@ namespace osu.Game.Screens.Edit.Timing
             grabbedMouseDown = true;
             IsHandlingTapping.Value = true;
 
-            handleTap();
-
             resetDelegate?.Cancel();
-            resetDelegate = Scheduler.AddDelayed(reset, 1000);
+
+            handleTap();
 
             textContainer.FadeColour(textColour, in_duration, Easing.OutQuint);
 
@@ -259,6 +262,9 @@ namespace osu.Game.Screens.Edit.Timing
             scaleContainer.ScaleTo(1, out_duration, Easing.OutQuint);
             innerCircle.ScaleTo(1, out_duration, Easing.OutQuint);
             innerCircleHighlight.FadeOut(out_duration, Easing.OutQuint);
+
+            resetDelegate = Scheduler.AddDelayed(reset, 1000);
+
             base.OnMouseUp(e);
         }
 
@@ -279,26 +285,6 @@ namespace osu.Game.Screens.Edit.Timing
             if (e.Action == GlobalAction.EditorTapForBPM)
                 OnMouseUp(new MouseUpEvent(e.CurrentState, MouseButton.Left));
         }
-
-        private void reset()
-        {
-            bpmText.FadeOut(500, Easing.OutQuint);
-
-            using (BeginDelayedSequence(tapTimings.Count > 0 ? 500 : 0))
-            {
-                Schedule(() => bpmText.Text = "the beat!");
-                bpmText.FadeIn(800, Easing.OutQuint);
-            }
-
-            foreach (var light in lights)
-                light.Hide();
-
-            tapTimings.Clear();
-            IsHandlingTapping.Value = false;
-        }
-
-        private const int initial_taps_to_ignore = 4;
-        private const int max_taps_to_consider = 8;
 
         private void handleTap()
         {
@@ -324,6 +310,23 @@ namespace osu.Game.Screens.Edit.Timing
                 // Intentionally use the rounded BPM here.
                 timingPoint.BeatLength = 60000 / bpm;
             }
+        }
+
+        private void reset()
+        {
+            bpmText.FadeOut(500, Easing.OutQuint);
+
+            using (BeginDelayedSequence(tapTimings.Count > 0 ? 500 : 0))
+            {
+                Schedule(() => bpmText.Text = "the beat!");
+                bpmText.FadeIn(800, Easing.OutQuint);
+            }
+
+            foreach (var light in lights)
+                light.Hide();
+
+            tapTimings.Clear();
+            IsHandlingTapping.Value = false;
         }
 
         private class Light : CompositeDrawable

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         private const int initial_taps_to_ignore = 4;
 
-        private const int max_taps_to_consider = 16;
+        private const int max_taps_to_consider = 128;
 
         private const double transition_length = 500;
 

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         private const int initial_taps_to_ignore = 4;
 
-        private const int max_taps_to_consider = 8;
+        private const int max_taps_to_consider = 16;
 
         private const double transition_length = 500;
 

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -6,7 +6,10 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -21,17 +24,23 @@ namespace osu.Game.Screens.Edit.Timing
         private OverlayColourProvider colourProvider { get; set; }
 
         private Circle hoverLayer;
+
         private CircularContainer innerCircle;
-        private Circle outerCircle;
+        private Box innerCircleHighlight;
+
+        private int currentLight;
 
         private Container scaleContainer;
+        private Container lights;
+
+        private const int light_count = 6;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Size = new Vector2(SIZE);
 
-            const float ring_width = 20;
+            const float ring_width = 18;
             const float light_padding = 3;
 
             InternalChild = scaleContainer = new Container
@@ -41,10 +50,14 @@ namespace osu.Game.Screens.Edit.Timing
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    outerCircle = new Circle
+                    new Circle
                     {
                         RelativeSizeAxes = Axes.Both,
                         Colour = colourProvider.Background3
+                    },
+                    lights = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
                     },
                     new CircularContainer
                     {
@@ -64,34 +77,64 @@ namespace osu.Game.Screens.Edit.Timing
                             },
                         }
                     },
+                    new Circle
+                    {
+                        Size = new Vector2(SIZE - ring_width * 2 + light_padding * 2),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Colour = colourProvider.Background3,
+                    },
                     innerCircle = new CircularContainer
                     {
-                        Size = new Vector2(SIZE - ring_width + light_padding),
+                        Size = new Vector2(SIZE - ring_width * 2),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Masking = true,
-                        BorderThickness = light_padding,
-                        BorderColour = colourProvider.Background3,
                         Children = new Drawable[]
                         {
                             new Box
                             {
                                 Colour = colourProvider.Background2,
                                 RelativeSizeAxes = Axes.Both,
-                                AlwaysPresent = true,
+                            },
+                            innerCircleHighlight = new Box
+                            {
+                                Colour = colourProvider.Colour3,
+                                Blending = BlendingParameters.Additive,
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0,
+                            },
+                            new OsuSpriteText
+                            {
+                                Font = OsuFont.Torus.With(size: 20),
+                                Colour = colourProvider.Background1,
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Text = "Tap!"
+                            },
+                            hoverLayer = new Circle
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = colourProvider.Background1.Opacity(0.3f),
+                                Blending = BlendingParameters.Additive,
+                                Alpha = 0,
                             },
                         }
                     },
-                    hoverLayer = new Circle
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.White.Opacity(0.01f),
-                        Blending = BlendingParameters.Additive,
-                        Alpha = 0,
-                    },
                 }
             };
+
+            for (int i = 0; i < light_count; i++)
+            {
+                lights.Add(new Light
+                {
+                    Rotation = i * (360f / light_count)
+                });
+            }
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            hoverLayer.ReceivePositionalInputAt(screenSpacePos);
 
         protected override bool OnHover(HoverEvent e)
         {
@@ -107,16 +150,87 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            scaleContainer.ScaleTo(0.98f, 200, Easing.OutQuint);
-            innerCircle.ScaleTo(0.95f, 200, Easing.OutQuint);
+            const double in_duration = 100;
+
+            scaleContainer.ScaleTo(0.99f, in_duration, Easing.OutQuint);
+            innerCircle.ScaleTo(0.96f, in_duration, Easing.OutQuint);
+
+            innerCircleHighlight
+                .FadeIn(50, Easing.OutQuint)
+                .FlashColour(Color4.White, 1000, Easing.OutQuint);
+
+            lights[currentLight % light_count].Hide();
+            lights[(currentLight + light_count / 2) % light_count].Hide();
+
+            currentLight++;
+
+            lights[currentLight % light_count].Show();
+            lights[(currentLight + light_count / 2) % light_count].Show();
+
             return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            scaleContainer.ScaleTo(1, 1200, Easing.OutQuint);
-            innerCircle.ScaleTo(1, 1200, Easing.OutQuint);
+            const double out_duration = 800;
+
+            scaleContainer.ScaleTo(1, out_duration, Easing.OutQuint);
+            innerCircle.ScaleTo(1, out_duration, Easing.OutQuint);
+            innerCircleHighlight.FadeOut(out_duration, Easing.OutQuint);
             base.OnMouseUp(e);
+        }
+
+        private class Light : CompositeDrawable
+        {
+            private CircularProgress fill;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RelativeSizeAxes = Axes.Both;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                InternalChildren = new Drawable[]
+                {
+                    new CircularProgress
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(0.99f),
+                        Current = { Value = 1f / light_count - 0.01f },
+                        Colour = colourProvider.Background2,
+                    },
+                    fill = new CircularProgress
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0,
+                        Size = new Vector2(0.99f),
+                        Current = { Value = 1f / light_count - 0.01f },
+                        Colour = colourProvider.Colour1,
+                        Blending = BlendingParameters.Additive
+                    },
+                };
+            }
+
+            public override void Show()
+            {
+                fill
+                    .FadeIn(50, Easing.OutQuint)
+                    .FlashColour(Color4.White, 1000, Easing.OutQuint);
+            }
+
+            public override void Hide()
+            {
+                fill
+                    .FadeOut(300, Easing.OutQuint);
+            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -377,6 +377,9 @@ namespace osu.Game.Screens.Edit.Timing
                                 Current = { Value = 1f / light_count - angular_gap },
                                 Blending = BlendingParameters.Additive
                             },
+                            // Please do not try and make sense of this.
+                            // Getting the visual effect I was going for relies on what I can only imagine is broken implementation
+                            // of `PadExtent`. If that's ever fixed in the future this will likely need to be adjusted.
                             Glow = new CircularProgress
                             {
                                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Timing
 {
     internal class TapButton : CircularContainer
     {
-        public const float SIZE = 100;
+        public const float SIZE = 140;
 
         public readonly BindableBool IsHandlingTapping = new BindableBool();
 
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.Edit.Timing
         {
             Size = new Vector2(SIZE);
 
-            const float ring_width = 18;
+            const float ring_width = 22;
             const float light_padding = 3;
 
             InternalChild = scaleContainer = new Container
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Edit.Timing
                     new Circle
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Background3
+                        Colour = colourProvider.Background4
                     },
                     lights = new Container
                     {
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Edit.Timing
                         Name = @"outer masking",
                         Masking = true,
                         BorderThickness = light_padding,
-                        BorderColour = colourProvider.Background3,
+                        BorderColour = colourProvider.Background4,
                         Children = new Drawable[]
                         {
                             new Box
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Edit.Timing
                         Size = new Vector2(SIZE - ring_width * 2 + light_padding * 2),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Colour = colourProvider.Background3,
+                        Colour = colourProvider.Background4,
                     },
                     lightsGlow = new Container
                     {
@@ -139,17 +139,18 @@ namespace osu.Game.Screens.Edit.Timing
                                 {
                                     new OsuSpriteText
                                     {
-                                        Font = OsuFont.Torus.With(size: 20),
+                                        Font = OsuFont.Torus.With(size: 34, weight: FontWeight.SemiBold),
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.BottomCentre,
-                                        Y = 3,
-                                        Text = "Tap"
+                                        Y = 5,
+                                        Text = "Tap",
                                     },
                                     bpmText = new OsuSpriteText
                                     {
-                                        Font = OsuFont.Torus.With(size: 14),
+                                        Font = OsuFont.Torus.With(size: 23, weight: FontWeight.Regular),
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.TopCentre,
+                                        Y = -1,
                                     },
                                 }
                             },
@@ -200,7 +201,7 @@ namespace osu.Game.Screens.Edit.Timing
         {
             hoverLayer.FadeIn(500, Easing.OutQuint);
             textContainer.FadeColour(textColour, 500, Easing.OutQuint);
-            return base.OnHover(e);
+            return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
@@ -322,12 +323,14 @@ namespace osu.Game.Screens.Edit.Timing
 
                 Size = new Vector2(0.98f); // Avoid bleed into masking edge.
 
+                const float angular_gap = 0.007f;
+
                 InternalChildren = new Drawable[]
                 {
                     new CircularProgress
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Current = { Value = 1f / light_count - 0.01f },
+                        Current = { Value = 1f / light_count - angular_gap },
                         Colour = colourProvider.Background2,
                     },
                     fillContent = new Container
@@ -340,7 +343,7 @@ namespace osu.Game.Screens.Edit.Timing
                             new CircularProgress
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Current = { Value = 1f / light_count - 0.01f },
+                                Current = { Value = 1f / light_count - angular_gap },
                                 Blending = BlendingParameters.Additive
                             },
                             Glow = new CircularProgress

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Screens.Edit.Timing
                         new Dimension(GridSizeMode.Absolute, 200),
                         new Dimension(GridSizeMode.Absolute, 60),
                         new Dimension(GridSizeMode.Absolute, 60),
+                        new Dimension(GridSizeMode.Absolute, 120),
                     },
                     Content = new[]
                     {
@@ -141,6 +142,14 @@ namespace osu.Game.Screens.Edit.Timing
                                     }
                                 }
                             },
+                        },
+                        new Drawable[]
+                        {
+                            new TapButton
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            }
                         }
                     }
                 },

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -25,6 +25,10 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private Bindable<ControlPointGroup> selectedGroup { get; set; }
 
+        private readonly BindableBool isHandlingTapping = new BindableBool();
+
+        private MetronomeDisplay metronome;
+
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
@@ -73,7 +77,7 @@ namespace osu.Game.Screens.Edit.Timing
                                         {
                                             new Drawable[]
                                             {
-                                                new MetronomeDisplay
+                                                metronome = new MetronomeDisplay
                                                 {
                                                     Anchor = Anchor.CentreLeft,
                                                     Origin = Anchor.CentreLeft,
@@ -149,11 +153,17 @@ namespace osu.Game.Screens.Edit.Timing
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
+                                IsHandlingTapping = { BindTarget = isHandlingTapping }
                             }
                         }
                     }
                 },
             };
+
+            isHandlingTapping.BindValueChanged(handling =>
+            {
+                metronome.EnableClicking = !handling.NewValue;
+            }, true);
         }
 
         private void adjustOffset(double adjust)

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -163,6 +163,12 @@ namespace osu.Game.Screens.Edit.Timing
             isHandlingTapping.BindValueChanged(handling =>
             {
                 metronome.EnableClicking = !handling.NewValue;
+
+                if (handling.NewValue)
+                {
+                    editorClock.Seek(selectedGroup.Value.Time);
+                    editorClock.Start();
+                }
             }, true);
         }
 

--- a/osu.Game/Screens/Edit/Timing/TimingAdjustButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingAdjustButton.cs
@@ -187,7 +187,7 @@ namespace osu.Game.Screens.Edit.Timing
                         Origin = direction,
                         Font = OsuFont.Default.With(size: 10, weight: FontWeight.Bold),
                         Text = $"{(index > 0 ? "+" : "-")}{Math.Abs(Multiplier * amount)}",
-                        Padding = new MarginPadding(5),
+                        Padding = new MarginPadding(2),
                         Alpha = 0,
                     }
                 };


### PR DESCRIPTION
Initial implementation of a tap button.

https://user-images.githubusercontent.com/191335/171552053-03e56c8a-0784-4b0b-9994-f74059915bc3.mp4

Will add localisation support in a second pass (I think this is easier from a review perspective, and I also forgot to add localisation to the surrounding components).

Note that this design is all mine, designed to be functional mostly, and may change when @arflyte sees it. Also I plan to add some buttons to the right-hand side of the circular button to balance things out. Maybe `x2` and `/2` bpm adjustments? Not sure yet.