### PR TITLE
Separate slider ball and followcircle skinnables into default/legacy classes

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
@@ -14,7 +14,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -93,10 +92,10 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             AddStep("set accent white", () => dho.AccentColour.Value = Color4.White);
-            AddAssert("ball is white", () => dho.ChildrenOfType<SliderBall>().Single().AccentColour == Color4.White);
+            AddAssert("ball is white", () => dho.ChildrenOfType<DrawableSliderBall>().Single().AccentColour == Color4.White);
 
             AddStep("set accent red", () => dho.AccentColour.Value = Color4.Red);
-            AddAssert("ball is red", () => dho.ChildrenOfType<SliderBall>().Single().AccentColour == Color4.Red);
+            AddAssert("ball is red", () => dho.ChildrenOfType<DrawableSliderBall>().Single().AccentColour == Color4.Red);
         }
 
         private Slider prepareObject(Slider slider)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -29,7 +29,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public DrawableSliderHead HeadCircle => headContainer.Child;
         public DrawableSliderTail TailCircle => tailContainer.Child;
 
-        public SliderBall Ball { get; private set; }
+        [Cached]
+        public DrawableSliderBall Ball { get; private set; }
+
         public SkinnableDrawable Body { get; private set; }
 
         /// <summary>
@@ -60,6 +62,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public DrawableSlider([CanBeNull] Slider s = null)
             : base(s)
         {
+            Ball = new DrawableSliderBall
+            {
+                GetInitialHitAction = () => HeadCircle.HitAction,
+                BypassAutoSizeAxes = Axes.Both,
+                AlwaysPresent = true,
+                Alpha = 0
+            };
         }
 
         [BackgroundDependencyLoader]
@@ -73,13 +82,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 repeatContainer = new Container<DrawableSliderRepeat> { RelativeSizeAxes = Axes.Both },
                 headContainer = new Container<DrawableSliderHead> { RelativeSizeAxes = Axes.Both },
                 OverlayElementContainer = new Container { RelativeSizeAxes = Axes.Both, },
-                Ball = new SliderBall(this)
-                {
-                    GetInitialHitAction = () => HeadCircle.HitAction,
-                    BypassAutoSizeAxes = Axes.Both,
-                    AlwaysPresent = true,
-                    Alpha = 0
-                },
+                Ball,
                 slidingSample = new PausableSkinnableSound { Looping = true }
             };
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultFollowCircle.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public class DefaultFollowCircle : CompositeDrawable
+    {
+        public DefaultFollowCircle()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChild = new CircularContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                BorderThickness = 5,
+                BorderColour = Color4.Orange,
+                Blending = BlendingParameters.Additive,
+                Child = new Box
+                {
+                    Colour = Color4.Orange,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.2f,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSliderBall.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public class DefaultSliderBall : CompositeDrawable
+    {
+        private Box box;
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableObject, ISkinSource skin)
+        {
+            var slider = (DrawableSlider)drawableObject;
+
+            RelativeSizeAxes = Axes.Both;
+
+            float radius = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderPathRadius)?.Value ?? OsuHitObject.OBJECT_RADIUS;
+
+            InternalChild = new CircularContainer
+            {
+                Masking = true,
+                RelativeSizeAxes = Axes.Both,
+                Scale = new Vector2(radius / OsuHitObject.OBJECT_RADIUS),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Blending = BlendingParameters.Additive,
+                BorderThickness = 10,
+                BorderColour = Color4.White,
+                Alpha = 1,
+                Child = box = new Box
+                {
+                    Blending = BlendingParameters.Additive,
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.White,
+                    AlwaysPresent = true,
+                    Alpha = 0
+                }
+            };
+
+            slider.Tracking.BindValueChanged(trackingChanged, true);
+        }
+
+        private void trackingChanged(ValueChangedEvent<bool> tracking) =>
+            box.FadeTo(tracking.NewValue ? 0.3f : 0.05f, 200, Easing.OutQuint);
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Legacy
+{
+    public class LegacyFollowCircle : CompositeDrawable
+    {
+        public LegacyFollowCircle(Drawable animationContent)
+        {
+            // follow circles are 2x the hitcircle resolution in legacy skins (since they are scaled down from >1x
+            animationContent.Scale *= 0.5f;
+            animationContent.Anchor = Anchor.Centre;
+            animationContent.Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+            InternalChild = animationContent;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -41,11 +41,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         return this.GetAnimation(component.LookupName, false, false);
 
                     case OsuSkinComponents.SliderFollowCircle:
-                        var followCircle = this.GetAnimation("sliderfollowcircle", true, true, true);
-                        if (followCircle != null)
-                            // follow circles are 2x the hitcircle resolution in legacy skins (since they are scaled down from >1x
-                            followCircle.Scale *= 0.5f;
-                        return followCircle;
+                        var followCircleContent = this.GetAnimation("sliderfollowcircle", true, true, true);
+                        if (followCircleContent != null)
+                            return new LegacyFollowCircle(followCircleContent);
+
+                        return null;
 
                     case OsuSkinComponents.SliderBall:
                         var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "");


### PR DESCRIPTION
Continuation of #14832 based on comments from #18795

The original PR was too ambitious. As mentioned, the changes should have been more granular. This is the first part of the original PR and aims to make improvements to the project's file structure, which is necessary to implement the slider anim changes. However, keeping with the idea of granularity, this PR is meant to be treated mostly individually, as this PR is intended to be beneficial on its own, whether or not the slider anim changes are accepted.

### Summary
* Separates slider ball and followcircle skinnables into `Default` and `Legacy` classes
* Moves game logic from `SliderBall` into new `DrawableSliderBall` class
* Renames `fullSizeFollowCircle` to `followCircleReceptor`

### Rationale
* Separating slider ball and followcircle into `Default` and `Legacy` classes:
    * Better fits the already in-place format that other skinnables follow (spinners, approach circles, etc.)
    * Provides more flexibility w.r.t. animating slider balls and followcircles
* Moving game logic into new `DrawableSliderBall` class:
    * Classes in the `Skinning` namespace should pertain to visuals, not to actual game logic (i.e. tracking, ball movement)
    * Necessary for splitting slider ball into `Default` and `Legacy` (without duplicating an ungodly amount of code)
* Renaming `fullSizeFollowCircle` to `followCircleReceptor`:
    * Better reflects what the object actually does (acts as an invisible, virtual hitbox)
    * Is similar to how `DrawableHitCircle` names its own hitbox
