### PR TITLE
Fix random mod generating off-screen sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils_Reposition.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils_Reposition.cs
@@ -198,6 +198,27 @@ namespace osu.Game.Rulesets.Osu.Utils
             var slider = (Slider)workingObject.HitObject;
             var possibleMovementBounds = calculatePossibleMovementBounds(slider);
 
+            // The slider rotation applied in computeModifiedPosition might make it impossible to fit the slider into the playfield
+            // For example, a long horizontal slider will be off-screen when rotated by 90 degrees
+            // In this case, limit the rotation to either 0 or 180 degrees
+            if (possibleMovementBounds.Width < 0 || possibleMovementBounds.Height < 0)
+            {
+                float currentRotation = getSliderRotation(slider);
+                float diff1 = getAngleDifference(workingObject.RotationOriginal, currentRotation);
+                float diff2 = getAngleDifference(workingObject.RotationOriginal + MathF.PI, currentRotation);
+
+                if (diff1 < diff2)
+                {
+                    RotateSlider(slider, workingObject.RotationOriginal - getSliderRotation(slider));
+                }
+                else
+                {
+                    RotateSlider(slider, workingObject.RotationOriginal + MathF.PI - getSliderRotation(slider));
+                }
+
+                possibleMovementBounds = calculatePossibleMovementBounds(slider);
+            }
+
             var previousPosition = workingObject.PositionModified;
 
             // Clamp slider position to the placement area
@@ -355,6 +376,18 @@ namespace osu.Game.Rulesets.Osu.Utils
             return MathF.Atan2(endPositionVector.Y, endPositionVector.X);
         }
 
+        /// <summary>
+        /// Get the absolute difference between 2 angles measured in Radians.
+        /// </summary>
+        /// <param name="angle1">The first angle</param>
+        /// <param name="angle2">The second angle</param>
+        /// <returns>The absolute difference with interval <c>[0, MathF.PI)</c></returns>
+        private static float getAngleDifference(float angle1, float angle2)
+        {
+            float diff = MathF.Abs(angle1 - angle2) % (MathF.PI * 2);
+            return MathF.Min(diff, MathF.PI * 2 - diff);
+        }
+
         public class ObjectPositionInfo
         {
             /// <summary>
@@ -397,6 +430,7 @@ namespace osu.Game.Rulesets.Osu.Utils
 
         private class WorkingObject
         {
+            public float RotationOriginal { get; }
             public Vector2 PositionOriginal { get; }
             public Vector2 PositionModified { get; set; }
             public Vector2 EndPositionModified { get; set; }
@@ -407,6 +441,7 @@ namespace osu.Game.Rulesets.Osu.Utils
             public WorkingObject(ObjectPositionInfo positionInfo)
             {
                 PositionInfo = positionInfo;
+                RotationOriginal = HitObject is Slider slider ? getSliderRotation(slider) : 0;
                 PositionModified = PositionOriginal = HitObject.Position;
                 EndPositionModified = HitObject.EndPosition;
             }


### PR DESCRIPTION
This is a fix for https://github.com/ppy/osu/pull/18559#issuecomment-1146909024

The issue is caused by long horizontal sliders spanning the whole width of the playfield. Rotating them 90 degrees causes them to go off-screen. This fix limits those large sliders to either 0 or 180 degrees rotation (whichever is closest to the original angle to which the algorithm wishes to rotate the slider).

Original map: 
![image](https://user-images.githubusercontent.com/25472513/172283963-e33dde56-bc1d-4a94-b4b0-ec43cc7853fd.png)

Old algorithm with seed 0:
![image](https://user-images.githubusercontent.com/25472513/172284195-629c5d80-b83d-445e-847d-d4c2db1b4802.png)

This fix with seed 0:
![image](https://user-images.githubusercontent.com/25472513/172284425-2c085a09-d642-42bd-87b9-e714b9f3eef9.png)
