### PR TITLE
Fix creating multiplayer game during server migration not joining new room correctly

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -64,26 +64,26 @@ namespace osu.Game.Online
             this.preferMessagePack = preferMessagePack;
 
             apiState.BindTo(api.State);
-            apiState.BindValueChanged(_ => connectIfPossible(), true);
+            apiState.BindValueChanged(_ => Task.Run(connectIfPossible), true);
         }
 
-        public void Reconnect()
+        public Task Reconnect()
         {
             Logger.Log($"{clientName} reconnecting...", LoggingTarget.Network);
-            Task.Run(connectIfPossible);
+            return Task.Run(connectIfPossible);
         }
 
-        private void connectIfPossible()
+        private async Task connectIfPossible()
         {
             switch (apiState.Value)
             {
                 case APIState.Failing:
                 case APIState.Offline:
-                    Task.Run(() => disconnect(true));
+                    await disconnect(true);
                     break;
 
                 case APIState.Online:
-                    Task.Run(connect);
+                    await connect();
                     break;
             }
         }

--- a/osu.Game/Online/IHubClientConnector.cs
+++ b/osu.Game/Online/IHubClientConnector.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Bindables;
 using osu.Game.Online.API;
@@ -32,6 +33,6 @@ namespace osu.Game.Online
         /// <summary>
         /// Reconnect if already connected.
         /// </summary>
-        void Reconnect();
+        Task Reconnect();
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -21,7 +21,6 @@ using osu.Game.Online.Rooms.RoomStatuses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
-using APIUser = osu.Game.Online.API.Requests.Responses.APIUser;
 
 namespace osu.Game.Online.Multiplayer
 {
@@ -91,7 +90,7 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// The joined <see cref="MultiplayerRoom"/>.
         /// </summary>
-        public virtual MultiplayerRoom? Room
+        public virtual MultiplayerRoom? Room // virtual for moq
         {
             get
             {
@@ -150,7 +149,7 @@ namespace osu.Game.Online.Multiplayer
                 // clean up local room state on server disconnect.
                 if (!connected.NewValue && Room != null)
                 {
-                    Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
+                    Logger.Log("Clearing room due to multiplayer server connection loss.", LoggingTarget.Runtime, LogLevel.Important);
                     LeaveRoom();
                 }
             }));

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Online.Multiplayer
 
             try
             {
+                // Importantly, use Invoke rather than Send to capture exceptions.
                 return await connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoomWithPassword), roomId, password ?? string.Empty);
             }
             catch (HubException exception)

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -86,7 +86,13 @@ namespace osu.Game.Online.Multiplayer
             catch (HubException exception)
             {
                 if (exception.GetHubExceptionMessage() == HubClientConnector.SERVER_SHUTDOWN_MESSAGE)
-                    connector?.Reconnect();
+                {
+                    Debug.Assert(connector != null);
+
+                    await connector.Reconnect();
+                    return await JoinRoom(roomId, password);
+                }
+
                 throw;
             }
         }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -56,7 +56,8 @@ namespace osu.Game.Online.Spectator
 
             try
             {
-                await connection.SendAsync(nameof(ISpectatorServer.BeginPlaySession), state);
+                // Importantly, use Invoke rather than Send to capture exceptions.
+                await connection.InvokeAsync(nameof(ISpectatorServer.BeginPlaySession), state);
             }
             catch (HubException exception)
             {

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -62,7 +62,14 @@ namespace osu.Game.Online.Spectator
             catch (HubException exception)
             {
                 if (exception.GetHubExceptionMessage() == HubClientConnector.SERVER_SHUTDOWN_MESSAGE)
-                    connector?.Reconnect();
+                {
+                    Debug.Assert(connector != null);
+
+                    await connector.Reconnect();
+                    await BeginPlayingInternal(state);
+                    return;
+                }
+
                 throw;
             }
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -70,12 +70,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             client.LoadRequested += onLoadRequested;
             client.RoomUpdated += onRoomUpdated;
 
-            isConnected.BindTo(client.IsConnected);
-            isConnected.BindValueChanged(connected =>
-            {
-                if (!connected.NewValue)
-                    handleRoomLost();
-            }, true);
+            if (!client.IsConnected.Value)
+                handleRoomLost();
         }
 
         protected override Drawable CreateMainContent() => new Container


### PR DESCRIPTION
Scenario: server is shutting down, bottom-right client is holding previous server open (last usage), top-right is creating a new room while connected to the old server (should get exception, reconnect, and join room on new server).

Before:

https://user-images.githubusercontent.com/191335/179398570-4d1741e9-f50d-400f-8824-92f8d4bbd9bb.mp4

Note that a manual join is required (to own game) after creating the match.

After:

https://user-images.githubusercontent.com/191335/179398381-a76e5805-e43c-4663-8fd3-da7d554a7a48.mp4


I knew this was broken when implementing, but was left to keep things simple. Turns out making it works isn't too hard.

- [x] Depends on https://github.com/ppy/osu/pull/19187