### PR TITLE
Imitate stable's slider ball fade in/out animation

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private readonly ISkin skin;
 
         [Resolved(canBeNull: true)]
-        private DrawableHitObject? drawableObject { get; set; }
+        private DrawableHitObject? parentObject { get; set; }
 
         private Sprite layerNd = null!;
         private Sprite layerSpec = null!;
@@ -66,10 +65,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             base.LoadComplete();
 
-            if (drawableObject != null)
+            if (parentObject != null)
             {
-                drawableObject.ApplyCustomUpdateState += updateStateTransforms;
-                updateStateTransforms(drawableObject, drawableObject.State.Value);
+                parentObject.ApplyCustomUpdateState += updateStateTransforms;
+                updateStateTransforms(parentObject, parentObject.State.Value);
             }
         }
 
@@ -84,15 +83,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             layerSpec.Rotation = -appliedRotation;
         }
 
-        private void updateStateTransforms(DrawableHitObject obj, ArmedState _)
+        private void updateStateTransforms(DrawableHitObject drawableObject, ArmedState _)
         {
             // Gets called by slider ticks, tails, etc., leading to duplicated
             // animations which in this case have no visual impact (due to
             // instant fade) but may negatively affect performance
-            if (obj is not DrawableSlider)
+            if (drawableObject is not DrawableSlider)
                 return;
-
-            Debug.Assert(drawableObject != null);
 
             using (BeginAbsoluteSequence(drawableObject.StateUpdateTime))
                 this.FadeIn();
@@ -105,8 +102,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             base.Dispose(isDisposing);
 
-            if (drawableObject != null)
-                drawableObject.ApplyCustomUpdateState -= updateStateTransforms;
+            if (parentObject != null)
+                parentObject.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK.Graphics;
 
@@ -85,6 +86,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private void updateStateTransforms(DrawableHitObject obj, ArmedState _)
         {
+            // Gets called by slider ticks, tails, etc., leading to duplicated
+            // animations which in this case have no visual impact (due to
+            // instant fade) but may negatively affect performance
+            if (obj is not DrawableSlider)
+                return;
+
             using (BeginAbsoluteSequence(drawableObject.AsNonNull().StateUpdateTime))
                 this.FadeIn();
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -1,8 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -92,10 +92,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             if (obj is not DrawableSlider)
                 return;
 
-            using (BeginAbsoluteSequence(drawableObject.AsNonNull().StateUpdateTime))
+            Debug.Assert(drawableObject != null);
+
+            using (BeginAbsoluteSequence(drawableObject.StateUpdateTime))
                 this.FadeIn();
 
-            using (BeginAbsoluteSequence(drawableObject.AsNonNull().HitStateUpdateTime))
+            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
                 this.FadeOut();
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         }
 
         [BackgroundDependencyLoader]
-        private void load(DrawableHitObject dho)
+        private void load()
         {
             var ballColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBall)?.Value ?? Color4.White;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -7,6 +7,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK.Graphics;
 
@@ -17,6 +19,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private readonly Drawable animationContent;
 
         private readonly ISkin skin;
+
+        private DrawableSlider slider;
 
         private Sprite layerNd;
         private Sprite layerSpec;
@@ -30,8 +34,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(DrawableHitObject dho)
         {
+            slider = (DrawableSlider)dho;
+
             var ballColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBall)?.Value ?? Color4.White;
 
             InternalChildren = new[]
@@ -56,6 +62,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     Blending = BlendingParameters.Additive,
                 },
             };
+
+            slider.ApplyCustomUpdateState += updateStateTransforms;
         }
 
         protected override void UpdateAfterChildren()
@@ -67,6 +75,26 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             layerNd.Rotation = -appliedRotation;
             layerSpec.Rotation = -appliedRotation;
+        }
+
+        private void updateStateTransforms(DrawableHitObject obj, ArmedState _)
+        {
+            if (obj is not DrawableSlider)
+                return;
+
+            using (BeginAbsoluteSequence(slider.StateUpdateTime))
+                this.FadeIn();
+
+            using (BeginAbsoluteSequence(slider.HitStateUpdateTime))
+                this.FadeOut();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (slider != null)
+                slider.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }


### PR DESCRIPTION
Continuation of #14832 - part 2

### Summary
* Makes slider ball fade in/out instantly, which is the same behavior as is currently in stable
* Only affects legacy skins

### Notes
Though only a minor change which is basically imperceptible for most skins, some skins actually draw the followcircle as part of the ball sprite, resulting in instantly fading followcircles. An example in a relatively popular skin is shigetora's, Seoul v10 ([reddit](https://www.reddit.com/r/OsuSkins/comments/rnwsz7/seoul_v10_skin_release_hdsd_169/)). The effect is slight but noticeable in this case, and doesn't work the same with lazer's current slider ball fade anims.
