### PR TITLE
Improve tournament player JSON storage using lightweight model

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentTeam.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentTeam.cs
@@ -25,13 +25,13 @@ namespace osu.Game.Tournament.Tests.Components
                 FullName = { Value = "Australia" },
                 Players =
                 {
-                    new TournamentPlayer { Username = "ASecretBox" },
-                    new TournamentPlayer { Username = "Dereban" },
-                    new TournamentPlayer { Username = "mReKk" },
-                    new TournamentPlayer { Username = "uyghti" },
-                    new TournamentPlayer { Username = "Parkes" },
-                    new TournamentPlayer { Username = "Shiroha" },
-                    new TournamentPlayer { Username = "Jordan The Bear" },
+                    new TournamentUser { Username = "ASecretBox" },
+                    new TournamentUser { Username = "Dereban" },
+                    new TournamentUser { Username = "mReKk" },
+                    new TournamentUser { Username = "uyghti" },
+                    new TournamentUser { Username = "Parkes" },
+                    new TournamentUser { Username = "Shiroha" },
+                    new TournamentUser { Username = "Jordan The Bear" },
                 }
             };
 

--- a/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentTeam.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentTeam.cs
@@ -5,7 +5,6 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tests.Visual;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
@@ -26,13 +25,13 @@ namespace osu.Game.Tournament.Tests.Components
                 FullName = { Value = "Australia" },
                 Players =
                 {
-                    new APIUser { Username = "ASecretBox" },
-                    new APIUser { Username = "Dereban" },
-                    new APIUser { Username = "mReKk" },
-                    new APIUser { Username = "uyghti" },
-                    new APIUser { Username = "Parkes" },
-                    new APIUser { Username = "Shiroha" },
-                    new APIUser { Username = "Jordan The Bear" },
+                    new TournamentPlayer { Username = "ASecretBox" },
+                    new TournamentPlayer { Username = "Dereban" },
+                    new TournamentPlayer { Username = "mReKk" },
+                    new TournamentPlayer { Username = "uyghti" },
+                    new TournamentPlayer { Username = "Parkes" },
+                    new TournamentPlayer { Username = "Shiroha" },
+                    new TournamentPlayer { Username = "Jordan The Bear" },
                 }
             };
 

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -27,13 +27,13 @@ namespace osu.Game.Tournament.Tests.Components
             Colour = "f2ca34"
         };
 
-        private readonly APIUser redUser = new APIUser
+        private readonly TournamentPlayer redPlayer = new TournamentPlayer
         {
             Username = "BanchoBot",
             Id = 3,
         };
 
-        private readonly APIUser blueUser = new APIUser
+        private readonly TournamentPlayer bluePlayer = new TournamentPlayer
         {
             Username = "Zallius",
             Id = 4,
@@ -59,11 +59,11 @@ namespace osu.Game.Tournament.Tests.Components
             {
                 Team1 =
                 {
-                    Value = new TournamentTeam { Players = new BindableList<APIUser> { redUser } }
+                    Value = new TournamentTeam { Players = new BindableList<TournamentPlayer> { redPlayer } }
                 },
                 Team2 =
                 {
-                    Value = new TournamentTeam { Players = new BindableList<APIUser> { blueUser } }
+                    Value = new TournamentTeam { Players = new BindableList<TournamentPlayer> { bluePlayer } }
                 }
             };
 
@@ -82,19 +82,19 @@ namespace osu.Game.Tournament.Tests.Components
 
             AddStep("message from team red", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {
-                Sender = redUser,
+                Sender = redPlayer.ToUser(),
                 Content = "I am team red."
             }));
 
             AddStep("message from team red", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {
-                Sender = redUser,
+                Sender = redPlayer.ToUser(),
                 Content = "I plan to win!"
             }));
 
             AddStep("message from team blue", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {
-                Sender = blueUser,
+                Sender = bluePlayer.ToUser(),
                 Content = "Not on my watch. Prepare to eat saaaaaaaaaand. Lots and lots of saaaaaaand."
             }));
 

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Tournament.Tests.Components
         private readonly TournamentPlayer redPlayer = new TournamentPlayer
         {
             Username = "BanchoBot",
-            Id = 3,
+            OnlineID = 3,
         };
 
         private readonly TournamentPlayer bluePlayer = new TournamentPlayer
         {
             Username = "Zallius",
-            Id = 4,
+            OnlineID = 4,
         };
 
         [Cached]

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -27,13 +27,13 @@ namespace osu.Game.Tournament.Tests.Components
             Colour = "f2ca34"
         };
 
