### PR TITLE
Add Touch input handler settings section

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -22,10 +22,12 @@ using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Joystick;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.Handlers.Tablet;
+using osu.Framework.Input.Handlers.Touch;
 using osu.Framework.Threading;
 using osu.Game.IO;
 using osu.Game.IPC;
 using osu.Game.Overlays.Settings;
+using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Overlays.Settings.Sections.Input;
 
 namespace osu.Desktop
@@ -155,6 +157,9 @@ namespace osu.Desktop
 
                 case JoystickHandler jh:
                     return new JoystickSettings(jh);
+
+                case TouchHandler th:
+                    return new InputSection.HandlerSection(th);
 
                 default:
                     return base.CreateSettingsSubsectionFor(handler);


### PR DESCRIPTION
Partially resolves https://github.com/ppy/osu/issues/19150 (hopefully) -- touch handling can now be disabled.

Though I'm not sure if this is something we want, as touch may be the only input option for some users. Disabling it will basically make the game unusable.

(This only affects desktop platforms, touch will always be enabled on mobile platforms.)