### PR TITLE
Show update button in beatmap carousel when beatmaps have online changes

### DIFF
--- a/osu.Game.Tests/Online/TestSceneBeatmapDownloading.cs
+++ b/osu.Game.Tests/Online/TestSceneBeatmapDownloading.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Online
         {
             AddStep("download beatmap", () => beatmaps.Download(test_db_model));
 
-            AddStep("cancel download from request", () => beatmaps.GetExistingDownload(test_db_model).Cancel());
+            AddStep("cancel download from request", () => beatmaps.GetExistingDownload(test_db_model)!.Cancel());
 
             AddUntilStep("is removed from download list", () => beatmaps.GetExistingDownload(test_db_model) == null);
             AddAssert("is notification cancelled", () => recentNotification.State == ProgressNotificationState.Cancelled);

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Tests.Online
                 => new TestDownloadRequest(set);
         }
 
-        private class TestDownloadRequest : ArchiveDownloadRequest<IBeatmapSetInfo>
+        internal class TestDownloadRequest : ArchiveDownloadRequest<IBeatmapSetInfo>
         {
             public new void SetProgress(float progress) => base.SetProgress(progress);
             public new void TriggerSuccess(string filename) => base.TriggerSuccess(filename);

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -126,10 +126,10 @@ namespace osu.Game.Tests.Online
             AddStep("start downloading", () => beatmapDownloader.Download(testBeatmapSet));
             addAvailabilityCheckStep("state downloading 0%", () => BeatmapAvailability.Downloading(0.0f));
 
-            AddStep("set progress 40%", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet)).SetProgress(0.4f));
+            AddStep("set progress 40%", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet))!.SetProgress(0.4f));
             addAvailabilityCheckStep("state downloading 40%", () => BeatmapAvailability.Downloading(0.4f));
 
-            AddStep("finish download", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet)).TriggerSuccess(testBeatmapFile));
+            AddStep("finish download", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet))!.TriggerSuccess(testBeatmapFile));
             addAvailabilityCheckStep("state importing", BeatmapAvailability.Importing);
 
             AddStep("allow importing", () => beatmaps.AllowImport.SetResult(true));

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -11,7 +11,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -42,29 +41,6 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void load(RulesetStore rulesets)
         {
             this.rulesets = rulesets;
-        }
-
-        [Test]
-        public void TestBeatmapWithOnlineUpdates()
-        {
-            var testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo();
-
-            createCarousel(new List<BeatmapSetInfo>
-            {
-                testBeatmapSetInfo,
-            });
-
-            AddAssert("update button not visible", () => !carousel.ChildrenOfType<UpdateBeatmapSetButton>().Any());
-
-            AddStep("update online hash", () =>
-            {
-                testBeatmapSetInfo.Beatmaps.First().OnlineMD5Hash = "different hash";
-                testBeatmapSetInfo.Beatmaps.First().LastOnlineUpdate = DateTimeOffset.Now;
-
-                carousel.UpdateBeatmapSet(testBeatmapSetInfo);
-            });
-
-            AddUntilStep("update button visible", () => carousel.ChildrenOfType<UpdateBeatmapSetButton>().Any());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -41,6 +42,29 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void load(RulesetStore rulesets)
         {
             this.rulesets = rulesets;
+        }
+
+        [Test]
+        public void TestBeatmapWithOnlineUpdates()
+        {
+            var testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo();
+
+            createCarousel(new List<BeatmapSetInfo>
+            {
+                testBeatmapSetInfo,
+            });
+
+            AddAssert("update button not visible", () => !carousel.ChildrenOfType<UpdateBeatmapSetButton>().Any());
+
+            AddStep("update online hash", () =>
+            {
+                testBeatmapSetInfo.Beatmaps.First().OnlineMD5Hash = "different hash";
+                testBeatmapSetInfo.Beatmaps.First().LastOnlineUpdate = DateTimeOffset.Now;
+
+                carousel.UpdateBeatmapSet(testBeatmapSetInfo);
+            });
+
+            AddUntilStep("update button visible", () => carousel.ChildrenOfType<UpdateBeatmapSetButton>().Any());
         }
 
         [Test]
@@ -825,7 +849,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             checkVisibleItemCount(true, 15);
         }
 
