### PR TITLE
Attempt to fix editor navigation test failures again

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorNavigation.cs
@@ -6,18 +6,14 @@ using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Screens.Select;
 using osu.Game.Tests.Resources;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
@@ -36,20 +32,21 @@ namespace osu.Game.Tests.Visual.Editing
                 () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet)
                       && Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect
                       && songSelect.IsLoaded);
-            AddUntilStep("wait for completion notification", () => Game.Notifications.ChildrenOfType<ProgressCompletionNotification>().Count() == 1);
-            AddStep("dismiss notifications", () => Game.Notifications.Hide());
             AddStep("switch ruleset", () => Game.Ruleset.Value = new ManiaRuleset().RulesetInfo);
 
             AddStep("open editor", () => ((PlaySongSelect)Game.ScreenStack.CurrentScreen).Edit(beatmapSet.Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == 0)));
             AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.ReadyForUse);
-            AddStep("test gameplay", () =>
+            AddStep("test gameplay", () => ((Editor)Game.ScreenStack.CurrentScreen).TestGameplay());
+
+            AddUntilStep("wait for player", () =>
             {
-                var testGameplayButton = this.ChildrenOfType<TestGameplayButton>().Single();
-                InputManager.MoveMouseTo(testGameplayButton);
-                InputManager.Click(MouseButton.Left);
+                // notifications may fire at almost any inopportune time and cause annoying test failures.
+                // relentlessly attempt to dismiss any and all interfering overlays, which includes notifications.
+                // this is theoretically not foolproof, but it's the best that can be done here.
+                Game.CloseAllOverlays();
+                return Game.ScreenStack.CurrentScreen is EditorPlayer editorPlayer && editorPlayer.IsLoaded;
             });
 
-            AddUntilStep("wait for player", () => Game.ScreenStack.CurrentScreen is EditorPlayer editorPlayer && editorPlayer.IsLoaded);
             AddAssert("current ruleset is osu!", () => Game.Ruleset.Value.Equals(new OsuRuleset().RulesetInfo));
 
             AddStep("exit to song select", () => Game.PerformFromScreen(_ => { }, typeof(PlaySongSelect).Yield()));


### PR DESCRIPTION
Context: https://discord.com/channels/188630481301012481/188630652340404224/991724028169552023

Try number 2 of throwing spaghetti at wall (try 1 was https://github.com/ppy/osu/pull/18910). I swear if this fails again I will delete the test fixture myself.

First of all, stop relying that `InputManager` will successfully press the gameplay test button, because it won't if it's obscured by the notification overlay. Closing the overlay in a loop doesn't work because there's a chance that a notification is posted, then all overlays are closed, then another notification is posted, and so the button still isn't clickable. Instead, use the `TestGameplay()` method directly.

Secondly, the notifications will still block `EditorPlayerLoader` from transitioning to `EditorPlayer`. Here we have no other choice than to aggressively dismiss notifications every spin of the relevant until step and hope we eventually progress to `EditorPlayer`.