### PR TITLE
Fix APIScore to use new Mods format in osu-web API

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIScore.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScore.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public int RulesetID { get; set; }
 
         [JsonProperty(@"mods")]
-        public IEnumerable<APIMod> Mods { get; set; }
+        public IEnumerable<APIMod> Mods { get; set; } = Array.Empty<APIMod>();
 
         [JsonProperty("rank")]
         [JsonConverter(typeof(StringEnumConverter))]

--- a/osu.Game/Online/API/Requests/Responses/APIScore.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScore.cs
@@ -71,6 +71,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public int RulesetID { get; set; }
 
         [JsonProperty(@"mods")]
+        [NotNull]
         public IEnumerable<APIMod> Mods { get; set; } = Array.Empty<APIMod>();
 
         [JsonProperty("rank")]

--- a/osu.Game/Online/API/Requests/Responses/APIScore.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScore.cs
@@ -71,10 +71,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public int RulesetID { get; set; }
 
         [JsonProperty(@"mods")]
-        private string[] mods { set => Mods = value.Select(acronym => new APIMod { Acronym = acronym }); }
-
-        [NotNull]
-        public IEnumerable<APIMod> Mods { get; set; } = Array.Empty<APIMod>();
+        public IEnumerable<APIMod> Mods { get; set; }
 
         [JsonProperty("rank")]
         [JsonConverter(typeof(StringEnumConverter))]


### PR DESCRIPTION
The latest osu-web changes (https://github.com/ppy/osu-web/commit/70c78bef7478b71a045dba7e3015d1c35e65aac7) meant that mods are now sent as an array of APIMod rather than an array of mod acronym strings. This meant that the "Ranks" section would not load as APIScore has not been updated to follow the new format.

Resolves https://github.com/ppy/osu/issues/19152.