### PR TITLE
Simplify error output when hub cannot connect

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Online
         /// </summary>
         private async Task handleErrorAndDelay(Exception exception, CancellationToken cancellationToken)
         {
-            Logger.Log($"{clientName} connection error: {exception}", LoggingTarget.Network);
+            Logger.Log($"{clientName} connect attempt failed: {exception.Message}", LoggingTarget.Network);
             await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Full call stack is useless in these cases.

Before:

```csharp

[network] 2022-07-07 16:05:31 [verbose]: OnlineMetadataClient connection error: System.Net.Http.HttpRequestException: Response status code does not indicate success: 403 (Forbidden).
[network] 2022-07-07 16:05:31 [verbose]: at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.NegotiateAsync(Uri url, HttpClient httpClient, ILogger logger, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.GetNegotiationResponseAsync(Uri uri, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.SelectAndStartTransport(TransferFormat transferFormat, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.StartAsyncCore(TransferFormat transferFormat, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.StartAsync(TransferFormat transferFormat, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionFactory.ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionFactory.ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.SignalR.Client.HubConnection.StartAsyncCore(CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.SignalR.Client.HubConnection.StartAsyncInner(CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at Microsoft.AspNetCore.SignalR.Client.HubConnection.StartAsync(CancellationToken cancellationToken)
[network] 2022-07-07 16:05:31 [verbose]: at osu.Game.Online.HubClientConnector.connect() in /Users/dean/Projects/osu/osu.Game/Online/HubClientConnector.cs:line 119

```

After:

```csharp

[network] 2022-07-07 16:06:59 [verbose]: OnlineMetadataClient connecting...
[network] 2022-07-07 16:06:59 [verbose]: OnlineMetadataClient connect attempt failed: Response status code does not indicate success: 403 (Forbidden).

```