### PR TITLE
osu!taiko performance points balancing

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -35,13 +35,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
             countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
 
-            double multiplier = 1.1; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things
-
-            if (score.Mods.Any(m => m is ModNoFail))
-                multiplier *= 0.90;
+            double multiplier = 1.12; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things
 
             if (score.Mods.Any(m => m is ModHidden))
-                multiplier *= 1.10;
+                multiplier *= 1.075;
+
+            if (score.Mods.Any(m => m is ModEasy))
+                multiplier *= 0.975;
 
             double difficultyValue = computeDifficultyValue(score, taikoAttributes);
             double accuracyValue = computeAccuracyValue(score, taikoAttributes);
@@ -61,12 +61,15 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
         {
-            double difficultyValue = Math.Pow(5 * Math.Max(1.0, attributes.StarRating / 0.175) - 4.0, 2.25) / 450.0;
+            double difficultyValue = Math.Pow(5 * Math.Max(1.0, attributes.StarRating / 0.115) - 4.0, 2.25) / 1150.0;
 
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;
 
-            difficultyValue *= Math.Pow(0.985, countMiss);
+            difficultyValue *= Math.Pow(0.986, countMiss);
+
+            if (score.Mods.Any(m => m is ModEasy))
+                difficultyValue *= 0.980;
 
             if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= 1.025;
@@ -74,7 +77,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= 1.05 * lengthBonus;
 
-            return difficultyValue * score.Accuracy;
+            return difficultyValue * Math.Pow(score.Accuracy, 1.5);
         }
 
         private double computeAccuracyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
@@ -82,10 +85,16 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (attributes.GreatHitWindow <= 0)
                 return 0;
 
-            double accValue = Math.Pow(150.0 / attributes.GreatHitWindow, 1.1) * Math.Pow(score.Accuracy, 15) * 22.0;
+            double accuracyValue = Math.Pow(140.0 / attributes.GreatHitWindow, 1.1) * Math.Pow(score.Accuracy, 12.0) * 27;
 
-            // Bonus for many objects - it's harder to keep good accuracy up for longer
-            return accValue * Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
+            double lengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
+            accuracyValue *= lengthBonus;
+
+            // Slight HDFL Bonus for accuracy.
+            if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>) && score.Mods.Any(m => m is ModHidden))
+                accuracyValue *= 1.10 * lengthBonus;
+
+            return accuracyValue;
         }
 
         private int totalHits => countGreat + countOk + countMeh + countMiss;


### PR DESCRIPTION
Changes included are:

1. Nerf the Hidden global multiplier to increase the gap between EZHD and HD only scores.
2. Addition of an EZ global multiplier nerf, as well as a difficulty PP nerf.
3. Decrease the miss penalty, as combo scaling is not present in taiko.
4. Increase the weight Accuracy has on Difficulty PP.
5. Lower Accuracy and great hit window scaling, and split out length-bonus to allow for a new slight HDFL bonus to accuracy scaled by length.
6. Removal of the NF multiplier to prevent sandbagging against the <50% end-fail mechanic

---

SR/PP sheet of this PR + https://github.com/ppy/osu/pull/19184 vs current master: https://docs.google.com/spreadsheets/d/1n0izkeJpz7QnecG-tjzpzKA2Ld-BU8HMg8t1rZoeWgA/edit

As of 9e299bb88b3d1938fb25ef18ec29aa49396d45bd / 5532f56a30282b7a9f8b26dd80995ebfa0d2ba5a.
Build from https://github.com/smoogipoo/osu/commit/a8c29a4e4c6222383a7dfd4cad328b7c6f0843b1