### PR TITLE
Replace `Country` class with enumeration

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual.Online
                 Id = 3103765,
                 IsOnline = true,
                 Statistics = new UserStatistics { GlobalRank = 1111 },
-                Country = new Country { FlagName = "JP" },
+                Country = Country.JP,
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c6.jpg"
             },
             new APIUser
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Online
                 Id = 2,
                 IsOnline = false,
                 Statistics = new UserStatistics { GlobalRank = 2222 },
-                Country = new Country { FlagName = "AU" },
+                Country = Country.AU,
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 IsSupporter = true,
                 SupportLevel = 3,
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Username = "Evast",
                 Id = 8195163,
-                Country = new Country { FlagName = "BY" },
+                Country = Country.BY,
                 CoverUrl = "https://assets.ppy.sh/user-profile-covers/8195163/4a8e2ad5a02a2642b631438cfa6c6bd7e2f9db289be881cb27df18331f64144c.jpeg",
                 IsOnline = false,
                 LastVisit = DateTimeOffset.Now

--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual.Online
                 Id = 3103765,
                 IsOnline = true,
                 Statistics = new UserStatistics { GlobalRank = 1111 },
-                Country = Country.JP,
+                CountryCode = CountryCode.JP,
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c6.jpg"
             },
             new APIUser
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Online
                 Id = 2,
                 IsOnline = false,
                 Statistics = new UserStatistics { GlobalRank = 2222 },
-                Country = Country.AU,
+                CountryCode = CountryCode.AU,
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 IsSupporter = true,
                 SupportLevel = 3,
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Username = "Evast",
                 Id = 8195163,
-                Country = Country.BY,
+                CountryCode = CountryCode.BY,
                 CoverUrl = "https://assets.ppy.sh/user-profile-covers/8195163/4a8e2ad5a02a2642b631438cfa6c6bd7e2f9db289be881cb27df18331f64144c.jpeg",
                 IsOnline = false,
                 LastVisit = DateTimeOffset.Now

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsCountryFilter.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsCountryFilter.cs
@@ -56,20 +56,12 @@ namespace osu.Game.Tests.Visual.Online
                 }
             });
 
-            var country = new Country
-            {
-                FlagName = "BY",
-                FullName = "Belarus"
-            };
-            var unknownCountry = new Country
-            {
-                FlagName = "CK",
-                FullName = "Cook Islands"
-            };
+            const Country country = Country.BY;
+            const Country unknown_country = Country.CK;
 
             AddStep("Set country", () => countryBindable.Value = country);
-            AddStep("Set null country", () => countryBindable.Value = null);
-            AddStep("Set country with no flag", () => countryBindable.Value = unknownCountry);
+            AddStep("Set default country", () => countryBindable.Value = default);
+            AddStep("Set country with no flag", () => countryBindable.Value = unknown_country);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsCountryFilter.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsCountryFilter.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tests.Visual.Online
 
         public TestSceneRankingsCountryFilter()
         {
-            var countryBindable = new Bindable<Country>();
+            var countryBindable = new Bindable<CountryCode>();
 
             AddRange(new Drawable[]
             {
@@ -56,8 +56,8 @@ namespace osu.Game.Tests.Visual.Online
                 }
             });
 
-            const Country country = Country.BY;
-            const Country unknown_country = Country.CK;
+            const CountryCode country = CountryCode.BY;
+            const CountryCode unknown_country = CountryCode.CK;
 
             AddStep("Set country", () => countryBindable.Value = country);
             AddStep("Set default country", () => countryBindable.Value = default);

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsHeader.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Online
 
         public TestSceneRankingsHeader()
         {
-            var countryBindable = new Bindable<Country>();
+            var countryBindable = new Bindable<CountryCode>();
             var ruleset = new Bindable<RulesetInfo>();
             var scope = new Bindable<RankingsScope>();
 
@@ -30,8 +30,8 @@ namespace osu.Game.Tests.Visual.Online
                 Ruleset = { BindTarget = ruleset }
             });
 
-            const Country country = Country.BY;
-            const Country unknown_country = Country.CK;
+            const CountryCode country = CountryCode.BY;
+            const CountryCode unknown_country = CountryCode.CK;
 
             AddStep("Set country", () => countryBindable.Value = country);
             AddStep("Set scope to Score", () => scope.Value = RankingsScope.Score);

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsHeader.cs
@@ -30,21 +30,12 @@ namespace osu.Game.Tests.Visual.Online
                 Ruleset = { BindTarget = ruleset }
             });
 
-            var country = new Country
-            {
-                FlagName = "BY",
-                FullName = "Belarus"
-            };
-
-            var unknownCountry = new Country
-            {
-                FlagName = "CK",
-                FullName = "Cook Islands"
-            };
+            const Country country = Country.BY;
+            const Country unknown_country = Country.CK;
 
             AddStep("Set country", () => countryBindable.Value = country);
             AddStep("Set scope to Score", () => scope.Value = RankingsScope.Score);
-            AddStep("Set country with no flag", () => countryBindable.Value = unknownCountry);
+            AddStep("Set country with no flag", () => countryBindable.Value = unknown_country);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.Online
         public void TestFlagScopeDependency()
         {
             AddStep("Set scope to Score", () => scope.Value = RankingsScope.Score);
-            AddAssert("Check country is default", () => countryBindable.Value == default);
+            AddAssert("Check country is default", () => countryBindable.IsDefault);
             AddStep("Set country", () => countryBindable.Value = CountryCode.US);
             AddAssert("Check scope is Performance", () => scope.Value == RankingsScope.Performance);
         }

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private TestRankingsOverlay rankingsOverlay;
 
-        private readonly Bindable<Country> countryBindable = new Bindable<Country>();
+        private readonly Bindable<CountryCode> countryBindable = new Bindable<CountryCode>();
         private readonly Bindable<RankingsScope> scope = new Bindable<RankingsScope>();
 
         [SetUp]
@@ -49,14 +49,14 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("Set scope to Score", () => scope.Value = RankingsScope.Score);
             AddAssert("Check country is default", () => countryBindable.Value == default);
-            AddStep("Set country", () => countryBindable.Value = Country.US);
+            AddStep("Set country", () => countryBindable.Value = CountryCode.US);
             AddAssert("Check scope is Performance", () => scope.Value == RankingsScope.Performance);
         }
 
         [Test]
         public void TestShowCountry()
         {
-            AddStep("Show US", () => rankingsOverlay.ShowCountry(Country.US));
+            AddStep("Show US", () => rankingsOverlay.ShowCountry(CountryCode.US));
         }
 
         private void loadRankingsOverlay()
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private class TestRankingsOverlay : RankingsOverlay
         {
-            public new Bindable<Country> Country => base.Country;
+            public new Bindable<CountryCode> Country => base.Country;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
@@ -48,15 +48,15 @@ namespace osu.Game.Tests.Visual.Online
         public void TestFlagScopeDependency()
         {
             AddStep("Set scope to Score", () => scope.Value = RankingsScope.Score);
-            AddAssert("Check country is Null", () => countryBindable.Value == null);
-            AddStep("Set country", () => countryBindable.Value = us_country);
+            AddAssert("Check country is default", () => countryBindable.Value == default);
+            AddStep("Set country", () => countryBindable.Value = Country.US);
             AddAssert("Check scope is Performance", () => scope.Value == RankingsScope.Performance);
         }
 
         [Test]
         public void TestShowCountry()
         {
-            AddStep("Show US", () => rankingsOverlay.ShowCountry(us_country));
+            AddStep("Show US", () => rankingsOverlay.ShowCountry(Country.US));
         }
 
         private void loadRankingsOverlay()
@@ -68,12 +68,6 @@ namespace osu.Game.Tests.Visual.Online
                 State = { Value = Visibility.Visible },
             };
         }
