### PR TITLE
Fix metronome playing mistimed beat sounds on editor clock resume

### DIFF
--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -47,6 +47,11 @@ namespace osu.Game.Screens.Edit.Timing
 
         public bool EnableClicking { get; set; } = true;
 
+        public MetronomeDisplay()
+        {
+            AllowMistimedEventFiring = false;
+        }
+
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {


### PR DESCRIPTION
When the editor resumes from a pause, the metronome receives an `OnNewBeat` call to update the display as if it was swinging from the last beat in the track. This causes mistimed metronome sound playback when rapidly pausing and resuming:

https://user-images.githubusercontent.com/22781491/174417631-4817f36f-3e5d-492c-b9d6-8f2c675f951b.mp4

To properly fix this, `AllowMistimedEventFiring` is set to false, making metronome ignore the `OnNewBeat` call from above. That slightly changes behaviour as now metronome requires waiting for a full beat to pass in order to start swinging:

https://user-images.githubusercontent.com/22781491/174418125-581a2032-47d6-4d70-947d-ed40129679f9.mp4

- [x] Depends on #18752 for auditive testing ease 