### PR TITLE
Enable nullable types in `ChatLine` and update timestamp colours to match design

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays.Chat
 
         private bool messageHasColour => Message.IsAction && senderHasColour;
 
-        [Resolved(CanBeNull = true)]
+        [Resolved]
         private ChannelManager? chatManager { get; set; }
 
         [Resolved]
@@ -258,7 +258,7 @@ namespace osu.Game.Overlays.Chat
                 this.sender = sender;
             }
 
-            [BackgroundDependencyLoader(true)]
+            [BackgroundDependencyLoader]
             private void load(UserProfileOverlay? profile, ChannelManager? chatManager)
             {
                 Action = () => profile?.ShowUser(sender);

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -26,33 +28,6 @@ namespace osu.Game.Overlays.Chat
 {
     public class ChatLine : CompositeDrawable
     {
-        protected virtual float TextSize => 20;
-
-        protected virtual float Spacing => 15;
-
-        protected virtual float TimestampWidth => 60;
-
-        protected virtual float UsernameWidth => 130;
-
-        private Color4 usernameColour;
-
-        private OsuSpriteText timestamp;
-
-        public ChatLine(Message message)
-        {
-            Message = message;
-            RelativeSizeAxes = Axes.X;
-            AutoSizeAxes = Axes.Y;
-        }
-
-        [Resolved(CanBeNull = true)]
-        private ChannelManager chatManager { get; set; }
-
-        private Message message;
-        private OsuSpriteText username;
-
-        public LinkFlowContainer ContentFlow { get; private set; }
-
         public Message Message
         {
             get => message;
@@ -69,10 +44,40 @@ namespace osu.Game.Overlays.Chat
             }
         }
 
+        public LinkFlowContainer ContentFlow { get; private set; } = null!;
+
+        protected virtual float TextSize => 20;
+
+        protected virtual float Spacing => 15;
+
+        protected virtual float TimestampWidth => 60;
+
+        protected virtual float UsernameWidth => 130;
+
+        private Color4 usernameColour;
+
+        private OsuSpriteText timestamp = null!;
+
+        private Message message = null!;
+
+        private OsuSpriteText username = null!;
+
+        private Container? highlight;
+
         private bool senderHasColour => !string.IsNullOrEmpty(message.Sender.Colour);
 
+        [Resolved(CanBeNull = true)]
+        private ChannelManager? chatManager { get; set; }
+
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
+
+        public ChatLine(Message message)
+        {
+            Message = message;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -150,8 +155,6 @@ namespace osu.Game.Overlays.Chat
             updateMessageContent();
             FinishTransforms(true);
         }
-
-        private Container highlight;
 
         /// <summary>
         /// Performs a highlight animation on this <see cref="ChatLine"/>.
@@ -250,10 +253,10 @@ namespace osu.Game.Overlays.Chat
         {
             private readonly APIUser sender;
 
-            private Action startChatAction;
+            private Action startChatAction = null!;
 
             [Resolved]
-            private IAPIProvider api { get; set; }
+            private IAPIProvider api { get; set; } = null!;
 
             public MessageSender(APIUser sender)
             {
@@ -261,7 +264,7 @@ namespace osu.Game.Overlays.Chat
             }
 
             [BackgroundDependencyLoader(true)]
-            private void load(UserProfileOverlay profile, ChannelManager chatManager)
+            private void load(UserProfileOverlay? profile, ChannelManager? chatManager)
             {
                 Action = () => profile?.ShowUser(sender);
                 startChatAction = () => chatManager?.OpenPrivateChannel(sender);

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -66,6 +66,8 @@ namespace osu.Game.Overlays.Chat
 
         private bool senderHasColour => !string.IsNullOrEmpty(message.Sender.Colour);
 
+        private bool messageHasColour => Message.IsAction && senderHasColour;
+
         [Resolved(CanBeNull = true)]
         private ChannelManager? chatManager { get; set; }
 
@@ -80,7 +82,7 @@ namespace osu.Game.Overlays.Chat
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OverlayColourProvider? colourProvider)
         {
             usernameColour = senderHasColour
                 ? Color4Extensions.FromHex(message.Sender.Colour)
@@ -113,6 +115,7 @@ namespace osu.Game.Overlays.Chat
                                     Origin = Anchor.CentreLeft,
                                     Font = OsuFont.GetFont(size: TextSize * 0.75f, weight: FontWeight.SemiBold, fixedWidth: true),
                                     MaxWidth = TimestampWidth,
+                                    Colour = colourProvider?.Background1 ?? Colour4.White,
                                 },
                                 new MessageSender(message.Sender)
                                 {
@@ -128,16 +131,8 @@ namespace osu.Game.Overlays.Chat
                         ContentFlow = new LinkFlowContainer(t =>
                         {
                             t.Shadow = false;
-
-                            if (Message.IsAction)
-                            {
-                                t.Font = OsuFont.GetFont(italics: true);
-
-                                if (senderHasColour)
-                                    t.Colour = Color4Extensions.FromHex(message.Sender.Colour);
-                            }
-
-                            t.Font = t.Font.With(size: TextSize);
+                            t.Font = t.Font.With(size: TextSize, italics: Message.IsAction);
+                            t.Colour = messageHasColour ? Color4Extensions.FromHex(message.Sender.Colour) : colourProvider?.Content1 ?? Colour4.White;
                         })
                         {
                             AutoSizeAxes = Axes.Y,


### PR DESCRIPTION
| X | Before | After |
|---|---|---|
| Overlay | ![overlay_before](https://user-images.githubusercontent.com/8362491/172628928-6a7d99e6-56af-4da3-baca-580fc25009a1.png) | ![overlay_after](https://user-images.githubusercontent.com/8362491/172628924-3e5808fd-50d0-48a0-8a66-9ce04adc1d56.png) |

