### PR TITLE
Fix intermittent realm migration test failures

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -920,6 +920,8 @@ namespace osu.Game.Database
 
             void restoreOperation()
             {
+                // Release of lock needs to happen here rather than on the update thread, as there may be another
+                // operation already blocking the update thread waiting for the blocking operation to complete.
                 Logger.Log(@"Restoring realm operations.", LoggingTarget.Database);
                 realmRetrievalLock.Release();
 


### PR DESCRIPTION
Finally figured this one out.

As seen at:

https://teamcity.ppy.sh/buildConfiguration/Osu_Build/1734?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true
and probably GitHub Actions but I can't find any immediately. came up a lot more on teamcity likely due to kubernetes cpu throttling (which is intentionally turned on to mix things up).

Forcing test runs to spin on failure, attaching showed this call stack:

![Parallels Desktop 2022-07-05 at 05 17 20](https://user-images.githubusercontent.com/191335/177254607-469613c0-5dfb-4657-85da-07b4c046fac6.png)

Cause was tests which perform two `Migrate` calls close to each other, on their own thread (the test runner thread):

https://github.com/ppy/osu/blob/64edc6888d84fc5a6b7e179a8a968c685ef5b19e/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs#L186-L190

First call would complete, and post the `restoreOperations` back to the update thread's `SynchronizationContext`, but only after releasing the `realmRetrievalLock`.

Before the posted operation is run, the second `Migrate` call runs and enters the `realmRetrievalLock` itself. This causes a deadlock when the update thread finally gets to running `ensureUpdateRealm` and cannot block on the retrieval lock. The second `Migrate` completes, but its `restoreOperations` is waiting behind the permanently blocked one.

Tested over 30 runs (would usually fail around 10% of the time):

![Safari 2022-07-05 at 05 25 49](https://user-images.githubusercontent.com/191335/177255629-752bb79e-5214-409d-b067-68e984af2d24.png)

Also attempted to write a repro using `Thread.Sleep`, but it's not easy to do due to the timing requirements.