### PR TITLE
Ensure any changes are committed before changing `LadderEditorSettings`'s target match

### DIFF
--- a/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
             editorInfo.Selected.ValueChanged += selection =>
             {
+                // ensure any ongoing edits are committed out to the *current* selection before changing to a new one.
+                GetContainingInputManager().TriggerFocusContention(null);
+
                 roundDropdown.Current = selection.NewValue?.Round;
                 losersCheckbox.Current = selection.NewValue?.Losers;
                 dateTimeBox.Current = selection.NewValue?.Date;


### PR DESCRIPTION
Basically this ensures any textboxes (or other future UI controls) perform their "commit on focus lost" before changing the active selection. If this isn't done here, the change may be lost, or even worse apply to the new selection.

Addresses remaining concern raised in https://github.com/ppy/osu/discussions/19094.