### PR TITLE
Fix chat tests failing 1/10000 runs

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -549,7 +549,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createPrivateChannel()
         {
-            int id = RNG.Next(0, 10000);
+            int id = RNG.Next(0, DummyAPIAccess.DUMMY_USER_ID - 1);
             return new Channel(new APIUser
             {
                 Id = id,
@@ -559,7 +559,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createAnnounceChannel()
         {
-            int id = RNG.Next(0, 10000);
+            int id = RNG.Next(0, DummyAPIAccess.DUMMY_USER_ID - 1);
             return new Channel
             {
                 Name = $"Announce {id}",

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -15,10 +15,12 @@ namespace osu.Game.Online.API
 {
     public class DummyAPIAccess : Component, IAPIProvider
     {
+        public const int DUMMY_USER_ID = 1001;
+
         public Bindable<APIUser> LocalUser { get; } = new Bindable<APIUser>(new APIUser
         {
             Username = @"Dummy",
-            Id = 1001,
+            Id = DUMMY_USER_ID,
         });
 
         public BindableList<APIUser> Friends { get; } = new BindableList<APIUser>();


### PR DESCRIPTION
https://github.com/ppy/osu/blob/31a447fda0532fcf15f8c8251ca890c533386492/osu.Game/Online/Chat/ChannelManager.cs#L412-L414

Sigh.

```csharp
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]:    Class: TestSceneChatOverlay
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]:    Test:  TestKeyboardNextChannel
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]: Chat is now polling every 60000 ms
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]:    Step #1 Setup request handler
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]:    Step #2 Add test channels
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]:    Step #3 Show overlay with channels
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]: Unhandled Request Type: osu.Game.Online.API.Requests.CreateChannelRequest
05:55:01     [network] 2022-06-27 05:55:01 [verbose]: Failing request osu.Game.Online.API.Requests.CreateChannelRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
05:55:01     [runtime] 2022-06-27 05:55:01 [verbose]: Unhandled Request Type: osu.Game.Online.API.Requests.CreateChannelRequest
05:55:01     [network] 2022-06-27 05:55:01 [verbose]: Failing request osu.Game.Online.API.Requests.CreateChannelRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: An unhandled error has occurred.
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: System.InvalidOperationException: Sequence contains no elements
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at System.Linq.ThrowHelper.ThrowNoElementsException()
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Game.Overlays.Chat.ChannelList.ChannelListItem.createIcon() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs:line 139
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Game.Overlays.Chat.ChannelList.ChannelListItem.load() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs:line 55
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: --- End of stack trace from previous location ---
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute.<>c__DisplayClass6_0.<CreateActivator>b__3(Object target, IReadOnlyDependencyContainer dc)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Allocation.DependencyActivator.activate(Object obj, IReadOnlyDependencyContainer dependencies)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Graphics.Drawable.load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Graphics.Drawable.Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies, Boolean isDirectAsyncContext)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.loadChild(Drawable child)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.AddInternal(Drawable drawable)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Framework.Graphics.Containers.Container`1.AddInternal(Drawable drawable)
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Game.Overlays.Chat.ChannelList.ChannelList.AddChannel(Channel channel) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Overlays/Chat/ChannelList/ChannelList.cs:line 88
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Game.Overlays.ChatOverlay.joinedChannelsChanged(Object sender, NotifyCollectionChangedEventArgs args) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Overlays/ChatOverlay.cs:line 363
05:55:01     [runtime] 2022-06-27 05:55:01 [error]: at osu.Game.Overlays.ChatOverlay.<LoadComplete>b__37_1() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Overlays/ChatOverlay.cs:line 177
```