### PR TITLE
Fix taiko circle fills missing after rewind

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Judgements;
@@ -321,12 +322,14 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private class ProxyContainer : LifetimeManagementContainer
         {
-            public new MarginPadding Padding
-            {
-                set => base.Padding = value;
-            }
-
             public void Add(Drawable proxy) => AddInternal(proxy);
+
+            public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+            {
+                // DrawableHitObject disables masking.
+                // Hitobject content is proxied and unproxied based on hit status and the IsMaskedAway value could get stuck because of this.
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/18478

Not sure on a better fix for this yet. Disabling masking in general is kinda dodgy, not entirely sure why it's done (likely so that updates continue to propagate or something) but I'd rather not break things for now.