### PR TITLE
Add local handling of cases where a beatmap's file cannot be found on disk

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -137,8 +137,17 @@ namespace osu.Game.Beatmaps
 
                 try
                 {
-                    using (var stream = new LineBufferedReader(GetStream(BeatmapSetInfo.GetPathForFile(BeatmapInfo.Path))))
-                        return Decoder.GetDecoder<Beatmap>(stream).Decode(stream);
+                    string fileStorePath = BeatmapSetInfo.GetPathForFile(BeatmapInfo.Path);
+                    var stream = GetStream(fileStorePath);
+
+                    if (stream == null)
+                    {
+                        Logger.Log($"Beatmap failed to load (file {BeatmapInfo.Path} not found on disk at expected location {fileStorePath}).", level: LogLevel.Error);
+                        return null;
+                    }
+
+                    using (var reader = new LineBufferedReader(stream))
+                        return Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
                 }
                 catch (Exception e)
                 {
@@ -154,7 +163,16 @@ namespace osu.Game.Beatmaps
 
                 try
                 {
-                    return resources.LargeTextureStore.Get(BeatmapSetInfo.GetPathForFile(Metadata.BackgroundFile));
+                    string fileStorePath = BeatmapSetInfo.GetPathForFile(Metadata.BackgroundFile);
+                    var texture = resources.LargeTextureStore.Get(fileStorePath);
+
+                    if (texture == null)
+                    {
+                        Logger.Log($"Beatmap background failed to load (file {Metadata.BackgroundFile} not found on disk at expected location {fileStorePath}).", level: LogLevel.Error);
+                        return null;
+                    }
+
+                    return texture;
                 }
                 catch (Exception e)
                 {
@@ -173,7 +191,16 @@ namespace osu.Game.Beatmaps
 
                 try
                 {
-                    return resources.Tracks.Get(BeatmapSetInfo.GetPathForFile(Metadata.AudioFile));
+                    string fileStorePath = BeatmapSetInfo.GetPathForFile(Metadata.AudioFile);
+                    var track = resources.Tracks.Get(fileStorePath);
+
+                    if (track == null)
+                    {
+                        Logger.Log($"Beatmap failed to load (file {Metadata.AudioFile} not found on disk at expected location {fileStorePath}).", level: LogLevel.Error);
+                        return null;
+                    }
+
+                    return track;
                 }
                 catch (Exception e)
                 {
@@ -192,8 +219,17 @@ namespace osu.Game.Beatmaps
 
                 try
                 {
-                    var trackData = GetStream(BeatmapSetInfo.GetPathForFile(Metadata.AudioFile));
-                    return trackData == null ? null : new Waveform(trackData);
+                    string fileStorePath = BeatmapSetInfo.GetPathForFile(Metadata.AudioFile);
+
+                    var trackData = GetStream(fileStorePath);
+
+                    if (trackData == null)
+                    {
+                        Logger.Log($"Beatmap waveform failed to load (file {Metadata.AudioFile} not found on disk at expected location {fileStorePath}).", level: LogLevel.Error);
+                        return null;
+                    }
+
+                    return new Waveform(trackData);
                 }
                 catch (Exception e)
                 {
@@ -211,19 +247,37 @@ namespace osu.Game.Beatmaps
 
                 try
                 {
-                    using (var stream = new LineBufferedReader(GetStream(BeatmapSetInfo.GetPathForFile(BeatmapInfo.Path))))
+                    string fileStorePath = BeatmapSetInfo.GetPathForFile(BeatmapInfo.Path);
+                    var stream = GetStream(fileStorePath);
+
+                    if (stream == null)
                     {
-                        var decoder = Decoder.GetDecoder<Storyboard>(stream);
+                        Logger.Log($"Beatmap failed to load (file {BeatmapInfo.Path} not found on disk at expected location {fileStorePath})", level: LogLevel.Error);
+                        return null;
+                    }
+
+                    using (var reader = new LineBufferedReader(stream))
+                    {
+                        var decoder = Decoder.GetDecoder<Storyboard>(reader);
 
                         string storyboardFilename = BeatmapSetInfo?.Files.FirstOrDefault(f => f.Filename.EndsWith(".osb", StringComparison.OrdinalIgnoreCase))?.Filename;
 
                         // todo: support loading from both set-wide storyboard *and* beatmap specific.
                         if (string.IsNullOrEmpty(storyboardFilename))
-                            storyboard = decoder.Decode(stream);
+                            storyboard = decoder.Decode(reader);
                         else
                         {
-                            using (var secondaryStream = new LineBufferedReader(GetStream(BeatmapSetInfo.GetPathForFile(storyboardFilename))))
-                                storyboard = decoder.Decode(stream, secondaryStream);
+                            string storyboardFileStorePath = BeatmapSetInfo.GetPathForFile(storyboardFilename);
+                            var secondaryStream = GetStream(storyboardFileStorePath);
+
+                            if (secondaryStream == null)
+                            {
+                                Logger.Log($"Storyboard failed to load (file {storyboardFilename} not found on disk at expected location {fileStorePath})", level: LogLevel.Error);
+                                return null;
+                            }
+
+                            using (var secondaryReader = new LineBufferedReader(secondaryStream))
+                                storyboard = decoder.Decode(reader, secondaryReader);
                         }
                     }
                 }


### PR DESCRIPTION
Came up because I noticed a single user [reported 6k errors](https://sentry.ppy.sh/organizations/ppy/issues/68/?project=2&query=is%3Aunresolved&sort=freq&statsPeriod=14d) to sentry of this variety. Not really helpful.

Also changes storyboard parsing logic to not completely fail if only `.osb` read fails via e81cebf.