### PR TITLE
Fix pause/fail overlay showing buttons as hovered with settings overlay open

### DIFF
--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -255,7 +255,9 @@ namespace osu.Game.Screens.Play
 
             protected override bool OnMouseMove(MouseMoveEvent e)
             {
-                State = SelectionState.Selected;
+                if (IsHovered)
+                    State = SelectionState.Selected;
+
                 return base.OnMouseMove(e);
             }
         }

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -255,8 +255,13 @@ namespace osu.Game.Screens.Play
 
             protected override bool OnMouseMove(MouseMoveEvent e)
             {
-                if (IsHovered)
-                    State = SelectionState.Selected;
+                // hover state updates after mouse move propagation, therefore we have to schedule to ensure this invokes afterwards.
+                // see: https://github.com/ppy/osu-framework/issues/3153
+                Schedule(() =>
+                {
+                    if (IsHovered)
+                        State = SelectionState.Selected;
+                });
 
                 return base.OnMouseMove(e);
             }


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/19213

Simple one, settings overlay takes hover away but `GameplayMenuOverlay` sets buttons to hovered state only if the mouse reaches them. Ensuring the button is hovered before selecting fixes the issue.