### PR TITLE
Pass online beatmap info into `DifficultyAttributes.FromDatabaseAttributes()`

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
@@ -31,9 +32,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             yield return (ATTRIB_ID_MAX_COMBO, MaxCombo);
         }
 
-        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
         {
-            base.FromDatabaseAttributes(values);
+            base.FromDatabaseAttributes(values, onlineInfo);
 
             StarRating = values[ATTRIB_ID_AIM];
             ApproachRate = values[ATTRIB_ID_APPROACH_RATE];

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyAttributes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Mania.Difficulty
@@ -37,9 +38,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             yield return (ATTRIB_ID_SCORE_MULTIPLIER, ScoreMultiplier);
         }
 
-        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
         {
-            base.FromDatabaseAttributes(values);
+            base.FromDatabaseAttributes(values, onlineInfo);
 
             MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
             StarRating = values[ATTRIB_ID_DIFFICULTY];

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyAttributes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 
@@ -96,9 +97,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             yield return (ATTRIB_ID_SLIDER_FACTOR, SliderFactor);
         }
 
-        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
         {
-            base.FromDatabaseAttributes(values);
+            base.FromDatabaseAttributes(values, onlineInfo);
 
             AimDifficulty = values[ATTRIB_ID_AIM];
             SpeedDifficulty = values[ATTRIB_ID_SPEED];
@@ -108,6 +109,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             StarRating = values[ATTRIB_ID_DIFFICULTY];
             FlashlightDifficulty = values.GetValueOrDefault(ATTRIB_ID_FLASHLIGHT);
             SliderFactor = values[ATTRIB_ID_SLIDER_FACTOR];
+
+            DrainRate = onlineInfo.DrainRate;
+            HitCircleCount = onlineInfo.CircleCount;
+            SliderCount = onlineInfo.SliderCount;
+            SpinnerCount = onlineInfo.SpinnerCount;
         }
 
         #region Newtonsoft.Json implicit ShouldSerialize() methods

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty
@@ -57,9 +58,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             yield return (ATTRIB_ID_GREAT_HIT_WINDOW, GreatHitWindow);
         }
 
-        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
+        public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
         {
-            base.FromDatabaseAttributes(values);
+            base.FromDatabaseAttributes(values, onlineInfo);
 
             MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
             StarRating = values[ATTRIB_ID_DIFFICULTY];

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;

--- a/osu.Game/Beatmaps/IBeatmapOnlineInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapOnlineInfo.cs
@@ -14,24 +14,49 @@ namespace osu.Game.Beatmaps
         int? MaxCombo { get; }
 
         /// <summary>
+        /// The approach rate.
+        /// </summary>
+        float ApproachRate { get; }
+
+        /// <summary>
+        /// The circle size.
+        /// </summary>
+        float CircleSize { get; }
+
+        /// <summary>
+        /// The drain rate.
+        /// </summary>
+        float DrainRate { get; }
+
+        /// <summary>
+        /// The overall difficulty.
+        /// </summary>
+        float OverallDifficulty { get; }
+
+        /// <summary>
         /// The amount of circles in this beatmap.
         /// </summary>
-        public int CircleCount { get; }
+        int CircleCount { get; }
 
         /// <summary>
         /// The amount of sliders in this beatmap.
         /// </summary>
-        public int SliderCount { get; }
+        int SliderCount { get; }
+
+        /// <summary>
+        /// The amount of spinners in tihs beatmap.
+        /// </summary>
+        int SpinnerCount { get; }
 
         /// <summary>
         /// The amount of plays this beatmap has.
         /// </summary>
-        public int PlayCount { get; }
+        int PlayCount { get; }
 
         /// <summary>
         /// The amount of passes this beatmap has.
         /// </summary>
-        public int PassCount { get; }
+        int PassCount { get; }
 
         APIFailTimes? FailTimes { get; }
     }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -69,6 +69,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"count_sliders")]
         public int SliderCount { get; set; }
 
+        [JsonProperty(@"count_spinners")]
+        public int SpinnerCount { get; set; }
+
         [JsonProperty(@"version")]
         public string DifficultyName { get; set; } = string.Empty;
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Difficulty
@@ -74,7 +75,8 @@ namespace osu.Game.Rulesets.Difficulty
         /// Reads osu-web database attribute mappings into this <see cref="DifficultyAttributes"/> object.
         /// </summary>
         /// <param name="values">The attribute mappings.</param>
-        public virtual void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values)
+        /// <param name="onlineInfo">The <see cref="IBeatmapOnlineInfo"/> where more information about the beatmap may be extracted from (such as AR/CS/OD/etc).</param>
+        public virtual void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
         {
         }
     }

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -31,7 +30,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// The mods which were applied to the beatmap.
         /// </summary>
-        public Mod[] Mods { get; set; }
+        public Mod[] Mods { get; set; } = Array.Empty<Mod>();
 
         /// <summary>
         /// The combined star rating of all skills.


### PR DESCRIPTION
Usages of this method need to do some extra mapping code for values that don't exist in difficulty attributes, such as: https://github.com/ppy/osu-queue-score-statistics/pull/15#discussion_r749167287

Most of the required parameters already existed either in this interface or in the only inheritor of it - `APIBeatmap`. The only new attribute is `SpinnerCount`.

In order to get rid of this, I've made `DifficultyAttributes.FromDatabaseAttributes()` take in an `IBeatmapOnlineInfo` parameter.