### PR TITLE
Ensure PlaylistItem's beatmap is not null

### DIFF
--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Online.Rooms
         /// In many cases, this will *not* contain any usable information apart from OnlineID.
         /// </summary>
         [JsonIgnore]
-        public IBeatmapInfo Beatmap { get; set; } = null!;
+        public IBeatmapInfo Beatmap { get; private set; }
 
         [JsonIgnore]
         public IBindable<bool> Valid => valid;
@@ -81,6 +81,7 @@ namespace osu.Game.Online.Rooms
 
         [JsonConstructor]
         private PlaylistItem()
+            : this(new APIBeatmap())
         {
         }
 


### PR DESCRIPTION
_May_ fix test failures as in https://github.com/ppy/osu/runs/7123898516?check_suite_focus=true

I'm not entirely sure how this could happen, and it's likely a symptom of something worse, but it could conceivably happen if the JSON text doesn't contain the beatmap.