### PR TITLE
Fix ID clash with announce and PM channels in chat overlay tests

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -576,12 +576,13 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createAnnounceChannel()
         {
-            int id = RNG.Next(0, DummyAPIAccess.DUMMY_USER_ID - 1);
+            const int announce_channel_id = 133337;
+
             return new Channel
             {
-                Name = $"Announce {id}",
+                Name = $"Announce {announce_channel_id}",
                 Type = ChannelType.Announce,
-                Id = id,
+                Id = announce_channel_id,
             };
         }
 


### PR DESCRIPTION
Yet Another Issue.

https://github.com/ppy/osu/runs/7159306924?check_suite_focus=true

Not sure why announce channel was using a user id for its channel ID.  Bad copy paste?