-
-        private static readonly Country us_country = new Country
-        {
-            FlagName = "US",
-            FullName = "United States"
-        };
 
         private class TestRankingsOverlay : RankingsOverlay
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
@@ -57,8 +57,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 new CountryStatistics
                 {
-                    Country = new Country { FlagName = "US", FullName = "United States" },
-                    FlagName = "US",
+                    Country = Country.US,
                     ActiveUsers = 2_972_623,
                     PlayCount = 3_086_515_743,
                     RankedScore = 449_407_643_332_546,
@@ -66,8 +65,7 @@ namespace osu.Game.Tests.Visual.Online
                 },
                 new CountryStatistics
                 {
-                    Country = new Country { FlagName = "RU", FullName = "Russian Federation" },
-                    FlagName = "RU",
+                    Country = Country.RU,
                     ActiveUsers = 1_609_989,
                     PlayCount = 1_637_052_841,
                     RankedScore = 221_660_827_473_004,
@@ -86,7 +84,7 @@ namespace osu.Game.Tests.Visual.Online
                 User = new APIUser
                 {
                     Username = "first active user",
-                    Country = new Country { FlagName = "JP" },
+                    Country = Country.JP,
                     Active = true,
                 },
                 Accuracy = 0.9972,
@@ -106,7 +104,7 @@ namespace osu.Game.Tests.Visual.Online
                 User = new APIUser
                 {
                     Username = "inactive user",
-                    Country = new Country { FlagName = "AU" },
+                    Country = Country.AU,
                     Active = false,
                 },
                 Accuracy = 0.9831,
@@ -126,7 +124,7 @@ namespace osu.Game.Tests.Visual.Online
                 User = new APIUser
                 {
                     Username = "second active user",
-                    Country = new Country { FlagName = "PL" },
+                    Country = Country.PL,
                     Active = true,
                 },
                 Accuracy = 0.9584,

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsTables.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 new CountryStatistics
                 {
-                    Country = Country.US,
+                    Code = CountryCode.US,
                     ActiveUsers = 2_972_623,
                     PlayCount = 3_086_515_743,
                     RankedScore = 449_407_643_332_546,
@@ -65,7 +65,7 @@ namespace osu.Game.Tests.Visual.Online
                 },
                 new CountryStatistics
                 {
-                    Country = Country.RU,
+                    Code = CountryCode.RU,
                     ActiveUsers = 1_609_989,
                     PlayCount = 1_637_052_841,
                     RankedScore = 221_660_827_473_004,
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.Online
                 User = new APIUser
                 {
                     Username = "first active user",
-                    Country = Country.JP,
+                    CountryCode = CountryCode.JP,
                     Active = true,
                 },
                 Accuracy = 0.9972,
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Visual.Online
                 User = new APIUser
                 {
                     Username = "inactive user",
-                    Country = Country.AU,
+                    CountryCode = CountryCode.AU,
                     Active = false,
                 },
                 Accuracy = 0.9831,
@@ -124,7 +124,7 @@ namespace osu.Game.Tests.Visual.Online
                 User = new APIUser
                 {
                     Username = "second active user",
-                    Country = Country.PL,
+                    CountryCode = CountryCode.PL,
                     Active = true,
                 },
                 Accuracy = 0.9584,

--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 6602580,
                             Username = @"waaiiru",
-                            Country = Country.ES,
+                            CountryCode = CountryCode.ES,
                         },
                         Mods = new[]
                         {
@@ -180,7 +180,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 4608074,
                             Username = @"Skycries",
-                            Country = Country.BR,
+                            CountryCode = CountryCode.BR,
                         },
                         Mods = new[]
                         {
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 1014222,
                             Username = @"eLy",
-                            Country = Country.JP,
+                            CountryCode = CountryCode.JP,
                         },
                         Mods = new[]
                         {
@@ -223,7 +223,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 1541390,
                             Username = @"Toukai",
-                            Country = Country.CA,
+                            CountryCode = CountryCode.CA,
                         },
                         Mods = new[]
                         {
@@ -243,7 +243,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 7151382,
                             Username = @"Mayuri Hana",
-                            Country = Country.TH,
+                            CountryCode = CountryCode.TH,
                         },
                         Rank = ScoreRank.D,
                         PP = 160,
@@ -282,7 +282,7 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     Id = 7151382,
                     Username = @"Mayuri Hana",
-                    Country = Country.TH,
+                    CountryCode = CountryCode.TH,
                 },
                 Rank = ScoreRank.D,
                 PP = 160,

--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -157,11 +157,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 6602580,
                             Username = @"waaiiru",
-                            Country = new Country
-                            {
-                                FullName = @"Spain",
-                                FlagName = @"ES",
-                            },
+                            Country = Country.ES,
                         },
                         Mods = new[]
                         {
@@ -184,11 +180,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 4608074,
                             Username = @"Skycries",
-                            Country = new Country
-                            {
-                                FullName = @"Brazil",
-                                FlagName = @"BR",
-                            },
+                            Country = Country.BR,
                         },
                         Mods = new[]
                         {
@@ -210,11 +202,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 1014222,
                             Username = @"eLy",
-                            Country = new Country
-                            {
-                                FullName = @"Japan",
-                                FlagName = @"JP",
-                            },
+                            Country = Country.JP,
                         },
                         Mods = new[]
                         {
@@ -235,11 +223,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 1541390,
                             Username = @"Toukai",
-                            Country = new Country
-                            {
-                                FullName = @"Canada",
-                                FlagName = @"CA",
-                            },
+                            Country = Country.CA,
                         },
                         Mods = new[]
                         {
@@ -259,11 +243,7 @@ namespace osu.Game.Tests.Visual.Online
                         {
                             Id = 7151382,
                             Username = @"Mayuri Hana",
-                            Country = new Country
-                            {
-                                FullName = @"Thailand",
-                                FlagName = @"TH",
-                            },
+                            Country = Country.TH,
                         },
                         Rank = ScoreRank.D,
                         PP = 160,
@@ -302,11 +282,7 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     Id = 7151382,
                     Username = @"Mayuri Hana",
-                    Country = new Country
-                    {
-                        FullName = @"Thailand",
-                        FlagName = @"TH",
-                    },
+                    Country = Country.TH,
                 },
                 Rank = ScoreRank.D,
                 PP = 160,

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         Username = @"flyte",
                         Id = 3103765,
-                        Country = Country.JP,
+                        CountryCode = CountryCode.JP,
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c6.jpg",
                         Status = { Value = new UserStatusOnline() }
                     }) { Width = 300 },
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         Username = @"peppy",
                         Id = 2,
-                        Country = Country.AU,
+                        CountryCode = CountryCode.AU,
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                         IsSupporter = true,
                         SupportLevel = 3,
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         Username = @"Evast",
                         Id = 8195163,
-                        Country = Country.BY,
+                        CountryCode = CountryCode.BY,
                         CoverUrl = @"https://assets.ppy.sh/user-profile-covers/8195163/4a8e2ad5a02a2642b631438cfa6c6bd7e2f9db289be881cb27df18331f64144c.jpeg",
                         IsOnline = false,
                         LastVisit = DateTimeOffset.Now

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         Username = @"flyte",
                         Id = 3103765,
-                        Country = new Country { FlagName = @"JP" },
+                        Country = Country.JP,
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c6.jpg",
                         Status = { Value = new UserStatusOnline() }
                     }) { Width = 300 },
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         Username = @"peppy",
                         Id = 2,
-                        Country = new Country { FlagName = @"AU" },
+                        Country = Country.AU,
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                         IsSupporter = true,
                         SupportLevel = 3,
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.Online
                     {
                         Username = @"Evast",
                         Id = 8195163,
-                        Country = new Country { FlagName = @"BY" },
+                        Country = Country.BY,
                         CoverUrl = @"https://assets.ppy.sh/user-profile-covers/8195163/4a8e2ad5a02a2642b631438cfa6c6bd7e2f9db289be881cb27df18331f64144c.jpeg",
                         IsOnline = false,
                         LastVisit = DateTimeOffset.Now

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             Username = @"Somebody",
             Id = 1,
-            CountryCode = CountryCode.XX,
+            CountryCode = CountryCode.Unknown,
             CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c1.jpg",
             JoinDate = DateTimeOffset.Now.AddDays(-1),
             LastVisit = DateTimeOffset.Now,

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             Username = @"Somebody",
             Id = 1,
-            Country = Country.XX,
+            CountryCode = CountryCode.XX,
             CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c1.jpg",
             JoinDate = DateTimeOffset.Now.AddDays(-1),
             LastVisit = DateTimeOffset.Now,
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.Online
                 Username = @"peppy",
                 Id = 2,
                 IsSupporter = true,
-                Country = Country.AU,
+                CountryCode = CountryCode.AU,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg"
             }));
 
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Username = @"flyte",
                 Id = 3103765,
-                Country = Country.JP,
+                CountryCode = CountryCode.JP,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c6.jpg"
             }));
 
@@ -99,7 +99,7 @@ namespace osu.Game.Tests.Visual.Online
                 Username = @"BanchoBot",
                 Id = 3,
                 IsBot = true,
-                Country = Country.SH,
+                CountryCode = CountryCode.SH,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c4.jpg"
             }));
 

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             Username = @"Somebody",
             Id = 1,
-            Country = new Country { FullName = @"Alien" },
+            Country = Country.XX,
             CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c1.jpg",
             JoinDate = DateTimeOffset.Now.AddDays(-1),
             LastVisit = DateTimeOffset.Now,
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.Online
                 Username = @"peppy",
                 Id = 2,
                 IsSupporter = true,
-                Country = new Country { FullName = @"Australia", FlagName = @"AU" },
+                Country = Country.AU,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg"
             }));
 
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Username = @"flyte",
                 Id = 3103765,
-                Country = new Country { FullName = @"Japan", FlagName = @"JP" },
+                Country = Country.JP,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c6.jpg"
             }));
 
