### PR TITLE
Fix settings text box header not blocking input from behind

### DIFF
--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
@@ -108,7 +109,7 @@ namespace osu.Game.Overlays
                 RelativeSizeAxes = Axes.Both,
                 ExpandableHeader = CreateHeader(),
                 SelectedSection = { BindTarget = CurrentSection },
-                FixedHeader = new Container
+                FixedHeader = new InputBlockingContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![osu Game Tests_2022-07-11_10-31-20](https://user-images.githubusercontent.com/35318437/178323340-0637cdb8-c792-44ec-b502-2ad89550c0cc.gif) | ![osu Game Tests_2022-07-11_10-30-17](https://user-images.githubusercontent.com/35318437/178323186-ab11c49e-a97f-4eb9-8fb5-e16e2b740f18.gif) |