### PR TITLE
Fix `BlueprintContainer` eating input from skin editor buttons

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -148,7 +148,11 @@ namespace osu.Game.Tests.Visual.Navigation
 
         private void switchToGameplayScene()
         {
-            AddStep("Click gameplay scene button", () => skinEditor.ChildrenOfType<SkinEditorSceneLibrary.SceneButton>().First(b => b.Text == "Gameplay").TriggerClick());
+            AddStep("Click gameplay scene button", () =>
+            {
+                InputManager.MoveMouseTo(skinEditor.ChildrenOfType<SkinEditorSceneLibrary.SceneButton>().First(b => b.Text == "Gameplay"));
+                InputManager.Click(MouseButton.Left);
+            });
 
             AddUntilStep("wait for player", () =>
             {

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -108,13 +108,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected virtual bool AllowDeselectionDuringDrag => true;
 
-        /// <remarks>
-        /// Positional input must be received outside the container's bounds,
-        /// in order to handle blueprints which are partially offscreen.
-        /// </remarks>
-        /// <seealso cref="SelectionHandler{T}.ReceivePositionalInputAt"/>
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
-
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             bool selectionPerformed = performMouseDownActions(e);

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -39,6 +39,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private PlacementBlueprint currentPlacement;
         private InputManager inputManager;
 
+        /// <remarks>
+        /// Positional input must be received outside the container's bounds,
+        /// in order to handle composer blueprints which are partially offscreen.
+        /// </remarks>
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
         public ComposeBlueprintContainer(HitObjectComposer composer)
             : base(composer)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -21,6 +21,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 using osuTK.Input;
 
@@ -103,7 +104,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Positional input must be received outside the container's bounds,
         /// in order to handle blueprints which are partially offscreen.
         /// </remarks>
-        /// <seealso cref="BlueprintContainer{T}.ReceivePositionalInputAt"/>
+        /// <seealso cref="ComposeBlueprintContainer.ReceivePositionalInputAt"/>
+        /// <seealso cref="TimelineBlueprintContainer.ReceivePositionalInputAt"/>
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -35,6 +35,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Bindable<HitObject> placement;
         private SelectionBlueprint<HitObject> placementBlueprint;
 
+        /// <remarks>
+        /// Positional input must be received outside the container's bounds,
+        /// in order to handle timeline blueprints which are stacked offscreen.
+        /// </remarks>
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => timeline.ReceivePositionalInputAt(screenSpacePos);
+
         public TimelineBlueprintContainer(HitObjectComposer composer)
             : base(composer)
         {


### PR DESCRIPTION
- Closes #18758 
- Regressed in #18649 as predicted in https://github.com/ppy/osu/pull/18649#discussion_r896485370

`TestSceneSkinEditorNavigation` was supposed to account for this, but failed to due to using `TriggerClick` which performs a direct click on the button, without intervention by other components.