### PR TITLE
Fix unsupported OS message stating Windows 8 to be supported

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -39,7 +39,7 @@ namespace osu.Desktop
                 {
                     SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
                         "Your operating system is too old to run osu!",
-                        "This version of osu! requires at least Windows 8 to run.\nPlease upgrade your operating system or consider using an older version of osu!.", IntPtr.Zero);
+                        "This version of osu! requires at least Windows 8.1 to run.\nPlease upgrade your operating system or consider using an older version of osu!.", IntPtr.Zero);
                     return;
                 }
 


### PR DESCRIPTION
Noticed while reading notifications and looking at https://github.com/ppy/osu/pull/19080. The condition was updated to show on Windows 8 as well, but the message was still stating that Windows 8 is supported.