@@ -99,7 +99,7 @@ namespace osu.Game.Tests.Visual.Online
                 Username = @"BanchoBot",
                 Id = 3,
                 IsBot = true,
-                Country = new Country { FullName = @"Saint Helena", FlagName = @"SH" },
+                Country = Country.SH,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c4.jpg"
             }));
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Id = 6602580,
                     Username = @"waaiiru",
-                    Country = Country.ES,
+                    CountryCode = CountryCode.ES,
                 },
             });
         }
@@ -160,7 +160,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Id = 6602580,
                     Username = @"waaiiru",
-                    Country = Country.ES,
+                    CountryCode = CountryCode.ES,
                 }
             });
         }
@@ -217,7 +217,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6602580,
                         Username = @"waaiiru",
-                        Country = Country.ES,
+                        CountryCode = CountryCode.ES,
                     },
                 },
                 new ScoreInfo
@@ -234,7 +234,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 4608074,
                         Username = @"Skycries",
-                        Country = Country.BR,
+                        CountryCode = CountryCode.BR,
                     },
                 },
                 new ScoreInfo
@@ -252,7 +252,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 1014222,
                         Username = @"eLy",
-                        Country = Country.JP,
+                        CountryCode = CountryCode.JP,
                     },
                 },
                 new ScoreInfo
@@ -270,7 +270,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 1541390,
                         Username = @"Toukai",
-                        Country = Country.CA,
+                        CountryCode = CountryCode.CA,
                     },
                 },
                 new ScoreInfo
@@ -288,7 +288,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 2243452,
                         Username = @"Satoruu",
-                        Country = Country.VE,
+                        CountryCode = CountryCode.VE,
                     },
                 },
                 new ScoreInfo
@@ -306,7 +306,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 2705430,
                         Username = @"Mooha",
-                        Country = Country.FR,
+                        CountryCode = CountryCode.FR,
                     },
                 },
                 new ScoreInfo
@@ -324,7 +324,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 7151382,
                         Username = @"Mayuri Hana",
-                        Country = Country.TH,
+                        CountryCode = CountryCode.TH,
                     },
                 },
                 new ScoreInfo
@@ -342,7 +342,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 2051389,
                         Username = @"FunOrange",
-                        Country = Country.CA,
+                        CountryCode = CountryCode.CA,
                     },
                 },
                 new ScoreInfo
@@ -360,7 +360,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6169483,
                         Username = @"-Hebel-",
-                        Country = Country.MX,
+                        CountryCode = CountryCode.MX,
                     },
                 },
                 new ScoreInfo
@@ -378,7 +378,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6702666,
                         Username = @"prhtnsm",
-                        Country = Country.DE,
+                        CountryCode = CountryCode.DE,
                     },
                 },
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -140,11 +140,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Id = 6602580,
                     Username = @"waaiiru",
-                    Country = new Country
-                    {
-                        FullName = @"Spain",
-                        FlagName = @"ES",
-                    },
+                    Country = Country.ES,
                 },
             });
         }
@@ -164,12 +160,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     Id = 6602580,
                     Username = @"waaiiru",
-                    Country = new Country
-                    {
-                        FullName = @"Spain",
-                        FlagName = @"ES",
-                    },
-                },
+                    Country = Country.ES,
+                }
             });
         }
 
@@ -225,11 +217,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6602580,
                         Username = @"waaiiru",
-                        Country = new Country
-                        {
-                            FullName = @"Spain",
-                            FlagName = @"ES",
-                        },
+                        Country = Country.ES,
                     },
                 },
                 new ScoreInfo
@@ -246,11 +234,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 4608074,
                         Username = @"Skycries",
-                        Country = new Country
-                        {
-                            FullName = @"Brazil",
-                            FlagName = @"BR",
-                        },
+                        Country = Country.BR,
                     },
                 },
                 new ScoreInfo
@@ -268,11 +252,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 1014222,
                         Username = @"eLy",
-                        Country = new Country
-                        {
-                            FullName = @"Japan",
-                            FlagName = @"JP",
-                        },
+                        Country = Country.JP,
                     },
                 },
                 new ScoreInfo
@@ -290,11 +270,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 1541390,
                         Username = @"Toukai",
-                        Country = new Country
-                        {
-                            FullName = @"Canada",
-                            FlagName = @"CA",
-                        },
+                        Country = Country.CA,
                     },
                 },
                 new ScoreInfo
@@ -312,11 +288,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 2243452,
                         Username = @"Satoruu",
-                        Country = new Country
-                        {
-                            FullName = @"Venezuela",
-                            FlagName = @"VE",
-                        },
+                        Country = Country.VE,
                     },
                 },
                 new ScoreInfo
@@ -334,11 +306,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 2705430,
                         Username = @"Mooha",
-                        Country = new Country
-                        {
-                            FullName = @"France",
-                            FlagName = @"FR",
-                        },
+                        Country = Country.FR,
                     },
                 },
                 new ScoreInfo
@@ -356,11 +324,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 7151382,
                         Username = @"Mayuri Hana",
-                        Country = new Country
-                        {
-                            FullName = @"Thailand",
-                            FlagName = @"TH",
-                        },
+                        Country = Country.TH,
                     },
                 },
                 new ScoreInfo
@@ -378,11 +342,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 2051389,
                         Username = @"FunOrange",
-                        Country = new Country
-                        {
-                            FullName = @"Canada",
-                            FlagName = @"CA",
-                        },
+                        Country = Country.CA,
                     },
                 },
                 new ScoreInfo
@@ -400,11 +360,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6169483,
                         Username = @"-Hebel-",
-                        Country = new Country
-                        {
-                            FullName = @"Mexico",
-                            FlagName = @"MX",
-                        },
+                        Country = Country.MX,
                     },
                 },
                 new ScoreInfo
@@ -422,11 +378,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6702666,
                         Username = @"prhtnsm",
-                        Country = new Country
-                        {
-                            FullName = @"Germany",
-                            FlagName = @"DE",
-                        },
+                        Country = Country.DE,
                     },
                 },
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUserTopScoreContainer.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUserTopScoreContainer.cs
@@ -69,11 +69,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6602580,
                         Username = @"waaiiru",
-                        Country = new Country
-                        {
-                            FullName = @"Spain",
-                            FlagName = @"ES",
-                        },
+                        Country = Country.ES,
                     },
                 },
                 new ScoreInfo
@@ -88,11 +84,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 4608074,
                         Username = @"Skycries",
-                        Country = new Country
-                        {
-                            FullName = @"Brazil",
-                            FlagName = @"BR",
-                        },
+                        Country = Country.BR,
                     },
                 },
                 new ScoreInfo
@@ -107,11 +99,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 1541390,
                         Username = @"Toukai",
-                        Country = new Country
-                        {
-                            FullName = @"Canada",
-                            FlagName = @"CA",
-                        },
+                        Country = Country.CA,
                     },
                 }
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUserTopScoreContainer.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUserTopScoreContainer.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 6602580,
                         Username = @"waaiiru",
-                        Country = Country.ES,
+                        CountryCode = CountryCode.ES,
                     },
                 },
                 new ScoreInfo
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 4608074,
                         Username = @"Skycries",
-                        Country = Country.BR,
+                        CountryCode = CountryCode.BR,
                     },
                 },
                 new ScoreInfo
@@ -99,7 +99,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         Id = 1541390,
                         Username = @"Toukai",
-                        Country = Country.CA,
+                        CountryCode = CountryCode.CA,
                     },
                 }
             };

--- a/osu.Game.Tournament/Models/TournamentUser.cs
+++ b/osu.Game.Tournament/Models/TournamentUser.cs
@@ -22,7 +22,8 @@ namespace osu.Game.Tournament.Models
         /// <summary>
         /// The player's country.
         /// </summary>
-        public Country? Country { get; set; }
+        [JsonProperty("country_code")]
+        public Country Country { get; set; }
 
         /// <summary>
         /// The player's global rank, or null if not available.

--- a/osu.Game.Tournament/Models/TournamentUser.cs
+++ b/osu.Game.Tournament/Models/TournamentUser.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tournament.Models
         /// The player's country.
         /// </summary>
         [JsonProperty("country_code")]
-        public Country Country { get; set; }
+        public CountryCode CountryCode { get; set; }
 
         /// <summary>
         /// The player's global rank, or null if not available.
@@ -41,7 +41,7 @@ namespace osu.Game.Tournament.Models
             {
                 Id = OnlineID,
                 Username = Username,
-                Country = Country,
+                CountryCode = CountryCode,
                 CoverUrl = CoverUrl,
             };
 

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -21,6 +21,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Tournament.IO;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
+using osu.Game.Users;
 using osuTK.Input;
 
 namespace osu.Game.Tournament
