### PR TITLE
Silence exception and provide more log output when import fails due to empty `.osu` files

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -292,6 +292,42 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
+        public void TestImportDirectoryWithEmptyOsuFiles()
+        {
+            RunTestWithRealmAsync(async (realm, storage) =>
+            {
+                using var importer = new BeatmapImporter(storage, realm);
+                using var store = new RealmRulesetStore(realm, storage);
+
+                string? temp = TestResources.GetTestBeatmapForImport();
+
+                string extractedFolder = $"{temp}_extracted";
+                Directory.CreateDirectory(extractedFolder);
+
+                try
+                {
+                    using (var zip = ZipArchive.Open(temp))
+                        zip.WriteToDirectory(extractedFolder);
+
+                    foreach (var file in new DirectoryInfo(extractedFolder).GetFiles("*.osu"))
+                    {
+                        using (file.Open(FileMode.Create))
+                        {
+                            // empty file.
+                        }
+                    }
+
+                    var imported = await importer.Import(new ImportTask(extractedFolder));
+                    Assert.IsNull(imported);
+                }
+                finally
+                {
+                    Directory.Delete(extractedFolder, true);
+                }
+            });
+        }
+
+        [Test]
         public void TestImportThenImportWithReZip()
         {
             RunTestWithRealmAsync(async (realm, storage) =>

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -177,8 +177,17 @@ namespace osu.Game.Beatmaps
             }
 
             Beatmap beatmap;
+
             using (var stream = new LineBufferedReader(reader.GetStream(mapName)))
+            {
+                if (stream.PeekLine() == null)
+                {
+                    Logger.Log($"No content found in first .osu file of beatmap archive ({reader.Name} / {mapName})", LoggingTarget.Database);
+                    return null;
+                }
+
                 beatmap = Decoder.GetDecoder<Beatmap>(stream).Decode(stream);
+            }
 
             return new BeatmapSetInfo
             {

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Beatmaps.Formats
             }
 
             if (line == null)
-                throw new IOException("Unknown file format (null)");
+                throw new IOException("Unknown file format (no content)");
 
             var decoder = typedDecoders.Where(d => line.StartsWith(d.Key, StringComparison.InvariantCulture)).Select(d => d.Value).FirstOrDefault();
 


### PR DESCRIPTION
Commonly found [on sentry](https://sentry.ppy.sh/organizations/ppy/issues/6/?project=2), but also not without enough details to be useful. I've added some log output so if a user provides logs we can at least figure out which beatmap is not being imported correctly.

Optionally, I can add back the `throw` so we still get these on sentry. Undecided if it's worth it.