### PR TITLE
Revert "Add automated commit to git-blame-ignore-revs"

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,2 @@
 # Normalize all the line endings
 32a74f95a5c80a0ed18e693f13a47522099df5c3
-# Enabled NRT globally
-f8830c6850128456266c82de83273204f8b74ac0


### PR DESCRIPTION
The ignore rev system doesn't really work with commits with only added lines (i.e. what will the added line's commit be then). In https://github.com/ppy/osu/blame/1bd6198da200feef99a2631800b86d6654f8e368/osu.Game/OsuGame.cs#L4, the line is now linked with an irrelevant commit:

![image](https://user-images.githubusercontent.com/35318437/174464918-fc2e1f01-8fa3-464c-abbf-01eea2871d9f.png)

From some research, git uses an algorithm to *try* to find the last commit. It works with changed lines but not so much with added lines, so only mass reformatting commits are the only use case for this.