### PR TITLE
Fix converting "inherited" mods to legacy mods

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchLegacyModConversionTest.cs
@@ -24,21 +24,24 @@ namespace osu.Game.Rulesets.Catch.Tests
             new object[] { LegacyMods.DoubleTime, new[] { typeof(CatchModDoubleTime) } },
             new object[] { LegacyMods.Relax, new[] { typeof(CatchModRelax) } },
             new object[] { LegacyMods.HalfTime, new[] { typeof(CatchModHalfTime) } },
-            new object[] { LegacyMods.Nightcore, new[] { typeof(CatchModNightcore) } },
             new object[] { LegacyMods.Flashlight, new[] { typeof(CatchModFlashlight) } },
             new object[] { LegacyMods.Autoplay, new[] { typeof(CatchModAutoplay) } },
-            new object[] { LegacyMods.Perfect, new[] { typeof(CatchModPerfect) } },
-            new object[] { LegacyMods.Cinema, new[] { typeof(CatchModCinema) } },
             new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(CatchModHardRock), typeof(CatchModDoubleTime) } }
         };
+
+        [TestCaseSource(nameof(catch_mod_mapping))]
+        [TestCase(LegacyMods.Cinema, new[] { typeof(CatchModCinema) })]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(CatchModCinema) })]
+        [TestCase(LegacyMods.Nightcore, new[] { typeof(CatchModNightcore) })]
+        [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(CatchModNightcore) })]
+        [TestCase(LegacyMods.Perfect, new[] { typeof(CatchModPerfect) })]
+        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(CatchModPerfect) })]
+        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         [TestCaseSource(nameof(catch_mod_mapping))]
         [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(CatchModCinema) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(CatchModNightcore) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(CatchModPerfect) })]
-        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
-
-        [TestCaseSource(nameof(catch_mod_mapping))]
         public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new CatchRuleset();

--- a/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
@@ -23,10 +23,8 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { LegacyMods.SuddenDeath, new[] { typeof(ManiaModSuddenDeath) } },
             new object[] { LegacyMods.DoubleTime, new[] { typeof(ManiaModDoubleTime) } },
             new object[] { LegacyMods.HalfTime, new[] { typeof(ManiaModHalfTime) } },
-            new object[] { LegacyMods.Nightcore, new[] { typeof(ManiaModNightcore) } },
             new object[] { LegacyMods.Flashlight, new[] { typeof(ManiaModFlashlight) } },
             new object[] { LegacyMods.Autoplay, new[] { typeof(ManiaModAutoplay) } },
-            new object[] { LegacyMods.Perfect, new[] { typeof(ManiaModPerfect) } },
             new object[] { LegacyMods.Key4, new[] { typeof(ManiaModKey4) } },
             new object[] { LegacyMods.Key5, new[] { typeof(ManiaModKey5) } },
             new object[] { LegacyMods.Key6, new[] { typeof(ManiaModKey6) } },
@@ -34,7 +32,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             new object[] { LegacyMods.Key8, new[] { typeof(ManiaModKey8) } },
             new object[] { LegacyMods.FadeIn, new[] { typeof(ManiaModFadeIn) } },
             new object[] { LegacyMods.Random, new[] { typeof(ManiaModRandom) } },
-            new object[] { LegacyMods.Cinema, new[] { typeof(ManiaModCinema) } },
             new object[] { LegacyMods.Key9, new[] { typeof(ManiaModKey9) } },
             new object[] { LegacyMods.KeyCoop, new[] { typeof(ManiaModDualStages) } },
             new object[] { LegacyMods.Key1, new[] { typeof(ManiaModKey1) } },
@@ -45,12 +42,18 @@ namespace osu.Game.Rulesets.Mania.Tests
         };
 
         [TestCaseSource(nameof(mania_mod_mapping))]
+        [TestCase(LegacyMods.Cinema, new[] { typeof(ManiaModCinema) })]
         [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(ManiaModCinema) })]
+        [TestCase(LegacyMods.Nightcore, new[] { typeof(ManiaModNightcore) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(ManiaModNightcore) })]
+        [TestCase(LegacyMods.Perfect, new[] { typeof(ManiaModPerfect) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(ManiaModPerfect) })]
         public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         [TestCaseSource(nameof(mania_mod_mapping))]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(ManiaModCinema) })]
+        [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(ManiaModNightcore) })]
+        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(ManiaModPerfect) })]
         public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new ManiaRuleset();

--- a/osu.Game.Rulesets.Osu.Tests/OsuLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuLegacyModConversionTest.cs
@@ -25,24 +25,27 @@ namespace osu.Game.Rulesets.Osu.Tests
             new object[] { LegacyMods.DoubleTime, new[] { typeof(OsuModDoubleTime) } },
             new object[] { LegacyMods.Relax, new[] { typeof(OsuModRelax) } },
             new object[] { LegacyMods.HalfTime, new[] { typeof(OsuModHalfTime) } },
