### PR TITLE
Apply various refactorings to `TestSceneSliderSnaking`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 AddStep("change component scale", () => Player.ChildrenOfType<LegacyScoreCounter>().First().Scale = new Vector2(2f));
                 AddStep("update target", () => Player.ChildrenOfType<SkinnableTargetContainer>().ForEach(LegacySkin.UpdateDrawableTarget));
                 AddStep("exit player", () => Player.Exit());
-                CreateTest(null);
+                CreateTest();
             }
 
             AddAssert("legacy HUD combo counter hidden", () =>

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void createPlayerTest()
         {
-            CreateTest(null);
+            CreateTest();
 
             AddAssert("storyboard loaded", () => Player.Beatmap.Value.Storyboard != null);
             waitUntilStoryboardSamplesPlay();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestStoryboardSkipOutro()
         {
             AddStep("set storyboard duration to long", () => currentStoryboardDuration = 200000);
-            CreateTest(null);
+            CreateTest();
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("skip outro", () => InputManager.Key(osuTK.Input.Key.Space));
             AddUntilStep("player is no longer current screen", () => !Player.IsCurrentScreen());
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestStoryboardNoSkipOutro()
         {
-            CreateTest(null);
+            CreateTest();
             AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
             AddUntilStep("wait for score shown", () => Player.IsScoreShown);
         }
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestStoryboardExitDuringOutroStillExits()
         {
-            CreateTest(null);
+            CreateTest();
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());
             AddAssert("player exited", () => !Player.IsCurrentScreen() && Player.GetChildScreen() == null);
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [TestCase(true)]
         public void TestStoryboardToggle(bool enabledAtBeginning)
         {
-            CreateTest(null);
+            CreateTest();
             AddStep($"{(enabledAtBeginning ? "enable" : "disable")} storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, enabledAtBeginning));
             AddStep("toggle storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, !enabledAtBeginning));
             AddUntilStep("wait for score shown", () => Player.IsScoreShown);
@@ -130,7 +130,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             SkipOverlay.FadeContainer fadeContainer() => Player.ChildrenOfType<SkipOverlay.FadeContainer>().First();
 
-            CreateTest(null);
+            CreateTest();
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddUntilStep("skip overlay content becomes visible", () => fadeContainer().State == Visibility.Visible);
 
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestPerformExitNoOutro()
         {
-            CreateTest(null);
+            CreateTest();
             AddStep("disable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, false));
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Timing;
 
 namespace osu.Game.Screens.Play
@@ -101,6 +102,8 @@ namespace osu.Game.Screens.Play
         /// <param name="time">The destination time to seek to.</param>
         public virtual void Seek(double time)
         {
+            Logger.Log($"{nameof(GameplayClockContainer)} seeking to {time}");
+
             AdjustableSource.Seek(time);
 
             // Manually process to make sure the gameplay clock is correctly updated after a seek.

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -39,10 +39,10 @@ namespace osu.Game.Tests.Visual
             base.SetUpSteps();
 
             if (!HasCustomSteps)
-                CreateTest(null);
+                CreateTest();
         }
 
-        protected void CreateTest(Action action)
+        protected void CreateTest([CanBeNull] Action action = null)
         {
             if (action != null && !HasCustomSteps)
                 throw new InvalidOperationException($"Cannot add custom test steps without {nameof(HasCustomSteps)} being set.");


### PR DESCRIPTION
I don't think this will fix the issue, but was written in a pretty weird way.

```csharp
TearDown : System.TimeoutException : "wait for seek to finish" timed out
--TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Tests/Visual/OsuTestScene.cs:line 503
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
------- Stdout: -------
[runtime] 2022-06-27 22:54:21 [verbose]: 💨 Class: TestSceneSliderSnaking
[runtime] 2022-06-27 22:54:21 [verbose]: 🔶 Test:  TestSnakingDisabled(2)
[runtime] 2022-06-27 22:54:21 [verbose]: 🔸 Step #1 have autoplay
[runtime] 2022-06-27 22:54:21 [verbose]: 🔸 Step #2 exit all screens
[runtime] 2022-06-27 22:54:21 [verbose]: 🔸 Step #3 osu!
[runtime] 2022-06-27 22:54:21 [verbose]: Game-wide working beatmap updated to Unknown - Unknown (Unknown Creator) [Normal]
[runtime] 2022-06-27 22:54:21 [verbose]: ScreenTestScene screen changed → TestPlayer
[runtime] 2022-06-27 22:54:21 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#333(depth:1) loading TestPlayer#371
[runtime] 2022-06-27 22:54:21 [verbose]: 🔸 Step #4 player loaded
[runtime] 2022-06-27 22:54:21 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#333(depth:1) entered TestPlayer#371
[runtime] 2022-06-27 22:54:21 [verbose]: 📺 BackgroundScreenStack#612(depth:1) loading BackgroundScreenBeatmap#507
[runtime] 2022-06-27 22:54:21 [verbose]: ✔️ 33 repetitions
[runtime] 2022-06-27 22:54:21 [verbose]: 📺 BackgroundScreenStack#612(depth:1) entered BackgroundScreenBeatmap#507
[runtime] 2022-06-27 22:54:21 [verbose]: 🔸 Step #5 wait for track to start running
[runtime] 2022-06-27 22:54:21 [verbose]: 🔸 Step #6 retrieve slider at index
[runtime] 2022-06-27 22:54:22 [verbose]: 🔸 Step #7 seek to slider
[runtime] 2022-06-27 22:54:22 [verbose]: 🔸 Step #8 wait for seek to finish
[runtime] 2022-06-27 22:54:32 [verbose]: 💥 Failed (on attempt 1,982)
[runtime] 2022-06-27 22:54:32 [verbose]: ⏳ Currently loading components (0)
[runtime] 2022-06-27 22:54:32 [verbose]: 🧵 Task schedulers
[runtime] 2022-06-27 22:54:32 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-06-27 22:54:32 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-06-27 22:54:32 [verbose]: 🎱 Thread pool
[runtime] 2022-06-27 22:54:32 [verbose]: worker:          min 1      max 32,767 available 32,766
[runtime] 2022-06-27 22:54:32 [verbose]: completion:      min 1      max 1,000  available 1,000
```

https://teamcity.ppy.sh/buildConfiguration/Osu_Build/549?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true