### PR TITLE
Move star difficulty filter to song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneDifficultyRangeFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneDifficultyRangeFilterControl.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Select;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneDifficultyRangeFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneDifficultyRangeFilterControl.cs
@@ -14,13 +14,16 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestBasic()
         {
-            Child = new DifficultyRangeFilterControl
+            AddStep("create control", () =>
             {
-                Width = 200,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Scale = new Vector2(3),
-            };
+                Child = new DifficultyRangeFilterControl
+                {
+                    Width = 200,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(3),
+                };
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneDifficultyRangeFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneDifficultyRangeFilterControl.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Screens.Select;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.SongSelect
+{
+    public class TestSceneDifficultyRangeFilterControl : OsuTestScene
+    {
+        [Test]
+        public void TestBasic()
+        {
+            Child = new DifficultyRangeFilterControl
+            {
+                Width = 200,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(3),
+            };
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -19,7 +19,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class Nub : CompositeDrawable, IHasCurrentValue<bool>, IHasAccentColour
+    public class Nub : Container, IHasCurrentValue<bool>, IHasAccentColour
     {
         public const float HEIGHT = 15;
 

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -38,8 +38,8 @@ namespace osu.Game.Graphics.UserInterface
         private T lastSampleValue;
 
         protected readonly Nub Nub;
-        private readonly Box leftBox;
-        private readonly Box rightBox;
+        protected readonly Box LeftBox;
+        protected readonly Box RightBox;
         private readonly Container nubContainer;
 
         public virtual LocalisableString TooltipText { get; private set; }
@@ -57,7 +57,7 @@ namespace osu.Game.Graphics.UserInterface
             set
             {
                 accentColour = value;
-                leftBox.Colour = value;
+                LeftBox.Colour = value;
             }
         }
 
@@ -69,7 +69,7 @@ namespace osu.Game.Graphics.UserInterface
             set
             {
                 backgroundColour = value;
-                rightBox.Colour = value;
+                RightBox.Colour = value;
             }
         }
 
@@ -96,7 +96,7 @@ namespace osu.Game.Graphics.UserInterface
                         CornerRadius = 5f,
                         Children = new Drawable[]
                         {
-                            leftBox = new Box
+                            LeftBox = new Box
                             {
                                 Height = 5,
                                 EdgeSmoothness = new Vector2(0, 0.5f),
@@ -104,7 +104,7 @@ namespace osu.Game.Graphics.UserInterface
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                             },
-                            rightBox = new Box
+                            RightBox = new Box
                             {
                                 Height = 5,
                                 EdgeSmoothness = new Vector2(0, 0.5f),
@@ -225,9 +225,9 @@ namespace osu.Game.Graphics.UserInterface
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
-            leftBox.Scale = new Vector2(Math.Clamp(
+            LeftBox.Scale = new Vector2(Math.Clamp(
                 RangePadding + Nub.DrawPosition.X - Nub.DrawWidth / 2, 0, DrawWidth), 1);
-            rightBox.Scale = new Vector2(Math.Clamp(
+            RightBox.Scale = new Vector2(Math.Clamp(
                 DrawWidth - Nub.DrawPosition.X - RangePadding - Nub.DrawWidth / 2, 0, DrawWidth), 1);
         }
 

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -111,7 +111,6 @@ namespace osu.Game.Graphics.UserInterface
                                 RelativeSizeAxes = Axes.None,
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,
-                                Alpha = 0.5f,
                             },
                         },
                     },
@@ -137,7 +136,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             sample = audio.Samples.Get(@"UI/notch-tick");
             AccentColour = colourProvider?.Highlight1 ?? colours.Pink;
-            BackgroundColour = colourProvider?.Background5 ?? colours.Pink.Opacity(0.5f);
+            BackgroundColour = colourProvider?.Background5 ?? colours.PinkDarker.Darken(1);
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -3,13 +3,10 @@
 
 #nullable disable
 
-using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Mods.Input;
 
@@ -17,20 +14,11 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
     public class SongSelectSettings : SettingsSubsection
     {
-        private Bindable<double> minStars;
-        private Bindable<double> maxStars;
-
         protected override LocalisableString Header => UserInterfaceStrings.SongSelectHeader;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            minStars = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
-            maxStars = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
-
-            minStars.ValueChanged += min => maxStars.Value = Math.Max(min.NewValue, maxStars.Value);
-            maxStars.ValueChanged += max => minStars.Value = Math.Min(max.NewValue, minStars.Value);
-
             Children = new Drawable[]
             {
                 new SettingsCheckbox
@@ -44,20 +32,6 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     LabelText = UserInterfaceStrings.ShowConvertedBeatmaps,
                     Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
                 },
-                new SettingsSlider<double, StarsSlider>
-                {
-                    LabelText = UserInterfaceStrings.StarsMinimum,
-                    Current = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum),
-                    KeyboardStep = 0.1f,
-                    Keywords = new[] { "minimum", "maximum", "star", "difficulty" }
-                },
-                new SettingsSlider<double, MaximumStarsSlider>
-                {
-                    LabelText = UserInterfaceStrings.StarsMaximum,
-                    Current = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum),
-                    KeyboardStep = 0.1f,
-                    Keywords = new[] { "minimum", "maximum", "star", "difficulty" }
-                },
                 new SettingsEnumDropdown<RandomSelectAlgorithm>
                 {
                     LabelText = UserInterfaceStrings.RandomSelectionAlgorithm,
@@ -70,16 +44,6 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     ClassicDefault = ModSelectHotkeyStyle.Classic
                 }
             };
-        }
-
-        private class MaximumStarsSlider : StarsSlider
-        {
-            public override LocalisableString TooltipText => Current.IsDefault ? UserInterfaceStrings.NoLimit : base.TooltipText;
-        }
-
-        private class StarsSlider : OsuSliderBar<double>
-        {
-            public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
         }
     }
 }

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -101,6 +102,12 @@ namespace osu.Game.Screens.Select
             public override LocalisableString TooltipText => Current.IsDefault
                 ? UserInterfaceStrings.NoLimit
                 : Current.Value.ToString(@"0.## stars");
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                base.OnHover(e);
+                return true; // Make sure only one nub shows hover effect at once.
+            }
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -23,37 +23,32 @@ namespace osu.Game.Screens.Select
         private Bindable<double> lowerStars;
         private Bindable<double> upperStars;
 
