### PR TITLE
Add and consume `SoloScoreInfo`

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Tests.Visual.Online
                 s.Statistics = new Dictionary<HitResult, int>
                 {
                     { HitResult.Great, RNG.Next(2000) },
-                    { HitResult.Good, RNG.Next(2000) },
+                    { HitResult.Ok, RNG.Next(2000) },
                     { HitResult.Meh, RNG.Next(2000) },
                     { HitResult.Miss, RNG.Next(2000) }
                 };

--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -18,6 +18,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet.Scores;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Users;
 using osuTK.Graphics;
@@ -146,12 +147,12 @@ namespace osu.Game.Tests.Visual.Online
         {
             var scores = new APIScoresCollection
             {
-                Scores = new List<APIScore>
+                Scores = new List<SoloScoreInfo>
                 {
-                    new APIScore
+                    new SoloScoreInfo
                     {
-                        Date = DateTimeOffset.Now,
-                        OnlineID = onlineID++,
+                        EndedAt = DateTimeOffset.Now,
+                        ID = onlineID++,
                         User = new APIUser
                         {
                             Id = 6602580,
@@ -175,10 +176,10 @@ namespace osu.Game.Tests.Visual.Online
                         TotalScore = 1234567890,
                         Accuracy = 1,
                     },
-                    new APIScore
+                    new SoloScoreInfo
                     {
-                        Date = DateTimeOffset.Now,
-                        OnlineID = onlineID++,
+                        EndedAt = DateTimeOffset.Now,
+                        ID = onlineID++,
                         User = new APIUser
                         {
                             Id = 4608074,
@@ -201,10 +202,10 @@ namespace osu.Game.Tests.Visual.Online
                         TotalScore = 1234789,
                         Accuracy = 0.9997,
                     },
-                    new APIScore
+                    new SoloScoreInfo
                     {
-                        Date = DateTimeOffset.Now,
-                        OnlineID = onlineID++,
+                        EndedAt = DateTimeOffset.Now,
+                        ID = onlineID++,
                         User = new APIUser
                         {
                             Id = 1014222,
@@ -226,10 +227,10 @@ namespace osu.Game.Tests.Visual.Online
                         TotalScore = 12345678,
                         Accuracy = 0.9854,
                     },
-                    new APIScore
+                    new SoloScoreInfo
                     {
-                        Date = DateTimeOffset.Now,
-                        OnlineID = onlineID++,
+                        EndedAt = DateTimeOffset.Now,
+                        ID = onlineID++,
                         User = new APIUser
                         {
                             Id = 1541390,
@@ -250,10 +251,10 @@ namespace osu.Game.Tests.Visual.Online
                         TotalScore = 1234567,
                         Accuracy = 0.8765,
                     },
-                    new APIScore
+                    new SoloScoreInfo
                     {
-                        Date = DateTimeOffset.Now,
-                        OnlineID = onlineID++,
+                        EndedAt = DateTimeOffset.Now,
+                        ID = onlineID++,
                         User = new APIUser
                         {
                             Id = 7151382,
@@ -275,12 +276,12 @@ namespace osu.Game.Tests.Visual.Online
 
             foreach (var s in scores.Scores)
             {
-                s.Statistics = new Dictionary<string, int>
+                s.Statistics = new Dictionary<HitResult, int>
                 {
-                    { "count_300", RNG.Next(2000) },
-                    { "count_100", RNG.Next(2000) },
-                    { "count_50", RNG.Next(2000) },
-                    { "count_miss", RNG.Next(2000) }
+                    { HitResult.Great, RNG.Next(2000) },
+                    { HitResult.Good, RNG.Next(2000) },
+                    { HitResult.Meh, RNG.Next(2000) },
+                    { HitResult.Miss, RNG.Next(2000) }
                 };
             }
 
@@ -289,10 +290,10 @@ namespace osu.Game.Tests.Visual.Online
 
         private APIScoreWithPosition createUserBest() => new APIScoreWithPosition
         {
-            Score = new APIScore
+            Score = new SoloScoreInfo
             {
-                Date = DateTimeOffset.Now,
-                OnlineID = onlineID++,
+                EndedAt = DateTimeOffset.Now,
+                ID = onlineID++,
                 User = new APIUser
                 {
                     Id = 7151382,

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Online.API
 
         public string WebsiteRootUrl { get; }
 
-        public int APIVersion => 20220217; // We may want to pull this from the game version eventually.
+        public int APIVersion => 20220705; // We may want to pull this from the game version eventually.
 
         public Exception LastLoginError { get; private set; }
 

--- a/osu.Game/Online/API/Requests/Responses/APIScoreWithPosition.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoreWithPosition.cs
@@ -16,11 +16,11 @@ namespace osu.Game.Online.API.Requests.Responses
         public int? Position;
 
         [JsonProperty(@"score")]
-        public APIScore Score;
+        public SoloScoreInfo Score;
 
         public ScoreInfo CreateScoreInfo(RulesetStore rulesets, BeatmapInfo beatmap = null)
         {
-            var score = Score.CreateScoreInfo(rulesets, beatmap);
+            var score = Score.ToScoreInfo(rulesets, beatmap);
             score.Position = Position;
             return score;
         }

--- a/osu.Game/Online/API/Requests/Responses/APIScoresCollection.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoresCollection.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Online.API.Requests.Responses
     public class APIScoresCollection
     {
         [JsonProperty(@"scores")]
-        public List<APIScore> Scores;
+        public List<SoloScoreInfo> Scores;
 
         [JsonProperty(@"userScore")]
         public APIScoreWithPosition UserScore;

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public DateTimeOffset? EndedAt { get; set; }
 
         [JsonProperty("mods")]
-        public List<APIMod> Mods { get; set; } = new List<APIMod>();
+        public APIMod[] Mods { get; set; } = Array.Empty<APIMod>();
 
         [JsonIgnore]
         [JsonProperty("created_at")]

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -18,9 +18,8 @@ namespace osu.Game.Online.API.Requests.Responses
     [Serializable]
     public class SoloScoreInfo : IHasOnlineID<long>
     {
-        [JsonIgnore]
-        [JsonProperty(" ")]
-        public long ID { get; set; }
+        [JsonProperty("replay")]
+        public bool HasReplay { get; set; }
 
         [JsonProperty("beatmap_id")]
         public int BeatmapID { get; set; }
@@ -42,12 +41,6 @@ namespace osu.Game.Online.API.Requests.Responses
 
         [JsonProperty("user_id")]
         public int UserID { get; set; }
-
-        /// <summary>
-        /// User may be provided via an osu-web response, but will not be present from raw database json.
-        /// </summary>
-        [JsonProperty("user")]
-        public APIUser? User { get; set; }
 
         // TODO: probably want to update this column to match user stats (short)?
         [JsonProperty("max_combo")]
@@ -80,6 +73,19 @@ namespace osu.Game.Online.API.Requests.Responses
 
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics { get; set; } = new Dictionary<HitResult, int>();
+
+        #region osu-web API additions (not stored to database).
+
+        [JsonProperty("id")]
+        public long? ID { get; set; }
+
+        [JsonProperty("user")]
+        public APIUser? User { get; set; }
+
+        [JsonProperty("pp")]
+        public double? PP { get; set; }
+
+        #endregion
 
         public override string ToString() => $"score_id: {ID} user_id: {UserID}";
 
@@ -116,7 +122,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public ScoreInfo ToScoreInfo(Mod[] mods) => new ScoreInfo
         {
             OnlineID = OnlineID,
-            User = new APIUser { Id = UserID },
+            User = User ?? new APIUser { Id = UserID },
             BeatmapInfo = new BeatmapInfo { OnlineID = BeatmapID },
             Ruleset = new RulesetInfo { OnlineID = RulesetID },
             Passed = Passed,
@@ -127,9 +133,11 @@ namespace osu.Game.Online.API.Requests.Responses
             Statistics = Statistics,
             Date = EndedAt ?? DateTimeOffset.Now,
             Hash = "online", // TODO: temporary?
+            HasReplay = HasReplay,
             Mods = mods,
+            PP = PP,
         };
 
-        public long OnlineID => ID;
+        public long OnlineID => ID ?? -1;
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -1,0 +1,124 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    public class SoloScoreInfo : IHasOnlineID<long>
+    {
+        [JsonIgnore]
+        public long id { get; set; }
+
+        public int user_id { get; set; }
+
+        public int beatmap_id { get; set; }
+
+        public int ruleset_id { get; set; }
+
+        public int? build_id { get; set; }
+
+        public bool passed { get; set; }
+
+        public int total_score { get; set; }
+
+        public double accuracy { get; set; }
+
+        public APIUser user { get; set; }
+
+        // TODO: probably want to update this column to match user stats (short)?
+        public int max_combo { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ScoreRank rank { get; set; }
+
+        public DateTimeOffset? started_at { get; set; }
+
+        public DateTimeOffset? ended_at { get; set; }
+
+        public List<APIMod> mods { get; set; } = new List<APIMod>();
+
+        [JsonProperty("statistics")]
+        public Dictionary<HitResult, int> Statistics { get; set; } = new Dictionary<HitResult, int>();
+
+        public override string ToString() => $"score_id: {id} user_id: {user_id}";
+
+        [JsonIgnore]
+        public DateTimeOffset created_at { get; set; }
+
+        [JsonIgnore]
+        public DateTimeOffset updated_at { get; set; }
+
+        [JsonIgnore]
+        public DateTimeOffset? deleted_at { get; set; }
+
+        /// <summary>
+        /// Create a <see cref="ScoreInfo"/> from an API score instance.
+        /// </summary>
+        /// <param name="rulesets">A ruleset store, used to populate a ruleset instance in the returned score.</param>
+        /// <param name="beatmap">An optional beatmap, copied into the returned score (for cases where the API does not populate the beatmap).</param>
+        /// <returns></returns>
+        public ScoreInfo CreateScoreInfo(RulesetStore rulesets, BeatmapInfo beatmap = null)
+        {
+            var ruleset = rulesets.GetRuleset(ruleset_id) ?? throw new InvalidOperationException($"Ruleset with ID of {ruleset_id} not found locally");
+
+            var rulesetInstance = ruleset.CreateInstance();
+
+            var modInstances = mods.Select(apiMod => rulesetInstance.CreateModFromAcronym(apiMod.Acronym)).Where(m => m != null).ToArray();
+
+            // all API scores provided by this class are considered to be legacy.
+            modInstances = modInstances.Append(rulesetInstance.CreateMod<ModClassic>()).ToArray();
+
+            var scoreInfo = new ScoreInfo
+            {
+                User = user ?? new APIUser { Id = user_id },
+                BeatmapInfo = beatmap ?? new BeatmapInfo { OnlineID = beatmap_id },
+                Passed = passed,
+                TotalScore = total_score,
+                Accuracy = accuracy,
+                MaxCombo = max_combo,
+                Rank = rank,
+                Statistics = Statistics,
+                OnlineID = OnlineID,
+                Date = ended_at ?? DateTimeOffset.Now,
+                // PP =
+                Hash = "online", // TODO: temporary?
+                Ruleset = ruleset,
+                Mods = modInstances,
+            };
+
+            return scoreInfo;
+        }
+
+        public ScoreInfo CreateScoreInfo(Mod[] mods) => new ScoreInfo
+        {
+            OnlineID = id,
+            User = new APIUser { Id = user_id },
+            BeatmapInfo = new BeatmapInfo { OnlineID = beatmap_id },
+            Ruleset = new RulesetInfo { OnlineID = ruleset_id },
+            Passed = passed,
+            TotalScore = total_score,
+            Accuracy = accuracy,
+            MaxCombo = max_combo,
+            Rank = rank,
+            Mods = mods,
+            Statistics = Statistics
+        };
+
+        public long OnlineID => id;
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -1,10 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -17,54 +15,73 @@ using osu.Game.Scoring;
 
 namespace osu.Game.Online.API.Requests.Responses
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     [Serializable]
     public class SoloScoreInfo : IHasOnlineID<long>
     {
         [JsonIgnore]
-        public long id { get; set; }
+        [JsonProperty(" ")]
+        public long ID { get; set; }
 
-        public int user_id { get; set; }
+        [JsonProperty("beatmap_id")]
+        public int BeatmapID { get; set; }
 
-        public int beatmap_id { get; set; }
+        [JsonProperty("ruleset_id")]
+        public int RulesetID { get; set; }
 
-        public int ruleset_id { get; set; }
+        [JsonProperty("build_id")]
+        public int? BuildID { get; set; }
 
-        public int? build_id { get; set; }
+        [JsonProperty("passed")]
+        public bool Passed { get; set; }
 
-        public bool passed { get; set; }
+        [JsonProperty("total_score")]
+        public int TotalScore { get; set; }
 
-        public int total_score { get; set; }
+        [JsonProperty("accuracy")]
+        public double Accuracy { get; set; }
 
-        public double accuracy { get; set; }
+        [JsonProperty("user_id")]
+        public int UserID { get; set; }
 
-        public APIUser user { get; set; }
+        /// <summary>
+        /// User may be provided via an osu-web response, but will not be present from raw database json.
+        /// </summary>
+        [JsonProperty("user")]
+        public APIUser? User { get; set; }
 
         // TODO: probably want to update this column to match user stats (short)?
-        public int max_combo { get; set; }
+        [JsonProperty("max_combo")]
+        public int MaxCombo { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public ScoreRank rank { get; set; }
+        [JsonProperty("rank")]
+        public ScoreRank Rank { get; set; }
 
-        public DateTimeOffset? started_at { get; set; }
+        [JsonProperty("started_at")]
+        public DateTimeOffset? StartedAt { get; set; }
 
-        public DateTimeOffset? ended_at { get; set; }
+        [JsonProperty("ended_at")]
+        public DateTimeOffset? EndedAt { get; set; }
 
-        public List<APIMod> mods { get; set; } = new List<APIMod>();
+        [JsonProperty("mods")]
+        public List<APIMod> Mods { get; set; } = new List<APIMod>();
+
+        [JsonIgnore]
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+
+        [JsonIgnore]
+        [JsonProperty("deleted_at")]
+        public DateTimeOffset? DeletedAt { get; set; }
 
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics { get; set; } = new Dictionary<HitResult, int>();
 
-        public override string ToString() => $"score_id: {id} user_id: {user_id}";
-
-        [JsonIgnore]
-        public DateTimeOffset created_at { get; set; }
-
-        [JsonIgnore]
-        public DateTimeOffset updated_at { get; set; }
-
-        [JsonIgnore]
-        public DateTimeOffset? deleted_at { get; set; }
+        public override string ToString() => $"score_id: {ID} user_id: {UserID}";
 
         /// <summary>
         /// Create a <see cref="ScoreInfo"/> from an API score instance.
@@ -72,53 +89,54 @@ namespace osu.Game.Online.API.Requests.Responses
         /// <param name="rulesets">A ruleset store, used to populate a ruleset instance in the returned score.</param>
         /// <param name="beatmap">An optional beatmap, copied into the returned score (for cases where the API does not populate the beatmap).</param>
         /// <returns></returns>
-        public ScoreInfo CreateScoreInfo(RulesetStore rulesets, BeatmapInfo beatmap = null)
+        public ScoreInfo CreateScoreInfo(RulesetStore rulesets, BeatmapInfo? beatmap = null)
         {
-            var ruleset = rulesets.GetRuleset(ruleset_id) ?? throw new InvalidOperationException($"Ruleset with ID of {ruleset_id} not found locally");
+            var ruleset = rulesets.GetRuleset(RulesetID) ?? throw new InvalidOperationException($"Ruleset with ID of {RulesetID} not found locally");
 
             var rulesetInstance = ruleset.CreateInstance();
 
-            var modInstances = mods.Select(apiMod => rulesetInstance.CreateModFromAcronym(apiMod.Acronym)).Where(m => m != null).ToArray();
+            var modInstances = Mods.Select(apiMod => rulesetInstance.CreateModFromAcronym(apiMod.Acronym)).Where(m => m != null).ToArray();
 
             // all API scores provided by this class are considered to be legacy.
             modInstances = modInstances.Append(rulesetInstance.CreateMod<ModClassic>()).ToArray();
 
             var scoreInfo = new ScoreInfo
             {
-                User = user ?? new APIUser { Id = user_id },
-                BeatmapInfo = beatmap ?? new BeatmapInfo { OnlineID = beatmap_id },
-                Passed = passed,
-                TotalScore = total_score,
-                Accuracy = accuracy,
-                MaxCombo = max_combo,
-                Rank = rank,
-                Statistics = Statistics,
                 OnlineID = OnlineID,
-                Date = ended_at ?? DateTimeOffset.Now,
-                // PP =
-                Hash = "online", // TODO: temporary?
+                User = User ?? new APIUser { Id = UserID },
+                BeatmapInfo = beatmap ?? new BeatmapInfo { OnlineID = BeatmapID },
                 Ruleset = ruleset,
+                Passed = Passed,
+                TotalScore = TotalScore,
+                Accuracy = Accuracy,
+                MaxCombo = MaxCombo,
+                Rank = Rank,
+                Statistics = Statistics,
+                Date = EndedAt ?? DateTimeOffset.Now,
+                Hash = "online", // TODO: temporary?
                 Mods = modInstances,
             };
 
             return scoreInfo;
         }
 
-        public ScoreInfo CreateScoreInfo(Mod[] mods) => new ScoreInfo
+        public ScoreInfo ToScoreInfo(Mod[] mods) => new ScoreInfo
         {
-            OnlineID = id,
-            User = new APIUser { Id = user_id },
-            BeatmapInfo = new BeatmapInfo { OnlineID = beatmap_id },
-            Ruleset = new RulesetInfo { OnlineID = ruleset_id },
-            Passed = passed,
-            TotalScore = total_score,
-            Accuracy = accuracy,
-            MaxCombo = max_combo,
-            Rank = rank,
+            OnlineID = ID,
+            User = new APIUser { Id = UserID },
+            BeatmapInfo = new BeatmapInfo { OnlineID = BeatmapID },
+            Ruleset = new RulesetInfo { OnlineID = RulesetID },
+            Passed = Passed,
+            TotalScore = TotalScore,
+            Accuracy = Accuracy,
+            MaxCombo = MaxCombo,
+            Rank = Rank,
+            Statistics = Statistics,
+            Date = EndedAt ?? DateTimeOffset.Now,
+            Hash = "online", // TODO: temporary?
             Mods = mods,
-            Statistics = Statistics
         };
 
-        public long OnlineID => id;
+        public long OnlineID => ID;
     }
 }

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     MD5Hash = apiBeatmap.MD5Hash
                 };
 
-                scoreManager.OrderByTotalScoreAsync(value.Scores.Select(s => s.CreateScoreInfo(rulesets, beatmapInfo)).ToArray(), loadCancellationSource.Token)
+                scoreManager.OrderByTotalScoreAsync(value.Scores.Select(s => s.ToScoreInfo(rulesets, beatmapInfo)).ToArray(), loadCancellationSource.Token)
                             .ContinueWith(task => Schedule(() =>
                             {
                                 if (loadCancellationSource.IsCancellationRequested)

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 scoreTable.Show();
 
                                 var userScore = value.UserScore;
-                                var userScoreInfo = userScore?.Score.CreateScoreInfo(rulesets, beatmapInfo);
+                                var userScoreInfo = userScore?.Score.ToScoreInfo(rulesets, beatmapInfo);
 
                                 topScoresContainer.Add(new DrawableTopScore(topScore));
 

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Ranking
                 return null;
 
             getScoreRequest = new GetScoresRequest(Score.BeatmapInfo, Score.Ruleset);
-            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineID != Score.OnlineID).Select(s => s.CreateScoreInfo(rulesets, Beatmap.Value.BeatmapInfo)));
+            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineID != Score.OnlineID).Select(s => s.ToScoreInfo(rulesets, Beatmap.Value.BeatmapInfo)));
             return getScoreRequest;
         }
 

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             req.Success += r =>
             {
-                scoreManager.OrderByTotalScoreAsync(r.Scores.Select(s => s.CreateScoreInfo(rulesets, fetchBeatmapInfo)).ToArray(), cancellationToken)
+                scoreManager.OrderByTotalScoreAsync(r.Scores.Select(s => s.ToScoreInfo(rulesets, fetchBeatmapInfo)).ToArray(), cancellationToken)
                             .ContinueWith(task => Schedule(() =>
                             {
                                 if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
One of the final steps required to prepare lazer for displaying lazer-first scores.

For now, this hooks up the new version of the osu-web API (see https://github.com/ppy/osu-web/pull/9083), which returns legacy scores in the new format.