### PR TITLE
Use more correct json casing in `APIScoresCollection`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIScoresCollection.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoresCollection.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"scores")]
         public List<SoloScoreInfo> Scores;
 
-        [JsonProperty(@"userScore")]
+        [JsonProperty(@"user_score")]
         public APIScoreWithPosition UserScore;
     }
 }


### PR DESCRIPTION
osu-web API is already returning both of these casings for backwards compatibility, but the former will be removed at some point.

See https://github.com/ppy/osu-web/blob/e540276721951b72bd1b6625260da5e6b33110b0/app/Http/Controllers/BeatmapsController.php#L314-L315