### PR TITLE
Replace culture-sensitive humanizer methods with fixed local reimplementations

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -19,3 +19,7 @@ P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetResult
 M:System.Threading.ManualResetEventSlim.Wait();Specify a timeout to avoid waiting forever.
 M:System.String.ToLower();string.ToLower() changes behaviour depending on CultureInfo.CurrentCulture. Use string.ToLowerInvariant() instead. If wanting culture-sensitive behaviour, explicitly provide CultureInfo.CurrentCulture or use LocalisableString.
 M:System.String.ToUpper();string.ToUpper() changes behaviour depending on CultureInfo.CurrentCulture. Use string.ToUpperInvariant() instead. If wanting culture-sensitive behaviour, explicitly provide CultureInfo.CurrentCulture or use LocalisableString.
+M:Humanizer.InflectorExtensions.Pascalize(System.String);Humanizer's .Pascalize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToPascalCase() instead.
+M:Humanizer.InflectorExtensions.Camelize(System.String);Humanizer's .Camelize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToCamelCase() instead.
+M:Humanizer.InflectorExtensions.Underscore(System.String);Humanizer's .Underscore() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToSnakeCase() instead.
+M:Humanizer.InflectorExtensions.Kebaberize(System.String);Humanizer's .Kebaberize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToKebabCase() instead.

