### PR TITLE
Fix replays showing incorrect star difficulty on load

### DIFF
--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -197,21 +197,19 @@ namespace osu.Game.Screens.Play
                 starRatingDisplay.Show();
             }
             else
-            {
                 starRatingDisplay.Hide();
 
-                starDifficulty.ValueChanged += d =>
-                {
-                    Debug.Assert(d.NewValue != null);
+            starDifficulty.ValueChanged += d =>
+            {
+                Debug.Assert(d.NewValue != null);
 
-                    starRatingDisplay.Current.Value = d.NewValue.Value;
+                starRatingDisplay.Current.Value = d.NewValue.Value;
 
-                    versionFlow.AutoSizeDuration = 300;
-                    versionFlow.AutoSizeEasing = Easing.OutQuint;
+                versionFlow.AutoSizeDuration = 300;
+                versionFlow.AutoSizeEasing = Easing.OutQuint;
 
-                    starRatingDisplay.FadeIn(300, Easing.InQuint);
-                };
-            }
+                starRatingDisplay.FadeIn(300, Easing.InQuint);
+            };
         }
 
         private class MetadataLineLabel : OsuSpriteText


### PR DESCRIPTION
- Closes #18980 

Replays update mods bindable with score mods on `OnEntering`, which can happen after `BeatmapMetadataDisplay` displays the current (no score mods) star rating.

Alternative fix would be to update the mods bindable much earlier (at BDL or load complete), but going with a more local fix for now.