### PR TITLE
Fix `ZoomableScrollContainer` attempting to update zoom with invalid range

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
@@ -79,6 +79,21 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestZoomRangeUpdate()
+        {
+            AddStep("set zoom to 2", () => scrollContainer.Zoom = 2);
+            AddStep("set min zoom to 5", () => scrollContainer.MinZoom = 5);
+            AddAssert("zoom = 5", () => scrollContainer.Zoom == 5);
+
+            AddStep("set max zoom to 10", () => scrollContainer.MaxZoom = 10);
+            AddAssert("zoom = 5", () => scrollContainer.Zoom == 5);
+
+            AddStep("set min zoom to 20", () => scrollContainer.MinZoom = 20);
+            AddStep("set max zoom to 40", () => scrollContainer.MaxZoom = 40);
+            AddAssert("zoom = 20", () => scrollContainer.Zoom == 20);
+        }
+
+        [Test]
         public void TestZoom0()
         {
             reset();

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -66,8 +66,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 minZoom = value;
 
-                if (Zoom < value)
-                    Zoom = value;
+                // ensure zoom range is in valid state before updating zoom.
+                if (MinZoom < MaxZoom)
+                    Zoom = Zoom;
             }
         }
 
@@ -86,8 +87,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 maxZoom = value;
 
-                if (Zoom > value)
-                    Zoom = value;
+                // ensure zoom range is in valid state before updating zoom.
+                if (MaxZoom > MinZoom)
+                    Zoom = Zoom;
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 // ensure zoom range is in valid state before updating zoom.
                 if (MinZoom < MaxZoom)
-                    Zoom = Zoom;
+                    updateZoom();
             }
         }
 
@@ -89,7 +89,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 // ensure zoom range is in valid state before updating zoom.
                 if (MaxZoom > MinZoom)
-                    Zoom = Zoom;
+                    updateZoom();
             }
         }
 
@@ -99,15 +99,17 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         public float Zoom
         {
             get => zoomTarget;
-            set
-            {
-                value = Math.Clamp(value, MinZoom, MaxZoom);
+            set => updateZoom(value);
+        }
 
-                if (IsLoaded)
-                    setZoomTarget(value, ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, 0), zoomedContent).X);
-                else
-                    currentZoom = zoomTarget = value;
-            }
+        private void updateZoom(float? value = null)
+        {
+            float newZoom = Math.Clamp(value ?? Zoom, MinZoom, MaxZoom);
+
+            if (IsLoaded)
+                setZoomTarget(newZoom, ToSpaceOfOtherDrawable(new Vector2(DrawWidth / 2, 0), zoomedContent).X);
+            else
+                currentZoom = zoomTarget = newZoom;
         }
 
         protected override void Update()


### PR DESCRIPTION
- Closes #18696 

Exiting editor after changing track causes a refetch to occur, which fires the following callback in `Timeline`:
https://github.com/ppy/osu/blob/9cc5df9b133450e987afce2187b01e73f0ba8c03/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs#L143-L152

With the new track, the first property to update (max zoom) may potentially be lower than the current min zoom value, causing `ZoomableScrollContainer` to throw invalid min/max exception upon trying to update `Zoom`.

Fixed by not updating `Zoom` if the range is invalid, to give the usage a chance to update the other property before throwing exception. 

Note that if the new min/max range were actually invalid after updating both properties, this will still throw if the user tries to changes zoom, so I think it's fine leaving `Zoom` in an invalid state during range update.