### PR TITLE
Redirect graceful exiting to standard exit flow

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -154,7 +154,7 @@ namespace osu.Desktop.Updater
                 Activated = () =>
                 {
                     updateManager.PrepareUpdateAsync()
-                                 .ContinueWith(_ => updateManager.Schedule(() => game?.GracefullyExit()));
+                                 .ContinueWith(_ => updateManager.Schedule(() => game?.AttemptExit()));
                     return true;
                 };
             }

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tournament.Screens.Setup
             dropdown.Items = storage.ListTournaments();
             dropdown.Current.BindValueChanged(v => Button.Enabled.Value = v.NewValue != startupTournament, true);
 
-            Action = () => game.GracefullyExit();
+            Action = () => game.AttemptExit();
             folderButton.Action = () => storage.PresentExternally();
 
             ButtonText = "Close osu!";

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -637,6 +637,12 @@ namespace osu.Game
             Add(performFromMainMenuTask = new PerformFromMenuRunner(action, validScreens, () => ScreenStack.CurrentScreen));
         }
 
+        public override void GracefullyExit()
+        {
+            // Using PerformFromScreen gives the user a chance to interrupt the exit process if needed.
+            PerformFromScreen(menu => menu.Exit());
+        }
+
         /// <summary>
         /// Wait for the game (and target component) to become loaded and then run an action.
         /// </summary>

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -637,7 +637,7 @@ namespace osu.Game
             Add(performFromMainMenuTask = new PerformFromMenuRunner(action, validScreens, () => ScreenStack.CurrentScreen));
         }
 
-        public override void GracefullyExit()
+        public override void AttemptExit()
         {
             // Using PerformFromScreen gives the user a chance to interrupt the exit process if needed.
             PerformFromScreen(menu => menu.Exit());

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -419,7 +419,7 @@ namespace osu.Game
         /// Use to programatically exit the game as if the user was triggering via alt-f4.
         /// Will keep persisting until an exit occurs (exit may be blocked multiple times).
         /// </summary>
-        public void GracefullyExit()
+        public virtual void GracefullyExit()
         {
             if (!OnExiting())
                 Exit();

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -418,13 +418,14 @@ namespace osu.Game
         /// <summary>
         /// Use to programatically exit the game as if the user was triggering via alt-f4.
         /// By default, will keep persisting until an exit occurs (exit may be blocked multiple times).
+        /// May be interrupted (see <see cref="OsuGame"/>'s override.
         /// </summary>
-        public virtual void GracefullyExit()
+        public virtual void AttemptExit()
         {
             if (!OnExiting())
                 Exit();
             else
-                Scheduler.AddDelayed(GracefullyExit, 2000);
+                Scheduler.AddDelayed(AttemptExit, 2000);
         }
 
         public bool Migrate(string path)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -418,7 +418,7 @@ namespace osu.Game
         /// <summary>
         /// Use to programatically exit the game as if the user was triggering via alt-f4.
         /// By default, will keep persisting until an exit occurs (exit may be blocked multiple times).
-        /// May be interrupted (see <see cref="OsuGame"/>'s override.
+        /// May be interrupted (see <see cref="OsuGame"/>'s override).
         /// </summary>
         public virtual void AttemptExit()
         {

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -417,7 +417,7 @@ namespace osu.Game
 
         /// <summary>
         /// Use to programatically exit the game as if the user was triggering via alt-f4.
-        /// Will keep persisting until an exit occurs (exit may be blocked multiple times).
+        /// By default, will keep persisting until an exit occurs (exit may be blocked multiple times).
         /// </summary>
         public virtual void GracefullyExit()
         {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                                 dialogOverlay.Push(new ConfirmDialog("To complete this operation, osu! will close. Please open it again to use the new data location.", () =>
                                 {
                                     (storage as OsuStorage)?.ChangeDataPath(target.FullName);
-                                    game.GracefullyExit();
+                                    game.AttemptExit();
                                 }, () => { }));
                             },
                             () => { }));

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                                 dialogOverlay.Push(new ConfirmDialog("To complete this operation, osu! will close. Please open it again to use the new data location.", () =>
                                 {
                                     (storage as OsuStorage)?.ChangeDataPath(target.FullName);
-                                    game.AttemptExit();
+                                    game.Exit();
                                 }, () => { }));
                             },
                             () => { }));


### PR DESCRIPTION
Rather than doing a completely forced exit as we were, this will now follow a more standard flow with the ability for the user to abort along the way. This is more in line with how I wanted this to work.

Note that this means a confirmation is now shown. It has been discussed in the past that this confirmation should only show when there's an ongoing action implies the user may want to cancel the exit. For now I think this is fine.

Addresses https://github.com/ppy/osu/discussions/18399#discussioncomment-2811311.
Closes #10630.