### PR TITLE
Fix potential crash on `CloseAllOverlays` due to collection mutation

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -249,7 +249,7 @@ namespace osu.Game
         /// <param name="hideToolbar">Whether the toolbar should also be hidden.</param>
         public void CloseAllOverlays(bool hideToolbar = true)
         {
-            foreach (var overlay in focusedOverlays)
+            foreach (var overlay in focusedOverlays.ToArray())
                 overlay.Hide();
 
             if (hideToolbar) Toolbar.Hide();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -231,7 +231,7 @@ namespace osu.Game
         /// <summary>
         /// Unregisters a blocking <see cref="OverlayContainer"/> that was not created by <see cref="OsuGame"/> itself.
         /// </summary>
-        private void unregisterBlockingOverlay(OverlayContainer overlayContainer)
+        private void unregisterBlockingOverlay(OverlayContainer overlayContainer) => Schedule(() =>
         {
             externalOverlays.Remove(overlayContainer);
 
@@ -239,7 +239,7 @@ namespace osu.Game
                 focusedOverlays.Remove(focusedOverlayContainer);
 
             overlayContainer.Expire();
-        }
+        });
 
         #endregion
 
@@ -249,7 +249,7 @@ namespace osu.Game
         /// <param name="hideToolbar">Whether the toolbar should also be hidden.</param>
         public void CloseAllOverlays(bool hideToolbar = true)
         {
-            foreach (var overlay in focusedOverlays.ToArray())
+            foreach (var overlay in focusedOverlays)
                 overlay.Hide();
 
             if (hideToolbar) Toolbar.Hide();


### PR DESCRIPTION

```csharp
TearDown : System.AggregateException : One or more errors occurred. (Collection was modified; enumeration operation may not execute.)
  ----> System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
Data:
  Sentry:Mechanism: AppDomain.UnhandledException
  Sentry:Handled: False
--TearDown
   at osu.Framework.Testing.TestScene.checkForErrors()
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
--InvalidOperationException
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at osu.Game.OsuGame.CloseAllOverlays(Boolean hideToolbar) in C:\BuildAgent\work\ecd860037212ac52\osu.Game\OsuGame.cs:line 252
   at osu.Game.PerformFromMenuRunner.checkCanComplete() in C:\BuildAgent\work\ecd860037212ac52\osu.Game\PerformFromMenuRunner.cs:line 80
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
```