### PR TITLE
Fix app version not updating on windows uninstaller entry

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -113,6 +113,9 @@ namespace osu.Desktop
             {
                 tools.CreateShortcutForThisExe();
                 tools.CreateUninstallerRegistryEntry();
+            }, onAppUpdate: (version, tools) =>
+            {
+                tools.CreateUninstallerRegistryEntry();
             }, onAppUninstall: (version, tools) =>
             {
                 tools.RemoveShortcutForThisExe();


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/6785

This has been tested and works as expected. It replaces the already existing entry and doesn't duplicate it.

~Note: You can test it yourself here: https://github.com/Joehuu/osu/releases:~ (deleted)
- download the old version (2022.323.0)
- see the version change to that in the entry (due to new install)
- update
- version changes in the entry to the "latest" one (2022.423.0) (due to this PR)

Both versions are the same apart from their abitrary version number and also have this change:
```diff
diff --git a/osu.Desktop/Updater/SquirrelUpdateManager.cs b/osu.Desktop/Updater/SquirrelUpdateManager.cs
index c09cce1235..649b226653 100644
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -57,7 +57,7 @@ private async Task<bool> checkForUpdateAsync(bool useDeltaPatching = true, Updat

             try
             {
-                updateManager ??= new GithubUpdateManager(@"https://github.com/ppy/osu", false, github_token, @"osulazer");
+                updateManager ??= new GithubUpdateManager(@"https://github.com/Joehuu/osu", false, github_token, @"osulazer");

                 var info = await updateManager.CheckForUpdate(!useDeltaPatching).ConfigureAwait(false);
```

If there is a better way of testing, let me know.