### PR TITLE
Improve tournament beatmap JSON storage using lightweight model

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tournament.Tests.Components
                 beatmap.Length = 123456;
                 beatmap.BPM = 133;
 
-                songBar.Beatmap = beatmap;
+                songBar.Beatmap = new TournamentBeatmap(beatmap);
             });
             AddStep("set mods to HR", () => songBar.Mods = LegacyMods.HardRock);
             AddStep("set mods to DT", () => songBar.Mods = LegacyMods.DoubleTime);

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentBeatmapPanel.cs
@@ -10,6 +10,7 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tests.Visual;
 using osu.Game.Tournament.Components;
+using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Tests.Components
 {
@@ -32,7 +33,7 @@ namespace osu.Game.Tournament.Tests.Components
 
         private void success(APIBeatmap beatmap)
         {
-            Add(new TournamentBeatmapPanel(beatmap)
+            Add(new TournamentBeatmapPanel(new TournamentBeatmap(beatmap))
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -11,6 +11,7 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Tournament.Components;
+using osu.Game.Tournament.Models;
 using osuTK;
 
 namespace osu.Game.Tournament.Tests.Components
@@ -53,7 +54,7 @@ namespace osu.Game.Tournament.Tests.Components
 
             foreach (var mod in mods)
             {
-                fillFlow.Add(new TournamentBeatmapPanel(beatmap, mod.Acronym)
+                fillFlow.Add(new TournamentBeatmapPanel(new TournamentBeatmap(beatmap), mod.Acronym)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -9,7 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
-using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Tests.Visual;
 using osu.Game.Tournament.IO;
@@ -154,10 +154,10 @@ namespace osu.Game.Tournament.Tests
             }
         };
 
-        public static APIBeatmap CreateSampleBeatmap() =>
-            new APIBeatmap
+        public static TournamentBeatmap CreateSampleBeatmap() =>
+            new TournamentBeatmap
             {
-                BeatmapSet = new APIBeatmapSet
+                Metadata = new BeatmapMetadata
                 {
                     Title = "Test Title",
                     Artist = "Test Artist",

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -14,9 +14,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Menu;
+using osu.Game.Tournament.Models;
 using osuTK;
 using osuTK.Graphics;
 
@@ -24,14 +24,14 @@ namespace osu.Game.Tournament.Components
 {
     public class SongBar : CompositeDrawable
     {
-        private APIBeatmap beatmap;
+        private TournamentBeatmap beatmap;
 
         public const float HEIGHT = 145 / 2f;
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; }
 
-        public APIBeatmap Beatmap
+        public TournamentBeatmap Beatmap
         {
             set
             {

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -14,7 +14,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tournament.Models;
 using osuTK.Graphics;
 
@@ -22,7 +21,7 @@ namespace osu.Game.Tournament.Components
 {
     public class TournamentBeatmapPanel : CompositeDrawable
     {
-        public readonly APIBeatmap Beatmap;
+        public readonly TournamentBeatmap Beatmap;
 
         private readonly string mod;
 
@@ -31,7 +30,7 @@ namespace osu.Game.Tournament.Components
         private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
         private Box flash;
 
-        public TournamentBeatmapPanel(APIBeatmap beatmap, string mod = null)
+        public TournamentBeatmapPanel(TournamentBeatmap beatmap, string mod = null)
         {
             if (beatmap == null) throw new ArgumentNullException(nameof(beatmap));
 
@@ -61,7 +60,7 @@ namespace osu.Game.Tournament.Components
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = OsuColour.Gray(0.5f),
-                    OnlineInfo = Beatmap.BeatmapSet,
+                    OnlineInfo = Beatmap,
                 },
                 new FillFlowContainer
                 {

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tournament.IPC
                                     else
                                     {
                                         beatmapLookupRequest = new GetBeatmapRequest(new APIBeatmap { OnlineID = beatmapId });
-                                        beatmapLookupRequest.Success += b => Beatmap.Value = b;
+                                        beatmapLookupRequest.Success += b => Beatmap.Value = new TournamentBeatmap(b);
                                         API.Queue(beatmapLookupRequest);
                                     }
                                 }

--- a/osu.Game.Tournament/IPC/MatchIPCInfo.cs
+++ b/osu.Game.Tournament/IPC/MatchIPCInfo.cs
@@ -6,13 +6,13 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.Legacy;
-using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.IPC
 {
     public class MatchIPCInfo : Component
     {
-        public Bindable<APIBeatmap> Beatmap { get; } = new Bindable<APIBeatmap>();
+        public Bindable<TournamentBeatmap> Beatmap { get; } = new Bindable<TournamentBeatmap>();
         public Bindable<LegacyMods> Mods { get; } = new Bindable<LegacyMods>();
         public Bindable<TourneyState> State { get; } = new Bindable<TourneyState>();
         public Bindable<string> ChatChannel { get; } = new Bindable<string>();

--- a/osu.Game.Tournament/Models/RoundBeatmap.cs
+++ b/osu.Game.Tournament/Models/RoundBeatmap.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using Newtonsoft.Json;
-using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Tournament.Models
 {
@@ -14,6 +13,6 @@ namespace osu.Game.Tournament.Models
         public string Mods;
 
         [JsonProperty("BeatmapInfo")]
-        public APIBeatmap Beatmap;
+        public TournamentBeatmap Beatmap;
     }
 }

--- a/osu.Game.Tournament/Models/SeedingBeatmap.cs
+++ b/osu.Game.Tournament/Models/SeedingBeatmap.cs
@@ -5,7 +5,6 @@
 
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
-using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Tournament.Models
 {
@@ -14,7 +13,7 @@ namespace osu.Game.Tournament.Models
         public int ID;
 
         [JsonProperty("BeatmapInfo")]
-        public APIBeatmap Beatmap;
+        public TournamentBeatmap Beatmap;
 
         public long Score;
 

--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Game.Beatmaps;
+using osu.Game.Extensions;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Tournament.Models
+{
+    public class TournamentBeatmap : IBeatmapInfo, IBeatmapSetOnlineInfo
+    {
+        public int OnlineID { get; set; }
+
+        public string DifficultyName { get; set; } = string.Empty;
+
+        public double BPM { get; set; }
+
+        public double Length { get; set; }
+
+        public double StarRating { get; set; }
+
+        public IBeatmapMetadataInfo Metadata { get; set; } = new BeatmapMetadata();
+
+        public IBeatmapDifficultyInfo Difficulty { get; set; } = new BeatmapDifficulty();
+
+        public BeatmapSetOnlineCovers Covers { get; set; }
+
+        public TournamentBeatmap()
+        {
+        }
+
+        public TournamentBeatmap(APIBeatmap beatmap)
+        {
+            OnlineID = beatmap.OnlineID;
+            DifficultyName = beatmap.DifficultyName;
+            BPM = beatmap.BPM;
+            Length = beatmap.Length;
+            StarRating = beatmap.StarRating;
+            Metadata = beatmap.Metadata;
+            Difficulty = beatmap.Difficulty;
+            Covers = beatmap.BeatmapSet.AsNonNull().Covers;
+        }
+
+        public bool Equals(IBeatmapInfo? other) => other is TournamentBeatmap b && this.MatchesOnlineID(b);
+
+        #region IBeatmapInfo/IBeatmapSetOnlineInfo explicit implementation
+
+        IBeatmapSetInfo IBeatmapInfo.BeatmapSet => throw new NotImplementedException();
+
+        string IBeatmapSetOnlineInfo.Preview => throw new NotImplementedException();
+
+        double IBeatmapSetOnlineInfo.BPM => throw new NotImplementedException();
+
+        int IBeatmapSetOnlineInfo.PlayCount => throw new NotImplementedException();
+
+        int IBeatmapSetOnlineInfo.FavouriteCount => throw new NotImplementedException();
+
+        bool IBeatmapSetOnlineInfo.HasFavourited => throw new NotImplementedException();
+
+        BeatmapSetOnlineAvailability IBeatmapSetOnlineInfo.Availability => throw new NotImplementedException();
+
+        BeatmapSetOnlineGenre IBeatmapSetOnlineInfo.Genre => throw new NotImplementedException();
+
+        BeatmapSetOnlineLanguage IBeatmapSetOnlineInfo.Language => throw new NotImplementedException();
+
+        int? IBeatmapSetOnlineInfo.TrackId => throw new NotImplementedException();
+
+        int[] IBeatmapSetOnlineInfo.Ratings => throw new NotImplementedException();
+
+        BeatmapSetHypeStatus IBeatmapSetOnlineInfo.HypeStatus => throw new NotImplementedException();
+
+        BeatmapSetNominationStatus IBeatmapSetOnlineInfo.NominationStatus => throw new NotImplementedException();
+
+        string IBeatmapInfo.Hash => throw new NotImplementedException();
+
+        string IBeatmapInfo.MD5Hash => throw new NotImplementedException();
+
+        IRulesetInfo IBeatmapInfo.Ruleset => throw new NotImplementedException();
+
+        DateTimeOffset IBeatmapSetOnlineInfo.Submitted => throw new NotImplementedException();
+
+        DateTimeOffset? IBeatmapSetOnlineInfo.Ranked => throw new NotImplementedException();
+
+        DateTimeOffset? IBeatmapSetOnlineInfo.LastUpdated => throw new NotImplementedException();
+
+        BeatmapOnlineStatus IBeatmapSetOnlineInfo.Status => throw new NotImplementedException();
+
+        bool IBeatmapSetOnlineInfo.HasExplicitContent => throw new NotImplementedException();
+
+        bool IBeatmapSetOnlineInfo.HasVideo => throw new NotImplementedException();
+
+        bool IBeatmapSetOnlineInfo.HasStoryboard => throw new NotImplementedException();
+
+        #endregion
+    }
+}

--- a/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
+++ b/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
@@ -7,9 +7,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.Legacy;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.IPC;
+using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Screens
 {
@@ -39,7 +39,7 @@ namespace osu.Game.Tournament.Screens
             SongBar.Mods = mods.NewValue;
         }
 
-        private void beatmapChanged(ValueChangedEvent<APIBeatmap> beatmap)
+        private void beatmapChanged(ValueChangedEvent<TournamentBeatmap> beatmap)
         {
             SongBar.FadeInFromZero(300, Easing.OutQuint);
             SongBar.Beatmap = beatmap.NewValue;

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Tournament.Screens.Editors
 
                             req.Success += res =>
                             {
-                                Model.Beatmap = res;
+                                Model.Beatmap = new TournamentBeatmap(res);
                                 updatePanel();
                             };
 

--- a/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Tournament.Screens.Editors
 
                             req.Success += res =>
                             {
-                                Model.Beatmap = res;
+                                Model.Beatmap = new TournamentBeatmap(res);
                                 updatePanel();
                             };
 

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
@@ -107,7 +106,7 @@ namespace osu.Game.Tournament.Screens.MapPool
             ipc.Beatmap.BindValueChanged(beatmapChanged);
         }
 
-        private void beatmapChanged(ValueChangedEvent<APIBeatmap> beatmap)
+        private void beatmapChanged(ValueChangedEvent<TournamentBeatmap> beatmap)
         {
             if (CurrentMatch.Value == null || CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) < 2)
                 return;

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Tournament
         {
             var beatmapsRequiringPopulation = ladder.Rounds
                                                     .SelectMany(r => r.Beatmaps)
-                                                    .Where(b => string.IsNullOrEmpty(b.Beatmap?.BeatmapSet?.Title) && b.ID > 0).ToList();
+                                                    .Where(b => b.Beatmap?.OnlineID == 0 && b.ID > 0).ToList();
 
             if (beatmapsRequiringPopulation.Count == 0)
                 return false;
@@ -222,7 +222,7 @@ namespace osu.Game.Tournament
 
                 var req = new GetBeatmapRequest(new APIBeatmap { OnlineID = b.ID });
                 API.Perform(req);
-                b.Beatmap = req.Response ?? new APIBeatmap();
+                b.Beatmap = new TournamentBeatmap(req.Response ?? new APIBeatmap());
 
                 updateLoadProgressMessage($"Populating round beatmaps ({i} / {beatmapsRequiringPopulation.Count})");
             }
@@ -238,7 +238,7 @@ namespace osu.Game.Tournament
             var beatmapsRequiringPopulation = ladder.Teams
                                                     .SelectMany(r => r.SeedingResults)
                                                     .SelectMany(r => r.Beatmaps)
-                                                    .Where(b => string.IsNullOrEmpty(b.Beatmap?.BeatmapSet?.Title) && b.ID > 0).ToList();
+                                                    .Where(b => b.Beatmap?.OnlineID == 0 && b.ID > 0).ToList();
 
             if (beatmapsRequiringPopulation.Count == 0)
                 return false;
@@ -249,7 +249,7 @@ namespace osu.Game.Tournament
 
                 var req = new GetBeatmapRequest(new APIBeatmap { OnlineID = b.ID });
                 API.Perform(req);
-                b.Beatmap = req.Response ?? new APIBeatmap();
+                b.Beatmap = new TournamentBeatmap(req.Response ?? new APIBeatmap());
 
                 updateLoadProgressMessage($"Populating seeding beatmaps ({i} / {beatmapsRequiringPopulation.Count})");
             }


### PR DESCRIPTION
One other and final step towards resolving https://github.com/ppy/osu/discussions/18681, in combination with #18750.

On a tournament with one round beatmap and one seeding beatmap, this lowers the overall size from 20KB down to 4KB (~80% off).

This one is up for discussion, as it's not simple pulling out unnecessary info without going through inheritance hell to allow compatibility with regular UI components (such as `UpdateableOnlineBeatmapSetCover`, which accepts `IBeatmapSetOnlineInfo`).

I went with the approach of explicitly implementing any other property that's not used by the tournament client and throwing `NotImplementedException`, but I'm not 100% sure about this approach.

I've also let the model inherit `IBeatmapSetOnlineInfo` to easily provide the beatmap's covers, I could instead define a `TournamentBeatmapSet` model class but found that to be unnecessary compared to just implementing the interface. Need opinions.