### PR TITLE
Fix default spinner's accent on rewind in user replays

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinnerDisc.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             base.LoadComplete();
 
-            complete.BindValueChanged(complete => updateComplete(complete.NewValue, 200));
+            complete.BindValueChanged(complete => updateDiscColour(complete.NewValue, 200));
             drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
 
             updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 this.ScaleTo(initial_scale);
                 this.RotateTo(0);
 
-                updateComplete(false, 0);
+                updateDiscColour(false);
 
                 using (BeginDelayedSequence(spinner.TimePreempt / 2))
                 {
@@ -182,11 +182,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (drawableSpinner.Result?.TimeCompleted is double completionTime)
             {
                 using (BeginAbsoluteSequence(completionTime))
-                    updateComplete(true, 200);
+                    updateDiscColour(true, 200);
             }
         }
 
-        private void updateComplete(bool complete, double duration)
+        private void updateDiscColour(bool complete, double duration = 0)
         {
             var colour = complete ? completeColour : normalColour;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinnerDisc.cs
@@ -137,6 +137,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 this.ScaleTo(initial_scale);
                 this.RotateTo(0);
 
+                updateComplete(false, 0);
+
                 using (BeginDelayedSequence(spinner.TimePreempt / 2))
                 {
                     // constant ambient rotation to give the spinner "spinning" character.
@@ -177,9 +179,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 }
             }
 
-            // transforms we have from completing the spinner will be rolled back, so reapply immediately.
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt))
-                updateComplete(state == ArmedState.Hit, 0);
+            if (drawableSpinner.Result?.TimeCompleted is double completionTime)
+            {
+                using (BeginAbsoluteSequence(completionTime))
+                    updateComplete(true, 200);
+            }
         }
 
         private void updateComplete(bool complete, double duration)


### PR DESCRIPTION
Rewinding from a point after the spinner's end to a point between the spinner's completion and its end should show a gold color, but instead it's blue, making it look like the spinner hasn't been completed yet.

The current approach is flawed because completed spinners that are still active (i.e. player is getting bonus points) are given `ArmedState.Idle` on rewind. `ArmedState.Hit`/`Miss` are for the spinner ending, not completing. This leads to the spinner taking on its normal color instead of its completed color on rewind. The solution here is similar to the approach taken here: https://github.com/ppy/osu/blob/50a546244668e46d0be75bb2e548facecb45dbba/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs#L127-L131 This fully fixes user replays, but only partially fixes editor spinners. Spinners are still broken if skipped past and then rewinded to, but I think that's an editor issue (#10455).