### PR TITLE
Wait for and dismiss notification in editor navigation test

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorNavigation.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
@@ -35,6 +36,8 @@ namespace osu.Game.Tests.Visual.Editing
                 () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet)
                       && Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect
                       && songSelect.IsLoaded);
+            AddUntilStep("wait for completion notification", () => Game.Notifications.ChildrenOfType<ProgressCompletionNotification>().Count() == 1);
+            AddStep("dismiss notifications", () => Game.Notifications.Hide());
             AddStep("switch ruleset", () => Game.Ruleset.Value = new ManiaRuleset().RulesetInfo);
 
             AddStep("open editor", () => ((PlaySongSelect)Game.ScreenStack.CurrentScreen).Edit(beatmapSet.Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == 0)));


### PR DESCRIPTION
Intended to address test flakiness (see: https://discord.com/channels/188630481301012481/188630652340404224/991009407645143072)

In the end of the day I don't think the first run overlay trail amounts to anything. If it was it interfering, then there should be a "click to resume first run setup" notification somewhere in the log output, but there is not.

I did however notice in debugging that if unlucky, the "import successful" completion notification in this particular test could be shown as late as inside the editor, which means that it visually obscures the gameplay test button, which makes the test get stuck in editor. To that end, this change makes it so that the test waits for the notification to show in song select, and dismisses the sidebar there to prevent it from meddling further later.

Maybe bit of a "left field" solution but I'm not sure I've got anything better to offer at this point in time.