### PR TITLE
Show leaderboard scores from new data source

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -274,14 +274,18 @@ namespace osu.Game.Tests.Visual.Online
                 }
             };
 
+            const int initial_great_count = 2000;
+
+            int greatCount = initial_great_count;
+
             foreach (var s in scores.Scores)
             {
                 s.Statistics = new Dictionary<HitResult, int>
                 {
-                    { HitResult.Great, RNG.Next(2000) },
-                    { HitResult.Ok, RNG.Next(2000) },
-                    { HitResult.Meh, RNG.Next(2000) },
-                    { HitResult.Miss, RNG.Next(2000) }
+                    { HitResult.Great, greatCount -= 100 },
+                    { HitResult.Ok, RNG.Next(100) },
+                    { HitResult.Meh, RNG.Next(100) },
+                    { HitResult.Miss, initial_great_count - greatCount }
                 };
             }
 

--- a/osu.Game/Database/EFToRealmMigrator.cs
+++ b/osu.Game/Database/EFToRealmMigrator.cs
@@ -443,7 +443,6 @@ namespace osu.Game.Database
                             TotalScore = score.TotalScore,
                             MaxCombo = score.MaxCombo,
                             Accuracy = score.Accuracy,
-                            HasReplay = ((IScoreInfo)score).HasReplay,
                             Date = score.Date,
                             PP = score.PP,
                             Rank = score.Rank,

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -59,8 +59,9 @@ namespace osu.Game.Database
         /// 13   2022-01-13    Final migration of beatmaps and scores to realm (multiple new storage fields).
         /// 14   2022-03-01    Added BeatmapUserSettings to BeatmapInfo.
         /// 15   2022-07-13    Added LastPlayed to BeatmapInfo.
+        /// 16   2022-07-15    Removed HasReplay from ScoreInfo.
         /// </summary>
-        private const int schema_version = 15;
+        private const int schema_version = 16;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Online/API/Requests/GetScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetScoresRequest.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Online.API.Requests
             this.mods = mods ?? Array.Empty<IMod>();
         }
 
-        protected override string Target => $@"beatmaps/{beatmapInfo.OnlineID}/scores{createQueryParameters()}";
+        protected override string Target => $@"beatmaps/{beatmapInfo.OnlineID}/solo-scores{createQueryParameters()}";
 
         private string createQueryParameters()
         {

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -103,9 +103,6 @@ namespace osu.Game.Online.API.Requests.Responses
 
             var mods = Mods.Select(apiMod => rulesetInstance.CreateModFromAcronym(apiMod.Acronym)).Where(m => m != null).ToArray();
 
-            // all API scores provided by this class are considered to be legacy.
-            mods = mods.Append(rulesetInstance.CreateMod<ModClassic>()).ToArray();
-
             var scoreInfo = ToScoreInfo(mods);
 
             scoreInfo.Ruleset = ruleset;

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -129,8 +129,7 @@ namespace osu.Game.Online.API.Requests.Responses
             Rank = Rank,
             Statistics = Statistics,
             Date = EndedAt ?? DateTimeOffset.Now,
-            Hash = "online", // TODO: temporary?
-            HasReplay = HasReplay,
+            Hash = HasReplay ? "online" : string.Empty, // TODO: temporary?
             Mods = mods,
             PP = PP,
         };

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Scoring
 
         public double Accuracy { get; set; }
 
-        public bool HasReplay { get; set; }
+        public bool HasReplay => !string.IsNullOrEmpty(Hash);
 
         public DateTimeOffset Date { get; set; }
 

--- a/osu.Game/Scoring/ScoreRank.cs
+++ b/osu.Game/Scoring/ScoreRank.cs
@@ -11,6 +11,10 @@ namespace osu.Game.Scoring
 {
     public enum ScoreRank
     {
+        // TODO: Localisable?
+        [Description(@"F")]
+        F = -1,
+
         [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.RankD))]
         [Description(@"D")]
         D,

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Ranking
                 if (State.Value == DownloadState.LocallyAvailable)
                     return ReplayAvailability.Local;
 
-                if (!string.IsNullOrEmpty(Score.Value?.Hash))
+                if (Score.Value?.HasReplay == true)
                     return ReplayAvailability.Online;
 
                 return ReplayAvailability.NotAvailable;


### PR DESCRIPTION
Uses the new endpoint exposed via osu-web https://github.com/ppy/osu-web/pull/9110. Mostly just-works, yay.

Please test using production for now, as the staging server isn't setup to process scores (and doesn't have any data loaded, nor is it deployed from the new branch).

Note that scores are currently re-indexing so not all scores are visible at the point of posting this. Will take around 6-8 hours for that to complete.

Also note that the indexing is currently not running in realtime. New scores will not show up immediately. There's still a couple of remaining connections to be made on production deployment to make this work (not too involved, will do this weekend).

---

This turns off the display of classic/legacy scores, and begins to show scores from the new "`solo_scores`" data source. Currently, this means that all lazer scores from the last few years will be visible, but also means that you will no longer be able to see non-lazer scores. They will eventually return when we are happy with the consistency and performance of the new storage mechanisms.

Do note that there is no guarantee that scores currently visible will remain. They may be deleted at any point. There are several concerns which are not yet addressed.

![osu! 2022-07-15 at 07 28 39](https://user-images.githubusercontent.com/191335/179174190-a33ebaac-7360-4310-a67c-2e8914739a64.png)
