### PR TITLE
Fix intermittent MusicController tests

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneMusicActionHandling.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMusicActionHandling.cs
@@ -24,10 +24,11 @@ namespace osu.Game.Tests.Visual.Menus
         public void TestMusicPlayAction()
         {
             AddStep("ensure playing something", () => Game.MusicController.EnsurePlayingSomething());
+            AddUntilStep("music playing", () => Game.MusicController.IsPlaying);
             AddStep("toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
-            AddAssert("music paused", () => !Game.MusicController.IsPlaying && Game.MusicController.UserPauseRequested);
+            AddUntilStep("music paused", () => !Game.MusicController.IsPlaying && Game.MusicController.UserPauseRequested);
             AddStep("toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
-            AddAssert("music resumed", () => Game.MusicController.IsPlaying && !Game.MusicController.UserPauseRequested);
+            AddUntilStep("music resumed", () => Game.MusicController.IsPlaying && !Game.MusicController.UserPauseRequested);
         }
 
         [Test]


### PR DESCRIPTION
Fixes recently-occurring intermittent tests such as https://teamcity.ppy.sh/buildConfiguration/Osu_Build/2165?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true due to usage of `StartAsync()`/`StopAsync()`/`RestartAsync()`.