### PR TITLE
Reduce `Bindable` allocations in hitobject classes via lazy initialisation

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkHitObject.cs
+++ b/osu.Game.Benchmarks/BenchmarkHitObject.cs
@@ -1,0 +1,116 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkHitObject : BenchmarkTest
+    {
+        [Params(1, 100, 1000)]
+        public int Count { get; set; }
+
+        [Params(false, true)]
+        public bool WithBindableAccess { get; set; }
+
+        [Benchmark]
+        public HitCircle[] OsuCircle()
+        {
+            var circles = new HitCircle[Count];
+
+            for (int i = 0; i < Count; i++)
+            {
+                circles[i] = new HitCircle();
+
+                if (WithBindableAccess)
+                {
+                    _ = circles[i].PositionBindable;
+                    _ = circles[i].ScaleBindable;
+                    _ = circles[i].ComboIndexBindable;
+                    _ = circles[i].ComboOffsetBindable;
+                    _ = circles[i].StackHeightBindable;
+                    _ = circles[i].LastInComboBindable;
+                    _ = circles[i].ComboIndexWithOffsetsBindable;
+                    _ = circles[i].IndexInCurrentComboBindable;
+                    _ = circles[i].SamplesBindable;
+                    _ = circles[i].StartTimeBindable;
+                }
+            }
+
+            return circles;
+        }
+
+        [Benchmark]
+        public Hit[] TaikoHit()
+        {
+            var hits = new Hit[Count];
+
+            for (int i = 0; i < Count; i++)
+            {
+                hits[i] = new Hit();
+
+                if (WithBindableAccess)
+                {
+                    _ = hits[i].TypeBindable;
+                    _ = hits[i].IsStrongBindable;
+                    _ = hits[i].SamplesBindable;
+                    _ = hits[i].StartTimeBindable;
+                }
+            }
+
+            return hits;
+        }
+
+        [Benchmark]
+        public Fruit[] CatchFruit()
+        {
+            var fruit = new Fruit[Count];
+
+            for (int i = 0; i < Count; i++)
+            {
+                fruit[i] = new Fruit();
+
+                if (WithBindableAccess)
+                {
+                    _ = fruit[i].OriginalXBindable;
+                    _ = fruit[i].XOffsetBindable;
+                    _ = fruit[i].ScaleBindable;
+                    _ = fruit[i].ComboIndexBindable;
+                    _ = fruit[i].HyperDashBindable;
+                    _ = fruit[i].LastInComboBindable;
+                    _ = fruit[i].ComboIndexWithOffsetsBindable;
+                    _ = fruit[i].IndexInCurrentComboBindable;
+                    _ = fruit[i].IndexInBeatmapBindable;
+                    _ = fruit[i].SamplesBindable;
+                    _ = fruit[i].StartTimeBindable;
+                }
+            }
+
+            return fruit;
+        }
+
+        [Benchmark]
+        public Note[] ManiaNote()
+        {
+            var notes = new Note[Count];
+
+            for (int i = 0; i < Count; i++)
+            {
+                notes[i] = new Note();
+
+                if (WithBindableAccess)
+                {
+                    _ = notes[i].ColumnBindable;
+                    _ = notes[i].SamplesBindable;
+                    _ = notes[i].StartTimeBindable;
+                }
+            }
+
+            return notes;
+        }
+    }
+}

--- a/osu.Game.Benchmarks/BenchmarkHitObject.cs
+++ b/osu.Game.Benchmarks/BenchmarkHitObject.cs
@@ -39,6 +39,29 @@ namespace osu.Game.Benchmarks
                     _ = circles[i].SamplesBindable;
                     _ = circles[i].StartTimeBindable;
                 }
