### PR TITLE
Track the full size of the follow circle at all times

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -1,0 +1,120 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [HeadlessTest]
+    public class TestSceneSliderFollowCircleInput : RateAdjustedBeatmapTestScene
+    {
+        private List<JudgementResult>? judgementResults;
+        private ScoreAccessibleReplayPlayer? currentPlayer;
+
+        [Test]
+        public void TestMaximumDistanceTrackingWithoutMovement(
+            [Values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
+            float circleSize,
+            [Values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
+            double velocity)
+        {
+            const double time_slider_start = 1000;
+
+            float circleRadius = OsuHitObject.OBJECT_RADIUS * (1.0f - 0.7f * (circleSize - 5) / 5) / 2;
+            float followCircleRadius = circleRadius * 1.2f;
+
+            performTest(new Beatmap<OsuHitObject>
+            {
+                HitObjects =
+                {
+                    new Slider
+                    {
+                        StartTime = time_slider_start,
+                        Position = new Vector2(0, 0),
+                        DifficultyControlPoint = new DifficultyControlPoint { SliderVelocity = velocity },
+                        Path = new SliderPath(PathType.Linear, new[]
+                        {
+                            Vector2.Zero,
+                            new Vector2(followCircleRadius, 0),
+                        }, followCircleRadius),
+                    },
+                },
+                BeatmapInfo =
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = circleSize,
+                        SliderTickRate = 1
+                    },
+                    Ruleset = new OsuRuleset().RulesetInfo
+                },
+            }, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Position = new Vector2(-circleRadius + 1, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
+            });
+
+            AddAssert("Tracking kept", assertMaxJudge);
+        }
+
+        private bool assertMaxJudge() => judgementResults?.Any() == true && judgementResults.All(t => t.Type == t.Judgement.MaxResult);
+
+        private void performTest(Beatmap<OsuHitObject> beatmap, List<ReplayFrame> frames)
+        {
+            AddStep("load player", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(beatmap);
+
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+
+                p.OnLoadComplete += _ =>
+                {
+                    p.ScoreProcessor.NewJudgement += result =>
+                    {
+                        if (currentPlayer == p) judgementResults?.Add(result);
+                    };
+                };
+
+                LoadScreen(currentPlayer = p);
+                judgementResults = new List<JudgementResult>();
+            });
+
+            AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep("Wait for completion", () => currentPlayer?.ScoreProcessor.HasCompleted.Value == true);
+        }
+
+        private class ScoreAccessibleReplayPlayer : ReplayPlayer
+        {
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            protected override bool PauseOnFocusLost => false;
+
+            public ScoreAccessibleReplayPlayer(Score score)
+                : base(score, new PlayerConfiguration
+                {
+                    AllowPause = false,
+                    ShowResults = false,
+                })
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -30,9 +30,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Apply classic note lock", "Applies note lock to the full hit window.")]
         public Bindable<bool> ClassicNoteLock { get; } = new BindableBool(true);
 
-        [SettingSource("Use fixed slider follow circle hit area", "Makes the slider follow circle track its final size at all times.")]
-        public Bindable<bool> FixedFollowCircleHitArea { get; } = new BindableBool(true);
-
         [SettingSource("Always play a slider's tail sample", "Always plays a slider's tail sample regardless of whether it was hit or not.")]
         public Bindable<bool> AlwaysPlayTailSample { get; } = new BindableBool(true);
 
@@ -62,10 +59,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             switch (obj)
             {
-                case DrawableSlider slider:
-                    slider.Ball.InputTracksVisualSize = !FixedFollowCircleHitArea.Value;
-                    break;
-
                 case DrawableSliderHead head:
                     head.TrackFollowCircle = !NoSliderHeadMovement.Value;
                     break;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -34,13 +34,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             set => ball.Colour = value;
         }
 
-        /// <summary>
-        /// Whether to track accurately to the visual size of this <see cref="SliderBall"/>.
-        /// If <c>false</c>, tracking will be performed at the final scale at all times.
-        /// </summary>
-        public bool InputTracksVisualSize = true;
-
         private readonly Drawable followCircle;
+        private readonly Drawable fullSizeFollowCircle;
         private readonly DrawableSlider drawableSlider;
         private readonly Drawable ball;
 
@@ -61,6 +56,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                     RelativeSizeAxes = Axes.Both,
                     Alpha = 0,
                     Child = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderFollowCircle), _ => new DefaultFollowCircle()),
