### PR TITLE
Increase leniences on `TestSceneSpectatorPlayback.TestWithSendFailure`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
@@ -167,11 +167,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("start failing sends", () =>
             {
                 spectatorClient.ShouldFailSendingFrames = true;
-                framesReceivedSoFar = replay.Frames.Count;
                 frameSendAttemptsSoFar = spectatorClient.FrameSendAttempts;
             });
 
-            AddUntilStep("wait for send attempts", () => spectatorClient.FrameSendAttempts > frameSendAttemptsSoFar + 5);
+            AddUntilStep("wait for next send attempt", () =>
+            {
+                framesReceivedSoFar = replay.Frames.Count;
+                return spectatorClient.FrameSendAttempts > frameSendAttemptsSoFar + 1;
+            });
+
+            AddUntilStep("wait for more send attempts", () => spectatorClient.FrameSendAttempts > frameSendAttemptsSoFar + 10);
             AddAssert("frames did not increase", () => framesReceivedSoFar == replay.Frames.Count);
 
             AddStep("stop failing sends", () => spectatorClient.ShouldFailSendingFrames = false);


### PR DESCRIPTION
Not really sure how to improve this further, but should help with cases like this:

```csharp
[runtime] 2022-06-28 05:32:06 [verbose]: 💨 Class: TestSceneSpectatorPlayback
[runtime] 2022-06-28 05:32:06 [verbose]: 🔶 Test:  TestWithSendFailure
[runtime] 2022-06-28 05:32:06 [verbose]: 🔸 Step #1 Setup containers
[runtime] 2022-06-28 05:32:06 [verbose]: Received 1 new frames (total 1 of 2)
[runtime] 2022-06-28 05:32:06 [verbose]: 🔸 Step #2 received frames
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 7 of 8)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 13 of 19)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 19 of 29)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 25 of 44)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 31 of 45)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 37 of 59)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 43 of 67)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 49 of 125)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 55 of 126)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 61 of 127)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 67 of 128)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 73 of 129)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 79 of 130)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 85 of 131)
[runtime] 2022-06-28 05:32:06 [verbose]: ✔️ 22 repetitions
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 91 of 132)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 97 of 133)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 103 of 134)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 109 of 135)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 115 of 136)
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 121 of 137)
[runtime] 2022-06-28 05:32:06 [verbose]: 🔸 Step #3 start failing sends
[runtime] 2022-06-28 05:32:06 [verbose]: Received 6 new frames (total 127 of 138)
[runtime] 2022-06-28 05:32:06 [verbose]: 🔸 Step #4 wait for send attempts
[runtime] 2022-06-28 05:32:06 [verbose]: 🔸 Step #5 frames did not increase
[runtime] 2022-06-28 05:32:06 [verbose]: 💥 Failed
[runtime] 2022-06-28 05:32:06 [verbose]: ⏳ Currently loading components (0)
[runtime] 2022-06-28 05:32:06 [verbose]: 🧵 Task schedulers
[runtime] 2022-06-28 05:32:06 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-06-28 05:32:06 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-06-28 05:32:06 [verbose]: 🎱 Thread pool
[runtime] 2022-06-28 05:32:06 [verbose]: worker:          min 1      max 32,767 available 32,766
[runtime] 2022-06-28 05:32:06 [verbose]: completion:      min 1      max 1,000  available 1,000
[runtime] 2022-06-28 05:32:06 [verbose]: Host execution state changed to Stopping
```

https://teamcity.ppy.sh/buildConfiguration/Osu_Build/811?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

Also moves exception handling outside of a `Schedule` call to avoid unobserved exceptions being unexpectedly thrown.