### PR TITLE
Fix spinner approach circle displaying on default legacy skin

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
@@ -78,7 +78,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 }
             });
 
-            if (!(source.FindProvider(s => s.GetTexture("spinner-top") != null) is DefaultLegacySkin))
+            var topProvider = source.FindProvider(s => s.GetTexture("spinner-top") != null);
+
+            if (topProvider is LegacySkinTransformer transformer && !(transformer.Skin is DefaultLegacySkin))
             {
                 AddInternal(ApproachCircle = new Sprite
                 {

--- a/osu.Game/Skinning/LegacySkinTransformer.cs
+++ b/osu.Game/Skinning/LegacySkinTransformer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Skinning
         /// The <see cref="ISkin"/> which is being transformed.
         /// </summary>
         [NotNull]
-        protected internal ISkin Skin { get; }
+        public ISkin Skin { get; }
 
         protected LegacySkinTransformer([NotNull] ISkin skin)
         {


### PR DESCRIPTION
The conditional hasn't been working since `FindProvider` returns `LegacySkinTransformer`s for legacy skins, rather than raw skins.

Following a similar approach to what's done in `SkinnableSprite`:
https://github.com/ppy/osu/blob/4bf11df57c9ac2ac19646f2ac83a94b75be2279c/osu.Game/Skinning/SkinnableSprite.cs#L101-L102