+                else
+                {
+                    _ = circles[i].Position;
+                    _ = circles[i].Scale;
+                    _ = circles[i].ComboIndex;
+                    _ = circles[i].ComboOffset;
+                    _ = circles[i].StackHeight;
+                    _ = circles[i].LastInCombo;
+                    _ = circles[i].ComboIndexWithOffsets;
+                    _ = circles[i].IndexInCurrentCombo;
+                    _ = circles[i].Samples;
+                    _ = circles[i].StartTime;
+                    _ = circles[i].Position;
+                    _ = circles[i].Scale;
+                    _ = circles[i].ComboIndex;
+                    _ = circles[i].ComboOffset;
+                    _ = circles[i].StackHeight;
+                    _ = circles[i].LastInCombo;
+                    _ = circles[i].ComboIndexWithOffsets;
+                    _ = circles[i].IndexInCurrentCombo;
+                    _ = circles[i].Samples;
+                    _ = circles[i].StartTime;
+                }
             }
 
             return circles;
@@ -59,6 +82,13 @@ namespace osu.Game.Benchmarks
                     _ = hits[i].IsStrongBindable;
                     _ = hits[i].SamplesBindable;
                     _ = hits[i].StartTimeBindable;
+                }
+                else
+                {
+                    _ = hits[i].Type;
+                    _ = hits[i].IsStrong;
+                    _ = hits[i].Samples;
+                    _ = hits[i].StartTime;
                 }
             }
 
@@ -88,6 +118,20 @@ namespace osu.Game.Benchmarks
                     _ = fruit[i].SamplesBindable;
                     _ = fruit[i].StartTimeBindable;
                 }
+                else
+                {
+                    _ = fruit[i].OriginalX;
+                    _ = fruit[i].XOffset;
+                    _ = fruit[i].Scale;
+                    _ = fruit[i].ComboIndex;
+                    _ = fruit[i].HyperDash;
+                    _ = fruit[i].LastInCombo;
+                    _ = fruit[i].ComboIndexWithOffsets;
+                    _ = fruit[i].IndexInCurrentCombo;
+                    _ = fruit[i].IndexInBeatmap;
+                    _ = fruit[i].Samples;
+                    _ = fruit[i].StartTime;
+                }
             }
 
             return fruit;
@@ -107,6 +151,12 @@ namespace osu.Game.Benchmarks
                     _ = notes[i].ColumnBindable;
                     _ = notes[i].SamplesBindable;
                     _ = notes[i].StartTimeBindable;
+                }
+                else
+                {
+                    _ = notes[i].Column;
+                    _ = notes[i].Samples;
+                    _ = notes[i].StartTime;
                 }
             }
 

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             set => lastInCombo.Value = value;
         }
 
