### PR TITLE
Use fire-and-forget async operations on global track

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.702.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.704.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.707.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -24,7 +22,7 @@ namespace osu.Game.Tests.Visual.Editing
     [TestFixture]
     public class TestSceneComposeScreen : EditorClockTestScene
     {
-        private EditorBeatmap editorBeatmap;
+        private EditorBeatmap editorBeatmap = null!;
 
         [Cached]
         private EditorClipboard clipboard = new EditorClipboard();

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
@@ -39,7 +37,9 @@ namespace osu.Game.Tests.Visual.Editing
         protected override bool IsolateSavingFromDatabase => false;
 
         [Resolved]
-        private BeatmapManager beatmapManager { get; set; }
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        private Guid currentBeatmapSetID => EditorBeatmap.BeatmapInfo.BeatmapSet?.ID ?? Guid.Empty;
 
         public override void SetUpSteps()
         {
@@ -50,19 +50,19 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("make new beatmap unique", () => EditorBeatmap.Metadata.Title = Guid.NewGuid().ToString());
         }
 
-        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null) => new DummyWorkingBeatmap(Audio, null);
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null) => new DummyWorkingBeatmap(Audio, null);
 
         [Test]
         public void TestCreateNewBeatmap()
         {
             AddStep("save beatmap", () => Editor.Save());
-            AddAssert("new beatmap in database", () => beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID)?.Value.DeletePending == false);
+            AddAssert("new beatmap in database", () => beatmapManager.QueryBeatmapSet(s => s.ID == currentBeatmapSetID)?.Value.DeletePending == false);
         }
 
         [Test]
         public void TestExitWithoutSave()
         {
-            EditorBeatmap editorBeatmap = null;
+            EditorBeatmap editorBeatmap = null!;
 
             AddStep("store editor beatmap", () => editorBeatmap = EditorBeatmap);
 
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("wait for exit", () => !Editor.IsCurrentScreen());
             AddStep("release", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("new beatmap not persisted", () => beatmapManager.QueryBeatmapSet(s => s.ID == editorBeatmap.BeatmapInfo.BeatmapSet.ID)?.Value.DeletePending == true);
+            AddAssert("new beatmap not persisted", () => beatmapManager.QueryBeatmapSet(s => s.ID == editorBeatmap.BeatmapInfo.BeatmapSet.AsNonNull().ID)?.Value.DeletePending == true);
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("new beatmap persisted", () =>
             {
                 var beatmap = beatmapManager.QueryBeatmap(b => b.DifficultyName == firstDifficultyName);
-                var set = beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID);
+                var set = beatmapManager.QueryBeatmapSet(s => s.ID == currentBeatmapSetID);
 
                 return beatmap != null
                        && beatmap.DifficultyName == firstDifficultyName
@@ -179,7 +179,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddUntilStep("wait for created", () =>
             {
-                string difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
+                string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != firstDifficultyName;
             });
 
@@ -195,7 +195,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("new beatmap persisted", () =>
             {
                 var beatmap = beatmapManager.QueryBeatmap(b => b.DifficultyName == secondDifficultyName);
-                var set = beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID);
+                var set = beatmapManager.QueryBeatmapSet(s => s.ID == currentBeatmapSetID);
 
                 return beatmap != null
                        && beatmap.DifficultyName == secondDifficultyName
@@ -246,7 +246,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("new beatmap persisted", () =>
             {
                 var beatmap = beatmapManager.QueryBeatmap(b => b.DifficultyName == originalDifficultyName);
-                var set = beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID);
+                var set = beatmapManager.QueryBeatmapSet(s => s.ID == currentBeatmapSetID);
 
                 return beatmap != null
                        && beatmap.DifficultyName == originalDifficultyName
@@ -262,7 +262,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddUntilStep("wait for created", () =>
             {
-                string difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
+                string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != originalDifficultyName;
             });
 
@@ -281,13 +281,13 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("save beatmap", () => Editor.Save());
 
-            BeatmapInfo refetchedBeatmap = null;
-            Live<BeatmapSetInfo> refetchedBeatmapSet = null;
+            BeatmapInfo? refetchedBeatmap = null;
+            Live<BeatmapSetInfo>? refetchedBeatmapSet = null;
 
             AddStep("refetch from database", () =>
             {
                 refetchedBeatmap = beatmapManager.QueryBeatmap(b => b.DifficultyName == copyDifficultyName);
-                refetchedBeatmapSet = beatmapManager.QueryBeatmapSet(s => s.ID == EditorBeatmap.BeatmapInfo.BeatmapSet.ID);
+                refetchedBeatmapSet = beatmapManager.QueryBeatmapSet(s => s.ID == currentBeatmapSetID);
             });
 
             AddAssert("new beatmap persisted", () =>
@@ -323,7 +323,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddUntilStep("wait for created", () =>
             {
-                string difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
+                string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != "New Difficulty";
             });
             AddAssert("new difficulty has correct name", () => EditorBeatmap.BeatmapInfo.DifficultyName == "New Difficulty (1)");
@@ -359,7 +359,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddUntilStep("wait for created", () =>
             {
-                string difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
+                string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != duplicate_difficulty_name;
             });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,20 +31,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public class TestSceneMultiSpectatorScreen : MultiplayerTestScene
     {
         [Resolved]
-        private OsuGameBase game { get; set; }
+        private OsuGameBase game { get; set; } = null!;
 
         [Resolved]
-        private OsuConfigManager config { get; set; }
+        private OsuConfigManager config { get; set; } = null!;
 
         [Resolved]
-        private BeatmapManager beatmapManager { get; set; }
+        private BeatmapManager beatmapManager { get; set; } = null!;
 
-        private MultiSpectatorScreen spectatorScreen;
+        private MultiSpectatorScreen spectatorScreen = null!;
 
         private readonly List<MultiplayerRoomUser> playingUsers = new List<MultiplayerRoomUser>();
 
-        private BeatmapSetInfo importedSet;
-        private BeatmapInfo importedBeatmap;
+        private BeatmapSetInfo importedSet = null!;
+        private BeatmapInfo importedBeatmap = null!;
+
         private int importedBeatmapId;
 
         [BackgroundDependencyLoader]
@@ -340,7 +339,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 sendFrames(getPlayerIds(count), 300);
             }
 
-            Player player = null;
+            Player? player = null;
 
             AddStep($"get {PLAYER_1_ID} player instance", () => player = getInstance(PLAYER_1_ID).ChildrenOfType<Player>().Single());
 
@@ -369,7 +368,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             b.Storyboard.GetLayer("Background").Add(sprite);
         });
 
-        private void testLeadIn(Action<WorkingBeatmap> applyToBeatmap = null)
+        private void testLeadIn(Action<WorkingBeatmap>? applyToBeatmap = null)
         {
             start(PLAYER_1_ID);
 
@@ -387,7 +386,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             assertRunning(PLAYER_1_ID);
         }
 
-        private void loadSpectateScreen(bool waitForPlayerLoad = true, Action<WorkingBeatmap> applyToBeatmap = null)
+        private void loadSpectateScreen(bool waitForPlayerLoad = true, Action<WorkingBeatmap>? applyToBeatmap = null)
         {
             AddStep("load screen", () =>
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -51,17 +49,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayer : ScreenTestScene
     {
-        private BeatmapManager beatmaps;
-        private RulesetStore rulesets;
-        private BeatmapSetInfo importedSet;
+        private BeatmapManager beatmaps = null!;
+        private RulesetStore rulesets = null!;
+        private BeatmapSetInfo importedSet = null!;
 
-        private TestMultiplayerComponents multiplayerComponents;
+        private TestMultiplayerComponents multiplayerComponents = null!;
 
         private TestMultiplayerClient multiplayerClient => multiplayerComponents.MultiplayerClient;
         private TestMultiplayerRoomManager roomManager => multiplayerComponents.RoomManager;
 
         [Resolved]
-        private OsuConfigManager config { get; set; }
+        private OsuConfigManager config { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -146,7 +144,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void removeLastUser()
         {
-            APIUser lastUser = multiplayerClient.ServerRoom?.Users.Last().User;
+            APIUser? lastUser = multiplayerClient.ServerRoom?.Users.Last().User;
 
             if (lastUser == null || lastUser == multiplayerClient.LocalUser?.User)
                 return;
@@ -156,7 +154,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void kickLastUser()
         {
-            APIUser lastUser = multiplayerClient.ServerRoom?.Users.Last().User;
+            APIUser? lastUser = multiplayerClient.ServerRoom?.Users.Last().User;
 
             if (lastUser == null || lastUser == multiplayerClient.LocalUser?.User)
                 return;
@@ -351,7 +349,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("select room", () => InputManager.Key(Key.Down));
             AddStep("join room", () => InputManager.Key(Key.Enter));
 
-            DrawableLoungeRoom.PasswordEntryPopover passwordEntryPopover = null;
+            DrawableLoungeRoom.PasswordEntryPopover? passwordEntryPopover = null;
             AddUntilStep("password prompt appeared", () => (passwordEntryPopover = InputManager.ChildrenOfType<DrawableLoungeRoom.PasswordEntryPopover>().FirstOrDefault()) != null);
             AddStep("enter password in text box", () => passwordEntryPopover.ChildrenOfType<TextBox>().First().Text = "password");
             AddStep("press join room button", () => passwordEntryPopover.ChildrenOfType<OsuButton>().First().TriggerClick());
@@ -678,7 +676,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestGameplayExitFlow()
         {
-            Bindable<double> holdDelay = null;
+            Bindable<double>? holdDelay = null;
 
             AddStep("Set hold delay to zero", () =>
             {
@@ -709,7 +707,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for lounge", () => multiplayerComponents.CurrentScreen is Screens.OnlinePlay.Multiplayer.Multiplayer);
 
             AddStep("stop holding", () => InputManager.ReleaseKey(Key.Escape));
-            AddStep("set hold delay to default", () => holdDelay.SetDefault());
+            AddStep("set hold delay to default", () => holdDelay?.SetDefault());
         }
 
         [Test]
@@ -992,7 +990,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for ready button to be enabled", () => readyButton.Enabled.Value);
 
             MultiplayerUserState lastState = MultiplayerUserState.Idle;
-            MultiplayerRoomUser user = null;
+            MultiplayerRoomUser? user = null;
 
             AddStep("click ready button", () =>
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -66,7 +64,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestRemoveUser()
         {
-            APIUser secondUser = null;
+            APIUser? secondUser = null;
 
             AddStep("add a user", () =>
             {
@@ -80,7 +78,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("remove host", () => MultiplayerClient.RemoveUser(API.LocalUser.Value));
 
-            AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().User.UserID == secondUser.Id);
+            AddAssert("single panel is for second user", () => this.ChildrenOfType<ParticipantPanel>().Single().User.UserID == secondUser?.Id);
         }
 
         [Test]
@@ -368,7 +366,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void createNewParticipantsList()
         {
-            ParticipantsList participantsList = null;
+            ParticipantsList? participantsList = null;
 
             AddStep("create new list", () => Child = participantsList = new ParticipantsList
             {
@@ -378,7 +376,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Size = new Vector2(380, 0.7f)
             });
 
-            AddUntilStep("wait for list to load", () => participantsList.IsLoaded);
+            AddUntilStep("wait for list to load", () => participantsList?.IsLoaded == true);
         }
 
         private void checkProgressBarVisibility(bool visible) =>

--- a/osu.Game.Tests/Visual/Online/TestSceneLeaderboardModSelector.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneLeaderboardModSelector.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Overlays.BeatmapSet;
 using System.Collections.Specialized;
 using System.Linq;
@@ -29,7 +27,7 @@ namespace osu.Game.Tests.Visual.Online
             LeaderboardModSelector modSelector;
             FillFlowContainer<SpriteText> selectedMods;
 
-            var ruleset = new Bindable<IRulesetInfo>();
+            var ruleset = new Bindable<IRulesetInfo?>();
 
             Add(selectedMods = new FillFlowContainer<SpriteText>
             {

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -133,9 +133,9 @@ namespace osu.Game.Overlays
                 UserPauseRequested = false;
 
             if (restart)
-                CurrentTrack.Restart();
+                CurrentTrack.RestartAsync();
             else if (!IsPlaying)
-                CurrentTrack.Start();
+                CurrentTrack.StartAsync();
 
             return true;
         }
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays
         {
             UserPauseRequested |= requestedByUser;
             if (CurrentTrack.IsRunning)
-                CurrentTrack.Stop();
+                CurrentTrack.StopAsync();
         }
 
         /// <summary>
@@ -250,7 +250,7 @@ namespace osu.Game.Overlays
         {
             // if not scheduled, the previously track will be stopped one frame later (see ScheduleAfterChildren logic in GameBase).
             // we probably want to move this to a central method for switching to a new working beatmap in the future.
-            Schedule(() => CurrentTrack.Restart());
+            Schedule(() => CurrentTrack.RestartAsync());
         }
 
         private WorkingBeatmap current;

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -430,9 +430,17 @@ namespace osu.Game.Tests.Visual
                     return accumulated == seek;
                 }
 
+                public override Task<bool> SeekAsync(double seek) => Task.FromResult(Seek(seek));
+
                 public override void Start()
                 {
                     running = true;
+                }
+
+                public override Task StartAsync()
+                {
+                    Start();
+                    return Task.CompletedTask;
                 }
 
                 public override void Reset()
@@ -448,6 +456,12 @@ namespace osu.Game.Tests.Visual
                         running = false;
                         lastReferenceTime = null;
                     }
+                }
+
+                public override Task StopAsync()
+                {
+                    Stop();
+                    return Task.CompletedTask;
                 }
 
                 public override bool IsRunning => running;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.14.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.704.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.707.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.702.0" />
     <PackageReference Include="Sentry" Version="3.17.1" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.704.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.707.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.702.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.704.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.707.0" />
     <PackageReference Include="SharpCompress" Version="0.31.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
This avoids any blocking overhead caused by a backlogged audio thread. Test seem to pass so might be okay?

Note that order of operations are still guaranteed due to the `EnqueueAction` queueing system framework-side.

Addresses one more performance concern raised in https://github.com/ppy/osu/discussions/19003