### PR TITLE
Fix latency certifier potentially reporting infinite mouse polling rate

### DIFF
--- a/osu.Game/Screens/Utility/LatencyCertifierScreen.cs
+++ b/osu.Game/Screens/Utility/LatencyCertifierScreen.cs
@@ -147,7 +147,7 @@ Do whatever you need to try and perceive the difference in latency, then choose 
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            if (lastPoll > 0)
+            if (lastPoll > 0 && Clock.CurrentTime != lastPoll)
                 pollingMax = (int)Math.Max(pollingMax, 1000 / (Clock.CurrentTime - lastPoll));
             lastPoll = Clock.CurrentTime;
             return base.OnMouseMove(e);


### PR DESCRIPTION
`OnMouseMove` could be fired more than once at the same frame (happens for me when applying extra force to moving my mouse on macOS), which leads to polling rate reporting infinity due to not guarding against that.