### PR TITLE
Fix performance overhead of large collections

### DIFF
--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Tests.Collections.IO
 
                     Assert.That(osu.CollectionManager.Collections.Count, Is.EqualTo(2));
 
+                    // Even with no beatmaps imported, collections are tracking the hashes and will continue to.
+                    // In the future this whole mechanism will be replaced with having the collections in realm,
+                    // but until that happens it makes rough sense that we want to track not-yet-imported beatmaps
+                    // and have them associate with collections if/when they become available.
+
                     Assert.That(osu.CollectionManager.Collections[0].Name.Value, Is.EqualTo("First"));
                     Assert.That(osu.CollectionManager.Collections[0].Beatmaps.Count, Is.EqualTo(1));
 

--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -50,10 +50,10 @@ namespace osu.Game.Tests.Collections.IO
                     Assert.That(osu.CollectionManager.Collections.Count, Is.EqualTo(2));
 
                     Assert.That(osu.CollectionManager.Collections[0].Name.Value, Is.EqualTo("First"));
-                    Assert.That(osu.CollectionManager.Collections[0].Beatmaps.Count, Is.Zero);
+                    Assert.That(osu.CollectionManager.Collections[0].Beatmaps.Count, Is.EqualTo(1));
 
                     Assert.That(osu.CollectionManager.Collections[1].Name.Value, Is.EqualTo("Second"));
-                    Assert.That(osu.CollectionManager.Collections[1].Beatmaps.Count, Is.Zero);
+                    Assert.That(osu.CollectionManager.Collections[1].Beatmaps.Count, Is.EqualTo(12));
                 }
                 finally
                 {

--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -55,10 +55,10 @@ namespace osu.Game.Tests.Collections.IO
                     // and have them associate with collections if/when they become available.
 
                     Assert.That(osu.CollectionManager.Collections[0].Name.Value, Is.EqualTo("First"));
-                    Assert.That(osu.CollectionManager.Collections[0].Beatmaps.Count, Is.EqualTo(1));
+                    Assert.That(osu.CollectionManager.Collections[0].BeatmapHashes.Count, Is.EqualTo(1));
 
                     Assert.That(osu.CollectionManager.Collections[1].Name.Value, Is.EqualTo("Second"));
-                    Assert.That(osu.CollectionManager.Collections[1].Beatmaps.Count, Is.EqualTo(12));
+                    Assert.That(osu.CollectionManager.Collections[1].BeatmapHashes.Count, Is.EqualTo(12));
                 }
                 finally
                 {
@@ -81,10 +81,10 @@ namespace osu.Game.Tests.Collections.IO
                     Assert.That(osu.CollectionManager.Collections.Count, Is.EqualTo(2));
 
                     Assert.That(osu.CollectionManager.Collections[0].Name.Value, Is.EqualTo("First"));
-                    Assert.That(osu.CollectionManager.Collections[0].Beatmaps.Count, Is.EqualTo(1));
+                    Assert.That(osu.CollectionManager.Collections[0].BeatmapHashes.Count, Is.EqualTo(1));
 
                     Assert.That(osu.CollectionManager.Collections[1].Name.Value, Is.EqualTo("Second"));
-                    Assert.That(osu.CollectionManager.Collections[1].Beatmaps.Count, Is.EqualTo(12));
+                    Assert.That(osu.CollectionManager.Collections[1].BeatmapHashes.Count, Is.EqualTo(12));
                 }
                 finally
                 {
@@ -147,8 +147,8 @@ namespace osu.Game.Tests.Collections.IO
                     await importCollectionsFromStream(osu, TestResources.OpenResource("Collections/collections.db"));
 
                     // Move first beatmap from second collection into the first.
-                    osu.CollectionManager.Collections[0].Beatmaps.Add(osu.CollectionManager.Collections[1].Beatmaps[0]);
-                    osu.CollectionManager.Collections[1].Beatmaps.RemoveAt(0);
+                    osu.CollectionManager.Collections[0].BeatmapHashes.Add(osu.CollectionManager.Collections[1].BeatmapHashes[0]);
+                    osu.CollectionManager.Collections[1].BeatmapHashes.RemoveAt(0);
 
                     // Rename the second collecction.
                     osu.CollectionManager.Collections[1].Name.Value = "Another";
@@ -169,10 +169,10 @@ namespace osu.Game.Tests.Collections.IO
                     Assert.That(osu.CollectionManager.Collections.Count, Is.EqualTo(2));
 
                     Assert.That(osu.CollectionManager.Collections[0].Name.Value, Is.EqualTo("First"));
-                    Assert.That(osu.CollectionManager.Collections[0].Beatmaps.Count, Is.EqualTo(2));
+                    Assert.That(osu.CollectionManager.Collections[0].BeatmapHashes.Count, Is.EqualTo(2));
 
                     Assert.That(osu.CollectionManager.Collections[1].Name.Value, Is.EqualTo("Another"));
-                    Assert.That(osu.CollectionManager.Collections[1].Beatmaps.Count, Is.EqualTo(11));
+                    Assert.That(osu.CollectionManager.Collections[1].BeatmapHashes.Count, Is.EqualTo(11));
                 }
                 finally
                 {

--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Tests.Visual.Collections
             AddStep("add two collections with same name", () => manager.Collections.AddRange(new[]
             {
                 new BeatmapCollection { Name = { Value = "1" } },
-                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0] } },
+                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
             }));
         }
 
