### PR TITLE
SFX consistency pass

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected readonly BeatmapDownloadTracker DownloadTracker;
 
         protected BeatmapCard(APIBeatmapSet beatmapSet, bool allowExpansion = true)
-            : base(HoverSampleSet.Submit)
+            : base(HoverSampleSet.Button)
         {
             Expanded = new BindableBool { Disabled = !allowExpansion };
 

--- a/osu.Game/Graphics/UserInterface/BackButton.cs
+++ b/osu.Game/Graphics/UserInterface/BackButton.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             Size = TwoLayerButton.SIZE_EXTENDED;
 
-            Child = button = new TwoLayerButton(HoverSampleSet.Submit)
+            Child = button = new TwoLayerButton
             {
                 Anchor = Anchor.TopLeft,
                 Origin = Anchor.TopLeft,

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Graphics.UserInterface
         private readonly SpriteText spriteText;
         private Vector2 hoverSpacing => new Vector2(3f, 0f);
 
-        public DialogButton()
-            : base(HoverSampleSet.Submit)
+        public DialogButton(HoverSampleSet sampleSet = HoverSampleSet.Button)
+            : base(sampleSet)
         {
             RelativeSizeAxes = Axes.X;
 

--- a/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
+++ b/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Graphics.UserInterface
                     Icon = FontAwesome.Solid.ExternalLinkAlt,
                     RelativeSizeAxes = Axes.Both
                 },
-                new HoverClickSounds(HoverSampleSet.Submit)
+                new HoverClickSounds()
             };
         }
 

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -7,6 +7,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
 using osuTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
@@ -37,7 +38,10 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (buttons.Contains(e.Button) && Contains(e.ScreenSpaceMousePosition))
-                sampleClick?.Play();
+            {
+                sampleClick.Frequency.Value = 0.99 + RNG.NextDouble(0.02);
+                sampleClick.Play();
+            }
 
             return base.OnClick(e);
         }

--- a/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
@@ -10,9 +10,6 @@ namespace osu.Game.Graphics.UserInterface
         [Description("default")]
         Default,
 
-        [Description("submit")]
-        Submit,
-
         [Description("button")]
         Button,
 

--- a/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class ShearedToggleButton : ShearedButton
     {
+        private Sample? sampleClick;
         private Sample? sampleOff;
         private Sample? sampleOn;
 
@@ -39,8 +40,9 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleOn = audio.Samples.Get(@"UI/check-on");
-            sampleOff = audio.Samples.Get(@"UI/check-off");
+            sampleClick = audio.Samples.Get(@"UI/default-select");
+            sampleOn = audio.Samples.Get(@"UI/dropdown-open");
+            sampleOff = audio.Samples.Get(@"UI/dropdown-close");
         }
 
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds(sampleSet);
@@ -67,6 +69,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private void playSample()
         {
+            sampleClick?.Play();
+
             if (Active.Value)
                 sampleOn?.Play();
             else

--- a/osu.Game/Online/Chat/DrawableLinkCompiler.cs
+++ b/osu.Game/Online/Chat/DrawableLinkCompiler.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Online.Chat
         }
 
         public DrawableLinkCompiler(IEnumerable<Drawable> parts)
-            : base(HoverSampleSet.Submit)
         {
             Parts = parts.ToList();
         }

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Overlays.BeatmapListing
                     Font = OsuFont.GetFont(size: 13, weight: FontWeight.Regular),
                     Text = LabelFor(Value)
                 },
-                new HoverClickSounds()
+                new HoverClickSounds(HoverSampleSet.TabSelect)
             });
 
             Enabled.Value = true;

--- a/osu.Game/Overlays/Chat/Listing/ChannelListingItem.cs
+++ b/osu.Game/Overlays/Chat/Listing/ChannelListingItem.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,6 +18,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Chat;
 using osuTK;
 
@@ -32,6 +35,8 @@ namespace osu.Game.Overlays.Chat.Listing
         public IEnumerable<LocalisableString> FilterTerms => new LocalisableString[] { Channel.Name, Channel.Topic ?? string.Empty };
         public bool MatchingFilter { set => this.FadeTo(value ? 1f : 0f, 100); }
 
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
+
         private Box hoverBox = null!;
         private SpriteIcon checkbox = null!;
         private OsuSpriteText channelText = null!;
@@ -46,14 +51,20 @@ namespace osu.Game.Overlays.Chat.Listing
 
         private const float vertical_margin = 1.5f;
 
+        private Sample? sampleJoin;
+        private Sample? sampleLeave;
+
         public ChannelListingItem(Channel channel)
         {
             Channel = channel;
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
+            sampleJoin = audio.Samples.Get(@"UI/check-on");
+            sampleLeave = audio.Samples.Get(@"UI/check-off");
+
             Masking = true;
             CornerRadius = 5;
             RelativeSizeAxes = Axes.X;
@@ -156,7 +167,19 @@ namespace osu.Game.Overlays.Chat.Listing
                 }
             }, true);
 
