### PR TITLE
Fix `SoloScoreInfo` not carrying mod settings in conversion methods

### DIFF
--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -65,7 +65,14 @@ namespace osu.Game.Online.API
                     if (!Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
                         continue;
 
-                    resultMod.CopyAdjustedSetting((IBindable)property.GetValue(resultMod), settingValue);
+                    try
+                    {
+                        resultMod.CopyAdjustedSetting((IBindable)property.GetValue(resultMod), settingValue);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Failed to copy mod setting value '{settingValue ?? "null"}' to \"{property.Name}\": {ex.Message}");
+                    }
                 }
             }
 

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
             var rulesetInstance = ruleset.CreateInstance();
 
-            var mods = Mods.Select(apiMod => rulesetInstance.CreateModFromAcronym(apiMod.Acronym)).Where(m => m != null).ToArray();
+            var mods = Mods.Select(apiMod => apiMod.ToMod(rulesetInstance)).ToArray();
 
             var scoreInfo = ToScoreInfo(mods);
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/19144

The fix was pretty simple, `SoloScoreInfo` was not using `APIMod.ToMod` which creates a `Mod` instance with the serialised settings applied to it.

However, upon testing the fix, I've came across a different issue which didn't become apparent until the fix was applied:

<img width="1230" alt="CleanShot 2022-07-17 at 06 15 39@2x" src="https://user-images.githubusercontent.com/22781491/179382404-8e48fb5c-e08b-4867-9487-540b4f39ee09.png">

<img width="312" alt="CleanShot 2022-07-17 at 06 22 47@2x" src="https://user-images.githubusercontent.com/22781491/179382421-f814283a-441e-4282-915d-619f8e85f544.png">

Turns out a score was submitted on build ID `6457` with a null value set to classic mod's `classic_note_lock` setting. The score ID is `39605466`, if wanted.

I've added a try-catch and log as we don't want the game taken down when more than one score has that failure. Not sure if the log will reach sentry however, we may want some method to log to sentry without interrupting the user.

```
[runtime] 2022-07-17 03:33:25 [verbose]: Failed to copy mod setting value 'null' to "ClassicNoteLock": Null object cannot be converted to a value type.
```