### PR TITLE
Remove one more `RealmArchiveModelImporter` `Import` method

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -15,7 +15,6 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Extensions;
-using osu.Game.IO.Archives;
 using osu.Game.Models;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
@@ -39,10 +38,7 @@ namespace osu.Game.Tests.Database
                 using (var importer = new BeatmapImporter(storage, realm))
                 using (new RealmRulesetStore(realm, storage))
                 {
-                    Live<BeatmapSetInfo>? beatmapSet;
-
-                    using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
-                        beatmapSet = await importer.Import(reader);
+                    var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
                     Assert.NotNull(beatmapSet);
                     Debug.Assert(beatmapSet != null);
@@ -83,10 +79,7 @@ namespace osu.Game.Tests.Database
                 using (var importer = new BeatmapImporter(storage, realm))
                 using (new RealmRulesetStore(realm, storage))
                 {
-                    Live<BeatmapSetInfo>? beatmapSet;
-
-                    using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
-                        beatmapSet = await importer.Import(reader);
+                    var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
                     Assert.NotNull(beatmapSet);
                     Debug.Assert(beatmapSet != null);
@@ -146,11 +139,8 @@ namespace osu.Game.Tests.Database
                 {
                     Task.Run(async () =>
                     {
-                        Live<BeatmapSetInfo>? beatmapSet;
-
-                        using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
-                            // ReSharper disable once AccessToDisposedClosure
-                            beatmapSet = await importer.Import(reader);
+                        // ReSharper disable once AccessToDisposedClosure
+                        var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
                         Assert.NotNull(beatmapSet);
                         Debug.Assert(beatmapSet != null);
@@ -173,13 +163,8 @@ namespace osu.Game.Tests.Database
                 using (var importer = new BeatmapImporter(storage, realm))
                 using (new RealmRulesetStore(realm, storage))
                 {
-                    Live<BeatmapSetInfo>? imported;
-
-                    using (var reader = new ZipArchiveReader(TestResources.GetTestBeatmapStream()))
-                    {
-                        imported = await importer.Import(reader);
-                        EnsureLoaded(realm.Realm);
-                    }
+                    var imported = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
+                    EnsureLoaded(realm.Realm);
 
                     Assert.AreEqual(1, realm.Realm.All<BeatmapSetInfo>().Count());
 

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -745,7 +745,7 @@ namespace osu.Game.Tests.Database
                     }
                 };
 
-                var imported = importer.Import(toImport);
+                var imported = importer.ImportModel(toImport);
 
                 realm.Run(r => r.Refresh());
 

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -227,10 +227,10 @@ namespace osu.Game.Tests.Online
                     this.testBeatmapManager = testBeatmapManager;
                 }
 
-                public override Live<BeatmapSetInfo> Import(BeatmapSetInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default)
+                public override Live<BeatmapSetInfo> ImportModel(BeatmapSetInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default)
                 {
                     testBeatmapManager.AllowImport.Task.WaitSafely();
-                    return (testBeatmapManager.CurrentImport = base.Import(item, archive, batchImport, cancellationToken));
+                    return (testBeatmapManager.CurrentImport = base.ImportModel(item, archive, batchImport, cancellationToken));
                 }
             }
         }

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -15,7 +15,6 @@ using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;
-using osu.Game.IO.Archives;
 using osu.Game.Skinning;
 using SharpCompress.Archives.Zip;
 
@@ -28,7 +27,7 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSingleImportDifferentFilename() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner"), "skin.osk"));
 
             // When the import filename doesn't match, it should be appended (and update the skin.ini).
             assertCorrectMetadata(import1, "test skin [skin]", "skinner", osu);
@@ -37,7 +36,7 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSingleImportWeirdIniFileCase() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner", iniFilename: "Skin.InI"), "skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner", iniFilename: "Skin.InI"), "skin.osk"));
 
             // When the import filename doesn't match, it should be appended (and update the skin.ini).
             assertCorrectMetadata(import1, "test skin [skin]", "skinner", osu);
@@ -46,7 +45,7 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSingleImportMissingSectionHeader() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner", includeSectionHeader: false), "skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner", includeSectionHeader: false), "skin.osk"));
 
             // When the import filename doesn't match, it should be appended (and update the skin.ini).
             assertCorrectMetadata(import1, "test skin [skin]", "skinner", osu);
@@ -55,7 +54,7 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSingleImportMatchingFilename() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "test skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner"), "test skin.osk"));
 
             // When the import filename matches it shouldn't be appended.
             assertCorrectMetadata(import1, "test skin", "skinner", osu);
