### PR TITLE
Fix spinner bonus tick sample not balanced again

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -79,7 +79,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 {
                     Result = { BindTarget = SpinsPerMinute },
                 },
-                ticks = new Container<DrawableSpinnerTick>(),
+                ticks = new Container<DrawableSpinnerTick>
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
                 new AspectContainer
                 {
                     Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSpinnerTick : DrawableOsuHitObject
@@ -10,13 +12,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected DrawableSpinner DrawableSpinner => (DrawableSpinner)ParentHitObject;
 
         public DrawableSpinnerTick()
-            : base(null)
+            : this(null)
         {
         }
 
         public DrawableSpinnerTick(SpinnerTick spinnerTick)
             : base(spinnerTick)
         {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
         }
 
         protected override double MaximumJudgementOffset => DrawableSpinner.HitObject.Duration;

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -69,8 +69,8 @@ namespace osu.Game.Rulesets.Osu.Objects
                 double startTime = StartTime + (float)(i + 1) / totalSpins * Duration;
 
                 AddNested(i < SpinsRequired
-                    ? new SpinnerTick { StartTime = startTime, Position = Position }
-                    : new SpinnerBonusTick { StartTime = startTime, Position = Position });
+                    ? new SpinnerTick { StartTime = startTime }
+                    : new SpinnerBonusTick { StartTime = startTime });
             }
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/16462 once again

As suspected in https://github.com/ppy/osu/issues/16462#issuecomment-1146793723, https://github.com/ppy/osu/pull/17860 has regressed this since it computes the balance based on the hitobject's draw position rather than `Position`, and the drawable representation for spinner ticks are positioned at top-left of the playfield.

I planned on writing test coverage for this, but realized how hard it is given that the balance is computed using the DHO's screen-space draw quad, requiring the spinner to be centred relative to the test's root container, which can't be possible given that `TestScene` has a test steps sidebar, offsetting the content to the right.