### PR TITLE
Fix background loading excessively on startup

### DIFF
--- a/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
+++ b/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
@@ -41,7 +41,11 @@ namespace osu.Game.Graphics.Backgrounds
             seasonalBackgroundMode.BindValueChanged(_ => SeasonalBackgroundChanged?.Invoke());
 
             seasonalBackgrounds = sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds);
-            seasonalBackgrounds.BindValueChanged(_ => SeasonalBackgroundChanged?.Invoke());
+            seasonalBackgrounds.BindValueChanged(response =>
+            {
+                if (response.NewValue?.Backgrounds?.Count > 0)
+                    SeasonalBackgroundChanged?.Invoke();
+            });
 
             apiState.BindTo(api.State);
             apiState.BindValueChanged(fetchSeasonalBackgrounds, true);

--- a/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
+++ b/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
@@ -38,17 +38,19 @@ namespace osu.Game.Graphics.Backgrounds
         private void load(OsuConfigManager config, SessionStatics sessionStatics)
         {
             seasonalBackgroundMode = config.GetBindable<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode);
-            seasonalBackgroundMode.BindValueChanged(_ => SeasonalBackgroundChanged?.Invoke());
+            seasonalBackgroundMode.BindValueChanged(_ => triggerSeasonalBackgroundChanged());
 
             seasonalBackgrounds = sessionStatics.GetBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds);
-            seasonalBackgrounds.BindValueChanged(response =>
-            {
-                if (response.NewValue?.Backgrounds?.Count > 0)
-                    SeasonalBackgroundChanged?.Invoke();
-            });
+            seasonalBackgrounds.BindValueChanged(_ => triggerSeasonalBackgroundChanged());
 
             apiState.BindTo(api.State);
             apiState.BindValueChanged(fetchSeasonalBackgrounds, true);
+        }
+
+        private void triggerSeasonalBackgroundChanged()
+        {
+            if (shouldShowSeasonal)
+                SeasonalBackgroundChanged?.Invoke();
         }
 
         private void fetchSeasonalBackgrounds(ValueChangedEvent<APIState> stateChanged)
@@ -68,20 +70,29 @@ namespace osu.Game.Graphics.Backgrounds
 
         public SeasonalBackground LoadNextBackground()
         {
-            if (seasonalBackgroundMode.Value == SeasonalBackgroundMode.Never
-                || (seasonalBackgroundMode.Value == SeasonalBackgroundMode.Sometimes && !isInSeason))
-            {
+            if (!shouldShowSeasonal)
                 return null;
-            }
 
-            var backgrounds = seasonalBackgrounds.Value?.Backgrounds;
-            if (backgrounds == null || !backgrounds.Any())
-                return null;
+            var backgrounds = seasonalBackgrounds.Value.Backgrounds;
 
             current = (current + 1) % backgrounds.Count;
             string url = backgrounds[current].Url;
 
             return new SeasonalBackground(url);
+        }
+
+        private bool shouldShowSeasonal
+        {
+            get
+            {
+                if (seasonalBackgroundMode.Value == SeasonalBackgroundMode.Never)
+                    return false;
+
+                if (seasonalBackgroundMode.Value == SeasonalBackgroundMode.Sometimes && !isInSeason)
+                    return false;
+
+                return seasonalBackgrounds.Value?.Backgrounds?.Any() == true;
+            }
         }
 
         private bool isInSeason => seasonalBackgrounds.Value != null && DateTimeOffset.Now < seasonalBackgrounds.Value.EndDate;

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.Backgrounds
         private const int background_count = 7;
         private IBindable<APIUser> user;
         private Bindable<Skin> skin;
-        private Bindable<BackgroundSource> mode;
+        private Bindable<BackgroundSource> source;
         private Bindable<IntroSequence> introSequence;
         private readonly SeasonalBackgroundLoader seasonalBackgroundLoader = new SeasonalBackgroundLoader();
 
