### PR TITLE
Fix new hitobject placements not taking on the existing sample settings

### DIFF
--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -73,6 +74,10 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="commitStart">Whether this call is committing a value for HitObject.StartTime and continuing with further adjustments.</param>
         protected void BeginPlacement(bool commitStart = false)
         {
+            var nearestSampleControlPoint = beatmap.HitObjects.LastOrDefault(h => h.GetEndTime() < HitObject.StartTime)?.SampleControlPoint?.DeepClone() as SampleControlPoint;
+
+            HitObject.SampleControlPoint = nearestSampleControlPoint ?? new SampleControlPoint();
+
             placementHandler.BeginPlacement(HitObject);
             if (commitStart)
                 PlacementActive = PlacementState.Active;


### PR DESCRIPTION
Similar to velocity / difficulty points, a user expectation is that volume and sample settings will be transferred to newly placed objects from the most recent one.

Closes https://github.com/ppy/osu/issues/18742.