### PR TITLE
Always perform full consistency checks for single imports

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -393,7 +393,6 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
-        [Ignore("intentionally broken by import optimisations")]
         public void TestImportThenImportWithChangedFile()
         {
             RunTestWithRealmAsync(async (realm, storage) =>
@@ -490,7 +489,6 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
-        [Ignore("intentionally broken by import optimisations")]
         public void TestImportCorruptThenImport()
         {
             RunTestWithRealmAsync(async (realm, storage) =>
@@ -502,16 +500,18 @@ namespace osu.Game.Tests.Database
 
                 var firstFile = imported.Files.First();
 
+                var fileStorage = storage.GetStorageForDirectory("files");
+
                 long originalLength;
-                using (var stream = storage.GetStream(firstFile.File.GetStoragePath()))
+                using (var stream = fileStorage.GetStream(firstFile.File.GetStoragePath()))
                     originalLength = stream.Length;
 
-                using (var stream = storage.CreateFileSafely(firstFile.File.GetStoragePath()))
+                using (var stream = fileStorage.CreateFileSafely(firstFile.File.GetStoragePath()))
                     stream.WriteByte(0);
 
                 var importedSecondTime = await LoadOszIntoStore(importer, realm.Realm);
 
-                using (var stream = storage.GetStream(firstFile.File.GetStoragePath()))
+                using (var stream = fileStorage.GetStream(firstFile.File.GetStoragePath()))
                     Assert.AreEqual(stream.Length, originalLength, "Corruption was not fixed on second import");
 
                 // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,7 +14,6 @@ using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Extensions;
@@ -27,8 +28,6 @@ using SharpCompress.Archives;
 using SharpCompress.Archives.Zip;
 using SharpCompress.Common;
 using SharpCompress.Writers.Zip;
-
-#nullable enable
 
 namespace osu.Game.Tests.Database
 {
@@ -622,7 +621,7 @@ namespace osu.Game.Tests.Database
                 using var importer = new BeatmapModelManager(realm, storage);
                 using var store = new RealmRulesetStore(realm, storage);
 
-                var imported = await LoadOszIntoStore(importer, realm.Realm);
+                var imported = await LoadOszIntoStore(importer, realm.Realm, batchImport: true);
 
                 deleteBeatmapSet(imported, realm.Realm);
 
@@ -678,7 +677,7 @@ namespace osu.Game.Tests.Database
         {
             RunTestWithRealmAsync(async (realm, storage) =>
             {
-                using var importer = new NonOptimisedBeatmapImporter(realm, storage);
+                using var importer = new BeatmapModelManager(realm, storage);
                 using var store = new RealmRulesetStore(realm, storage);
 
                 var imported = await LoadOszIntoStore(importer, realm.Realm);
@@ -960,11 +959,11 @@ namespace osu.Game.Tests.Database
             return realm.All<BeatmapSetInfo>().FirstOrDefault(beatmapSet => beatmapSet.ID == importedSet!.ID);
         }
 
-        public static async Task<BeatmapSetInfo> LoadOszIntoStore(BeatmapImporter importer, Realm realm, string? path = null, bool virtualTrack = false)
+        public static async Task<BeatmapSetInfo> LoadOszIntoStore(BeatmapImporter importer, Realm realm, string? path = null, bool virtualTrack = false, bool batchImport = false)
         {
             string? temp = path ?? TestResources.GetTestBeatmapForImport(virtualTrack);
 
-            var importedSet = await importer.Import(new ImportTask(temp));
+            var importedSet = await importer.Import(new ImportTask(temp), batchImport);
 
             Assert.NotNull(importedSet);
             Debug.Assert(importedSet != null);
@@ -1080,16 +1079,6 @@ namespace osu.Game.Tests.Database
             }
 
             Assert.Fail(failureMessage);
-        }
-
-        public class NonOptimisedBeatmapImporter : BeatmapImporter
-        {
-            public NonOptimisedBeatmapImporter(RealmAccess realm, Storage storage)
-                : base(realm, storage)
-            {
-            }
-
-            protected override bool HasCustomHashFunction => true;
         }
     }
 }

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -225,10 +225,10 @@ namespace osu.Game.Tests.Online
                     this.testBeatmapManager = testBeatmapManager;
                 }
 
-                public override Live<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, CancellationToken cancellationToken = default)
+                public override Live<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool quickSkipIfExisting = false, CancellationToken cancellationToken = default)
                 {
                     testBeatmapManager.AllowImport.Task.WaitSafely();
-                    return (testBeatmapManager.CurrentImport = base.Import(item, archive, cancellationToken));
+                    return (testBeatmapManager.CurrentImport = base.Import(item, archive, quickSkipIfExisting, cancellationToken));
                 }
             }
         }

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -225,10 +225,10 @@ namespace osu.Game.Tests.Online
                     this.testBeatmapManager = testBeatmapManager;
                 }
 
