### PR TITLE
Remove necessity to provide `BeatmapDifficultyCache` as a function to `ScoreManager`

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -264,14 +264,16 @@ namespace osu.Game
 
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 
+            dependencies.Cache(difficultyCache = new BeatmapDifficultyCache());
+
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
-            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, Scheduler, () => difficultyCache, LocalConfig));
+            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, Scheduler, difficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, realm, RulesetStore, API, Audio, Resources, Host, defaultBeatmap, performOnlineLookups: true));
 
             dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API));
             dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API));
 
-            dependencies.Cache(difficultyCache = new BeatmapDifficultyCache());
+            // Add after all the above cache operations as it depends on them.
             AddInternal(difficultyCache);
 
             dependencies.Cache(userCache = new UserLookupCache());

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -27,16 +27,16 @@ namespace osu.Game.Scoring
     public class ScoreManager : ModelManager<ScoreInfo>, IModelImporter<ScoreInfo>
     {
         private readonly Scheduler scheduler;
-        private readonly Func<BeatmapDifficultyCache> difficulties;
+        private readonly BeatmapDifficultyCache difficultyCache;
         private readonly OsuConfigManager configManager;
         private readonly ScoreImporter scoreImporter;
 
         public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmAccess realm, Scheduler scheduler,
-                            Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
+                            BeatmapDifficultyCache difficultyCache = null, OsuConfigManager configManager = null)
             : base(storage, realm)
         {
             this.scheduler = scheduler;
-            this.difficulties = difficulties;
+            this.difficultyCache = difficultyCache;
             this.configManager = configManager;
 
             scoreImporter = new ScoreImporter(rulesets, beatmaps, storage, realm)
@@ -65,8 +65,6 @@ namespace osu.Game.Scoring
         /// <returns>The given <paramref name="scores"/> ordered by decreasing total score.</returns>
         public async Task<ScoreInfo[]> OrderByTotalScoreAsync(ScoreInfo[] scores, CancellationToken cancellationToken = default)
         {
-            var difficultyCache = difficulties?.Invoke();
-
             if (difficultyCache != null)
             {
                 // Compute difficulties asynchronously first to prevent blocking via the GetTotalScore() call below.
@@ -168,11 +166,11 @@ namespace osu.Game.Scoring
                     return score.BeatmapInfo.MaxCombo.Value;
 #pragma warning restore CS0618
 
-                if (difficulties == null)
+                if (difficultyCache == null)
                     return null;
 
                 // We can compute the max combo locally after the async beatmap difficulty computation.
-                var difficulty = await difficulties().GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, cancellationToken).ConfigureAwait(false);
+                var difficulty = await difficultyCache.GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, cancellationToken).ConfigureAwait(false);
                 return difficulty?.MaxCombo;
             }
 


### PR DESCRIPTION
Came up while figuring out the structure for more flexible beatmap updating, where I didn't want to have to pass this as a function to new usages (ie. `BeatmapManager`).