### PR TITLE
Revert Xamarin regression workaround in Android CI build definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,27 +96,20 @@ jobs:
 
   build-only-android:
     name: Build only (Android)
-    runs-on: macos-latest
+    runs-on: windows-latest
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      # Pin Xamarin.Android version to 11.2 for now to avoid build failures caused by a Xamarin-side regression.
-      # See: https://github.com/xamarin/xamarin-android/issues/6284
-      # This can be removed/reverted when the fix makes it to upstream and is deployed on github runners.
-      - name: Set default Xamarin SDK version
-        run: |
-            $VM_ASSETS/select-xamarin-sdk-v2.sh --mono=6.12 --android=11.2
 
       - name: Install .NET 6.0.x
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "6.0.x"
 
-      # Contrary to seemingly any other msbuild, msbuild running on macOS/Mono
-      # cannot accept .sln(f) files as arguments.
-      # Build just the main game for now.
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+
       - name: Build
         run: msbuild osu.Android/osu.Android.csproj /restore /p:Configuration=Debug
 


### PR DESCRIPTION
This commit is (mostly) a revert of 53e52d2c4b8f32eb7ce07cb7c2ed8a8cae05c5a3. Partially done because the workaround is no longer needed, partially because Xamarin builds on macOS images have [begun](https://github.com/ppy/osu/runs/6922389779?check_suite_focus=true) [to](https://github.com/ppy/osu/runs/6922949126?check_suite_focus=true) [fail](https://github.com/ppy/osu/runs/6923343139?check_suite_focus=true) today after a [new image](https://github.com/actions/virtual-environments/blob/macOS-11/20220614.2/images/macos/macos-11-Readme.md) rollout with bumped NuGet versions.

Link to successful run: https://github.com/bdach/osu/runs/6924629226?check_suite_focus=true

Note that still only the main game is built. This is because the android test projects currently don't build for no less than three reasons, all of which are fixed by https://github.com/ppy/osu/pull/17462. I'm only PRing this to temporarily unblock the android workflow.

I don't know what to do about the iOS failures, other than to wait. I may open an issue over at https://github.com/actions/virtual-environments in a day or two if this doesn't automagically get fixed.