### PR TITLE
Fix spectator client not correctly reconnecting after shutdown

### DIFF
--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Online.Multiplayer
 
             try
             {
+                // Importantly, use Invoke rather than Send to capture exceptions.
                 return await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty);
             }
             catch (HubException exception)

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -80,7 +80,6 @@ namespace osu.Game.Online.Multiplayer
 
             try
             {
-                // Importantly, use Invoke rather than Send to capture exceptions.
                 return await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty);
             }
             catch (HubException exception)

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -56,7 +56,8 @@ namespace osu.Game.Online.Spectator
 
             try
             {
-                await connection.SendAsync(nameof(ISpectatorServer.BeginPlaySession), state);
+                // Importantly, use Invoke rather than Send to capture exceptions.
+                await connection.InvokeAsync(nameof(ISpectatorServer.BeginPlaySession), state);
             }
             catch (HubException exception)
             {

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -56,7 +56,6 @@ namespace osu.Game.Online.Spectator
 
             try
             {
-                // Importantly, use Invoke rather than Send to capture exceptions.
                 await connection.InvokeAsync(nameof(ISpectatorServer.BeginPlaySession), state);
             }
             catch (HubException exception)
@@ -74,7 +73,7 @@ namespace osu.Game.Online.Spectator
 
             Debug.Assert(connection != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.SendFrameData), bundle);
+            return connection.InvokeAsync(nameof(ISpectatorServer.SendFrameData), bundle);
         }
 
         protected override Task EndPlayingInternal(SpectatorState state)
@@ -84,7 +83,7 @@ namespace osu.Game.Online.Spectator
 
             Debug.Assert(connection != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.EndPlaySession), state);
+            return connection.InvokeAsync(nameof(ISpectatorServer.EndPlaySession), state);
         }
 
         protected override Task WatchUserInternal(int userId)
@@ -94,7 +93,7 @@ namespace osu.Game.Online.Spectator
 
             Debug.Assert(connection != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.StartWatchingUser), userId);
+            return connection.InvokeAsync(nameof(ISpectatorServer.StartWatchingUser), userId);
         }
 
         protected override Task StopWatchingUserInternal(int userId)
@@ -104,7 +103,7 @@ namespace osu.Game.Online.Spectator
 
             Debug.Assert(connection != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.EndWatchingUser), userId);
+            return connection.InvokeAsync(nameof(ISpectatorServer.EndWatchingUser), userId);
         }
     }
 }


### PR DESCRIPTION
When switching servers over, I've notice a disparity in connections switching to the new spectator server (via datadog metrics). Users' clients would be stuck on the old spectator hub but also unable to make new spectator sessions.

Turns out this is due to incorrect use of `SendAsync` instead of `InvokeAsync`. The former does not block, nor propagate exceptions.

I'm not sure about the remaining `SendAsync` usage in `SpectatorHub`. We may want to switch them over as well.

I've tested this manually to work as expected.