### PR TITLE
Fix potential crash during shutdown sequence if intro playback was aborted

### DIFF
--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -77,8 +77,9 @@ namespace osu.Game.Screens.Menu
                     AddInternal(intro);
 
                     // There is a chance that the intro timed out before being displayed, and this scheduled callback could
-                    // happen during the outro rather than intro. In such a scenario the game may already be in a disposing state
-                    // which will trigger errors during attempted audio playback.
+                    // happen during the outro rather than intro.
+                    // In such a scenario, we don't want to play the intro sample, nor attempt to start the intro track
+                    // (that may have already been since disposed by MusicController).
                     if (DidLoadMenu)
                         return;
 

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -72,9 +72,16 @@ namespace osu.Game.Screens.Menu
                     RelativeSizeAxes = Axes.Both,
                     Clock = decoupledClock,
                     LoadMenu = LoadMenu
-                }, t =>
+                }, _ =>
                 {
-                    AddInternal(t);
+                    AddInternal(intro);
+
+                    // There is a chance that the intro timed out before being displayed, and this scheduled callback could
+                    // happen during the outro rather than intro. In such a scenario the game may already be in a disposing state
+                    // which will trigger errors during attempted audio playback.
+                    if (DidLoadMenu)
+                        return;
+
                     if (!UsingThemedIntro)
                         welcome?.Play();
 


### PR DESCRIPTION
Fixes one of the audio related `ObjectDisposedException`s (https://sentry.ppy.sh/organizations/ppy/issues/92/events/12f282f048cb4a4fae85810e8a70b68d/?project=2&query=is%3Aunresolved&sort=freq&statsPeriod=7d).

Ran into this while testing locally. See `IntroScreen.ensureEventuallyArrivingAtMenu` for the related cause of this happening (forced continuing to next screen if the intro doesn't load in time).