-            Action = () => (channelJoined.Value ? OnRequestLeave : OnRequestJoin)?.Invoke(Channel);
+            Action = () =>
+            {
+                if (channelJoined.Value)
+                {
+                    OnRequestLeave?.Invoke(Channel);
+                    sampleLeave?.Play();
+                }
+                else
+                {
+                    OnRequestJoin?.Invoke(Channel);
+                    sampleJoin?.Play();
+                }
+            };
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/News/NewsCard.cs
+++ b/osu.Game/Overlays/News/NewsCard.cs
@@ -14,7 +14,6 @@ using osu.Framework.Platform;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Overlays.News
@@ -29,7 +28,6 @@ namespace osu.Game.Overlays.News
         private TextFlowContainer main;
 
         public NewsCard(APINewsPost post)
-            : base(HoverSampleSet.Submit)
         {
             this.post = post;
 

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -18,7 +18,6 @@ using System.Diagnostics;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Platform;
-using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.News.Sidebar
 {
@@ -129,7 +128,6 @@ namespace osu.Game.Overlays.News.Sidebar
             private readonly APINewsPost post;
 
             public PostButton(APINewsPost post)
-                : base(HoverSampleSet.Submit)
             {
                 this.post = post;
 

--- a/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private Sample sampleOpen;
         private Sample sampleClose;
 
-        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds();
 
         public ExpandDetailsButton()
         {

--- a/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Profile.Sections
 {
@@ -18,7 +17,6 @@ namespace osu.Game.Overlays.Profile.Sections
         private readonly IBeatmapInfo beatmapInfo;
 
         protected BeatmapMetadataContainer(IBeatmapInfo beatmapInfo)
-            : base(HoverSampleSet.Submit)
         {
             this.beatmapInfo = beatmapInfo;
 

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -20,7 +20,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osuTK;
 using osuTK.Graphics;
@@ -83,7 +82,6 @@ namespace osu.Game.Overlays.Toolbar
         private RealmAccess realm { get; set; }
 
         protected ToolbarButton()
-            : base(HoverSampleSet.Toolbar)
         {
             Width = Toolbar.HEIGHT;
             RelativeSizeAxes = Axes.Y;

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -11,7 +11,6 @@ using osu.Framework.Input.Events;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
@@ -29,7 +28,6 @@ namespace osu.Game.Overlays.Toolbar
         private AnalogClockDisplay analog;
 
         public ToolbarClock()
-            : base(HoverSampleSet.Toolbar)
         {
             RelativeSizeAxes = Axes.Y;
             AutoSizeAxes = Axes.X;

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         private void load(AudioManager audio)
         {
             sampleSelect = audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
-            sampleJoin = audio.Samples.Get($@"UI/{HoverSampleSet.Submit.GetDescription()}-select");
+            sampleJoin = audio.Samples.Get($@"UI/{HoverSampleSet.Button.GetDescription()}-select");
 
             AddRangeInternal(new Drawable[]
             {

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Select
         private readonly Box light;
 
         public FooterButton()
-            : base(HoverSampleSet.Button)
+            : base(HoverSampleSet.Toolbar)
         {
             AutoSizeAxes = Axes.Both;
             Shear = SHEAR;

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Select.Options
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
         public BeatmapOptionsButton()
-            : base(HoverSampleSet.Submit)
+            : base(HoverSampleSet.Button)
         {
             Width = width;
             RelativeSizeAxes = Axes.Y;

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Users.Drawables
@@ -73,11 +72,6 @@ namespace osu.Game.Users.Drawables
         private class ClickableArea : OsuClickableContainer
         {
             private LocalisableString tooltip = default_tooltip_text;
-
-            public ClickableArea()
-                : base(HoverSampleSet.Submit)
-            {
-            }
 
             public override LocalisableString TooltipText
             {

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Users.Drawables
                     {
                         RelativeSizeAxes = Axes.Both
                     },
-                    new HoverClickSounds(HoverSampleSet.Submit)
+                    new HoverClickSounds()
                 }
             };
         }

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Users
         protected Drawable Background { get; private set; }
 
         protected UserPanel(APIUser user)
-            : base(HoverSampleSet.Submit)
+            : base(HoverSampleSet.Button)
         {
             if (user == null)
                 throw new ArgumentNullException(nameof(user));


### PR DESCRIPTION
Consistency pass to fix components with missing/incorrect sounds and to use more appropriate sounds in some places.

Also:
- Removes/replaces 'Submit' SampleSet usage (didn't feel like it added much)
- Removes usage of 'Toolbar' SampleSet (felt odd having different samples for the Toolbar), temporarily repurposing for `FooterButton` (footer buttons in song select) while I decide on what to do