-        private readonly TournamentPlayer redPlayer = new TournamentPlayer
+        private readonly TournamentUser redUser = new TournamentUser
         {
             Username = "BanchoBot",
             OnlineID = 3,
         };
 
-        private readonly TournamentPlayer bluePlayer = new TournamentPlayer
+        private readonly TournamentUser blueUser = new TournamentUser
         {
             Username = "Zallius",
             OnlineID = 4,
@@ -59,11 +59,11 @@ namespace osu.Game.Tournament.Tests.Components
             {
                 Team1 =
                 {
-                    Value = new TournamentTeam { Players = new BindableList<TournamentPlayer> { redPlayer } }
+                    Value = new TournamentTeam { Players = new BindableList<TournamentUser> { redUser } }
                 },
                 Team2 =
                 {
-                    Value = new TournamentTeam { Players = new BindableList<TournamentPlayer> { bluePlayer } }
+                    Value = new TournamentTeam { Players = new BindableList<TournamentUser> { blueUser } }
                 }
             };
 
@@ -82,19 +82,19 @@ namespace osu.Game.Tournament.Tests.Components
 
             AddStep("message from team red", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {
-                Sender = redPlayer.ToUser(),
+                Sender = redUser.ToAPIUser(),
                 Content = "I am team red."
             }));
 
             AddStep("message from team red", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {
-                Sender = redPlayer.ToUser(),
+                Sender = redUser.ToAPIUser(),
                 Content = "I plan to win!"
             }));
 
             AddStep("message from team blue", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {
-                Sender = bluePlayer.ToUser(),
+                Sender = blueUser.ToAPIUser(),
                 Content = "Not on my watch. Prepare to eat saaaaaaaaaand. Lots and lots of saaaaaaand."
             }));
 

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -121,11 +121,11 @@ namespace osu.Game.Tournament.Tests
                     },
                     Players =
                     {
-                        new TournamentPlayer { Username = "Hello", Rank = 12 },
-                        new TournamentPlayer { Username = "Hello", Rank = 16 },
-                        new TournamentPlayer { Username = "Hello", Rank = 20 },
-                        new TournamentPlayer { Username = "Hello", Rank = 24 },
-                        new TournamentPlayer { Username = "Hello", Rank = 30 },
+                        new TournamentUser { Username = "Hello", Rank = 12 },
+                        new TournamentUser { Username = "Hello", Rank = 16 },
+                        new TournamentUser { Username = "Hello", Rank = 20 },
+                        new TournamentUser { Username = "Hello", Rank = 24 },
+                        new TournamentUser { Username = "Hello", Rank = 30 },
                     }
                 }
             },
@@ -138,11 +138,11 @@ namespace osu.Game.Tournament.Tests
                     FullName = { Value = "United States" },
                     Players =
                     {
-                        new TournamentPlayer { Username = "Hello" },
-                        new TournamentPlayer { Username = "Hello" },
-                        new TournamentPlayer { Username = "Hello" },
-                        new TournamentPlayer { Username = "Hello" },
-                        new TournamentPlayer { Username = "Hello" },
+                        new TournamentUser { Username = "Hello" },
+                        new TournamentUser { Username = "Hello" },
+                        new TournamentUser { Username = "Hello" },
+                        new TournamentUser { Username = "Hello" },
+                        new TournamentUser { Username = "Hello" },
                     }
                 }
             },

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -15,8 +15,6 @@ using osu.Game.Tests.Visual;
 using osu.Game.Tournament.IO;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
