### PR TITLE
Truncate difficulty name in score panel

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Tests.Visual.Ranking
             beatmap.Metadata.Author = author;
             beatmap.Metadata.Title = "Verrrrrrrrrrrrrrrrrrry looooooooooooooooooooooooong beatmap title";
             beatmap.Metadata.Artist = "Verrrrrrrrrrrrrrrrrrry looooooooooooooooooooooooong beatmap artist";
+            beatmap.DifficultyName = "Verrrrrrrrrrrrrrrrrrry looooooooooooooooooooooooong difficulty name";
 
             return beatmap;
         }

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -159,6 +159,8 @@ namespace osu.Game.Screens.Ranking.Expanded
                                         Origin = Anchor.TopCentre,
                                         Text = beatmap.DifficultyName,
                                         Font = OsuFont.Torus.With(size: 16, weight: FontWeight.SemiBold),
+                                        MaxWidth = ScorePanel.EXPANDED_WIDTH - padding * 2,
+                                        Truncate = true,
                                     },
                                     new OsuTextFlowContainer(s => s.Font = OsuFont.Torus.With(size: 12))
                                     {


### PR DESCRIPTION
Closes #18598 

I found #8919 right after posting the issue, so I fixed this in the same manner.

![image](https://user-images.githubusercontent.com/25472513/172293918-439c3b16-84fb-423e-a6cf-4b240c3a0c36.png)
