### PR TITLE
Fix clicking search link from song select sometimes not switching search mode to "relevance"

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         public void Search(string query)
-            => searchControl.Query.Value = query;
+            => Schedule(() => searchControl.Query.Value = query);
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Select/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/Select/NoResultsPlaceholder.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.Select
                 textFlow.AddParagraph("No beatmaps found!");
                 textFlow.AddParagraph(string.Empty);
 
-                textFlow.AddParagraph("Consider using the \"");
+                textFlow.AddParagraph("- Consider running the \"");
                 textFlow.AddLink(FirstRunSetupOverlayStrings.FirstRunSetupTitle, () => firstRunSetupOverlay?.Show());
                 textFlow.AddText("\" to download or import some beatmaps!");
             }
@@ -141,15 +141,14 @@ namespace osu.Game.Screens.Select
                     textFlow.AddLink(" enabling ", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
                     textFlow.AddText("automatic conversion!");
                 }
-
-                if (!string.IsNullOrEmpty(filter?.SearchText))
-                {
-                    textFlow.AddParagraph("- Try ");
-                    textFlow.AddLink("searching online", LinkAction.SearchBeatmapSet, filter.SearchText);
-                    textFlow.AddText($" for \"{filter.SearchText}\".");
-                }
             }
 
+            if (!string.IsNullOrEmpty(filter?.SearchText))
+            {
+                textFlow.AddParagraph("- Try ");
+                textFlow.AddLink("searching online", LinkAction.SearchBeatmapSet, filter.SearchText);
+                textFlow.AddText($" for \"{filter.SearchText}\".");
+            }
             // TODO: add clickable link to reset criteria.
         }
     }


### PR DESCRIPTION
Noticed in normal usage. This is caused by the bound events happening in `LoadComplete` while the `Search` call from `OsuGame.SearchBeatmapSet` happens potentially before the first load of the overlay.

Also show the online search message even when there's no beatmaps loaded locally, which was a bit of an oversight.