### PR TITLE
Change `skin.ini` boolean parsing to match osu!stable

### DIFF
--- a/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
@@ -59,11 +59,13 @@ namespace osu.Game.Tests.Skins
             AddAssert("Check float parse lookup", () => requester.GetConfig<string, float>("FloatTest")?.Value == 1.1f);
         }
 
-        [Test]
-        public void TestBoolLookup()
+        [TestCase("0", false)]
+        [TestCase("1", true)]
+        [TestCase("2", true)] // https://github.com/ppy/osu/issues/18579
+        public void TestBoolLookup(string originalValue, bool expectedParsedValue)
         {
-            AddStep("Add config values", () => userSource.Configuration.ConfigDictionary["BoolTest"] = "1");
-            AddAssert("Check bool parse lookup", () => requester.GetConfig<string, bool>("BoolTest")?.Value == true);
+            AddStep("Add config values", () => userSource.Configuration.ConfigDictionary["BoolTest"] = originalValue);
+            AddAssert("Check bool parse lookup", () => requester.GetConfig<string, bool>("BoolTest")?.Value == expectedParsedValue);
         }
 
         [Test]

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -303,8 +303,13 @@ namespace osu.Game.Skinning
                 if (Configuration.ConfigDictionary.TryGetValue(lookup.ToString(), out string val))
                 {
                     // special case for handling skins which use 1 or 0 to signify a boolean state.
+                    // ..or in some cases 2 (https://github.com/ppy/osu/issues/18579).
                     if (typeof(TValue) == typeof(bool))
-                        val = val == "1" ? "true" : "false";
+                    {
+                        val = bool.TryParse(val, out bool boolVal)
+                            ? Convert.ChangeType(boolVal, typeof(bool)).ToString()
+                            : Convert.ChangeType(Convert.ToInt32(val), typeof(bool)).ToString();
+                    }
 
                     var bindable = new Bindable<TValue>();
                     if (val != null)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/18579.

I'm not sure it's worth adding test coverage for such a broken case, but it can easily be added if we want it.