+                },
+                fullSizeFollowCircle = new CircularContainer
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true
                 },
                 ball = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderBall), _ => new DefaultSliderBall())
                 {
@@ -104,14 +106,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
                 tracking = value;
 
-                if (InputTracksVisualSize)
-                    followCircle.ScaleTo(tracking ? 2.4f : 1f, 300, Easing.OutQuint);
-                else
-                {
-                    // We need to always be tracking the final size, at both endpoints. For now, this is achieved by removing the scale duration.
-                    followCircle.ScaleTo(tracking ? 2.4f : 1f);
-                }
+                fullSizeFollowCircle.Scale = new Vector2(tracking ? 2.4f : 1f);
 
+                followCircle.ScaleTo(tracking ? 2.4f : 1f, 300, Easing.OutQuint);
                 followCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
             }
         }
@@ -170,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 // in valid time range
                 Time.Current >= drawableSlider.HitObject.StartTime && Time.Current < drawableSlider.HitObject.EndTime &&
                 // in valid position range
-                lastScreenSpaceMousePosition.HasValue && followCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
+                lastScreenSpaceMousePosition.HasValue && fullSizeFollowCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
                 // valid action
                 (actions?.Any(isValidTrackingAction) ?? false);
 


### PR DESCRIPTION
Alternative to / closes https://github.com/ppy/osu/pull/14832

The above PR also has further changes related to slider ticks/animations/etc, but I think those should be done in more granular PRs instead, if at all.

## Abstract

The main reason for this PR is that I'm worried that the current implementation of follow circles in non-classic mode leads to an edge case where a player may hit a (kick-)slider that is not supposed to be followed (i.e. the slider path is in the opposite direction of the beatmap flow) on the very edge of the circle and lose tracking.

## Changes

There are two pathways that I considered:
1. Tracking a virtual follow circle area (this PR).
2. Speeding up the follow circle animation such that it will always cover the cursor for duration of the animation (https://github.com/ppy/osu/compare/master...smoogipoo:full-size-follow-circle?expand=1).

I chose to add a virtual follow circle area because speeding up the animation makes it a bit jarring. I think the 300ms OutQuint animation looks pretty nice, and it would need to be sped up by 2-6x most of the time, at which point we might as well remove the animation.
One workaround I considered is changing the easing mode at smaller durations, but I don't think that's a good idea. I think it looks better if the animation is consistent in both duration and easing.

**This PR also removes the classic mod setting.**

### Extra edge case

While investigating (2), I also found out that the follow circle size is always 1 frame behind due to transforms. That's why in (2) I had to change `SliderBall` to update the tracking value in `UpdateAfterChildren()`, in order to update it after the follow circle transforms updated.

Using the virtual follow circle area eliminates this issue.

## Testing

Aside from the provided test case, I've played a bit with the _previous_ classic mod (instant animation), and both of the proposed changes. It's subtle, but I still find this is the best looking variant.

## Data

The following is a table of the _minimum_ slider velocity at which master (non-classic) loses tracking at varying circle sizes in the situation from the abstract. Tracking is lost at all higher slider velocity values.

| circle size | velocity |
| --- | --- |
| 0 | 4.0 |
| 1 | 4.0 |
| 2 | 4.0 |
| 3 | 4.0 |
| 4 | 3.0 |
| 5 | 3.0 |
| 6 | 3.0 |
| 7 | 2.0 |
| 8 | 2.0 |
| 9 | 2.0 |
| 10 | 1.0 |

Given that the above was tested at 60BPM, and SV increases as BPM increases, I think it's fair to say that the above will be the case more often than not.