### PR TITLE
Fix occasional failure in realm test proceedings due to incorrect `Debug.Assert`

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -102,6 +102,12 @@ namespace osu.Game.Database
 
         private Realm? updateRealm;
 
+        /// <summary>
+        /// Tracks whether a realm was ever fetched from this instance.
+        /// After a fetch occurs, blocking operations will be guaranteed to restore any subscriptions.
+        /// </summary>
+        private bool hasInitialisedOnce;
+
         private bool isSendingNotificationResetEvents;
 
         public Realm Realm => ensureUpdateRealm();
@@ -121,6 +127,7 @@ namespace osu.Game.Database
                 if (updateRealm == null)
                 {
                     updateRealm = getRealmInstance();
+                    hasInitialisedOnce = true;
 
                     Logger.Log(@$"Opened realm ""{updateRealm.Config.DatabasePath}"" at version {updateRealm.Config.SchemaVersion}");
 
@@ -806,13 +813,7 @@ namespace osu.Game.Database
 
                 lock (realmLock)
                 {
-                    if (updateRealm == null)
-                    {
-                        // null realm means the update thread has not yet retrieved its instance.
-                        // we don't need to worry about reviving the update instance in this case, so don't bother with the SynchronizationContext.
-                        Debug.Assert(!ThreadSafety.IsUpdateThread);
-                    }
-                    else
+                    if (hasInitialisedOnce)
                     {
                         if (!ThreadSafety.IsUpdateThread)
                             throw new InvalidOperationException(@$"{nameof(BlockAllOperations)} must be called from the update thread.");
@@ -827,12 +828,12 @@ namespace osu.Game.Database
                             action.Value?.Dispose();
                             customSubscriptionsResetMap[action.Key] = null;
                         }
+
+                        updateRealm?.Dispose();
+                        updateRealm = null;
                     }
 
                     Logger.Log(@"Blocking realm operations.", LoggingTarget.Database);
-
-                    updateRealm?.Dispose();
-                    updateRealm = null;
                 }
 
                 const int sleep_length = 200;


### PR DESCRIPTION
After a `BlockAllOperations`, the restoration of the `updateRealm` instance is not instance. It is posted to a `SynchronizationContext`. The assertion which has been removed in this commit was assuming it
would always be an immediate operation.

To ensure this works as expected, I've tracked the initialised state via a new `bool`.

```csharp
System.TimeoutException : Attempting to block for migration took too long.

  1) Host threw exception System.AggregateException: One or more errors occurred. (: )
 ---> NUnit.Framework.AssertionException: :
   at osu.Framework.Logging.ThrowingTraceListener.Fail(String message1, String message2)
   at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
   at System.Diagnostics.TraceInternal.TraceProvider.Fail(String message, String detailMessage)
   at System.Diagnostics.Debug.Fail(String message, String detailMessage)
   at osu.Game.Database.RealmAccess.BlockAllOperations() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Database/RealmAccess.cs:line 813
   at osu.Game.OsuGameBase.<>c__DisplayClass108_1.<Migrate>b__0() in /opt/buildagent/work/ecd860037212ac52/osu.Game/OsuGameBase.cs:line 449
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
```

https://teamcity.ppy.sh/buildConfiguration/Osu_Build/322?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true