### PR TITLE
Add basic volume control support in toolbar music button

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -30,6 +30,21 @@ namespace osu.Game.Tests.Visual.Menus
         [Resolved]
         private IRulesetStore rulesets { get; set; }
 
+        [Cached]
+        private readonly NowPlayingOverlay nowPlayingOverlay = new NowPlayingOverlay
+        {
+            Anchor = Anchor.TopRight,
+            Origin = Anchor.TopRight,
+            Y = Toolbar.HEIGHT,
+        };
+
+        [Cached]
+        private readonly VolumeOverlay volumeOverlay = new VolumeOverlay
+        {
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
+        };
+
         private readonly Mock<TestNotificationOverlay> notifications = new Mock<TestNotificationOverlay>();
 
         private readonly BindableInt unreadNotificationCount = new BindableInt();
@@ -44,7 +59,15 @@ namespace osu.Game.Tests.Visual.Menus
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = toolbar = new TestToolbar { State = { Value = Visibility.Visible } };
+            Remove(nowPlayingOverlay);
+            Remove(volumeOverlay);
+
+            Children = new Drawable[]
+            {
+                nowPlayingOverlay,
+                volumeOverlay,
+                toolbar = new TestToolbar { State = { Value = Visibility.Visible } },
+            };
         });
 
         [Test]
@@ -122,6 +145,19 @@ namespace osu.Game.Tests.Visual.Menus
             AddStep("hover toolbar", () => InputManager.MoveMouseTo(toolbar));
             AddStep("perform scroll", () => InputManager.ScrollVerticalBy(500));
             AddAssert("not scrolled", () => scroll.Current == 0);
+        }
+
+        [Test]
+        public void TestVolumeControlViaMusicButton()
+        {
+            AddStep("hover toolbar music button", () => InputManager.MoveMouseTo(this.ChildrenOfType<ToolbarMusicButton>().Single()));
+
+            AddStep("reset volume", () => Audio.Volume.Value = 1);
+
+            AddRepeatStep("scroll down", () => InputManager.ScrollVerticalBy(-10), 5);
+            AddAssert("volume lowered down", () => Audio.Volume.Value < 1);
+            AddRepeatStep("scroll up", () => InputManager.ScrollVerticalBy(10), 5);
+            AddAssert("volume raised up", () => Audio.Volume.Value == 1);
         }
 
         public class TestToolbar : Toolbar

--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using JetBrains.Annotations;
 using Moq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -13,6 +14,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets;
 using osuTK.Graphics;
@@ -28,14 +30,14 @@ namespace osu.Game.Tests.Visual.Menus
         [Resolved]
         private IRulesetStore rulesets { get; set; }
 
-        private readonly Mock<INotificationOverlay> notifications = new Mock<INotificationOverlay>();
+        private readonly Mock<TestNotificationOverlay> notifications = new Mock<TestNotificationOverlay>();
 
         private readonly BindableInt unreadNotificationCount = new BindableInt();
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Dependencies.CacheAs(notifications.Object);
+            Dependencies.CacheAs<INotificationOverlay>(notifications.Object);
             notifications.SetupGet(n => n.UnreadCount).Returns(unreadNotificationCount);
         }
 
@@ -125,6 +127,22 @@ namespace osu.Game.Tests.Visual.Menus
         public class TestToolbar : Toolbar
         {
             public new Bindable<OverlayActivation> OverlayActivationMode => base.OverlayActivationMode as Bindable<OverlayActivation>;
+        }
+
+        // interface mocks break hot reload, mocking this stub implementation instead works around it.
+        // see: https://github.com/moq/moq4/issues/1252
+        [UsedImplicitly]
+        public class TestNotificationOverlay : INotificationOverlay
+        {
+            public virtual void Post(Notification notification)
+            {
+            }
+
+            public virtual void Hide()
+            {
+            }
+
+            public virtual IBindable<int> UnreadCount => null;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Tests.Visual.Menus
         }
 
         [Test]
