### PR TITLE
Fix `TestStoryboardSkipOutro` occasionally failing due to strict timings

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -52,10 +52,11 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestStoryboardSkipOutro()
         {
+            AddStep("set storyboard duration to long", () => currentStoryboardDuration = 200000);
             CreateTest(null);
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("skip outro", () => InputManager.Key(osuTK.Input.Key.Space));
-            AddAssert("player is no longer current screen", () => !Player.IsCurrentScreen());
+            AddUntilStep("player is no longer current screen", () => !Player.IsCurrentScreen());
             AddUntilStep("wait for score shown", () => Player.IsScoreShown);
         }
 


### PR DESCRIPTION
Previously this would fail because very occasionally the results haven't been loaded in time for the non-waiting step.

Making the storyboard insanely long allows us to more correctly use an `UntilStep` and ensure this is actually a reliable test.