### PR TITLE
Fix dialog overlay potentially pushing dialog while not loaded

### DIFF
--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Overlays
                 dialogContainer.Add(dialog);
 
                 Show();
-            }, false);
+            }, !IsLoaded);
         }
 
         public override bool IsPresent => Scheduler.HasPendingTasks || dialogContainer.Children.Count > 0;

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -98,7 +98,8 @@ namespace osu.Game.Overlays
             base.PopOut();
             lowPassFilter.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF, 100, Easing.InCubic);
 
-            if (CurrentDialog?.State.Value == Visibility.Visible)
+            // PopOut gets called initially, but we only want to hide dialog when we have been loaded and are present.
+            if (IsLoaded && CurrentDialog?.State.Value == Visibility.Visible)
                 CurrentDialog.Hide();
         }
 

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -57,7 +57,12 @@ namespace osu.Game.Overlays
             // a DialogOverlay instance has finished loading.
             CurrentDialog = dialog;
 
-            Scheduler.Add(() =>
+            if (IsLoaded)
+                Scheduler.Add(pushDialog, false);
+            else
+                Schedule(pushDialog);
+
+            void pushDialog()
             {
                 // if any existing dialog is being displayed, dismiss it before showing a new one.
                 lastDialog?.Hide();
@@ -65,7 +70,7 @@ namespace osu.Game.Overlays
                 dialogContainer.Add(dialog);
 
                 Show();
-            }, !IsLoaded);
+            }
         }
 
         public override bool IsPresent => Scheduler.HasPendingTasks || dialogContainer.Children.Count > 0;

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -66,7 +66,8 @@ namespace osu.Game.Overlays
             {
                 // if any existing dialog is being displayed, dismiss it before showing a new one.
                 lastDialog?.Hide();
-                dialog.State.ValueChanged += state => onDialogOnStateChanged(dialog, state.NewValue);
+
+                dialog.State.ValueChanged += state => onDialogStateChanged(dialog, state.NewValue), true);
                 dialogContainer.Add(dialog);
 
                 Show();
@@ -77,9 +78,9 @@ namespace osu.Game.Overlays
 
         protected override bool BlockNonPositionalInput => true;
 
-        private void onDialogOnStateChanged(VisibilityContainer dialog, Visibility v)
+        private void onDialogStateChanged(VisibilityContainer dialog, Visibility newState)
         {
-            if (v != Visibility.Hidden) return;
+            if (newState != Visibility.Hidden) return;
 
             // handle the dialog being dismissed.
             dialog.Delay(PopupDialog.EXIT_DURATION).Expire();

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays
                 // if any existing dialog is being displayed, dismiss it before showing a new one.
                 lastDialog?.Hide();
 
-                // is the new dialog is hidden before added to the dialogContainer, bypass any further operations.
+                // if the new dialog is hidden before added to the dialogContainer, bypass any further operations.
                 if (dialog.State.Value == Visibility.Hidden)
                 {
                     dismiss();

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -57,12 +57,7 @@ namespace osu.Game.Overlays
             // a DialogOverlay instance has finished loading.
             CurrentDialog = dialog;
 
-            if (IsLoaded)
-                Scheduler.Add(pushDialog, false);
-            else
-                Schedule(pushDialog);
-
-            void pushDialog()
+            Schedule(() =>
             {
                 // if any existing dialog is being displayed, dismiss it before showing a new one.
                 lastDialog?.Hide();
@@ -71,7 +66,7 @@ namespace osu.Game.Overlays
                 dialogContainer.Add(dialog);
 
                 Show();
-            }
+            });
         }
 
         public override bool IsPresent => Scheduler.HasPendingTasks || dialogContainer.Children.Count > 0;

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays
                 // if any existing dialog is being displayed, dismiss it before showing a new one.
                 lastDialog?.Hide();
 
-                dialog.State.ValueChanged += state => onDialogStateChanged(dialog, state.NewValue), true);
+                dialog.State.BindValueChanged(state => onDialogStateChanged(dialog, state.NewValue), true);
                 dialogContainer.Add(dialog);
 
                 Show();


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/runs/7324796490?check_suite_focus=true.

The cause of this is `DialogOverlay.Push()` adding the dialog to `dialogContainer` while that container is in `Loading` state. This can rarely occur, but can be simulated by adding a wait step before the dialog push step and make `dialogContainer` stuck on `Loading` state by sleeping on its BDL.

Not sure why the push is not always scheduled, but went with the simplest fix rather than changing it and end up with more issues. Open for discussion.