### PR TITLE
Show an error message on startup when attempting to run on an unsupported version of windows

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -14,6 +14,7 @@ using osu.Framework.Platform;
 using osu.Game;
 using osu.Game.IPC;
 using osu.Game.Tournament;
+using SDL2;
 using Squirrel;
 
 namespace osu.Desktop
@@ -29,7 +30,19 @@ namespace osu.Desktop
         {
             // run Squirrel first, as the app may exit after these run
             if (OperatingSystem.IsWindows())
+            {
+                var windowsVersion = Environment.OSVersion.Version;
+
+                if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 1))
+                {
+                    SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
+                        "Your operating system is too old to run osu!",
+                        "This version of osu! requires at least Windows 8 to run.\nPlease upgrade your operating system or consider using an older version of osu!.", IntPtr.Zero);
+                    return;
+                }
+
                 setupSquirrel();
+            }
 
             // Back up the cwd before DesktopGameHost changes it
             string cwd = Environment.CurrentDirectory;

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -33,7 +33,9 @@ namespace osu.Desktop
             {
                 var windowsVersion = Environment.OSVersion.Version;
 
-                if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 1))
+                // While .NET 6 still supports Windows 7 and above, we are limited by realm currently, as they choose to only support 8.1 and higher.
+                // See https://www.mongodb.com/docs/realm/sdk/dotnet/#supported-platforms
+                if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
                     SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
                         "Your operating system is too old to run osu!",


### PR DESCRIPTION
A lot of sentry error reports are coming from realm / EF failures due to the host operating system being too old. Let's give the user some proper feedback rather than a silent crash and error report hitting our logging.

![Parallels Desktop 2022-07-12 at 06 47 46](https://user-images.githubusercontent.com/191335/178426581-9974f367-e171-45b1-bc55-1b9ed3ffdeef.png)

