### PR TITLE
Add `MetadataClient` to handle online metadata changes

### DIFF
--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -212,17 +212,17 @@ namespace osu.Game.Tests.Online
             {
             }
 
-            protected override BeatmapImporter CreateBeatmapImporter(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapUpdater beatmapUpdater)
+            protected override BeatmapImporter CreateBeatmapImporter(Storage storage, RealmAccess realm)
             {
-                return new TestBeatmapImporter(this, storage, realm, beatmapUpdater);
+                return new TestBeatmapImporter(this, storage, realm);
             }
 
             internal class TestBeatmapImporter : BeatmapImporter
             {
                 private readonly TestBeatmapManager testBeatmapManager;
 
-                public TestBeatmapImporter(TestBeatmapManager testBeatmapManager, Storage storage, RealmAccess databaseAccess, BeatmapUpdater beatmapUpdater)
-                    : base(storage, databaseAccess, beatmapUpdater)
+                public TestBeatmapImporter(TestBeatmapManager testBeatmapManager, Storage storage, RealmAccess databaseAccess)
+                    : base(storage, databaseAccess)
                 {
                     this.testBeatmapManager = testBeatmapManager;
                 }

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -31,12 +31,11 @@ namespace osu.Game.Beatmaps
 
         protected override string[] HashableFileTypes => new[] { ".osu" };
 
-        private readonly BeatmapUpdater? beatmapUpdater;
+        public Action<BeatmapSetInfo>? ProcessBeatmap { private get; set; }
 
-        public BeatmapImporter(Storage storage, RealmAccess realm, BeatmapUpdater? beatmapUpdater = null)
+        public BeatmapImporter(Storage storage, RealmAccess realm)
             : base(storage, realm)
         {
-            this.beatmapUpdater = beatmapUpdater;
         }
 
         protected override bool ShouldDeleteArchive(string path) => Path.GetExtension(path).ToLowerInvariant() == ".osz";
@@ -100,7 +99,7 @@ namespace osu.Game.Beatmaps
         {
             base.PostImport(model, realm);
 
-            beatmapUpdater?.Process(model);
+            ProcessBeatmap?.Invoke(model);
         }
 
         private void validateOnlineIds(BeatmapSetInfo beatmapSet, Realm realm)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -34,14 +34,15 @@ namespace osu.Game.Beatmaps
     /// Handles general operations related to global beatmap management.
     /// </summary>
     [ExcludeFromDynamicCompile]
-    public class BeatmapManager : ModelManager<BeatmapSetInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache, IDisposable
+    public class BeatmapManager : ModelManager<BeatmapSetInfo>, IModelImporter<BeatmapSetInfo>, IWorkingBeatmapCache
     {
         public ITrackStore BeatmapTrackStore { get; }
 
         private readonly BeatmapImporter beatmapImporter;
 
         private readonly WorkingBeatmapCache workingBeatmapCache;
-        private readonly BeatmapUpdater? beatmapUpdater;
+
+        public Action<BeatmapSetInfo>? ProcessBeatmap { private get; set; }
 
         public BeatmapManager(Storage storage, RealmAccess realm, RulesetStore rulesets, IAPIProvider? api, AudioManager audioManager, IResourceStore<byte[]> gameResources, GameHost? host = null,
                               WorkingBeatmap? defaultBeatmap = null, BeatmapDifficultyCache? difficultyCache = null, bool performOnlineLookups = false)
@@ -54,15 +55,14 @@ namespace osu.Game.Beatmaps
 
                 if (difficultyCache == null)
                     throw new ArgumentNullException(nameof(difficultyCache), "Difficulty cache must be provided if online lookups are required.");
-
-                beatmapUpdater = new BeatmapUpdater(this, difficultyCache, api, storage);
             }
 
             var userResources = new RealmFileStore(realm, storage).Store;
 
             BeatmapTrackStore = audioManager.GetTrackStore(userResources);
 
-            beatmapImporter = CreateBeatmapImporter(storage, realm, rulesets, beatmapUpdater);
+            beatmapImporter = CreateBeatmapImporter(storage, realm);
+            beatmapImporter.ProcessBeatmap = obj => ProcessBeatmap?.Invoke(obj);
             beatmapImporter.PostNotification = obj => PostNotification?.Invoke(obj);
 
             workingBeatmapCache = CreateWorkingBeatmapCache(audioManager, gameResources, userResources, defaultBeatmap, host);
@@ -74,8 +74,7 @@ namespace osu.Game.Beatmaps
             return new WorkingBeatmapCache(BeatmapTrackStore, audioManager, resources, storage, defaultBeatmap, host);
         }
 