@@ -45,14 +46,14 @@ namespace osu.Game.Screens.Backgrounds
         {
             user = api.LocalUser.GetBoundCopy();
             skin = skinManager.CurrentSkin.GetBoundCopy();
-            mode = config.GetBindable<BackgroundSource>(OsuSetting.MenuBackgroundSource);
+            source = config.GetBindable<BackgroundSource>(OsuSetting.MenuBackgroundSource);
             introSequence = config.GetBindable<IntroSequence>(OsuSetting.IntroSequence);
 
             AddInternal(seasonalBackgroundLoader);
 
             user.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
             skin.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
-            mode.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
+            source.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
             beatmap.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
             introSequence.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
             seasonalBackgroundLoader.SeasonalBackgroundChanged += () => Scheduler.AddOnce(loadNextIfRequired);
@@ -62,7 +63,13 @@ namespace osu.Game.Screens.Backgrounds
             Next();
 
             // helper function required for AddOnce usage.
-            void loadNextIfRequired() => Next();
+            void loadNextIfRequired()
+            {
+                if (!IsLoaded)
+                    return;
+
+                Next();
+            }
         }
 
         private ScheduledDelegate nextTask;
@@ -79,6 +86,8 @@ namespace osu.Game.Screens.Backgrounds
             // in the case that the background hasn't changed, we want to avoid cancelling any tasks that could still be loading.
             if (nextBackground == background)
                 return false;
+
+            Logger.Log("🌅 Background change queued");
 
             cancellationTokenSource?.Cancel();
             cancellationTokenSource = new CancellationTokenSource();
