### PR TITLE
Populate MaxCombo difficulty attribute for osu!mania

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
@@ -14,11 +14,11 @@ namespace osu.Game.Rulesets.Mania.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Mania";
 
-        [TestCase(2.3449735700206298d, 151, "diffcalc-test")]
+        [TestCase(2.3449735700206298d, 242, "diffcalc-test")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(2.7879104989252959d, 151, "diffcalc-test")]
+        [TestCase(2.7879104989252959d, 242, "diffcalc-test")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new ManiaModDoubleTime());
 

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             foreach (var v in base.ToDatabaseAttributes())
                 yield return v;
 
-            // Todo: osu!mania doesn't output MaxCombo attribute for some reason.
+            yield return (ATTRIB_ID_MAX_COMBO, MaxCombo);
             yield return (ATTRIB_ID_DIFFICULTY, StarRating);
             yield return (ATTRIB_ID_GREAT_HIT_WINDOW, GreatHitWindow);
             yield return (ATTRIB_ID_SCORE_MULTIPLIER, ScoreMultiplier);
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         {
             base.FromDatabaseAttributes(values);
 
+            MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
             StarRating = values[ATTRIB_ID_DIFFICULTY];
             GreatHitWindow = values[ATTRIB_ID_GREAT_HIT_WINDOW];
             ScoreMultiplier = values[ATTRIB_ID_SCORE_MULTIPLIER];

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -52,8 +52,16 @@ namespace osu.Game.Rulesets.Mania.Difficulty
                 // This is done the way it is to introduce fractional differences in order to match osu-stable for the time being.
                 GreatHitWindow = Math.Ceiling((int)(getHitWindow300(mods) * clockRate) / clockRate),
                 ScoreMultiplier = getScoreMultiplier(mods),
-                MaxCombo = beatmap.HitObjects.Sum(h => h is HoldNote ? 2 : 1),
+                MaxCombo = beatmap.HitObjects.Sum(maxComboForObject)
             };
+        }
+
+        private static int maxComboForObject(HitObject hitObject)
+        {
+            if (hitObject is HoldNote hold)
+                return 1 + (int)((hold.EndTime - hold.StartTime) / 100);
+
+            return 1;
         }
 
         protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/18493

This is an MVP implementation in order to fill out the MaxCombo attribute in the DB to eventually be consumed by clients. It's not intended to be the perfect-looking fix, and is only intended to be backwards compatible with the `release-diffcalc` branch.

Two changes here:
1. Actually outputting the attribute.
2. Changing the difficulty calculator to account for ticks. In stable, these are every 100ms.

Note however, that osu!stable's implementation is kinda buggy. The value from this PR will match the osu!stable _editor_, but will likely not match gameplay since osu!stable can't decide what to do during gameplay - changing the beatmap rate (via 5-9 keys on Cutting Edge) will change the amount of combo for an auto play.

This PR will need to be backported to the release-diffcalc branch if accepted.

Further work will be done to adjust osu!lazer's scoring - upon earlier voice discussion we also agreed that lazer should do a similar thing.