--- a/osu.Game.Tests/Extensions/StringDehumanizeExtensionsTest.cs
+++ b/osu.Game.Tests/Extensions/StringDehumanizeExtensionsTest.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Extensions;
+
+namespace osu.Game.Tests.Extensions
+{
+    [TestFixture]
+    public class StringDehumanizeExtensionsTest
+    {
+        [Test]
+        [TestCase("single", "Single")]
+        [TestCase("example word", "ExampleWord")]
+        [TestCase("mixed Casing test", "MixedCasingTest")]
+        [TestCase("PascalCase", "PascalCase")]
+        [TestCase("camelCase", "CamelCase")]
+        [TestCase("snake_case", "SnakeCase")]
+        [TestCase("kebab-case", "KebabCase")]
+        [TestCase("i will not break in a different culture", "IWillNotBreakInADifferentCulture", "tr-TR")]
+        public void TestToPascalCase(string input, string expectedOutput, string? culture = null)
+        {
+            using (temporaryCurrentCulture(culture))
+                Assert.That(input.ToPascalCase(), Is.EqualTo(expectedOutput));
+        }
+
+        [Test]
+        [TestCase("single", "single")]
+        [TestCase("example word", "exampleWord")]
+        [TestCase("mixed Casing test", "mixedCasingTest")]
+        [TestCase("PascalCase", "pascalCase")]
+        [TestCase("camelCase", "camelCase")]
+        [TestCase("snake_case", "snakeCase")]
+        [TestCase("kebab-case", "kebabCase")]
+        [TestCase("I will not break in a different culture", "iWillNotBreakInADifferentCulture", "tr-TR")]
+        public void TestToCamelCase(string input, string expectedOutput, string? culture = null)
+        {
+            using (temporaryCurrentCulture(culture))
+                Assert.That(input.ToCamelCase(), Is.EqualTo(expectedOutput));
+        }
+
+        [Test]
+        [TestCase("single", "single")]
+        [TestCase("example word", "example_word")]
+        [TestCase("mixed Casing test", "mixed_casing_test")]
+        [TestCase("PascalCase", "pascal_case")]
+        [TestCase("camelCase", "camel_case")]
+        [TestCase("snake_case", "snake_case")]
+        [TestCase("kebab-case", "kebab_case")]
+        [TestCase("I will not break in a different culture", "i_will_not_break_in_a_different_culture", "tr-TR")]
+        public void TestToSnakeCase(string input, string expectedOutput, string? culture = null)
+        {
+            using (temporaryCurrentCulture(culture))
+                Assert.That(input.ToSnakeCase(), Is.EqualTo(expectedOutput));
+        }
+
+        [Test]
+        [TestCase("single", "single")]
+        [TestCase("example word", "example-word")]
+        [TestCase("mixed Casing test", "mixed-casing-test")]
+        [TestCase("PascalCase", "pascal-case")]
+        [TestCase("camelCase", "camel-case")]
+        [TestCase("snake_case", "snake-case")]
+        [TestCase("kebab-case", "kebab-case")]
+        [TestCase("I will not break in a different culture", "i-will-not-break-in-a-different-culture", "tr-TR")]
+        public void TestToKebabCase(string input, string expectedOutput, string? culture = null)
+        {
+            using (temporaryCurrentCulture(culture))
+                Assert.That(input.ToKebabCase(), Is.EqualTo(expectedOutput));
+        }
+
+        private IDisposable temporaryCurrentCulture(string? cultureName)
+        {
+            var storedCulture = CultureInfo.CurrentCulture;
+
+            if (cultureName != null)
+                CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+
+            return new InvokeOnDisposal(() => CultureInfo.CurrentCulture = storedCulture);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -4,13 +4,13 @@
 #nullable disable
 
 using System.Linq;
-using Humanizer;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             };
 
             control.Query.BindValueChanged(q => query.Text = $"Query: {q.NewValue}", true);
-            control.General.BindCollectionChanged((_, _) => general.Text = $"General: {(control.General.Any() ? string.Join('.', control.General.Select(i => i.ToString().Underscore())) : "")}", true);
+            control.General.BindCollectionChanged((_, _) => general.Text = $"General: {(control.General.Any() ? string.Join('.', control.General.Select(i => i.ToString().ToSnakeCase())) : "")}", true);
             control.Ruleset.BindValueChanged(r => ruleset.Text = $"Ruleset: {r.NewValue}", true);
             control.Category.BindValueChanged(c => category.Text = $"Category: {c.NewValue}", true);
             control.Genre.BindValueChanged(g => genre.Text = $"Genre: {g.NewValue}", true);

--- a/osu.Game/Beatmaps/BeatmapStatisticIcon.cs
+++ b/osu.Game/Beatmaps/BeatmapStatisticIcon.cs
@@ -3,10 +3,10 @@
 
 #nullable disable
 
-using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Game.Extensions;
 
 namespace osu.Game.Beatmaps
 {
@@ -25,7 +25,7 @@ namespace osu.Game.Beatmaps
         [BackgroundDependencyLoader]
         private void load(TextureStore textures)
         {
-            Texture = textures.Get($"Icons/BeatmapDetails/{iconType.ToString().Kebaberize()}");
+            Texture = textures.Get($"Icons/BeatmapDetails/{iconType.ToString().ToKebabCase()}");
         }
     }
 

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Humanizer;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -67,7 +66,7 @@ namespace osu.Game.Extensions
 
                 foreach (var (_, property) in component.GetSettingsSourceProperties())
                 {
-                    if (!info.Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
+                    if (!info.Settings.TryGetValue(property.Name.ToSnakeCase(), out object settingValue))
                         continue;
 
                     skinnable.CopyAdjustedSetting((IBindable)property.GetValue(component), settingValue);

--- a/osu.Game/Extensions/StringDehumanizeExtensions.cs
+++ b/osu.Game/Extensions/StringDehumanizeExtensions.cs
@@ -1,0 +1,94 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Based on code from the Humanizer library (https://github.com/Humanizr/Humanizer/blob/606e958cb83afc9be5b36716ac40d4daa9fa73a7/src/Humanizer/InflectorExtensions.cs)
+//
+// Humanizer is licenced under the MIT License (MIT)
+//
+// Copyright (c) .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Text.RegularExpressions;
+
+namespace osu.Game.Extensions
+{
+    /// <summary>
+    /// Class with extension methods used to turn human-readable strings to casing conventions frequently used in code.
+    /// Often used for communicating with other systems (web API, spectator server).
+    /// All of the operations in this class are intentionally culture-invariant.
+    /// </summary>
+    public static class StringDehumanizeExtensions
+    {
+        /// <summary>
+        /// Converts the string to "Pascal case" (also known as "upper camel case").
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// "this is a test string".ToPascalCase() == "ThisIsATestString"
+        /// </code>
+        /// </example>
+        public static string ToPascalCase(this string input)
+        {
+            return Regex.Replace(input, "(?:^|_|-| +)(.)", match => match.Groups[1].Value.ToUpperInvariant());
+        }
+
+        /// <summary>
+        /// Converts the string to (lower) "camel case".
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// "this is a test string".ToCamelCase() == "thisIsATestString"
+        /// </code>
+        /// </example>
+        public static string ToCamelCase(this string input)
+        {
+            string word = input.ToPascalCase();
+            return word.Length > 0 ? word.Substring(0, 1).ToLowerInvariant() + word.Substring(1) : word;
+        }
+
+        /// <summary>
+        /// Converts the string to "snake case".
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// "this is a test string".ToSnakeCase() == "this_is_a_test_string"
+        /// </code>
+        /// </example>
+        public static string ToSnakeCase(this string input)
+        {
+            return Regex.Replace(
+                Regex.Replace(
+                    Regex.Replace(input, @"([\p{Lu}]+)([\p{Lu}][\p{Ll}])", "$1_$2"), @"([\p{Ll}\d])([\p{Lu}])", "$1_$2"), @"[-\s]", "_").ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Converts the string to "kebab case".
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// "this is a test string".ToKebabCase() == "this-is-a-test-string"
+        /// </code>
+        /// </example>
+        public static string ToKebabCase(this string input)
+        {
+            return ToSnakeCase(input).Replace('_', '-');
+        }
+    }
+}

--- a/osu.Game/IO/Serialization/SnakeCaseKeyContractResolver.cs
+++ b/osu.Game/IO/Serialization/SnakeCaseKeyContractResolver.cs
@@ -3,8 +3,8 @@
 
 #nullable disable
 
-using Humanizer;
 using Newtonsoft.Json.Serialization;
+using osu.Game.Extensions;
 
 namespace osu.Game.IO.Serialization
 {
@@ -12,7 +12,7 @@ namespace osu.Game.IO.Serialization
     {
         protected override string ResolvePropertyName(string propertyName)
         {
-            return propertyName.Underscore();
+            return propertyName.ToSnakeCase();
         }
     }
 }

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -7,12 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Humanizer;
 using MessagePack;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 
@@ -45,7 +45,7 @@ namespace osu.Game.Online.API
                 var bindable = (IBindable)property.GetValue(mod);
 
                 if (!bindable.IsDefault)
-                    Settings.Add(property.Name.Underscore(), bindable.GetUnderlyingSettingValue());
+                    Settings.Add(property.Name.ToSnakeCase(), bindable.GetUnderlyingSettingValue());
             }
         }
 
@@ -63,7 +63,7 @@ namespace osu.Game.Online.API
             {
                 foreach (var (_, property) in resultMod.GetSettingsSourceProperties())
                 {
-                    if (!Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
+                    if (!Settings.TryGetValue(property.Name.ToSnakeCase(), out object settingValue))
                         continue;
 
                     try

--- a/osu.Game/Online/API/Requests/GetCommentsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetCommentsRequest.cs
@@ -4,7 +4,7 @@
 #nullable disable
 
 using osu.Framework.IO.Network;
-using Humanizer;
+using osu.Game.Extensions;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Comments;
 
@@ -32,7 +32,7 @@ namespace osu.Game.Online.API.Requests
             var req = base.CreateWebRequest();
 
             req.AddParameter("commentable_id", commentableId.ToString());
-            req.AddParameter("commentable_type", type.ToString().Underscore().ToLowerInvariant());
+            req.AddParameter("commentable_type", type.ToString().ToSnakeCase().ToLowerInvariant());
             req.AddParameter("page", page.ToString());
             req.AddParameter("sort", sort.ToString().ToLowerInvariant());
 

--- a/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserBeatmapsRequest.cs
@@ -3,8 +3,8 @@
 
 #nullable disable
 
-using Humanizer;
 using System.Collections.Generic;
+using osu.Game.Extensions;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Online.API.Requests
@@ -22,7 +22,7 @@ namespace osu.Game.Online.API.Requests
             this.type = type;
         }
 
-        protected override string Target => $@"users/{userId}/beatmapsets/{type.ToString().Underscore()}";
+        protected override string Target => $@"users/{userId}/beatmapsets/{type.ToString().ToSnakeCase()}";
     }
 
     public enum BeatmapSetType

--- a/osu.Game/Online/API/Requests/Responses/APIRecentActivity.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIRecentActivity.cs
@@ -4,8 +4,8 @@
 #nullable disable
 
 using System;
-using Humanizer;
 using Newtonsoft.Json;
+using osu.Game.Extensions;
 using osu.Game.Scoring;
 
 namespace osu.Game.Online.API.Requests.Responses
@@ -21,7 +21,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty]
         private string type
         {
-            set => Type = (RecentActivityType)Enum.Parse(typeof(RecentActivityType), value.Pascalize());
+            set => Type = (RecentActivityType)Enum.Parse(typeof(RecentActivityType), value.ToPascalCase());
         }
 
         public RecentActivityType Type;

--- a/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
+++ b/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.IO.Network;
 using osu.Game.Extensions;
@@ -86,7 +85,7 @@ namespace osu.Game.Online.API.Requests
                 req.AddParameter("q", query);
 
             if (General != null && General.Any())
-                req.AddParameter("c", string.Join('.', General.Select(e => e.ToString().Underscore())));
+                req.AddParameter("c", string.Join('.', General.Select(e => e.ToString().ToSnakeCase())));
 
             if (ruleset.OnlineID >= 0)
                 req.AddParameter("m", ruleset.OnlineID.ToString());

--- a/osu.Game/Online/Rooms/GetRoomsRequest.cs
+++ b/osu.Game/Online/Rooms/GetRoomsRequest.cs
@@ -4,8 +4,8 @@
 #nullable disable
 
 using System.Collections.Generic;
-using Humanizer;
 using osu.Framework.IO.Network;
+using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 
@@ -27,7 +27,7 @@ namespace osu.Game.Online.Rooms
             var req = base.CreateWebRequest();
 
             if (status != RoomStatusFilter.Open)
-                req.AddParameter("mode", status.ToString().Underscore().ToLowerInvariant());
+                req.AddParameter("mode", status.ToString().ToSnakeCase().ToLowerInvariant());
 
             if (!string.IsNullOrEmpty(category))
                 req.AddParameter("category", category);

--- a/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -71,7 +70,7 @@ namespace osu.Game.Screens.Play.HUD
                 var bindable = (IBindable)property.GetValue(component);
 
                 if (!bindable.IsDefault)
-                    Settings.Add(property.Name.Underscore(), bindable.GetUnderlyingSettingValue());
+                    Settings.Add(property.Name.ToSnakeCase(), bindable.GetUnderlyingSettingValue());
             }
 
             if (component is Container<Drawable> container)


### PR DESCRIPTION
Closes #18729.

Upstream has been silent for about a month now, so I think the hopes of fixing there are low. Therefore this pull introduces local copies of humanizer's `.Pascalize()`, `.Camelize()`, `.Underscore()` and `.Kebaberize()`, but ones that do not have the flaw of being culture-variant, and bans the usage of the faulty originals. This fixes weird interchange-related issues that occur only in some cultures (like the one in the issue above) and hopefully prevents these sorts of bugs in the future.

To abide by humanizer's license terms the modified copies come with attribution of the original (via a mention and link to source) and a copy of the original MIT licence notice.