### PR TITLE
Allow beatmaps to load endlessly when entering Player

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -520,7 +520,8 @@ namespace osu.Game.Screens.Play
             }
             catch (Exception e)
             {
-                Logger.Error(e, "Could not load beatmap successfully!");
+                if (this.IsCurrentScreen())
+                    Logger.Error(e, "Could not load beatmap successfully!");
                 //couldn't load, hard abort!
                 return null;
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -518,10 +518,14 @@ namespace osu.Game.Screens.Play
                     return null;
                 }
             }
+            catch (OperationCanceledException)
+            {
+                // Load has been cancelled. No logging is required.
+                return null;
+            }
             catch (Exception e)
             {
-                if (this.IsCurrentScreen())
-                    Logger.Error(e, "Could not load beatmap successfully!");
+                Logger.Error(e, "Could not load beatmap successfully!");
                 //couldn't load, hard abort!
                 return null;
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -181,7 +182,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, OsuConfigManager config, OsuGameBase game)
+        private void load(AudioManager audio, OsuConfigManager config, OsuGameBase game, CancellationToken cancellationToken)
         {
             var gameplayMods = Mods.Value.Select(m => m.DeepClone()).ToArray();
 
@@ -194,7 +195,7 @@ namespace osu.Game.Screens.Play
             if (Beatmap.Value is DummyWorkingBeatmap)
                 return;
 
-            IBeatmap playableBeatmap = loadPlayableBeatmap(gameplayMods);
+            IBeatmap playableBeatmap = loadPlayableBeatmap(gameplayMods, cancellationToken);
 
             if (playableBeatmap == null)
                 return;
@@ -483,7 +484,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private IBeatmap loadPlayableBeatmap(Mod[] gameplayMods)
+        private IBeatmap loadPlayableBeatmap(Mod[] gameplayMods, CancellationToken cancellationToken)
         {
             IBeatmap playable;
 
@@ -500,7 +501,7 @@ namespace osu.Game.Screens.Play
 
                 try
                 {
-                    playable = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, gameplayMods);
+                    playable = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, gameplayMods, cancellationToken);
                 }
                 catch (BeatmapInvalidForRulesetException)
                 {
@@ -508,7 +509,7 @@ namespace osu.Game.Screens.Play
                     rulesetInfo = Beatmap.Value.BeatmapInfo.Ruleset;
                     ruleset = rulesetInfo.CreateInstance();
 
-                    playable = Beatmap.Value.GetPlayableBeatmap(rulesetInfo, gameplayMods);
+                    playable = Beatmap.Value.GetPlayableBeatmap(rulesetInfo, gameplayMods, cancellationToken);
                 }
 
                 if (playable.HitObjects.Count == 0)


### PR DESCRIPTION
It was brought up to me in private that we probably want to let load continue until the game possibly crashes, for slower systems to have a chance to load beatmaps. See: https://sentry.ppy.sh/organizations/ppy/issues/148/events/?project=2&query=ruleset%3A%22osu%22

I believe that this should work. I've tested some very simple cases:
1. Entering solo player, quitting out: cancels the load but does not trigger a notification.
2. Entering solo player, waiting on an endless loop: loading never stops.
4. Entering multi player, waiting on an endless loop: user booted to match subscreen. Triggers the `Gameplay aborted because loading the beatmap took too long` notification from `Multiplayer`.

Can be tested with:
```diff
diff --git a/osu.Game/Beatmaps/WorkingBeatmap.cs b/osu.Game/Beatmaps/WorkingBeatmap.cs
index 09072ec897..108119f0df 100644
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -221,6 +221,8 @@ private Task<IBeatmap> loadBeatmapAsync()

         #region Playable beatmap

+        public static bool Flag;
+
         public IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
         {
             try
@@ -244,6 +246,13 @@ public virtual IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<M
             if (rulesetInstance == null)
                 throw new RulesetLoadException("Creating ruleset instance failed when attempting to create playable beatmap.");

+            if (Flag)
+            {
+                while (!token.IsCancellationRequested)
+                    Thread.Sleep(10);
+                Flag = false;
+            }
+
             IBeatmapConverter converter = CreateBeatmapConverter(Beatmap, rulesetInstance);

             // Check if the beatmap can be converted
diff --git a/osu.Game/Screens/Play/Player.cs b/osu.Game/Screens/Play/Player.cs
index 5548203fe2..ec2cf86064 100644
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -499,6 +499,8 @@ private IBeatmap loadPlayableBeatmap(Mod[] gameplayMods, CancellationToken cance
                 if (ruleset == null)
                     throw new RulesetLoadException("Instantiation failure");

+                WorkingBeatmap.Flag = true;
+
                 try
                 {
                     playable = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, gameplayMods, cancellationToken);
```