### PR TITLE
Fix changelog overlay tests failing due to missing `CreatedAt` date

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -108,6 +108,7 @@ namespace osu.Game.Tests.Visual.Online
                 Version = "2018.712.0",
                 DisplayVersion = "2018.712.0",
                 UpdateStream = streams[OsuGameBase.CLIENT_STREAM_NAME],
+                CreatedAt = new DateTime(2018, 7, 12),
                 ChangelogEntries = new List<APIChangelogEntry>
                 {
                     new APIChangelogEntry
@@ -171,6 +172,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Version = "2019.920.0",
                 DisplayVersion = "2019.920.0",
+                CreatedAt = new DateTime(2019, 9, 20),
                 UpdateStream = new APIUpdateStream
                 {
                     Name = "Test",


### PR DESCRIPTION
No idea why these don't show on CI, but locally it fails with:

<img width="1486" alt="CleanShot 2022-07-21 at 07 22 23@2x" src="https://user-images.githubusercontent.com/22781491/180129354-c09e69c5-8275-47d8-b296-480cdffaf409.png">

EDIT: Turns out it's showing only on my end because my system's calendar got involved in this during date formatting (notice `UmAlQuraCalendar`):

<img width="1409" alt="CleanShot 2022-07-21 at 07 31 18@2x" src="https://user-images.githubusercontent.com/22781491/180130280-ee56ed4f-6e50-43f7-bd15-9a293d9a4666.png">

Should still be a correct change either way.