### PR TITLE
Prevent score submission when exiting/failing with bonus hits only

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -165,6 +165,24 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);
         }
 
+        [TestCase(HitResult.SmallBonus)]
+        [TestCase(HitResult.LargeBonus)]
+        public void TestNoSubmissionOnBonusOnlyFail(HitResult type)
+        {
+            prepareTestAPI(true);
+
+            createPlayerTest(true);
+
+            AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            addFakeHit(type);
+
+            AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
+            AddStep("exit", () => Player.Exit());
+
+            AddAssert("ensure no submission", () => Player.SubmittedScore == null);
+        }
+
         [Test]
         public void TestSubmissionOnFail()
         {
@@ -190,6 +208,22 @@ namespace osu.Game.Tests.Visual.Gameplay
             createPlayerTest();
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            AddStep("exit", () => Player.Exit());
+            AddAssert("ensure no submission", () => Player.SubmittedScore == null);
+        }
+
+        [TestCase(HitResult.SmallBonus)]
+        [TestCase(HitResult.LargeBonus)]
+        public void TestNoSubmissionOnBonusOnlyExit(HitResult type)
+        {
+            prepareTestAPI(true);
+
+            createPlayerTest();
+
+            AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            addFakeHit(type);
 
             AddStep("exit", () => Player.Exit());
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);
@@ -329,16 +363,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
-        private void addFakeHit()
+        private void addFakeHit(HitResult type = HitResult.Great)
         {
             AddUntilStep("wait for first result", () => Player.Results.Count > 0);
 
-            AddStep("force successfuly hit", () =>
+            AddStep($"force {type.ToString().ToLower()} hit", () =>
             {
                 Player.ScoreProcessor.RevertResult(Player.Results.First());
                 Player.ScoreProcessor.ApplyResult(new OsuJudgementResult(Beatmap.Value.Beatmap.HitObjects.First(), new OsuJudgement())
                 {
-                    Type = HitResult.Great,
+                    Type = type,
                 });
             });
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -167,7 +167,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [TestCase(HitResult.SmallBonus)]
         [TestCase(HitResult.LargeBonus)]
-        public void TestNoSubmissionOnBonusOnlyFail(HitResult type)
+        [TestCase(HitResult.SmallTickHit)]
+        [TestCase(HitResult.LargeTickHit)]
+        public void TestNoSubmissionOnFailWithNonBasicHits(HitResult type)
         {
             prepareTestAPI(true);
 
@@ -215,7 +217,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [TestCase(HitResult.SmallBonus)]
         [TestCase(HitResult.LargeBonus)]
-        public void TestNoSubmissionOnBonusOnlyExit(HitResult type)
+        [TestCase(HitResult.SmallTickHit)]
+        [TestCase(HitResult.LargeTickHit)]
+        public void TestNoSubmissionOnExitWithNonBasicHits(HitResult type)
         {
             prepareTestAPI(true);
 

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Play
                 return scoreSubmissionSource.Task;
 
             // if the user never hit anything, this score should not be counted in any way.
-            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0))
+            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && !s.Key.IsBonus() && s.Value > 0))
                 return Task.CompletedTask;
 
             scoreSubmissionSource = new TaskCompletionSource<bool>();

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Play
                 return scoreSubmissionSource.Task;
 
             // if the user never hit anything, this score should not be counted in any way.
-            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && !s.Key.IsBonus() && s.Value > 0))
+            if (!score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Key.IsBasic() && s.Value > 0))
                 return Task.CompletedTask;
 
             scoreSubmissionSource = new TaskCompletionSource<bool>();


### PR DESCRIPTION
- Closes #18513 

Previously, score will be submitted regardless of whether the player has only gathered bonus hits, which can lead to submission failure as bonus hits are not acknowledged by osu-web (see https://github.com/ppy/osu/issues/18513#issuecomment-1142955984 for more details).