### PR TITLE
Remove unnecessary file existence check in model import process

### DIFF
--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -521,8 +521,7 @@ namespace osu.Game.Stores
             // for the best or worst, we copy and import files of a new import before checking whether
             // it is a duplicate. so to check if anything has changed, we can just compare all File IDs.
             getIDs(existing.Files).SequenceEqual(getIDs(import.Files)) &&
-            getFilenames(existing.Files).SequenceEqual(getFilenames(import.Files)) &&
-            checkAllFilesExist(existing);
+            getFilenames(existing.Files).SequenceEqual(getFilenames(import.Files));
 
         private bool checkAllFilesExist(TModel model) =>
             model.Files.All(f => Files.Storage.Exists(f.File.GetStoragePath()));


### PR DESCRIPTION
This is not required due to `createFileInfos` always being run before we get to this point (I believe this was added after the initial code to check existence was added).

This flow is covered in `BeatmapImportTests.TestImportThenReimportAfterMissingFiles`, which still passes with the change.

While this check isn't doing any harm, as I'm going through the flow for import-skipping, less checks are appreciated.