### PR TITLE
Change retry button icon from ArrowCircleLeft to Redo

### DIFF
--- a/osu.Game/Screens/Ranking/RetryButton.cs
+++ b/osu.Game/Screens/Ranking/RetryButton.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Ranking
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Size = new Vector2(13),
-                    Icon = FontAwesome.Solid.ArrowCircleLeft,
+                    Icon = FontAwesome.Solid.Redo,
                 },
             };
 


### PR DESCRIPTION
The current icon is a bit misleading to look at, and can be easily mistaken for a "go back" key. The redo icon is a much clearer representation of a retry button.

## ArrowCircleLeft (Current)
![image](https://user-images.githubusercontent.com/51536154/179375333-1dc6204b-964b-48f5-8890-0ff8f0ba98bc.png)

## Redo (New)
![image](https://user-images.githubusercontent.com/51536154/179375346-f4fbaeb9-5e0e-4cc6-8337-69bce6b85b50.png)