-                public override Live<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool quickSkipIfExisting = false, CancellationToken cancellationToken = default)
+                public override Live<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default)
                 {
                     testBeatmapManager.AllowImport.Task.WaitSafely();
-                    return (testBeatmapManager.CurrentImport = base.Import(item, archive, quickSkipIfExisting, cancellationToken));
+                    return (testBeatmapManager.CurrentImport = base.Import(item, archive, batchImport, cancellationToken));
                 }
             }
         }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Beatmaps
 
         public Task<Live<BeatmapSetInfo>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default) => beatmapModelManager.Import(archive, lowPriority, cancellationToken);
 
-        public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, CancellationToken cancellationToken = default) => beatmapModelManager.Import(item, archive, cancellationToken);
+        public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, CancellationToken cancellationToken = default) => beatmapModelManager.Import(item, archive, false, cancellationToken);
 
         public IEnumerable<string> HandledExtensions => beatmapModelManager.HandledExtensions;
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -353,9 +353,9 @@ namespace osu.Game.Beatmaps
 
         public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => beatmapModelManager.Import(notification, tasks);
 
-        public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default) => beatmapModelManager.Import(task, lowPriority, cancellationToken);
+        public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default) => beatmapModelManager.Import(task, batchImport, cancellationToken);
 
-        public Task<Live<BeatmapSetInfo>?> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default) => beatmapModelManager.Import(archive, lowPriority, cancellationToken);
+        public Task<Live<BeatmapSetInfo>?> Import(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default) => beatmapModelManager.Import(archive, batchImport, cancellationToken);
 
         public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, CancellationToken cancellationToken = default) => beatmapModelManager.Import(item, archive, false, cancellationToken);
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Scoring
 
         public Task<IEnumerable<Live<ScoreInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => scoreModelManager.Import(notification, tasks);
 
-        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default) => scoreModelManager.Import(item, archive, cancellationToken);
+        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default) => scoreModelManager.Import(item, archive, lowPriority, cancellationToken);
 
         public bool IsAvailableLocally(ScoreInfo model) => scoreModelManager.IsAvailableLocally(model);
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Scoring
 
         public Task<IEnumerable<Live<ScoreInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => scoreModelManager.Import(notification, tasks);
 
-        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default) => scoreModelManager.Import(item, archive, lowPriority, cancellationToken);
+        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default) => scoreModelManager.Import(item, archive, batchImport, cancellationToken);
 
         public bool IsAvailableLocally(ScoreInfo model) => scoreModelManager.IsAvailableLocally(model);
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -276,10 +276,10 @@ namespace osu.Game.Skinning
 
         public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => skinModelManager.Import(notification, tasks);
 
-        public Task<Live<SkinInfo>> Import(ImportTask task, bool lowPriority = false, CancellationToken cancellationToken = default) => skinModelManager.Import(task, lowPriority, cancellationToken);
+        public Task<Live<SkinInfo>> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default) => skinModelManager.Import(task, batchImport, cancellationToken);
 
-        public Task<Live<SkinInfo>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default) =>
-            skinModelManager.Import(archive, lowPriority, cancellationToken);
+        public Task<Live<SkinInfo>> Import(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default) =>
+            skinModelManager.Import(archive, batchImport, cancellationToken);
 
         #endregion
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -281,9 +281,6 @@ namespace osu.Game.Skinning
         public Task<Live<SkinInfo>> Import(ArchiveReader archive, bool lowPriority = false, CancellationToken cancellationToken = default) =>
             skinModelManager.Import(archive, lowPriority, cancellationToken);
 
-        public Live<SkinInfo> Import(SkinInfo item, ArchiveReader archive = null, bool lowPriority = false, CancellationToken cancellationToken = default) =>
-            skinModelManager.Import(item, archive, cancellationToken);
-
         #endregion
 
         #region Implementation of IModelManager<SkinInfo>

--- a/osu.Game/Skinning/SkinModelManager.cs
+++ b/osu.Game/Skinning/SkinModelManager.cs
@@ -46,8 +46,6 @@ namespace osu.Game.Skinning
 
         private const string unknown_creator_string = @"Unknown";
 
-        protected override bool HasCustomHashFunction => true;
-
         protected override void Populate(SkinInfo model, ArchiveReader? archive, Realm realm, CancellationToken cancellationToken = default)
         {
             var skinInfoFile = model.Files.SingleOrDefault(f => f.Filename == skin_info_file);

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Stores
         /// Note that this bypasses the UI flow and should only be used for special cases or testing.
         /// </summary>
         /// <param name="task">The <see cref="ImportTask"/> containing data about the <typeparamref name="TModel"/> to import.</param>
-        /// <param name="batchImport">Whether this is a low priority import.</param>
+        /// <param name="batchImport">Whether this import is part of a larger batch.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The imported model, if successful.</returns>
         public async Task<Live<TModel>?> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default)
@@ -205,7 +205,7 @@ namespace osu.Game.Stores
         /// Silently import an item from an <see cref="ArchiveReader"/>.
         /// </summary>
         /// <param name="archive">The archive to be imported.</param>
