### PR TITLE
Fix login overlay not displaying error message for disabled accounts

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -163,7 +163,13 @@ namespace osu.Game.Online.API
 
                         userReq.Failure += ex =>
                         {
-                            if (ex is WebException webException && webException.Message == @"Unauthorized")
+                            if (ex is APIException)
+                            {
+                                LastLoginError = ex;
+                                log.Add("Login failed on local user retrieval!");
+                                Logout();
+                            }
+                            else if (ex is WebException webException && webException.Message == @"Unauthorized")
                             {
                                 log.Add(@"Login no longer valid");
                                 Logout();


### PR DESCRIPTION
- Closes #19135 

I'm not entirely sure why logins are successful on disabled accounts but failure only happens on `GetUserRequest` (I don't understand the concept behind it and its difference with "restricted" as well), but I'm PR'ing this in case that's intended for one reason or another.