### PR TITLE
Remove null default value in `ImportSkinTest` helper method

### DIFF
--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Tests.Skins.IO
             }
         }
 
-        private async Task<Live<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ImportTask import = null)
+        private async Task<Live<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ImportTask import)
         {
             var skinManager = osu.Dependencies.Get<SkinManager>();
             return await skinManager.Import(import);


### PR DESCRIPTION
Noticed in passing in #18776.

This null default never made any amount of sense. Unless one likes shooting self in foot with `NullReferenceException`s, I guess.