### PR TITLE
Highlight perfect slider tick/end values in beatmap info leaderboards

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -255,18 +255,25 @@ namespace osu.Game.Tests.Visual.Online
             };
 
             const int initial_great_count = 2000;
+            const int initial_tick_count = 100;
 
             int greatCount = initial_great_count;
+            int tickCount = initial_tick_count;
 
             foreach (var s in scores.Scores)
             {
                 s.Statistics = new Dictionary<HitResult, int>
                 {
-                    { HitResult.Great, greatCount -= 100 },
+                    { HitResult.Great, greatCount },
+                    { HitResult.LargeTickHit, tickCount },
                     { HitResult.Ok, RNG.Next(100) },
                     { HitResult.Meh, RNG.Next(100) },
-                    { HitResult.Miss, initial_great_count - greatCount }
+                    { HitResult.Miss, initial_great_count - greatCount },
+                    { HitResult.LargeTickMiss, initial_tick_count - tickCount },
                 };
+
+                greatCount -= 100;
+                tickCount -= RNG.Next(1, 5);
             }
 
             return scores;

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -23,6 +23,7 @@ using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Localisation;
 using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
@@ -37,8 +38,6 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         private ScoreManager scoreManager { get; set; }
 
         private readonly FillFlowContainer backgroundFlow;
-
-        private Color4 highAccuracyColour;
 
         public ScoreTable()
         {
@@ -55,12 +54,6 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 Padding = new MarginPadding { Horizontal = -horizontal_inset },
                 Margin = new MarginPadding { Top = row_height }
             });
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            highAccuracyColour = colours.GreenLight;
         }
 
         /// <summary>
@@ -158,12 +151,10 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     Current = scoreManager.GetBindableTotalScoreString(score),
                     Font = OsuFont.GetFont(size: text_size, weight: index == 0 ? FontWeight.Bold : FontWeight.Medium)
                 },
-                new OsuSpriteText
+                new StatisticText(score.Accuracy, 1, showTooltip: false)
                 {
                     Margin = new MarginPadding { Right = horizontal_inset },
                     Text = score.DisplayAccuracy,
-                    Font = OsuFont.GetFont(size: text_size),
-                    Colour = score.Accuracy == 1 ? highAccuracyColour : Color4.White
                 },
                 new UpdateableFlag(score.User.CountryCode)
                 {
@@ -171,14 +162,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     ShowPlaceholderOnUnknown = false,
                 },
                 username,
-                new OsuSpriteText
-                {
-                    Text = score.MaxCombo.ToLocalisableString(@"0\x"),
-                    Font = OsuFont.GetFont(size: text_size),
 #pragma warning disable 618
-                    Colour = score.MaxCombo == score.BeatmapInfo.MaxCombo ? highAccuracyColour : Color4.White
+                new StatisticText(score.MaxCombo, score.BeatmapInfo.MaxCombo, @"0\x"),
 #pragma warning restore 618
-                }
             };
 
             var availableStatistics = score.GetStatisticsForDisplay().ToDictionary(tuple => tuple.Result);
@@ -188,23 +174,13 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 if (!availableStatistics.TryGetValue(result.result, out var stat))
                     stat = new HitResultDisplayStatistic(result.result, 0, null, result.displayName);
 
-                content.Add(new OsuSpriteText
-                {
-                    Text = stat.MaxCount == null ? stat.Count.ToLocalisableString(@"N0") : (LocalisableString)$"{stat.Count}/{stat.MaxCount}",
-                    Font = OsuFont.GetFont(size: text_size),
-                    Colour = stat.Count == 0 ? Color4.Gray : Color4.White
-                });
+                content.Add(new StatisticText(stat.Count, stat.MaxCount, @"N0") { Colour = stat.Count == 0 ? Color4.Gray : Color4.White });
             }
 
             if (showPerformancePoints)
             {
                 Debug.Assert(score.PP != null);
-
-                content.Add(new OsuSpriteText
-                {
-                    Text = score.PP.ToLocalisableString(@"N0"),
-                    Font = OsuFont.GetFont(size: text_size)
-                });
+                content.Add(new StatisticText(score.PP.Value, format: @"N0"));
             }
 
             content.Add(new ScoreboardTime(score.Date, text_size)
@@ -241,6 +217,32 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             private void load(OverlayColourProvider colourProvider)
             {
                 Colour = colourProvider.Foreground1;
+            }
+        }
+
+        private class StatisticText : OsuSpriteText, IHasTooltip
+        {
+            private readonly double count;
+            private readonly double? maxCount;
+            private readonly bool showTooltip;
+
+            public LocalisableString TooltipText => maxCount == null || !showTooltip ? string.Empty : $"{count}/{maxCount}";
+
+            public StatisticText(double count, double? maxCount = null, string format = null, bool showTooltip = true)
+            {
+                this.count = count;
+                this.maxCount = maxCount;
+                this.showTooltip = showTooltip;
+
+                Text = count.ToLocalisableString(format);
+                Font = OsuFont.GetFont(size: text_size);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                if (count == maxCount)
+                    Colour = colours.GreenLight;
             }
         }
     }


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/19194#discussioncomment-3178581

I've also took the time to centralise the statistic text logic so that combo receives a tooltip as well, given that the maximum value is known and is highlighted on FC.

Not sure about the top score panel since it doesn't highlight perfect statistics currently, maybe a good place to show the maximum statistics as well?

---

Replacing the existing maximum count display and moves that to a tooltip that displays when hovering over the statistic.

https://user-images.githubusercontent.com/22781491/179854821-7a8c7b71-9c0a-4495-a93f-17dfff2cd343.mp4


