### PR TITLE
Added subheadings to maintenance section in settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -17,14 +14,15 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     public class BeatmapSettings : SettingsSubsection
     {
         protected override LocalisableString Header => "Beatmaps";
-        private SettingsButton importBeatmapsButton;
-        private SettingsButton deleteBeatmapsButton;
-        private SettingsButton deleteBeatmapVideosButton;
-        private SettingsButton restoreButton;
-        private SettingsButton undeleteButton;
 
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(BeatmapManager beatmaps, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        private SettingsButton importBeatmapsButton = null!;
+        private SettingsButton deleteBeatmapsButton = null!;
+        private SettingsButton deleteBeatmapVideosButton = null!;
+        private SettingsButton restoreButton = null!;
+        private SettingsButton undeleteButton = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(BeatmapManager beatmaps, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
         {
             if (legacyImportManager?.SupportsImportFromStable == true)
             {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
@@ -35,54 +35,54 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                         legacyImportManager.ImportFromStableAsync(StableContent.Beatmaps).ContinueWith(t => Schedule(() => importBeatmapsButton.Enabled.Value = true));
                     }
                 });
-
-                Add(deleteBeatmapsButton = new DangerousSettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.DeleteAllBeatmaps,
-                    Action = () =>
-                    {
-                        dialogOverlay?.Push(new MassDeleteConfirmationDialog(() =>
-                        {
-                            deleteBeatmapsButton.Enabled.Value = false;
-                            Task.Run(() => beatmaps.Delete()).ContinueWith(t => Schedule(() => deleteBeatmapsButton.Enabled.Value = true));
-                        }));
-                    }
-                });
-
-                Add(deleteBeatmapVideosButton = new DangerousSettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.DeleteAllBeatmapVideos,
-                    Action = () =>
-                    {
-                        dialogOverlay?.Push(new MassVideoDeleteConfirmationDialog(() =>
-                        {
-                            deleteBeatmapVideosButton.Enabled.Value = false;
-                            Task.Run(beatmaps.DeleteAllVideos).ContinueWith(t => Schedule(() => deleteBeatmapVideosButton.Enabled.Value = true));
-                        }));
-                    }
-                });
-                AddRange(new Drawable[]
-                {
-                    restoreButton = new SettingsButton
-                    {
-                        Text = MaintenanceSettingsStrings.RestoreAllHiddenDifficulties,
-                        Action = () =>
-                        {
-                            restoreButton.Enabled.Value = false;
-                            Task.Run(beatmaps.RestoreAll).ContinueWith(t => Schedule(() => restoreButton.Enabled.Value = true));
-                        }
-                    },
-                    undeleteButton = new SettingsButton
-                    {
-                        Text = MaintenanceSettingsStrings.RestoreAllRecentlyDeletedBeatmaps,
-                        Action = () =>
-                        {
-                            undeleteButton.Enabled.Value = false;
-                            Task.Run(beatmaps.UndeleteAll).ContinueWith(t => Schedule(() => undeleteButton.Enabled.Value = true));
-                        }
-                    }
-                });
             }
+
+            Add(deleteBeatmapsButton = new DangerousSettingsButton
+            {
+                Text = MaintenanceSettingsStrings.DeleteAllBeatmaps,
+                Action = () =>
+                {
+                    dialogOverlay?.Push(new MassDeleteConfirmationDialog(() =>
+                    {
+                        deleteBeatmapsButton.Enabled.Value = false;
+                        Task.Run(() => beatmaps.Delete()).ContinueWith(t => Schedule(() => deleteBeatmapsButton.Enabled.Value = true));
+                    }));
+                }
+            });
+
+            Add(deleteBeatmapVideosButton = new DangerousSettingsButton
+            {
+                Text = MaintenanceSettingsStrings.DeleteAllBeatmapVideos,
+                Action = () =>
+                {
+                    dialogOverlay?.Push(new MassVideoDeleteConfirmationDialog(() =>
+                    {
+                        deleteBeatmapVideosButton.Enabled.Value = false;
+                        Task.Run(beatmaps.DeleteAllVideos).ContinueWith(t => Schedule(() => deleteBeatmapVideosButton.Enabled.Value = true));
+                    }));
+                }
+            });
+            AddRange(new Drawable[]
+            {
+                restoreButton = new SettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.RestoreAllHiddenDifficulties,
+                    Action = () =>
+                    {
+                        restoreButton.Enabled.Value = false;
+                        Task.Run(beatmaps.RestoreAll).ContinueWith(t => Schedule(() => restoreButton.Enabled.Value = true));
+                    }
+                },
+                undeleteButton = new SettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.RestoreAllRecentlyDeletedBeatmaps,
+                    Action = () =>
+                    {
+                        undeleteButton.Enabled.Value = false;
+                        Task.Run(beatmaps.UndeleteAll).ContinueWith(t => Schedule(() => undeleteButton.Enabled.Value = true));
+                    }
+                }
+            });
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
@@ -9,31 +9,25 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
-using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.Localisation;
 using osu.Game.Scoring;
