### PR TITLE
Fix dangerous `File.Copy` causing intermittent realm migration test failures

### DIFF
--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -254,7 +254,7 @@ namespace osu.Game.Tests.NonVisual
                     Assert.That(File.Exists(Path.Combine(customPath, OsuGameBase.CLIENT_DATABASE_FILENAME)));
 
                     Directory.CreateDirectory(customPath2);
-                    File.Copy(Path.Combine(customPath, OsuGameBase.CLIENT_DATABASE_FILENAME), Path.Combine(customPath2, OsuGameBase.CLIENT_DATABASE_FILENAME));
+                    File.WriteAllText(Path.Combine(customPath2, OsuGameBase.CLIENT_DATABASE_FILENAME), "I am a text");
 
                     // Fails because file already exists.
                     Assert.Throws<ArgumentException>(() => osu.Migrate(customPath2));


### PR DESCRIPTION
Resolves an issue I've been able to locally reproduce on windows.  Basically, the `File.Copy` would begin while realm was blocking. The "restore" operation is posted to the `SynchronizationContext` to run on next update call, but in the mean time the copy would begin, causing a conflict of interest.

Very dangerous. Only really noticeable on windows.

```csharp
Multiple failures or warnings in test:
  1) Host threw exception System.AggregateException: One or more errors occurred. (Unable to open a realm at path 'C:\BuildAgent\temp\buildTmp\of-test-headless\custom-path-3c0b26ef-b28c-4e5c-9e37-42083d37cc3f\client.realm'. Please use a path where your app has read-write permissions.)
 ---> Realms.Exceptions.RealmPermissionDeniedException: Unable to open a realm at path 'C:\BuildAgent\temp\buildTmp\of-test-headless\custom-path-3c0b26ef-b28c-4e5c-9e37-42083d37cc3f\client.realm'. Please use a path where your app has read-write permissions.
   at Realms.NativeException.ThrowIfNecessary(Func`2 overrider)
   at Realms.SharedRealmHandle.Open(Configuration configuration, RealmSchema schema, Byte[] encryptionKey)
   at Realms.RealmConfiguration.CreateHandle(RealmSchema schema)
   at Realms.RealmConfigurationBase.CreateRealm()
   at Realms.Realm.GetInstance(RealmConfigurationBase config)
   at osu.Game.Database.RealmAccess.getRealmInstance() in C:\BuildAgent\work\ecd860037212ac52\osu.Game\Database\RealmAccess.cs:line 583
   at osu.Game.Database.RealmAccess.ensureUpdateRealm() in C:\BuildAgent\work\ecd860037212ac52\osu.Game\Database\RealmAccess.cs:line 123
   at osu.Game.Database.RealmAccess.<>c__DisplayClass44_0.<BlockAllOperations>b__3(Object _) in C:\BuildAgent\work\ecd860037212ac52\osu.Game\Database\RealmAccess.cs:line 901
   at osu.Framework.Threading.GameThreadSynchronizationContext.<>c__DisplayClass5_0.<Post>b__0()
   at osu.Framework.Threading.ScheduledDelegate.InvokeTask()
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Threading.GameThreadSynchronizationContext.RunWork()
   at osu.Framework.Threading.GameThread.processFrame()
--- End of stack trace from previous location ---
   at osu.Framework.Platform.GameHost.<>c__DisplayClass128_0.<abortExecutionFromException>b__0()
   at osu.Framework.Threading.ScheduledDelegate.InvokeTask()
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Threading.GameThread.processFrame()
   at osu.Framework.Threading.GameThread.RunSingleFrame()
   at osu.Framework.Platform.ThreadRunner.RunMainLoop()
   at osu.Framework.Platform.GameHost.windowUpdate()
   at osu.Framework.Platform.GameHost.Run(Game game)
   at osu.Game.Tests.ImportTest.<>c__DisplayClass0_0.<LoadOsuIntoHost>b__0() in C:\BuildAgent\work\ecd860037212ac52\osu.Game.Tests\ImportTest.cs:line 23
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__272_0(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   --- End of inner exception stack trace ---
  2)   Expected: <System.ArgumentException>
  But was:  <System.TimeoutException: Attempting to block for migration took too long.
   at osu.Game.OsuGameBase.Migrate(String path) in C:\BuildAgent\work\ecd860037212ac52\osu.Game\OsuGameBase.cs:line 455
   at osu.Game.Tests.NonVisual.CustomDataDirectoryTest.<>c__DisplayClass6_1.<TestMigrationFailsOnExistingData>b__1() in C:\BuildAgent\work\ecd860037212ac52\osu.Game.Tests\NonVisual\CustomDataDirectoryTest.cs:line 260
   at NUnit.Framework.Assert.Throws(IResolveConstraint expression, TestDelegate code, String message, Object[] args)>
   at osu.Game.Tests.NonVisual.CustomDataDirectoryTest.TestMigrationFailsOnExistingData() in C:\BuildAgent\work\ecd860037212ac52\osu.Game.Tests\NonVisual\CustomDataDirectoryTest.cs:line 260
```