### PR TITLE
Add log output for custom storage usage

### DIFF
--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -94,6 +94,8 @@ namespace osu.Game.IO
             error = OsuStorageError.None;
             Storage lastStorage = UnderlyingStorage;
 
+            Logger.Log($"Attempting to use custom storage location {CustomStoragePath}");
+
             try
             {
                 Storage userStorage = host.GetStorage(CustomStoragePath);
@@ -102,12 +104,16 @@ namespace osu.Game.IO
                     error = OsuStorageError.AccessibleButEmpty;
 
                 ChangeTargetStorage(userStorage);
+                Logger.Log($"Storage successfully changed to {CustomStoragePath}.");
             }
             catch
             {
                 error = OsuStorageError.NotAccessible;
                 ChangeTargetStorage(lastStorage);
             }
+
+            if (error != OsuStorageError.None)
+                Logger.Log($"Custom storage location could not be used ({error}).");
 
             return error == OsuStorageError.None;
         }


### PR DESCRIPTION
Sometimes I am not sure where my osu! is reading files from. This should
help somewhat.

```csharp
/Users/dean/Projects/osu/osu.Desktop/bin/Debug/net6.0/osu!
[runtime] 2022-07-13 07:22:03 [verbose]: Starting legacy IPC provider...
[runtime] 2022-07-13 07:22:03 [verbose]: Attempting to use custom storage location /Users/dean/Games/osu-lazer-2
[runtime] 2022-07-13 07:22:03 [verbose]: Storage successfully changed to /Users/dean/Games/osu-lazer-2.
[runtime] 2022-07-13 07:22:05 [verbose]: GL Initialized
```