### PR TITLE
Add ability to handle `osu://` scheme links via IPC on desktop

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -11,6 +11,7 @@ using osu.Framework;
 using osu.Framework.Development;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Game;
 using osu.Game.IPC;
 using osu.Game.Tournament;
 using Squirrel;
@@ -65,19 +66,8 @@ namespace osu.Desktop
             {
                 if (!host.IsPrimaryInstance)
                 {
-                    if (args.Length > 0 && args[0].Contains('.')) // easy way to check for a file import in args
-                    {
-                        var importer = new ArchiveImportIPCChannel(host);
-
-                        foreach (string file in args)
-                        {
-                            Console.WriteLine(@"Importing {0}", file);
-                            if (!importer.ImportAsync(Path.GetFullPath(file, cwd)).Wait(3000))
-                                throw new TimeoutException(@"IPC took too long to send");
-                        }
-
+                    if (trySendIPCMessage(host, cwd, args))
                         return;
-                    }
 
                     // we want to allow multiple instances to be started when in debug.
                     if (!DebugUtils.IsDebugBuild)
@@ -106,6 +96,34 @@ namespace osu.Desktop
                 else
                     host.Run(new OsuGameDesktop(args));
             }
+        }
+
+        private static bool trySendIPCMessage(IIpcHost host, string cwd, string[] args)
+        {
+            if (args.Length == 1 && args[0].StartsWith(OsuGameBase.OSU_PROTOCOL, StringComparison.Ordinal))
+            {
+                var osuSchemeLinkHandler = new OsuSchemeLinkIPCChannel(host);
+                if (!osuSchemeLinkHandler.HandleLinkAsync(args[0]).Wait(3000))
+                    throw new IPCTimeoutException(osuSchemeLinkHandler.GetType());
+
+                return true;
+            }
+
+            if (args.Length > 0 && args[0].Contains('.')) // easy way to check for a file import in args
+            {
+                var importer = new ArchiveImportIPCChannel(host);
+
+                foreach (string file in args)
+                {
+                    Console.WriteLine(@"Importing {0}", file);
+                    if (!importer.ImportAsync(Path.GetFullPath(file, cwd)).Wait(3000))
+                        throw new IPCTimeoutException(importer.GetType());
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         [SupportedOSPlatform("windows")]

--- a/osu.Game.Tests/Visual/Navigation/TestSceneInterProcessCommunication.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneInterProcessCommunication.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("dispose IPC receiver", () => osuSchemeLinkIPCReceiver.Dispose());
             AddStep("dispose IPC sender", () =>
             {
-                osuSchemeLinkIPCReceiver.Dispose();
+                osuSchemeLinkIPCSender.Dispose();
                 ipcSenderHost.Dispose();
             });
             base.TearDownSteps();

--- a/osu.Game.Tests/Visual/Navigation/TestSceneInterProcessCommunication.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneInterProcessCommunication.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.IPC;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    [TestFixture]
+    [Ignore("This test cannot be run headless, as it requires the game host running the nested game to have IPC bound.")]
+    public class TestSceneInterProcessCommunication : OsuGameTestScene
+    {
+        private HeadlessGameHost ipcSenderHost = null!;
+
+        private OsuSchemeLinkIPCChannel osuSchemeLinkIPCReceiver = null!;
+        private OsuSchemeLinkIPCChannel osuSchemeLinkIPCSender = null!;
+
+        private const int requested_beatmap_set_id = 1;
+
+        [Resolved]
+        private GameHost gameHost { get; set; } = null!;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+            AddStep("set up request handling", () =>
+            {
+                ((DummyAPIAccess)API).HandleRequest = request =>
+                {
+                    switch (request)
+                    {
+                        case GetBeatmapSetRequest gbr:
+
+                            var apiBeatmapSet = CreateAPIBeatmapSet();
+                            apiBeatmapSet.OnlineID = requested_beatmap_set_id;
+                            apiBeatmapSet.Beatmaps = apiBeatmapSet.Beatmaps.Append(new APIBeatmap
+                            {
+                                DifficultyName = "Target difficulty",
+                                OnlineID = 75,
+                            }).ToArray();
+                            gbr.TriggerSuccess(apiBeatmapSet);
+                            return true;
+                    }
+
+                    return false;
+                };
+            });
+            AddStep("create IPC receiver channel", () => osuSchemeLinkIPCReceiver = new OsuSchemeLinkIPCChannel(gameHost, Game));
+            AddStep("create IPC sender channel", () =>
+            {
+                ipcSenderHost = new HeadlessGameHost(gameHost.Name, new HostOptions { BindIPC = true });
+                osuSchemeLinkIPCSender = new OsuSchemeLinkIPCChannel(ipcSenderHost);
+            });
+        }
+
+        [Test]
+        public void TestOsuSchemeLinkIPCChannel()
+        {
+            AddStep("open beatmap via IPC", () => osuSchemeLinkIPCSender.HandleLinkAsync($@"osu://s/{requested_beatmap_set_id}").WaitSafely());
+            AddUntilStep("beatmap overlay displayed", () => Game.ChildrenOfType<BeatmapSetOverlay>().FirstOrDefault()?.State.Value == Visibility.Visible);
+            AddUntilStep("beatmap overlay showing content", () => Game.ChildrenOfType<BeatmapSetOverlay>().FirstOrDefault()?.Header.BeatmapSet.Value.OnlineID == requested_beatmap_set_id);
+        }
+
+        public override void TearDownSteps()
+        {
+            AddStep("dispose IPC receiver", () => osuSchemeLinkIPCReceiver.Dispose());
+            AddStep("dispose IPC sender", () =>
+            {
+                osuSchemeLinkIPCReceiver.Dispose();
+                ipcSenderHost.Dispose();
+            });
+            base.TearDownSteps();
+        }
+    }
+}

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
+using osu.Game.Online;
 using osu.Game.Users;
 
 namespace osu.Game.Graphics.Containers
@@ -25,7 +26,7 @@ namespace osu.Game.Graphics.Containers
         }
 
         [Resolved(CanBeNull = true)]
