### PR TITLE
Add ranked and submitted date storage and filtering

### DIFF
--- a/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineLookupQueue.cs
@@ -102,6 +102,8 @@ namespace osu.Game.Beatmaps
 
                     beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
+                    beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
+                    beatmapInfo.BeatmapSet.DateSubmitted = res.BeatmapSet?.Submitted;
 
                     beatmapInfo.OnlineMD5Hash = res.MD5Hash;
                     beatmapInfo.LastOnlineUpdate = res.LastUpdated;
@@ -194,7 +196,8 @@ namespace osu.Game.Beatmaps
 
                     using (var cmd = db.CreateCommand())
                     {
-                        cmd.CommandText = "SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
+                        cmd.CommandText =
+                            "SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
 
                         cmd.Parameters.Add(new SqliteParameter("@MD5Hash", beatmapInfo.MD5Hash));
                         cmd.Parameters.Add(new SqliteParameter("@OnlineID", beatmapInfo.OnlineID));
@@ -212,6 +215,7 @@ namespace osu.Game.Beatmaps
 
                                 beatmapInfo.BeatmapSet.Status = status;
                                 beatmapInfo.BeatmapSet.OnlineID = reader.GetInt32(0);
+                                // TODO: DateSubmitted and DateRanked are not provided by local cache.
                                 beatmapInfo.OnlineID = reader.GetInt32(1);
                                 beatmapInfo.Metadata.Author.OnlineID = reader.GetInt32(3);
 

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -26,6 +26,16 @@ namespace osu.Game.Beatmaps
 
         public DateTimeOffset DateAdded { get; set; }
 
+        /// <summary>
+        /// The date this beatmap set was first submitted.
+        /// </summary>
+        public DateTimeOffset? DateSubmitted { get; set; }
+
+        /// <summary>
+        /// The date this beatmap set was ranked.
+        /// </summary>
+        public DateTimeOffset? DateRanked { get; set; }
+
         [JsonIgnore]
         public IBeatmapMetadataInfo Metadata => Beatmaps.FirstOrDefault()?.Metadata ?? new BeatmapMetadata();
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -62,8 +62,9 @@ namespace osu.Game.Database
         /// 16   2022-07-15    Removed HasReplay from ScoreInfo.
         /// 17   2022-07-16    Added CountryCode to RealmUser.
         /// 18   2022-07-19    Added OnlineMD5Hash and LastOnlineUpdate to BeatmapInfo.
+        /// 19   2022-07-19    Added DateSubmitted and DateRanked to BeatmapSetInfo.
         /// </summary>
-        private const int schema_version = 18;
+        private const int schema_version = 19;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Screens.Select.Carousel
             match &= !criteria.Artist.HasFilter || criteria.Artist.Matches(BeatmapInfo.Metadata.Artist) ||
                      criteria.Artist.Matches(BeatmapInfo.Metadata.ArtistUnicode);
 
+            match &= criteria.Sort != SortMode.DateRanked || BeatmapInfo.BeatmapSet?.DateRanked != null;
+
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarRating);
 
             if (match && criteria.SearchTerms.Length > 0)

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -81,6 +81,13 @@ namespace osu.Game.Screens.Select.Carousel
                 case SortMode.DateAdded:
                     return otherSet.BeatmapSet.DateAdded.CompareTo(BeatmapSet.DateAdded);
 
+                case SortMode.DateRanked:
+                    // Beatmaps which have no ranked date should already be filtered away in this mode.
+                    if (BeatmapSet.DateRanked == null || otherSet.BeatmapSet.DateRanked == null)
+                        return 0;
+
+                    return otherSet.BeatmapSet.DateRanked.Value.CompareTo(BeatmapSet.DateRanked.Value);
+
                 case SortMode.LastPlayed:
                     return -compareUsingAggregateMax(otherSet, b => (b.LastPlayed ?? DateTimeOffset.MinValue).ToUnixTimeSeconds());
 

--- a/osu.Game/Screens/Select/Filter/SortMode.cs
+++ b/osu.Game/Screens/Select/Filter/SortMode.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Screens.Select.Filter
         [Description("Date Added")]
         DateAdded,
 
+        [Description("Date Ranked")]
+        DateRanked,
+
         [Description("Last Played")]
         LastPlayed,
 


### PR DESCRIPTION
- [x] Depends on #19230
- Closes https://github.com/ppy/osu/issues/2425

For the time being, this also applies a filter to only show ranked beatmaps. Note that as most imported beatmaps will not yet have metadata populated (and the local sqlite database doesn't even contain this metadata) this will be rather useless for now.

It will become more useful with an upcoming component that will do background fetching of beatmap metadata and populate these fields. For testing, you can set a value in realm manually.

Can leave this PR open until said component is online if it seems pointless to merge in as-is.