-        private StarsSlider lowerSlider;
-        private MaximumStarsSlider upperSlider;
-
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
             const float vertical_offset = 13;
 
-            InternalChildren = new[]
+            InternalChildren = new Drawable[]
             {
                 new OsuSpriteText
                 {
                     Text = "Difficulty range",
                     Font = OsuFont.GetFont(size: 14),
                 },
-                upperSlider = new MaximumStarsSlider
+                new MaximumStarsSlider
                 {
                     Current = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum),
                     KeyboardStep = 0.1f,
                     RelativeSizeAxes = Axes.X,
                     Y = vertical_offset,
                 },
-                lowerSlider = new MinimumStarsSlider
+                new MinimumStarsSlider
                 {
                     Current = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum),
                     KeyboardStep = 0.1f,
                     RelativeSizeAxes = Axes.X,
                     Y = vertical_offset,
-                },
-                upperSlider.Nub.CreateProxy(),
-                lowerSlider.Nub.CreateProxy(),
+                }
             };
 
             lowerStars = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
@@ -106,8 +101,6 @@ namespace osu.Game.Screens.Select
             public override LocalisableString TooltipText => Current.IsDefault
                 ? UserInterfaceStrings.NoLimit
                 : Current.Value.ToString(@"0.## stars");
-
-            public new Nub Nub => base.Nub;
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -21,8 +20,8 @@ namespace osu.Game.Screens.Select
 {
     internal class DifficultyRangeFilterControl : CompositeDrawable
     {
-        private Bindable<double> lowerStars;
-        private Bindable<double> upperStars;
+        private Bindable<double> lowerStars = null!;
+        private Bindable<double> upperStars = null!;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
@@ -97,8 +96,6 @@ namespace osu.Game.Screens.Select
 
         private class StarsSlider : OsuSliderBar<double>
         {
-            private OsuSpriteText currentDisplay;
-
             public override LocalisableString TooltipText => Current.IsDefault
                 ? UserInterfaceStrings.NoLimit
                 : Current.Value.ToString(@"0.## stars");
@@ -114,6 +111,8 @@ namespace osu.Game.Screens.Select
                 base.LoadComplete();
                 Nub.Width = Nub.HEIGHT;
                 RangePadding = Nub.Width / 2;
+
+                OsuSpriteText currentDisplay;
 
                 Nub.Add(currentDisplay = new OsuSpriteText
                 {

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+using osuTK;
+
+namespace osu.Game.Screens.Select
+{
+    internal class DifficultyRangeFilterControl : CompositeDrawable
+    {
+        private Bindable<double> minStars;
+        private Bindable<double> maxStars;
+
+        private StarsSlider lowerSlider;
+        private MaximumStarsSlider upperSlider;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            const float vertical_offset = 15;
+
+            InternalChildren = new[]
+            {
+                new OsuSpriteText
+                {
+                    Text = "Difficulty range",
+                    Font = OsuFont.GetFont(size: 14),
+                },
+                upperSlider = new MaximumStarsSlider
+                {
+                    Current = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum),
+                    KeyboardStep = 0.1f,
+                    RelativeSizeAxes = Axes.X,
+                    Y = vertical_offset,
+                },
+                lowerSlider = new StarsSlider
+                {
+                    Current = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum),
+                    KeyboardStep = 0.1f,
+                    RelativeSizeAxes = Axes.X,
+                    Y = vertical_offset,
+                },
+                lowerSlider.Nub.CreateProxy(),
+                upperSlider.Nub.CreateProxy(),
+            };
+
+            lowerSlider.LeftBox.Height = 6;
+
+            minStars = config.GetBindable<double>(OsuSetting.DisplayStarsMinimum);
+            maxStars = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
+
+            lowerSlider.AccentColour = lowerSlider.BackgroundColour;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            minStars.ValueChanged += min => maxStars.Value = Math.Max(min.NewValue, maxStars.Value);
+            maxStars.ValueChanged += max => minStars.Value = Math.Min(max.NewValue, minStars.Value);
+        }
+
+        private class MaximumStarsSlider : StarsSlider
+        {
+            public override LocalisableString TooltipText => Current.IsDefault ? UserInterfaceStrings.NoLimit : base.TooltipText;
+        }
+
+        private class StarsSlider : OsuSliderBar<double>
+        {
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Nub.ReceivePositionalInputAt(screenSpacePos);
+
+            public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
+
+            public new Nub Nub => base.Nub;
+            public new Box LeftBox => base.LeftBox;
+        }
+    }
+}

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -83,8 +83,6 @@ namespace osu.Game.Screens.Select
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
                 base.ReceivePositionalInputAt(screenSpacePos)
                 && screenSpacePos.X <= Nub.ScreenSpaceDrawQuad.TopRight.X;
-
-            public override LocalisableString TooltipText => Current.IsDefault ? UserInterfaceStrings.NoLimit : base.TooltipText;
         }
 
         private class MaximumStarsSlider : StarsSlider
@@ -99,12 +97,15 @@ namespace osu.Game.Screens.Select
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
                 base.ReceivePositionalInputAt(screenSpacePos)
                 && screenSpacePos.X >= Nub.ScreenSpaceDrawQuad.TopLeft.X;
-            public override LocalisableString TooltipText => Current.IsDefault ? UserInterfaceStrings.NoLimit : base.TooltipText;
         }
 
         private class StarsSlider : OsuSliderBar<double>
         {
-            public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
+            private OsuSpriteText currentDisplay;
+
+            public override LocalisableString TooltipText => Current.IsDefault
+                ? UserInterfaceStrings.NoLimit
+                : Current.Value.ToString(@"0.## stars");
 
             public new Nub Nub => base.Nub;
 
@@ -113,6 +114,20 @@ namespace osu.Game.Screens.Select
                 base.LoadComplete();
                 Nub.Width = Nub.HEIGHT;
                 RangePadding = Nub.Width / 2;
+
+                Nub.Add(currentDisplay = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Y = -0.5f,
+                    Colour = Color4.White,
+                    Font = OsuFont.Torus.With(size: 10),
+                });
+
+                Current.BindValueChanged(current =>
+                {
+                    currentDisplay.Text = current.NewValue != Current.Default ? current.NewValue.ToString("N1") : "∞";
+                }, true);
             }
         }
     }

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Select
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            const float vertical_offset = 15;
+            const float vertical_offset = 13;
 
             InternalChildren = new[]
             {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -158,6 +158,11 @@ namespace osu.Game.Screens.Select
                                 Height = 20,
                                 Children = new Drawable[]
                                 {
+                                    new DifficultyRangeFilterControl
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Width = 0.5f,
+                                    },
                                     collectionDropdown = new CollectionFilterDropdown
                                     {
                                         Anchor = Anchor.TopRight,

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -155,20 +155,23 @@ namespace osu.Game.Screens.Select
                             new Container
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Height = 20,
+                                Height = 40,
                                 Children = new Drawable[]
                                 {
                                     new DifficultyRangeFilterControl
                                     {
+                                        Anchor = Anchor.TopLeft,
+                                        Origin = Anchor.TopLeft,
                                         RelativeSizeAxes = Axes.Both,
-                                        Width = 0.5f,
+                                        Width = 0.48f,
                                     },
                                     collectionDropdown = new CollectionFilterDropdown
                                     {
                                         Anchor = Anchor.TopRight,
                                         Origin = Anchor.TopRight,
                                         RelativeSizeAxes = Axes.X,
-                                        Width = 0.4f,
+                                        Y = 4,
+                                        Width = 0.5f,
                                     }
                                 }
                             },


### PR DESCRIPTION
A lot of people accidentally set this setting in the global settings then can't see any beatmaps. Moving it to song select is a usability priority, to the point I've taken some shortcuts to get this in sooner (before the full song select redesign). Focus is on usability, not getting the control looking great, but I think it works okay.

https://user-images.githubusercontent.com/191335/176836029-f860ff4c-8153-4737-8a59-b164fa635c67.mp4

Please don't mind the visual artifacts (slight bleeding on the left side of the control; thickness of middle line section changing when at extremities). If I can put up with them you can too 🙃 .

Usability concerns I'm not addressing for now as it will get a bit more complicated:
- Dragging in the middle of the range should move both values (or update the closest one, alternatively)
- Double-click should probably reset the clicked nub (but so should all `SliderBar`s)

I'm leaving the now unused localisations because we may use in the future. Can remove if preferred.