### PR TITLE
Improve asserts in `TestSeekPerformsInGameplayTime` to be more descriptive

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -9,7 +9,6 @@ using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
-using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
@@ -116,10 +115,10 @@ namespace osu.Game.Tests.Gameplay
                 AddStep($"set audio offset to {userOffset}", () => localConfig.SetValue(OsuSetting.AudioOffset, userOffset));
 
             AddStep("seek to 2500", () => gameplayClockContainer.Seek(2500));
-            AddAssert("gameplay clock time = 2500", () => Precision.AlmostEquals(gameplayClockContainer.CurrentTime, 2500, 10f));
+            AddStep("gameplay clock time = 2500", () => Assert.AreEqual(gameplayClockContainer.CurrentTime, 2500, 10f));
 
             AddStep("seek to 10000", () => gameplayClockContainer.Seek(10000));
-            AddAssert("gameplay clock time = 10000", () => Precision.AlmostEquals(gameplayClockContainer.CurrentTime, 10000, 10f));
+            AddStep("gameplay clock time = 10000", () => Assert.AreEqual(gameplayClockContainer.CurrentTime, 10000, 10f));
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Provides better test fail output to identify the cause of the test's flakiness.