### PR TITLE
Fix unsafe sample playback in `GameplaySampleTriggerSource`

### DIFF
--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -56,12 +56,12 @@ namespace osu.Game.Rulesets.UI
             PlaySamples(samples);
         }
 
-        protected void PlaySamples(ISampleInfo[] samples)
+        protected void PlaySamples(ISampleInfo[] samples) => Schedule(() =>
         {
             var hitSound = getNextSample();
             hitSound.Samples = samples;
             hitSound.Play();
-        }
+        });
 
         protected HitObject GetMostValidObject()
         {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/18727.

Added delay from `Schedule` should be minimal as it is always called
from the `Update` thread (input propagation) anyway.