-        private OsuGame game { get; set; }
+        private ILinkHandler linkHandler { get; set; }
 
         [Resolved]
         private GameHost host { get; set; }
@@ -81,8 +82,8 @@ namespace osu.Game.Graphics.Containers
             {
                 if (action != null)
                     action();
-                else if (game != null)
-                    game.HandleLink(link);
+                else if (linkHandler != null)
+                    linkHandler.HandleLink(link);
                 // fallback to handle cases where OsuGame is not available, ie. tournament client.
                 else if (link.Action == LinkAction.External)
                     host.OpenUrlExternally(link.Argument.ToString());

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownLinkText.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownLinkText.cs
@@ -8,6 +8,7 @@ using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers.Markdown;
+using osu.Game.Online;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 
@@ -16,7 +17,7 @@ namespace osu.Game.Graphics.Containers.Markdown
     public class OsuMarkdownLinkText : MarkdownLinkText
     {
         [Resolved(canBeNull: true)]
-        private OsuGame game { get; set; }
+        private ILinkHandler linkHandler { get; set; }
 
         private readonly string text;
         private readonly string title;
@@ -51,7 +52,7 @@ namespace osu.Game.Graphics.Containers.Markdown
             };
         }
 
-        protected override void OnLinkPressed() => game?.HandleLink(Url);
+        protected override void OnLinkPressed() => linkHandler?.HandleLink(Url);
 
         private class OsuMarkdownLinkCompiler : DrawableLinkCompiler
         {

--- a/osu.Game/IPC/IPCTimeoutException.cs
+++ b/osu.Game/IPC/IPCTimeoutException.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.IPC
+{
+    public class IPCTimeoutException : TimeoutException
+    {
+        public IPCTimeoutException(Type channelType)
+            : base($@"IPC took too long to send message via channel {channelType}")
+        {
+        }
+    }
+}

--- a/osu.Game/IPC/OsuSchemeLinkIPCChannel.cs
+++ b/osu.Game/IPC/OsuSchemeLinkIPCChannel.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.Threading.Tasks;
+using osu.Framework.Platform;
+using osu.Game.Online;
+
+namespace osu.Game.IPC
+{
+    public class OsuSchemeLinkIPCChannel : IpcChannel<OsuSchemeLinkMessage>
+    {
+        private readonly ILinkHandler? linkHandler;
+
+        public OsuSchemeLinkIPCChannel(IIpcHost host, ILinkHandler? linkHandler = null)
+            : base(host)
+        {
+            this.linkHandler = linkHandler;
+
+            MessageReceived += msg =>
+            {
+                Debug.Assert(linkHandler != null);
+                linkHandler.HandleLink(msg.Link);
+                return null;
+            };
+        }
+
+        public async Task HandleLinkAsync(string url)
+        {
+            if (linkHandler == null)
+            {
+                await SendMessageAsync(new OsuSchemeLinkMessage(url)).ConfigureAwait(false);
+                return;
+            }
+
+            linkHandler.HandleLink(url);
+        }
+    }
+
+    public class OsuSchemeLinkMessage
+    {
+        public string Link { get; }
+
+        public OsuSchemeLinkMessage(string link)
+        {
+            Link = link;
+        }
+    }
+}

--- a/osu.Game/Online/ILinkHandler.cs
+++ b/osu.Game/Online/ILinkHandler.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Online.Chat;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// Handle an arbitrary URL. Displays via in-game overlays where possible.
+    /// Methods can be called from a non-thread-safe non-game-loaded state.
+    /// </summary>
+    [Cached]
+    public interface ILinkHandler
+    {
+        /// <summary>
+        /// Handle an arbitrary URL. Displays via in-game overlays where possible.
+        /// This can be called from a non-thread-safe non-game-loaded state.
+        /// </summary>
+        /// <param name="url">The URL to load.</param>
+        void HandleLink(string url);
+
+        /// <summary>
+        /// Handle a specific <see cref="LinkDetails"/>.
+        /// This can be called from a non-thread-safe non-game-loaded state.
+        /// </summary>
+        /// <param name="link">The link to load.</param>
+        void HandleLink(LinkDetails link);
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -39,6 +39,7 @@ using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.IO;
 using osu.Game.Localisation;
+using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
@@ -69,7 +70,7 @@ namespace osu.Game
     /// The full osu! experience. Builds on top of <see cref="OsuGameBase"/> to add menus and binding logic
     /// for initial components that are generally retrieved via DI.
     /// </summary>
-    public class OsuGame : OsuGameBase, IKeyBindingHandler<GlobalAction>, ILocalUserPlayInfo, IPerformFromScreenRunner, IOverlayManager
+    public class OsuGame : OsuGameBase, IKeyBindingHandler<GlobalAction>, ILocalUserPlayInfo, IPerformFromScreenRunner, IOverlayManager, ILinkHandler
     {
         /// <summary>
         /// The amount of global offset to apply when a left/right anchored overlay is displayed (ie. settings or notifications).

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Tests.Visual
         }
 
         [TearDownSteps]
-        public void TearDownSteps()
+        public virtual void TearDownSteps()
         {
             if (DebugUtils.IsNUnitRunning && Game != null)
             {


### PR DESCRIPTION
- Supersedes / closes https://github.com/ppy/osu/pull/17630

Now with 100% less wheel reinvention. I figure this was a good one to re-do because having `osu://` links redirect to the game once it's open is a pretty big staple of stable. (Note that this already works on `master` when the game isn't open, via the normal args flow.)

Of note:

- This only lives in the desktop project, because on mobile this (a) probably wouldn't work and (b) isn't even needed (this already works fine on android via the intent system).
- There is some test coverage, but it's very weak as the functionality is awkward to test. It'll only work from visual test browser as headless test runner [does not bind to IPC](https://github.com/ppy/osu-framework/blob/3ab72997c8484c43ff868f9375a74efa15481066/osu.Framework/Testing/TestRunHeadlessGameHost.cs#L37-L38). If anyone has ideas how to improve, I'm all ears.
- The desktop-specific pathways in `Program` I don't know how to test. I could move out `trySendIPCMessage()` to game and try to test that on request - but it's not *very* hard to test this manually, so I didn't do this yet.
- I've also moved some code around that uses `ArchiveImportIPCChannel`, but this IPC channel is - as far as I can tell - actually dead right now (as in you can send messages over it, but they are never actually received). This was previously used in the ol' `ArchiveModelManager` which got nuked in https://github.com/ppy/osu/pull/16428. I'm not touching that for the time being to not interfere with work on #18665.
- Also added NRT coverage in `OsuGameDesktop` because I needed NRT, and extracted an interface for the link handlage.