### PR TITLE
Remove room null assertion in `TestMultiplayerClient.ChangeState` to avoid assert

### DIFF
--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -272,8 +272,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public override Task ChangeState(MultiplayerUserState newState)
         {
-            Debug.Assert(Room != null);
-
             if (newState == MultiplayerUserState.Idle && LocalUser?.State == MultiplayerUserState.WaitingForLoad)
                 return Task.CompletedTask;
 


### PR DESCRIPTION
This method is run from async contexts, but `get_Room` asserts update thread which is not the case. Was causing silent test failures (showing as pass but failing `dotnet-test` via return code):

TestSceneMultiplayer.TestGameplayFlow

```
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: Score preparation failed!
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: NUnit.Framework.AssertionException: :
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at osu.Framework.Logging.ThrowingTraceListener.Fail(String message1, String message2)
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at System.Diagnostics.TraceInternal.TraceProvider.Fail(String message, String detailMessage)
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at System.Diagnostics.Debug.Fail(String message, String detailMessage)
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at osu.Game.Online.Multiplayer.MultiplayerClient.get_Room() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Online/Multiplayer/MultiplayerClient.cs:line 98
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at osu.Game.Tests.Visual.Multiplayer.TestMultiplayerClient.ChangeState(MultiplayerUserState newState) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs:line 275
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at osu.Game.Screens.OnlinePlay.Multiplayer.MultiplayerPlayer.PrepareScoreForResultsAsync(Score score) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs:line 223
[13:13:17] :         [dotnet test] [runtime] 2022-06-22 13:13:16 [error]: at osu.Game.Screens.Play.Player.prepareScoreForResults() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Screens/Play/Player.cs:line 747
```

Not sure if there's a better way to avoid removing the check. Also as for the underlying test issue aka `Debug.Assert` not failing the test,  @smoogipoo has mentioned he will take a look into it.