### PR TITLE
Fix crash when currently played beatmap finishes download while multiplayer spectating

### DIFF
--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -338,10 +338,10 @@ namespace osu.Game.Database
                     // import to store
                     realm.Add(item);
 
+                    PostImport(item, realm);
+
                     transaction.Commit();
                 }
-
-                PostImport(item, realm);
 
                 LogForModel(item, @"Import successfully completed!");
             }
@@ -479,7 +479,7 @@ namespace osu.Game.Database
         }
 
         /// <summary>
-        /// Perform any final actions after the import has been committed to the database.
+        /// Perform any final actions before the import has been committed to the database.
         /// </summary>
         /// <param name="model">The model prepared for import.</param>
         /// <param name="realm">The current realm context.</param>

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -314,6 +314,9 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
+            // Should be a noop in most cases, but let's ensure beyond doubt that the beatmap is in a correct state.
+            updateWorkingBeatmap();
+
             onLeaving();
             base.OnSuspending(e);
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -53,9 +53,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         [CanBeNull]
         public Score Score { get; private set; }
 
-        [Resolved]
-        private BeatmapManager beatmapManager { get; set; }
-
         private readonly BindableDouble volumeAdjustment = new BindableDouble();
         private readonly Container gameplayContent;
         private readonly LoadingLayer loadingLayer;
@@ -84,6 +81,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             GameplayClock.Source = masterClock;
         }
 
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; }
+
         public void LoadScore([NotNull] Score score)
         {
             if (Score != null)
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             Score = score;
 
-            gameplayContent.Child = new PlayerIsolationContainer(beatmapManager.GetWorkingBeatmap(Score.ScoreInfo.BeatmapInfo), Score.ScoreInfo.Ruleset, Score.ScoreInfo.Mods)
+            gameplayContent.Child = new PlayerIsolationContainer(beatmap.Value, Score.ScoreInfo.Ruleset, Score.ScoreInfo.Mods)
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = stack = new OsuScreenStack


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/19053.

I fixed this in three different ways. Each of the commits along will resolve the issue to some extent, but all were pretty wrong.

### 0434c10914 Use global `WorkingBeatmap` in `PlayerArea` for the time being

This was done to allow different players to play different versions of the beatmap, but is not used yet and therefore untested/unsafe. If any two users were playing different beatmaps, the same crash that this issue attempts to fix would reoccur, because `LoadTrack` would not be called.

We should address this at a later point when this functionality is required.

### 8b6665cb5b Ensure initial beatmap processing is done inside the import transaction

Pretty big oversight. This meant that beatmaps were first imported and then the metadata was corrected, which may be okay if we want imports to finish faster, but for now let's ensure everything is in a good state at initial import to simplify things.

Without this, components like `OnlinePlayBeatmapAvailabilityTracker` would report the import as being complete, but sooner after the `WorkingBeatmapCache` would invalidate the same beatmap. Usually, this would occur *after* an initial retrieval, causing two different instances of the same `WorkingBeatmap` to exist where we would not expect that to be the case.

### 8116a4b6f6 Fix multiplayer spectator crash due to track potentially not being loaded in time

This won't actually resolve the issue on its own, but seems like a good safety to have in place. And it matches with the `OnResuming` call so that's nice I think.