### PR TITLE
Isolate "server-side" multiplayer rooms in testing

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -197,6 +197,7 @@ namespace osu.Game.Online.Multiplayer
 
                     APIRoom.Playlist.Clear();
                     APIRoom.Playlist.AddRange(joinedRoom.Playlist.Select(createPlaylistItem));
+                    APIRoom.CurrentPlaylistItem.Value = APIRoom.Playlist.Single(item => item.ID == joinedRoom.Settings.PlaylistItemId);
 
                     Debug.Assert(LocalUser != null);
                     addUserToAPIRoom(LocalUser);
@@ -737,6 +738,7 @@ namespace osu.Game.Online.Multiplayer
             APIRoom.Type.Value = Room.Settings.MatchType;
             APIRoom.QueueMode.Value = Room.Settings.QueueMode;
             APIRoom.AutoStartDuration.Value = Room.Settings.AutoStartDuration;
+            APIRoom.CurrentPlaylistItem.Value = APIRoom.Playlist.Single(item => item.ID == settings.PlaylistItemId);
 
             RoomUpdated?.Invoke();
         }

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -61,7 +61,13 @@ namespace osu.Game.Online.Rooms
         /// Used for serialising to the API.
         /// </summary>
         [JsonProperty("beatmap_id")]
-        private int onlineBeatmapId => Beatmap.OnlineID;
+        private int onlineBeatmapId
+        {
+            get => Beatmap.OnlineID;
+            // This setter is only required for client-side serialise-then-deserialise operations.
+            // Serialisation is supposed to emit only a `beatmap_id`, but a (non-null) `beatmap` is required on deserialise.
+            set => Beatmap = new APIBeatmap { OnlineID = value };
+        }
 
         /// <summary>
         /// A beatmap representing this playlist item.

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -162,6 +162,13 @@ namespace osu.Game.Online.Rooms
             Password.BindValueChanged(p => HasPassword.Value = !string.IsNullOrEmpty(p.NewValue));
         }
 
+        /// <summary>
+        /// Copies values from another <see cref="Room"/> into this one.
+        /// </summary>
+        /// <remarks>
+        /// **Beware**: This will store references between <see cref="Room"/>s.
+        /// </remarks>
+        /// <param name="other">The <see cref="Room"/> to copy values from.</param>
         public void CopyFrom(Room other)
         {
             RoomID.Value = other.RoomID.Value;

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -44,9 +45,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             switch (request)
             {
                 case CreateRoomRequest createRoomRequest:
-                    var apiRoom = new Room();
-
-                    apiRoom.CopyFrom(createRoomRequest.Room);
+                    var apiRoom = cloneRoom(createRoomRequest.Room);
 
                     // Passwords are explicitly not copied between rooms.
                     apiRoom.HasPassword.Value = !string.IsNullOrEmpty(createRoomRequest.Room.Password.Value);
@@ -178,12 +177,13 @@ namespace osu.Game.Tests.Visual.OnlinePlay
 
         private Room createResponseRoom(Room room, bool withParticipants)
         {
-            var responseRoom = new Room();
-            responseRoom.CopyFrom(room);
+            var responseRoom = cloneRoom(room);
             responseRoom.Password.Value = null;
             if (!withParticipants)
                 responseRoom.RecentParticipants.Clear();
             return responseRoom;
         }
+
+        private Room cloneRoom(Room source) => JsonConvert.DeserializeObject<Room>(JsonConvert.SerializeObject(source));
     }
 }

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -179,9 +179,15 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         private Room createResponseRoom(Room room, bool withParticipants)
         {
             var responseRoom = cloneRoom(room);
+
+            // Password is hidden from the response, and is only propagated via HasPassword.
+            bool hadPassword = responseRoom.HasPassword.Value;
             responseRoom.Password.Value = null;
+            responseRoom.HasPassword.Value = hadPassword;
+
             if (!withParticipants)
                 responseRoom.RecentParticipants.Clear();
+
             return responseRoom;
         }
 

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
@@ -184,6 +185,18 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             return responseRoom;
         }
 
-        private Room cloneRoom(Room source) => JsonConvert.DeserializeObject<Room>(JsonConvert.SerializeObject(source));
+        private Room cloneRoom(Room source)
+        {
+            var result = JsonConvert.DeserializeObject<Room>(JsonConvert.SerializeObject(source));
+            Debug.Assert(result != null);
+
+            // Playlist item IDs aren't serialised.
+            if (source.CurrentPlaylistItem.Value != null)
+                result.CurrentPlaylistItem.Value.ID = source.CurrentPlaylistItem.Value.ID;
+            for (int i = 0; i < source.Playlist.Count; i++)
+                result.Playlist[i].ID = source.Playlist[i].ID;
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Hoping to fix test failures such as https://github.com/ppy/osu/runs/6722347962?check_suite_focus=true

The following is what I suspect is happening here:

- `Room.CopyRoom` copies items by reference, in particular `PlaylistItem`s but also many other properties:
  https://github.com/ppy/osu/blob/538ad1bc98d416d6ce6da3af22a2c59338b8ef3c/osu.Game/Online/Rooms/Room.cs#L195-L199
- `TestRoomRequestsHandler.cs` stores the rooms as "server-side" rooms, which are then consumed by `TestMultiplayerClient`:
  https://github.com/ppy/osu/blob/538ad1bc98d416d6ce6da3af22a2c59338b8ef3c/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs#L26-L28
  https://github.com/ppy/osu/blob/538ad1bc98d416d6ce6da3af22a2c59338b8ef3c/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs#L191
- When gameplay is finished, `TestMultiplayerClient` is expected to advance to the next playlist item. In doing so it
  1) Changes the expired state and triggers a `PlaylistItemChanged` event.
  2) Changes the item order and triggers another `PlaylistItemChanged` event.
- It's _supposed_ to do all these operations on the "server-side" rooms and not touch the client-side ones at all. However, due to the copying by reference, it actually changes the client-side `PlaylistItem`s.
- When processing the `PlaylistItemChanged` event, on the update thread, the playlist item is inadvertently changed by the `TestMultiplayerClient` and the equality comparer fails:
  https://github.com/ppy/osu/blob/538ad1bc98d416d6ce6da3af22a2c59338b8ef3c/osu.Game/Online/Rooms/PlaylistItem.cs#L131-L138

I've isolated the fix to `TestRoomRequestsHandler` since this is one of the only two relevant callsites to `CopyRoom()`. The other is from polling requests at which point the rooms are known to be isolated. Adding a second copy in all cases therefore seems wasteful.