@@ -162,7 +162,7 @@ namespace osu.Game.Tests.Visual.Collections
             AddStep("add two collections", () => manager.Collections.AddRange(new[]
             {
                 new BeatmapCollection { Name = { Value = "1" } },
-                new BeatmapCollection { Name = { Value = "2" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0] } },
+                new BeatmapCollection { Name = { Value = "2" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
             }));
 
             assertCollectionCount(2);
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Collections
         {
             AddStep("add two collections", () => manager.Collections.AddRange(new[]
             {
-                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0] } },
+                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
             }));
 
             assertCollectionCount(1);

--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Tests.Visual.Collections
             AddStep("add two collections with same name", () => manager.Collections.AddRange(new[]
             {
                 new BeatmapCollection { Name = { Value = "1" } },
-                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
+                new BeatmapCollection { Name = { Value = "1" }, BeatmapHashes = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
             }));
         }
 
@@ -162,7 +162,7 @@ namespace osu.Game.Tests.Visual.Collections
             AddStep("add two collections", () => manager.Collections.AddRange(new[]
             {
                 new BeatmapCollection { Name = { Value = "1" } },
-                new BeatmapCollection { Name = { Value = "2" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
+                new BeatmapCollection { Name = { Value = "2" }, BeatmapHashes = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
             }));
 
             assertCollectionCount(2);
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Collections
         {
             AddStep("add two collections", () => manager.Collections.AddRange(new[]
             {
-                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
+                new BeatmapCollection { Name = { Value = "1" }, BeatmapHashes = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash } },
             }));
 
             assertCollectionCount(1);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -151,10 +151,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("add collection", () => collectionManager.Collections.Add(new BeatmapCollection { Name = { Value = "1" } }));
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
 
-            AddStep("add beatmap to collection", () => collectionManager.Collections[0].Beatmaps.Add(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddStep("add beatmap to collection", () => collectionManager.Collections[0].BeatmapHashes.Add(Beatmap.Value.BeatmapInfo.MD5Hash));
             AddAssert("button is minus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.MinusSquare));
 
-            AddStep("remove beatmap from collection", () => collectionManager.Collections[0].Beatmaps.Clear());
+            AddStep("remove beatmap from collection", () => collectionManager.Collections[0].BeatmapHashes.Clear());
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
         }
 
@@ -169,11 +169,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection contains beatmap", () => collectionManager.Collections[0].Beatmaps.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddAssert("collection contains beatmap", () => collectionManager.Collections[0].BeatmapHashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             AddAssert("button is minus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.MinusSquare));
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection does not contain beatmap", () => !collectionManager.Collections[0].Beatmaps.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
+            AddAssert("collection does not contain beatmap", () => !collectionManager.Collections[0].BeatmapHashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("add collection", () => collectionManager.Collections.Add(new BeatmapCollection { Name = { Value = "1" } }));
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
 
-            AddStep("add beatmap to collection", () => collectionManager.Collections[0].Beatmaps.Add(Beatmap.Value.BeatmapInfo));
+            AddStep("add beatmap to collection", () => collectionManager.Collections[0].Beatmaps.Add(Beatmap.Value.BeatmapInfo.MD5Hash));
             AddAssert("button is minus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.MinusSquare));
 
             AddStep("remove beatmap from collection", () => collectionManager.Collections[0].Beatmaps.Clear());
@@ -169,11 +169,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection contains beatmap", () => collectionManager.Collections[0].Beatmaps.Contains(Beatmap.Value.BeatmapInfo));
+            AddAssert("collection contains beatmap", () => collectionManager.Collections[0].Beatmaps.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             AddAssert("button is minus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.MinusSquare));
 
             addClickAddOrRemoveButtonStep(1);
-            AddAssert("collection does not contain beatmap", () => !collectionManager.Collections[0].Beatmaps.Contains(Beatmap.Value.BeatmapInfo));
+            AddAssert("collection does not contain beatmap", () => !collectionManager.Collections[0].Beatmaps.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
             AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
         }
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -90,6 +90,7 @@ namespace osu.Game.Beatmaps
 
         public double StarRating { get; set; }
 
+        [Indexed]
         public string MD5Hash { get; set; } = string.Empty;
 
         [JsonIgnore]

--- a/osu.Game/Collections/BeatmapCollection.cs
+++ b/osu.Game/Collections/BeatmapCollection.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Collections
         /// <summary>
         /// The <see cref="BeatmapInfo.MD5Hash"/>es of beatmaps contained by the collection.
         /// </summary>
-        public readonly BindableList<string> Beatmaps = new BindableList<string>();
+        public readonly BindableList<string> BeatmapHashes = new BindableList<string>();
 
         /// <summary>
         /// The date when this collection was last modified.
@@ -34,7 +34,7 @@ namespace osu.Game.Collections
 
         public BeatmapCollection()
         {
-            Beatmaps.CollectionChanged += (_, __) => onChange();
+            BeatmapHashes.CollectionChanged += (_, __) => onChange();
             Name.ValueChanged += _ => onChange();
         }
 

--- a/osu.Game/Collections/BeatmapCollection.cs
+++ b/osu.Game/Collections/BeatmapCollection.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Collections
         public readonly Bindable<string> Name = new Bindable<string>();
 
         /// <summary>
-        /// The beatmaps contained by the collection.
+        /// The <see cref="BeatmapInfo.MD5Hash"/>es of beatmaps contained by the collection.
         /// </summary>
-        public readonly BindableList<BeatmapInfo> Beatmaps = new BindableList<BeatmapInfo>();
+        public readonly BindableList<string> Beatmaps = new BindableList<string>();
 
         /// <summary>
         /// The date when this collection was last modified.

--- a/osu.Game/Collections/CollectionFilterDropdown.cs
+++ b/osu.Game/Collections/CollectionFilterDropdown.cs
@@ -95,10 +95,10 @@ namespace osu.Game.Collections
             beatmaps.CollectionChanged -= filterBeatmapsChanged;
 
             if (filter.OldValue?.Collection != null)
-                beatmaps.UnbindFrom(filter.OldValue.Collection.Beatmaps);
+                beatmaps.UnbindFrom(filter.OldValue.Collection.BeatmapHashes);
 
             if (filter.NewValue?.Collection != null)
-                beatmaps.BindTo(filter.NewValue.Collection.Beatmaps);
+                beatmaps.BindTo(filter.NewValue.Collection.BeatmapHashes);
 
             beatmaps.CollectionChanged += filterBeatmapsChanged;
 
@@ -208,7 +208,7 @@ namespace osu.Game.Collections
             public CollectionDropdownMenuItem(MenuItem item)
                 : base(item)
             {
-                collectionBeatmaps = Item.Collection?.Beatmaps.GetBoundCopy();
+                collectionBeatmaps = Item.Collection?.BeatmapHashes.GetBoundCopy();
                 collectionName = Item.CollectionName.GetBoundCopy();
             }
 

--- a/osu.Game/Collections/CollectionFilterDropdown.cs
+++ b/osu.Game/Collections/CollectionFilterDropdown.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Collections
         }
 
         private readonly IBindableList<BeatmapCollection> collections = new BindableList<BeatmapCollection>();
-        private readonly IBindableList<BeatmapInfo> beatmaps = new BindableList<BeatmapInfo>();
+        private readonly IBindableList<string> beatmaps = new BindableList<string>();
         private readonly BindableList<CollectionFilterMenuItem> filters = new BindableList<CollectionFilterMenuItem>();
 
         [Resolved(CanBeNull = true)]
@@ -196,7 +196,7 @@ namespace osu.Game.Collections
             private IBindable<WorkingBeatmap> beatmap { get; set; }
 
             [CanBeNull]
-            private readonly BindableList<BeatmapInfo> collectionBeatmaps;
+            private readonly BindableList<string> collectionBeatmaps;
 
             [NotNull]
             private readonly Bindable<string> collectionName;
@@ -258,7 +258,7 @@ namespace osu.Game.Collections
             {
                 Debug.Assert(collectionBeatmaps != null);
 
-                beatmapInCollection = collectionBeatmaps.Contains(beatmap.Value.BeatmapInfo);
+                beatmapInCollection = collectionBeatmaps.Contains(beatmap.Value.BeatmapInfo.MD5Hash);
 
                 addOrRemoveButton.Enabled.Value = !beatmap.IsDefault;
                 addOrRemoveButton.Icon = beatmapInCollection ? FontAwesome.Solid.MinusSquare : FontAwesome.Solid.PlusSquare;
@@ -285,8 +285,8 @@ namespace osu.Game.Collections
             {
                 Debug.Assert(collectionBeatmaps != null);
 
-                if (!collectionBeatmaps.Remove(beatmap.Value.BeatmapInfo))
-                    collectionBeatmaps.Add(beatmap.Value.BeatmapInfo);
+                if (!collectionBeatmaps.Remove(beatmap.Value.BeatmapInfo.MD5Hash))
+                    collectionBeatmaps.Add(beatmap.Value.BeatmapInfo.MD5Hash);
             }
 
             protected override Drawable CreateContent() => content = (Content)base.CreateContent();

--- a/osu.Game/Collections/CollectionManager.cs
+++ b/osu.Game/Collections/CollectionManager.cs
@@ -169,10 +169,10 @@ namespace osu.Game.Collections
                         if (existing == null)
                             Collections.Add(existing = new BeatmapCollection { Name = { Value = newCol.Name.Value } });
 
-                        foreach (string newBeatmap in newCol.Beatmaps)
+                        foreach (string newBeatmap in newCol.BeatmapHashes)
                         {
-                            if (!existing.Beatmaps.Contains(newBeatmap))
-                                existing.Beatmaps.Add(newBeatmap);
+                            if (!existing.BeatmapHashes.Contains(newBeatmap))
+                                existing.BeatmapHashes.Add(newBeatmap);
                         }
                     }
 
@@ -222,7 +222,7 @@ namespace osu.Game.Collections
 
                             string checksum = sr.ReadString();
 
-                            collection.Beatmaps.Add(checksum);
+                            collection.BeatmapHashes.Add(checksum);
                         }
 
                         if (notification != null)
@@ -293,7 +293,7 @@ namespace osu.Game.Collections
                             {
                                 sw.Write(c.Name.Value);
 
-                                string[] beatmapsCopy = c.Beatmaps.ToArray();
+                                string[] beatmapsCopy = c.BeatmapHashes.ToArray();
 
                                 sw.Write(beatmapsCopy.Length);
 

--- a/osu.Game/Collections/CollectionManager.cs
+++ b/osu.Game/Collections/CollectionManager.cs
@@ -13,7 +13,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.IO.Legacy;
@@ -39,9 +38,6 @@ namespace osu.Game.Collections
         private const string database_backup_name = "collection.db.bak";
 
         public readonly BindableList<BeatmapCollection> Collections = new BindableList<BeatmapCollection>();
-
-        [Resolved]
-        private BeatmapManager beatmaps { get; set; }
 
         private readonly Storage storage;
 
@@ -173,7 +169,7 @@ namespace osu.Game.Collections
                         if (existing == null)
                             Collections.Add(existing = new BeatmapCollection { Name = { Value = newCol.Name.Value } });
 
-                        foreach (var newBeatmap in newCol.Beatmaps)
+                        foreach (string newBeatmap in newCol.Beatmaps)
                         {
                             if (!existing.Beatmaps.Contains(newBeatmap))
                                 existing.Beatmaps.Add(newBeatmap);
@@ -226,9 +222,7 @@ namespace osu.Game.Collections
 
                             string checksum = sr.ReadString();
 
-                            var beatmap = beatmaps.QueryBeatmap(b => b.MD5Hash == checksum);
-                            if (beatmap != null)
-                                collection.Beatmaps.Add(beatmap);
+                            collection.Beatmaps.Add(checksum);
                         }
 
                         if (notification != null)
@@ -299,11 +293,12 @@ namespace osu.Game.Collections
                             {
                                 sw.Write(c.Name.Value);
 
-                                var beatmapsCopy = c.Beatmaps.ToArray();
+                                string[] beatmapsCopy = c.Beatmaps.ToArray();
+
                                 sw.Write(beatmapsCopy.Length);
 
-                                foreach (var b in beatmapsCopy)
-                                    sw.Write(b.MD5Hash);
+                                foreach (string b in beatmapsCopy)
+                                    sw.Write(b);
                             }
                         }
 

--- a/osu.Game/Collections/DeleteCollectionDialog.cs
+++ b/osu.Game/Collections/DeleteCollectionDialog.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Collections
         public DeleteCollectionDialog(BeatmapCollection collection, Action deleteAction)
         {
             HeaderText = "Confirm deletion of";
-            BodyText = $"{collection.Name.Value} ({"beatmap".ToQuantity(collection.Beatmaps.Count)})";
+            BodyText = $"{collection.Name.Value} ({"beatmap".ToQuantity(collection.BeatmapHashes.Count)})";
 
             Icon = FontAwesome.Regular.TrashAlt;
 

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Collections
             {
                 background.FlashColour(Color4.White, 150);
 
-                if (collection.Beatmaps.Count == 0)
+                if (collection.BeatmapHashes.Count == 0)
                     deleteCollection();
                 else
                     dialogOverlay?.Push(new DeleteCollectionDialog(collection, deleteCollection));

--- a/osu.Game/Overlays/Music/Playlist.cs
+++ b/osu.Game/Overlays/Music/Playlist.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.Music
                 else
                 {
                     item.InSelectedCollection = item.Model.Value.Beatmaps.Select(b => b.MD5Hash)
-                                                    .Any(criteria.Collection.Beatmaps.Contains);
+                                                    .Any(criteria.Collection.BeatmapHashes.Contains);
                 }
             }
 

--- a/osu.Game/Overlays/Music/Playlist.cs
+++ b/osu.Game/Overlays/Music/Playlist.cs
@@ -31,20 +31,25 @@ namespace osu.Game.Overlays.Music
 
             foreach (var item in items.OfType<PlaylistItem>())
             {
-                var beatmapHashes = item.Model.Value.Beatmaps.Select(b => b.MD5Hash);
-
-                bool contained = false;
-
-                foreach (string hash in beatmapHashes)
+                if (criteria.Collection == null)
+                    item.InSelectedCollection = true;
+                else
                 {
-                    if (criteria.Collection?.Beatmaps.Contains(hash) == true)
-                    {
-                        contained = true;
-                        break;
-                    }
-                }
+                    var beatmapHashes = item.Model.Value.Beatmaps.Select(b => b.MD5Hash);
 
-                item.InSelectedCollection = contained;
+                    bool contained = false;
+
+                    foreach (string hash in beatmapHashes)
+                    {
+                        if (criteria.Collection?.Beatmaps.Contains(hash) == true)
+                        {
+                            contained = true;
+                            break;
+                        }
+                    }
+
+                    item.InSelectedCollection = contained;
+                }
             }
 
             items.SearchTerm = criteria.SearchText;

--- a/osu.Game/Overlays/Music/Playlist.cs
+++ b/osu.Game/Overlays/Music/Playlist.cs
@@ -35,20 +35,8 @@ namespace osu.Game.Overlays.Music
                     item.InSelectedCollection = true;
                 else
                 {
-                    var beatmapHashes = item.Model.Value.Beatmaps.Select(b => b.MD5Hash);
-
-                    bool contained = false;
-
-                    foreach (string hash in beatmapHashes)
-                    {
-                        if (criteria.Collection?.Beatmaps.Contains(hash) == true)
-                        {
-                            contained = true;
-                            break;
-                        }
-                    }
-
-                    item.InSelectedCollection = contained;
+                    item.InSelectedCollection = item.Model.Value.Beatmaps.Select(b => b.MD5Hash)
+                                                    .Any(criteria.Collection.Beatmaps.Contains);
                 }
             }
 

--- a/osu.Game/Overlays/Music/Playlist.cs
+++ b/osu.Game/Overlays/Music/Playlist.cs
@@ -30,7 +30,22 @@ namespace osu.Game.Overlays.Music
             var items = (SearchContainer<RearrangeableListItem<Live<BeatmapSetInfo>>>)ListContainer;
 
             foreach (var item in items.OfType<PlaylistItem>())
-                item.InSelectedCollection = criteria.Collection?.Beatmaps.Any(b => item.Model.ID == b.BeatmapSet?.ID) ?? true;
+            {
+                var beatmapHashes = item.Model.Value.Beatmaps.Select(b => b.MD5Hash);
+
+                bool contained = false;
+
+                foreach (string hash in beatmapHashes)
+                {
+                    if (criteria.Collection?.Beatmaps.Contains(hash) == true)
+                    {
+                        contained = true;
+                        break;
+                    }
+                }
+
+                item.InSelectedCollection = contained;
+            }
 
             items.SearchTerm = criteria.SearchText;
         }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
 
             if (match)
-                match &= criteria.Collection?.Beatmaps.Contains(BeatmapInfo) ?? true;
+                match &= criteria.Collection?.Beatmaps.Contains(BeatmapInfo.MD5Hash) ?? true;
 
             if (match && criteria.RulesetCriteria != null)
                 match &= criteria.RulesetCriteria.Matches(BeatmapInfo);

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
 
             if (match)
-                match &= criteria.Collection?.Beatmaps.Contains(BeatmapInfo.MD5Hash) ?? true;
+                match &= criteria.Collection?.BeatmapHashes.Contains(BeatmapInfo.MD5Hash) ?? true;
 
             if (match && criteria.RulesetCriteria != null)
                 match &= criteria.RulesetCriteria.Matches(BeatmapInfo);

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -256,12 +256,12 @@ namespace osu.Game.Screens.Select.Carousel
             return new ToggleMenuItem(collection.Name.Value, MenuItemType.Standard, s =>
             {
                 if (s)
-                    collection.Beatmaps.Add(beatmapInfo.MD5Hash);
+                    collection.BeatmapHashes.Add(beatmapInfo.MD5Hash);
                 else
-                    collection.Beatmaps.Remove(beatmapInfo.MD5Hash);
+                    collection.BeatmapHashes.Remove(beatmapInfo.MD5Hash);
             })
             {
-                State = { Value = collection.Beatmaps.Contains(beatmapInfo.MD5Hash) }
+                State = { Value = collection.BeatmapHashes.Contains(beatmapInfo.MD5Hash) }
             };
         }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -256,12 +256,12 @@ namespace osu.Game.Screens.Select.Carousel
             return new ToggleMenuItem(collection.Name.Value, MenuItemType.Standard, s =>
             {
                 if (s)
-                    collection.Beatmaps.Add(beatmapInfo);
+                    collection.Beatmaps.Add(beatmapInfo.MD5Hash);
                 else
-                    collection.Beatmaps.Remove(beatmapInfo);
+                    collection.Beatmaps.Remove(beatmapInfo.MD5Hash);
             })
             {
-                State = { Value = collection.Beatmaps.Contains(beatmapInfo) }
+                State = { Value = collection.Beatmaps.Contains(beatmapInfo.MD5Hash) }
             };
         }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             TernaryState state;
 
-            int countExisting = beatmapSet.Beatmaps.Count(b => collection.Beatmaps.Contains(b));
+            int countExisting = beatmapSet.Beatmaps.Count(b => collection.Beatmaps.Contains(b.MD5Hash));
 
             if (countExisting == beatmapSet.Beatmaps.Count)
                 state = TernaryState.True;
@@ -261,14 +261,14 @@ namespace osu.Game.Screens.Select.Carousel
                     switch (s)
                     {
                         case TernaryState.True:
-                            if (collection.Beatmaps.Contains(b))
+                            if (collection.Beatmaps.Contains(b.MD5Hash))
                                 continue;
 
-                            collection.Beatmaps.Add(b);
+                            collection.Beatmaps.Add(b.MD5Hash);
                             break;
 
                         case TernaryState.False:
-                            collection.Beatmaps.Remove(b);
+                            collection.Beatmaps.Remove(b.MD5Hash);
                             break;
                     }
                 }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             TernaryState state;
 
