### PR TITLE
Send beatmap hash to server on solo score request

### DIFF
--- a/osu.Game/Online/Solo/CreateSoloScoreRequest.cs
+++ b/osu.Game/Online/Solo/CreateSoloScoreRequest.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using System.Net.Http;
 using osu.Framework.IO.Network;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 
@@ -13,13 +14,13 @@ namespace osu.Game.Online.Solo
 {
     public class CreateSoloScoreRequest : APIRequest<APIScoreToken>
     {
-        private readonly int beatmapId;
+        private readonly BeatmapInfo beatmapInfo;
         private readonly int rulesetId;
         private readonly string versionHash;
 
-        public CreateSoloScoreRequest(int beatmapId, int rulesetId, string versionHash)
+        public CreateSoloScoreRequest(BeatmapInfo beatmapInfo, int rulesetId, string versionHash)
         {
-            this.beatmapId = beatmapId;
+            this.beatmapInfo = beatmapInfo;
             this.rulesetId = rulesetId;
             this.versionHash = versionHash;
         }
@@ -29,10 +30,11 @@ namespace osu.Game.Online.Solo
             var req = base.CreateWebRequest();
             req.Method = HttpMethod.Post;
             req.AddParameter("version_hash", versionHash);
+            req.AddParameter("beatmap_hash", beatmapInfo.MD5Hash);
             req.AddParameter("ruleset_id", rulesetId.ToString(CultureInfo.InvariantCulture));
             return req;
         }
 
-        protected override string Target => $@"beatmaps/{beatmapId}/solo/scores";
+        protected override string Target => $@"beatmaps/{beatmapInfo.OnlineID}/solo/scores";
     }
 }

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Play
             if (!Ruleset.Value.IsLegacyRuleset())
                 return null;
 
-            return new CreateSoloScoreRequest(beatmapId, rulesetId, Game.VersionHash);
+            return new CreateSoloScoreRequest(Beatmap.Value.BeatmapInfo, rulesetId, Game.VersionHash);
         }
 
         protected override bool HandleTokenRetrievalFailure(Exception exception) => false;


### PR DESCRIPTION
Right now, the client does nothing to ensure a beatmap is in a valid state before requesting to submit a score. There is further work to be done client-side so it is more aware of this state (already handled for playlists, but not for the solo gameplay loop), but the solution I have in mind for that is a bit more involved.

This is not used server-side yet, but I want to get this sending so we can start using it for some very basic validation.

Will resolve the basic portion of #11922 after implemented server-side.