### PR TITLE
Fix audio/background equality not correctly using `BeatmapInfo` local filenames

### DIFF
--- a/osu.Game.Tests/NonVisual/BeatmapSetInfoEqualityTest.cs
+++ b/osu.Game.Tests/NonVisual/BeatmapSetInfoEqualityTest.cs
@@ -62,9 +62,45 @@ namespace osu.Game.Tests.NonVisual
             Assert.IsTrue(beatmapSetA.Beatmaps.Single().AudioEquals(beatmapSetB.Beatmaps.Single()));
         }
 
-        private static void addAudioFile(BeatmapSetInfo beatmapSetInfo, string hash = null)
+        [Test]
+        public void TestAudioEqualityBeatmapInfoSameHash()
         {
-            beatmapSetInfo.Files.Add(new RealmNamedFileUsage(new RealmFile { Hash = hash ?? Guid.NewGuid().ToString() }, "audio.mp3"));
+            var beatmapSet = TestResources.CreateTestBeatmapSetInfo(2);
+
+            addAudioFile(beatmapSet);
+
+            var beatmap1 = beatmapSet.Beatmaps.First();
+            var beatmap2 = beatmapSet.Beatmaps.Last();
+
+            Assert.AreNotEqual(beatmap1, beatmap2);
+            Assert.IsTrue(beatmap1.AudioEquals(beatmap2));
+        }
+
+        [Test]
+        public void TestAudioEqualityBeatmapInfoDifferentHash()
+        {
+            var beatmapSet = TestResources.CreateTestBeatmapSetInfo(2);
+
+            const string filename1 = "audio1.mp3";
+            const string filename2 = "audio2.mp3";
+
+            addAudioFile(beatmapSet, filename: filename1);
+            addAudioFile(beatmapSet, filename: filename2);
+
+            var beatmap1 = beatmapSet.Beatmaps.First();
+            var beatmap2 = beatmapSet.Beatmaps.Last();
+
+            Assert.AreNotEqual(beatmap1, beatmap2);
+
+            beatmap1.Metadata.AudioFile = filename1;
+            beatmap2.Metadata.AudioFile = filename2;
+
+            Assert.IsFalse(beatmap1.AudioEquals(beatmap2));
+        }
+
+        private static void addAudioFile(BeatmapSetInfo beatmapSetInfo, string hash = null, string filename = null)
+        {
+            beatmapSetInfo.Files.Add(new RealmNamedFileUsage(new RealmFile { Hash = hash ?? Guid.NewGuid().ToString() }, filename ?? "audio.mp3"));
         }
 
         [Test]

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Tests.Resources
                         BPM = bpm,
                         Hash = Guid.NewGuid().ToString().ComputeMD5Hash(),
                         Ruleset = rulesetInfo,
-                        Metadata = metadata,
+                        Metadata = metadata.DeepClone(),
                         Difficulty = new BeatmapDifficulty
                         {
                             OverallDifficulty = diff,

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -169,8 +169,8 @@ namespace osu.Game.Beatmaps
             Debug.Assert(x.BeatmapSet != null);
             Debug.Assert(y.BeatmapSet != null);
 
-            string? fileHashX = x.BeatmapSet.Files.FirstOrDefault(f => f.Filename == getFilename(x.BeatmapSet.Metadata))?.File.Hash;
-            string? fileHashY = y.BeatmapSet.Files.FirstOrDefault(f => f.Filename == getFilename(y.BeatmapSet.Metadata))?.File.Hash;
+            string? fileHashX = x.BeatmapSet.Files.FirstOrDefault(f => f.Filename == getFilename(x.Metadata))?.File.Hash;
+            string? fileHashY = y.BeatmapSet.Files.FirstOrDefault(f => f.Filename == getFilename(y.Metadata))?.File.Hash;
 
             return fileHashX == fileHashY;
         }


### PR DESCRIPTION
Big oops easy fix. Closes https://github.com/ppy/osu/issues/19161.