@@ -64,7 +63,7 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSingleImportNoIniFile() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithNonIniFile(), "test skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithNonIniFile(), "test skin.osk"));
 
             // When the import filename matches it shouldn't be appended.
             assertCorrectMetadata(import1, "test skin", "Unknown", osu);
@@ -73,7 +72,7 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestEmptyImportImportsWithFilename() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createEmptyOsk(), "test skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createEmptyOsk(), "test skin.osk"));
 
             // When the import filename matches it shouldn't be appended.
             assertCorrectMetadata(import1, "test skin", "Unknown", osu);
@@ -86,8 +85,8 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestImportTwiceWithSameMetadataAndFilename() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "skin.osk"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner"), "skin.osk"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner"), "skin.osk"));
 
             assertImportedOnce(import1, import2);
         });
@@ -96,8 +95,8 @@ namespace osu.Game.Tests.Skins.IO
         public Task TestImportTwiceWithNoMetadataSameDownloadFilename() => runSkinTest(async osu =>
         {
             // if a user downloads two skins that do have skin.ini files but don't have any creator metadata in the skin.ini, they should both import separately just for safety.
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni(string.Empty, string.Empty), "download.osk"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni(string.Empty, string.Empty), "download.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni(string.Empty, string.Empty), "download.osk"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni(string.Empty, string.Empty), "download.osk"));
 
             assertImportedOnce(import1, import2);
         });
@@ -105,10 +104,10 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestImportUpperCasedOskArchive() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "name 1.OsK"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "name 1.OsK"));
             assertCorrectMetadata(import1, "name 1", "author 1", osu);
 
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "name 1.oSK"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "name 1.oSK"));
 
             assertImportedOnce(import1, import2);
         });
@@ -118,7 +117,7 @@ namespace osu.Game.Tests.Skins.IO
         {
             MemoryStream exportStream = new MemoryStream();
 
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "custom.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "custom.osk"));
             assertCorrectMetadata(import1, "name 1 [custom]", "author 1", osu);
 
             import1.PerformRead(s =>
@@ -128,7 +127,7 @@ namespace osu.Game.Tests.Skins.IO
 
             string exportFilename = import1.GetDisplayString();
 
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(exportStream, $"{exportFilename}.osk"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(exportStream, $"{exportFilename}.osk"));
             assertCorrectMetadata(import2, "name 1 [custom]", "author 1", osu);
 
             assertImportedOnce(import1, import2);
@@ -137,8 +136,8 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSameMetadataNameSameFolderName() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "my custom skin 1"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "my custom skin 1"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "my custom skin 1"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "my custom skin 1"));
 
             assertImportedOnce(import1, import2);
             assertCorrectMetadata(import1, "name 1 [my custom skin 1]", "author 1", osu);
@@ -151,8 +150,8 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestImportTwiceWithSameMetadataButDifferentFilename() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "skin.osk"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin", "skinner"), "skin2.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner"), "skin.osk"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin", "skinner"), "skin2.osk"));
 
             assertImportedBoth(import1, import2);
         });
@@ -161,8 +160,8 @@ namespace osu.Game.Tests.Skins.IO
         public Task TestImportTwiceWithNoMetadataDifferentDownloadFilename() => runSkinTest(async osu =>
         {
             // if a user downloads two skins that do have skin.ini files but don't have any creator metadata in the skin.ini, they should both import separately just for safety.
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni(string.Empty, string.Empty), "download.osk"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni(string.Empty, string.Empty), "download2.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni(string.Empty, string.Empty), "download.osk"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni(string.Empty, string.Empty), "download2.osk"));
 
             assertImportedBoth(import1, import2);
         });
@@ -170,8 +169,8 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestImportTwiceWithSameFilenameDifferentMetadata() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin v2", "skinner"), "skin.osk"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("test skin v2.1", "skinner"), "skin.osk"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin v2", "skinner"), "skin.osk"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("test skin v2.1", "skinner"), "skin.osk"));
 
             assertImportedBoth(import1, import2);
             assertCorrectMetadata(import1, "test skin v2 [skin]", "skinner", osu);
@@ -181,8 +180,8 @@ namespace osu.Game.Tests.Skins.IO
         [Test]
         public Task TestSameMetadataNameDifferentFolderName() => runSkinTest(async osu =>
         {
-            var import1 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "my custom skin 1"));
-            var import2 = await loadSkinIntoOsu(osu, new ZipArchiveReader(createOskWithIni("name 1", "author 1"), "my custom skin 2"));
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "my custom skin 1"));
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "my custom skin 2"));
 
             assertImportedBoth(import1, import2);
             assertCorrectMetadata(import1, "name 1 [my custom skin 1]", "author 1", osu);
