### PR TITLE
Allow scrolling overflow of ruleset buttons in the toolbar

### DIFF
--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -14,6 +14,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets;
 using osu.Framework.Input.Bindings;
+using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
 
 namespace osu.Game.Overlays.Toolbar
@@ -65,45 +66,115 @@ namespace osu.Game.Overlays.Toolbar
             Children = new Drawable[]
             {
                 new ToolbarBackground(),
-                new FillFlowContainer
+                new GridContainer
                 {
-                    Direction = FillDirection.Horizontal,
-                    RelativeSizeAxes = Axes.Y,
-                    AutoSizeAxes = Axes.X,
-                    Children = new Drawable[]
+                    RelativeSizeAxes = Axes.Both,
+                    ColumnDimensions = new[]
                     {
-                        new ToolbarSettingsButton(),
-                        new ToolbarHomeButton
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(),
+                        new Dimension(GridSizeMode.AutoSize)
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
                         {
-                            Action = () => OnHome?.Invoke()
+                            new Container
+                            {
+                                Name = "Left buttons",
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X,
+                                Depth = float.MinValue,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        Colour = OsuColour.Gray(0.1f),
+                                        RelativeSizeAxes = Axes.Both,
+                                    },
+                                    new FillFlowContainer
+                                    {
+                                        Direction = FillDirection.Horizontal,
+                                        RelativeSizeAxes = Axes.Y,
+                                        AutoSizeAxes = Axes.X,
+                                        Children = new Drawable[]
+                                        {
+                                            new ToolbarSettingsButton(),
+                                            new ToolbarHomeButton
+                                            {
+                                                Action = () => OnHome?.Invoke()
+                                            },
+                                        },
+                                    },
+                                }
+                            },
+                            new Container
+                            {
+                                Name = "Ruleset selector",
+                                RelativeSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    new OsuScrollContainer(Direction.Horizontal)
+                                    {
+                                        ScrollbarVisible = false,
+                                        RelativeSizeAxes = Axes.Both,
+                                        Masking = false,
+                                        Children = new Drawable[]
+                                        {
+                                            rulesetSelector = new ToolbarRulesetSelector()
+                                        }
+                                    },
+                                    new Box
+                                    {
+                                        Colour = ColourInfo.GradientHorizontal(OsuColour.Gray(0.1f).Opacity(0), OsuColour.Gray(0.1f)),
+                                        Width = 50,
+                                        RelativeSizeAxes = Axes.Y,
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                    },
+                                }
+                            },
+                            new Container
+                            {
+                                Name = "Right buttons",
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        Colour = OsuColour.Gray(0.1f),
+                                        RelativeSizeAxes = Axes.Both,
+                                    },
+                                    new FillFlowContainer
+                                    {
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                        Direction = FillDirection.Horizontal,
+                                        RelativeSizeAxes = Axes.Y,
+                                        AutoSizeAxes = Axes.X,
+                                        Children = new Drawable[]
+                                        {
+                                            new ToolbarNewsButton(),
+                                            new ToolbarChangelogButton(),
+                                            new ToolbarRankingsButton(),
+                                            new ToolbarBeatmapListingButton(),
+                                            new ToolbarChatButton(),
+                                            new ToolbarSocialButton(),
+                                            new ToolbarWikiButton(),
+                                            new ToolbarMusicButton(),
+                                            //new ToolbarButton
+                                            //{
+                                            //    Icon = FontAwesome.Solid.search
+                                            //},
+                                            userButton = new ToolbarUserButton(),
+                                            new ToolbarClock(),
+                                            new ToolbarNotificationButton(),
+                                        }
+                                    },
+                                }
+                            },
                         },
-                        rulesetSelector = new ToolbarRulesetSelector()
-                    }
-                },
-                new FillFlowContainer
-                {
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight,
-                    Direction = FillDirection.Horizontal,
-                    RelativeSizeAxes = Axes.Y,
-                    AutoSizeAxes = Axes.X,
-                    Children = new Drawable[]
-                    {
-                        new ToolbarNewsButton(),
-                        new ToolbarChangelogButton(),
-                        new ToolbarRankingsButton(),
-                        new ToolbarBeatmapListingButton(),
-                        new ToolbarChatButton(),
-                        new ToolbarSocialButton(),
-                        new ToolbarWikiButton(),
-                        new ToolbarMusicButton(),
-                        //new ToolbarButton
-                        //{
-                        //    Icon = FontAwesome.Solid.search
-                        //},
-                        userButton = new ToolbarUserButton(),
-                        new ToolbarClock(),
-                        new ToolbarNotificationButton(),
                     }
                 }
             };

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Overlays.Toolbar
             };
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e) => true;
+        protected override bool OnMouseDown(MouseDownEvent e) => false;
 
         protected override bool OnClick(ClickEvent e)
         {


### PR DESCRIPTION
Just a proposal to make the toolbar a bit more dynamic when rolling the scroll wheel. I've seen users which have enough rulesets to not fit in the toolbar, so this should make things better until we potentially come up with a better display method.

I'd like to make the scroll happen regardless of where you scroll on the toolbar (including the left/right buttons) but that's a bit harder.

- [x] Depends on #18690.