### PR TITLE
#5390's fix

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Select.Carousel
                     return otherSet.BeatmapSet.DateAdded.CompareTo(BeatmapSet.DateAdded);
 
                 case SortMode.LastPlayed:
-                    return compare(otherSet, b => (b.LastPlayed ?? DateTimeOffset.MinValue).ToUnixTimeSeconds());
+                    return -compare(otherSet, b => (b.LastPlayed ?? DateTimeOffset.MinValue).ToUnixTimeSeconds());
 
                 case SortMode.BPM:
                     return compare(otherSet, b => b.BPM);


### PR DESCRIPTION
The method is to split beatmap set and merge adjacent betamap sets with the same ID after sorting

Since this method modifies the logic of root carousel, the unit tests are adjusted accordingly

[This](https://github.com/ppy/osu/compare/master...QingQiz:osu:master#diff-437bd878785b8f4f58e4aca38024be5bb60f6a2c16567504c50ccddcbcedc7edR855-R899) is the test of the issue mentioned by #5390 (use star rating instead of length)