### PR TITLE
Update flag sizes after switch to twemoji assets

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.615.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.616.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.615.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game.Tournament/Components/DrawableTeamFlag.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamFlag.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tournament.Components
         {
             if (team == null) return;
 
-            Size = new Vector2(75, 50);
+            Size = new Vector2(75, 54);
             Masking = true;
             CornerRadius = 5;
             Child = flagSprite = new Sprite

--- a/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
         public class ScrollingTeam : DrawableTournamentTeam
         {
             public const float WIDTH = 58;
-            public const float HEIGHT = 41;
+            public const float HEIGHT = 44;
 
             private readonly Box outline;
 

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -183,7 +183,7 @@ namespace osu.Game.Online.Leaderboards
                                                         {
                                                             Anchor = Anchor.CentreLeft,
                                                             Origin = Anchor.CentreLeft,
-                                                            Size = new Vector2(30f, 20f),
+                                                            Size = new Vector2(28, 20),
                                                         },
                                                         new DateLabel(Score.Date)
                                                         {

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 },
                 new UpdateableFlag(score.User.Country)
                 {
-                    Size = new Vector2(19, 13),
+                    Size = new Vector2(19, 14),
                     ShowPlaceholderOnNull = false,
                 },
                 username,

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
-                                Size = new Vector2(19, 13),
+                                Size = new Vector2(19, 14),
                                 Margin = new MarginPadding { Top = 3 }, // makes spacing look more even
                                 ShowPlaceholderOnNull = false,
                             },

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays.Profile.Header
                                             {
                                                 userFlag = new UpdateableFlag
                                                 {
-                                                    Size = new Vector2(30, 20),
+                                                    Size = new Vector2(28, 20),
                                                     ShowPlaceholderOnNull = false,
                                                 },
                                                 userCountryText = new OsuSpriteText

--- a/osu.Game/Overlays/Rankings/CountryPill.cs
+++ b/osu.Game/Overlays/Rankings/CountryPill.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Overlays.Rankings
                                     {
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
-                                        Size = new Vector2(30, 20)
+                                        Size = new Vector2(28, 20)
                                     },
                                     countryName = new OsuSpriteText
                                     {

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Overlays.Rankings.Tables
             {
                 new UpdateableFlag(GetCountry(item))
                 {
-                    Size = new Vector2(30, 20),
+                    Size = new Vector2(28, 20),
                     ShowPlaceholderOnNull = false,
                 },
                 CreateFlagContent(item)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
-                                            Size = new Vector2(30, 20),
+                                            Size = new Vector2(28, 20),
                                             Country = user?.Country
                                         },
                                         new OsuSpriteText

--- a/osu.Game/Users/ExtendedUserPanel.cs
+++ b/osu.Game/Users/ExtendedUserPanel.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Users
 
         protected UpdateableFlag CreateFlag() => new UpdateableFlag(User.Country)
         {
-            Size = new Vector2(39, 26),
+            Size = new Vector2(36, 26),
             Action = Action,
         };
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.14.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.615.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.615.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.616.0" />
     <PackageReference Include="Sentry" Version="3.17.1" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.615.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.615.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.616.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
   <PropertyGroup>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/16422
- [x] Depends on https://github.com/ppy/osu-resources/pull/197

The old flags used a size of 140x94, while the new assets based on twemoji use a size of 150x108. This PR updates existing usages to match this new aspect ratio better.

One area that probably warrants closer inspection is tournament client, as it uses flags extensively. I've fixed one non-obvious design usage on the drawings screen, but it's probably a good idea to run this by official osu! world cup assets and make sure nothing looks out of the ordinary. I'd hope not - the change in aspect ratio usually boils down to only a few pixels of difference at most.