### PR TITLE
Add game-side FPS counter

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFPSCounter.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFPSCounter.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneFPSCounter : OsuTestScene
+    {
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create display", () =>
+            {
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.White,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new FillFlowContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Children = new Drawable[]
+                        {
+                            new FPSCounter(),
+                            new FPSCounter { Scale = new Vector2(2) },
+                            new FPSCounter { Scale = new Vector2(4) },
+                        }
+                    },
+                };
+            });
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+        }
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -224,6 +224,12 @@ namespace osu.Game.Configuration
 
             return new TrackedSettings
             {
+                new TrackedSetting<bool>(OsuSetting.ShowFpsDisplay, state => new SettingDescription(
+                    rawValue: state,
+                    name: GlobalActionKeyBindingStrings.ToggleFPSCounter,
+                    value: state ? CommonStrings.Enabled.ToLower() : CommonStrings.Disabled.ToLower(),
+                    shortcut: LookupKeyBindings(GlobalAction.ToggleFPSDisplay))
+                ),
                 new TrackedSetting<bool>(OsuSetting.MouseDisableButtons, disabledState => new SettingDescription(
                     rawValue: !disabledState,
                     name: GlobalActionKeyBindingStrings.ToggleGameplayMouseButtons,

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -20,7 +20,7 @@ using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class FPSCounter : CompositeDrawable, IHasCustomTooltip
+    public class FPSCounter : VisibilityContainer, IHasCustomTooltip
     {
         private RollingCounter<double> msCounter = null!;
         private RollingCounter<double> fpsCounter = null!;
@@ -31,7 +31,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float idle_background_alpha = 0.4f;
 
-        private Bindable<bool> showFpsDisplay = null!;
+        private readonly BindableBool showFpsDisplay = new BindableBool(true);
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -83,7 +83,7 @@ namespace osu.Game.Graphics.UserInterface
                 },
             };
 
-            showFpsDisplay = config.GetBindable<bool>(OsuSetting.ShowFpsDisplay);
+            config.BindWith(OsuSetting.ShowFpsDisplay, showFpsDisplay);
         }
 
         protected override void LoadComplete()
@@ -94,10 +94,17 @@ namespace osu.Game.Graphics.UserInterface
 
             showFpsDisplay.BindValueChanged(showFps =>
             {
-                this.FadeTo(showFps.NewValue ? 1 : 0, 100);
-                displayTemporarily();
+                State.Value = showFps.NewValue ? Visibility.Visible : Visibility.Hidden;
+                if (showFps.NewValue)
+                    displayTemporarily();
             }, true);
+
+            State.BindValueChanged(state => showFpsDisplay.Value = state.NewValue == Visibility.Visible);
         }
+
+        protected override void PopIn() => this.FadeIn(100);
+
+        protected override void PopOut() => this.FadeOut(100);
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -165,7 +166,7 @@ namespace osu.Game.Graphics.UserInterface
             // TODO: this is wrong (elapsed clock time, not actual run time).
             double newUpdateFrameTime = gameHost.UpdateThread.Clock.ElapsedFrameTime;
             // use elapsed frame time rather then FramesPerSecond to better catch stutter frames.
-            double newDrawFps = 1000 / gameHost.DrawThread.Clock.ElapsedFrameTime;
+            double newDrawFps = 1000 / Math.Max(0.001, gameHost.DrawThread.Clock.ElapsedFrameTime);
 
             const double spike_time_ms = 20;
 

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -73,13 +73,13 @@ namespace osu.Game.Graphics.UserInterface
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
                             Margin = new MarginPadding(1),
