### PR TITLE
Fix APIScore to use new json property name for Date

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIScore.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScore.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"replay")]
         public bool HasReplay { get; set; }
 
-        [JsonProperty(@"created_at")]
+        [JsonProperty(@"ended_at")]
         public DateTimeOffset Date { get; set; }
 
         [JsonProperty(@"beatmap")]


### PR DESCRIPTION
The latest osu-web changes (https://github.com/ppy/osu-web/commit/70c78bef7478b71a045dba7e3015d1c35e65aac7) meant that the date of a score is now sent as `ended_at` instead of `created_at`. This meant that the "Ranks" section would show all scores with the default DateTimeOffset.

Resolves https://github.com/ppy/osu/issues/19146.