### PR TITLE
Fix more chat test failures

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Tests.Visual.Online
         private ChannelManager channelManager;
 
         private APIUser testUser;
-        private Channel testPMChannel;
         private Channel[] testChannels;
 
         private Channel testChannel1 => testChannels[0];
@@ -53,7 +52,6 @@ namespace osu.Game.Tests.Visual.Online
         public void SetUp() => Schedule(() =>
         {
             testUser = new APIUser { Username = "test user", Id = 5071479 };
-            testPMChannel = new Channel(testUser);
             testChannels = Enumerable.Range(1, 10).Select(createPublicChannel).ToArray();
 
             Child = new DependencyProvidingContainer
@@ -181,7 +179,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Show overlay", () => chatOverlay.Show());
             AddAssert("Listing is visible", () => listingIsVisible);
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             waitForChannel1Visible();
         }
@@ -203,12 +201,11 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestChannelCloseButton()
         {
+            var testPMChannel = new Channel(testUser);
+
             AddStep("Show overlay", () => chatOverlay.Show());
-            AddStep("Join PM and public channels", () =>
-            {
-                channelManager.JoinChannel(testChannel1);
-                channelManager.JoinChannel(testPMChannel);
-            });
+            joinTestChannel(0);
+            joinChannel(testPMChannel);
             AddStep("Select PM channel", () => clickDrawable(getChannelListItem(testPMChannel)));
             AddStep("Click close button", () =>
             {
@@ -229,7 +226,7 @@ namespace osu.Game.Tests.Visual.Online
         public void TestChatCommand()
         {
             AddStep("Show overlay", () => chatOverlay.Show());
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             AddStep("Open chat with user", () => channelManager.PostCommand($"chat {testUser.Username}"));
             AddAssert("PM channel is selected", () =>
@@ -248,14 +245,16 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestMultiplayerChannelIsNotShown()
         {
-            Channel multiplayerChannel = null;
+            Channel multiplayerChannel;
 
             AddStep("Show overlay", () => chatOverlay.Show());
-            AddStep("Join multiplayer channel", () => channelManager.JoinChannel(multiplayerChannel = new Channel(new APIUser())
+
+            joinChannel(multiplayerChannel = new Channel(new APIUser())
             {
                 Name = "#mp_1",
                 Type = ChannelType.Multiplayer,
-            }));
+            });
+
             AddAssert("Channel is joined", () => channelManager.JoinedChannels.Contains(multiplayerChannel));
             AddUntilStep("Channel not present in listing", () => !chatOverlay.ChildrenOfType<ChannelListingItem>()
                                                                              .Where(item => item.IsPresent)
@@ -269,7 +268,7 @@ namespace osu.Game.Tests.Visual.Online
             Message message = null;
 
             AddStep("Show overlay", () => chatOverlay.Show());
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             AddStep("Send message in channel 1", () =>
             {
@@ -291,8 +290,8 @@ namespace osu.Game.Tests.Visual.Online
             Message message = null;
 
             AddStep("Show overlay", () => chatOverlay.Show());
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
-            AddStep("Join channel 2", () => channelManager.JoinChannel(testChannel2));
+            joinTestChannel(0);
+            joinTestChannel(1);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             AddStep("Send message in channel 2", () =>
             {
@@ -314,8 +313,8 @@ namespace osu.Game.Tests.Visual.Online
             Message message = null;
 
             AddStep("Show overlay", () => chatOverlay.Show());
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
-            AddStep("Join channel 2", () => channelManager.JoinChannel(testChannel2));
+            joinTestChannel(0);
+            joinTestChannel(1);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             AddStep("Send message in channel 2", () =>
             {
@@ -337,7 +336,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             Message message = null;
 
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Send message in channel 1", () =>
             {
                 testChannel1.AddNewMessages(message = new Message
@@ -357,7 +356,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             Message message = null;
 
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Send message in channel 1", () =>
             {
                 testChannel1.AddNewMessages(message = new Message
@@ -378,7 +377,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Show overlay", () => chatOverlay.Show());
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             waitForChannel1Visible();
             AddAssert("TextBox is focused", () => InputManager.FocusedDrawable == chatOverlayTextBox);
@@ -404,11 +403,11 @@ namespace osu.Game.Tests.Visual.Online
                 chatOverlay.Show();
                 chatOverlay.SlowLoading = true;
             });
-            AddStep("Join channel 1", () => channelManager.JoinChannel(testChannel1));
+            joinTestChannel(0);
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             AddUntilStep("Channel 1 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel1).LoadState == LoadState.Loading);
 
-            AddStep("Join channel 2", () => channelManager.JoinChannel(testChannel2));
+            joinTestChannel(1);
             AddStep("Select channel 2", () => clickDrawable(getChannelListItem(testChannel2)));
             AddUntilStep("Channel 2 loading", () => !channelIsVisible && chatOverlay.GetSlowLoadingChannel(testChannel2).LoadState == LoadState.Loading);
 
@@ -461,15 +460,13 @@ namespace osu.Game.Tests.Visual.Online
             Channel pmChannel1 = createPrivateChannel();
             Channel pmChannel2 = createPrivateChannel();
 
-            AddStep("Show overlay with channels", () =>
-            {
-                channelManager.JoinChannel(testChannel1);
-                channelManager.JoinChannel(testChannel2);
-                channelManager.JoinChannel(pmChannel1);
-                channelManager.JoinChannel(pmChannel2);
-                channelManager.JoinChannel(announceChannel);
-                chatOverlay.Show();
-            });
+            joinTestChannel(0);
+            joinTestChannel(1);
+            joinChannel(pmChannel1);
+            joinChannel(pmChannel2);
+            joinChannel(announceChannel);
+
+            AddStep("Show overlay", () => chatOverlay.Show());
 
             AddStep("Select channel 1", () => clickDrawable(getChannelListItem(testChannel1)));
             waitForChannel1Visible();
@@ -488,6 +485,18 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep("Press document next keys", () => InputManager.Keys(PlatformAction.DocumentNext));
             waitForChannel1Visible();
+        }
+
+        private void joinTestChannel(int i)
+        {
+            AddStep($"Join test channel {i}", () => channelManager.JoinChannel(testChannels[i]));
+            AddUntilStep("wait for join completed", () => testChannels[i].Joined.Value);
+        }
+
+        private void joinChannel(Channel channel)
+        {
+            AddStep($"Join channel {channel}", () => channelManager.JoinChannel(channel));
+            AddUntilStep("wait for join completed", () => channel.Joined.Value);
         }
 
         private void waitForChannel1Visible() =>

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -78,6 +78,14 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     switch (req)
                     {
+                        case CreateChannelRequest createRequest:
+                            createRequest.TriggerSuccess(new APIChatChannel
+                            {
+                                ChannelID = ((int)createRequest.Channel.Id),
+                                RecentMessages = new List<Message>()
+                            });
+                            return true;
+
                         case GetUpdatesRequest getUpdates:
                             getUpdates.TriggerFailure(new WebException());
                             return true;


### PR DESCRIPTION
Ordering was not guaranteed because joins are asynchronous.

All test channel joines are confirmed before continuing now, guaranteeing order.

https://teamcity.ppy.sh/buildConfiguration/Osu_Build/833?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

```csharp
TearDown : System.TimeoutException : "PM Channel 1 displayed" timed out
--TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Tests/Visual/OsuTestScene.cs:line 503
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
------- Stdout: -------
[runtime] 2022-06-28 08:36:43 [verbose]: 💨 Class: TestSceneChatOverlay
[runtime] 2022-06-28 08:36:43 [verbose]: 🔶 Test:  TestKeyboardNextChannel
[runtime] 2022-06-28 08:36:43 [verbose]: Chat is now polling every 60000 ms
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #1 Setup request handler
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #2 Add test channels
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #3 Show overlay with channels
[runtime] 2022-06-28 08:36:43 [verbose]: Attempting to join public channel #channel-1
[runtime] 2022-06-28 08:36:43 [verbose]: Attempting to join public channel #channel-2
[runtime] 2022-06-28 08:36:43 [verbose]: Attempting to join PM channel test user 854
[runtime] 2022-06-28 08:36:43 [verbose]: Current channel changed to test user 854
[runtime] 2022-06-28 08:36:43 [verbose]: Attempting to join PM channel test user 270
[runtime] 2022-06-28 08:36:43 [verbose]: Attempting to join public channel #channel-9
[runtime] 2022-06-28 08:36:43 [verbose]: Joined public channel #channel-1
[runtime] 2022-06-28 08:36:43 [verbose]: Joined public channel #channel-2
[runtime] 2022-06-28 08:36:43 [verbose]: Unhandled Request Type: osu.Game.Online.API.Requests.CreateChannelRequest
[network] 2022-06-28 08:36:43 [verbose]: Failing request osu.Game.Online.API.Requests.CreateChannelRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-28 08:36:43 [verbose]: Failed to join PM channel test user 854 (DummyAPIAccess cannot process this request.)
[runtime] 2022-06-28 08:36:43 [verbose]: Unhandled Request Type: osu.Game.Online.API.Requests.CreateChannelRequest
[network] 2022-06-28 08:36:43 [verbose]: Failing request osu.Game.Online.API.Requests.CreateChannelRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-28 08:36:43 [verbose]: Failed to join PM channel test user 270 (DummyAPIAccess cannot process this request.)
[runtime] 2022-06-28 08:36:43 [verbose]: Joined public channel #channel-9
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #4 Select channel 1
[runtime] 2022-06-28 08:36:43 [verbose]: Current channel changed to #channel-1
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #5 Channel 1 is visible
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #6 Press document next keys
[runtime] 2022-06-28 08:36:43 [verbose]: Current channel changed to #channel-2
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #7 Channel 2 is visible
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #8 Press document next keys
[runtime] 2022-06-28 08:36:43 [verbose]: Current channel changed to #channel-9
[runtime] 2022-06-28 08:36:43 [verbose]: 🔸 Step #9 PM Channel 1 displayed
[network] 2022-06-28 08:36:44 [verbose]: Request to https://a.ppy.sh/854 failed with System.Net.WebException: NotFound.
[network] 2022-06-28 08:36:44 [verbose]: Request to https://a.ppy.sh/270 failed with System.Net.WebException: NotFound.
[runtime] 2022-06-28 08:36:53 [verbose]: 💥 Failed (on attempt 7,820)
[runtime] 2022-06-28 08:36:53 [verbose]: ⏳ Currently loading components (0)
[runtime] 2022-06-28 08:36:53 [verbose]: 🧵 Task schedulers
[runtime] 2022-06-28 08:36:53 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-06-28 08:36:53 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-06-28 08:36:53 [verbose]: 🎱 Thread pool
[runtime] 2022-06-28 08:36:53 [verbose]: worker:          min 32     max 32,767 available 32,766
[runtime] 2022-06-28 08:36:53 [verbose]: completion:      min 32     max 1,000  available 1,000
[runtime] 2022-06-28 08:36:53 [debug]: Focus on "ChatTextBox" no longer valid as a result of unfocusIfNoLongerValid.
[runtime] 2022-06-28 08:36:53 [debug]: Focus changed from ChatTextBox to nothing.
```