-                            Y = -1,
+                            Y = -2,
                         },
                         fpsCounter = new FramesPerSecondCounter
                         {
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
-                            Margin = new MarginPadding(1),
+                            Margin = new MarginPadding(2),
                             Y = 10,
                             Scale = new Vector2(0.8f),
                         }

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -131,9 +131,13 @@ namespace osu.Game.Graphics.UserInterface
         private void displayTemporarily()
         {
             if (!isDisplayed)
+            {
                 mainContent.FadeTo(1, 300, Easing.OutQuint);
+                isDisplayed = true;
+            }
 
             fadeOutDelegate?.Cancel();
+            fadeOutDelegate = null;
 
             if (!IsHovered)
             {

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -13,6 +14,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 
@@ -29,6 +31,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float idle_background_alpha = 0.4f;
 
+        private Bindable<bool> showFpsDisplay = null!;
+
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
@@ -38,7 +42,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
             InternalChildren = new Drawable[]
             {
@@ -78,12 +82,21 @@ namespace osu.Game.Graphics.UserInterface
                     }
                 },
             };
+
+            showFpsDisplay = config.GetBindable<bool>(OsuSetting.ShowFpsDisplay);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             displayTemporarily();
+
+            showFpsDisplay.BindValueChanged(showFps =>
+            {
+                this.FadeTo(showFps.NewValue ? 1 : 0, 100);
+                displayTemporarily();
+            }, true);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class FPSCounter : CompositeDrawable, IHasCustomTooltip
+    {
+        private RollingCounter<double> msCounter = null!;
+        private RollingCounter<double> fpsCounter = null!;
+
+        private Container mainContent = null!;
+
+        public FPSCounter()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            InternalChildren = new Drawable[]
+            {
+                mainContent = new Container
+                {
+                    Alpha = 0,
+                    Size = new Vector2(30),
+                    Children = new Drawable[]
+                    {
+                        msCounter = new FrameTimeCounter
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Colour = colours.Orange2,
+                        },
+                        fpsCounter = new FramesPerSecondCounter
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Y = 11,
+                            Scale = new Vector2(0.8f),
+                            Colour = colours.Lime3,
+                        }
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            displayTemporarily();
+        }
+
+        private bool isDisplayed;
+
+        private ScheduledDelegate? fadeOutDelegate;
+
+        private void displayTemporarily()
+        {
+            if (!isDisplayed)
+                mainContent.FadeTo(1, 300, Easing.OutQuint);
+
+            fadeOutDelegate?.Cancel();
+            fadeOutDelegate = Scheduler.AddDelayed(() =>
+            {
+                mainContent.FadeTo(0, 1000, Easing.In);
+                isDisplayed = false;
+            }, 2000);
+        }
+
+        [Resolved]
+        private GameHost gameHost { get; set; } = null!;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // TODO: this is wrong (elapsed clock time, not actual run time).
+            double newFrameTime = gameHost.UpdateThread.Clock.ElapsedFrameTime;
+            double newFps = gameHost.DrawThread.Clock.FramesPerSecond;
+
+            bool hasSignificantChanges =
+                Math.Abs(msCounter.Current.Value - newFrameTime) > 5 ||
+                Math.Abs(fpsCounter.Current.Value - newFps) > 10;
+
+            if (hasSignificantChanges)
+                displayTemporarily();
+
+            msCounter.Current.Value = newFrameTime;
+            fpsCounter.Current.Value = newFps;
+        }
+
+        public ITooltip GetCustomTooltip() => new FPSCounterTooltip();
+
+        public object TooltipContent => this;
+
+        public class FramesPerSecondCounter : RollingCounter<double>
+        {
+            protected override double RollingDuration => 400;
+
+            protected override OsuSpriteText CreateSpriteText()
+            {
+                return new OsuSpriteText
+                {
+                    Font = OsuFont.Default.With(fixedWidth: true, size: 16, weight: FontWeight.SemiBold),
+                    Spacing = new Vector2(-2),
+                };
+            }
+
+            protected override LocalisableString FormatCount(double count)
+            {
+                return $"{count:#,0}fps";
+            }
+        }
+
+        public class FrameTimeCounter : RollingCounter<double>
+        {
+            protected override double RollingDuration => 1000;
+
+            protected override OsuSpriteText CreateSpriteText()
+            {
+                return new OsuSpriteText
+                {
+                    Font = OsuFont.Default.With(fixedWidth: true, size: 16, weight: FontWeight.SemiBold),
+                    Spacing = new Vector2(-1),
+                };
+            }
+
+            protected override LocalisableString FormatCount(double count)
+            {
+                if (count < 1)
+                    return $"{count:N1}ms";
+
+                return $"{count:N0}ms";
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -49,13 +49,14 @@ namespace osu.Game.Graphics.UserInterface
                 mainContent = new Container
                 {
                     Alpha = 0,
-                    AutoSizeAxes = Axes.Both,
+                    Size = new Vector2(42, 26),
                     Children = new Drawable[]
                     {
                         background = new Container
                         {
                             RelativeSizeAxes = Axes.Both,
                             CornerRadius = 5,
+                            CornerExponent = 5f,
                             Masking = true,
                             Alpha = idle_background_alpha,
                             Children = new Drawable[]
@@ -71,12 +72,15 @@ namespace osu.Game.Graphics.UserInterface
                         {
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
+                            Margin = new MarginPadding(1),
+                            Y = -1,
                         },
                         fpsCounter = new FramesPerSecondCounter
                         {
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
-                            Y = 11,
+                            Margin = new MarginPadding(1),
+                            Y = 10,
                             Scale = new Vector2(0.8f),
                         }
                     }
@@ -135,7 +139,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 fadeOutDelegate = Scheduler.AddDelayed(() =>
                 {
-                    mainContent.FadeTo(0, 1000, Easing.In);
+                    mainContent.FadeTo(0, 300, Easing.OutQuint);
                     isDisplayed = false;
                 }, 2000);
             }
@@ -177,9 +181,9 @@ namespace osu.Game.Graphics.UserInterface
         private ColourInfo getColour(double performanceRatio)
         {
             if (performanceRatio < 0.5f)
-                return Interpolation.ValueAt(performanceRatio, colours.Red, colours.Orange2, 0, 0.5, Easing.Out);
+                return Interpolation.ValueAt(performanceRatio, colours.Red, colours.Orange2, 0, 0.5);
 
-            return Interpolation.ValueAt(performanceRatio, colours.Orange2, colours.Lime3, 0.5, 1, Easing.Out);
+            return Interpolation.ValueAt(performanceRatio, colours.Orange2, colours.Lime0, 0.5, 0.9);
         }
 
         public ITooltip GetCustomTooltip() => new FPSCounterTooltip();

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -198,6 +198,8 @@ namespace osu.Game.Graphics.UserInterface
             {
                 return new OsuSpriteText
                 {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
                     Font = OsuFont.Default.With(fixedWidth: true, size: 16, weight: FontWeight.SemiBold),
                     Spacing = new Vector2(-2),
                 };
@@ -217,6 +219,8 @@ namespace osu.Game.Graphics.UserInterface
             {
                 return new OsuSpriteText
                 {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
                     Font = OsuFont.Default.With(fixedWidth: true, size: 16, weight: FontWeight.SemiBold),
                     Spacing = new Vector2(-1),
                 };

--- a/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
@@ -1,0 +1,96 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Platform;
+using osu.Game.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class FPSCounterTooltip : CompositeDrawable, ITooltip
+    {
+        private OsuTextFlowContainer textFlow = null!;
+
+        [Resolved]
+        private GameHost gameHost { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            AutoSizeAxes = Axes.Both;
+
+            CornerRadius = 15;
+            Masking = true;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.Gray1,
+                    Alpha = 1,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuTextFlowContainer(cp =>
+                {
+                    cp.Font = OsuFont.Default.With(weight: FontWeight.SemiBold);
+                    cp.Spacing = new Vector2(-1);
+                })
+                {
+                    AutoSizeAxes = Axes.Both,
+                    TextAnchor = Anchor.TopRight,
+                    Margin = new MarginPadding { Left = 5, Vertical = 10 },
+                    Text = string.Join('\n', gameHost.Threads.Select(t => t.Name))
+                },
+                textFlow = new OsuTextFlowContainer(cp =>
+                {
+                    cp.Font = OsuFont.Default.With(fixedWidth: true, weight: FontWeight.Regular);
+                    cp.Spacing = new Vector2(-1);
+                })
+                {
+                    Width = 190,
+                    Margin = new MarginPadding { Left = 35, Right = 10, Vertical = 10 },
+                    AutoSizeAxes = Axes.Y,
+                    TextAnchor = Anchor.TopRight,
+                },
+            };
+        }
+
+        private int lastUpdate;
+
+        protected override void Update()
+        {
+            int currentSecond = (int)(Clock.CurrentTime / 100);
+
+            if (currentSecond != lastUpdate)
+            {
+                lastUpdate = currentSecond;
+
+                textFlow.Clear();
+
+                foreach (var thread in gameHost.Threads)
+                {
+                    var clock = thread.Clock;
+
+                    string maximum = $"{(clock.MaximumUpdateHz > 0 && clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞"),4}";
+
+                    textFlow.AddParagraph($"{clock.FramesPerSecond:0}/{maximum}fps ({clock.ElapsedFrameTime:0.00}ms)");
+                }
+            }
+        }
+
+        public void SetContent(object content)
+        {
+        }
+
+        public void Move(Vector2 pos)
+        {
+            Position = pos;
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
@@ -39,7 +39,6 @@ namespace osu.Game.Graphics.UserInterface
                 new OsuTextFlowContainer(cp =>
                 {
                     cp.Font = OsuFont.Default.With(weight: FontWeight.SemiBold);
-                    cp.Spacing = new Vector2(-1);
                 })
                 {
                     AutoSizeAxes = Axes.Both,

--- a/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounterTooltip.cs
@@ -76,9 +76,11 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     var clock = thread.Clock;
 
-                    string maximum = $"{(clock.MaximumUpdateHz > 0 && clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞"),4}";
+                    string maximum = clock.Throttling
+                        ? $"/{(clock.MaximumUpdateHz > 0 && clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞"),4}"
+                        : string.Empty;
 
-                    textFlow.AddParagraph($"{clock.FramesPerSecond:0}/{maximum}fps ({clock.ElapsedFrameTime:0.00}ms)");
+                    textFlow.AddParagraph($"{clock.FramesPerSecond:0}{maximum}fps ({clock.ElapsedFrameTime:0.00}ms)");
                 }
             }
         }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F9, GlobalAction.ToggleSocial),
             new KeyBinding(InputKey.F10, GlobalAction.ToggleGameplayMouseButtons),
             new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, GlobalAction.ToggleFPSDisplay),
 
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.R }, GlobalAction.ResetInputSettings),
             new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
