### PR TITLE
Fix custom rulesets not importing scores at all

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             public override string Description => "custom";
             public override string ShortName => "custom";
 
-            public new int LegacyID => -1;
+            int ILegacyRuleset.LegacyID => -1;
 
             public override ScoreProcessor CreateScoreProcessor() => new ScoreProcessor(this);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
@@ -82,6 +83,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("set custom ruleset", () => customRuleset = createCustomRuleset());
 
             CreateTest();
+
+            AddAssert("score has custom ruleset", () => Player.Score.ScoreInfo.Ruleset.Equals(customRuleset.AsNonNull().RulesetInfo));
 
             AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    [HeadlessTest] // Importing rulesets doesn't work in interactive flows.
+    public class TestScenePlayerLocalScoreImport : PlayerTestScene
+    {
+        private Ruleset? customRuleset;
+
+        protected override bool ImportBeatmapToDatabase => true;
+
+        protected override Ruleset CreatePlayerRuleset() => customRuleset ?? new OsuRuleset();
+
+        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new TestPlayer(false);
+
+        protected override bool HasCustomSteps => true;
+
+        protected override bool AllowFail => false;
+
+        [Test]
+        public void TestScoreStoredLocally()
+        {
+            AddStep("set no custom ruleset", () => customRuleset = null);
+
+            CreateTest();
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+
+            AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
+
+            AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
+            AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
+        }
+
+        [Test]
+        public void TestScoreStoredLocallyCustomRuleset()
+        {
+            Ruleset createCustomRuleset() => new OsuRuleset
+            {
+                RulesetInfo =
+                {
+                    Name = "custom",
+                    ShortName = "custom",
+                    OnlineID = -1
+                }
+            };
+
+            AddStep("import custom ruleset", () => Realm.Write(r => r.Add(createCustomRuleset().RulesetInfo)));
+            AddStep("set custom ruleset", () => customRuleset = createCustomRuleset());
+
+            CreateTest();
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+
+            AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
+
+            AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
+            AddUntilStep("score in database", () => Realm.Run(r => r.All<ScoreInfo>().Count() == 1));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Tests.Resources;
@@ -75,15 +76,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestScoreStoredLocallyCustomRuleset()
         {
-            Ruleset createCustomRuleset() => new OsuRuleset
-            {
-                RulesetInfo =
-                {
-                    Name = "custom",
-                    ShortName = "custom",
-                    OnlineID = -1
-                }
-            };
+            Ruleset createCustomRuleset() => new CustomRuleset();
 
             AddStep("import custom ruleset", () => Realm.Write(r => r.Add(createCustomRuleset().RulesetInfo)));
             AddStep("set custom ruleset", () => customRuleset = createCustomRuleset());
@@ -96,6 +89,16 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
             AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
+        }
+
+        private class CustomRuleset : OsuRuleset, ILegacyRuleset
+        {
+            public override string Description => "custom";
+            public override string ShortName => "custom";
+
+            public new int LegacyID => -1;
+
+            public override ScoreProcessor CreateScoreProcessor() => new ScoreProcessor(this);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -363,23 +363,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 await AllowImportCompletion.WaitAsync().ConfigureAwait(false);
 
-                ImportedScore = score;
+                await base.ImportScore(score);
 
-                // It was discovered that Score members could sometimes be half-populated.
-                // In particular, the RulesetID property could be set to 0 even on non-osu! maps.
-                // We want to test that the state of that property is consistent in this test.
-                // EF makes this impossible.
-                //
-                // First off, because of the EF navigational property-explicit foreign key field duality,
-                // it can happen that - for example - the Ruleset navigational property is correctly initialised to mania,
-                // but the RulesetID foreign key property is not initialised and remains 0.
-                // EF silently bypasses this by prioritising the Ruleset navigational property over the RulesetID foreign key one.
-                //
-                // Additionally, adding an entity to an EF DbSet CAUSES SIDE EFFECTS with regard to the foreign key property.
-                // In the above instance, if a ScoreInfo with Ruleset = {mania} and RulesetID = 0 is attached to an EF context,
-                // RulesetID WILL BE SILENTLY SET TO THE CORRECT VALUE of 3.
-                //
-                // For the above reasons, actual importing is disabled in this test.
+                ImportedScore = score;
             }
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -363,9 +363,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 await AllowImportCompletion.WaitAsync().ConfigureAwait(false);
 
-                await base.ImportScore(score);
-
                 ImportedScore = score;
+
+                // Calling base.ImportScore is omitted as it will fail for the test method which uses a custom ruleset.
+                // This can be resolved by doing something similar to what TestScenePlayerLocalScoreImport is doing,
+                // but requires a bit of restructuring.
             }
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -143,6 +143,28 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestLocallyAvailableWithoutReplay()
+        {
+            Live<ScoreInfo> imported = null;
+
+            AddStep("import score", () => imported = scoreManager.Import(getScoreInfo(false, false)));
+
+            AddStep("create button without replay", () =>
+            {
+                Child = downloadButton = new TestReplayDownloadButton(imported.Value)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                };
+            });
+
+            AddUntilStep("wait for load", () => downloadButton.IsLoaded);
+
+            AddUntilStep("state is not downloaded", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
+        }
+
+        [Test]
         public void TestScoreImportThenDelete()
         {
             Live<ScoreInfo> imported = null;
@@ -189,11 +211,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
         }
 
-        private ScoreInfo getScoreInfo(bool replayAvailable)
+        private ScoreInfo getScoreInfo(bool replayAvailable, bool hasOnlineId = true)
         {
             return new APIScore
             {
-                OnlineID = online_score_id,
+                OnlineID = hasOnlineId ? online_score_id : 0,
                 RulesetID = 0,
                 Beatmap = CreateAPIBeatmapSet(new OsuRuleset().RulesetInfo).Beatmaps.First(),
                 HasReplay = replayAvailable,

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -22,6 +22,7 @@ using osu.Framework.Threading;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Graphics.Containers;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
@@ -1064,12 +1065,15 @@ namespace osu.Game.Screens.Play
             if (DrawableRuleset.ReplayScore != null)
                 return Task.CompletedTask;
 
-            LegacyByteArrayReader replayReader;
+            LegacyByteArrayReader replayReader = null;
 
-            using (var stream = new MemoryStream())
+            if (score.ScoreInfo.Ruleset.IsLegacyRuleset())
             {
-                new LegacyScoreEncoder(score, GameplayState.Beatmap).Encode(stream);
-                replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
+                using (var stream = new MemoryStream())
+                {
+                    new LegacyScoreEncoder(score, GameplayState.Beatmap).Encode(stream);
+                    replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
+                }
             }
 
             // the import process will re-attach managed beatmap/rulesets to this score. we don't want this for now, so create a temporary copy to import.

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Development;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -26,8 +27,12 @@ namespace osu.Game.Tests.Visual
         protected virtual bool HasCustomSteps => false;
 
         /// <summary>
-        /// WARNING: ONLY WORKS IF RUN HEADLESS because reasons.
+        /// Import the beatmap to the database before starting gameplay. Handy for testing local score storage and the likes.
         /// </summary>
+        /// <remarks>
+        /// Only works under headless operation currently due to realm isolation difficulties.
+        /// If this is ever needed to change, consideration needs to be given to the fact that BeatmapManager is attached to the global realm.
+        /// </remarks>
         protected virtual bool ImportBeatmapToDatabase => false;
 
         protected TestPlayer Player;
@@ -77,6 +82,8 @@ namespace osu.Game.Tests.Visual
 
             if (ImportBeatmapToDatabase)
             {
+                Debug.Assert(DebugUtils.IsNUnitRunning, $@"Importing beatmaps in {nameof(PlayerTestScene)} requires headless environment.");
+
                 Debug.Assert(beatmap.BeatmapInfo.BeatmapSet != null);
 
                 var imported = beatmaps.Import(beatmap.BeatmapInfo.BeatmapSet);

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -4,16 +4,12 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Development;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Database;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 
@@ -25,15 +21,6 @@ namespace osu.Game.Tests.Visual
         /// Whether custom test steps are provided. Custom tests should invoke <see cref="CreateTest"/> to create the test steps.
         /// </summary>
         protected virtual bool HasCustomSteps => false;
-
-        /// <summary>
-        /// Import the beatmap to the database before starting gameplay. Handy for testing local score storage and the likes.
-        /// </summary>
-        /// <remarks>
-        /// Only works under headless operation currently due to realm isolation difficulties.
-        /// If this is ever needed to change, consideration needs to be given to the fact that BeatmapManager is attached to the global realm.
-        /// </remarks>
-        protected virtual bool ImportBeatmapToDatabase => false;
 
         protected TestPlayer Player;
 
@@ -70,31 +57,12 @@ namespace osu.Game.Tests.Visual
 
         protected virtual bool Autoplay => false;
 
-        [Resolved]
-        private BeatmapManager beatmaps { get; set; }
-
         protected void LoadPlayer()
         {
             var ruleset = CreatePlayerRuleset();
             Ruleset.Value = ruleset.RulesetInfo;
 
             var beatmap = CreateBeatmap(ruleset.RulesetInfo);
-
-            if (ImportBeatmapToDatabase)
-            {
-                Debug.Assert(DebugUtils.IsNUnitRunning, $@"Importing beatmaps in {nameof(PlayerTestScene)} requires headless environment.");
-
-                Debug.Assert(beatmap.BeatmapInfo.BeatmapSet != null);
-
-                var imported = beatmaps.Import(beatmap.BeatmapInfo.BeatmapSet);
-
-                Debug.Assert(imported != null);
-
-                beatmap.BeatmapInfo = null;
-                beatmap.Difficulty = null;
-
-                beatmap.BeatmapInfo = imported.Value.Detach().Beatmaps.First();
-            }
 
             Beatmap.Value = CreateWorkingBeatmap(beatmap);
             SelectedMods.Value = Array.Empty<Mod>();

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -4,12 +4,15 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 
@@ -21,6 +24,11 @@ namespace osu.Game.Tests.Visual
         /// Whether custom test steps are provided. Custom tests should invoke <see cref="CreateTest"/> to create the test steps.
         /// </summary>
         protected virtual bool HasCustomSteps => false;
+
+        /// <summary>
+        /// WARNING: ONLY WORKS IF RUN HEADLESS because reasons.
+        /// </summary>
+        protected virtual bool ImportBeatmapToDatabase => false;
 
         protected TestPlayer Player;
 
@@ -49,7 +57,7 @@ namespace osu.Game.Tests.Visual
 
             action?.Invoke();
 
-            AddStep(CreatePlayerRuleset().Description, LoadPlayer);
+            AddStep($"Load player for {CreatePlayerRuleset().Description}", LoadPlayer);
             AddUntilStep("player loaded", () => Player.IsLoaded && Player.Alpha == 1);
         }
 
@@ -57,12 +65,29 @@ namespace osu.Game.Tests.Visual
 
         protected virtual bool Autoplay => false;
 
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
         protected void LoadPlayer()
         {
             var ruleset = CreatePlayerRuleset();
             Ruleset.Value = ruleset.RulesetInfo;
 
             var beatmap = CreateBeatmap(ruleset.RulesetInfo);
+
+            if (ImportBeatmapToDatabase)
+            {
+                Debug.Assert(beatmap.BeatmapInfo.BeatmapSet != null);
+
+                var imported = beatmaps.Import(beatmap.BeatmapInfo.BeatmapSet);
+
+                Debug.Assert(imported != null);
+
+                beatmap.BeatmapInfo = null;
+                beatmap.Difficulty = null;
+
+                beatmap.BeatmapInfo = imported.Value.Detach().Beatmaps.First();
+            }
 
             Beatmap.Value = CreateWorkingBeatmap(beatmap);
             SelectedMods.Value = Array.Empty<Mod>();


### PR DESCRIPTION
Replaces the error with the ability to import, minus replays.

Closes https://github.com/ppy/osu/issues/17350 (arguably, but let's go with it for now).