### PR TITLE
Make sure stats name are title-cased when score panel is contracted

### DIFF
--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -214,7 +215,7 @@ namespace osu.Game.Screens.Ranking.Contracted
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    Text = key,
+                    Text = key.ToTitle(),
                     Font = OsuFont.GetFont(size: 12, weight: FontWeight.SemiBold)
                 },
                 new OsuSpriteText


### PR DESCRIPTION
Let's ensure that all stats are cased properly. This way even when statistic names are using wrong casing in the rulesets it will come out looking not out of place at least.

Fixes #19155.