-        public void TestVolumeControlViaMusicButton()
+        public void TestVolumeControlViaMusicButtonScroll()
         {
             AddStep("hover toolbar music button", () => InputManager.MoveMouseTo(this.ChildrenOfType<ToolbarMusicButton>().Single()));
 
@@ -157,6 +157,19 @@ namespace osu.Game.Tests.Visual.Menus
             AddRepeatStep("scroll down", () => InputManager.ScrollVerticalBy(-10), 5);
             AddAssert("volume lowered down", () => Audio.Volume.Value < 1);
             AddRepeatStep("scroll up", () => InputManager.ScrollVerticalBy(10), 5);
+            AddAssert("volume raised up", () => Audio.Volume.Value == 1);
+        }
+
+        [Test]
+        public void TestVolumeControlViaMusicButtonArrowKeys()
+        {
+            AddStep("hover toolbar music button", () => InputManager.MoveMouseTo(this.ChildrenOfType<ToolbarMusicButton>().Single()));
+
+            AddStep("reset volume", () => Audio.Volume.Value = 1);
+
+            AddRepeatStep("arrow down", () => InputManager.Key(Key.Down), 5);
+            AddAssert("volume lowered down", () => Audio.Volume.Value < 1);
+            AddRepeatStep("arrow up", () => InputManager.Key(Key.Up), 5);
             AddAssert("volume raised up", () => Audio.Volume.Value == 1);
         }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -2,29 +2,78 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
     public class ToolbarMusicButton : ToolbarOverlayToggleButton
     {
+        private Circle volumeBar;
+
         protected override Anchor TooltipAnchor => Anchor.TopRight;
 
         public ToolbarMusicButton()
         {
             Hotkey = GlobalAction.ToggleNowPlaying;
+            AutoSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader(true)]
         private void load(NowPlayingOverlay music)
         {
             StateContainer = music;
+
+            Flow.Padding = new MarginPadding { Horizontal = Toolbar.HEIGHT / 4 };
+            Flow.Add(new Container
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Width = 3f,
+                Height = IconContainer.Height,
+                Margin = new MarginPadding { Horizontal = 2.5f },
+                Masking = true,
+                Children = new[]
+                {
+                    new Circle
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White.Opacity(0.25f),
+                    },
+                    volumeBar = new Circle
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Height = 0f,
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Colour = Color4.White,
+                    }
+                }
+            });
         }
+
+        [Resolved]
+        private AudioManager audio { get; set; }
 
         [Resolved(canBeNull: true)]
         private VolumeOverlay volume { get; set; }
+
+        private IBindable<double> globalVolume;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            globalVolume = audio.Volume.GetBoundCopy();
+            globalVolume.BindValueChanged(v => volumeBar.Height = (float)v.NewValue, true);
+        }
 
         protected override bool OnScroll(ScrollEvent e)
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -13,6 +13,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Threading;
 using osu.Game.Input.Bindings;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Overlays.Toolbar
 {
@@ -76,6 +77,24 @@ namespace osu.Game.Overlays.Toolbar
 
             globalVolume = audio.Volume.GetBoundCopy();
             globalVolume.BindValueChanged(v => volumeBar.ResizeHeightTo((float)v.NewValue, 200, Easing.OutQuint), true);
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            switch (e.Key)
+            {
+                case Key.Up:
+                    focusForAdjustment();
+                    volume?.Adjust(GlobalAction.IncreaseVolume);
+                    return true;
+
+                case Key.Down:
+                    focusForAdjustment();
+                    volume?.Adjust(GlobalAction.IncreaseVolume, -1);
+                    return true;
+            }
+
+            return base.OnKeyDown(e);
         }
 
         protected override bool OnScroll(ScrollEvent e)

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
 
 namespace osu.Game.Overlays.Toolbar
@@ -20,6 +21,15 @@ namespace osu.Game.Overlays.Toolbar
         private void load(NowPlayingOverlay music)
         {
             StateContainer = music;
+        }
+
+        [Resolved(canBeNull: true)]
+        private VolumeOverlay volume { get; set; }
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            volume?.Adjust(GlobalAction.IncreaseVolume, e.ScrollDelta.Y, e.IsPrecise);
+            return true;
         }
     }
 }

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Overlays.Toolbar
 
                 case Key.Down:
                     focusForAdjustment();
-                    volume?.Adjust(GlobalAction.IncreaseVolume, -1);
+                    volume?.Adjust(GlobalAction.DecreaseVolume);
                     return true;
             }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnScroll(ScrollEvent e)
         {
+            volume?.FocusMasterVolume();
             volume?.Adjust(GlobalAction.IncreaseVolume, e.ScrollDelta.Y, e.IsPrecise);
             return true;
         }

--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -140,11 +140,16 @@ namespace osu.Game.Overlays
 
         private ScheduledDelegate popOutDelegate;
 
+        public void FocusMasterVolume()
+        {
+            volumeMeters.Select(volumeMeterMaster);
+        }
+
         public override void Show()
         {
             // Focus on the master meter as a default if previously hidden
             if (State.Value == Visibility.Hidden)
-                volumeMeters.Select(volumeMeterMaster);
+                FocusMasterVolume();
 
             if (State.Value == Visibility.Visible)
                 schedulePopOut();


### PR DESCRIPTION
Now that toolbar blocks scrolling input from passing through (#18690), volume can no longer be controlled by hovering over empty area in toolbar. Therefore basic/temporary volume control support is added to the toolbar music button for the time being. 

UI will be reiterated on along with the toolbar redesign. I believe volume control will come in its own button rather than merged with the "now playing" button.

---

https://user-images.githubusercontent.com/22781491/173671587-0fbbb4cc-7d9d-411c-b62a-ef4780593ac4.mp4

