### PR TITLE
Fix potential null reference in skin editor if target screen is null (during exit)

### DIFF
--- a/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorOverlay.cs
@@ -127,6 +127,9 @@ namespace osu.Game.Skinning.Editor
 
         private void setTarget(OsuScreen target)
         {
+            if (target == null)
+                return;
+
             Debug.Assert(skinEditor != null);
 
             if (!target.IsLoaded)


### PR DESCRIPTION
```csharp
[runtime] 2022-06-06 09:24:31 [verbose]: Host execution state changed to Stopping
[runtime] 2022-06-06 09:24:31 [error]: An unhandled error has occurred.
[runtime] 2022-06-06 09:24:31 [error]: System.NullReferenceException: Object reference not set to an instance of an object.
[runtime] 2022-06-06 09:24:31 [error]: at osu.Game.Skinning.Editor.SkinEditorOverlay.setTarget(OsuScreen target) in
/Users/dean/Projects/osu/osu.Game/Skinning/Editor/SkinEditorOverlay.cs:line 173
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Threading.Scheduler.Update()
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Graphics.Drawable.UpdateSubTree()
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
[runtime] 2022-06-06 09:24:31 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
```