-        private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null, Func<FilterCriteria> initialCriteria = null, Action<BeatmapCarousel> carouselAdjust = null, int? count = null, bool randomDifficulties = false)
+        private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null, Func<FilterCriteria> initialCriteria = null, Action<BeatmapCarousel> carouselAdjust = null, int? count = null,
+                                  bool randomDifficulties = false)
         {
             bool changed = false;
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Carousel;
+using osu.Game.Tests.Online;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.SongSelect
+{
+    [TestFixture]
+    public class TestSceneUpdateBeatmapSetButton : OsuManualInputManagerTestScene
+    {
+        private BeatmapCarousel carousel = null!;
+
+        private TestSceneOnlinePlayBeatmapAvailabilityTracker.TestBeatmapModelDownloader beatmapDownloader = null!;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            var importer = parent.Get<BeatmapImporter>();
+
+            dependencies.CacheAs<BeatmapModelDownloader>(beatmapDownloader = new TestSceneOnlinePlayBeatmapAvailabilityTracker.TestBeatmapModelDownloader(importer, API));
+            return dependencies;
+        }
+
+        [Test]
+        public void TestBeatmapWithOnlineUpdates()
+        {
+            ArchiveDownloadRequest<IBeatmapSetInfo>? downloadRequest = null;
+
+            UpdateBeatmapSetButton? getUpdateButton() => carousel.ChildrenOfType<UpdateBeatmapSetButton>().SingleOrDefault();
+
+            var testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo();
+
+            AddStep("create carousel", () =>
+            {
+                Child = carousel = new BeatmapCarousel
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    BeatmapSets = new List<BeatmapSetInfo>
+                    {
+                        testBeatmapSetInfo,
+                    }
+                };
+            });
+
+            AddUntilStep("wait for load", () => carousel.BeatmapSetsLoaded);
+
+            AddAssert("update button not visible", () => getUpdateButton() == null);
+
+            AddStep("update online hash", () =>
+            {
+                testBeatmapSetInfo.Beatmaps.First().OnlineMD5Hash = "different hash";
+                testBeatmapSetInfo.Beatmaps.First().LastOnlineUpdate = DateTimeOffset.Now;
+
+                carousel.UpdateBeatmapSet(testBeatmapSetInfo);
+            });
+
+            AddUntilStep("update button visible", () => getUpdateButton() != null);
+
+            AddStep("click button", () => getUpdateButton()?.TriggerClick());
+
+            AddUntilStep("wait for download started", () =>
+            {
+                downloadRequest = beatmapDownloader.GetExistingDownload(testBeatmapSetInfo);
+                return downloadRequest != null;
+            });
+
+            AddUntilStep("progress download to completion", () =>
+            {
+                if (downloadRequest is TestSceneOnlinePlayBeatmapAvailabilityTracker.TestDownloadRequest testRequest)
+                {
+                    testRequest.SetProgress(testRequest.Progress + 0.1f);
+
+                    if (testRequest.Progress >= 1)
+                    {
+                        testRequest.TriggerSuccess();
+
+                        // usually this would be done by the import process.
+                        testBeatmapSetInfo.Beatmaps.First().MD5Hash = "different hash";
+                        testBeatmapSetInfo.Beatmaps.First().LastOnlineUpdate = DateTimeOffset.Now;
+
+                        // usually this would be done by a realm subscription.
+                        carousel.UpdateBeatmapSet(testBeatmapSetInfo);
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            var importer = parent.Get<BeatmapImporter>();
+            var importer = parent.Get<BeatmapManager>();
 
             dependencies.CacheAs<BeatmapModelDownloader>(beatmapDownloader = new TestSceneOnlinePlayBeatmapAvailabilityTracker.TestBeatmapModelDownloader(importer, API));
             return dependencies;

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -92,6 +92,16 @@ namespace osu.Game.Beatmaps
         [Indexed]
         public string MD5Hash { get; set; } = string.Empty;
 
+        public string OnlineMD5Hash { get; set; } = string.Empty;
+
+        public DateTimeOffset? LastOnlineUpdate { get; set; }
+
+        /// <summary>
+        /// Whether this beatmap matches the online version, based on fetched online metadata.
+        /// Will return <c>true</c> if no online metadata is available.
+        /// </summary>
+        public bool MatchesOnlineVersion => LastOnlineUpdate == null || MD5Hash == OnlineMD5Hash;
+
         [JsonIgnore]
         public bool Hidden { get; set; }
 

--- a/osu.Game/Beatmaps/BeatmapModelDownloader.cs
+++ b/osu.Game/Beatmaps/BeatmapModelDownloader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -14,7 +12,7 @@ namespace osu.Game.Beatmaps
         protected override ArchiveDownloadRequest<IBeatmapSetInfo> CreateDownloadRequest(IBeatmapSetInfo set, bool minimiseDownloadSize) =>
             new DownloadBeatmapSetRequest(set, minimiseDownloadSize);
 
-        public override ArchiveDownloadRequest<IBeatmapSetInfo> GetExistingDownload(IBeatmapSetInfo model)
+        public override ArchiveDownloadRequest<IBeatmapSetInfo>? GetExistingDownload(IBeatmapSetInfo model)
             => CurrentDownloads.Find(r => r.Model.OnlineID == model.OnlineID);
 
         public BeatmapModelDownloader(IModelImporter<BeatmapSetInfo> beatmapImporter, IAPIProvider api)

--- a/osu.Game/Beatmaps/BeatmapOnlineChangeIngest.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineChangeIngest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable enable
-
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Game.Database;

--- a/osu.Game/Beatmaps/BeatmapOnlineChangeIngest.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineChangeIngest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Game.Database;
+using osu.Game.Online.Metadata;
+
+namespace osu.Game.Beatmaps
+{
+    /// <summary>
+    /// Ingests any changes that happen externally to the client, reprocessing as required.
+    /// </summary>
+    public class BeatmapOnlineChangeIngest : Component
+    {
+        private readonly BeatmapUpdater beatmapUpdater;
+        private readonly RealmAccess realm;
+        private readonly MetadataClient metadataClient;
+
+        public BeatmapOnlineChangeIngest(BeatmapUpdater beatmapUpdater, RealmAccess realm, MetadataClient metadataClient)
+        {
+            this.beatmapUpdater = beatmapUpdater;
+            this.realm = realm;
+            this.metadataClient = metadataClient;
+
+            metadataClient.ChangedBeatmapSetsArrived += changesDetected;
+        }
+
+        private void changesDetected(int[] beatmapSetIds)
+        {
+            // May want to batch incoming updates further if the background realm operations ever becomes a concern.
+            realm.Run(r =>
+            {
+                foreach (int id in beatmapSetIds)
+                {
+                    var matchingSet = r.All<BeatmapSetInfo>().FirstOrDefault(s => s.OnlineID == id);
+
+                    if (matchingSet != null)
+                        beatmapUpdater.Queue(matchingSet.ToLive(realm));
+                }
+            });
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            metadataClient.ChangedBeatmapSetsArrived -= changesDetected;
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
@@ -102,9 +102,12 @@ namespace osu.Game.Beatmaps
 
                     beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
+                    beatmapInfo.OnlineMD5Hash = res.MD5Hash;
                     beatmapInfo.OnlineID = res.OnlineID;
 
                     beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
+
+                    beatmapInfo.LastOnlineUpdate = DateTimeOffset.Now;
 
                     logForModel(set, $"Online retrieval mapped {beatmapInfo} to {res.OnlineBeatmapSetID} / {res.OnlineID}.");
                 }
@@ -190,7 +193,7 @@ namespace osu.Game.Beatmaps
 
                     using (var cmd = db.CreateCommand())
                     {
-                        cmd.CommandText = "SELECT beatmapset_id, beatmap_id, approved, user_id FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
+                        cmd.CommandText = "SELECT beatmapset_id, beatmap_id, approved, user_id, checksum FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
 
                         cmd.Parameters.Add(new SqliteParameter("@MD5Hash", beatmapInfo.MD5Hash));
                         cmd.Parameters.Add(new SqliteParameter("@OnlineID", beatmapInfo.OnlineID));
@@ -209,8 +212,8 @@ namespace osu.Game.Beatmaps
                                 beatmapInfo.BeatmapSet.Status = status;
                                 beatmapInfo.BeatmapSet.OnlineID = reader.GetInt32(0);
                                 beatmapInfo.OnlineID = reader.GetInt32(1);
-
                                 beatmapInfo.Metadata.Author.OnlineID = reader.GetInt32(3);
+                                beatmapInfo.OnlineMD5Hash = reader.GetString(4);
 
                                 logForModel(set, $"Cached local retrieval for {beatmapInfo}.");
                                 return true;

--- a/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
@@ -102,12 +102,13 @@ namespace osu.Game.Beatmaps
 
                     beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
+
                     beatmapInfo.OnlineMD5Hash = res.MD5Hash;
+                    beatmapInfo.LastOnlineUpdate = res.LastUpdated;
+
                     beatmapInfo.OnlineID = res.OnlineID;
 
                     beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
-
-                    beatmapInfo.LastOnlineUpdate = DateTimeOffset.Now;
 
                     logForModel(set, $"Online retrieval mapped {beatmapInfo} to {res.OnlineBeatmapSetID} / {res.OnlineID}.");
                 }
@@ -193,7 +194,7 @@ namespace osu.Game.Beatmaps
 
                     using (var cmd = db.CreateCommand())
                     {
-                        cmd.CommandText = "SELECT beatmapset_id, beatmap_id, approved, user_id, checksum FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
+                        cmd.CommandText = "SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
 
                         cmd.Parameters.Add(new SqliteParameter("@MD5Hash", beatmapInfo.MD5Hash));
                         cmd.Parameters.Add(new SqliteParameter("@OnlineID", beatmapInfo.OnlineID));
@@ -213,7 +214,9 @@ namespace osu.Game.Beatmaps
                                 beatmapInfo.BeatmapSet.OnlineID = reader.GetInt32(0);
                                 beatmapInfo.OnlineID = reader.GetInt32(1);
                                 beatmapInfo.Metadata.Author.OnlineID = reader.GetInt32(3);
+
                                 beatmapInfo.OnlineMD5Hash = reader.GetString(4);
+                                beatmapInfo.LastOnlineUpdate = reader.GetDateTimeOffset(5);
 
                                 logForModel(set, $"Cached local retrieval for {beatmapInfo}.");
                                 return true;

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -93,5 +93,7 @@ namespace osu.Game.Beatmaps
         IEnumerable<IBeatmapInfo> IBeatmapSetInfo.Beatmaps => Beatmaps;
 
         IEnumerable<INamedFileUsage> IHasNamedFiles.Files => Files;
+
+        public bool AllBeatmapsUpToDate => Beatmaps.All(b => b.MatchesOnlineVersion);
     }
 }

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Beatmaps
             // Before we use below, we want to invalidate.
             workingBeatmapCache.Invalidate(beatmapSet);
 
+            // TODO: this call currently uses the local `online.db` lookup.
+            // We probably don't want this to happen after initial import (as the data may be stale).
             onlineLookupQueue.Update(beatmapSet);
 
             foreach (var beatmap in beatmapSet.Beatmaps)

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Online.API;
@@ -33,18 +34,9 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Queue a beatmap for background processing.
         /// </summary>
-        public void Queue(int beatmapSetId)
-        {
-            // TODO: implement
-        }
-
-        /// <summary>
-        /// Queue a beatmap for background processing.
-        /// </summary>
         public void Queue(Live<BeatmapSetInfo> beatmap)
         {
-            // For now, just fire off a task.
-            // TODO: Add actual queueing probably.
+            Logger.Log($"Queueing change for local beatmap {beatmap}");
             Task.Factory.StartNew(() => beatmap.PerformRead(Process));
         }
 

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Database
                 notification.State = ProgressNotificationState.Cancelled;
 
                 if (!(error is OperationCanceledException))
-                    Logger.Error(error, $"{importer.HumanisedModelName.Titleize()} download failed!");
+                    Logger.Error(error, $"{importer?.HumanisedModelName.Titleize()} download failed!");
             }
         }
 

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,18 +17,18 @@ namespace osu.Game.Database
         where TModel : class, IHasGuidPrimaryKey, ISoftDelete, IEquatable<TModel>, T
         where T : class
     {
-        public Action<Notification> PostNotification { protected get; set; }
+        public Action<Notification>? PostNotification { protected get; set; }
 
-        public event Action<ArchiveDownloadRequest<T>> DownloadBegan;
+        public event Action<ArchiveDownloadRequest<T>>? DownloadBegan;
 
-        public event Action<ArchiveDownloadRequest<T>> DownloadFailed;
+        public event Action<ArchiveDownloadRequest<T>>? DownloadFailed;
 
         private readonly IModelImporter<TModel> importer;
-        private readonly IAPIProvider api;
+        private readonly IAPIProvider? api;
 
         protected readonly List<ArchiveDownloadRequest<T>> CurrentDownloads = new List<ArchiveDownloadRequest<T>>();
 
-        protected ModelDownloader(IModelImporter<TModel> importer, IAPIProvider api)
+        protected ModelDownloader(IModelImporter<TModel> importer, IAPIProvider? api)
         {
             this.importer = importer;
             this.api = api;
@@ -87,7 +85,7 @@ namespace osu.Game.Database
             CurrentDownloads.Add(request);
             PostNotification?.Invoke(notification);
 
-            api.PerformAsync(request);
+            api?.PerformAsync(request);
 
             DownloadBegan?.Invoke(request);
             return true;
@@ -101,11 +99,11 @@ namespace osu.Game.Database
                 notification.State = ProgressNotificationState.Cancelled;
 
                 if (!(error is OperationCanceledException))
-                    Logger.Error(error, $"{importer?.HumanisedModelName.Titleize()} download failed!");
+                    Logger.Error(error, $"{importer.HumanisedModelName.Titleize()} download failed!");
             }
         }
 
-        public abstract ArchiveDownloadRequest<T> GetExistingDownload(T model);
+        public abstract ArchiveDownloadRequest<T>? GetExistingDownload(T model);
 
         private bool canDownload(T model) => GetExistingDownload(model) == null && api != null;
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -61,8 +61,9 @@ namespace osu.Game.Database
         /// 15   2022-07-13    Added LastPlayed to BeatmapInfo.
         /// 16   2022-07-15    Removed HasReplay from ScoreInfo.
         /// 17   2022-07-16    Added CountryCode to RealmUser.
+        /// 18   2022-07-19    Added OnlineMD5Hash and LastOnlineUpdate to BeatmapInfo.
         /// </summary>
-        private const int schema_version = 17;
+        private const int schema_version = 18;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -81,6 +81,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"max_combo")]
         public int? MaxCombo { get; set; }
 
+        [JsonProperty(@"last_updated")]
+        public DateTimeOffset LastUpdated { get; set; }
+
         public double BPM { get; set; }
 
         #region Implementation of IBeatmapInfo

--- a/osu.Game/Online/Metadata/MetadataClient.cs
+++ b/osu.Game/Online/Metadata/MetadataClient.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Graphics;
 
@@ -11,5 +13,13 @@ namespace osu.Game.Online.Metadata
         public abstract Task BeatmapSetsUpdated(BeatmapUpdates updates);
 
         public abstract Task<BeatmapUpdates> GetChangesSince(int queueId);
+
+        public Action<int[]>? ChangedBeatmapSetsArrived;
+
+        protected Task ProcessChanges(int[] beatmapSetIDs)
+        {
+            ChangedBeatmapSetsArrived?.Invoke(beatmapSetIDs.Distinct().ToArray());
+            return Task.CompletedTask;
+        }
     }
 }

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
-using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Online.API;
 
@@ -15,7 +14,6 @@ namespace osu.Game.Online.Metadata
 {
     public class OnlineMetadataClient : MetadataClient
     {
-        private readonly BeatmapUpdater beatmapUpdater;
         private readonly string endpoint;
 
         private IHubClientConnector? connector;
@@ -24,9 +22,8 @@ namespace osu.Game.Online.Metadata
 
         private HubConnection? connection => connector?.CurrentConnection;
 
-        public OnlineMetadataClient(EndpointConfiguration endpoints, BeatmapUpdater beatmapUpdater)
+        public OnlineMetadataClient(EndpointConfiguration endpoints)
         {
-            this.beatmapUpdater = beatmapUpdater;
             endpoint = endpoints.MetadataEndpointUrl;
         }
 
@@ -100,17 +97,6 @@ namespace osu.Game.Online.Metadata
                 lastQueueId.Value = updates.LastProcessedQueueID;
 
             await ProcessChanges(updates.BeatmapSetIDs);
-        }
-
-        protected Task ProcessChanges(int[] beatmapSetIDs)
-        {
-            foreach (int id in beatmapSetIDs)
-            {
-                Logger.Log($"Processing {id}...");
-                beatmapUpdater.Queue(id);
-            }
-
-            return Task.CompletedTask;
         }
 
         public override Task<BeatmapUpdates> GetChangesSince(int queueId)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -289,6 +289,8 @@ namespace osu.Game
             dependencies.CacheAs(multiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
 
+            AddInternal(new BeatmapOnlineChangeIngest(beatmapUpdater, realm, metadataClient));
+
             BeatmapManager.ProcessBeatmap = set => beatmapUpdater.Process(set);
 
             dependencies.Cache(userCache = new UserLookupCache());

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -287,7 +287,7 @@ namespace osu.Game
 
             dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(multiplayerClient = new OnlineMultiplayerClient(endpoints));
-            dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints, beatmapUpdater));
+            dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
 
             BeatmapManager.ProcessBeatmap = set => beatmapUpdater.Process(set);
 

--- a/osu.Game/Scoring/ScoreModelDownloader.cs
+++ b/osu.Game/Scoring/ScoreModelDownloader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.Online.API;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -153,17 +153,12 @@ namespace osu.Game.Screens.Select.Carousel
                                 {
                                     Direction = FillDirection.Horizontal,
                                     Spacing = new Vector2(4, 0),
+                                    Scale = new Vector2(0.8f),
                                     AutoSizeAxes = Axes.Both,
                                     Children = new Drawable[]
                                     {
-                                        new TopLocalRank(beatmapInfo)
-                                        {
-                                            Scale = new Vector2(0.8f),
-                                        },
-                                        starCounter = new StarCounter
-                                        {
-                                            Scale = new Vector2(0.8f),
-                                        }
+                                        new TopLocalRank(beatmapInfo),
+                                        starCounter = new StarCounter()
                                     }
                                 }
                             }

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Select.Carousel
                                     RelativeSizeAxes = Axes.Y,
                                     Children = new Drawable[]
                                     {
-                                        new UpdateRequiredIcon(beatmapSet),
+                                        new UpdateBeatmapSetButton(beatmapSet),
                                     }
                                 },
                             new BeatmapSetOnlineStatusPill

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -61,14 +61,15 @@ namespace osu.Game.Screens.Select.Carousel
                         Direction = FillDirection.Horizontal,
                         AutoSizeAxes = Axes.Both,
                         Margin = new MarginPadding { Top = 5 },
