### PR TITLE
Handle subdirectories during beatmap stable import

### DIFF
--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Database;
+using osu.Game.IO;
+
+namespace osu.Game.Tests.Database
+{
+    [TestFixture]
+    public class LegacyBeatmapImporterTest
+    {
+        private readonly TestLegacyBeatmapImporter importer = new TestLegacyBeatmapImporter();
+
+        [Test]
+        public void TestSongsSubdirectories()
+        {
+            using (var storage = new TemporaryNativeStorage("stable-songs-folder"))
+            {
+                var songsStorage = storage.GetStorageForDirectory(StableStorage.STABLE_DEFAULT_SONGS_PATH);
+
+                // normal beatmap folder
+                var beatmap1 = songsStorage.GetStorageForDirectory("beatmap1");
+                beatmap1.CreateFileSafely("beatmap.osu");
+
+                // songs subdirectory
+                var subdirectory = songsStorage.GetStorageForDirectory("subdirectory");
+                subdirectory.CreateFileSafely(subdirectory.GetFullPath(Path.Combine("beatmap2", "beatmap.osu"), true));
+                subdirectory.CreateFileSafely(subdirectory.GetFullPath(Path.Combine("beatmap3", "beatmap.osu"), true));
+                subdirectory.CreateFileSafely(subdirectory.GetFullPath(Path.Combine("sub-subdirectory", "beatmap4", "beatmap.osu"), true));
+
+                // songs subdirectory with system file
+                var subdirectory2 = songsStorage.GetStorageForDirectory("subdirectory2");
+                subdirectory2.CreateFileSafely(subdirectory2.GetFullPath(".DS_Store"));
+                subdirectory2.CreateFileSafely(subdirectory2.GetFullPath(Path.Combine("beatmap5", "beatmap.osu"), true));
+                subdirectory2.CreateFileSafely(subdirectory2.GetFullPath(Path.Combine("beatmap6", "beatmap.osu"), true));
+
+                // empty songs subdirectory
+                songsStorage.GetStorageForDirectory("subdirectory3");
+
+                string[] paths = importer.GetStableImportPaths(songsStorage).ToArray();
+                Assert.That(paths.Length, Is.EqualTo(6));
+                Assert.That(paths.Contains(songsStorage.GetFullPath("beatmap1")));
+                Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory", "beatmap2"))));
+                Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory", "beatmap3"))));
+                Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory", "sub-subdirectory", "beatmap4"))));
+                Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory2", "beatmap5"))));
+                Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory2", "beatmap6"))));
+            }
+        }
+
+        private class TestLegacyBeatmapImporter : LegacyBeatmapImporter
+        {
+            public TestLegacyBeatmapImporter()
+                : base(null)
+            {
+            }
+
+            public new IEnumerable<string> GetStableImportPaths(Storage storage) => base.GetStableImportPaths(storage);
+        }
+    }
+}

--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -26,19 +26,19 @@ namespace osu.Game.Tests.Database
 
                 // normal beatmap folder
                 var beatmap1 = songsStorage.GetStorageForDirectory("beatmap1");
-                beatmap1.CreateFileSafely("beatmap.osu");
+                createFile(beatmap1, "beatmap.osu");
 
                 // songs subdirectory
                 var subdirectory = songsStorage.GetStorageForDirectory("subdirectory");
-                subdirectory.CreateFileSafely(subdirectory.GetFullPath(Path.Combine("beatmap2", "beatmap.osu"), true));
-                subdirectory.CreateFileSafely(subdirectory.GetFullPath(Path.Combine("beatmap3", "beatmap.osu"), true));
-                subdirectory.CreateFileSafely(subdirectory.GetFullPath(Path.Combine("sub-subdirectory", "beatmap4", "beatmap.osu"), true));
+                createFile(subdirectory, Path.Combine("beatmap2", "beatmap.osu"));
+                createFile(subdirectory, Path.Combine("beatmap3", "beatmap.osu"));
+                createFile(subdirectory, Path.Combine("sub-subdirectory", "beatmap4", "beatmap.osu"));
 
                 // songs subdirectory with system file
                 var subdirectory2 = songsStorage.GetStorageForDirectory("subdirectory2");
-                subdirectory2.CreateFileSafely(subdirectory2.GetFullPath(".DS_Store"));
-                subdirectory2.CreateFileSafely(subdirectory2.GetFullPath(Path.Combine("beatmap5", "beatmap.osu"), true));
-                subdirectory2.CreateFileSafely(subdirectory2.GetFullPath(Path.Combine("beatmap6", "beatmap.osu"), true));
+                createFile(subdirectory2, ".DS_Store");
+                createFile(subdirectory2, Path.Combine("beatmap5", "beatmap.osu"));
+                createFile(subdirectory2, Path.Combine("beatmap6", "beatmap.osu"));
 
                 // empty songs subdirectory
                 songsStorage.GetStorageForDirectory("subdirectory3");
