### PR TITLE
Adjust menu cursor rotation to use a floating centre-point

### DIFF
--- a/osu.Game/Graphics/Cursor/MenuCursor.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursor.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Graphics.Cursor
         {
             if (dragRotationState != DragRotationState.NotDragging)
             {
+                if (Vector2.Distance(positionMouseDown, e.MousePosition) > 100)
+                    positionMouseDown = Interpolation.ValueAt(0.001f, positionMouseDown, e.MousePosition, 0, Clock.ElapsedFrameTime);
+
                 var position = e.MousePosition;
                 float distance = Vector2Extensions.Distance(position, positionMouseDown);
 

--- a/osu.Game/Graphics/Cursor/MenuCursor.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursor.cs
@@ -51,15 +51,16 @@ namespace osu.Game.Graphics.Cursor
         {
             if (dragRotationState != DragRotationState.NotDragging)
             {
-                if (Vector2.Distance(positionMouseDown, e.MousePosition) > 100)
-                    positionMouseDown = Interpolation.ValueAt(0.001f, positionMouseDown, e.MousePosition, 0, Clock.ElapsedFrameTime);
+                // make the rotation centre point floating.
+                if (Vector2.Distance(positionMouseDown, e.MousePosition) > 60)
+                    positionMouseDown = Interpolation.ValueAt(0.005f, positionMouseDown, e.MousePosition, 0, Clock.ElapsedFrameTime);
 
                 var position = e.MousePosition;
                 float distance = Vector2Extensions.Distance(position, positionMouseDown);
 
                 // don't start rotating until we're moved a minimum distance away from the mouse down location,
                 // else it can have an annoying effect.
-                if (dragRotationState == DragRotationState.DragStarted && distance > 30)
+                if (dragRotationState == DragRotationState.DragStarted && distance > 80)
                     dragRotationState = DragRotationState.Rotating;
 
                 // don't rotate when distance is zero to avoid NaN
@@ -74,7 +75,7 @@ namespace osu.Game.Graphics.Cursor
                     if (diff > 180) diff -= 360;
                     degrees = activeCursor.Rotation + diff;
 
-                    activeCursor.RotateTo(degrees, 600, Easing.OutQuint);
+                    activeCursor.RotateTo(degrees, 120, Easing.OutQuint);
                 }
             }
 
@@ -114,7 +115,7 @@ namespace osu.Game.Graphics.Cursor
 
                 if (dragRotationState != DragRotationState.NotDragging)
                 {
-                    activeCursor.RotateTo(0, 600 * (1 + Math.Abs(activeCursor.Rotation / 720)), Easing.OutElasticHalf);
+                    activeCursor.RotateTo(0, 400 * (0.5f + Math.Abs(activeCursor.Rotation / 960)), Easing.OutElasticQuarter);
                     dragRotationState = DragRotationState.NotDragging;
                 }
 


### PR DESCRIPTION
Been bugging me for a while. Adjusted snappiness of animations and fixed centre point being stuck at original mouse down location.