@@ -328,5 +329,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTapForBPM))]
         EditorTapForBPM,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleFPSCounter))]
+        ToggleFPSDisplay,
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -275,6 +275,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ToggleSkinEditor => new TranslatableString(getKey(@"toggle_skin_editor"), @"Toggle skin editor");
 
         /// <summary>
+        /// "Toggle FPS counter"
+        /// </summary>
+        public static LocalisableString ToggleFPSCounter => new TranslatableString(getKey(@"toggle_fps_counter"), @"Toggle FPS counter");
+
+        /// <summary>
         /// "Previous volume meter"
         /// </summary>
         public static LocalisableString PreviousVolumeMeter => new TranslatableString(getKey(@"previous_volume_meter"), @"Previous volume meter");

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -820,7 +820,7 @@ namespace osu.Game
             {
                 Anchor = Anchor.BottomRight,
                 Origin = Anchor.BottomRight,
-                Margin = new MarginPadding(10),
+                Margin = new MarginPadding(5),
             }, topMostOverlayContent.Add);
 
             if (!args?.Any(a => a == @"--no-version-overlay") ?? true)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -814,6 +814,13 @@ namespace osu.Game
             ScreenStack.ScreenPushed += screenPushed;
             ScreenStack.ScreenExited += screenExited;
 