-using osu.Game.Skinning;
 
 namespace osu.Game.Overlays.Settings.Sections.Maintenance
 {
-    public class GeneralSettings : SettingsSubsection
+    public class BeatmapSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => "General";
-
+        protected override LocalisableString Header => "Beatmaps";
         private SettingsButton importBeatmapsButton;
         private SettingsButton importScoresButton;
-        private SettingsButton importSkinsButton;
-        private SettingsButton importCollectionsButton;
         private SettingsButton deleteBeatmapsButton;
+        private SettingsButton deleteBeatmapVideosButton;
         private SettingsButton deleteScoresButton;
-        private SettingsButton deleteSkinsButton;
         private SettingsButton restoreButton;
         private SettingsButton undeleteButton;
-        private SettingsButton deleteBeatmapVideosButton;
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(BeatmapManager beatmaps, ScoreManager scores, SkinManager skins, [CanBeNull] CollectionManager collectionManager, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        private void load(BeatmapManager beatmaps, ScoreManager scores, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
         {
             if (legacyImportManager?.SupportsImportFromStable == true)
             {
@@ -44,6 +38,15 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     {
                         importBeatmapsButton.Enabled.Value = false;
                         legacyImportManager.ImportFromStableAsync(StableContent.Beatmaps).ContinueWith(t => Schedule(() => importBeatmapsButton.Enabled.Value = true));
+                    }
+                });
+                Add(importScoresButton = new SettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.ImportScoresFromStable,
+                    Action = () =>
+                    {
+                        importScoresButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Scores).ContinueWith(t => Schedule(() => importScoresButton.Enabled.Value = true));
                     }
                 });
             }
@@ -74,19 +77,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                 }
             });
 
-            if (legacyImportManager?.SupportsImportFromStable == true)
-            {
-                Add(importScoresButton = new SettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.ImportScoresFromStable,
-                    Action = () =>
-                    {
-                        importScoresButton.Enabled.Value = false;
-                        legacyImportManager.ImportFromStableAsync(StableContent.Scores).ContinueWith(t => Schedule(() => importScoresButton.Enabled.Value = true));
-                    }
-                });
-            }
-
             Add(deleteScoresButton = new DangerousSettingsButton
             {
                 Text = MaintenanceSettingsStrings.DeleteAllScores,
@@ -99,58 +89,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     }));
                 }
             });