@@ -187,7 +188,7 @@ namespace osu.Game.Tournament
             var playersRequiringPopulation = ladder.Teams
                                                    .SelectMany(t => t.Players)
                                                    .Where(p => string.IsNullOrEmpty(p.Username)
-                                                               || p.CountryCode == default
+                                                               || p.CountryCode == CountryCode.Unknown
                                                                || p.Rank == null).ToList();
 
             if (playersRequiringPopulation.Count == 0)

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -186,7 +186,9 @@ namespace osu.Game.Tournament
         {
             var playersRequiringPopulation = ladder.Teams
                                                    .SelectMany(t => t.Players)
-                                                   .Where(p => string.IsNullOrEmpty(p.Username) || p.Rank == null).ToList();
+                                                   .Where(p => string.IsNullOrEmpty(p.Username)
+                                                               || p.Country == default
+                                                               || p.Rank == null).ToList();
 
             if (playersRequiringPopulation.Count == 0)
                 return false;

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -187,7 +187,7 @@ namespace osu.Game.Tournament
             var playersRequiringPopulation = ladder.Teams
                                                    .SelectMany(t => t.Players)
                                                    .Where(p => string.IsNullOrEmpty(p.Username)
-                                                               || p.Country == default
+                                                               || p.CountryCode == default
                                                                || p.Rank == null).ToList();
 
             if (playersRequiringPopulation.Count == 0)
@@ -290,7 +290,7 @@ namespace osu.Game.Tournament
 
                 user.Username = res.Username;
                 user.CoverUrl = res.CoverUrl;
-                user.Country = res.Country;
+                user.CountryCode = res.CountryCode;
                 user.Rank = res.Statistics?.GlobalRank;
 
                 success?.Invoke();

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using JetBrains.Annotations;
 
 namespace osu.Game.Localisation
 {
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public enum Language
     {
         [Description(@"English")]

--- a/osu.Game/Online/API/Requests/GetUserRankingsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRankingsRequest.cs
@@ -13,21 +13,21 @@ namespace osu.Game.Online.API.Requests
     {
         public readonly UserRankingsType Type;
 
-        private readonly Country country;
+        private readonly CountryCode countryCode;
 
-        public GetUserRankingsRequest(RulesetInfo ruleset, UserRankingsType type = UserRankingsType.Performance, int page = 1, Country country = default)
+        public GetUserRankingsRequest(RulesetInfo ruleset, UserRankingsType type = UserRankingsType.Performance, int page = 1, CountryCode countryCode = default)
             : base(ruleset, page)
         {
             Type = type;
-            this.country = country;
+            this.countryCode = countryCode;
         }
 
         protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
 
-            if (country != default)
-                req.AddParameter("country", country.ToString());
+            if (countryCode != default)
+                req.AddParameter("country", countryCode.ToString());
 
             return req;
         }

--- a/osu.Game/Online/API/Requests/GetUserRankingsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRankingsRequest.cs
@@ -5,6 +5,7 @@
 
 using osu.Framework.IO.Network;
 using osu.Game.Rulesets;
+using osu.Game.Users;
 
 namespace osu.Game.Online.API.Requests
 {
@@ -12,9 +13,9 @@ namespace osu.Game.Online.API.Requests
     {
         public readonly UserRankingsType Type;
 
-        private readonly string country;
+        private readonly Country country;
 
-        public GetUserRankingsRequest(RulesetInfo ruleset, UserRankingsType type = UserRankingsType.Performance, int page = 1, string country = null)
+        public GetUserRankingsRequest(RulesetInfo ruleset, UserRankingsType type = UserRankingsType.Performance, int page = 1, Country country = default)
             : base(ruleset, page)
         {
             Type = type;
@@ -25,8 +26,8 @@ namespace osu.Game.Online.API.Requests
         {
             var req = base.CreateWebRequest();
 
-            if (country != null)
-                req.AddParameter("country", country);
+            if (country != default)
+                req.AddParameter("country", country.ToString());
 
             return req;
         }

--- a/osu.Game/Online/API/Requests/GetUserRankingsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRankingsRequest.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Online.API.Requests
 
         private readonly CountryCode countryCode;
 
-        public GetUserRankingsRequest(RulesetInfo ruleset, UserRankingsType type = UserRankingsType.Performance, int page = 1, CountryCode countryCode = default)
+        public GetUserRankingsRequest(RulesetInfo ruleset, UserRankingsType type = UserRankingsType.Performance, int page = 1, CountryCode countryCode = CountryCode.Unknown)
             : base(ruleset, page)
         {
             Type = type;
@@ -26,7 +26,7 @@ namespace osu.Game.Online.API.Requests
         {
             var req = base.CreateWebRequest();
 
-            if (countryCode != default)
+            if (countryCode != CountryCode.Unknown)
                 req.AddParameter("country", countryCode.ToString());
 
             return req;

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -46,12 +46,6 @@ namespace osu.Game.Online.API.Requests.Responses
         [CanBeNull]
         [JsonProperty(@"country")]
         private Country country;
-
-        private class Country
-        {
-            [JsonProperty(@"code")]
-            public string Code;
-        }
 #pragma warning restore 649
 
         public readonly Bindable<UserStatus> Status = new Bindable<UserStatus>();
@@ -273,5 +267,13 @@ namespace osu.Game.Online.API.Requests.Responses
         public int OnlineID => Id;
 
         public bool Equals(APIUser other) => this.MatchesOnlineID(other);
+
+#pragma warning disable 649
+        private class Country
+        {
+            [JsonProperty(@"code")]
+            public string Code;
+        }
+#pragma warning restore 649
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -38,11 +38,12 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public Country Country
         {
-            get => country ??= (Enum.TryParse(userCountry.Code, out Country result) ? result : default);
+            get => country ??= (Enum.TryParse(userCountry?.Code, out Country result) ? result : default);
             set => country = value;
         }
 
 #pragma warning disable 649
+        [CanBeNull]
         [JsonProperty(@"country")]
         private UserCountry userCountry;
 

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -34,20 +34,20 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"previous_usernames")]
         public string[] PreviousUsernames;
 
-        private Country? country;
+        private CountryCode? countryCode;
 
-        public Country Country
+        public CountryCode CountryCode
         {
-            get => country ??= (Enum.TryParse(userCountry?.Code, out Country result) ? result : default);
-            set => country = value;
+            get => countryCode ??= (Enum.TryParse(country?.Code, out CountryCode result) ? result : default);
+            set => countryCode = value;
         }
 
 #pragma warning disable 649
         [CanBeNull]
         [JsonProperty(@"country")]
-        private UserCountry userCountry;
+        private Country country;
 
-        private class UserCountry
+        private class Country
         {
             [JsonProperty(@"code")]
             public string Code;

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -34,8 +34,24 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"previous_usernames")]
         public string[] PreviousUsernames;
 
+        private Country? country;
+
+        public Country Country
+        {
+            get => country ??= (Enum.TryParse(userCountry.Code, out Country result) ? result : default);
+            set => country = value;
+        }
+
+#pragma warning disable 649
         [JsonProperty(@"country")]
-        public Country Country;
+        private UserCountry userCountry;
+
+        private class UserCountry
+        {
+            [JsonProperty(@"code")]
+            public string Code;
+        }
+#pragma warning restore 649
 
         public readonly Bindable<UserStatus> Status = new Bindable<UserStatus>();
 

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Online.Leaderboards
                                                     Masking = true,
                                                     Children = new Drawable[]
                                                     {
-                                                        new UpdateableFlag(user.Country)
+                                                        new UpdateableFlag(user.CountryCode)
                                                         {
                                                             Anchor = Anchor.CentreLeft,
                                                             Origin = Anchor.CentreLeft,

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     Font = OsuFont.GetFont(size: text_size),
                     Colour = score.Accuracy == 1 ? highAccuracyColour : Color4.White
                 },
-                new UpdateableFlag(score.User.Country)
+                new UpdateableFlag(score.User.CountryCode)
                 {
                     Size = new Vector2(19, 14),
                     ShowPlaceholderOnUnknown = false,

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 new UpdateableFlag(score.User.Country)
                 {
                     Size = new Vector2(19, 14),
-                    ShowPlaceholderOnNull = false,
+                    ShowPlaceholderOnUnknown = false,
                 },
                 username,
                 new OsuSpriteText

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 Origin = Anchor.CentreLeft,
                                 Size = new Vector2(19, 14),
                                 Margin = new MarginPadding { Top = 3 }, // makes spacing look more even
-                                ShowPlaceholderOnNull = false,
+                                ShowPlaceholderOnUnknown = false,
                             },
                         }
                     }

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             set
             {
                 avatar.User = value.User;
-                flag.Country = value.User.Country;
+                flag.CountryCode = value.User.CountryCode;
                 achievedOn.Date = value.Date;
 
                 usernameText.Clear();

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -175,8 +175,8 @@ namespace osu.Game.Overlays.Profile.Header
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"{api.WebsiteRootUrl}/users/{user?.Id ?? 0}";
-            userFlag.Country = user?.Country ?? default;
-            userCountryText.Text = (user?.Country ?? default).GetDescription();
+            userFlag.CountryCode = user?.CountryCode ?? default;
+            userCountryText.Text = (user?.CountryCode ?? default).GetDescription();
             supporterTag.SupportLevel = user?.SupportLevel ?? 0;
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Overlays.Profile.Header
                                                 userFlag = new UpdateableFlag
                                                 {
                                                     Size = new Vector2(28, 20),
-                                                    ShowPlaceholderOnNull = false,
+                                                    ShowPlaceholderOnUnknown = false,
                                                 },
                                                 userCountryText = new OsuSpriteText
                                                 {

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -5,6 +5,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -174,8 +175,8 @@ namespace osu.Game.Overlays.Profile.Header
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"{api.WebsiteRootUrl}/users/{user?.Id ?? 0}";
-            userFlag.Country = user?.Country;
-            userCountryText.Text = user?.Country?.FullName ?? "Alien";
+            userFlag.Country = user?.Country ?? default;
+            userCountryText.Text = (user?.Country ?? default).GetDescription();
             supporterTag.SupportLevel = user?.SupportLevel ?? 0;
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");

--- a/osu.Game/Overlays/Rankings/CountryFilter.cs
+++ b/osu.Game/Overlays/Rankings/CountryFilter.cs
@@ -16,14 +16,14 @@ using osuTK;
 
 namespace osu.Game.Overlays.Rankings
 {
-    public class CountryFilter : CompositeDrawable, IHasCurrentValue<Country>
+    public class CountryFilter : CompositeDrawable, IHasCurrentValue<CountryCode>
     {
         private const int duration = 200;
         private const int height = 70;
 
-        private readonly BindableWithCurrent<Country> current = new BindableWithCurrent<Country>();
+        private readonly BindableWithCurrent<CountryCode> current = new BindableWithCurrent<CountryCode>();
 
-        public Bindable<Country> Current
+        public Bindable<CountryCode> Current
         {
             get => current.Current;
             set => current.Current = value;
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.Rankings
             Current.BindValueChanged(onCountryChanged, true);
         }
 
-        private void onCountryChanged(ValueChangedEvent<Country> country)
+        private void onCountryChanged(ValueChangedEvent<CountryCode> country)
         {
             if (country.NewValue == default)
             {

--- a/osu.Game/Overlays/Rankings/CountryFilter.cs
+++ b/osu.Game/Overlays/Rankings/CountryFilter.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Overlays.Rankings
 
         private void onCountryChanged(ValueChangedEvent<Country> country)
         {
-            if (country.NewValue == null)
+            if (country.NewValue == default)
             {
                 countryPill.Collapse();
                 this.ResizeHeightTo(0, duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Rankings/CountryFilter.cs
+++ b/osu.Game/Overlays/Rankings/CountryFilter.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Overlays.Rankings
 
         private void onCountryChanged(ValueChangedEvent<CountryCode> country)
         {
-            if (country.NewValue == default)
+            if (Current.Value == CountryCode.Unknown)
             {
                 countryPill.Collapse();
                 this.ResizeHeightTo(0, duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Rankings/CountryPill.cs
+++ b/osu.Game/Overlays/Rankings/CountryPill.cs
@@ -22,13 +22,13 @@ using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Rankings
 {
-    public class CountryPill : CompositeDrawable, IHasCurrentValue<Country>
+    public class CountryPill : CompositeDrawable, IHasCurrentValue<CountryCode>
     {
         private const int duration = 200;
 
-        private readonly BindableWithCurrent<Country> current = new BindableWithCurrent<Country>();
+        private readonly BindableWithCurrent<CountryCode> current = new BindableWithCurrent<CountryCode>();
 
-        public Bindable<Country> Current
+        public Bindable<CountryCode> Current
         {
             get => current.Current;
             set => current.Current = value;
@@ -131,12 +131,12 @@ namespace osu.Game.Overlays.Rankings
             this.FadeOut(duration, Easing.OutQuint);
         }
 
-        private void onCountryChanged(ValueChangedEvent<Country> country)
+        private void onCountryChanged(ValueChangedEvent<CountryCode> country)
         {
             if (country.NewValue == default)
                 return;
 
-            flag.Country = country.NewValue;
+            flag.CountryCode = country.NewValue;
             countryName.Text = country.NewValue.GetDescription();
         }
 

--- a/osu.Game/Overlays/Rankings/CountryPill.cs
+++ b/osu.Game/Overlays/Rankings/CountryPill.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays.Rankings
 
         private void onCountryChanged(ValueChangedEvent<CountryCode> country)
         {
-            if (country.NewValue == default)
+            if (Current.Value == CountryCode.Unknown)
                 return;
 
             flag.CountryCode = country.NewValue;

--- a/osu.Game/Overlays/Rankings/CountryPill.cs
+++ b/osu.Game/Overlays/Rankings/CountryPill.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -93,7 +94,7 @@ namespace osu.Game.Overlays.Rankings
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                Action = () => Current.Value = null
+                                Action = Current.SetDefault,
                             }
                         }
                     }
@@ -132,11 +133,11 @@ namespace osu.Game.Overlays.Rankings
 
         private void onCountryChanged(ValueChangedEvent<Country> country)
         {
-            if (country.NewValue == null)
+            if (country.NewValue == default)
                 return;
 
             flag.Country = country.NewValue;
-            countryName.Text = country.NewValue.FullName;
+            countryName.Text = country.NewValue.GetDescription();
         }
 
         private class CloseButton : OsuHoverContainer

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Overlays.Rankings
     {
         public Bindable<RulesetInfo> Ruleset => rulesetSelector.Current;
 
-        public Bindable<Country> Country => countryFilter.Current;
+        public Bindable<CountryCode> Country => countryFilter.Current;
 
         private OverlayRulesetSelector rulesetSelector;
         private CountryFilter countryFilter;

--- a/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Overlays.Rankings.Tables
             new RankingsTableColumn(RankingsStrings.StatAveragePerformance, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
         };
 
-        protected override Country GetCountry(CountryStatistics item) => item.Country;
+        protected override CountryCode GetCountryCode(CountryStatistics item) => item.Code;
 
-        protected override Drawable CreateFlagContent(CountryStatistics item) => new CountryName(item.Country);
+        protected override Drawable CreateFlagContent(CountryStatistics item) => new CountryName(item.Code);
 
         protected override Drawable[] CreateAdditionalContent(CountryStatistics item) => new Drawable[]
         {
@@ -71,15 +71,15 @@ namespace osu.Game.Overlays.Rankings.Tables
             [Resolved(canBeNull: true)]
             private RankingsOverlay rankings { get; set; }
 
-            public CountryName(Country country)
+            public CountryName(CountryCode countryCode)
                 : base(t => t.Font = OsuFont.GetFont(size: 12))
             {
                 AutoSizeAxes = Axes.X;
                 RelativeSizeAxes = Axes.Y;
                 TextAnchor = Anchor.CentreLeft;
 
-                if (country != default)
-                    AddLink(country.GetDescription(), () => rankings?.ShowCountry(country));
+                if (countryCode != default)
+                    AddLink(countryCode.GetDescription(), () => rankings?.ShowCountry(countryCode));
             }
         }
     }

--- a/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Overlays.Rankings.Tables
                 RelativeSizeAxes = Axes.Y;
                 TextAnchor = Anchor.CentreLeft;
 
-                if (countryCode != default)
+                if (countryCode != CountryCode.Unknown)
                     AddLink(countryCode.GetDescription(), () => rankings?.ShowCountry(countryCode));
             }
         }

--- a/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/CountriesTable.cs
@@ -11,6 +11,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Game.Resources.Localisation.Web;
 
@@ -77,8 +78,8 @@ namespace osu.Game.Overlays.Rankings.Tables
                 RelativeSizeAxes = Axes.Y;
                 TextAnchor = Anchor.CentreLeft;
 
-                if (!string.IsNullOrEmpty(country.FullName))
-                    AddLink(country.FullName, () => rankings?.ShowCountry(country));
+                if (country != default)
+                    AddLink(country.GetDescription(), () => rankings?.ShowCountry(country));
             }
         }
     }

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Rankings.Tables
         protected sealed override Drawable CreateHeader(int index, TableColumn column)
             => (column as RankingsTableColumn)?.CreateHeaderText() ?? new HeaderText(column?.Header ?? default, false);
 
-        protected abstract Country GetCountry(TModel item);
+        protected abstract CountryCode GetCountryCode(TModel item);
 
         protected abstract Drawable CreateFlagContent(TModel item);
 
@@ -97,7 +97,7 @@ namespace osu.Game.Overlays.Rankings.Tables
             Margin = new MarginPadding { Bottom = row_spacing },
             Children = new[]
             {
-                new UpdateableFlag(GetCountry(item))
+                new UpdateableFlag(GetCountryCode(item))
                 {
                     Size = new Vector2(28, 20),
                     ShowPlaceholderOnUnknown = false,

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Overlays.Rankings.Tables
                 new UpdateableFlag(GetCountry(item))
                 {
                     Size = new Vector2(28, 20),
-                    ShowPlaceholderOnNull = false,
+                    ShowPlaceholderOnUnknown = false,
                 },
                 CreateFlagContent(item)
             }

--- a/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/UserBasedTable.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.Rankings.Tables
              .Concat(GradeColumns.Select(grade => new GradeTableColumn(grade, Anchor.Centre, new Dimension(GridSizeMode.AutoSize))))
              .ToArray();
 
-        protected sealed override Country GetCountry(UserStatistics item) => item.User.Country;
+        protected sealed override CountryCode GetCountryCode(UserStatistics item) => item.User.CountryCode;
 
         protected sealed override Drawable CreateFlagContent(UserStatistics item)
         {

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays
 {
     public class RankingsOverlay : TabbableOnlineOverlay<RankingsOverlayHeader, RankingsScope>
     {
-        protected Bindable<Country> Country => Header.Country;
+        protected Bindable<CountryCode> Country => Header.Country;
 
         private APIRequest lastRequest;
 
@@ -85,7 +85,7 @@ namespace osu.Game.Overlays
 
         protected override RankingsOverlayHeader CreateHeader() => new RankingsOverlayHeader();
 
-        public void ShowCountry(Country requested)
+        public void ShowCountry(CountryCode requested)
         {
             if (requested == default)
                 return;
@@ -128,7 +128,7 @@ namespace osu.Game.Overlays
             switch (Header.Current.Value)
             {
                 case RankingsScope.Performance:
-                    return new GetUserRankingsRequest(ruleset.Value, country: Country.Value);
+                    return new GetUserRankingsRequest(ruleset.Value, countryCode: Country.Value);
 
                 case RankingsScope.Country:
                     return new GetCountryRankingsRequest(ruleset.Value);

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays
             Country.BindValueChanged(_ =>
             {
                 // if a country is requested, force performance scope.
-                if (Country.Value != null)
+                if (!Country.IsDefault)
                     Header.Current.Value = RankingsScope.Performance;
 
                 Scheduler.AddOnce(triggerTabChanged);
@@ -76,7 +76,7 @@ namespace osu.Game.Overlays
         {
             // country filtering is only valid for performance scope.
             if (Header.Current.Value != RankingsScope.Performance)
-                Country.Value = null;
+                Country.SetDefault();
 
             Scheduler.AddOnce(triggerTabChanged);
         }
@@ -87,7 +87,7 @@ namespace osu.Game.Overlays
 
         public void ShowCountry(Country requested)
         {
-            if (requested == null)
+            if (requested == default)
                 return;
 
             Show();
@@ -128,7 +128,7 @@ namespace osu.Game.Overlays
             switch (Header.Current.Value)
             {
                 case RankingsScope.Performance:
-                    return new GetUserRankingsRequest(ruleset.Value, country: Country.Value?.FlagName);
+                    return new GetUserRankingsRequest(ruleset.Value, country: Country.Value);
 
                 case RankingsScope.Country:
                     return new GetCountryRankingsRequest(ruleset.Value);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             Size = new Vector2(28, 20),
-                                            Country = user?.Country
+                                            Country = user?.Country ?? default
                                         },
                                         new OsuSpriteText
                                         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             Size = new Vector2(28, 20),
-                                            Country = user?.Country ?? default
+                                            CountryCode = user?.CountryCode ?? default
                                         },
                                         new OsuSpriteText
                                         {

--- a/osu.Game/Users/Country.cs
+++ b/osu.Game/Users/Country.cs
@@ -1,27 +1,767 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System;
+using System.ComponentModel;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace osu.Game.Users
 {
-    public class Country : IEquatable<Country>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum Country
     {
-        /// <summary>
-        /// The name of this country.
-        /// </summary>
-        [JsonProperty(@"name")]
-        public string FullName;
+        [Description("Alien")]
+        XX = 0,
 
-        /// <summary>
-        /// Two-letter flag acronym (ISO 3166 standard)
-        /// </summary>
-        [JsonProperty(@"code")]
-        public string FlagName;
+        [Description("Bangladesh")]
+        BD,
 
-        public bool Equals(Country other) => FlagName == other?.FlagName;
+        [Description("Belgium")]
+        BE,
+
+        [Description("Burkina Faso")]
+        BF,
+
+        [Description("Bulgaria")]
+        BG,
+
+        [Description("Bosnia and Herzegovina")]
+        BA,
+
+        [Description("Barbados")]
+        BB,
+
+        [Description("Wallis and Futuna")]
+        WF,
+
+        [Description("Saint Barthelemy")]
+        BL,
+
+        [Description("Bermuda")]
+        BM,
+
+        [Description("Brunei")]
+        BN,
+
+        [Description("Bolivia")]
+        BO,
+
+        [Description("Bahrain")]
+        BH,
+
+        [Description("Burundi")]
+        BI,
+
+        [Description("Benin")]
+        BJ,
+
+        [Description("Bhutan")]
+        BT,
+
+        [Description("Jamaica")]
+        JM,
+
+        [Description("Bouvet Island")]
+        BV,
+
+        [Description("Botswana")]
+        BW,
+
+        [Description("Samoa")]
+        WS,
+
+        [Description("Bonaire, Saint Eustatius and Saba")]
+        BQ,
+
+        [Description("Brazil")]
+        BR,
+
+        [Description("Bahamas")]
+        BS,
+
+        [Description("Jersey")]
+        JE,
+
+        [Description("Belarus")]
+        BY,
+
+        [Description("Belize")]
+        BZ,
+
+        [Description("Russia")]
+        RU,
+
+        [Description("Rwanda")]
+        RW,
+
+        [Description("Serbia")]
+        RS,
+
+        [Description("East Timor")]
+        TL,
+
+        [Description("Reunion")]
+        RE,
+
+        [Description("Turkmenistan")]
+        TM,
+
+        [Description("Tajikistan")]
+        TJ,
+
+        [Description("Romania")]
+        RO,
+
+        [Description("Tokelau")]
+        TK,
+
+        [Description("Guinea-Bissau")]
+        GW,
+
+        [Description("Guam")]
+        GU,
+
+        [Description("Guatemala")]
+        GT,
+
+        [Description("South Georgia and the South Sandwich Islands")]
+        GS,
+
+        [Description("Greece")]
+        GR,
+
+        [Description("Equatorial Guinea")]
+        GQ,
+
+        [Description("Guadeloupe")]
+        GP,
+
+        [Description("Japan")]
+        JP,
+
+        [Description("Guyana")]
+        GY,
+
+        [Description("Guernsey")]
+        GG,
+
+        [Description("French Guiana")]
+        GF,
+
+        [Description("Georgia")]
+        GE,
+
+        [Description("Grenada")]
+        GD,
+
+        [Description("United Kingdom")]
+        GB,
+
+        [Description("Gabon")]
+        GA,
+
+        [Description("El Salvador")]
+        SV,
+
+        [Description("Guinea")]
+        GN,
+
+        [Description("Gambia")]
+        GM,
+
+        [Description("Greenland")]
+        GL,
+
+        [Description("Gibraltar")]
+        GI,
+
+        [Description("Ghana")]
+        GH,
+
+        [Description("Oman")]
+        OM,
+
+        [Description("Tunisia")]
+        TN,
+
+        [Description("Jordan")]
+        JO,
+
+        [Description("Croatia")]
+        HR,
+
+        [Description("Haiti")]
+        HT,
+
+        [Description("Hungary")]
+        HU,
+
+        [Description("Hong Kong")]
+        HK,
+
+        [Description("Honduras")]
+        HN,
+
+        [Description("Heard Island and McDonald Islands")]
+        HM,
+
+        [Description("Venezuela")]
+        VE,
+
+        [Description("Puerto Rico")]
+        PR,
+
+        [Description("Palestinian Territory")]
+        PS,
+
+        [Description("Palau")]
+        PW,
+
+        [Description("Portugal")]
+        PT,
+
+        [Description("Svalbard and Jan Mayen")]
+        SJ,
+
+        [Description("Paraguay")]
+        PY,
+
+        [Description("Iraq")]
+        IQ,
+
+        [Description("Panama")]
+        PA,
+
+        [Description("French Polynesia")]
+        PF,
+
+        [Description("Papua New Guinea")]
+        PG,
+
+        [Description("Peru")]
+        PE,
+
+        [Description("Pakistan")]
+        PK,
+
+        [Description("Philippines")]
+        PH,
+
+        [Description("Pitcairn")]
+        PN,
+
+        [Description("Poland")]
+        PL,
+
+        [Description("Saint Pierre and Miquelon")]
+        PM,
+
+        [Description("Zambia")]
+        ZM,
+
+        [Description("Western Sahara")]
+        EH,
+
+        [Description("Estonia")]
+        EE,
+
+        [Description("Egypt")]
+        EG,
+
+        [Description("South Africa")]
+        ZA,
+
+        [Description("Ecuador")]
+        EC,
+
+        [Description("Italy")]
+        IT,
+
+        [Description("Vietnam")]
+        VN,
+
+        [Description("Solomon Islands")]
+        SB,
+
+        [Description("Ethiopia")]
+        ET,
+
+        [Description("Somalia")]
+        SO,
+
+        [Description("Zimbabwe")]
+        ZW,
+
+        [Description("Saudi Arabia")]
+        SA,
+
+        [Description("Spain")]
+        ES,
+
+        [Description("Eritrea")]
+        ER,
+
+        [Description("Montenegro")]
+        ME,
+
+        [Description("Moldova")]
+        MD,
+
+        [Description("Madagascar")]
+        MG,
+
+        [Description("Saint Martin")]
+        MF,
+
+        [Description("Morocco")]
+        MA,
+
+        [Description("Monaco")]
+        MC,
+
+        [Description("Uzbekistan")]
+        UZ,
+
+        [Description("Myanmar")]
+        MM,
+
+        [Description("Mali")]
+        ML,
+
+        [Description("Macao")]
+        MO,
+
+        [Description("Mongolia")]
+        MN,
+
+        [Description("Marshall Islands")]
+        MH,
+
+        [Description("North Macedonia")]
+        MK,
+
+        [Description("Mauritius")]
+        MU,
+
+        [Description("Malta")]
+        MT,
+
+        [Description("Malawi")]
+        MW,
+
+        [Description("Maldives")]
+        MV,
+
+        [Description("Martinique")]
+        MQ,
+
+        [Description("Northern Mariana Islands")]
+        MP,
+
+        [Description("Montserrat")]
+        MS,
+
+        [Description("Mauritania")]
+        MR,
+
+        [Description("Isle of Man")]
+        IM,
+
+        [Description("Uganda")]
+        UG,
+
+        [Description("Tanzania")]
+        TZ,
+
+        [Description("Malaysia")]
+        MY,
+
+        [Description("Mexico")]
+        MX,
+
+        [Description("Israel")]
+        IL,
+
+        [Description("France")]
+        FR,
+
+        [Description("British Indian Ocean Territory")]
+        IO,
+
+        [Description("Saint Helena")]
+        SH,
+
+        [Description("Finland")]
+        FI,
+
+        [Description("Fiji")]
+        FJ,
+
+        [Description("Falkland Islands")]
+        FK,
+
+        [Description("Micronesia")]
+        FM,
+
+        [Description("Faroe Islands")]
+        FO,
+
+        [Description("Nicaragua")]
+        NI,
+
+        [Description("Netherlands")]
+        NL,
+
+        [Description("Norway")]
+        NO,
+
+        [Description("Namibia")]
+        NA,
+
+        [Description("Vanuatu")]
+        VU,
+
+        [Description("New Caledonia")]
+        NC,
+
+        [Description("Niger")]
+        NE,
+
+        [Description("Norfolk Island")]
+        NF,
+
+        [Description("Nigeria")]
+        NG,
+
+        [Description("New Zealand")]
+        NZ,
+
+        [Description("Nepal")]
+        NP,
+
+        [Description("Nauru")]
+        NR,
+
+        [Description("Niue")]
+        NU,
+
+        [Description("Cook Islands")]
+        CK,
+
+        [Description("Kosovo")]
+        XK,
+
+        [Description("Ivory Coast")]
+        CI,
+
+        [Description("Switzerland")]
+        CH,
+
+        [Description("Colombia")]
+        CO,
+
+        [Description("China")]
+        CN,
+
+        [Description("Cameroon")]
+        CM,
+
+        [Description("Chile")]
+        CL,
+
+        [Description("Cocos Islands")]
+        CC,
+
+        [Description("Canada")]
+        CA,
+
+        [Description("Republic of the Congo")]
+        CG,
+
+        [Description("Central African Republic")]
+        CF,
+
+        [Description("Democratic Republic of the Congo")]
+        CD,
+
+        [Description("Czech Republic")]
+        CZ,
+
+        [Description("Cyprus")]
+        CY,
+
+        [Description("Christmas Island")]
+        CX,
+
+        [Description("Costa Rica")]
+        CR,
+
+        [Description("Curacao")]
+        CW,
+
+        [Description("Cabo Verde")]
+        CV,
+
+        [Description("Cuba")]
+        CU,
+
+        [Description("Eswatini")]
+        SZ,
+
+        [Description("Syria")]
+        SY,
+
+        [Description("Sint Maarten")]
+        SX,
+
+        [Description("Kyrgyzstan")]
+        KG,
+
+        [Description("Kenya")]
+        KE,
+
+        [Description("South Sudan")]
+        SS,
+
+        [Description("Suriname")]
+        SR,
+
+        [Description("Kiribati")]
+        KI,
+
+        [Description("Cambodia")]
+        KH,
+
+        [Description("Saint Kitts and Nevis")]
+        KN,
+
+        [Description("Comoros")]
+        KM,
+
+        [Description("Sao Tome and Principe")]
+        ST,
+
+        [Description("Slovakia")]
+        SK,
+
+        [Description("South Korea")]
+        KR,
+
+        [Description("Slovenia")]
+        SI,
+
+        [Description("North Korea")]
+        KP,
+
+        [Description("Kuwait")]
+        KW,
+
+        [Description("Senegal")]
+        SN,
+
+        [Description("San Marino")]
+        SM,
+
+        [Description("Sierra Leone")]
+        SL,
+
+        [Description("Seychelles")]
+        SC,
+
+        [Description("Kazakhstan")]
+        KZ,
+
+        [Description("Cayman Islands")]
+        KY,
+
+        [Description("Singapore")]
+        SG,
+
+        [Description("Sweden")]
+        SE,
+
+        [Description("Sudan")]
+        SD,
+
+        [Description("Dominican Republic")]
+        DO,
+
+        [Description("Dominica")]
+        DM,
+
+        [Description("Djibouti")]
+        DJ,
+
+        [Description("Denmark")]
+        DK,
+
+        [Description("British Virgin Islands")]
+        VG,
+
+        [Description("Germany")]
+        DE,
+
+        [Description("Yemen")]
+        YE,
+
+        [Description("Algeria")]
+        DZ,
+
+        [Description("United States")]
+        US,
+
+        [Description("Uruguay")]
+        UY,
+
+        [Description("Mayotte")]
+        YT,
+
+        [Description("United States Minor Outlying Islands")]
+        UM,
+
+        [Description("Lebanon")]
+        LB,
+
+        [Description("Saint Lucia")]
+        LC,
+
+        [Description("Laos")]
+        LA,
+
+        [Description("Tuvalu")]
+        TV,
+
+        [Description("Taiwan")]
+        TW,
+
+        [Description("Trinidad and Tobago")]
+        TT,
+
+        [Description("Turkey")]
+        TR,
+
+        [Description("Sri Lanka")]
+        LK,
+
+        [Description("Liechtenstein")]
+        LI,
+
+        [Description("Latvia")]
+        LV,
+
+        [Description("Tonga")]
+        TO,
+
+        [Description("Lithuania")]
+        LT,
+
+        [Description("Luxembourg")]
+        LU,
+
+        [Description("Liberia")]
+        LR,
+
+        [Description("Lesotho")]
+        LS,
+
+        [Description("Thailand")]
+        TH,
+
+        [Description("French Southern Territories")]
+        TF,
+
+        [Description("Togo")]
+        TG,
+
+        [Description("Chad")]
+        TD,
+
+        [Description("Turks and Caicos Islands")]
+        TC,
+
+        [Description("Libya")]
+        LY,
+
+        [Description("Vatican")]
+        VA,
+
+        [Description("Saint Vincent and the Grenadines")]
+        VC,
+
+        [Description("United Arab Emirates")]
+        AE,
+
+        [Description("Andorra")]
+        AD,
+
+        [Description("Antigua and Barbuda")]
+        AG,
+
+        [Description("Afghanistan")]
+        AF,
+
+        [Description("Anguilla")]
+        AI,
+
+        [Description("U.S. Virgin Islands")]
+        VI,
+
+        [Description("Iceland")]
+        IS,
+
+        [Description("Iran")]
+        IR,
+
+        [Description("Armenia")]
+        AM,
+
+        [Description("Albania")]
+        AL,
+
+        [Description("Angola")]
+        AO,
+
+        [Description("Antarctica")]
+        AQ,
+
+        [Description("American Samoa")]
+        AS,
+
+        [Description("Argentina")]
+        AR,
+
+        [Description("Australia")]
+        AU,
+
+        [Description("Austria")]
+        AT,
+
+        [Description("Aruba")]
+        AW,
+
+        [Description("India")]
+        IN,
+
+        [Description("Aland Islands")]
+        AX,
+
+        [Description("Azerbaijan")]
+        AZ,
+
+        [Description("Ireland")]
+        IE,
+
+        [Description("Indonesia")]
+        ID,
+
+        [Description("Ukraine")]
+        UA,
+
+        [Description("Qatar")]
+        QA,
+
+        [Description("Mozambique")]
+        MZ,
     }
 }

--- a/osu.Game/Users/Country.cs
+++ b/osu.Game/Users/Country.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Converters;
 namespace osu.Game.Users
 {
     [JsonConverter(typeof(StringEnumConverter))]
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public enum Country
     {
         [Description("Alien")]

--- a/osu.Game/Users/Country.cs
+++ b/osu.Game/Users/Country.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Users
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public enum Country
     {
-        [Description("Alien")]
+        [Description("Unknown")]
         XX = 0,
 
         [Description("Bangladesh")]

--- a/osu.Game/Users/CountryCode.cs
+++ b/osu.Game/Users/CountryCode.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Users
     public enum CountryCode
     {
         [Description("Unknown")]
-        XX = 0,
+        Unknown = 0,
 
         [Description("Bangladesh")]
         BD,

--- a/osu.Game/Users/CountryCode.cs
+++ b/osu.Game/Users/CountryCode.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Users
 {
     [JsonConverter(typeof(StringEnumConverter))]
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-    public enum Country
+    public enum CountryCode
     {
         [Description("Unknown")]
         XX = 0,

--- a/osu.Game/Users/CountryStatistics.cs
+++ b/osu.Game/Users/CountryStatistics.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Users
     public class CountryStatistics
     {
         [JsonProperty(@"code")]
-        public Country Country;
+        public CountryCode Code;
 
         [JsonProperty(@"active_users")]
         public long ActiveUsers;

--- a/osu.Game/Users/CountryStatistics.cs
+++ b/osu.Game/Users/CountryStatistics.cs
@@ -9,11 +9,8 @@ namespace osu.Game.Users
 {
     public class CountryStatistics
     {
-        [JsonProperty]
-        public Country Country;
-
         [JsonProperty(@"code")]
-        public string FlagName;
+        public Country Country;
 
         [JsonProperty(@"active_users")]
         public long ActiveUsers;

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -15,13 +15,13 @@ namespace osu.Game.Users.Drawables
 {
     public class DrawableFlag : Sprite, IHasTooltip
     {
-        private readonly Country country;
+        private readonly CountryCode countryCode;
 
-        public LocalisableString TooltipText => country == default ? string.Empty : country.GetDescription();
+        public LocalisableString TooltipText => countryCode == default ? string.Empty : countryCode.GetDescription();
 
-        public DrawableFlag(Country country)
+        public DrawableFlag(CountryCode countryCode)
         {
-            this.country = country;
+            this.countryCode = countryCode;
         }
 
         [BackgroundDependencyLoader]
@@ -30,7 +30,7 @@ namespace osu.Game.Users.Drawables
             if (ts == null)
                 throw new ArgumentNullException(nameof(ts));
 
-            string textureName = country == default ? "__" : country.ToString();
+            string textureName = countryCode == default ? "__" : countryCode.ToString();
             Texture = ts.Get($@"Flags/{textureName}") ?? ts.Get(@"Flags/__");
         }
     }

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -5,6 +5,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
@@ -16,7 +17,7 @@ namespace osu.Game.Users.Drawables
     {
         private readonly Country country;
 
-        public LocalisableString TooltipText => country?.FullName;
+        public LocalisableString TooltipText => country == default ? string.Empty : country.GetDescription();
 
         public DrawableFlag(Country country)
         {
@@ -29,7 +30,8 @@ namespace osu.Game.Users.Drawables
             if (ts == null)
                 throw new ArgumentNullException(nameof(ts));
 
-            Texture = ts.Get($@"Flags/{country?.FlagName ?? @"__"}") ?? ts.Get(@"Flags/__");
+            string textureName = country == default ? "__" : country.ToString();
+            Texture = ts.Get($@"Flags/{textureName}") ?? ts.Get(@"Flags/__");
         }
     }
 }

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Users.Drawables
     {
         private readonly CountryCode countryCode;
 
-        public LocalisableString TooltipText => countryCode == default ? string.Empty : countryCode.GetDescription();
+        public LocalisableString TooltipText => countryCode == CountryCode.Unknown ? string.Empty : countryCode.GetDescription();
 
         public DrawableFlag(CountryCode countryCode)
         {
@@ -30,7 +30,7 @@ namespace osu.Game.Users.Drawables
             if (ts == null)
                 throw new ArgumentNullException(nameof(ts));
 
-            string textureName = countryCode == default ? "__" : countryCode.ToString();
+            string textureName = countryCode == CountryCode.Unknown ? "__" : countryCode.ToString();
             Texture = ts.Get($@"Flags/{textureName}") ?? ts.Get(@"Flags/__");
         }
     }

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -13,9 +13,9 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Users.Drawables
 {
-    public class UpdateableFlag : ModelBackedDrawable<Country>
+    public class UpdateableFlag : ModelBackedDrawable<CountryCode>
     {
-        public Country Country
+        public CountryCode CountryCode
         {
             get => Model;
             set => Model = value;
@@ -32,14 +32,14 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public Action Action;
 
-        public UpdateableFlag(Country country = default)
+        public UpdateableFlag(CountryCode countryCode = default)
         {
-            Country = country;
+            CountryCode = countryCode;
         }
 
-        protected override Drawable CreateDrawable(Country country)
+        protected override Drawable CreateDrawable(CountryCode countryCode)
         {
-            if (country == default && !ShowPlaceholderOnUnknown)
+            if (countryCode == default && !ShowPlaceholderOnUnknown)
                 return null;
 
             return new Container
@@ -47,7 +47,7 @@ namespace osu.Game.Users.Drawables
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new DrawableFlag(country)
+                    new DrawableFlag(countryCode)
                     {
                         RelativeSizeAxes = Axes.Both
                     },
@@ -62,7 +62,7 @@ namespace osu.Game.Users.Drawables
         protected override bool OnClick(ClickEvent e)
         {
             Action?.Invoke();
-            rankingsOverlay?.ShowCountry(Country);
+            rankingsOverlay?.ShowCountry(CountryCode);
             return true;
         }
     }

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -32,14 +32,14 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public Action Action;
 
-        public UpdateableFlag(Country country = null)
+        public UpdateableFlag(Country country = default)
         {
             Country = country;
         }
 
         protected override Drawable CreateDrawable(Country country)
         {
-            if (country == null && !ShowPlaceholderOnNull)
+            if (country == default && !ShowPlaceholderOnNull)
                 return null;
 
             return new Container

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -32,14 +32,14 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public Action Action;
 
-        public UpdateableFlag(CountryCode countryCode = default)
+        public UpdateableFlag(CountryCode countryCode = CountryCode.Unknown)
         {
             CountryCode = countryCode;
         }
 
         protected override Drawable CreateDrawable(CountryCode countryCode)
         {
-            if (countryCode == default && !ShowPlaceholderOnUnknown)
+            if (countryCode == CountryCode.Unknown && !ShowPlaceholderOnUnknown)
                 return null;
 
             return new Container

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -22,9 +22,9 @@ namespace osu.Game.Users.Drawables
         }
 
         /// <summary>
-        /// Whether to show a place holder on null country.
+        /// Whether to show a place holder on unknown country.
         /// </summary>
-        public bool ShowPlaceholderOnNull = true;
+        public bool ShowPlaceholderOnUnknown = true;
 
         /// <summary>
         /// Perform an action in addition to showing the country ranking.
@@ -39,7 +39,7 @@ namespace osu.Game.Users.Drawables
 
         protected override Drawable CreateDrawable(Country country)
         {
-            if (country == default && !ShowPlaceholderOnNull)
+            if (country == default && !ShowPlaceholderOnUnknown)
                 return null;
 
             return new Container

--- a/osu.Game/Users/ExtendedUserPanel.cs
+++ b/osu.Game/Users/ExtendedUserPanel.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Users
 
         protected UpdateableAvatar CreateAvatar() => new UpdateableAvatar(User, false);
 
-        protected UpdateableFlag CreateFlag() => new UpdateableFlag(User.Country)
+        protected UpdateableFlag CreateFlag() => new UpdateableFlag(User.CountryCode)
         {
             Size = new Vector2(36, 26),
             Action = Action,


### PR DESCRIPTION
One step towards supporting inclusion of user country in local scores. Countries have been copied from the `countries.json` map with help from VIM keybindings, which will be removed in a follow-up PR given the current size of this PR and the usage behind that file.

Reason for changing it to enum is to make it easier to store the user's country in local scores, by only specifying the acronym rather than passing the full `Country` structure and making a Realm version of it which inherits `EmbeddedObject`. It is also a good code-quality change overall seeing how it reflects on the test scenes.