### PR TITLE
Fix torus alternate font not handling "medium" weight

### DIFF
--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Graphics
         /// <returns>The string representation of <paramref name="weight"/> in the specified <paramref name="family"/>.</returns>
         public static string GetWeightString(string family, FontWeight weight)
         {
-            if (family == @"Torus" && weight == FontWeight.Medium)
+            if ((family == @"Torus" || family == @"Torus-Alternate") && weight == FontWeight.Medium)
                 // torus doesn't have a medium; fallback to regular.
                 weight = FontWeight.Regular;
 

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -54,16 +54,16 @@ namespace osu.Game.Graphics
             switch (typeface)
             {
                 case Typeface.Venera:
-                    return "Venera";
+                    return @"Venera";
 
                 case Typeface.Torus:
-                    return "Torus";
+                    return @"Torus";
 
                 case Typeface.TorusAlternate:
-                    return "Torus-Alternate";
+                    return @"Torus-Alternate";
 
                 case Typeface.Inter:
-                    return "Inter";
+                    return @"Inter";
             }
 
             return null;

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -35,7 +35,10 @@ namespace osu.Game.Graphics
         /// <param name="fixedWidth">Whether all characters should be spaced the same distance apart.</param>
         /// <returns>The <see cref="FontUsage"/>.</returns>
         public static FontUsage GetFont(Typeface typeface = Typeface.Torus, float size = DEFAULT_FONT_SIZE, FontWeight weight = FontWeight.Medium, bool italics = false, bool fixedWidth = false)
-            => new FontUsage(GetFamilyString(typeface), size, GetWeightString(typeface, weight), getItalics(italics), fixedWidth);
+        {
+            string familyString = GetFamilyString(typeface);
+            return new FontUsage(familyString, size, GetWeightString(familyString, weight), getItalics(italics), fixedWidth);
+        }
 
         private static bool getItalics(in bool italicsRequested)
         {
@@ -72,25 +75,17 @@ namespace osu.Game.Graphics
         /// <summary>
         /// Retrieves the string representation of a <see cref="FontWeight"/>.
         /// </summary>
-        /// <param name="typeface">The <see cref="Typeface"/>.</param>
-        /// <param name="weight">The <see cref="FontWeight"/>.</param>
-        /// <returns>The string representation of <paramref name="weight"/> in the specified <paramref name="typeface"/>.</returns>
-        public static string GetWeightString(Typeface typeface, FontWeight weight)
+        /// <param name="family">The font family.</param>
+        /// <param name="weight">The font weight.</param>
+        /// <returns>The string representation of <paramref name="weight"/> in the specified <paramref name="family"/>.</returns>
+        public static string GetWeightString(string family, FontWeight weight)
         {
-            if (typeface == Typeface.Torus && weight == FontWeight.Medium)
+            if (family == @"Torus" && weight == FontWeight.Medium)
                 // torus doesn't have a medium; fallback to regular.
                 weight = FontWeight.Regular;
 
-            return GetWeightString(GetFamilyString(typeface), weight);
+            return weight.ToString();
         }
-
-        /// <summary>
-        /// Retrieves the string representation of a <see cref="FontWeight"/>.
-        /// </summary>
-        /// <param name="family">The family string.</param>
-        /// <param name="weight">The <see cref="FontWeight"/>.</param>
-        /// <returns>The string representation of <paramref name="weight"/> in the specified <paramref name="family"/>.</returns>
-        public static string GetWeightString(string family, FontWeight weight) => weight.ToString();
     }
 
     public static class OsuFontExtensions


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18637

Since `Torus` doesn't have a "medium" weight version, they're mapped to "regular" instead. That should also be the case for `TorusAlternate`.