### PR TITLE
Fix adjusting offset via button seeking to timing point's offset unexpectedly

### DIFF
--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -195,6 +195,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void adjustOffset(double adjust)
         {
+            bool wasAtStart = editorClock.CurrentTimeAccurate == selectedGroup.Value.Time;
+
             // VERY TEMPORARY
             var currentGroupItems = selectedGroup.Value.ControlPoints.ToArray();
 
@@ -208,7 +210,7 @@ namespace osu.Game.Screens.Edit.Timing
             // the control point might not necessarily exist yet, if currentGroupItems was empty.
             selectedGroup.Value = beatmap.ControlPointInfo.GroupAt(newOffset, true);
 
-            if (!editorClock.IsRunning)
+            if (!editorClock.IsRunning && wasAtStart)
                 editorClock.Seek(newOffset);
         }
 


### PR DESCRIPTION
This was added with the intention of tracking the offset when already at the start (the most common case when you're using the tap timing wizard), but was also seeking when the user may be much further beyond or before it.

Addresses https://github.com/ppy/osu/discussions/18741#discussioncomment-2975051.