### PR TITLE
Fix tutorial download state not matching correctly when already available locally

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
+++ b/osu.Game/Beatmaps/Drawables/BundledBeatmapDownloader.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Beatmaps.Drawables
                 downloadTrackers.Add(beatmapDownloadTracker);
                 AddInternal(beatmapDownloadTracker);
 
+                // Note that this is downloading the beatmaps even if they are already downloaded.
+                // We could rely more on `BeatmapDownloadTracker`'s exposed state to avoid this.
                 beatmapDownloader.Download(beatmapSet);
             }
         }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
@@ -154,12 +154,15 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             var downloadTracker = tutorialDownloader.DownloadTrackers.First();
 
+            downloadTracker.State.BindValueChanged(state =>
+            {
+                if (state.NewValue == DownloadState.LocallyAvailable)
+                    downloadTutorialButton.Complete();
+            }, true);
+
             downloadTracker.Progress.BindValueChanged(progress =>
             {
                 downloadTutorialButton.SetProgress(progress.NewValue, false);
-
-                if (progress.NewValue == 1)
-                    downloadTutorialButton.Complete();
             }, true);
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/18468.

This doesn't stop the tutorial from downloading a second time, but at least displays the correct status afterwards. Avoiding the download is a bit more involved and requires a change to the flow. Probably not worth it just yet.

To test, recommend switching to production environment, as dev server doesn't have correct metadata for tutorial resulting in weirdness.