### PR TITLE
Change default window mode to "Borderless" on macOS

### DIFF
--- a/osu.Game/Localisation/LayoutSettingsStrings.cs
+++ b/osu.Game/Localisation/LayoutSettingsStrings.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Localisation
         public static LocalisableString UnableToRunExclusiveFullscreen => new TranslatableString(getKey(@"unable_to_run_exclusive_fullscreen"), @"Unable to run exclusive fullscreen. You'll still experience some input latency.");
 
         /// <summary>
-        /// "Running fullscreen on macOS takes full control away from the system, this could lead to system-wide freezes if the game becomes unresponsive."
+        /// "Using fullscreen on macOS makes interacting with the menu bar and spaces no longer work, and may lead to freezes if a system dialog is presented. Using borderless is recommended."
         /// </summary>
-        public static LocalisableString FullscreenMacOSNote => new TranslatableString(getKey(@"fullscreen_macos_note"), @"Running fullscreen on macOS takes full control away from the system, this could lead to system-wide freezes if the game becomes unresponsive.");
+        public static LocalisableString FullscreenMacOSNote => new TranslatableString(getKey(@"fullscreen_macos_note"), @"Using fullscreen on macOS makes interacting with the menu bar and spaces no longer work, and may lead to freezes if a system dialog is presented. Using borderless is recommended.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/LayoutSettingsStrings.cs
+++ b/osu.Game/Localisation/LayoutSettingsStrings.cs
@@ -24,6 +24,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString UnableToRunExclusiveFullscreen => new TranslatableString(getKey(@"unable_to_run_exclusive_fullscreen"), @"Unable to run exclusive fullscreen. You'll still experience some input latency.");
 
+        /// <summary>
+        /// "Running fullscreen on macOS takes full control away from the system, this could lead to system-wide freezes if the game becomes unresponsive."
+        /// </summary>
+        public static LocalisableString FullscreenMacOSNote => new TranslatableString(getKey(@"fullscreen_macos_note"), @"Running fullscreen on macOS takes full control away from the system, this could lead to system-wide freezes if the game becomes unresponsive.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -664,7 +664,7 @@ namespace osu.Game
             {
                 // General expectation that osu! starts in fullscreen by default (also gives the most predictable performance).
                 // However, macOS is bound to have issues when using exclusive fullscreen as it takes full control away from OS, therefore borderless is default there.
-                { FrameworkSetting.WindowMode, RuntimeInfo.IsApple ? WindowMode.Borderless : WindowMode.Fullscreen }
+                { FrameworkSetting.WindowMode, RuntimeInfo.OS == RuntimeInfo.Platform.macOS ? WindowMode.Borderless : WindowMode.Fullscreen }
             };
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
 using JetBrains.Annotations;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -658,11 +659,14 @@ namespace osu.Game
         }
 
         protected override IDictionary<FrameworkSetting, object> GetFrameworkConfigDefaults()
-            => new Dictionary<FrameworkSetting, object>
+        {
+            return new Dictionary<FrameworkSetting, object>
             {
-                // General expectation that osu! starts in fullscreen by default (also gives the most predictable performance)
-                { FrameworkSetting.WindowMode, WindowMode.Fullscreen }
+                // General expectation that osu! starts in fullscreen by default (also gives the most predictable performance).
+                // However, macOS is bound to have issues when using exclusive fullscreen as it takes full control away from OS, therefore borderless is default there.
+                { FrameworkSetting.WindowMode, RuntimeInfo.IsApple ? WindowMode.Borderless : WindowMode.Fullscreen }
             };
+        }
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Drawing;
 using System.Linq;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -227,6 +228,12 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             if (windowModeDropdown.Current.Value != WindowMode.Fullscreen)
             {
                 windowModeDropdown.SetNoticeText(GraphicsSettingsStrings.NotFullscreenNote, true);
+                return;
+            }
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
+            {
+                windowModeDropdown.SetNoticeText(LayoutSettingsStrings.FullscreenMacOSNote, true);
                 return;
             }
 

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -225,15 +225,19 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private void updateScreenModeWarning()
         {
-            if (windowModeDropdown.Current.Value != WindowMode.Fullscreen)
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
             {
-                windowModeDropdown.SetNoticeText(GraphicsSettingsStrings.NotFullscreenNote, true);
+                if (windowModeDropdown.Current.Value == WindowMode.Fullscreen)
+                    windowModeDropdown.SetNoticeText(LayoutSettingsStrings.FullscreenMacOSNote, true);
+                else
+                    windowModeDropdown.ClearNoticeText();
+
                 return;
             }
 
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
+            if (windowModeDropdown.Current.Value != WindowMode.Fullscreen)
             {
-                windowModeDropdown.SetNoticeText(LayoutSettingsStrings.FullscreenMacOSNote, true);
+                windowModeDropdown.SetNoticeText(GraphicsSettingsStrings.NotFullscreenNote, true);
                 return;
             }
 


### PR DESCRIPTION
[As mentioned in discord](https://discord.com/channels/188630481301012481/188630652340404224/981699301812101162), using "Fullscreen" takes full control away from the OS, which means that if the game were to deadlock, or if an OS pop-up which freezes the game has opened, or if a breakpoint was hit (happens a lot for me), then the game can't be escaped from and the only option available is to halt the system down using the power button.

I had thought about removing "Fullscreen" entirely on macOS countless times, since it's not friendly in any way, but that prevents the user from running on exclusive fullscreen and/or switching display modes, and I suppose that's probably not fine. Therefore I've kept it for now but changed the default to "Borderless" at least.