### PR TITLE
Fix message notifier not handling unresolved PM channels

### DIFF
--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Online.Chat
             if (!messages.Any())
                 return;
 
-            var channel = channelManager.JoinedChannels.SingleOrDefault(c => c.Id == messages.First().ChannelId);
+            var channel = channelManager.JoinedChannels.SingleOrDefault(c => c.Id > 0 && c.Id == messages.First().ChannelId);
 
             if (channel == null)
                 return;


### PR DESCRIPTION
- Closes #18456 

When opening PM for the first time, the channel ID remains unresolved [until a message is posted](https://github.com/ppy/osu/blob/8f596520f3ea360cd5398fa42c762a9a3ee37e66/osu.Game/Online/Chat/ChannelManager.cs#L185-L206). Opening another PM while current one is not resolved and sending a message afterwards will bring up #18456.

Went with the simplest fix of ignoring unresolved channels for the time being, as message notifier should not be checking for messages from them.