### PR TITLE
Enable NRT and simplify `LineBufferedReader`

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/LineBufferedReaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LineBufferedReaderTest.cs
@@ -108,19 +108,13 @@ namespace osu.Game.Tests.Beatmaps.IO
         [Test]
         public void TestReadToEndAfterReadsAndPeeks()
         {
-            const string contents = "this line is gone\rthis one shouldn't be\r\nthese ones\ndefinitely not";
+            const string contents = "first line\r\nsecond line";
 
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                Assert.AreEqual("this line is gone", bufferedReader.ReadLine());
-                Assert.AreEqual("this one shouldn't be", bufferedReader.PeekLine());
-
-                string[] endingLines = bufferedReader.ReadToEnd().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                Assert.AreEqual(3, endingLines.Length);
-                Assert.AreEqual("this one shouldn't be", endingLines[0]);
-                Assert.AreEqual("these ones", endingLines[1]);
-                Assert.AreEqual("definitely not", endingLines[2]);
+                bufferedReader.PeekLine();
+                Assert.Throws<InvalidOperationException>(() => bufferedReader.ReadToEnd());
             }
         }
     }

--- a/osu.Game.Tests/Beatmaps/IO/LineBufferedReaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LineBufferedReaderTest.cs
@@ -108,13 +108,19 @@ namespace osu.Game.Tests.Beatmaps.IO
         [Test]
         public void TestReadToEndAfterReadsAndPeeks()
         {
-            const string contents = "first line\r\nsecond line";
+            const string contents = "this line is gone\rthis one shouldn't be\r\nthese ones\ndefinitely not";
 
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(contents)))
             using (var bufferedReader = new LineBufferedReader(stream))
             {
-                bufferedReader.PeekLine();
-                Assert.Throws<InvalidOperationException>(() => bufferedReader.ReadToEnd());
+                Assert.AreEqual("this line is gone", bufferedReader.ReadLine());
+                Assert.AreEqual("this one shouldn't be", bufferedReader.PeekLine());
+
+                string[] endingLines = bufferedReader.ReadToEnd().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                Assert.AreEqual(3, endingLines.Length);
+                Assert.AreEqual("this one shouldn't be", endingLines[0]);
+                Assert.AreEqual("these ones", endingLines[1]);
+                Assert.AreEqual("definitely not", endingLines[2]);
             }
         }
     }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Beatmaps.Formats
         {
             Section section = Section.General;
 
-            string line;
+            string? line;
 
             while ((line = stream.ReadLine()) != null)
             {

--- a/osu.Game/IO/LineBufferedReader.cs
+++ b/osu.Game/IO/LineBufferedReader.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -17,58 +14,51 @@ namespace osu.Game.IO
     public class LineBufferedReader : IDisposable
     {
         private readonly StreamReader streamReader;
-        private readonly Queue<string> lineBuffer;
+
+        private string? peekedLine;
 
         public LineBufferedReader(Stream stream, bool leaveOpen = false)
         {
             streamReader = new StreamReader(stream, Encoding.UTF8, true, 1024, leaveOpen);
-            lineBuffer = new Queue<string>();
         }
 
         /// <summary>
         /// Reads the next line from the stream without consuming it.
         /// Subsequent calls to <see cref="PeekLine"/> without a <see cref="ReadLine"/> will return the same string.
         /// </summary>
-        public string PeekLine()
-        {
-            if (lineBuffer.Count > 0)
-                return lineBuffer.Peek();
-
-            string line = streamReader.ReadLine();
-            if (line != null)
-                lineBuffer.Enqueue(line);
-            return line;
-        }
+        public string? PeekLine() => peekedLine ??= streamReader.ReadLine();
 
         /// <summary>
         /// Reads the next line from the stream and consumes it.
         /// If a line was peeked, that same line will then be consumed and returned.
         /// </summary>
-        public string ReadLine() => lineBuffer.Count > 0 ? lineBuffer.Dequeue() : streamReader.ReadLine();
+        public string? ReadLine()
+        {
+            try
+            {
+                return peekedLine ?? streamReader.ReadLine();
+            }
+            finally
+            {
+                peekedLine = null;
+            }
+        }
 
         /// <summary>
         /// Reads the stream to its end and returns the text read.
-        /// This includes any peeked but unconsumed lines.
+        /// Not compatible with calls to <see cref="PeekLine"/>.
         /// </summary>
         public string ReadToEnd()
         {
-            string remainingText = streamReader.ReadToEnd();
-            if (lineBuffer.Count == 0)
-                return remainingText;
+            if (peekedLine != null)
+                throw new InvalidOperationException($"Do not use {nameof(ReadToEnd)} when also peeking for lines.");
 
-            var builder = new StringBuilder();
-
-            // this might not be completely correct due to varying platform line endings
-            while (lineBuffer.Count > 0)
-                builder.AppendLine(lineBuffer.Dequeue());
-            builder.Append(remainingText);
-
-            return builder.ToString();
+            return streamReader.ReadToEnd();
         }
 
         public void Dispose()
         {
-            streamReader?.Dispose();
+            streamReader.Dispose();
         }
     }
 }

--- a/osu.Game/IO/LineBufferedReader.cs
+++ b/osu.Game/IO/LineBufferedReader.cs
@@ -46,14 +46,21 @@ namespace osu.Game.IO
 
         /// <summary>
         /// Reads the stream to its end and returns the text read.
-        /// Not compatible with calls to <see cref="PeekLine"/>.
+        /// This includes any peeked but unconsumed lines.
         /// </summary>
         public string ReadToEnd()
         {
-            if (peekedLine != null)
-                throw new InvalidOperationException($"Do not use {nameof(ReadToEnd)} when also peeking for lines.");
+            string remainingText = streamReader.ReadToEnd();
+            if (peekedLine == null)
+                return remainingText;
 
-            return streamReader.ReadToEnd();
+            var builder = new StringBuilder();
+
+            // this might not be completely correct due to varying platform line endings
+            builder.AppendLine(peekedLine);
+            builder.Append(remainingText);
+
+            return builder.ToString();
         }
 
         public void Dispose()

--- a/osu.Game/IO/LineBufferedReader.cs
+++ b/osu.Game/IO/LineBufferedReader.cs
@@ -19,7 +19,7 @@ namespace osu.Game.IO
 
         public LineBufferedReader(Stream stream, bool leaveOpen = false)
         {
-            streamReader = new StreamReader(stream, Encoding.UTF8, true, 1024, leaveOpen);
+            streamReader = new StreamReader(stream, Encoding.UTF8, true, -1, leaveOpen);
         }
 
         /// <summary>

--- a/osu.Game/IO/LineBufferedReader.cs
+++ b/osu.Game/IO/LineBufferedReader.cs
@@ -34,14 +34,10 @@ namespace osu.Game.IO
         /// </summary>
         public string? ReadLine()
         {
-            try
-            {
-                return peekedLine ?? streamReader.ReadLine();
-            }
-            finally
-            {
-                peekedLine = null;
-            }
+            string? line = peekedLine ?? streamReader.ReadLine();
+
+            peekedLine = null;
+            return line;
         }
 
         /// <summary>


### PR DESCRIPTION
- Not sure why a `Queue` was being used for a maximum of a single peeked line.
- `ReadToEnd` is only used in cases of reading the whole file. We shouldn't need to account for the peeking.