### PR TITLE
Fix timing adjustment repeat buttons firing one change per repeat invocation

### DIFF
--- a/osu.Game/Screens/Edit/Timing/RepeatingButtonBehaviour.cs
+++ b/osu.Game/Screens/Edit/Timing/RepeatingButtonBehaviour.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Screens.Edit.Timing
 
         private Sample sample;
 
+        public Action RepeatBegan;
+        public Action RepeatEnded;
+
         /// <summary>
         /// An additive modifier for the frequency of the sample played on next actuation.
         /// This can be adjusted during the button's <see cref="Drawable.OnClick"/> event to affect the repeat sample playback of that click.
@@ -44,6 +47,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
+            RepeatBegan?.Invoke();
             beginRepeat();
             return true;
         }
@@ -51,6 +55,7 @@ namespace osu.Game.Screens.Edit.Timing
         protected override void OnMouseUp(MouseUpEvent e)
         {
             adjustDelegate?.Cancel();
+            RepeatEnded?.Invoke();
             base.OnMouseUp(e);
         }
 

--- a/osu.Game/Screens/Edit/Timing/TimingAdjustButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingAdjustButton.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; }
 
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
         public TimingAdjustButton(double adjustAmount)
         {
             this.adjustAmount = adjustAmount;
@@ -72,7 +75,11 @@ namespace osu.Game.Screens.Edit.Timing
                 }
             });
 
-            AddInternal(repeatBehaviour = new RepeatingButtonBehaviour(this));
+            AddInternal(repeatBehaviour = new RepeatingButtonBehaviour(this)
+            {
+                RepeatBegan = () => editorBeatmap.BeginChange(),
+                RepeatEnded = () => editorBeatmap.EndChange()
+            });
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Noticed this with #18668. Also tested against that branch.