### PR TITLE
Add back online view container to chat overlay

### DIFF
--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -18,6 +18,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
+using osu.Game.Online;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat;
 using osu.Game.Overlays.Chat.ChannelList;
@@ -100,23 +101,10 @@ namespace osu.Game.Overlays
                     RelativeSizeAxes = Axes.X,
                     Height = top_bar_height,
                 },
-                channelList = new ChannelList
-                {
-                    RelativeSizeAxes = Axes.Y,
-                    Width = side_bar_width,
-                    Padding = new MarginPadding { Top = top_bar_height },
-                },
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight,
-                    Padding = new MarginPadding
-                    {
-                        Top = top_bar_height,
-                        Left = side_bar_width,
-                        Bottom = chat_bar_height,
-                    },
+                    Padding = new MarginPadding { Top = top_bar_height },
                     Children = new Drawable[]
                     {
                         new Box
@@ -124,24 +112,50 @@ namespace osu.Game.Overlays
                             RelativeSizeAxes = Axes.Both,
                             Colour = colourProvider.Background4,
                         },
-                        currentChannelContainer = new Container<DrawableChannel>
+                        new OnlineViewContainer("Sign in to chat")
                         {
                             RelativeSizeAxes = Axes.Both,
-                        },
-                        loading = new LoadingLayer(true),
-                        channelListing = new ChannelListing
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                    },
-                },
-                textBar = new ChatTextBar
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                    Padding = new MarginPadding { Left = side_bar_width },
-                },
+                            Children = new Drawable[]
+                            {
+                                channelList = new ChannelList
+                                {
+                                    RelativeSizeAxes = Axes.Y,
+                                    Width = side_bar_width,
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight,
+                                    Padding = new MarginPadding
+                                    {
+                                        Left = side_bar_width,
+                                        Bottom = chat_bar_height,
+                                    },
+                                    Children = new Drawable[]
+                                    {
+                                        currentChannelContainer = new Container<DrawableChannel>
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        loading = new LoadingLayer(true),
+                                        channelListing = new ChannelListing
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                    },
+                                },
+                                textBar = new ChatTextBar
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.BottomRight,
+                                    Padding = new MarginPadding { Left = side_bar_width },
+                                },
+                            }
+                        }
+                    }
+                }
             };
         }
 


### PR DESCRIPTION
The redesign didn't put back the online view container, causing chat to look like you're online until you try to type something.

The diff looks better without whitespace changes.