-        protected virtual BeatmapImporter CreateBeatmapImporter(Storage storage, RealmAccess realm, RulesetStore rulesets, BeatmapUpdater? beatmapUpdater) =>
-            new BeatmapImporter(storage, realm, beatmapUpdater);
+        protected virtual BeatmapImporter CreateBeatmapImporter(Storage storage, RealmAccess realm) => new BeatmapImporter(storage, realm);
 
         /// <summary>
         /// Create a new beatmap set, backed by a <see cref="BeatmapSetInfo"/> model,
@@ -323,7 +322,7 @@ namespace osu.Game.Beatmaps
 
                     setInfo.CopyChangesToRealm(liveBeatmapSet);
 
-                    beatmapUpdater?.Process(liveBeatmapSet, r);
+                    ProcessBeatmap?.Invoke(liveBeatmapSet);
                 });
             }
 
@@ -465,15 +464,6 @@ namespace osu.Game.Beatmaps
         }
 
         public override bool IsAvailableLocally(BeatmapSetInfo model) => Realm.Run(realm => realm.All<BeatmapSetInfo>().Any(s => s.OnlineID == model.OnlineID));
-
-        #endregion
-
-        #region Implementation of IDisposable
-
-        public void Dispose()
-        {
-            beatmapUpdater?.Dispose();
-        }
 
         #endregion
 

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -52,15 +52,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Run all processing on a beatmap immediately.
         /// </summary>
-        public void Process(BeatmapSetInfo beatmapSet)
-        {
-            if (beatmapSet.Realm.IsInTransaction)
-                Process(beatmapSet, beatmapSet.Realm);
-            else
-                beatmapSet.Realm.Write(r => Process(beatmapSet, r));
-        }
-
-        public void Process(BeatmapSetInfo beatmapSet, Realm realm)
+        public void Process(BeatmapSetInfo beatmapSet) => beatmapSet.Realm.Write(r =>
         {
             // Before we use below, we want to invalidate.
             workingBeatmapCache.Invalidate(beatmapSet);
@@ -85,7 +77,7 @@ namespace osu.Game.Beatmaps
 
             // And invalidate again afterwards as re-fetching the most up-to-date database metadata will be required.
             workingBeatmapCache.Invalidate(beatmapSet);
-        }
+        });
 
         private double calculateLength(IBeatmap b)
         {

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -10,7 +10,6 @@ using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Rulesets.Objects;
-using Realms;
 
 namespace osu.Game.Beatmaps
 {

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -34,6 +34,14 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Queue a beatmap for background processing.
         /// </summary>
+        public void Queue(int beatmapSetId)
+        {
+            // TODO: implement
+        }
+
+        /// <summary>
+        /// Queue a beatmap for background processing.
+        /// </summary>
         public void Queue(Live<BeatmapSetInfo> beatmap)
         {
             // For now, just fire off a task.
@@ -44,7 +52,13 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Run all processing on a beatmap immediately.
         /// </summary>
-        public void Process(BeatmapSetInfo beatmapSet) => beatmapSet.Realm.Write(r => Process(beatmapSet, r));
+        public void Process(BeatmapSetInfo beatmapSet)
+        {
+            if (beatmapSet.Realm.IsInTransaction)
+                Process(beatmapSet, beatmapSet.Realm);
+            else
+                beatmapSet.Realm.Write(r => Process(beatmapSet, r));
+        }
 
         public void Process(BeatmapSetInfo beatmapSet, Realm realm)
         {

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -167,6 +167,8 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
 
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f);
+
+            SetDefault(OsuSetting.LastProcessedMetadataId, -1);
         }
 
         public IDictionary<OsuSetting, string> GetLoggableState() =>
@@ -363,5 +365,6 @@ namespace osu.Game.Configuration
         DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
         ShowOnlineExplicitContent,
+        LastProcessedMetadataId
     }
 }

--- a/osu.Game/Online/DevelopmentEndpointConfiguration.cs
+++ b/osu.Game/Online/DevelopmentEndpointConfiguration.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Online
             APIClientID = "5";
             SpectatorEndpointUrl = $"{APIEndpointUrl}/spectator";
             MultiplayerEndpointUrl = $"{APIEndpointUrl}/multiplayer";
+            MetadataEndpointUrl = $"{APIEndpointUrl}/metadata";
         }
     }
 }

--- a/osu.Game/Online/EndpointConfiguration.cs
+++ b/osu.Game/Online/EndpointConfiguration.cs
@@ -39,5 +39,10 @@ namespace osu.Game.Online
         /// The endpoint for the SignalR multiplayer server.
         /// </summary>
         public string MultiplayerEndpointUrl { get; set; }