@@ -358,10 +357,10 @@ namespace osu.Game.Tests.Skins.IO
             }
         }
 
-        private async Task<Live<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ArchiveReader archive = null)
+        private async Task<Live<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ImportTask import = null)
         {
             var skinManager = osu.Dependencies.Get<SkinManager>();
-            return await skinManager.Import(archive);
+            return await skinManager.Import(import);
         }
     }
 }

--- a/osu.Game.Tests/Skins/TestSceneBeatmapSkinResources.cs
+++ b/osu.Game.Tests/Skins/TestSceneBeatmapSkinResources.cs
@@ -10,7 +10,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Testing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
-using osu.Game.IO.Archives;
+using osu.Game.Database;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual;
 
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Skins
         [BackgroundDependencyLoader]
         private void load()
         {
-            var imported = beatmaps.Import(new ZipArchiveReader(TestResources.OpenResource("Archives/ogg-beatmap.osz"))).GetResultSafely();
+            var imported = beatmaps.Import(new ImportTask(TestResources.OpenResource("Archives/ogg-beatmap.osz"), "ogg-beatmap.osz")).GetResultSafely();
 
             imported?.PerformRead(s =>
             {

--- a/osu.Game.Tests/Skins/TestSceneSkinResources.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinResources.cs
@@ -8,7 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Testing;
 using osu.Game.Audio;
-using osu.Game.IO.Archives;
+using osu.Game.Database;
 using osu.Game.Skinning;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual;
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Skins
         [BackgroundDependencyLoader]
         private void load()
         {
-            var imported = skins.Import(new ZipArchiveReader(TestResources.OpenResource("Archives/ogg-skin.osk"))).GetResultSafely();
+            var imported = skins.Import(new ImportTask(TestResources.OpenResource("Archives/ogg-skin.osk"), "ogg-skin.osk")).GetResultSafely();
             skin = imported.PerformRead(skinInfo => skins.GetSkin(skinInfo));
         }
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -409,9 +409,6 @@ namespace osu.Game.Beatmaps
         public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default) =>
             beatmapImporter.Import(task, batchImport, cancellationToken);
 
-        public Task<Live<BeatmapSetInfo>?> Import(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default) =>
-            beatmapImporter.Import(archive, batchImport, cancellationToken);
-
         public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, CancellationToken cancellationToken = default) =>
             beatmapImporter.Import(item, archive, false, cancellationToken);
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Beatmaps
             foreach (BeatmapInfo b in beatmapSet.Beatmaps)
                 b.BeatmapSet = beatmapSet;
 
-            var imported = beatmapImporter.Import(beatmapSet);
+            var imported = beatmapImporter.ImportModel(beatmapSet);
 
             if (imported == null)
                 throw new InvalidOperationException("Failed to import new beatmap");
@@ -410,7 +410,7 @@ namespace osu.Game.Beatmaps
             beatmapImporter.Import(task, batchImport, cancellationToken);
 
         public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, CancellationToken cancellationToken = default) =>
-            beatmapImporter.Import(item, archive, false, cancellationToken);
+            beatmapImporter.ImportModel(item, archive, false, cancellationToken);
 
         public IEnumerable<string> HandledExtensions => beatmapImporter.HandledExtensions;
 

--- a/osu.Game/Database/ImportTask.cs
+++ b/osu.Game/Database/ImportTask.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Database
         }
 
         /// <summary>
-        /// Construct a new import task from a stream.
+        /// Construct a new import task from a stream. The provided stream will be disposed after reading.
         /// </summary>
         public ImportTask(Stream stream, string filename)
         {

--- a/osu.Game/Database/ImportTask.cs
+++ b/osu.Game/Database/ImportTask.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Database
             {
                 // This isn't used in any current path. May need to reconsider for performance reasons (ie. if we don't expect the incoming stream to be copied out).
                 memoryStream = new MemoryStream(stream.ReadAllBytesToArray());
+                stream.Dispose();
             }
 
             if (ZipUtils.IsZipArchive(memoryStream))

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -236,7 +236,7 @@ namespace osu.Game.Database
                 return null;
             }
 
