### PR TITLE
Ensure that multiple `BeatmapSetInfo` with same `OnlineID` don't cause import failures

### DIFF
--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -80,9 +80,8 @@ namespace osu.Game.Beatmaps
 
             if (beatmapSet.OnlineID > 0)
             {
-                var existingSetWithSameOnlineID = realm.All<BeatmapSetInfo>().SingleOrDefault(b => b.OnlineID == beatmapSet.OnlineID);
-
-                if (existingSetWithSameOnlineID != null)
+                // OnlineID should really be unique, but to avoid catastrophic failure let's iterate just to be sure.
+                foreach (var existingSetWithSameOnlineID in realm.All<BeatmapSetInfo>().Where(b => b.OnlineID == beatmapSet.OnlineID))
                 {
                     existingSetWithSameOnlineID.DeletePending = true;
                     existingSetWithSameOnlineID.OnlineID = -1;
@@ -90,7 +89,7 @@ namespace osu.Game.Beatmaps
                     foreach (var b in existingSetWithSameOnlineID.Beatmaps)
                         b.OnlineID = -1;
 
-                    LogForModel(beatmapSet, $"Found existing beatmap set with same OnlineID ({beatmapSet.OnlineID}). It will be deleted.");
+                    LogForModel(beatmapSet, $"Found existing beatmap set with same OnlineID ({beatmapSet.OnlineID}). It will be disassociated and marked for deletion.");
                 }
             }
         }


### PR DESCRIPTION
This really shouldn't happen but I managed to make it happen while working on re-downloading already present beatmaps. Realm doesn't provide any kind of unique restrictions, so I figure this is a better way of handling the edge case where things are in a bad state.

Until this comes up again in a way that matters, let's just fix the LINQ crash from `SingleOrDefault`.