### PR TITLE
Fix flaky song select placeholder test by changing ruleset post-display

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -100,11 +100,12 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestPlaceholderConvertSetting()
         {
-            changeRuleset(2);
             addRulesetImportStep(0);
             AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
 
             createSongSelect();
+
+            changeRuleset(2);
 
             AddUntilStep("wait for placeholder visible", () => getPlaceholder()?.State.Value == Visibility.Visible);
 


### PR DESCRIPTION
Was failing occasionally due to the beatmap present operation causing the test's ruleset change to undo.

```csharp
TearDown : System.TimeoutException : "wait for placeholder visible" timed out
--TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Tests/Visual/OsuTestScene.cs:line 503
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
------- Stdout: -------
[runtime] 2022-06-29 10:36:45 [verbose]: 💨 Class: TestScenePlaySongSelect
[runtime] 2022-06-29 10:36:45 [verbose]: 🔶 Test:  TestPlaceholderConvertSetting
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #1 exit all screens
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #2 reset defaults
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #3 delete all beatmaps
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #4 change ruleset to 2
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #5 import test map for ruleset 0
[database] 2022-06-29 10:36:45 [verbose]: [efc1a] Beginning import from unknown...
[database] 2022-06-29 10:36:45 [verbose]: [efc1a] Import successfully completed!
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #6 wait for imported to arrive in carousel
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #7 change convert setting
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #8 create song select
[runtime] 2022-06-29 10:36:45 [verbose]: ScreenTestScene screen changed → TestScenePlaySongSelect+TestSongSelect
[runtime] 2022-06-29 10:36:45 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#338(depth:1) loading TestScenePlaySongSelect+TestSongSelect#263
[runtime] 2022-06-29 10:36:45 [verbose]: decoupled ruleset transferred ("" -> "osu!catch")
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #9 wait for present
[runtime] 2022-06-29 10:36:45 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#338(depth:1) entered TestScenePlaySongSelect+TestSongSelect#263
[runtime] 2022-06-29 10:36:45 [verbose]: 📺 BackgroundScreenStack#328(depth:1) loading BackgroundScreenBeatmap#338
[runtime] 2022-06-29 10:36:45 [verbose]: 📺 BackgroundScreenStack#328(depth:1) entered BackgroundScreenBeatmap#338
[runtime] 2022-06-29 10:36:45 [verbose]: Song select updating selection with beatmap:null ruleset:fruits
[runtime] 2022-06-29 10:36:45 [verbose]: Song select changing beatmap from "please load a beatmap! - no beatmaps available!" to "null"
[runtime] 2022-06-29 10:36:45 [verbose]: Song select working beatmap updated to Some Artist 0 - Some Song (set id 6224) ece7b702-895c-4f15-892f-05e4ff5e9a24 (Some Guy 3) [Normal 6224000 (length 0:50, bpm 106.7)]
[runtime] 2022-06-29 10:36:45 [verbose]: Song select updating selection with beatmap:null ruleset:osu
[runtime] 2022-06-29 10:36:45 [verbose]: decoupled ruleset transferred ("osu!catch" -> "osu!")
[runtime] 2022-06-29 10:36:45 [verbose]: Song select updating selection with beatmap:74232aa2-2a1f-4920-b643-e85976838251 ruleset:osu
[runtime] 2022-06-29 10:36:45 [verbose]: Song select decided to ensurePlayingSelected
[runtime] 2022-06-29 10:36:45 [verbose]: Game-wide working beatmap updated to Some Artist 0 - Some Song (set id 6224) ece7b702-895c-4f15-892f-05e4ff5e9a24 (Some Guy 3) [Normal 6224000 (length 0:50, bpm 106.7)]
[runtime] 2022-06-29 10:36:45 [debug]: Focus changed from nothing to SeekLimitedSearchTextBox.
[network] 2022-06-29 10:36:45 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
[runtime] 2022-06-29 10:36:45 [verbose]: ✔️ 16 repetitions
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #10 wait for carousel loaded
[runtime] 2022-06-29 10:36:45 [verbose]: 🔸 Step #11 wait for placeholder visible
[runtime] 2022-06-29 10:36:55 [verbose]: 💥 Failed (on attempt 1,459)
[runtime] 2022-06-29 10:36:55 [verbose]: ⏳ Currently loading components (0)
[runtime] 2022-06-29 10:36:55 [verbose]: 🧵 Task schedulers
[runtime] 2022-06-29 10:36:55 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
[runtime] 2022-06-29 10:36:55 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
[runtime] 2022-06-29 10:36:55 [verbose]: 🎱 Thread pool
[runtime] 2022-06-29 10:36:55 [verbose]: worker:          min 1      max 32,767 available 32,766
[runtime] 2022-06-29 10:36:55 [verbose]: completion:      min 1      max 1,000  available 1,000
[runtime] 2022-06-29 10:36:55 [debug]: Focus on "SeekLimitedSearchTextBox" no longer valid as a result of unfocusIfNoLongerValid.
[runtime] 2022-06-29 10:36:55 [debug]: Focus changed from SeekLimitedSearchTextBox to nothing.
```