### PR TITLE
Fix "Perfect" mod not marking "Autopilot" as incompatible

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModPerfect.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModPerfect.cs
@@ -3,11 +3,14 @@
 
 #nullable disable
 
+using System;
+using System.Linq;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModPerfect : ModPerfect
     {
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new Type[] { typeof(OsuModAutopilot) }).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModPerfect.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModPerfect.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModPerfect : ModPerfect
     {
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new Type[] { typeof(OsuModAutopilot) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot) }).ToArray();
     }
 }


### PR DESCRIPTION
Autopilot already has Perfect listed as an incompatible mod, but Perfect did not have the same for Autopilot.

Resolves https://github.com/ppy/osu/issues/19199.