### PR TITLE
Improve safety of file chooser textbox disposal

### DIFF
--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,10 +29,10 @@ namespace osu.Game.Screens.Edit.Setup
 
         public IEnumerable<string> HandledExtensions => handledExtensions;
 
-        private readonly Bindable<FileInfo> currentFile = new Bindable<FileInfo>();
+        private readonly Bindable<FileInfo?> currentFile = new Bindable<FileInfo?>();
 
         [Resolved]
-        private OsuGameBase game { get; set; }
+        private OsuGameBase game { get; set; } = null!;
 
         public FileChooserLabelledTextBox(params string[] handledExtensions)
         {
@@ -45,7 +47,7 @@ namespace osu.Game.Screens.Edit.Setup
             currentFile.BindValueChanged(onFileSelected);
         }
 
-        private void onFileSelected(ValueChangedEvent<FileInfo> file)
+        private void onFileSelected(ValueChangedEvent<FileInfo?> file)
         {
             if (file.NewValue == null)
                 return;
@@ -72,7 +74,7 @@ namespace osu.Game.Screens.Edit.Setup
 
         private class FileChooserPopover : OsuPopover
         {
-            public FileChooserPopover(string[] handledExtensions, Bindable<FileInfo> currentFile)
+            public FileChooserPopover(string[] handledExtensions, Bindable<FileInfo?> currentFile)
             {
                 Child = new Container
                 {

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -67,7 +68,9 @@ namespace osu.Game.Screens.Edit.Setup
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            game.UnregisterImportHandler(this);
+
+            if (game.IsNotNull())
+                game.UnregisterImportHandler(this);
         }
 
         public override Popover GetPopover() => new FileChooserPopover(handledExtensions, currentFile);


### PR DESCRIPTION
Should fix test failures as seen on CI: https://github.com/ppy/osu/runs/6703075869?check_suite_focus=true#step:5:26

Diff also features NRT annotation coverage for the class, as well as a usage of the [newly-introduced extension methods](https://github.com/ppy/osu-framework/pull/5207) which were intended for checks in disposal such as this one.