### PR TITLE
Update mod icon colors

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.UI;
@@ -14,9 +14,23 @@ namespace osu.Game.Tests.Visual.UserInterface
     public class TestSceneModIcon : OsuTestScene
     {
         [Test]
+        public void TestShowAllMods()
+        {
+            AddStep("create mod icons", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Full,
+                    ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods().Select(m => new ModIcon(m)),
+                };
+            });
+        }
+
+        [Test]
         public void TestChangeModType()
         {
-            ModIcon icon = null;
+            ModIcon icon = null!;
 
             AddStep("create mod icon", () => Child = icon = new ModIcon(new OsuModDoubleTime()));
             AddStep("change mod", () => icon.Mod = new OsuModEasy());
@@ -25,7 +39,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestInterfaceModType()
         {
-            ModIcon icon = null;
+            ModIcon icon = null!;
 
             var ruleset = new OsuRuleset();
 

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -127,33 +127,33 @@ namespace osu.Game.Rulesets.UI
             {
                 default:
                 case ModType.DifficultyIncrease:
-                    backgroundColour = colours.Yellow;
-                    highlightedColour = colours.YellowLight;
+                    backgroundColour = colours.Red1;
+                    highlightedColour = colours.Red0;
                     break;
 
                 case ModType.DifficultyReduction:
-                    backgroundColour = colours.Green;
-                    highlightedColour = colours.GreenLight;
+                    backgroundColour = colours.Lime1;
+                    highlightedColour = colours.Lime0;
                     break;
 
                 case ModType.Automation:
-                    backgroundColour = colours.Blue;
-                    highlightedColour = colours.BlueLight;
+                    backgroundColour = colours.Blue1;
+                    highlightedColour = colours.Blue0;
                     break;
 
                 case ModType.Conversion:
-                    backgroundColour = colours.Purple;
-                    highlightedColour = colours.PurpleLight;
+                    backgroundColour = colours.Purple1;
+                    highlightedColour = colours.Purple0;
                     break;
 
                 case ModType.Fun:
-                    backgroundColour = colours.Pink;
-                    highlightedColour = colours.PinkLight;
+                    backgroundColour = colours.Pink1;
+                    highlightedColour = colours.Pink0;
                     break;
 
                 case ModType.System:
-                    backgroundColour = colours.Gray6;
-                    highlightedColour = colours.Gray7;
+                    backgroundColour = colours.Gray7;
+                    highlightedColour = colours.Gray8;
                     modIcon.Colour = colours.Yellow;
                     break;
             }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -123,40 +123,12 @@ namespace osu.Game.Rulesets.UI
                 modAcronym.FadeOut();
             }
 
-            switch (value.Type)
-            {
-                default:
-                case ModType.DifficultyIncrease:
-                    backgroundColour = colours.Red1;
-                    highlightedColour = colours.Red0;
-                    break;
+            Color4 typeColour = colours.ForModType(value.Type);
+            backgroundColour = typeColour;
+            highlightedColour = ((Colour4)typeColour).Lighten(.2f);
 
-                case ModType.DifficultyReduction:
-                    backgroundColour = colours.Lime1;
-                    highlightedColour = colours.Lime0;
-                    break;
-
-                case ModType.Automation:
-                    backgroundColour = colours.Blue1;
-                    highlightedColour = colours.Blue0;
-                    break;
-
-                case ModType.Conversion:
-                    backgroundColour = colours.Purple1;
-                    highlightedColour = colours.Purple0;
-                    break;
-
-                case ModType.Fun:
-                    backgroundColour = colours.Pink1;
-                    highlightedColour = colours.Pink0;
-                    break;
-
-                case ModType.System:
-                    backgroundColour = colours.Gray7;
-                    highlightedColour = colours.Gray8;
-                    modIcon.Colour = colours.Yellow;
-                    break;
-            }
+            if (value.Type == ModType.System)
+                modIcon.Colour = colours.Yellow;
 
             updateColour();
         }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.UI
@@ -53,7 +54,6 @@ namespace osu.Game.Rulesets.UI
         private OsuColour colours { get; set; }
 
         private Color4 backgroundColour;
-        private Color4 highlightedColour;
 
         /// <summary>
         /// Construct a new instance.
@@ -123,19 +123,13 @@ namespace osu.Game.Rulesets.UI
                 modAcronym.FadeOut();
             }
 
-            Color4 typeColour = colours.ForModType(value.Type);
-            backgroundColour = typeColour;
-            highlightedColour = ((Colour4)typeColour).Lighten(.2f);
-
-            if (value.Type == ModType.System)
-                modIcon.Colour = colours.Yellow;
-
+            backgroundColour = colours.ForModType(value.Type);
             updateColour();
         }
 
         private void updateColour()
         {
-            background.Colour = Selected.Value ? highlightedColour : backgroundColour;
+            background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
         }
     }
 }


### PR DESCRIPTION
Closes #19002

Updates `ModIcon.backgroundColour` case values to the same ones found in `OsuColour.ForModType`.
As a note, this changes the color scheme from the one defined in osu-web, to the "basic color scheme" defined in the figma. As such, the differences between background and highlight color become more apparent.