### PR TITLE
Rework doubletap detection in osu!'s Speed evaluator

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -41,8 +41,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             {
                 double currDeltaTime = Math.Max(1, osuCurrObj.DeltaTime);
                 double nextDeltaTime = Math.Max(1, osuNextObj.DeltaTime);
-                double speedRatio = Math.Min(1, currDeltaTime / nextDeltaTime);
-                double windowRatio = Math.Min(1, currDeltaTime / greatWindowFull);
+                double deltaDifference = Math.Abs(nextDeltaTime - currDeltaTime);
+                double speedRatio = Math.Min(1, currDeltaTime / deltaDifference);
+                double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / greatWindowFull), 2);
                 doubletapness = Math.Pow(speedRatio, 1 - windowRatio);
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                 double currDeltaTime = Math.Max(1, osuCurrObj.DeltaTime);
                 double nextDeltaTime = Math.Max(1, osuNextObj.DeltaTime);
                 double deltaDifference = Math.Abs(nextDeltaTime - currDeltaTime);
-                double speedRatio = Math.Min(1, currDeltaTime / deltaDifference);
+                double speedRatio = currDeltaTime / Math.Max(currDeltaTime, deltaDifference);
                 double windowRatio = Math.Pow(Math.Min(1, currDeltaTime / greatWindowFull), 2);
                 doubletapness = Math.Pow(speedRatio, 1 - windowRatio);
             }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
@@ -31,14 +30,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // derive strainTime for calculation
             var osuCurrObj = (OsuDifficultyHitObject)current;
             var osuPrevObj = current.Index > 0 ? (OsuDifficultyHitObject)current.Previous(0) : null;
+            var osuNextObj = (OsuDifficultyHitObject)current.Next(0);
 
             double strainTime = osuCurrObj.StrainTime;
             double greatWindowFull = greatWindow * 2;
-            double speedWindowRatio = strainTime / greatWindowFull;
+            double doubletapness = 1;
 
-            // Aim to nerf cheesy rhythms (Very fast consecutive doubles with large deltatimes between)
-            if (osuPrevObj != null && strainTime < greatWindowFull && osuPrevObj.StrainTime > strainTime)
-                strainTime = Interpolation.Lerp(osuPrevObj.StrainTime, strainTime, speedWindowRatio);
+            // Nerf doubletappable doubles.
+            if (osuNextObj != null)
+            {
+                double currDeltaTime = Math.Max(1, osuCurrObj.DeltaTime);
+                double nextDeltaTime = Math.Max(1, osuNextObj.DeltaTime);
+                double speedRatio = Math.Min(1, currDeltaTime / nextDeltaTime);
+                double windowRatio = Math.Min(1, currDeltaTime / greatWindowFull);
+                doubletapness = Math.Pow(speedRatio, 1 - windowRatio);
+            }
 
             // Cap deltatime to the OD 300 hitwindow.
             // 0.93 is derived from making sure 260bpm OD8 streams aren't nerfed harshly, whilst 0.92 limits the effect of the cap.
@@ -53,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             double travelDistance = osuPrevObj?.TravelDistance ?? 0;
             double distance = Math.Min(single_spacing_threshold, travelDistance + osuCurrObj.MinimumJumpDistance);
 
-            return (speedBonus + speedBonus * Math.Pow(distance / single_spacing_threshold, 3.5)) / strainTime;
+            return (speedBonus + speedBonus * Math.Pow(distance / single_spacing_threshold, 3.5)) * doubletapness / strainTime;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Evaluators;
+using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
@@ -35,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         protected override double StrainValueAt(DifficultyHitObject current)
         {
-            currentStrain *= strainDecay(current.DeltaTime);
+            currentStrain *= strainDecay(((OsuDifficultyHitObject)current).StrainTime);
             currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current, greatWindow) * skillMultiplier;
 
             currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current, greatWindow);


### PR DESCRIPTION
Addresses https://osu.ppy.sh/beatmapsets/1691083/discussion/-/generalAll#/3020552
Desmos link for the maths: https://www.desmos.com/calculator/vr8nzfqo4b
Rankings for this proposal: https://pp.huismetbenen.nl/rankings/players/apollo2

This proposal rebalances the state of doubletappable doubles, punishing them more accurately for how easily cheesable they are. This is done by calculating the time to press the current and next object, as well as comparing the intervals to the 300 hitwindow.

This takes advantage of the fact we can access the next object to work out the "doubletapness" of the current object, can refer to the code / desmos since it pretty much speaks for itself... also switches strain decay to take in `StrainTime` instead of `DeltaTime`. Results here appear to be a lot better IMO than the previous iteration on quite a few notable maps with cheesable doubles / 2B.