+            loadComponentSingleFile(new FPSCounter
+            {
+                Anchor = Anchor.BottomRight,
+                Origin = Anchor.BottomRight,
+                Margin = new MarginPadding(10),
+            }, topMostOverlayContent.Add);
+
             if (!args?.Any(a => a == @"--no-version-overlay") ?? true)
                 loadComponentSingleFile(versionManager = new VersionManager { Depth = int.MinValue }, ScreenContainer.Add);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -159,6 +159,8 @@ namespace osu.Game
 
         protected FirstRunSetupOverlay FirstRunOverlay { get; private set; }
 
+        private FPSCounter fpsCounter;
+
         private VolumeOverlay volume;
 
         private OsuLogo osuLogo;
@@ -814,7 +816,7 @@ namespace osu.Game
             ScreenStack.ScreenPushed += screenPushed;
             ScreenStack.ScreenExited += screenExited;
 
-            loadComponentSingleFile(new FPSCounter
+            loadComponentSingleFile(fpsCounter = new FPSCounter
             {
                 Anchor = Anchor.BottomRight,
                 Origin = Anchor.BottomRight,
@@ -1121,6 +1123,10 @@ namespace osu.Game
 
             switch (e.Action)
             {
+                case GlobalAction.ToggleFPSDisplay:
+                    fpsCounter.ToggleVisibility();
+                    return true;
+
                 case GlobalAction.ToggleSkinEditor:
                     skinEditor.ToggleVisibility();
                     return true;

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -17,7 +17,6 @@ using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Performance;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
@@ -191,8 +190,6 @@ namespace osu.Game
         private Container content;
 
         private DependencyContainer dependencies;
-
-        private Bindable<bool> fpsDisplayVisible;
 
         private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(global_track_volume_adjust);
 
@@ -402,19 +399,6 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera/Venera-Light");
             AddFont(Resources, @"Fonts/Venera/Venera-Bold");
             AddFont(Resources, @"Fonts/Venera/Venera-Black");
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            // TODO: This is temporary until we reimplement the local FPS display.
-            // It's just to allow end-users to access the framework FPS display without knowing the shortcut key.
-            fpsDisplayVisible = LocalConfig.GetBindable<bool>(OsuSetting.ShowFpsDisplay);
-            fpsDisplayVisible.ValueChanged += visible => { FrameStatistics.Value = visible.NewValue ? FrameStatisticsMode.Minimal : FrameStatisticsMode.None; };
-            fpsDisplayVisible.TriggerChange();
-
-            FrameStatistics.ValueChanged += e => fpsDisplayVisible.Value = e.NewValue != FrameStatisticsMode.None;
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>


### PR DESCRIPTION
~~There's a bug with `RollingCounter` autosize updating a frame too late causing the counter to look weird. I can't immediately see how to fix this, so advice on that would be appreciated.~~ Fixed via [c7313b4](https://github.com/ppy/osu/pull/19250/commits/c7313b4198179801e1ebdec47da70063cf5d052e).

(Arguably) closes #18891.

---

This is a first implementation to build off. Figure it's easier to get this out as a "better than what we had" then build individual pieces into it.

- Frame time is currently displayed similar to stable (actual time between frames, not cpu time). Will probably change this to match the o!f display, but that requires more pieces to be exposed from the framework side.
- Tooltip is very temporary. I plan to replace it with the actual FPS display expanding out to a larger size to reveal more information.

https://user-images.githubusercontent.com/191335/180018974-5e2b2af3-daa0-4eed-893e-ec3231f186c8.mp4

