### PR TITLE
Add sentry tag for selected beatmap

### DIFF
--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -159,6 +159,7 @@ namespace osu.Game.Utils
                         Game = game.Clock.CurrentTime,
                     };
 
+                    scope.SetTag(@"beatmap", $"{beatmap.OnlineID}");
                     scope.SetTag(@"ruleset", ruleset.ShortName);
                     scope.SetTag(@"os", $"{RuntimeInfo.OS} ({Environment.OSVersion})");
                     scope.SetTag(@"processor count", Environment.ProcessorCount.ToString());


### PR DESCRIPTION
Similar to `ruleset`, helpful to nail down all beatmaps affected by a specific issue that's not immediately visible without going through each different report/event manually (i.e. https://sentry.ppy.sh/organizations/ppy/issues/12 and https://github.com/ppy/osu/issues/17215#issuecomment-1143041912).

Example: https://sentry.ppy.sh/organizations/ppy/issues/2231