-            new object[] { LegacyMods.Nightcore, new[] { typeof(OsuModNightcore) } },
             new object[] { LegacyMods.Flashlight, new[] { typeof(OsuModFlashlight) } },
             new object[] { LegacyMods.Autoplay, new[] { typeof(OsuModAutoplay) } },
             new object[] { LegacyMods.SpunOut, new[] { typeof(OsuModSpunOut) } },
             new object[] { LegacyMods.Autopilot, new[] { typeof(OsuModAutopilot) } },
-            new object[] { LegacyMods.Perfect, new[] { typeof(OsuModPerfect) } },
-            new object[] { LegacyMods.Cinema, new[] { typeof(OsuModCinema) } },
             new object[] { LegacyMods.Target, new[] { typeof(OsuModTarget) } },
             new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(OsuModHardRock), typeof(OsuModDoubleTime) } }
         };
 
         [TestCaseSource(nameof(osu_mod_mapping))]
+        [TestCase(LegacyMods.Cinema, new[] { typeof(OsuModCinema) })]
         [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(OsuModCinema) })]
+        [TestCase(LegacyMods.Nightcore, new[] { typeof(OsuModNightcore) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(OsuModNightcore) })]
+        [TestCase(LegacyMods.Perfect, new[] { typeof(OsuModPerfect) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(OsuModPerfect) })]
         public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         [TestCaseSource(nameof(osu_mod_mapping))]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(OsuModCinema) })]
+        [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(OsuModNightcore) })]
+        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(OsuModPerfect) })]
         public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new OsuRuleset();

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoLegacyModConversionTest.cs
@@ -24,22 +24,25 @@ namespace osu.Game.Rulesets.Taiko.Tests
             new object[] { LegacyMods.DoubleTime, new[] { typeof(TaikoModDoubleTime) } },
             new object[] { LegacyMods.Relax, new[] { typeof(TaikoModRelax) } },
             new object[] { LegacyMods.HalfTime, new[] { typeof(TaikoModHalfTime) } },
-            new object[] { LegacyMods.Nightcore, new[] { typeof(TaikoModNightcore) } },
             new object[] { LegacyMods.Flashlight, new[] { typeof(TaikoModFlashlight) } },
             new object[] { LegacyMods.Autoplay, new[] { typeof(TaikoModAutoplay) } },
-            new object[] { LegacyMods.Perfect, new[] { typeof(TaikoModPerfect) } },
             new object[] { LegacyMods.Random, new[] { typeof(TaikoModRandom) } },
-            new object[] { LegacyMods.Cinema, new[] { typeof(TaikoModCinema) } },
             new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(TaikoModHardRock), typeof(TaikoModDoubleTime) } }
         };
+
+        [TestCaseSource(nameof(taiko_mod_mapping))]
+        [TestCase(LegacyMods.Cinema, new[] { typeof(TaikoModCinema) })]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(TaikoModCinema) })]
+        [TestCase(LegacyMods.Nightcore, new[] { typeof(TaikoModNightcore) })]
+        [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(TaikoModNightcore) })]
+        [TestCase(LegacyMods.Perfect, new[] { typeof(TaikoModPerfect) })]
+        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(TaikoModPerfect) })]
+        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         [TestCaseSource(nameof(taiko_mod_mapping))]
         [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(TaikoModCinema) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(TaikoModNightcore) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(TaikoModPerfect) })]
-        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
-
-        [TestCaseSource(nameof(taiko_mod_mapping))]
         public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new TaikoRuleset();

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets
                         break;
 
                     case ModPerfect:
-                        value |= LegacyMods.Perfect;
+                        value |= LegacyMods.Perfect | LegacyMods.SuddenDeath;
                         break;
 
                     case ModSuddenDeath:
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets
                         break;
 
                     case ModNightcore:
-                        value |= LegacyMods.Nightcore;
+                        value |= LegacyMods.Nightcore | LegacyMods.DoubleTime;
                         break;
 
                     case ModDoubleTime:
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets
                         break;
 
                     case ModCinema:
-                        value |= LegacyMods.Cinema;
+                        value |= LegacyMods.Cinema | LegacyMods.Autoplay;
                         break;
 
                     case ModAutoplay:


### PR DESCRIPTION
osu-stable outputs NC+DT, PF+SD, and Cinema+Autoplay, to both scores (stored in the database) and replays. Of particular importance, the DT mod specifically is used to look up difficulty attributes in the database.

Although this change applies to replays too, it doesn't have any effect as both lazer and stable handle not having both mods listed.