-            var scheduledImport = Task.Factory.StartNew(() => Import(model, archive, batchImport, cancellationToken),
+            var scheduledImport = Task.Factory.StartNew(() => ImportModel(model, archive, batchImport, cancellationToken),
                 cancellationToken,
                 TaskCreationOptions.HideScheduler,
                 batchImport ? import_scheduler_batch : import_scheduler);
@@ -251,7 +251,7 @@ namespace osu.Game.Database
         /// <param name="archive">An optional archive to use for model population.</param>
         /// <param name="batchImport">If <c>true</c>, imports will be skipped before they begin, given an existing model matches on hash and filenames. Should generally only be used for large batch imports, as it may defy user expectations when updating an existing model.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        public virtual Live<TModel>? Import(TModel item, ArchiveReader? archive = null, bool batchImport = false, CancellationToken cancellationToken = default) => Realm.Run(realm =>
+        public virtual Live<TModel>? ImportModel(TModel item, ArchiveReader? archive = null, bool batchImport = false, CancellationToken cancellationToken = default) => Realm.Run(realm =>
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Database
 
             Live<TModel>? import;
             using (ArchiveReader reader = task.GetReader())
-                import = await Import(reader, batchImport, cancellationToken).ConfigureAwait(false);
+                import = await importFromArchive(reader, batchImport, cancellationToken).ConfigureAwait(false);
 
             // We may or may not want to delete the file depending on where it is stored.
             //  e.g. reconstructing/repairing database with items from default storage.
@@ -213,7 +213,7 @@ namespace osu.Game.Database
         /// <param name="archive">The archive to be imported.</param>
         /// <param name="batchImport">Whether this import is part of a larger batch.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        public async Task<Live<TModel>?> Import(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default)
+        private async Task<Live<TModel>?> importFromArchive(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -228,13 +228,6 @@ namespace osu.Game.Database
 
                 if (model == null)
                     return null;
-
-                var scheduledImport = Task.Factory.StartNew(() => ImportModel(model, archive, batchImport, cancellationToken),
-                    cancellationToken,
-                    TaskCreationOptions.HideScheduler,
-                    batchImport ? import_scheduler_batch : import_scheduler);
-
-                return await scheduledImport.ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -245,6 +238,13 @@ namespace osu.Game.Database
                 LogForModel(model, @$"Model creation of {archive.Name} failed.", e);
                 return null;
             }
+
+            var scheduledImport = Task.Factory.StartNew(() => ImportModel(model, archive, batchImport, cancellationToken),
+                cancellationToken,
+                TaskCreationOptions.HideScheduler,
+                batchImport ? import_scheduler_batch : import_scheduler);
+
+            return await scheduledImport.ConfigureAwait(false);
         }
 
         /// <summary>

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -265,7 +265,7 @@ namespace osu.Game.Scoring
         public Task<IEnumerable<Live<ScoreInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => scoreImporter.Import(notification, tasks);
 
         public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default) =>
-            scoreImporter.Import(item, archive, batchImport, cancellationToken);
+            scoreImporter.ImportModel(item, archive, batchImport, cancellationToken);
 
         #region Implementation of IPresentImports<ScoreInfo>
 

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -19,7 +19,6 @@ using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
-using osu.Game.IO.Archives;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
@@ -141,7 +140,7 @@ namespace osu.Game.Screens.Menu
                 {
                     // if we detect that the theme track or beatmap is unavailable this is either first startup or things are in a bad state.
                     // this could happen if a user has nuked their files store. for now, reimport to repair this.
-                    var import = beatmaps.Import(new ZipArchiveReader(game.Resources.GetStream($"Tracks/{BeatmapFile}"), BeatmapFile)).GetResultSafely();
+                    var import = beatmaps.Import(new ImportTask(game.Resources.GetStream($"Tracks/{BeatmapFile}"), BeatmapFile)).GetResultSafely();
 
                     import?.PerformWrite(b => b.Protected = true);
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Skinning
                     Name = NamingUtils.GetNextBestName(existingSkinNames, $@"{s.Name} (modified)")
                 };
 
-                var result = skinImporter.Import(skinInfo);
+                var result = skinImporter.ImportModel(skinInfo);
 
                 if (result != null)
                 {

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -24,7 +24,6 @@ using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Database;
 using osu.Game.IO;
-using osu.Game.IO.Archives;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Utils;
 
@@ -274,9 +273,6 @@ namespace osu.Game.Skinning
         public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => skinImporter.Import(notification, tasks);
 
         public Task<Live<SkinInfo>> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default) => skinImporter.Import(task, batchImport, cancellationToken);
-
-        public Task<Live<SkinInfo>> Import(ArchiveReader archive, bool batchImport = false, CancellationToken cancellationToken = default) =>
-            skinImporter.Import(archive, batchImport, cancellationToken);
 
         #endregion
 


### PR DESCRIPTION
One at a time. This one is a pretty straightforward change. In all existing usages of the `ArchiveReader` parameter method, the `ArchiveReader` was being created in basically the same way as `ImportTask` does internally.

I've also renamed `ImportModel` in 92f1a2958c to differentiate the intended use case of the method.