### PR TITLE
Fix `BeatmapInfoWedge` test potentially failing due to quick initial load

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -53,13 +53,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 Margin = new MarginPadding { Top = 20 }
             });
 
-            AddStep("show", () =>
-            {
-                infoWedge.Show();
-                infoWedge.Beatmap = Beatmap.Value;
-            });
+            AddStep("show", () => infoWedge.Show());
 
-            // select part is redundant, but wait for load isn't
             selectBeatmap(Beatmap.Value.Beatmap);
 
             AddWaitStep("wait for select", 3);


### PR DESCRIPTION
Was doing a comparison of previous vs new content after explicitly doing a load in a previous step.

https://github.com/ppy/osu/runs/7149741587?check_suite_focus=true