### PR TITLE
Populate failed scores with "miss" results for all remaining hitobjects

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -103,9 +103,11 @@ namespace osu.Game.Tests.Gameplay
                     new TestHitObject(),
                     new TestHitObject(HitResult.LargeTickHit),
                     new TestHitObject(HitResult.SmallTickHit),
+                    new TestHitObject(HitResult.SmallBonus),
                     new TestHitObject(),
                     new TestHitObject(HitResult.LargeTickHit),
                     new TestHitObject(HitResult.SmallTickHit),
+                    new TestHitObject(HitResult.LargeBonus),
                 }
             };
 
@@ -115,17 +117,21 @@ namespace osu.Game.Tests.Gameplay
             scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], beatmap.HitObjects[0].CreateJudgement()) { Type = HitResult.Ok });
             scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], beatmap.HitObjects[1].CreateJudgement()) { Type = HitResult.LargeTickHit });
             scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[2], beatmap.HitObjects[2].CreateJudgement()) { Type = HitResult.SmallTickMiss });
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[3], beatmap.HitObjects[3].CreateJudgement()) { Type = HitResult.SmallBonus });
 
             var score = new ScoreInfo { Ruleset = new OsuRuleset().RulesetInfo };
             scoreProcessor.FailScore(score);
 
             Assert.That(score.Rank, Is.EqualTo(ScoreRank.F));
-            Assert.That(score.Statistics.Count(kvp => kvp.Value > 0), Is.EqualTo(5));
+            Assert.That(score.Passed, Is.False);
+            Assert.That(score.Statistics.Count(kvp => kvp.Value > 0), Is.EqualTo(7));
             Assert.That(score.Statistics[HitResult.Ok], Is.EqualTo(1));
             Assert.That(score.Statistics[HitResult.Miss], Is.EqualTo(1));
             Assert.That(score.Statistics[HitResult.LargeTickHit], Is.EqualTo(1));
             Assert.That(score.Statistics[HitResult.LargeTickMiss], Is.EqualTo(1));
             Assert.That(score.Statistics[HitResult.SmallTickMiss], Is.EqualTo(2));
+            Assert.That(score.Statistics[HitResult.SmallBonus], Is.EqualTo(1));
+            Assert.That(score.Statistics[HitResult.IgnoreMiss], Is.EqualTo(1));
         }
 
         private class TestJudgement : Judgement

--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -15,6 +16,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Tests.Gameplay
@@ -91,6 +93,41 @@ namespace osu.Game.Tests.Gameplay
             Assert.That(scoreProcessor.Combo.Value, Is.EqualTo(0));
         }
 
