### PR TITLE
Disallow usage of `string.To{Upper,Lower}()` without explicit culture

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -17,3 +17,5 @@ M:Realms.CollectionExtensions.SubscribeForNotifications`1(System.Collections.Gen
 M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.
 P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetResultSafely() to ensure we avoid deadlocks.
 M:System.Threading.ManualResetEventSlim.Wait();Specify a timeout to avoid waiting forever.
+M:System.String.ToLower();string.ToLower() changes behaviour depending on CultureInfo.CurrentCulture. Use string.ToLowerInvariant() instead. If wanting culture-sensitive behaviour, explicitly provide CultureInfo.CurrentCulture or use LocalisableString.
+M:System.String.ToUpper();string.ToUpper() changes behaviour depending on CultureInfo.CurrentCulture. Use string.ToUpperInvariant() instead. If wanting culture-sensitive behaviour, explicitly provide CultureInfo.CurrentCulture or use LocalisableString.

--- a/osu.Game.Rulesets.Catch/CatchSkinComponent.cs
+++ b/osu.Game.Rulesets.Catch/CatchSkinComponent.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Catch
 
         protected override string RulesetPrefix => "catch"; // todo: use CatchRuleset.SHORT_NAME;
 
-        protected override string ComponentName => Component.ToString().ToLower();
+        protected override string ComponentName => Component.ToString().ToLowerInvariant();
     }
 }

--- a/osu.Game.Rulesets.Mania/ManiaSkinComponent.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSkinComponent.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mania
 
         protected override string RulesetPrefix => ManiaRuleset.SHORT_NAME;
 
-        protected override string ComponentName => Component.ToString().ToLower();
+        protected override string ComponentName => Component.ToString().ToLowerInvariant();
     }
 
     public enum ManiaSkinComponents

--- a/osu.Game.Rulesets.Osu/OsuSkinComponent.cs
+++ b/osu.Game.Rulesets.Osu/OsuSkinComponent.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Osu
 
         protected override string RulesetPrefix => OsuRuleset.SHORT_NAME;
 
-        protected override string ComponentName => Component.ToString().ToLower();
+        protected override string ComponentName => Component.ToString().ToLowerInvariant();
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             createDrawableRuleset();
 
             assertStateAfterResult(new JudgementResult(new Swell(), new TaikoSwellJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Clear);
-            AddUntilStep($"state reverts to {expectedStateAfterClear.ToString().ToLower()}", () => allMascotsIn(expectedStateAfterClear));
+            AddUntilStep($"state reverts to {expectedStateAfterClear.ToString().ToLowerInvariant()}", () => allMascotsIn(expectedStateAfterClear));
         }
 
         private void setBeatmap(bool kiai = false)
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             TaikoMascotAnimationState[] mascotStates = null;
 
-            AddStep($"{judgementResult.Type.ToString().ToLower()} result for {judgementResult.Judgement.GetType().Name.Humanize(LetterCasing.LowerCase)}",
+            AddStep($"{judgementResult.Type.ToString().ToLowerInvariant()} result for {judgementResult.Judgement.GetType().Name.Humanize(LetterCasing.LowerCase)}",
                 () =>
                 {
                     applyNewResult(judgementResult);
@@ -204,7 +204,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
                     Schedule(() => mascotStates = animatedMascots.Select(mascot => mascot.State.Value).ToArray());
                 });
 
-            AddAssert($"state is {expectedState.ToString().ToLower()}", () => mascotStates.All(state => state == expectedState));
+            AddAssert($"state is {expectedState.ToString().ToLowerInvariant()}", () => mascotStates.All(state => state == expectedState));
         }
 
         private void applyNewResult(JudgementResult judgementResult)

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponent.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponent.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Taiko
 
         protected override string RulesetPrefix => TaikoRuleset.SHORT_NAME;
 
-        protected override string ComponentName => Component.ToString().ToLower();
+        protected override string ComponentName => Component.ToString().ToLowerInvariant();
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimation.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimation.cs
@@ -139,10 +139,10 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private static Texture getAnimationFrame(ISkin skin, TaikoMascotAnimationState state, int frameIndex)
         {
-            var texture = skin.GetTexture($"pippidon{state.ToString().ToLower()}{frameIndex}");
+            var texture = skin.GetTexture($"pippidon{state.ToString().ToLowerInvariant()}{frameIndex}");
 
             if (frameIndex == 0 && texture == null)
-                texture = skin.GetTexture($"pippidon{state.ToString().ToLower()}");
+                texture = skin.GetTexture($"pippidon{state.ToString().ToLowerInvariant()}");
 
             return texture;
         }

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Tests.Gameplay
             AddStep("apply perfect hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = HitResult.Perfect }));
             AddAssert("not failed", () => !processor.HasFailed);
 
-            AddStep($"apply {resultApplied.ToString().ToLower()} hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = resultApplied }));
+            AddStep($"apply {resultApplied.ToString().ToLowerInvariant()} hit result", () => processor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new Judgement()) { Type = resultApplied }));
             AddAssert("failed", () => processor.HasFailed);
         }
 

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -66,14 +66,14 @@ namespace osu.Game.Tournament.Models
             {
                 // use a sane default flag name based on acronym.
                 if (val.OldValue.StartsWith(FlagName.Value, StringComparison.InvariantCultureIgnoreCase))
-                    FlagName.Value = val.NewValue.Length >= 2 ? val.NewValue?.Substring(0, 2).ToUpper() : string.Empty;
+                    FlagName.Value = val.NewValue.Length >= 2 ? val.NewValue?.Substring(0, 2).ToUpperInvariant() : string.Empty;
             };
 
             FullName.ValueChanged += val =>
             {
                 // use a sane acronym based on full name.
                 if (val.OldValue.StartsWith(Acronym.Value, StringComparison.InvariantCultureIgnoreCase))
-                    Acronym.Value = val.NewValue.Length >= 3 ? val.NewValue?.Substring(0, 3).ToUpper() : string.Empty;
+                    Acronym.Value = val.NewValue.Length >= 3 ? val.NewValue?.Substring(0, 3).ToUpperInvariant() : string.Empty;
             };
         }
 

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentRound.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentRound.cs
@@ -49,10 +49,10 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             };
 
             name = round.Name.GetBoundCopy();
-            name.BindValueChanged(n => textName.Text = ((losers ? "Losers " : "") + round.Name).ToUpper(), true);
+            name.BindValueChanged(n => textName.Text = ((losers ? "Losers " : "") + round.Name).ToUpperInvariant(), true);
 
             description = round.Description.GetBoundCopy();
-            description.BindValueChanged(n => textDescription.Text = round.Description.Value?.ToUpper(), true);
+            description.BindValueChanged(n => textDescription.Text = round.Description.Value?.ToUpperInvariant(), true);
         }
     }
 }

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                     {
                         row.Add(new Sprite
                         {
-                            Texture = textures.Get($"Mods/{mods.ToLower()}"),
+                            Texture = textures.Get($"Mods/{mods.ToLowerInvariant()}"),
                             Scale = new Vector2(0.5f)
                         });
                     }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/FavouriteButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/FavouriteButton.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             };
             favouriteRequest.Failure += e =>
             {
-                Logger.Error(e, $"Failed to {actionType.ToString().ToLower()} beatmap: {e.Message}");
+                Logger.Error(e, $"Failed to {actionType.ToString().ToLowerInvariant()} beatmap: {e.Message}");
                 Enabled.Value = true;
             };
 

--- a/osu.Game/Database/IModelImporter.cs
+++ b/osu.Game/Database/IModelImporter.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Database
         /// <summary>
         /// A user displayable name for the model type associated with this manager.
         /// </summary>
-        string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLower()}";
+        string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLowerInvariant()}";
 
         /// <summary>
         /// Fired when the user requests to view the resulting import.

--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -201,6 +201,6 @@ namespace osu.Game.Database
 
         public Action<Notification>? PostNotification { get; set; }
 
-        public virtual string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLower()}";
+        public virtual string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLowerInvariant()}";
     }
 }

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -549,6 +549,6 @@ namespace osu.Game.Database
                 yield return f.Filename;
         }
 
-        public virtual string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLower()}";
+        public virtual string HumanisedModelName => $"{typeof(TModel).Name.Replace(@"Info", "").ToLowerInvariant()}";
     }
 }

--- a/osu.Game/Online/API/Requests/GetSpotlightRankingsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetSpotlightRankingsRequest.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Online.API.Requests
             var req = base.CreateWebRequest();
 
             req.AddParameter("spotlight", spotlight.ToString());
-            req.AddParameter("filter", sort.ToString().ToLower());
+            req.AddParameter("filter", sort.ToString().ToLowerInvariant());
 
             return req;
         }

--- a/osu.Game/Online/API/Requests/GetUserRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRequest.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Online.API.Requests
             Ruleset = ruleset;
         }
 
-        protected override string Target => Lookup != null ? $@"users/{Lookup}/{Ruleset?.ShortName}?key={lookupType.ToString().ToLower()}" : $@"me/{Ruleset?.ShortName}";
+        protected override string Target => Lookup != null ? $@"users/{Lookup}/{Ruleset?.ShortName}?key={lookupType.ToString().ToLowerInvariant()}" : $@"me/{Ruleset?.ShortName}";
 
         private enum LookupType
         {

--- a/osu.Game/Online/Leaderboards/UserTopScoreContainer.cs
+++ b/osu.Game/Online/Leaderboards/UserTopScoreContainer.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Online.Leaderboards
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
-                            Text = @"your personal best".ToUpper(),
+                            Text = @"your personal best".ToUpperInvariant(),
                             Font = OsuFont.GetFont(size: 15, weight: FontWeight.Bold),
                         },
                         scoreContainer = new Container

--- a/osu.Game/Overlays/Chat/DaySeparator.cs
+++ b/osu.Game/Overlays/Chat/DaySeparator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -79,7 +80,7 @@ namespace osu.Game.Overlays.Chat
                                     {
                                         Anchor = Anchor.CentreRight,
                                         Origin = Anchor.CentreRight,
-                                        Text = time.ToLocalTime().ToString("dd MMMM yyyy").ToUpper(),
+                                        Text = time.ToLocalTime().ToLocalisableString(@"dd MMMM yyyy").ToUpper(),
                                         Font = OsuFont.Torus.With(size: TextSize, weight: FontWeight.SemiBold),
                                         Colour = colourProvider?.Content1 ?? Colour4.White,
                                     },

--- a/osu.Game/Overlays/News/NewsCard.cs
+++ b/osu.Game/Overlays/News/NewsCard.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -146,7 +147,7 @@ namespace osu.Game.Overlays.News
                     },
                     new OsuSpriteText
                     {
-                        Text = date.ToString("d MMM yyyy").ToUpper(),
+                        Text = date.ToLocalisableString(@"d MMM yyyy").ToUpper(),
                         Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
                         Margin = new MarginPadding
                         {

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -109,15 +109,15 @@ namespace osu.Game.Overlays
                     : base(value)
                 {
                     if (!(Value is Enum enumValue))
-                        Text.Text = Value.ToString().ToLower();
+                        Text.Text = Value.ToString().ToLowerInvariant();
                     else
                     {
                         var localisableDescription = enumValue.GetLocalisableDescription();
                         string nonLocalisableDescription = enumValue.GetDescription();
 
-                        // If localisable == non-localisable, then we must have a basic string, so .ToLower() is used.
+                        // If localisable == non-localisable, then we must have a basic string, so .ToLowerInvariant() is used.
                         Text.Text = localisableDescription.Equals(nonLocalisableDescription)
-                            ? nonLocalisableDescription.ToLower()
+                            ? nonLocalisableDescription.ToLowerInvariant()
                             : localisableDescription;
                     }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckMutedObjects.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (edgeType == EdgeType.None)
                 yield break;
 
-            string postfix = hitObject is IHasDuration ? edgeType.ToString().ToLower() : null;
+            string postfix = hitObject is IHasDuration ? edgeType.ToString().ToLowerInvariant() : null;
 
             if (maxVolume <= muted_threshold)
             {

--- a/osu.Game/Rulesets/Edit/Checks/CheckTooShortAudioFiles.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckTooShortAudioFiles.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             }
         }
 
-        private bool hasAudioExtension(string filename) => audioExtensions.Any(filename.ToLower().EndsWith);
+        private bool hasAudioExtension(string filename) => audioExtensions.Any(filename.ToLowerInvariant().EndsWith);
         private bool probablyHasAudioData(Stream data) => data.Length > min_bytes_threshold;
 
         public class IssueTemplateTooShort : IssueTemplate

--- a/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
                         new OsuSpriteText
                         {
                             Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 12),
-                            Text = title.ToUpper(),
+                            Text = title.ToUpperInvariant(),
                         },
                         content = new Container
                         {

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Select
         {
             foreach (Match match in query_syntax_regex.Matches(query))
             {
-                string key = match.Groups["key"].Value.ToLower();
+                string key = match.Groups["key"].Value.ToLowerInvariant();
                 var op = parseOperator(match.Groups["op"].Value);
                 string value = match.Groups["value"].Value;
 


### PR DESCRIPTION
Same as https://github.com/ppy/osu-framework/pull/5261. Vaguely related to https://github.com/ppy/osu/issues/18729.

I have changes planned to address the issue linked by replacing humanizer methods with game-side fixed copies but I'm PRing this separately to reduce size since this touches a good few files.

Guidelines taken when replacing:

- String is not user-facing (lookup string, filename) => convert as invariant
- String is user-facing in a context where localisation doesn't matter (tourney client, visual tests) => convert as invariant
- String is user-facing but localisation is not easy to support for whatever reason => convert as invariant for now
- String is user-facing and can be easily localised => use `LocalisableString` (two cases of this here).