### PR TITLE
Allow MIDI and joysticks to trigger the osu! cookie on the initial screen

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -205,6 +205,28 @@ namespace osu.Game.Screens.Menu
             return base.OnKeyDown(e);
         }
 
+        protected override bool OnJoystickPress(JoystickPressEvent e)
+        {
+            if (State == ButtonSystemState.Initial)
+            {
+                logo?.TriggerClick();
+                return true;
+            }
+
+            return base.OnJoystickPress(e);
+        }
+
+        protected override bool OnMidiDown(MidiDownEvent e)
+        {
+            if (State == ButtonSystemState.Initial)
+            {
+                logo?.TriggerClick();
+                return true;
+            }
+
+            return base.OnMidiDown(e);
+        }
+
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
             if (e.Repeat)

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -191,38 +191,44 @@ namespace osu.Game.Screens.Menu
                 State = ButtonSystemState.Initial;
         }
 
-        protected override bool OnKeyDown(KeyDownEvent e)
+        /// <summary>
+        /// Triggers the <see cref="logo"/> if the current <see cref="State"/> is <see cref="ButtonSystemState.Initial"/>.
+        /// </summary>
+        /// <returns><c>true</c> if the <see cref="logo"/> was triggered, <c>false</c> otherwise.</returns>
+        private bool triggerInitialOsuLogo()
         {
-            if (e.Repeat || e.ControlPressed || e.ShiftPressed || e.AltPressed || e.SuperPressed)
-                return false;
-
             if (State == ButtonSystemState.Initial)
             {
                 logo?.TriggerClick();
                 return true;
             }
+
+            return false;
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat || e.ControlPressed || e.ShiftPressed || e.AltPressed || e.SuperPressed)
+                return false;
+
+            if (triggerInitialOsuLogo())
+                return true;
 
             return base.OnKeyDown(e);
         }
 
         protected override bool OnJoystickPress(JoystickPressEvent e)
         {
-            if (State == ButtonSystemState.Initial)
-            {
-                logo?.TriggerClick();
+            if (triggerInitialOsuLogo())
                 return true;
-            }
 
             return base.OnJoystickPress(e);
         }
 
         protected override bool OnMidiDown(MidiDownEvent e)
         {
-            if (State == ButtonSystemState.Initial)
-            {
-                logo?.TriggerClick();
+            if (triggerInitialOsuLogo())
                 return true;
-            }
 
             return base.OnMidiDown(e);
         }


### PR DESCRIPTION
Makes sense as all keyboard keys currently trigger it.
Will hopefully aid in visibility that such input methods natively work in osu! (without having to dig into settings).