+        [Test]
+        public void TestFailScore()
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                HitObjects =
+                {
+                    new TestHitObject(),
+                    new TestHitObject(HitResult.LargeTickHit),
+                    new TestHitObject(HitResult.SmallTickHit),
+                    new TestHitObject(),
+                    new TestHitObject(HitResult.LargeTickHit),
+                    new TestHitObject(HitResult.SmallTickHit),
+                }
+            };
+
+            var scoreProcessor = new ScoreProcessor(new OsuRuleset());
+            scoreProcessor.ApplyBeatmap(beatmap);
+
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], beatmap.HitObjects[0].CreateJudgement()) { Type = HitResult.Ok });
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], beatmap.HitObjects[1].CreateJudgement()) { Type = HitResult.LargeTickHit });
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[2], beatmap.HitObjects[2].CreateJudgement()) { Type = HitResult.SmallTickMiss });
+
+            var score = new ScoreInfo { Ruleset = new OsuRuleset().RulesetInfo };
+            scoreProcessor.FailScore(score);
+
+            Assert.That(score.Rank, Is.EqualTo(ScoreRank.F));
+            Assert.That(score.Statistics.Count(kvp => kvp.Value > 0), Is.EqualTo(5));
+            Assert.That(score.Statistics[HitResult.Ok], Is.EqualTo(1));
+            Assert.That(score.Statistics[HitResult.Miss], Is.EqualTo(1));
+            Assert.That(score.Statistics[HitResult.LargeTickHit], Is.EqualTo(1));
+            Assert.That(score.Statistics[HitResult.LargeTickMiss], Is.EqualTo(1));
+            Assert.That(score.Statistics[HitResult.SmallTickMiss], Is.EqualTo(2));
+        }
+
         private class TestJudgement : Judgement
         {
             public override HitResult MaxResult { get; }
@@ -99,6 +136,18 @@ namespace osu.Game.Tests.Gameplay
             {
                 MaxResult = maxResult;
             }
+        }
+
+        private class TestHitObject : HitObject
+        {
+            private readonly HitResult maxResult;
+
+            public TestHitObject(HitResult maxResult = HitResult.Perfect)
+            {
+                this.maxResult = maxResult;
+            }
+
+            public override Judgement CreateJudgement() => new TestJudgement(maxResult);
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -126,6 +126,9 @@ namespace osu.Game.Rulesets.Scoring
         private bool beatmapApplied;
 
         private readonly Dictionary<HitResult, int> scoreResultCounts = new Dictionary<HitResult, int>();
+
+        private Dictionary<HitResult, int>? maximumResultCounts;
+
         private readonly List<HitEvent> hitEvents = new List<HitEvent>();
         private HitObject? lastHitObject;
 
@@ -410,12 +413,16 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.Reset(storeResults);
 
-            scoreResultCounts.Clear();
             hitEvents.Clear();
             lastHitObject = null;
 
             if (storeResults)
+            {
                 maximumScoringValues = currentScoringValues;
+                maximumResultCounts = new Dictionary<HitResult, int>(scoreResultCounts);
+            }
+
+            scoreResultCounts.Clear();
 
             currentScoringValues = default;
             currentMaximumScoringValues = default;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -472,7 +472,7 @@ namespace osu.Game.Rulesets.Scoring
             if (maximumResultCounts.TryGetValue(HitResult.SmallTickHit, out int maximumSmallTick))
                 scoreResultCounts[HitResult.SmallTickMiss] = maximumSmallTick - scoreResultCounts.GetValueOrDefault(HitResult.SmallTickHit);
 
-            int maximumBasic = maximumResultCounts.Single(kvp => kvp.Key.IsBasic()).Value;
+            int maximumBasic = maximumResultCounts.SingleOrDefault(kvp => kvp.Key.IsBasic()).Value;
             int currentBasic = scoreResultCounts.Where(kvp => kvp.Key.IsBasic() && kvp.Key != HitResult.Miss).Sum(kvp => kvp.Value);
             scoreResultCounts[HitResult.Miss] = maximumBasic - currentBasic;
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -462,9 +462,7 @@ namespace osu.Game.Rulesets.Scoring
                 return;
 
             score.Passed = false;
-
             Rank.Value = ScoreRank.F;
-            Rank.Disabled = true;
 
             Debug.Assert(maximumResultCounts != null);
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -474,6 +474,10 @@ namespace osu.Game.Rulesets.Scoring
             if (maximumResultCounts.TryGetValue(HitResult.SmallTickHit, out int maximumSmallTick))
                 scoreResultCounts[HitResult.SmallTickMiss] = maximumSmallTick - scoreResultCounts.GetValueOrDefault(HitResult.SmallTickHit);
 
+            int maximumBonusOrIgnore = maximumResultCounts.Where(kvp => kvp.Key.IsBonus() || kvp.Key == HitResult.IgnoreHit).Sum(kvp => kvp.Value);
+            int currentBonusOrIgnore = scoreResultCounts.Where(kvp => kvp.Key.IsBonus() || kvp.Key == HitResult.IgnoreHit).Sum(kvp => kvp.Value);
+            scoreResultCounts[HitResult.IgnoreMiss] = maximumBonusOrIgnore - currentBonusOrIgnore;
+
             int maximumBasic = maximumResultCounts.SingleOrDefault(kvp => kvp.Key.IsBasic()).Value;
             int currentBasic = scoreResultCounts.Where(kvp => kvp.Key.IsBasic() && kvp.Key != HitResult.Miss).Sum(kvp => kvp.Value);
             scoreResultCounts[HitResult.Miss] = maximumBasic - currentBasic;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -461,6 +461,8 @@ namespace osu.Game.Rulesets.Scoring
             if (Rank.Value == ScoreRank.F)
                 return;
 
+            score.Passed = false;
+
             Rank.Value = ScoreRank.F;
             Rank.Disabled = true;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -851,7 +851,6 @@ namespace osu.Game.Screens.Play
             // fail completion is a good point to mark a score as failed,
             // since the last judgement that caused the fail only applies to score processor after onFail.
             // todo: this should probably be handled better.
-            Score.ScoreInfo.Passed = false;
             ScoreProcessor.FailScore(Score.ScoreInfo);
 
             GameplayClockContainer.Stop();
@@ -1030,10 +1029,7 @@ namespace osu.Game.Screens.Play
 
                 // if arriving here and the results screen preparation task hasn't run, it's safe to say the user has not completed the beatmap.
                 if (prepareScoreForDisplayTask == null)
-                {
-                    Score.ScoreInfo.Passed = false;
                     ScoreProcessor.FailScore(Score.ScoreInfo);
-                }
 
                 // EndPlaying() is typically called from ReplayRecorder.Dispose(). Disposal is currently asynchronous.
                 // To resolve test failures, forcefully end playing synchronously when this screen exits.

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -267,12 +267,7 @@ namespace osu.Game.Screens.Play
                 },
                 FailOverlay = new FailOverlay
                 {
-                    SaveReplay = () =>
-                    {
-                        Score.ScoreInfo.Passed = false;
-                        Score.ScoreInfo.Rank = ScoreRank.F;
-                        return prepareAndImportScore();
-                    },
+                    SaveReplay = prepareAndImportScore,
                     OnRetry = Restart,
                     OnQuit = () => PerformExit(true),
                 },
@@ -831,7 +826,6 @@ namespace osu.Game.Screens.Play
                 return false;
 
             GameplayState.HasFailed = true;
-            Score.ScoreInfo.Passed = false;
 
             updateGameplayState();
 
@@ -849,9 +843,17 @@ namespace osu.Game.Screens.Play
             return true;
         }
 
-        // Called back when the transform finishes
+        /// <summary>
+        /// Invoked when the fail animation has finished.
+        /// </summary>
         private void onFailComplete()
         {
+            // fail completion is a good point to mark a score as failed,
+            // since the last judgement that caused the fail only applies to score processor after onFail.
+            // todo: this should probably be handled better.
+            Score.ScoreInfo.Passed = false;
+            ScoreProcessor.FailScore(Score.ScoreInfo);
+
             GameplayClockContainer.Stop();
 
             FailOverlay.Retries = RestartCount;
@@ -1030,7 +1032,7 @@ namespace osu.Game.Screens.Play
                 if (prepareScoreForDisplayTask == null)
                 {
                     Score.ScoreInfo.Passed = false;
-                    Score.ScoreInfo.Rank = ScoreRank.F;
+                    ScoreProcessor.FailScore(Score.ScoreInfo);
                 }
 
                 // EndPlaying() is typically called from ReplayRecorder.Dispose(). Disposal is currently asynchronous.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/19259

Not 100% sure about this as a final fix, but works well for now. Have also took the time to move the assignment of F rank to `ScoreProcessor` so that the rank bindable is also updated and locked in place.