### PR TITLE
Block scroll input from passing through game toolbar

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -6,11 +6,16 @@ using Moq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
+using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets;
+using osuTK.Graphics;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Menus
@@ -93,6 +98,28 @@ namespace osu.Game.Tests.Visual.Menus
                 AddAssert("toolbar still hidden", () => toolbar.State.Value == Visibility.Hidden);
             else
                 AddAssert("toolbar is visible", () => toolbar.State.Value == Visibility.Visible);
+        }
+
+        [Test]
+        public void TestScrollInput()
+        {
+            OsuScrollContainer scroll = null;
+
+            AddStep("add scroll layer", () => Add(scroll = new OsuScrollContainer
+            {
+                Depth = 1f,
+                RelativeSizeAxes = Axes.Both,
+                Child = new Box
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = DrawHeight * 2,
+                    Colour = ColourInfo.GradientVertical(Color4.Gray, Color4.DarkGray),
+                }
+            }));
+
+            AddStep("hover toolbar", () => InputManager.MoveMouseTo(toolbar));
+            AddStep("perform scroll", () => InputManager.ScrollVerticalBy(500));
+            AddAssert("not scrolled", () => scroll.Current == 0);
         }
 
         public class TestToolbar : Toolbar

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -41,8 +41,6 @@ namespace osu.Game.Overlays.Toolbar
         // Toolbar and its components need keyboard input even when hidden.
         public override bool PropagateNonPositionalInputSubTree => true;
 
-        protected override bool BlockScrollInput => false;
-
         public Toolbar()
         {
             RelativeSizeAxes = Axes.X;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18673

As mentioned in https://github.com/ppy/osu/issues/18673#issuecomment-1153660357, the only benefit from scrolling in toolbar is for controlling volume, but the toolbar may potentially be horizontally scrollable itself, and the volume controls are likely to be moved to the toolbar as well rather than only appearing via scroll.