### PR TITLE
Attempt to fix flaky `EditorNavigation` test

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorNavigation.cs
@@ -9,10 +9,12 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Screens.Select;
 using osu.Game.Tests.Resources;
@@ -38,7 +40,10 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("switch ruleset", () => Game.Ruleset.Value = new ManiaRuleset().RulesetInfo);
 
             AddStep("open editor", () => ((PlaySongSelect)Game.ScreenStack.CurrentScreen).Edit(beatmapSet.Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == 0)));
-            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.IsLoaded);
+            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor
+                                                       && editor.IsLoaded
+                                                       && editor.ChildrenOfType<HitObjectComposer>().FirstOrDefault()?.IsLoaded == true
+                                                       && editor.ChildrenOfType<TimelineArea>().FirstOrDefault()?.IsLoaded == true);
             AddStep("test gameplay", () =>
             {
                 var testGameplayButton = this.ChildrenOfType<TestGameplayButton>().Single();


### PR DESCRIPTION
Conditionals taken from
https://github.com/ppy/osu/blob/f8830c6850128456266c82de83273204f8b74ac0/osu.Game/Tests/Visual/EditorTestScene.cs#L61-L62
where it seemed to resolve other similar cases.

I'm sure this can be found on github actions, but it failed more than
any other test on teamcity. One such fail log is below:

```csharp
TearDown : System.TimeoutException : "wait for player" timed out
--TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in C:\BuildAgent\work\ecd860037212ac52\osu.Game\Tests\Visual\OsuTestScene.cs:line 503
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
------- Stdout: -------
[runtime] 2022-06-26 16:26:11 [verbose]: 💨 Class: TestSceneEditorNavigation
[runtime] 2022-06-26 16:26:11 [verbose]: 🔶 Test:  TestEditorGameplayTestAlwaysUsesOriginalRuleset
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #1 Create new game instance
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded UpdateManager!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading FirstRunSetupOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading ManageCollectionsDialog...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading BeatmapListingOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading DashboardOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading NewsOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading RankingsOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading ChannelManager...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading ChatOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading MessageNotifier...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading SettingsOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading ChangelogOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading UserProfileOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading BeatmapSetOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading WikiOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading SkinEditorOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading LoginOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading NowPlayingOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading AccountCreationOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading DialogOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loading HighPerformanceSession...
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/FontAwesome5/FontAwesome-Solid
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/FontAwesome5/FontAwesome-Regular
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Roboto/Roboto-Regular
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/FontAwesome5/FontAwesome-Brands
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Roboto/Roboto-RegularItalic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Roboto/Roboto-Bold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Roboto/Roboto-BoldItalic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/RobotoCondensed/RobotoCondensed-Regular
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/RobotoCondensed/RobotoCondensed-Bold
[runtime] 2022-06-26 16:26:11 [verbose]: Beginning realm file store cleanup
[runtime] 2022-06-26 16:26:11 [verbose]: Opened realm "C:\BuildAgent\temp\buildTmp\of-test-headless\TestSceneEditorNavigation-09ef831b-c724-4116-ab5b-4d41c3e54fca\client.realm" at version 14
[runtime] 2022-06-26 16:26:11 [verbose]: Finished realm file store cleanup (0 of 0 deleted)
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/osuFont
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus/Torus-Regular
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus/Torus-Light
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus/Torus-SemiBold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus/Torus-Bold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus-Alternate/Torus-Alternate-Regular
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus-Alternate/Torus-Alternate-Light
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus-Alternate/Torus-Alternate-SemiBold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Torus-Alternate/Torus-Alternate-Bold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-Regular
[performance] 2022-06-26 16:26:11 [verbose]: TextureAtlas initialised (1024x1024)
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-RegularItalic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-Light
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-LightItalic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-SemiBold
[runtime] 2022-06-26 16:26:11 [verbose]: Game-wide working beatmap updated to please load a beatmap! - no beatmaps available!
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-SemiBoldItalic
[performance] 2022-06-26 16:26:11 [verbose]: TextureAtlas initialised (1024x1024)
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-Bold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Inter/Inter-BoldItalic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Noto/Noto-Basic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Noto/Noto-Hangul
[runtime] 2022-06-26 16:26:11 [verbose]: Loading VersionManager...
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Noto/Noto-CJK-Basic
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Noto/Noto-CJK-Compatibility
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Noto/Noto-Thai
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Venera/Venera-Light
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Venera/Venera-Bold
[runtime] 2022-06-26 16:26:11 [verbose]: Cached font load for Fonts/Venera/Venera-Black
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #2 Wait for load
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #3 Wait for intro
[performance] 2022-06-26 16:26:11 [verbose]: Texture requested (1920x8) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded VersionManager!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading OsuLogo...
[performance] 2022-06-26 16:26:11 [verbose]: TextureAtlas size exceeded 1 time(s); generating new texture (1024x1024)
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 OsuScreenStack#132(depth:1) loading OsuGameTestScene+TestLoader#563
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 OsuScreenStack#132(depth:1) entered OsuGameTestScene+TestLoader#563
[database] 2022-06-26 16:26:11 [verbose]: [?????] Beginning import...
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded OsuLogo!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading Toolbar...
[performance] 2022-06-26 16:26:11 [verbose]: TextureAtlas size exceeded 2 time(s); generating new texture (1024x1024)
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded Toolbar!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading VolumeOverlay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded VolumeOverlay!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading OnScreenDisplay...
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded OnScreenDisplay!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading NotificationOverlay...
[database] 2022-06-26 16:26:11 [verbose]: [3c8b1] Import successfully completed!
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 OsuScreenStack#132(depth:1) suspended OsuGameTestScene+TestLoader#563 (waiting on IntroCircles#379)
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 OsuScreenStack#132(depth:2) entered IntroCircles#379
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 BackgroundScreenStack#579(depth:1) loading BackgroundScreenBlack#559
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded NotificationOverlay!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading CollectionManager...
[runtime] 2022-06-26 16:26:11 [verbose]: Game-wide working beatmap updated to nekodex - circles! (peppy)
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 BackgroundScreenStack#579(depth:1) entered BackgroundScreenBlack#559
[runtime] 2022-06-26 16:26:11 [verbose]: ✔️ 129 repetitions
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #4 Wait for main menu
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded CollectionManager!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading LegacyImportManager...
[runtime] 2022-06-26 16:26:11 [verbose]: decoupled ruleset transferred ("" -> "osu!")
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 OsuScreenStack#132(depth:2) suspended IntroCircles#379 (waiting on MainMenu#431)
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 OsuScreenStack#132(depth:3) entered MainMenu#431
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 BackgroundScreenStack#579(depth:2) suspended BackgroundScreenBlack#559 (waiting on BackgroundScreenDefault#261)
[runtime] 2022-06-26 16:26:11 [verbose]: 📺 BackgroundScreenStack#579(depth:2) entered BackgroundScreenDefault#261
[runtime] 2022-06-26 16:26:11 [verbose]: ✔️ 14 repetitions
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #5 import test beatmap
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded LegacyImportManager!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading ScreenshotManager...
[performance] 2022-06-26 16:26:11 [verbose]: TextureAtlas size exceeded 1 time(s); generating new texture (1024x1024)
[database] 2022-06-26 16:26:11 [verbose]: [?????] Beginning import...
[database] 2022-06-26 16:26:11 [verbose]: [672a6] Import successfully completed!
[runtime] 2022-06-26 16:26:11 [verbose]: Loaded ScreenshotManager!
[runtime] 2022-06-26 16:26:11 [verbose]: Loading UpdateManager...
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #6 retrieve beatmap
[runtime] 2022-06-26 16:26:11 [verbose]: 🔸 Step #7 present beatmap
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded UpdateManager!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading FirstRunSetupOverlay...
[runtime] 2022-06-26 16:26:12 [verbose]: Game-wide working beatmap updated to Soleily - Renatus (Gamu) [Hard]
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:3) suspended MainMenu#431 (waiting on PlaySongSelect#274)
[runtime] 2022-06-26 16:26:12 [verbose]: ButtonSystem's state changed from Initial to EnteringMode
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:4) entered PlaySongSelect#274
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 BackgroundScreenStack#579(depth:3) loading BackgroundScreenBeatmap#547
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded FirstRunSetupOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading ManageCollectionsDialog...
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 BackgroundScreenStack#579(depth:3) suspended BackgroundScreenDefault#261 (waiting on BackgroundScreenBeatmap#547)
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 BackgroundScreenStack#579(depth:3) entered BackgroundScreenBeatmap#547
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded ManageCollectionsDialog!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading BeatmapListingOverlay...
[runtime] 2022-06-26 16:26:12 [verbose]: 🔸 Step #8 wait for song select
[runtime] 2022-06-26 16:26:12 [verbose]: updating selection with beatmap:cad02b3e-4e6e-483d-8fd3-3ac522191428 ruleset:osu
[network] 2022-06-26 16:26:12 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[network] 2022-06-26 16:26:12 [verbose]: Request to https://a.ppy.sh/1001 failed with System.Net.WebException: NotFound.
[runtime] 2022-06-26 16:26:12 [verbose]: ⚠️ Imported 1 of 1 beatmaps
[runtime] 2022-06-26 16:26:12 [verbose]: Focus contention triggered by NotificationOverlay.
[runtime] 2022-06-26 16:26:12 [verbose]: 🔸 Step #9 switch ruleset
[runtime] 2022-06-26 16:26:12 [verbose]: 🔸 Step #10 open editor
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:4) suspended PlaySongSelect#274 (waiting on EditorLoader#231)
[runtime] 2022-06-26 16:26:12 [verbose]: decoupled ruleset transferred ("osu!" -> "osu!mania")
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:5) loading EditorLoader#231
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:5) entered EditorLoader#231
[runtime] 2022-06-26 16:26:12 [verbose]: updating selection with beatmap:cad02b3e-4e6e-483d-8fd3-3ac522191428 ruleset:mania
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:5) suspended EditorLoader#231 (waiting on Editor#613)
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:6) loading Editor#613
[runtime] 2022-06-26 16:26:12 [verbose]: ⚠️ Imported Soleily - Renatus (Deif)! Click to view.
[runtime] 2022-06-26 16:26:12 [verbose]: Focus contention triggered by NotificationOverlay.
[runtime] 2022-06-26 16:26:12 [verbose]: 🔸 Step #11 wait for editor open
[runtime] 2022-06-26 16:26:12 [verbose]: updating selection with beatmap:cad02b3e-4e6e-483d-8fd3-3ac522191428 ruleset:osu
[performance] 2022-06-26 16:26:12 [verbose]: TextureAtlas size exceeded 2 time(s); generating new texture (1024x1024)
[runtime] 2022-06-26 16:26:12 [verbose]: 📺 OsuScreenStack#132(depth:6) entered Editor#613
[runtime] 2022-06-26 16:26:12 [verbose]: ✔️ 2 repetitions
[runtime] 2022-06-26 16:26:12 [verbose]: 🔸 Step #12 test gameplay
[runtime] 2022-06-26 16:26:12 [verbose]: 🔸 Step #13 wait for player
[runtime] 2022-06-26 16:26:12 [verbose]: Waveform resampling with 34901 points...
[runtime] 2022-06-26 16:26:12 [verbose]: Waveform resample complete with 0 points.
[performance] 2022-06-26 16:26:12 [verbose]: TextureAtlas size exceeded 3 time(s); generating new texture (1024x1024)
[performance] 2022-06-26 16:26:12 [verbose]: TextureAtlas size exceeded 4 time(s); generating new texture (1024x1024)
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded BeatmapListingOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading DashboardOverlay...
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded DashboardOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading NewsOverlay...
[performance] 2022-06-26 16:26:12 [verbose]: Texture requested (1400x310) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded NewsOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading RankingsOverlay...
[performance] 2022-06-26 16:26:12 [verbose]: Texture requested (1800x600) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded RankingsOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading ChannelManager...
[runtime] 2022-06-26 16:26:12 [verbose]: Chat is now polling every 60000 ms
[network] 2022-06-26 16:26:12 [verbose]: Failing request osu.Game.Online.API.Requests.GetUpdatesRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded ChannelManager!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading ChatOverlay...
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded ChatOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading MessageNotifier...
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded MessageNotifier!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading SettingsOverlay...
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded SettingsOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading ChangelogOverlay...
[performance] 2022-06-26 16:26:12 [verbose]: Texture requested (1400x310) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded ChangelogOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading UserProfileOverlay...
[runtime] 2022-06-26 16:26:12 [verbose]: Loaded UserProfileOverlay!
[runtime] 2022-06-26 16:26:12 [verbose]: Loading BeatmapSetOverlay...
[performance] 2022-06-26 16:26:12 [verbose]: TextureAtlas size exceeded 3 time(s); generating new texture (1024x1024)
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded BeatmapSetOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading WikiOverlay...
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded WikiOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading SkinEditorOverlay...
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded SkinEditorOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading LoginOverlay...
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded LoginOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading NowPlayingOverlay...
[performance] 2022-06-26 16:26:13 [verbose]: Texture requested (1366x768) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded NowPlayingOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading AccountCreationOverlay...
[runtime] 2022-06-26 16:26:13 [verbose]: 📺 ScreenStack#175(depth:1) scheduling push ScreenWelcome#152
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded AccountCreationOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading DialogOverlay...
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded DialogOverlay!
[runtime] 2022-06-26 16:26:13 [verbose]: Loading HighPerformanceSession...
[runtime] 2022-06-26 16:26:13 [verbose]: Loaded HighPerformanceSession!
[network] 2022-06-26 16:26:14 [verbose]: Failing request osu.Game.Online.API.Requests.GetUpdatesRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[network] 2022-06-26 16:26:16 [verbose]: Failing request osu.Game.Online.API.Requests.GetUpdatesRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[network] 2022-06-26 16:26:17 [verbose]: Failing request osu.Game.Online.API.Requests.GetUpdatesRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[network] 2022-06-26 16:26:19 [verbose]: Failing request osu.Game.Online.API.Requests.GetUpdatesRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[network] 2022-06-26 16:26:20 [verbose]: Failing request osu.Game.Online.API.Requests.GetUpdatesRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-26 16:26:22 [verbose]: 💥 Failed (on attempt 1,843)
[runtime] 2022-06-26 16:26:22 [verbose]: ⏳ Currently loading components (2)
[runtime] 2022-06-26 16:26:22 [verbose]: Drawable+EmptyDrawable
[runtime] 2022-06-26 16:26:22 [verbose]: - thread: ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2022-06-26 16:26:22 [verbose]: - state:  Ready
[runtime] 2022-06-26 16:26:22 [verbose]: Drawable+EmptyDrawable
[runtime] 2022-06-26 16:26:22 [verbose]: - thread: ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2022-06-26 16:26:22 [verbose]: - state:  Ready
[runtime] 2022-06-26 16:26:22 [verbose]: 🧵 Task schedulers
[runtime] 2022-06-26 16:26:22 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-06-26 16:26:22 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-06-26 16:26:22 [verbose]: 🎱 Thread pool
[runtime] 2022-06-26 16:26:22 [verbose]: worker:          min 16     max 32,767 available 32,766
[runtime] 2022-06-26 16:26:22 [verbose]: completion:      min 16     max 1,000  available 1,000
[runtime] 2022-06-26 16:26:22 [debug]: Focus on "NotificationOverlay" no longer valid as a result of unfocusIfNoLongerValid.
[runtime] 2022-06-26 16:26:22 [debug]: Focus changed from NotificationOverlay to nothing.
[runtime] 2022-06-26 16:26:22 [verbose]: Waveform resampling with 2710873 points...
[runtime] 2022-06-26 16:26:22 [verbose]: Waveform resample complete with 0 points.
[runtime] 2022-06-26 16:26:22 [verbose]: Chat is now polling every 600000 ms
[runtime] 2022-06-26 16:26:22 [verbose]: Host execution state changed to Stopping
```