### PR TITLE
Add "last played" sort mode to song select

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -58,6 +59,20 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected override bool HasCustomSteps => true;
 
         protected override bool AllowFail => false;
+
+        [Test]
+        public void TestLastPlayedUpdated()
+        {
+            DateTimeOffset? getLastPlayed() => Realm.Run(r => r.Find<BeatmapInfo>(Beatmap.Value.BeatmapInfo.ID)?.LastPlayed);
+
+            AddStep("set no custom ruleset", () => customRuleset = null);
+            AddAssert("last played is null", () => getLastPlayed() == null);
+
+            CreateTest();
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+            AddUntilStep("wait for last played to update", () => getLastPlayed() != null);
+        }
 
         [Test]
         public void TestScoreStoredLocally()

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -111,6 +111,11 @@ namespace osu.Game.Beatmaps
         public bool SamplesMatchPlaybackRate { get; set; } = true;
 
         /// <summary>
+        /// The time at which this beatmap was last played by the local user.
+        /// </summary>
+        public DateTimeOffset? LastPlayed { get; set; }
+
+        /// <summary>
         /// The ratio of distance travelled per time unit.
         /// Generally used to decouple the spacing between hit objects from the enforced "velocity" of the beatmap (see <see cref="DifficultyControlPoint.SliderVelocity"/>).
         /// </summary>

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -58,8 +58,9 @@ namespace osu.Game.Database
         /// 12   2021-11-24    Add Status to RealmBeatmapSet.
         /// 13   2022-01-13    Final migration of beatmaps and scores to realm (multiple new storage fields).
         /// 14   2022-03-01    Added BeatmapUserSettings to BeatmapInfo.
+        /// 15   2022-07-13    Added LastPlayed to BeatmapInfo.
         /// </summary>
-        private const int schema_version = 14;
+        private const int schema_version = 15;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.Play
             base.StartGameplay();
 
             // User expectation is that last played should be updated when entering the gameplay loop
-            // from multiplayer / playlists / solo, even when using autoplay mod.
+            // from multiplayer / playlists / solo.
             realm.WriteAsync(r =>
             {
                 var realmBeatmap = r.Find<BeatmapInfo>(Beatmap.Value.BeatmapInfo.ID);

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -11,6 +11,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Scoring;
@@ -115,6 +117,23 @@ namespace osu.Game.Screens.Play
             score.ScoreInfo.Date = DateTimeOffset.Now;
 
             await submitScore(score).ConfigureAwait(false);
+        }
+
+        [Resolved]
+        private RealmAccess realm { get; set; }
+
+        protected override void StartGameplay()
+        {
+            base.StartGameplay();
+
+            // User expectation is that last played should be updated when entering the gameplay loop
+            // from multiplayer / playlists / solo, even when using autoplay mod.
+            realm.WriteAsync(r =>
+            {
+                var realmBeatmap = r.Find<BeatmapInfo>(Beatmap.Value.BeatmapInfo.ID);
+                if (realmBeatmap != null)
+                    realmBeatmap.LastPlayed = DateTimeOffset.Now;
+            });
         }
 
         public override bool OnExiting(ScreenExitEvent e)

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -81,6 +81,9 @@ namespace osu.Game.Screens.Select.Carousel
                 case SortMode.DateAdded:
                     return otherSet.BeatmapSet.DateAdded.CompareTo(BeatmapSet.DateAdded);
 
+                case SortMode.LastPlayed:
+                    return -compareUsingAggregateMax(otherSet, b => (b.LastPlayed ?? DateTimeOffset.MinValue).ToUnixTimeSeconds());
+
                 case SortMode.BPM:
                     return compareUsingAggregateMax(otherSet, b => b.BPM);
 

--- a/osu.Game/Screens/Select/Filter/SortMode.cs
+++ b/osu.Game/Screens/Select/Filter/SortMode.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Screens.Select.Filter
         [Description("Date Added")]
         DateAdded,
 
+        [Description("Last Played")]
+        LastPlayed,
+
         [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.ListingSearchSortingDifficulty))]
         Difficulty,
 


### PR DESCRIPTION
Decided to take this one on to see if it was as easy as expected. Spoiler: it was.

Note that this will consider the most recent play of any beatmap in beatmap set groups for now, similar to other sort methods.


https://user-images.githubusercontent.com/191335/178679829-89f0a4ac-0488-45e9-975b-27b65b54c567.mp4



Closes https://github.com/ppy/osu/issues/19092.