### PR TITLE
Fix toolbar music button handling keys while not hovered

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -17,6 +17,7 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets;
+using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
 
@@ -153,11 +154,23 @@ namespace osu.Game.Tests.Visual.Menus
             AddStep("hover toolbar music button", () => InputManager.MoveMouseTo(this.ChildrenOfType<ToolbarMusicButton>().Single()));
 
             AddStep("reset volume", () => Audio.Volume.Value = 1);
+            AddStep("hide volume overlay", () => volumeOverlay.Hide());
 
             AddRepeatStep("scroll down", () => InputManager.ScrollVerticalBy(-10), 5);
             AddAssert("volume lowered down", () => Audio.Volume.Value < 1);
             AddRepeatStep("scroll up", () => InputManager.ScrollVerticalBy(10), 5);
             AddAssert("volume raised up", () => Audio.Volume.Value == 1);
+
+            AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
+            AddAssert("button not hovered", () => !this.ChildrenOfType<ToolbarMusicButton>().Single().IsHovered);
+
+            AddStep("set volume to 0.5", () => Audio.Volume.Value = 0.5);
+            AddStep("hide volume overlay", () => volumeOverlay.Hide());
+
+            AddRepeatStep("scroll down", () => InputManager.ScrollVerticalBy(-10), 5);
+            AddAssert("volume not changed", () => Audio.Volume.Value == 0.5);
+            AddRepeatStep("scroll up", () => InputManager.ScrollVerticalBy(10), 5);
+            AddAssert("volume not changed", () => Audio.Volume.Value == 0.5);
         }
 
         [Test]
@@ -166,11 +179,24 @@ namespace osu.Game.Tests.Visual.Menus
             AddStep("hover toolbar music button", () => InputManager.MoveMouseTo(this.ChildrenOfType<ToolbarMusicButton>().Single()));
 
             AddStep("reset volume", () => Audio.Volume.Value = 1);
+            AddStep("hide volume overlay", () => volumeOverlay.Hide());
 
             AddRepeatStep("arrow down", () => InputManager.Key(Key.Down), 5);
             AddAssert("volume lowered down", () => Audio.Volume.Value < 1);
             AddRepeatStep("arrow up", () => InputManager.Key(Key.Up), 5);
             AddAssert("volume raised up", () => Audio.Volume.Value == 1);
+
+            AddStep("hide volume overlay", () => volumeOverlay.Hide());
+            AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.Zero));
+            AddAssert("button not hovered", () => !this.ChildrenOfType<ToolbarMusicButton>().Single().IsHovered);
+
+            AddStep("set volume", () => Audio.Volume.Value = 0.5);
+            AddStep("hide volume overlay", () => volumeOverlay.Hide());
+
+            AddRepeatStep("arrow down", () => InputManager.Key(Key.Down), 5);
+            AddAssert("volume not changed", () => Audio.Volume.Value == 0.5);
+            AddRepeatStep("arrow up", () => InputManager.Key(Key.Up), 5);
+            AddAssert("volume not changed", () => Audio.Volume.Value == 0.5);
         }
 
         public class TestToolbar : Toolbar

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -81,6 +81,9 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            if (!IsHovered)
+                return false;
+
             switch (e.Key)
             {
                 case Key.Up:


### PR DESCRIPTION
 - Closes #18738

`OnKeyDown`/`OnKeyUp` do not propagate using positional input queues, which means `ToolbarMusicButton` must ensure it is hovered first before trying to handle `Key.Up`/`Key.Down`.

This ended up causing up/down arrows to not work game-wide, and is partially my fault for not testing enough in #18693.