### PR TITLE
Add logging for various cases of `SongSelect.FinaliseSelection` being aborted

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
@@ -78,7 +79,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         protected override bool SelectItem(PlaylistItem item)
         {
             if (operationInProgress.Value)
+            {
+                Logger.Log($"{nameof(SelectedItem)} aborted due to {nameof(operationInProgress)}");
                 return false;
+            }
 
             // If the client is already in a room, update via the client.
             // Otherwise, update the playlist directly in preparation for it to be submitted to the API on match creation.

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -360,7 +360,10 @@ namespace osu.Game.Screens.Select
         {
             // This is very important as we have not yet bound to screen-level bindables before the carousel load is completed.
             if (!Carousel.BeatmapSetsLoaded)
+            {
+                Logger.Log($"{nameof(FinaliseSelection)} aborted as carousel beatmaps are not yet loaded");
                 return;
+            }
 
             if (ruleset != null)
                 Ruleset.Value = ruleset;


### PR DESCRIPTION
I'm 99% sure this is due to an `ongoingOperation`, but fixing isn't so simple (and there are calls to this from many tests scenes). Would like confirmation before attempting a fix.

https://teamcity.ppy.sh/buildConfiguration/Osu_Build/94?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true
https://teamcity.ppy.sh/buildConfiguration/Osu_Build/115?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

```csharp
TearDown : System.TimeoutException : "wait for return to match" timed out
--TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Tests/Visual/OsuTestScene.cs:line 503
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
------- Stdout: -------
[runtime] 2022-06-24 18:43:54 [verbose]: 💨 Class: TestSceneAllPlayersQueueMode
[runtime] 2022-06-24 18:43:54 [verbose]: 🔶 Test:  TestCorrectRulesetSelectedAfterNewItemAdded
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #1 exit all screens
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #2 import beatmap
[database] 2022-06-24 18:43:54 [verbose]: [?????] Beginning import...
[database] 2022-06-24 18:43:54 [verbose]: [dce8f] Found existing beatmap for Soleily - RenatusQuick (Deif) (ID ef3b094c-d8c2-4900-8647-631ea32a02de) – skipping import.
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #3 load multiplayer
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 TestMultiplayerComponents(OsuScreenStack)#662(depth:1) scheduling push TestMultiplayerComponents+TestMultiplayer#492
[runtime] 2022-06-24 18:43:54 [verbose]: ScreenTestScene screen changed → TestMultiplayerComponents
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#405(depth:1) loading TestMultiplayerComponents#424
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#405(depth:1) entered TestMultiplayerComponents#424
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 TestMultiplayerComponents(OsuScreenStack)#662(depth:1) entered TestMultiplayerComponents+TestMultiplayer#492
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:1) loading Lounge#650
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #4 wait for multiplayer to load
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:1) entered Lounge#650
[runtime] 2022-06-24 18:43:54 [verbose]: Polling adjusted (listing: 15000)
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:1) loading LoungeBackgroundScreen#418
[runtime] 2022-06-24 18:43:54 [verbose]: Polling adjusted (listing: 15000)
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:1) entered LoungeBackgroundScreen#418
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #5 wait for lounge to load
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #6 wait for lounge
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #7 open room
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:1) suspended Lounge#650 (waiting on New room#669)
[runtime] 2022-06-24 18:43:54 [verbose]: Polling adjusted (listing: 0)
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:2) loading New room#669
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #8 wait for room open
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:2) entered New room#669
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:2) loading RoomBackgroundScreen#364
[runtime] 2022-06-24 18:43:54 [verbose]: ✔️ 5 repetitions
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:2) suspended LoungeBackgroundScreen#418 (waiting on RoomBackgroundScreen#364)
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:2) entered RoomBackgroundScreen#364
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #9 wait for transition 0/2
[runtime] 2022-06-24 18:43:54 [verbose]: ✔️ 2 repetitions
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #10 wait for CreateOrUpdateButton enabled
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #11 click CreateOrUpdateButton
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #12 wait for join
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #13 click add button
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:2) suspended New room#669 (waiting on MultiplayerMatchSongSelect#597)
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:3) loading MultiplayerMatchSongSelect#597
[runtime] 2022-06-24 18:43:54 [verbose]: decoupled ruleset transferred ("" -> "osu!")
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #14 wait for song select
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #15 wait for loaded
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 OnlinePlaySubScreenStack#613(depth:3) entered MultiplayerMatchSongSelect#597
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:3) loading BackgroundScreenBeatmap#613
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:3) suspended RoomBackgroundScreen#364 (waiting on BackgroundScreenBeatmap#613)
[runtime] 2022-06-24 18:43:54 [verbose]: 📺 BackgroundScreenStack#654(depth:3) entered BackgroundScreenBeatmap#613
[runtime] 2022-06-24 18:43:54 [verbose]: ✔️ 13 repetitions
[runtime] 2022-06-24 18:43:54 [verbose]: updating selection with beatmap:8592edf7-fa75-48a8-9f2f-ef51b08f366a ruleset:osu
[network] 2022-06-24 18:43:54 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #16 set osu!catch ruleset
[runtime] 2022-06-24 18:43:54 [verbose]: 🔸 Step #17 select other beatmap
[runtime] 2022-06-24 18:43:54 [verbose]: decoupled ruleset transferred ("osu!" -> "osu!catch")
[runtime] 2022-06-24 18:43:54 [verbose]: updating selection with beatmap:a84f1af9-19c5-4e03-b55f-9810e1998138 ruleset:fruits
[runtime] 2022-06-24 18:43:54 [verbose]: beatmap changed from "Soleily - RenatusQuick (Gamu) [Hard]" to "Soleily - RenatusQuick (Gamu) [Normal]"
[runtime] 2022-06-24 18:43:54 [verbose]: Song select working beatmap updated to Soleily - RenatusQuick (Gamu) [Normal]
[network] 2022-06-24 18:43:54 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-24 18:43:55 [verbose]: 🔸 Step #18 wait for return to match
[runtime] 2022-06-24 18:44:05 [verbose]: 💥 Failed (on attempt 1,134)
[runtime] 2022-06-24 18:44:05 [verbose]: ⏳ Currently loading components (2)
[runtime] 2022-06-24 18:44:05 [verbose]: DrawableRoomPlaylistItem
[runtime] 2022-06-24 18:44:05 [verbose]: - thread: ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2022-06-24 18:44:05 [verbose]: - state:  Ready
[runtime] 2022-06-24 18:44:05 [verbose]: DrawableRoomPlaylistItem
[runtime] 2022-06-24 18:44:05 [verbose]: - thread: ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2022-06-24 18:44:05 [verbose]: - state:  Ready
[runtime] 2022-06-24 18:44:05 [verbose]: 🧵 Task schedulers
[runtime] 2022-06-24 18:44:05 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-06-24 18:44:05 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-06-24 18:44:05 [verbose]: 🎱 Thread pool
[runtime] 2022-06-24 18:44:05 [verbose]: worker:          min 1      max 32,767 available 32,766
[runtime] 2022-06-24 18:44:05 [verbose]: completion:      min 1      max 1,000  available 1,000
[runtime] 2022-06-24 18:44:05 [debug]: Focus on "SeekLimitedSearchTextBox" no longer valid as a result of unfocusIfNoLongerValid.
[runtime] 2022-06-24 18:44:05 [debug]: Focus changed from SeekLimitedSearchTextBox to nothing.
```