+
+        /// <summary>
+        /// The endpoint for the SignalR metadata server.
+        /// </summary>
+        public string MetadataEndpointUrl { get; set; }
     }
 }

--- a/osu.Game/Online/Metadata/BeatmapUpdates.cs
+++ b/osu.Game/Online/Metadata/BeatmapUpdates.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Metadata
+{
+    /// <summary>
+    /// Describes a set of beatmaps which have been updated in some way.
+    /// </summary>
+    [MessagePackObject]
+    [Serializable]
+    public class BeatmapUpdates
+    {
+        [Key(0)]
+        public int[] BeatmapSetIDs { get; set; }
+
+        [Key(1)]
+        public uint LastProcessedQueueID { get; set; }
+
+        public BeatmapUpdates(int[] beatmapSetIDs, uint lastProcessedQueueID)
+        {
+            BeatmapSetIDs = beatmapSetIDs;
+            LastProcessedQueueID = lastProcessedQueueID;
+        }
+    }
+}

--- a/osu.Game/Online/Metadata/BeatmapUpdates.cs
+++ b/osu.Game/Online/Metadata/BeatmapUpdates.cs
@@ -17,9 +17,9 @@ namespace osu.Game.Online.Metadata
         public int[] BeatmapSetIDs { get; set; }
 
         [Key(1)]
-        public uint LastProcessedQueueID { get; set; }
+        public int LastProcessedQueueID { get; set; }
 
-        public BeatmapUpdates(int[] beatmapSetIDs, uint lastProcessedQueueID)
+        public BeatmapUpdates(int[] beatmapSetIDs, int lastProcessedQueueID)
         {
             BeatmapSetIDs = beatmapSetIDs;
             LastProcessedQueueID = lastProcessedQueueID;

--- a/osu.Game/Online/Metadata/IMetadataClient.cs
+++ b/osu.Game/Online/Metadata/IMetadataClient.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+
+namespace osu.Game.Online.Metadata
+{
+    public interface IMetadataClient
+    {
+        Task BeatmapSetsUpdated(BeatmapUpdates updates);
+    }
+}

--- a/osu.Game/Online/Metadata/IMetadataServer.cs
+++ b/osu.Game/Online/Metadata/IMetadataServer.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Online.Metadata
         /// </summary>
         /// <param name="queueId">The last processed queue ID.</param>
         /// <returns></returns>
-        Task<BeatmapUpdates> GetChangesSince(uint queueId);
+        Task<BeatmapUpdates> GetChangesSince(int queueId);
     }
 }