-
-            if (legacyImportManager?.SupportsImportFromStable == true)
-            {
-                Add(importSkinsButton = new SettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.ImportSkinsFromStable,
-                    Action = () =>
-                    {
-                        importSkinsButton.Enabled.Value = false;
-                        legacyImportManager.ImportFromStableAsync(StableContent.Skins).ContinueWith(t => Schedule(() => importSkinsButton.Enabled.Value = true));
-                    }
-                });
-            }
-
-            Add(deleteSkinsButton = new DangerousSettingsButton
-            {
-                Text = MaintenanceSettingsStrings.DeleteAllSkins,
-                Action = () =>
-                {
-                    dialogOverlay?.Push(new MassDeleteConfirmationDialog(() =>
-                    {
-                        deleteSkinsButton.Enabled.Value = false;
-                        Task.Run(() => skins.Delete()).ContinueWith(t => Schedule(() => deleteSkinsButton.Enabled.Value = true));
-                    }));
-                }
-            });
-
-            if (collectionManager != null)
-            {
-                if (legacyImportManager?.SupportsImportFromStable == true)
-                {
-                    Add(importCollectionsButton = new SettingsButton
-                    {
-                        Text = MaintenanceSettingsStrings.ImportCollectionsFromStable,
-                        Action = () =>
-                        {
-                            importCollectionsButton.Enabled.Value = false;
-                            legacyImportManager.ImportFromStableAsync(StableContent.Collections).ContinueWith(t => Schedule(() => importCollectionsButton.Enabled.Value = true));
-                        }
-                    });
-                }
-
-                Add(new DangerousSettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.DeleteAllCollections,
-                    Action = () =>
-                    {
-                        dialogOverlay?.Push(new MassDeleteConfirmationDialog(collectionManager.DeleteAll));
-                    }
-                });
-            }
-
             AddRange(new Drawable[]
             {
                 restoreButton = new SettingsButton

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
             if (collectionManager == null) return;
 
             if (legacyImportManager?.SupportsImportFromStable == true)
-
             {
                 Add(importCollectionsButton = new SettingsButton
                 {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Game.Collections;
+using osu.Game.Database;
+using osu.Game.Localisation;
+
+namespace osu.Game.Overlays.Settings.Sections.Maintenance
+{
+    public class CollectionsSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => "Collections";
+        private SettingsButton importCollectionsButton;
+
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load([CanBeNull] CollectionManager collectionManager, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        {
+            if (collectionManager != null)
+            {
+                if (legacyImportManager?.SupportsImportFromStable == true)
+                {
+                    Add(importCollectionsButton = new SettingsButton
+                    {
+                        Text = MaintenanceSettingsStrings.ImportCollectionsFromStable,
+                        Action = () =>
+                        {
+                            importCollectionsButton.Enabled.Value = false;
+                            legacyImportManager.ImportFromStableAsync(StableContent.Collections).ContinueWith(t => Schedule(() => importCollectionsButton.Enabled.Value = true));
+                        }
+                    });
+                }
+
+                Add(new DangerousSettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.DeleteAllCollections,
+                    Action = () =>
+                    {
+                        dialogOverlay?.Push(new MassDeleteConfirmationDialog(collectionManager.DeleteAll));
+                    }
+                });
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -20,30 +20,30 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load([CanBeNull] CollectionManager collectionManager, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
         {
-            if (collectionManager != null)
-            {
-                if (legacyImportManager?.SupportsImportFromStable == true)
-                {
-                    Add(importCollectionsButton = new SettingsButton
-                    {
-                        Text = MaintenanceSettingsStrings.ImportCollectionsFromStable,
-                        Action = () =>
-                        {
-                            importCollectionsButton.Enabled.Value = false;
-                            legacyImportManager.ImportFromStableAsync(StableContent.Collections).ContinueWith(t => Schedule(() => importCollectionsButton.Enabled.Value = true));
-                        }
-                    });
-                }
+            if (collectionManager == null) return;
 
-                Add(new DangerousSettingsButton
+            if (legacyImportManager?.SupportsImportFromStable == true)
+
+            {
+                Add(importCollectionsButton = new SettingsButton
                 {
-                    Text = MaintenanceSettingsStrings.DeleteAllCollections,
+                    Text = MaintenanceSettingsStrings.ImportCollectionsFromStable,
                     Action = () =>
                     {
-                        dialogOverlay?.Push(new MassDeleteConfirmationDialog(collectionManager.DeleteAll));
+                        importCollectionsButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Collections).ContinueWith(t => Schedule(() => importCollectionsButton.Enabled.Value = true));
                     }
                 });
             }
+
+            Add(new DangerousSettingsButton
+            {
+                Text = MaintenanceSettingsStrings.DeleteAllCollections,
+                Action = () =>
+                {
+                    dialogOverlay?.Push(new MassDeleteConfirmationDialog(collectionManager.DeleteAll));
+                }
+            });
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Collections;
@@ -15,10 +12,11 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     public class CollectionsSettings : SettingsSubsection
     {
         protected override LocalisableString Header => "Collections";
-        private SettingsButton importCollectionsButton;
 
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load([CanBeNull] CollectionManager collectionManager, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        private SettingsButton importCollectionsButton = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(CollectionManager? collectionManager, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
         {
             if (collectionManager == null) return;
 

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.Localisation;
+using osu.Game.Scoring;
+
+namespace osu.Game.Overlays.Settings.Sections.Maintenance
+{
+    public class ScoreSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => "Scores";
+        private SettingsButton importScoresButton;
+        private SettingsButton deleteScoresButton;
+
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load(ScoreManager scores, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        {
+            if (legacyImportManager?.SupportsImportFromStable == true)
+            {
+                Add(importScoresButton = new SettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.ImportScoresFromStable,
+                    Action = () =>
+                    {
+                        importScoresButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Scores).ContinueWith(t => Schedule(() => importScoresButton.Enabled.Value = true));
+                    }
+                });
+            }
+
+            Add(deleteScoresButton = new DangerousSettingsButton
+            {
+                Text = MaintenanceSettingsStrings.DeleteAllScores,
+                Action = () =>
+                {
+                    dialogOverlay?.Push(new MassDeleteConfirmationDialog(() =>
+                    {
+                        deleteScoresButton.Enabled.Value = false;
+                        Task.Run(() => scores.Delete()).ContinueWith(t => Schedule(() => deleteScoresButton.Enabled.Value = true));
+                    }));
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Database;
@@ -16,11 +13,12 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     public class ScoreSettings : SettingsSubsection
     {
         protected override LocalisableString Header => "Scores";
-        private SettingsButton importScoresButton;
-        private SettingsButton deleteScoresButton;
 
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(ScoreManager scores, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        private SettingsButton importScoresButton = null!;
+        private SettingsButton deleteScoresButton = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(ScoreManager scores, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
         {
             if (legacyImportManager?.SupportsImportFromStable == true)
             {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.Localisation;
+using osu.Game.Skinning;
+
+namespace osu.Game.Overlays.Settings.Sections.Maintenance
+{
+    public class SkinSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => "Skins";
+        private SettingsButton importSkinsButton;
+        private SettingsButton deleteSkinsButton;
+
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load(SkinManager skins, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        {
+            if (legacyImportManager?.SupportsImportFromStable == true)
+            {
+                Add(importSkinsButton = new SettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.ImportSkinsFromStable,
+                    Action = () =>
+                    {
+                        importSkinsButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Skins).ContinueWith(t => Schedule(() => importSkinsButton.Enabled.Value = true));
+                    }
+                });
+            }
+
+            Add(deleteSkinsButton = new DangerousSettingsButton
+            {
+                Text = MaintenanceSettingsStrings.DeleteAllSkins,
+                Action = () =>
+                {
+                    dialogOverlay?.Push(new MassDeleteConfirmationDialog(() =>
+                    {
+                        deleteSkinsButton.Enabled.Value = false;
+                        Task.Run(() => skins.Delete()).ContinueWith(t => Schedule(() => deleteSkinsButton.Enabled.Value = true));
+                    }));
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Database;
@@ -16,11 +13,12 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     public class SkinSettings : SettingsSubsection
     {
         protected override LocalisableString Header => "Skins";
-        private SettingsButton importSkinsButton;
-        private SettingsButton deleteSkinsButton;
 
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(SkinManager skins, [CanBeNull] LegacyImportManager legacyImportManager, IDialogOverlay dialogOverlay)
+        private SettingsButton importSkinsButton = null!;
+        private SettingsButton deleteSkinsButton = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skins, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
         {
             if (legacyImportManager?.SupportsImportFromStable == true)
             {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>.Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -24,7 +24,10 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             Children = new Drawable[]
             {
-                new GeneralSettings()
+                new BeatmapSettings(),
+                new SkinSettings(),
+                new CollectionsSettings(),
+                new ScoreSettings()
             };
         }
     }


### PR DESCRIPTION
At the moment, the maintenance section is just one big block of buttons, seemingly ordered in no meaningful way.
This PR separates each 'category' into its own subheading to improve the general feel of that section, even though it's not generally used.


![osu_2022-06-21_23-48-08](https://user-images.githubusercontent.com/36936474/174909481-a26e485d-55ea-4cd3-b88c-7cdcb1ec5a9e.jpg)

