### PR TITLE
Ensure `ChannelManager` has access to API from point of construction

### DIFF
--- a/osu.Game.Tests/Chat/TestSceneChannelManager.cs
+++ b/osu.Game.Tests/Chat/TestSceneChannelManager.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Chat
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            var container = new ChannelManagerContainer();
+            var container = new ChannelManagerContainer(API);
             Child = container;
             channelManager = container.ChannelManager;
         });
@@ -145,11 +145,11 @@ namespace osu.Game.Tests.Chat
         private class ChannelManagerContainer : CompositeDrawable
         {
             [Cached]
-            public ChannelManager ChannelManager { get; } = new ChannelManager();
+            public ChannelManager ChannelManager { get; }
 
-            public ChannelManagerContainer()
+            public ChannelManagerContainer(IAPIProvider apiProvider)
             {
-                InternalChild = ChannelManager;
+                InternalChild = ChannelManager = new ChannelManager(apiProvider);
             }
         }
     }

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             linkColour = colours.Blue;
 
-            var chatManager = new ChannelManager();
+            var chatManager = new ChannelManager(API);
             BindableList<Channel> availableChannels = (BindableList<Channel>)chatManager.AvailableChannels;
             availableChannels.Add(new Channel { Name = "#english" });
             availableChannels.Add(new Channel { Name = "#japanese" });

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Online
                 RelativeSizeAxes = Axes.Both,
                 CachedDependencies = new (Type, object)[]
                 {
-                    (typeof(ChannelManager), channelManager = new ChannelManager()),
+                    (typeof(ChannelManager), channelManager = new ChannelManager(API)),
                 },
                 Children = new Drawable[]
                 {

--- a/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneMessageNotifier.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Online
 
             Schedule(() =>
             {
-                Child = testContainer = new TestContainer(new[] { publicChannel, privateMessageChannel })
+                Child = testContainer = new TestContainer(API, new[] { publicChannel, privateMessageChannel })
                 {
                     RelativeSizeAxes = Axes.Both,
                 };
@@ -229,7 +229,7 @@ namespace osu.Game.Tests.Visual.Online
         private class TestContainer : Container
         {
             [Cached]
-            public ChannelManager ChannelManager { get; } = new ChannelManager();
+            public ChannelManager ChannelManager { get; }
 
             [Cached(typeof(INotificationOverlay))]
             public NotificationOverlay NotificationOverlay { get; } = new NotificationOverlay
@@ -245,9 +245,10 @@ namespace osu.Game.Tests.Visual.Online
 
             private readonly Channel[] channels;
 
-            public TestContainer(Channel[] channels)
+            public TestContainer(IAPIProvider api, Channel[] channels)
             {
                 this.channels = channels;
+                ChannelManager = new ChannelManager(api);
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Chat;
 using osuTK.Input;
@@ -44,17 +45,22 @@ namespace osu.Game.Tests.Visual.Online
             Id = 5,
         };
 
-        [Cached]
-        private ChannelManager channelManager = new ChannelManager();
+        private ChannelManager channelManager;
 
         private TestStandAloneChatDisplay chatDisplay;
         private int messageIdSequence;
 
         private Channel testChannel;
 
-        public TestSceneStandAloneChatDisplay()
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
-            Add(channelManager);
+            Add(channelManager = new ChannelManager(parent.Get<IAPIProvider>()));
+
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            dependencies.Cache(channelManager);
+
+            return dependencies;
         }
 
         [SetUp]

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Online.API;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat;
 using osu.Game.Tournament.IPC;
@@ -29,7 +30,7 @@ namespace osu.Game.Tournament.Components
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(MatchIPCInfo ipc)
+        private void load(MatchIPCInfo ipc, IAPIProvider api)
         {
             if (ipc != null)
             {
@@ -45,7 +46,7 @@ namespace osu.Game.Tournament.Components
 
                     if (manager == null)
                     {
-                        AddInternal(manager = new ChannelManager { HighPollRate = { Value = true } });
+                        AddInternal(manager = new ChannelManager(api) { HighPollRate = { Value = true } });
                         Channel.BindTo(manager.CurrentChannel);
                     }
 

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -61,8 +61,7 @@ namespace osu.Game.Online.Chat
         /// </summary>
         public IBindableList<Channel> AvailableChannels => availableChannels;
 
-        [Resolved]
-        private IAPIProvider api { get; set; }
+        private readonly IAPIProvider api;
 
         [Resolved]
         private UserLookupCache users { get; set; }
@@ -71,8 +70,9 @@ namespace osu.Game.Online.Chat
 
         private readonly IBindable<bool> isIdle = new BindableBool();
 
-        public ChannelManager()
+        public ChannelManager(IAPIProvider api)
         {
+            this.api = api;
             CurrentChannel.ValueChanged += currentChannelChanged;
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -851,7 +851,7 @@ namespace osu.Game
             loadComponentSingleFile(dashboard = new DashboardOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(news = new NewsOverlay(), overlayContent.Add, true);
             var rankingsOverlay = loadComponentSingleFile(new RankingsOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(channelManager = new ChannelManager(), AddInternal, true);
+            loadComponentSingleFile(channelManager = new ChannelManager(API), AddInternal, true);
             loadComponentSingleFile(chatOverlay = new ChatOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(new MessageNotifier(), AddInternal, true);
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/18451.

There's potentially other issues with having `ChannelManager` not loaded by the point of usage, but this should be a good first step to close out the crashes we're seeing (although they are much less likely to happen with #18619). I did experiment with `Schedule`ing all `public` calls in the class, but `JoinChannel` is a hard one to manage this for. Likely better to address when we switch to the newer websocket chat API and rewrite the whole class..