-using osu.Game.Users;
-using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
 
 namespace osu.Game.Tournament.Tests
 {
@@ -123,11 +121,11 @@ namespace osu.Game.Tournament.Tests
                     },
                     Players =
                     {
-                        new APIUser { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 12 } },
-                        new APIUser { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 16 } },
-                        new APIUser { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 20 } },
-                        new APIUser { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 24 } },
-                        new APIUser { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 30 } },
+                        new TournamentPlayer { Username = "Hello", Rank = 12 },
+                        new TournamentPlayer { Username = "Hello", Rank = 16 },
+                        new TournamentPlayer { Username = "Hello", Rank = 20 },
+                        new TournamentPlayer { Username = "Hello", Rank = 24 },
+                        new TournamentPlayer { Username = "Hello", Rank = 30 },
                     }
                 }
             },
@@ -140,11 +138,11 @@ namespace osu.Game.Tournament.Tests
                     FullName = { Value = "United States" },
                     Players =
                     {
-                        new APIUser { Username = "Hello" },
-                        new APIUser { Username = "Hello" },
-                        new APIUser { Username = "Hello" },
-                        new APIUser { Username = "Hello" },
-                        new APIUser { Username = "Hello" },
+                        new TournamentPlayer { Username = "Hello" },
+                        new TournamentPlayer { Username = "Hello" },
+                        new TournamentPlayer { Username = "Hello" },
+                        new TournamentPlayer { Username = "Hello" },
+                        new TournamentPlayer { Username = "Hello" },
                     }
                 }
             },

--- a/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tournament.Components
                 },
             };
 
-            TournamentSpriteText createPlayerText(TournamentPlayer p) =>
+            TournamentSpriteText createPlayerText(TournamentUser p) =>
                 new TournamentSpriteText
                 {
                     Text = p.Username,

--- a/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tournament.Models;
 using osuTK;
 using osuTK.Graphics;
@@ -56,7 +55,7 @@ namespace osu.Game.Tournament.Components
                 },
             };
 