@@ -51,6 +51,12 @@ namespace osu.Game.Tests.Database
                 Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory", "sub-subdirectory", "beatmap4"))));
                 Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory2", "beatmap5"))));
                 Assert.That(paths.Contains(songsStorage.GetFullPath(Path.Combine("subdirectory2", "beatmap6"))));
+            }
+
+            static void createFile(Storage storage, string path)
+            {
+                using (var stream = storage.CreateFileSafely(path))
+                    stream.WriteByte(0);
             }
         }
 

--- a/osu.Game/Database/LegacyBeatmapImporter.cs
+++ b/osu.Game/Database/LegacyBeatmapImporter.cs
@@ -18,19 +18,19 @@ namespace osu.Game.Database
 
         protected override IEnumerable<string> GetStableImportPaths(Storage storage)
         {
-            foreach (string beatmapDirectory in storage.GetDirectories(string.Empty))
+            foreach (string directory in storage.GetDirectories(string.Empty))
             {
-                var beatmapStorage = storage.GetStorageForDirectory(beatmapDirectory);
+                var directoryStorage = storage.GetStorageForDirectory(directory);
 
-                if (!beatmapStorage.GetFiles(string.Empty).ExcludeSystemFileNames().Any())
+                if (!directoryStorage.GetFiles(string.Empty).ExcludeSystemFileNames().Any())
                 {
                     // if a directory doesn't contain files, attempt looking for beatmaps inside of that directory.
                     // this is a special behaviour in stable for beatmaps only, see https://github.com/ppy/osu/issues/18615.
-                    foreach (string beatmapInDirectory in GetStableImportPaths(beatmapStorage))
-                        yield return beatmapStorage.GetFullPath(beatmapInDirectory);
+                    foreach (string subDirectory in GetStableImportPaths(directoryStorage))
+                        yield return subDirectory;
                 }
                 else
-                    yield return storage.GetFullPath(beatmapDirectory);
+                    yield return storage.GetFullPath(directory);
             }
         }
 

--- a/osu.Game/Database/LegacyBeatmapImporter.cs
+++ b/osu.Game/Database/LegacyBeatmapImporter.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.IO;
@@ -12,6 +15,24 @@ namespace osu.Game.Database
         protected override string ImportFromStablePath => ".";
 
         protected override Storage PrepareStableStorage(StableStorage stableStorage) => stableStorage.GetSongStorage();
+
+        protected override IEnumerable<string> GetStableImportPaths(Storage storage)
+        {
+            foreach (string beatmapDirectory in storage.GetDirectories(string.Empty))
+            {
+                var beatmapStorage = storage.GetStorageForDirectory(beatmapDirectory);
+
+                if (!beatmapStorage.GetFiles(string.Empty).ExcludeSystemFileNames().Any())
+                {
+                    // if a directory doesn't contain files, attempt looking for beatmaps inside of that directory.
+                    // this is a special behaviour in stable for beatmaps only, see https://github.com/ppy/osu/issues/18615.
+                    foreach (string beatmapInDirectory in GetStableImportPaths(beatmapStorage))
+                        yield return beatmapStorage.GetFullPath(beatmapInDirectory);
+                }
+                else
+                    yield return storage.GetFullPath(beatmapDirectory);
+            }
+        }
 
         public LegacyBeatmapImporter(IModelImporter<BeatmapSetInfo> importer)
             : base(importer)

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -14,7 +14,7 @@ namespace osu.Game.IO
     /// </summary>
     public class StableStorage : DesktopStorage
     {
-        private const string stable_default_songs_path = "Songs";
+        public const string STABLE_DEFAULT_SONGS_PATH = "Songs";
 
         private readonly DesktopGameHost host;
         private readonly Lazy<string> songsPath;
@@ -62,7 +62,7 @@ namespace osu.Game.IO
                 }
             }
 
-            return GetFullPath(stable_default_songs_path);
+            return GetFullPath(STABLE_DEFAULT_SONGS_PATH);
         }
     }
 }


### PR DESCRIPTION
- Closes #18615 

Upon checking in stable, it seems this behaviour is limited to beatmaps and also works recursively. While test coverage is added, I've also confirmed this works manually given that the scope of that test.