--- a/osu.Game/Online/Metadata/IMetadataServer.cs
+++ b/osu.Game/Online/Metadata/IMetadataServer.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+
+namespace osu.Game.Online.Metadata
+{
+    /// <summary>
+    /// Metadata server is responsible for keeping the osu! client up-to-date with any changes.
+    /// </summary>
+    public interface IMetadataServer
+    {
+        /// <summary>
+        /// Get any changes since a specific point in the queue.
+        /// Should be used to allow the client to catch up with any changes after being closed or disconnected.
+        /// </summary>
+        /// <param name="queueId">The last processed queue ID.</param>
+        /// <returns></returns>
+        Task<BeatmapUpdates> GetChangesSince(uint queueId);
+    }
+}

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Online.Metadata
+{
+    public abstract class MetadataClient : Component, IMetadataClient, IMetadataServer
+    {
+        public abstract Task BeatmapSetsUpdated(BeatmapUpdates updates);
+
+        public abstract Task<BeatmapUpdates> GetChangesSince(uint queueId);
+    }
+}

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Online.Metadata
     {
         public abstract Task BeatmapSetsUpdated(BeatmapUpdates updates);
 
-        public abstract Task<BeatmapUpdates> GetChangesSince(uint queueId);
+        public abstract Task<BeatmapUpdates> GetChangesSince(int queueId);
     }
 }

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client;
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
+using osu.Game.Online.API;
+
+namespace osu.Game.Online.Metadata
+{
+    public class OnlineMetadataClient : MetadataClient
+    {
+        private readonly string endpoint;
+
+        private IHubClientConnector? connector;
+
+        private HubConnection? connection => connector?.CurrentConnection;
+
+        public OnlineMetadataClient(EndpointConfiguration endpoints)
+        {
+            endpoint = endpoints.MetadataEndpointUrl;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IAPIProvider api)
+        {
+            // Importantly, we are intentionally not using MessagePack here to correctly support derived class serialization.
+            // More information on the limitations / reasoning can be found in osu-server-spectator's initialisation code.
+            connector = api.GetHubConnector(nameof(OnlineMetadataClient), endpoint);
+
+            if (connector != null)
+            {
+                connector.ConfigureConnection = connection =>
+                {
+                    // this is kind of SILLY
+                    // https://github.com/dotnet/aspnetcore/issues/15198
+                    connection.On<BeatmapUpdates>(nameof(IMetadataClient.BeatmapSetsUpdated), ((IMetadataClient)this).BeatmapSetsUpdated);
+                };
+            }
+        }
+
+        public override Task BeatmapSetsUpdated(BeatmapUpdates updates)
+        {
+            Logger.Log($"Received beatmap updates {updates.BeatmapSetIDs.Length} updates with last id {updates.LastProcessedQueueID}");
+            return Task.CompletedTask;
+        }
+
+        public override Task<BeatmapUpdates> GetChangesSince(uint queueId)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            connector?.Dispose();
+        }
+    }
+}

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -7,12 +7,14 @@ using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 
 namespace osu.Game.Online.Metadata
 {
     public class OnlineMetadataClient : MetadataClient
     {
+        private readonly BeatmapUpdater beatmapUpdater;
         private readonly string endpoint;
 
         private IHubClientConnector? connector;
@@ -21,8 +23,9 @@ namespace osu.Game.Online.Metadata
 
         private HubConnection? connection => connector?.CurrentConnection;
 
-        public OnlineMetadataClient(EndpointConfiguration endpoints)
+        public OnlineMetadataClient(EndpointConfiguration endpoints, BeatmapUpdater beatmapUpdater)
         {
+            this.beatmapUpdater = beatmapUpdater;
             endpoint = endpoints.MetadataEndpointUrl;
         }
 
@@ -99,7 +102,11 @@ namespace osu.Game.Online.Metadata
         protected Task ProcessChanges(int[] beatmapSetIDs)
         {
             foreach (int id in beatmapSetIDs)
+            {
                 Logger.Log($"Processing {id}...");
+                beatmapUpdater.Queue(id);
+            }
+
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/ProductionEndpointConfiguration.cs
+++ b/osu.Game/Online/ProductionEndpointConfiguration.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Online
             APIClientID = "5";
             SpectatorEndpointUrl = "https://spectator.ppy.sh/spectator";
             MultiplayerEndpointUrl = "https://spectator.ppy.sh/multiplayer";
+            MetadataEndpointUrl = "https://spectator.ppy.sh/metadata";
         }
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -41,6 +40,7 @@ using osu.Game.IO;
 using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.Chat;
+using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Spectator;
 using osu.Game.Overlays;
@@ -52,6 +52,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Utils;
+using File = System.IO.File;
 using RuntimeInfo = osu.Framework.RuntimeInfo;
 
 namespace osu.Game
@@ -180,6 +181,8 @@ namespace osu.Game
 
         private MultiplayerClient multiplayerClient;
 
+        private MetadataClient metadataClient;
+
         private RealmAccess realm;
 
         protected override Container<Drawable> Content => content;
@@ -265,6 +268,7 @@ namespace osu.Game
 
             dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(multiplayerClient = new OnlineMultiplayerClient(endpoints));
+            dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
 
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 
@@ -316,8 +320,10 @@ namespace osu.Game
             // add api components to hierarchy.
             if (API is APIAccess apiAccess)
                 AddInternal(apiAccess);
+
             AddInternal(spectatorClient);
             AddInternal(multiplayerClient);
+            AddInternal(metadataClient);
 
             AddInternal(rulesetConfigCache);
 


### PR DESCRIPTION
This is an initial PR which adds the full flow of client-server-client metadata update propagation.

Includes

- Streaming of metadata updates from server
- Resilience client-side to catch-up on startup and reconnect to server

Does not yet perform operations on receiving updates. That will come as a follow-up effort. But I did change the structure to at least hook up the propgation of data to the new `BeatmapUpdater` class.

No tests as of yet because I'm honestly not sure which part requires testing. Probably going to continue developing this out and add tests as requested/required?


Standard handling:

https://user-images.githubusercontent.com/191335/177335972-561e12b0-8b7e-4630-aa50-cd297bd2daa0.mp4

Catch-up after disconnect:


https://user-images.githubusercontent.com/191335/177336201-fc0c002d-efc6-4716-b741-c418dc0a82c6.mp4


- [x] Depends on https://github.com/ppy/osu/pull/19027