-                        Children = new Drawable[]
+                        Spacing = new Vector2(5),
+                        Children = new[]
                         {
+                            beatmapSet.AllBeatmapsUpToDate ? Empty() : new UpdateRequiredIcon(beatmapSet),
                             new BeatmapSetOnlineStatusPill
                             {
                                 AutoSizeAxes = Axes.Both,
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
-                                Margin = new MarginPadding { Right = 5 },
                                 TextSize = 11,
                                 TextPadding = new MarginPadding { Horizontal = 8, Vertical = 2 },
                                 Status = beatmapSet.Status
@@ -76,6 +77,8 @@ namespace osu.Game.Screens.Select.Carousel
                             new FillFlowContainer<DifficultyIcon>
                             {
                                 AutoSizeAxes = Axes.Both,
+                                Origin = Anchor.CentreLeft,
+                                Anchor = Anchor.CentreLeft,
                                 Spacing = new Vector2(3),
                                 ChildrenEnumerable = getDifficultyIcons(),
                             },

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -64,7 +64,17 @@ namespace osu.Game.Screens.Select.Carousel
                         Spacing = new Vector2(5),
                         Children = new[]
                         {
-                            beatmapSet.AllBeatmapsUpToDate ? Empty() : new UpdateRequiredIcon(beatmapSet),
+                            beatmapSet.AllBeatmapsUpToDate
+                                ? Empty()
+                                : new Container
+                                {
+                                    AutoSizeAxes = Axes.X,
+                                    RelativeSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
+                                    {
+                                        new UpdateRequiredIcon(beatmapSet),
+                                    }
+                                },
                             new BeatmapSetOnlineStatusPill
                             {
                                 AutoSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,9 +19,8 @@ namespace osu.Game.Screens.Select.Carousel
     public class UpdateBeatmapSetButton : OsuAnimatedButton
     {
         private readonly BeatmapSetInfo beatmapSetInfo;
-        private SpriteIcon icon;
-
-        private Box progressFill;
+        private SpriteIcon icon = null!;
+        private Box progressFill = null!;
 
         public UpdateBeatmapSetButton(BeatmapSetInfo beatmapSetInfo)
         {

--- a/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
@@ -90,12 +90,9 @@ namespace osu.Game.Screens.Select.Carousel
                 },
             });
 
-            TooltipText = "Update beatmap with online changes";
-
             Action = () =>
             {
                 beatmapDownloader.Download(beatmapSetInfo);
-
                 attachExistingDownload();
             };
         }
@@ -116,7 +113,15 @@ namespace osu.Game.Screens.Select.Carousel
                 Enabled.Value = false;
                 TooltipText = string.Empty;
 
-                download.DownloadProgressed += progress => progressFill.ResizeWidthTo(progress, 100);
+                download.DownloadProgressed += progress => progressFill.ResizeWidthTo(progress, 100, Easing.OutQuint);
+                download.Failure += _ => attachExistingDownload();
+            }
+            else
+            {
+                Enabled.Value = true;
+                TooltipText = "Update beatmap with online changes";
+
+                progressFill.ResizeWidthTo(0, 100, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Screens/Select/Carousel/UpdateRequiredIcon.cs
+++ b/osu.Game/Screens/Select/Carousel/UpdateRequiredIcon.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Game.Screens.Select.Carousel
+{
+    public class UpdateRequiredIcon : OsuAnimatedButton
+    {
+        private readonly BeatmapSetInfo beatmapSetInfo;
+        private SpriteIcon icon;
+
+        public UpdateRequiredIcon(BeatmapSetInfo beatmapSetInfo)
+        {
+            this.beatmapSetInfo = beatmapSetInfo;
+
+            AutoSizeAxes = Axes.Both;
+
+            Anchor = Anchor.CentreLeft;
+            Origin = Anchor.CentreLeft;
+        }
+
+        [Resolved]
+        private BeatmapModelDownloader beatmaps { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            const float icon_size = 14;
+
+            Content.Anchor = Anchor.CentreLeft;
+            Content.Origin = Anchor.CentreLeft;
+
+            Content.AddRange(new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    Padding = new MarginPadding { Horizontal = 5, Vertical = 3 },
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(4),
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            Size = new Vector2(icon_size),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Children = new Drawable[]
+                            {
+                                icon = new SpriteIcon
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Icon = FontAwesome.Solid.SyncAlt,
+                                    Size = new Vector2(icon_size),
+                                },
+                            }
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                            Text = "Update",
+                        }
+                    }
+                },
+            });
+
+            TooltipText = "Update beatmap with online changes";
+
+            Action = () => beatmaps.Download(beatmapSetInfo);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            icon.Spin(4000, RotationDirection.Clockwise);
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            icon.Spin(400, RotationDirection.Clockwise);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            icon.Spin(4000, RotationDirection.Clockwise);
+            base.OnHoverLost(e);
+        }
+    }
+}

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -809,6 +809,7 @@ See the LICENCE file in the repository root for full licence text.&#xD;
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=NUnit_002EFramework_002EInternal_002ELogger/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=OpenTabletDriver_002EPlugin_002EDependencyInjection_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=Realms_002ELogging_002ELogger/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002EComponentModel_002EComponent/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002EComponentModel_002EContainer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002ENumerics_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002ESecurity_002ECryptography_002ERSA/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Closes #4823
- Addresses #16467

---

Comes with a few caveats:
- Currently only shows when there are actual `.osu` file changes (feature parity with stable). Eventually we'd want to show this for any changes (ie. if only the background has changed), but doing so requires a beatmap set level hash. I have a forward plan for making this happen, but it involves having individual file hashes stored and communicated client-server. Note that even with this limitation, it will still **update all files** in the beatmap (better than stable) because it's performing a full re-download.
- Any already imported beatmaps will not have a `LastOnlineUpdate` set, therefore will not show available updates. At some point all beatmaps with a null value will be queried in the background to resolve this. Not a huge deal IMO.
- New imports are using the local cached beatmap info, which means in the super rare edge case that a beatmap is unranked and changed, it may be in an incorrect state even though its realm status shows that it's consistent. I've left a note about this in `BeatmapUpdater` but not sure it's worth acting on, for now.

https://user-images.githubusercontent.com/191335/179715519-78cab07f-1aed-4d20-b286-645c8bbc32e0.mp4