@@ -108,12 +117,12 @@ namespace osu.Game.Screens.Backgrounds
 
             if (newBackground == null && user.Value?.IsSupporter == true)
             {
-                switch (mode.Value)
+                switch (source.Value)
                 {
                     case BackgroundSource.Beatmap:
                     case BackgroundSource.BeatmapWithStoryboard:
                     {
-                        if (mode.Value == BackgroundSource.BeatmapWithStoryboard && AllowStoryboardBackground)
+                        if (source.Value == BackgroundSource.BeatmapWithStoryboard && AllowStoryboardBackground)
                             newBackground = new BeatmapBackgroundWithStoryboard(beatmap.Value, getBackgroundTextureName());
                         newBackground ??= new BeatmapBackground(beatmap.Value, getBackgroundTextureName());
 

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -51,25 +51,24 @@ namespace osu.Game.Screens.Backgrounds
 
             AddInternal(seasonalBackgroundLoader);
 
-            user.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
-            skin.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
-            source.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
-            beatmap.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
-            introSequence.ValueChanged += _ => Scheduler.AddOnce(loadNextIfRequired);
-            seasonalBackgroundLoader.SeasonalBackgroundChanged += () => Scheduler.AddOnce(loadNextIfRequired);
-
+            // Load first background asynchronously as part of BDL load.
             currentDisplay = RNG.Next(0, background_count);
-
             Next();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            user.ValueChanged += _ => Scheduler.AddOnce(next);
+            skin.ValueChanged += _ => Scheduler.AddOnce(next);
+            source.ValueChanged += _ => Scheduler.AddOnce(next);
+            beatmap.ValueChanged += _ => Scheduler.AddOnce(next);
+            introSequence.ValueChanged += _ => Scheduler.AddOnce(next);
+            seasonalBackgroundLoader.SeasonalBackgroundChanged += () => Scheduler.AddOnce(next);
 
             // helper function required for AddOnce usage.
-            void loadNextIfRequired()
-            {
-                if (!IsLoaded)
-                    return;
-
-                Next();
-            }
+            void next() => Next();
         }
 
         private ScheduledDelegate nextTask;

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -206,7 +206,7 @@ namespace osu.Game.Screens.Menu
         {
             this.FadeIn(300);
 
-            ApplyToBackground(b => b.FadeColour(Color4.Black));
+            ApplyToBackground(b => b.FadeColour(Color4.Black, 100));
 
             double fadeOutTime = exit_delay;
 

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -252,10 +252,10 @@ namespace osu.Game.Screens.Menu
 
         private bool backgroundFaded;
 
-        protected void FadeInBackground(float fadeInTime)
+        protected void FadeInBackground(float duration = 0)
         {
+            ApplyToBackground(b => b.FadeColour(Color4.White, duration));
             backgroundFaded = true;
-            ApplyToBackground(b => b.FadeColour(Color4.White, fadeInTime));
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -88,6 +88,11 @@ namespace osu.Game.Screens.Menu
         /// </summary>
         protected bool UsingThemedIntro { get; private set; }
 
+        protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault(false)
+        {
+            Colour = Color4.Black
+        };
+
         protected IntroScreen([CanBeNull] Func<MainMenu> createNextScreen = null)
         {
             this.createNextScreen = createNextScreen;
@@ -201,6 +206,8 @@ namespace osu.Game.Screens.Menu
         {
             this.FadeIn(300);
 
+            ApplyToBackground(b => b.FadeColour(Color4.Black));
+
             double fadeOutTime = exit_delay;
 
             var track = musicController.CurrentTrack;
@@ -243,13 +250,22 @@ namespace osu.Game.Screens.Menu
             base.OnResuming(e);
         }
 
+        private bool backgroundFaded;
+
+        protected void FadeInBackground(float fadeInTime)
+        {
+            backgroundFaded = true;
+            ApplyToBackground(b => b.FadeColour(Color4.White, fadeInTime));
+        }
+
         public override void OnSuspending(ScreenTransitionEvent e)
         {
             base.OnSuspending(e);
             initialBeatmap = null;
-        }
 
-        protected override BackgroundScreen CreateBackground() => new BackgroundScreenBlack();
+            if (!backgroundFaded)
+                FadeInBackground(200);
+        }
 
         protected virtual void StartTrack()
         {

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -8,19 +8,18 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Screens;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
-using osu.Framework.Utils;
+using osu.Framework.Screens;
 using osu.Framework.Timing;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
-using osu.Game.Screens.Backgrounds;
 using osuTK;
 using osuTK.Graphics;
 
@@ -32,15 +31,8 @@ namespace osu.Game.Screens.Menu
 
         protected override string BeatmapFile => "triangles.osz";
 
-        protected override BackgroundScreen CreateBackground() => background = new BackgroundScreenDefault(false)
-        {
-            Alpha = 0,
-        };
-
         [Resolved]
         private AudioManager audio { get; set; }
-
-        private BackgroundScreenDefault background;
 
         private Sample welcome;
 
@@ -75,7 +67,7 @@ namespace osu.Game.Screens.Menu
                 if (UsingThemedIntro)
                     decoupledClock.ChangeSource(Track);
 
-                LoadComponentAsync(intro = new TrianglesIntroSequence(logo, background)
+                LoadComponentAsync(intro = new TrianglesIntroSequence(logo, () => FadeInBackground(0))
                 {
                     RelativeSizeAxes = Axes.Both,
                     Clock = decoupledClock,
@@ -95,17 +87,8 @@ namespace osu.Game.Screens.Menu
         {
             base.OnSuspending(e);
 
-            // ensure the background is shown, even if the TriangleIntroSequence failed to do so.
-            background.ApplyToBackground(b => b.Show());
-
             // important as there is a clock attached to a track which will likely be disposed before returning to this screen.
             intro.Expire();
-        }
-
-        public override void OnResuming(ScreenTransitionEvent e)
-        {
-            base.OnResuming(e);
-            background.FadeOut(100);
         }
 
         protected override void StartTrack()
@@ -116,7 +99,7 @@ namespace osu.Game.Screens.Menu
         private class TrianglesIntroSequence : CompositeDrawable
         {
             private readonly OsuLogo logo;
-            private readonly BackgroundScreenDefault background;
+            private readonly Action showBackgroundAction;
             private OsuSpriteText welcomeText;
 
             private RulesetFlow rulesets;
@@ -128,10 +111,10 @@ namespace osu.Game.Screens.Menu
 
             public Action LoadMenu;
 
-            public TrianglesIntroSequence(OsuLogo logo, BackgroundScreenDefault background)
+            public TrianglesIntroSequence(OsuLogo logo, Action showBackgroundAction)
             {
                 this.logo = logo;
-                this.background = background;
+                this.showBackgroundAction = showBackgroundAction;
             }
 
             [Resolved]
@@ -205,7 +188,6 @@ namespace osu.Game.Screens.Menu
 
                 rulesets.Hide();
                 lazerLogo.Hide();
-                background.ApplyToBackground(b => b.Hide());
 
                 using (BeginAbsoluteSequence(0))
                 {
@@ -267,7 +249,7 @@ namespace osu.Game.Screens.Menu
 
                             logo.FadeIn();
 
-                            background.ApplyToBackground(b => b.Show());
+                            showBackgroundAction();
 
                             game.Add(new GameWideFlash());
 

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Menu
                 if (UsingThemedIntro)
                     decoupledClock.ChangeSource(Track);
 
-                LoadComponentAsync(intro = new TrianglesIntroSequence(logo, () => FadeInBackground(0))
+                LoadComponentAsync(intro = new TrianglesIntroSequence(logo, () => FadeInBackground())
                 {
                     RelativeSizeAxes = Axes.Both,
                     Clock = decoupledClock,

--- a/osu.Game/Screens/Menu/IntroWelcome.cs
+++ b/osu.Game/Screens/Menu/IntroWelcome.cs
@@ -5,11 +5,9 @@
 
 using System;
 using JetBrains.Annotations;
-using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Screens;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -17,8 +15,8 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Online.API;
-using osu.Game.Screens.Backgrounds;
 using osu.Game.Skinning;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Menu
@@ -34,13 +32,6 @@ namespace osu.Game.Screens.Menu
 
         private ISample pianoReverb;
         protected override string SeeyaSampleName => "Intro/Welcome/seeya";
-
-        protected override BackgroundScreen CreateBackground() => background = new BackgroundScreenDefault(false)
-        {
-            Alpha = 0,
-        };
-
-        private BackgroundScreenDefault background;
 
         public IntroWelcome([CanBeNull] Func<MainMenu> createNextScreen = null)
             : base(createNextScreen)
@@ -100,18 +91,12 @@ namespace osu.Game.Screens.Menu
                         logo.ScaleTo(1);
                         logo.FadeIn(fade_in_time);
 
-                        background.FadeIn(fade_in_time);
+                        FadeInBackground(fade_in_time);
 
                         LoadMenu();
                     }, delay_step_two);
                 });
             }
-        }
-
-        public override void OnResuming(ScreenTransitionEvent e)
-        {
-            base.OnResuming(e);
-            background.FadeOut(100);
         }
 
         private class WelcomeIntroSequence : Container

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -65,9 +65,7 @@ namespace osu.Game.Screens.Menu
         [Resolved(canBeNull: true)]
         private IDialogOverlay dialogOverlay { get; set; }
 
-        private BackgroundScreenDefault background;
-
-        protected override BackgroundScreen CreateBackground() => background;
+        protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault();
 
         protected override bool PlayExitSound => false;
 
@@ -148,7 +146,6 @@ namespace osu.Game.Screens.Menu
             Buttons.OnSettings = () => settings?.ToggleVisibility();
             Buttons.OnBeatmapListing = () => beatmapListing?.ToggleVisibility();
 
-            LoadComponentAsync(background = new BackgroundScreenDefault());
             preloadSongSelect();
         }
 


### PR DESCRIPTION
Noticed that in a normal startup the background can change between three and six times depending on screen scaling, seasonal beatmaps and game settings. This reduces that count to 1-2 times (1 base, 1 on *successful* seasonal load).

This also resolves the weirdness mentioned in https://github.com/ppy/osu/discussions/18810 by forcing all intros to have an opaque background.

See individual commits for more details on each change.
