### PR TITLE
Fix realm backup creation failing when run from `RealmAccess` constructor

### DIFF
--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Tests.Collections.IO
         {
             string firstRunName;
 
-            using (var host = new CleanRunHeadlessGameHost(bypassCleanup: true))
+            using (var host = new CleanRunHeadlessGameHost(bypassCleanupOnDispose: true))
             {
                 firstRunName = host.Name;
 

--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -315,6 +315,26 @@ namespace osu.Game.Tests.NonVisual
             }
         }
 
+        [Test]
+        public void TestBackupCreatedOnCorruptRealm()
+        {
+            using (var host = new CustomTestHeadlessGameHost())
+            {
+                try
+                {
+                    File.WriteAllText(host.InitialStorage.GetFullPath(OsuGameBase.CLIENT_DATABASE_FILENAME, true), "i am definitely not a realm file");
+
+                    LoadOsuIntoHost(host);
+
+                    Assert.That(host.InitialStorage.GetFiles(string.Empty, "*_corrupt.realm"), Has.One.Items);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
         private static string getDefaultLocationFor(CustomTestHeadlessGameHost host)
         {
             string path = Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, host.Name);
@@ -347,7 +367,7 @@ namespace osu.Game.Tests.NonVisual
             public Storage InitialStorage { get; }
 
             public CustomTestHeadlessGameHost([CallerMemberName] string callingMethodName = @"")
-                : base(callingMethodName: callingMethodName)
+                : base(callingMethodName: callingMethodName, bypassCleanupOnSetup: true)
             {
                 string defaultStorageLocation = getDefaultLocationFor(this);
 

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -132,11 +132,12 @@ namespace osu.Game.Database
             {
                 try
                 {
-                    realm.CreateBackup(Path.Combine(backup_folder, $"client.{backupSuffix}.realm"), realmBlockOperations);
+                    realm.CreateBackup(Path.Combine(backup_folder, $"client.{backupSuffix}.realm"));
                 }
                 finally
                 {
-                    // Above call will dispose of the blocking token when done.
+                    // Once the backup is created, we need to stop blocking operations so the migration can complete.
+                    realmBlockOperations.Dispose();
                     // Clean up here so we don't accidentally dispose twice.
                     realmBlockOperations = null;
                 }

--- a/osu.Game/Tests/CleanRunHeadlessGameHost.cs
+++ b/osu.Game/Tests/CleanRunHeadlessGameHost.cs
@@ -15,30 +15,38 @@ namespace osu.Game.Tests
     /// </summary>
     public class CleanRunHeadlessGameHost : TestRunHeadlessGameHost
     {
+        private readonly bool bypassCleanupOnSetup;
+
         /// <summary>
         /// Create a new instance.
         /// </summary>
         /// <param name="bindIPC">Whether to bind IPC channels.</param>
         /// <param name="realtime">Whether the host should be forced to run in realtime, rather than accelerated test time.</param>
-        /// <param name="bypassCleanup">Whether to bypass directory cleanup on host disposal. Should be used only if a subsequent test relies on the files still existing.</param>
+        /// <param name="bypassCleanupOnSetup">Whether to bypass directory cleanup on <see cref="SetupForRun"/>.</param>
+        /// <param name="bypassCleanupOnDispose">Whether to bypass directory cleanup on host disposal. Should be used only if a subsequent test relies on the files still existing.</param>
         /// <param name="callingMethodName">The name of the calling method, used for test file isolation and clean-up.</param>
-        public CleanRunHeadlessGameHost(bool bindIPC = false, bool realtime = true, bool bypassCleanup = false, [CallerMemberName] string callingMethodName = @"")
+        public CleanRunHeadlessGameHost(bool bindIPC = false, bool realtime = true, bool bypassCleanupOnSetup = false, bool bypassCleanupOnDispose = false,
+                                        [CallerMemberName] string callingMethodName = @"")
             : base($"{callingMethodName}-{Guid.NewGuid()}", new HostOptions
             {
                 BindIPC = bindIPC,
-            }, bypassCleanup: bypassCleanup, realtime: realtime)
+            }, bypassCleanup: bypassCleanupOnDispose, realtime: realtime)
         {
+            this.bypassCleanupOnSetup = bypassCleanupOnSetup;
         }
 
         protected override void SetupForRun()
         {
-            try
+            if (!bypassCleanupOnSetup)
             {
-                Storage.DeleteDirectory(string.Empty);
-            }
-            catch
-            {
-                // May fail if a logging target has already been set via OsuStorage.ChangeTargetStorage.
+                try
+                {
+                    Storage.DeleteDirectory(string.Empty);
+                }
+                catch
+                {
+                    // May fail if a logging target has already been set via OsuStorage.ChangeTargetStorage.
+                }
             }
 
             // base call needs to be run *after* storage is emptied, as it updates the (static) logger's storage and may start writing


### PR DESCRIPTION
At the point of construction, we are not on the update thread, but it doesn't really matter at this point because there's no other usages. Bit of an ugly regression.