### PR TITLE
Show basic error message when score submission fails

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.Play
 
             request.Failure += e =>
             {
-                Logger.Error(e, "Failed to submit score");
+                Logger.Error(e, $"Failed to submit score ({e.Message})");
                 scoreSubmissionSource.SetResult(false);
             };
 


### PR DESCRIPTION
Feels better to let the user know why it failed. Top notification is new version:

![osu! 2022-07-12 at 06 11 08](https://user-images.githubusercontent.com/191335/178420915-172de964-2c4b-4593-9805-312f805c76a5.png)