-        /// <param name="batchImport">Whether this is a low priority import.</param>
+        /// <param name="batchImport">Whether this import is part of a larger batch.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         public async Task<Live<TModel>?> Import(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default)
         {

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -32,7 +32,16 @@ namespace osu.Game.Stores
     public abstract class RealmArchiveModelImporter<TModel> : IModelImporter<TModel>
         where TModel : RealmObject, IHasRealmFiles, IHasGuidPrimaryKey, ISoftDelete
     {
+        /// <summary>
+        /// The maximum number of concurrent imports to run per import scheduler.
+        /// </summary>
         private const int import_queue_request_concurrency = 1;
+
+        /// <summary>
+        /// The minimum number of items in a single import call in order for the import to be processed as a batch.
+        /// Batch imports will apply optimisations preferring speed over consistency when detecting changes in already-imported items.
+        /// </summary>
+        private const int minimum_items_considered_batch_import = 10;
 
         /// <summary>
         /// A singleton scheduler shared by all <see cref="RealmArchiveModelImporter{TModel}"/>.
@@ -100,7 +109,7 @@ namespace osu.Game.Stores
 
             var imported = new List<Live<TModel>>();
 
-            bool isBatchImport = tasks.Length > 1;
+            bool isBatchImport = tasks.Length >= minimum_items_considered_batch_import;
 
             try
             {

--- a/osu.Game/Stores/RealmArchiveModelImporter.cs
+++ b/osu.Game/Stores/RealmArchiveModelImporter.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Stores
             bool checkedExisting = false;
             TModel? existing = null;
 
-            if (quickSkipIfExisting && archive != null && !HasCustomHashFunction)
+            if (quickSkipIfExisting && archive != null)
             {
                 // this is a fast bail condition to improve large import performance.
                 item.Hash = computeHashFast(archive);
@@ -374,18 +374,12 @@ namespace osu.Game.Stores
         }
 
         /// <summary>
-        /// Whether the implementation overrides <see cref="ComputeHash"/> with a custom implementation.
-        /// Custom hash implementations must bypass the early exit in the import flow (see <see cref="computeHashFast"/> usage).
-        /// </summary>
-        protected virtual bool HasCustomHashFunction => false;
-
-        /// <summary>
         /// Create a SHA-2 hash from the provided archive based on file content of all files matching <see cref="HashableFileTypes"/>.
         /// </summary>
         /// <remarks>
         ///  In the case of no matching files, a hash will be generated from the passed archive's <see cref="ArchiveReader.Name"/>.
         /// </remarks>
-        protected virtual string ComputeHash(TModel item)
+        protected string ComputeHash(TModel item)
         {
             // for now, concatenate all hashable files in the set to create a unique hash.
             MemoryStream hashable = new MemoryStream();

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Tests.Visual
 
             protected override BeatmapModelManager CreateBeatmapModelManager(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapOnlineLookupQueue onlineLookupQueue)
             {
-                return new TestBeatmapModelManager(storage, realm, onlineLookupQueue);
+                return new BeatmapModelManager(realm, storage, onlineLookupQueue);
             }
 
             protected override WorkingBeatmapCache CreateWorkingBeatmapCache(AudioManager audioManager, IResourceStore<byte[]> resources, IResourceStore<byte[]> storage, WorkingBeatmap defaultBeatmap, GameHost host)
@@ -179,17 +179,6 @@ namespace osu.Game.Tests.Visual
 
                 public override WorkingBeatmap GetWorkingBeatmap(BeatmapInfo beatmapInfo)
                     => testBeatmapManager.TestBeatmap;
-            }
-
-            internal class TestBeatmapModelManager : BeatmapModelManager
-            {
-                public TestBeatmapModelManager(Storage storage, RealmAccess databaseAccess, BeatmapOnlineLookupQueue beatmapOnlineLookupQueue)
-                    : base(databaseAccess, storage, beatmapOnlineLookupQueue)
-                {
-                }
-
-                protected override string ComputeHash(BeatmapSetInfo item)
-                    => string.Empty;
             }
 
             public override void Save(BeatmapInfo info, IBeatmap beatmapContent, ISkin beatmapSkin = null)


### PR DESCRIPTION
With the introduction of the "quick" path for imports, we broke user expectations. Importing a beatmap which is already loaded would never replace it, even if some files had been changed or corrupted.

This is a first step to restore sanity. Now any imports which are single item imports will always run through full consistency checks. The positive effect of this can be seen by the two ignored tests which have been re-enabled (cac724f436).

Again, this is only a first step. I am reassessing how to handle this going forward, with the hope of completely removing this "quick" mode once we have the ability to reprocess beatmaps more correctly, as mentioned in the [inline comment](https://github.com/ppy/osu/blob/88d5e074a8c6ca4060101ca0747bfc5bf01b4f1a/osu.Game/Stores/RealmArchiveModelImporter.cs#L267-L268) I left some time ago.

Bundled in this PR is the removal of the custom hash functionality (f11fe54385) which was used in the past by `SkinManager` but is no longer required. This simplifies things considerably.

I also renamed `lowPriority` to `batchImport` (88d5e074a8) to make it very clear what the flag is being used for.

Closes https://github.com/ppy/osu/issues/18600.