-        private HitObjectProperty<float> scale;
+        private HitObjectProperty<float> scale = new HitObjectProperty<float>(1);
 
         public Bindable<float> ScaleBindable => scale.Bindable;
 

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -19,7 +19,9 @@ namespace osu.Game.Rulesets.Catch.Objects
     {
         public const float OBJECT_RADIUS = 64;
 
-        public readonly Bindable<float> OriginalXBindable = new Bindable<float>();
+        private HitObjectProperty<float> originalX;
+
+        public Bindable<float> OriginalXBindable => originalX.Bindable;
 
         /// <summary>
         /// The horizontal position of the hit object between 0 and <see cref="CatchPlayfield.WIDTH"/>.
@@ -31,18 +33,20 @@ namespace osu.Game.Rulesets.Catch.Objects
         [JsonIgnore]
         public float X
         {
-            set => OriginalXBindable.Value = value;
+            set => originalX.Value = value;
         }
 
-        public readonly Bindable<float> XOffsetBindable = new Bindable<float>();
+        private HitObjectProperty<float> xOffset;
+
+        public Bindable<float> XOffsetBindable => xOffset.Bindable;
 
         /// <summary>
         /// A random offset applied to the horizontal position, set by the beatmap processing.
         /// </summary>
         public float XOffset
         {
-            get => XOffsetBindable.Value;
-            set => XOffsetBindable.Value = value;
+            get => xOffset.Value;
+            set => xOffset.Value = value;
         }
 
         /// <summary>
@@ -54,8 +58,8 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </remarks>
         public float OriginalX
         {
-            get => OriginalXBindable.Value;
-            set => OriginalXBindable.Value = value;
+            get => originalX.Value;
+            set => originalX.Value = value;
         }
 
         /// <summary>
@@ -69,59 +73,71 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         public double TimePreempt { get; set; } = 1000;
 
-        public readonly Bindable<int> IndexInBeatmapBindable = new Bindable<int>();
+        private HitObjectProperty<int> indexInBeatmap;
+
+        public Bindable<int> IndexInBeatmapBindable => indexInBeatmap.Bindable;
 
         public int IndexInBeatmap
         {
-            get => IndexInBeatmapBindable.Value;
-            set => IndexInBeatmapBindable.Value = value;
+            get => indexInBeatmap.Value;
+            set => indexInBeatmap.Value = value;
         }
 
         public virtual bool NewCombo { get; set; }
 
         public int ComboOffset { get; set; }
 
-        public Bindable<int> IndexInCurrentComboBindable { get; } = new Bindable<int>();
+        private HitObjectProperty<int> indexInCurrentCombo;
+
+        public Bindable<int> IndexInCurrentComboBindable => indexInCurrentCombo.Bindable;
 
         public int IndexInCurrentCombo
         {
-            get => IndexInCurrentComboBindable.Value;
-            set => IndexInCurrentComboBindable.Value = value;
+            get => indexInCurrentCombo.Value;
+            set => indexInCurrentCombo.Value = value;
         }
 
-        public Bindable<int> ComboIndexBindable { get; } = new Bindable<int>();
+        private HitObjectProperty<int> comboIndex;
+
+        public Bindable<int> ComboIndexBindable => comboIndex.Bindable;
 
         public int ComboIndex
         {
-            get => ComboIndexBindable.Value;
-            set => ComboIndexBindable.Value = value;
+            get => comboIndex.Value;
+            set => comboIndex.Value = value;
         }
 
-        public Bindable<int> ComboIndexWithOffsetsBindable { get; } = new Bindable<int>();
+        private HitObjectProperty<int> comboIndexWithOffsets;
+
+        public Bindable<int> ComboIndexWithOffsetsBindable => comboIndexWithOffsets.Bindable;
 
         public int ComboIndexWithOffsets
         {
-            get => ComboIndexWithOffsetsBindable.Value;
-            set => ComboIndexWithOffsetsBindable.Value = value;
+            get => comboIndexWithOffsets.Value;
+            set => comboIndexWithOffsets.Value = value;
         }
 
-        public Bindable<bool> LastInComboBindable { get; } = new Bindable<bool>();
+        private HitObjectProperty<bool> lastInCombo;
+
+        public Bindable<bool> LastInComboBindable => lastInCombo.Bindable;
 
         /// <summary>
         /// The next fruit starts a new combo. Used for explodey.
         /// </summary>
         public virtual bool LastInCombo
         {
-            get => LastInComboBindable.Value;
-            set => LastInComboBindable.Value = value;
+            get => lastInCombo.Value;
+            set => lastInCombo.Value = value;
         }
 
-        public readonly Bindable<float> ScaleBindable = new Bindable<float>(1);
+        private HitObjectProperty<float> scale;
+
+        public Bindable<float> ScaleBindable => scale.Bindable;
 
         public float Scale
         {
-            get => ScaleBindable.Value;
-            set => ScaleBindable.Value = value;
+            get => scale.Value;
+            set => scale.Value = value;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/Objects/PalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/PalpableCatchHitObject.cs
@@ -5,6 +5,7 @@
 
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
 using osuTK.Graphics;
@@ -24,12 +25,14 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </summary>
         public float DistanceToHyperDash { get; set; }
 
-        public readonly Bindable<bool> HyperDashBindable = new Bindable<bool>();
+        private HitObjectProperty<bool> hyperDash;
+
+        public Bindable<bool> HyperDashBindable => hyperDash.Bindable;
 
         /// <summary>
         /// Whether this fruit can initiate a hyperdash.
         /// </summary>
-        public bool HyperDash => HyperDashBindable.Value;
+        public bool HyperDash => hyperDash.Value;
 
         private CatchHitObject hyperDashTarget;
 

--- a/osu.Game.Rulesets.Mania/Objects/ManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/ManiaHitObject.cs
@@ -13,12 +13,14 @@ namespace osu.Game.Rulesets.Mania.Objects
 {
     public abstract class ManiaHitObject : HitObject, IHasColumn, IHasXPosition
     {
-        public readonly Bindable<int> ColumnBindable = new Bindable<int>();
+        private HitObjectProperty<int> column;
+
+        public Bindable<int> ColumnBindable => column.Bindable;
 
         public virtual int Column
         {
-            get => ColumnBindable.Value;
-            set => ColumnBindable.Value = value;
+            get => column.Value;
+            set => column.Value = value;
         }
 
         protected override HitWindows CreateHitWindows() => new ManiaHitWindows();

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public double Radius => OBJECT_RADIUS * Scale;
 
-        private HitObjectProperty<float> scaleProperty;
+        private HitObjectProperty<float> scaleProperty = new HitObjectProperty<float>(1);
 
         public Bindable<float> ScaleBindable => scaleProperty.Bindable;
 

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -55,80 +55,80 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public Vector2 StackedEndPosition => EndPosition + StackOffset;
 
-        private HitObjectProperty<int> stackHeightProperty;
+        private HitObjectProperty<int> stackHeight;
 
-        public Bindable<int> StackHeightBindable => stackHeightProperty.Bindable;
+        public Bindable<int> StackHeightBindable => stackHeight.Bindable;
 
         public int StackHeight
         {
-            get => StackHeightBindable.Value;
-            set => StackHeightBindable.Value = value;
+            get => stackHeight.Value;
+            set => stackHeight.Value = value;
         }
 
         public virtual Vector2 StackOffset => new Vector2(StackHeight * Scale * -6.4f);
 
         public double Radius => OBJECT_RADIUS * Scale;
 
-        private HitObjectProperty<float> scaleProperty = new HitObjectProperty<float>(1);
+        private HitObjectProperty<float> scale = new HitObjectProperty<float>(1);
 
-        public Bindable<float> ScaleBindable => scaleProperty.Bindable;
+        public Bindable<float> ScaleBindable => scale.Bindable;
 
         public float Scale
         {
-            get => ScaleBindable.Value;
-            set => ScaleBindable.Value = value;
+            get => scale.Value;
+            set => scale.Value = value;
         }
 
         public virtual bool NewCombo { get; set; }
 
-        private HitObjectProperty<int> comboOffsetProperty;
+        private HitObjectProperty<int> comboOffset;
 
-        public Bindable<int> ComboOffsetBindable => comboOffsetProperty.Bindable;
+        public Bindable<int> ComboOffsetBindable => comboOffset.Bindable;
 
         public int ComboOffset
         {
-            get => ComboOffsetBindable.Value;
-            set => ComboOffsetBindable.Value = value;
+            get => comboOffset.Value;
+            set => comboOffset.Value = value;
         }
 
-        private HitObjectProperty<int> indexInCurrentComboProperty;
+        private HitObjectProperty<int> indexInCurrentCombo;
 
-        public Bindable<int> IndexInCurrentComboBindable => indexInCurrentComboProperty.Bindable;
+        public Bindable<int> IndexInCurrentComboBindable => indexInCurrentCombo.Bindable;
 
         public virtual int IndexInCurrentCombo
         {
-            get => IndexInCurrentComboBindable.Value;
-            set => IndexInCurrentComboBindable.Value = value;
+            get => indexInCurrentCombo.Value;
+            set => indexInCurrentCombo.Value = value;
         }
 
-        private HitObjectProperty<int> comboIndexProperty;
+        private HitObjectProperty<int> comboIndex;
 
-        public Bindable<int> ComboIndexBindable => comboIndexProperty.Bindable;
+        public Bindable<int> ComboIndexBindable => comboIndex.Bindable;
 
         public virtual int ComboIndex
         {
-            get => ComboIndexBindable.Value;
-            set => ComboIndexBindable.Value = value;
+            get => comboIndex.Value;
+            set => comboIndex.Value = value;
         }
 
-        private HitObjectProperty<int> comboIndexWithOffsetsProperty;
+        private HitObjectProperty<int> comboIndexWithOffsets;
 
-        public Bindable<int> ComboIndexWithOffsetsBindable => comboIndexWithOffsetsProperty.Bindable;
+        public Bindable<int> ComboIndexWithOffsetsBindable => comboIndexWithOffsets.Bindable;
 
         public int ComboIndexWithOffsets
         {
-            get => ComboIndexWithOffsetsBindable.Value;
-            set => ComboIndexWithOffsetsBindable.Value = value;
+            get => comboIndexWithOffsets.Value;
+            set => comboIndexWithOffsets.Value = value;
         }
 
-        private HitObjectProperty<bool> lastInComboProperty;
+        private HitObjectProperty<bool> lastInCombo;
 
-        public Bindable<bool> LastInComboBindable => lastInComboProperty.Bindable;
+        public Bindable<bool> LastInComboBindable => lastInCombo.Bindable;
 
         public bool LastInCombo
         {
-            get => LastInComboBindable.Value;
-            set => LastInComboBindable.Value = value;
+            get => lastInCombo.Value;
+            set => lastInCombo.Value = value;
         }
 
         protected OsuHitObject()

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -7,12 +7,12 @@ using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Objects;
-using osuTK;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
@@ -36,12 +36,14 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double TimePreempt = 600;
         public double TimeFadeIn = 400;
 
-        public readonly Bindable<Vector2> PositionBindable = new Bindable<Vector2>();
+        private HitObjectProperty<Vector2> position;
+
+        public Bindable<Vector2> PositionBindable => position.Bindable;
 
         public virtual Vector2 Position
         {
-            get => PositionBindable.Value;
-            set => PositionBindable.Value = value;
+            get => position.Value;
+            set => position.Value = value;
         }
 
         public float X => Position.X;
@@ -53,7 +55,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public Vector2 StackedEndPosition => EndPosition + StackOffset;
 
-        public readonly Bindable<int> StackHeightBindable = new Bindable<int>();
+        private HitObjectProperty<int> stackHeightProperty;
+
+        public Bindable<int> StackHeightBindable => stackHeightProperty.Bindable;
 
         public int StackHeight
         {
@@ -65,7 +69,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public double Radius => OBJECT_RADIUS * Scale;
 
-        public readonly Bindable<float> ScaleBindable = new BindableFloat(1);
+        private HitObjectProperty<float> scaleProperty;
+
+        public Bindable<float> ScaleBindable => scaleProperty.Bindable;
 
         public float Scale
         {
@@ -75,7 +81,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public virtual bool NewCombo { get; set; }
 
-        public readonly Bindable<int> ComboOffsetBindable = new Bindable<int>();
+        private HitObjectProperty<int> comboOffsetProperty;
+
+        public Bindable<int> ComboOffsetBindable => comboOffsetProperty.Bindable;
 
         public int ComboOffset
         {
@@ -83,7 +91,9 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => ComboOffsetBindable.Value = value;
         }
 
-        public Bindable<int> IndexInCurrentComboBindable { get; } = new Bindable<int>();
+        private HitObjectProperty<int> indexInCurrentComboProperty;
+
+        public Bindable<int> IndexInCurrentComboBindable => indexInCurrentComboProperty.Bindable;
 
         public virtual int IndexInCurrentCombo
         {
@@ -91,7 +101,9 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => IndexInCurrentComboBindable.Value = value;
         }
 
-        public Bindable<int> ComboIndexBindable { get; } = new Bindable<int>();
+        private HitObjectProperty<int> comboIndexProperty;
+
+        public Bindable<int> ComboIndexBindable => comboIndexProperty.Bindable;
 
         public virtual int ComboIndex
         {
@@ -99,7 +111,9 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => ComboIndexBindable.Value = value;
         }
 
-        public Bindable<int> ComboIndexWithOffsetsBindable { get; } = new Bindable<int>();
+        private HitObjectProperty<int> comboIndexWithOffsetsProperty;
+
+        public Bindable<int> ComboIndexWithOffsetsBindable => comboIndexWithOffsetsProperty.Bindable;
 
         public int ComboIndexWithOffsets
         {
@@ -107,7 +121,9 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => ComboIndexWithOffsetsBindable.Value = value;
         }
 
-        public Bindable<bool> LastInComboBindable { get; } = new Bindable<bool>();
+        private HitObjectProperty<bool> lastInComboProperty;
+
+        public Bindable<bool> LastInComboBindable => lastInComboProperty.Bindable;
 
         public bool LastInCombo
         {

--- a/osu.Game.Rulesets.Taiko/Objects/BarLine.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/BarLine.cs
@@ -11,13 +11,15 @@ namespace osu.Game.Rulesets.Taiko.Objects
 {
     public class BarLine : TaikoHitObject, IBarLine
     {
+        private HitObjectProperty<bool> major;
+
+        public Bindable<bool> MajorBindable => major.Bindable;
+
         public bool Major
         {
-            get => MajorBindable.Value;
-            set => MajorBindable.Value = value;
+            get => major.Value;
+            set => major.Value = value;
         }
-
-        public readonly Bindable<bool> MajorBindable = new BindableBool();
 
         public override Judgement CreateJudgement() => new IgnoreJudgement();
     }

--- a/osu.Game.Rulesets.Taiko/Objects/Hit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Hit.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Audio;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK.Graphics;
 
@@ -14,18 +15,20 @@ namespace osu.Game.Rulesets.Taiko.Objects
 {
     public class Hit : TaikoStrongableHitObject, IHasDisplayColour
     {
-        public readonly Bindable<HitType> TypeBindable = new Bindable<HitType>();
+        private HitObjectProperty<HitType> type;
 
-        public Bindable<Color4> DisplayColour { get; } = new Bindable<Color4>(COLOUR_CENTRE);
+        public Bindable<HitType> TypeBindable => type.Bindable;
 
         /// <summary>
         /// The <see cref="HitType"/> that actuates this <see cref="Hit"/>.
         /// </summary>
         public HitType Type
         {
-            get => TypeBindable.Value;
-            set => TypeBindable.Value = value;
+            get => type.Value;
+            set => type.Value = value;
         }
+
+        public Bindable<Color4> DisplayColour { get; } = new Bindable<Color4>(COLOUR_CENTRE);
 
         public static readonly Color4 COLOUR_CENTRE = Color4Extensions.FromHex(@"bb1177");
         public static readonly Color4 COLOUR_RIM = Color4Extensions.FromHex(@"2299bb");

--- a/osu.Game/Rulesets/Objects/HitObjectProperty.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectProperty.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// The underlying <see cref="Bindable{T}"/>, only initialised on first access.
         /// </summary>
-        public Bindable<T> Bindable => backingBindable ??= new Bindable<T> { Value = backingValue };
+        public Bindable<T> Bindable => backingBindable ??= new Bindable<T>(defaultValue) { Value = backingValue };
 
         /// <summary>
         /// The current value, derived from and delegated to <see cref="Bindable"/> if initialised, or a temporary field otherwise.
@@ -39,6 +39,14 @@ namespace osu.Game.Rulesets.Objects
                 else
                     backingValue = value;
             }
+        }
+
+        private readonly T defaultValue;
+
+        public HitObjectProperty(T value = default)
+        {
+            backingValue = defaultValue = value;
+            backingBindable = null;
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/HitObjectProperty.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectProperty.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using JetBrains.Annotations;
+using osu.Framework.Bindables;
+
+namespace osu.Game.Rulesets.Objects
+{
+    /// <summary>
+    /// Represents a wrapper containing a lazily-initialised <see cref="Bindable{T}"/>, backed by a temporary field used for <see cref="Value"/> storage until initialisation.
+    /// </summary>
+    public struct HitObjectProperty<T>
+    {
+        [CanBeNull]
+        private Bindable<T> backingBindable;
+
+        /// <summary>
+        /// A temporary field to store the current value to, prior to <see cref="Bindable"/>'s initialisation.
+        /// </summary>
+        private T backingValue;
+
+        /// <summary>
+        /// The underlying <see cref="Bindable{T}"/>, only initialised on first access.
+        /// </summary>
+        public Bindable<T> Bindable => backingBindable ??= new Bindable<T> { Value = backingValue };
+
+        /// <summary>
+        /// The current value, derived from and delegated to <see cref="Bindable"/> if initialised, or a temporary field otherwise.
+        /// </summary>
+        public T Value
+        {
+            get => backingBindable != null ? backingBindable.Value : backingValue;
+            set
+            {
+                if (backingBindable != null)
+                    backingBindable.Value = value;
+                else
+                    backingValue = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/18357#discussioncomment-2801608 to some extent, ideal solution envisioned [here](https://github.com/ppy/osu/discussions/18357#discussioncomment-2801608).

This focuses on ruleset implementations which allocate a heavy number of bindables but are left unused in any non-`Editor` context. By replacing them with a wrapper struct which stores the current value to a temporary field until `Bindable` is first accessed (if ever).

There are exceptions like `TaikoStrongableHitObject` which accesses its bindable straight up at constructor, and I don't really intend to complicate the wrapper any further so I left it alone.

But all other ruleset have gained a marginal performance improvement. Here's a snippet of the benchmark showing osu! hitobjects construction time and allocation size with and without its bindables being accessed:
|    Method | Count | WithBindableAccess |         Mean |        Error |       StdDev |    Gen 0 |    Gen 1 |   Gen 2 |   Allocated |
|---------- |------ |------------------- |-------------:|-------------:|-------------:|---------:|---------:|--------:|------------:|
| OsuCircle |     1 |              False |     139.6 ns |      1.04 ns |      0.92 ns |   0.3443 |        - |       - |       720 B |
| OsuCircle |     1 |               True |     228.2 ns |      4.52 ns |      4.22 ns |   0.6387 |        - |       - |     1,336 B |
| OsuCircle |   100 |              False |  15,636.7 ns |    206.41 ns |    182.98 ns |  32.3181 |   1.7395 |       - |    69,624 B |
| OsuCircle |   100 |               True |  26,288.1 ns |    294.60 ns |    275.57 ns |  45.6848 |  15.2283 |       - |   131,224 B |
| OsuCircle |  1000 |              False | 318,118.7 ns |  2,372.91 ns |  2,219.63 ns | 332.0313 | 166.0156 |       - |   696,024 B |
| OsuCircle |  1000 |               True | 783,922.3 ns | 12,895.10 ns | 12,062.08 ns | 539.0625 | 248.0469 | 68.3594 | 1,312,086 B |

For reference, here is the same snippet of the benchmark running on master:

|     Method | Count | WithBindableAccess |         Mean |        Error |       StdDev |    Gen 0 |    Gen 1 |   Gen 2 |   Allocated |
|----------- |------ |------------------- |-------------:|-------------:|-------------:|---------:|---------:|--------:|------------:|
|  OsuCircle |     1 |              False |     228.1 ns |      1.54 ns |      1.29 ns |   0.6273 |        - |       - |     1,312 B |
|  OsuCircle |     1 |               True |     229.8 ns |      0.91 ns |      0.80 ns |   0.6273 |        - |       - |     1,312 B |
|  OsuCircle |   100 |              False |  26,808.0 ns |    153.19 ns |    135.80 ns |  47.6379 |  17.3340 |       - |   128,824 B |
|  OsuCircle |   100 |               True |  26,561.0 ns |    162.98 ns |    136.10 ns |  47.7905 |  17.4561 |       - |   128,824 B |
|  OsuCircle |  1000 |              False | 811,268.3 ns |  4,387.02 ns |  3,663.36 ns | 585.9375 | 285.1563 | 78.1250 | 1,288,099 B |
|  OsuCircle |  1000 |               True | 817,345.7 ns |  4,436.15 ns |  3,704.39 ns | 583.0078 | 283.2031 | 80.0781 | 1,288,101 B |