-            TournamentSpriteText createPlayerText(APIUser p) =>
+            TournamentSpriteText createPlayerText(TournamentPlayer p) =>
                 new TournamentSpriteText
                 {
                     Text = p.Username,

--- a/osu.Game.Tournament/Models/TournamentPlayer.cs
+++ b/osu.Game.Tournament/Models/TournamentPlayer.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Database;
+using Newtonsoft.Json;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Users;
 
@@ -14,7 +14,8 @@ namespace osu.Game.Tournament.Models
     [Serializable]
     public class TournamentPlayer : IUser
     {
-        public int Id { get; set; }
+        [JsonProperty(@"id")]
+        public int OnlineID { get; set; }
 
         public string Username { get; set; } = string.Empty;
 
@@ -37,7 +38,7 @@ namespace osu.Game.Tournament.Models
         {
             var user = new APIUser
             {
-                Id = Id,
+                Id = OnlineID,
                 Username = Username,
                 Country = Country,
                 CoverUrl = CoverUrl,
@@ -51,8 +52,6 @@ namespace osu.Game.Tournament.Models
 
             return user;
         }
-
-        int IHasOnlineID<int>.OnlineID => Id;
 
         bool IUser.IsBot => false;
     }

--- a/osu.Game.Tournament/Models/TournamentPlayer.cs
+++ b/osu.Game.Tournament/Models/TournamentPlayer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Database;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Users;
+
+namespace osu.Game.Tournament.Models
+{
+    /// <summary>
+    /// A tournament player, containing simple information about the player.
+    /// </summary>
+    [Serializable]
+    public class TournamentPlayer : IUser
+    {
+        public int Id { get; set; }
+
+        public string Username { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The player's country.
+        /// </summary>
+        public Country? Country { get; set; }
+
+        /// <summary>
+        /// The player's global rank, or null if not available.
+        /// </summary>
+        public int? Rank { get; set; }
+
+        /// <summary>
+        /// A URL to the player's profile cover.
+        /// </summary>
+        public string CoverUrl { get; set; } = string.Empty;
+
+        public APIUser ToUser()
+        {
+            var user = new APIUser
+            {
+                Id = Id,
+                Username = Username,
+                Country = Country,
+                CoverUrl = CoverUrl,
+            };
+
+            user.Statistics = new UserStatistics
+            {
+                User = user,
+                GlobalRank = Rank
+            };
+
+            return user;
+        }
+
+        int IHasOnlineID<int>.OnlineID => Id;
+
+        bool IUser.IsBot => false;
+    }
+}

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tournament.Models
         };
 
         [JsonProperty]
-        public BindableList<TournamentPlayer> Players { get; set; } = new BindableList<TournamentPlayer>();
+        public BindableList<TournamentUser> Players { get; set; } = new BindableList<TournamentUser>();
 
         public TournamentTeam()
         {

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -7,7 +7,6 @@ using System;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
-using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Tournament.Models
 {
@@ -38,7 +37,7 @@ namespace osu.Game.Tournament.Models
         {
             get
             {
-                int[] ranks = Players.Select(p => p.Statistics?.GlobalRank)
+                int[] ranks = Players.Select(p => p.Rank)
                                      .Where(i => i.HasValue)
                                      .Select(i => i.Value)
                                      .ToArray();
@@ -59,7 +58,7 @@ namespace osu.Game.Tournament.Models
         };
 
         [JsonProperty]
-        public BindableList<APIUser> Players { get; set; } = new BindableList<APIUser>();
+        public BindableList<TournamentPlayer> Players { get; set; } = new BindableList<TournamentPlayer>();
 
         public TournamentTeam()
         {

--- a/osu.Game.Tournament/Models/TournamentUser.cs
+++ b/osu.Game.Tournament/Models/TournamentUser.cs
@@ -9,10 +9,10 @@ using osu.Game.Users;
 namespace osu.Game.Tournament.Models
 {
     /// <summary>
-    /// A tournament player, containing simple information about the player.
+    /// A tournament player user, containing simple information about the player.
     /// </summary>
     [Serializable]
-    public class TournamentPlayer : IUser
+    public class TournamentUser : IUser
     {
         [JsonProperty(@"id")]
         public int OnlineID { get; set; }
@@ -34,7 +34,7 @@ namespace osu.Game.Tournament.Models
         /// </summary>
         public string CoverUrl { get; set; } = string.Empty;
 
-        public APIUser ToUser()
+        public APIUser ToAPIUser()
         {
             var user = new APIUser
             {

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -201,14 +201,14 @@ namespace osu.Game.Tournament.Screens.Editors
 
                 public void CreateNew()
                 {
-                    var player = new TournamentPlayer();
+                    var player = new TournamentUser();
                     team.Players.Add(player);
                     flow.Add(new PlayerRow(team, player));
                 }
 
                 public class PlayerRow : CompositeDrawable
                 {
-                    private readonly TournamentPlayer player;
+                    private readonly TournamentUser user;
 
                     [Resolved]
                     protected IAPIProvider API { get; private set; }
@@ -220,9 +220,9 @@ namespace osu.Game.Tournament.Screens.Editors
 
                     private readonly Container drawableContainer;
 
-                    public PlayerRow(TournamentTeam team, TournamentPlayer player)
+                    public PlayerRow(TournamentTeam team, TournamentUser user)
                     {
-                        this.player = player;
+                        this.user = user;
 
                         Margin = new MarginPadding(10);
 
@@ -271,7 +271,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Action = () =>
                                 {
                                     Expire();
-                                    team.Players.Remove(player);
+                                    team.Players.Remove(user);
                                 },
                             }
                         };
@@ -280,27 +280,27 @@ namespace osu.Game.Tournament.Screens.Editors
                     [BackgroundDependencyLoader]
                     private void load()
                     {
-                        playerId.Value = player.OnlineID;
+                        playerId.Value = user.OnlineID;
                         playerId.BindValueChanged(id =>
                         {
-                            player.OnlineID = id.NewValue ?? 0;
+                            user.OnlineID = id.NewValue ?? 0;
 
                             if (id.NewValue != id.OldValue)
-                                player.Username = string.Empty;
+                                user.Username = string.Empty;
 
-                            if (!string.IsNullOrEmpty(player.Username))
+                            if (!string.IsNullOrEmpty(user.Username))
                             {
                                 updatePanel();
                                 return;
                             }
 
-                            game.PopulatePlayer(player, updatePanel, updatePanel);
+                            game.PopulatePlayer(user, updatePanel, updatePanel);
                         }, true);
                     }
 
                     private void updatePanel()
                     {
-                        drawableContainer.Child = new UserGridPanel(player.ToUser()) { Width = 300 };
+                        drawableContainer.Child = new UserGridPanel(user.ToAPIUser()) { Width = 300 };
                     }
                 }
             }

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
@@ -202,14 +201,14 @@ namespace osu.Game.Tournament.Screens.Editors
 
                 public void CreateNew()
                 {
-                    var user = new APIUser();
-                    team.Players.Add(user);
-                    flow.Add(new PlayerRow(team, user));
+                    var player = new TournamentPlayer();
+                    team.Players.Add(player);
+                    flow.Add(new PlayerRow(team, player));
                 }
 
                 public class PlayerRow : CompositeDrawable
                 {
-                    private readonly APIUser user;
+                    private readonly TournamentPlayer player;
 
                     [Resolved]
                     protected IAPIProvider API { get; private set; }
@@ -217,13 +216,13 @@ namespace osu.Game.Tournament.Screens.Editors
                     [Resolved]
                     private TournamentGameBase game { get; set; }
 
-                    private readonly Bindable<int?> userId = new Bindable<int?>();
+                    private readonly Bindable<int?> playerId = new Bindable<int?>();
 
                     private readonly Container drawableContainer;
 
-                    public PlayerRow(TournamentTeam team, APIUser user)
+                    public PlayerRow(TournamentTeam team, TournamentPlayer player)
                     {
-                        this.user = user;
+                        this.player = player;
 
                         Margin = new MarginPadding(10);
 
@@ -254,7 +253,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                         LabelText = "User ID",
                                         RelativeSizeAxes = Axes.None,
                                         Width = 200,
-                                        Current = userId,
+                                        Current = playerId,
                                     },
                                     drawableContainer = new Container
                                     {
@@ -272,7 +271,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Action = () =>
                                 {
                                     Expire();
-                                    team.Players.Remove(user);
+                                    team.Players.Remove(player);
                                 },
                             }
                         };
@@ -281,27 +280,27 @@ namespace osu.Game.Tournament.Screens.Editors
                     [BackgroundDependencyLoader]
                     private void load()
                     {
-                        userId.Value = user.Id;
-                        userId.BindValueChanged(id =>
+                        playerId.Value = player.Id;
+                        playerId.BindValueChanged(id =>
                         {
-                            user.Id = id.NewValue ?? 0;
+                            player.Id = id.NewValue ?? 0;
 
                             if (id.NewValue != id.OldValue)
-                                user.Username = string.Empty;
+                                player.Username = string.Empty;
 
-                            if (!string.IsNullOrEmpty(user.Username))
+                            if (!string.IsNullOrEmpty(player.Username))
                             {
                                 updatePanel();
                                 return;
                             }
 
-                            game.PopulateUser(user, updatePanel, updatePanel);
+                            game.PopulatePlayer(player, updatePanel, updatePanel);
                         }, true);
                     }
 
                     private void updatePanel()
                     {
-                        drawableContainer.Child = new UserGridPanel(user) { Width = 300 };
+                        drawableContainer.Child = new UserGridPanel(player.ToUser()) { Width = 300 };
                     }
                 }
             }

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -280,10 +280,10 @@ namespace osu.Game.Tournament.Screens.Editors
                     [BackgroundDependencyLoader]
                     private void load()
                     {
-                        playerId.Value = player.Id;
+                        playerId.Value = player.OnlineID;
                         playerId.BindValueChanged(id =>
                         {
-                            player.Id = id.NewValue ?? 0;
+                            player.OnlineID = id.NewValue ?? 0;
 
                             if (id.NewValue != id.OldValue)
                                 player.Username = string.Empty;

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                 };
 
                 foreach (var p in team.Players)
-                    fill.Add(new RowDisplay(p.Username, p.Statistics?.GlobalRank?.ToString("\\##,0") ?? "-"));
+                    fill.Add(new RowDisplay(p.Username, p.Rank?.ToString("\\##,0") ?? "-"));
             }
 
             internal class RowDisplay : CompositeDrawable

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -256,9 +256,9 @@ namespace osu.Game.Tournament
 
         private void updateLoadProgressMessage(string s) => Schedule(() => initialisationText.Text = s);
 
-        public void PopulatePlayer(TournamentPlayer player, Action success = null, Action failure = null, bool immediate = false)
+        public void PopulatePlayer(TournamentUser user, Action success = null, Action failure = null, bool immediate = false)
         {
-            var req = new GetUserRequest(player.OnlineID, ladder.Ruleset.Value);
+            var req = new GetUserRequest(user.OnlineID, ladder.Ruleset.Value);
 
             if (immediate)
             {
@@ -270,7 +270,7 @@ namespace osu.Game.Tournament
                 req.Success += res => { populate(); };
                 req.Failure += _ =>
                 {
-                    player.OnlineID = 1;
+                    user.OnlineID = 1;
                     failure?.Invoke();
                 };
 
@@ -284,12 +284,12 @@ namespace osu.Game.Tournament
                 if (res == null)
                     return;
 
-                player.OnlineID = res.Id;
+                user.OnlineID = res.Id;
 
-                player.Username = res.Username;
-                player.CoverUrl = res.CoverUrl;
-                player.Country = res.Country;
-                player.Rank = res.Statistics?.GlobalRank;
+                user.Username = res.Username;
+                user.CoverUrl = res.CoverUrl;
+                user.Country = res.Country;
+                user.Rank = res.Statistics?.GlobalRank;
 
                 success?.Invoke();
             }

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -258,7 +258,7 @@ namespace osu.Game.Tournament
 
         public void PopulatePlayer(TournamentPlayer player, Action success = null, Action failure = null, bool immediate = false)
         {
-            var req = new GetUserRequest(player.Id, ladder.Ruleset.Value);
+            var req = new GetUserRequest(player.OnlineID, ladder.Ruleset.Value);
 
             if (immediate)
             {
@@ -270,7 +270,7 @@ namespace osu.Game.Tournament
                 req.Success += res => { populate(); };
                 req.Failure += _ =>
                 {
-                    player.Id = 1;
+                    player.OnlineID = 1;
                     failure?.Invoke();
                 };
 
@@ -284,7 +284,7 @@ namespace osu.Game.Tournament
                 if (res == null)
                     return;
 
-                player.Id = res.Id;
+                player.OnlineID = res.Id;
 
                 player.Username = res.Username;
                 player.CoverUrl = res.CoverUrl;


### PR DESCRIPTION
This is a first step towards improving the overall size of brackets JSON file on larger tournaments, as reported in https://github.com/ppy/osu/discussions/18681.

On a tournament with only 8 teams in which each team consists of 3 players, this lowers the overall size of the brackets JSON file from 75.4KB down to 8KB, i.e. 90% off.

An alternative would be to cull out rank history during user population, but I've decided to define a specific model class instead since `APIUser`s are probably not meant to be stored in disk.

Migration should be automatic, done by deserialising the `id` property in master's JSON to `TournamentPlayer.Id` and populating the rest using [the pre-existing population logic](https://github.com/ppy/osu/blob/b977ce79959fbda38114cc5da3e1703c95eba7e7/osu.Game.Tournament/TournamentGameBase.cs#L182-L202).