-            int countExisting = beatmapSet.Beatmaps.Count(b => collection.Beatmaps.Contains(b.MD5Hash));
+            int countExisting = beatmapSet.Beatmaps.Count(b => collection.BeatmapHashes.Contains(b.MD5Hash));
 
             if (countExisting == beatmapSet.Beatmaps.Count)
                 state = TernaryState.True;
@@ -261,14 +261,14 @@ namespace osu.Game.Screens.Select.Carousel
                     switch (s)
                     {
                         case TernaryState.True:
-                            if (collection.Beatmaps.Contains(b.MD5Hash))
+                            if (collection.BeatmapHashes.Contains(b.MD5Hash))
                                 continue;
 
-                            collection.Beatmaps.Add(b.MD5Hash);
+                            collection.BeatmapHashes.Add(b.MD5Hash);
                             break;
 
                         case TernaryState.False:
-                            collection.Beatmaps.Remove(b.MD5Hash);
+                            collection.BeatmapHashes.Remove(b.MD5Hash);
                             break;
                     }
                 }


### PR DESCRIPTION
As discovered at https://github.com/ppy/osu/issues/18451#issuecomment-1149611172.

The way `CollectionManager` was implemented led to high realm overhead, from the per-item realm context opening (on an async thread no less, so it comes with full overhead), the query on a non-indexed property and biggest of all the `Detach` operation.

None of this was required.

I've gone with the fastest implementation available since the whole class is a bit temporary (ie. changing the type but still adding directly, rather than having `BeatmapCollection.Add(IBeatmapInfo)` as I'd prefer to have).

`CollectionManager` load times

Before `MD5Hash` Index:

8:58:58
9:00:36

After `MD5Hash` Index:
8:44:08
8:45:10

This PR:

09:12:04
09:12:04

Massive test database with every beatmap in one collection: https://cdn.discordapp.com/attachments/188630652340404224/984028197056286761/mother_fucking_collection.7z

Note that I've added the index on `MD5Hash` here for good measure, as we use it elsewhere. It is applied without a migration and doesn't take long / much space (seems to be the same space on disk weirdly..)