### PR TITLE
Change carousel terminology to not use `Children` / `InternalChildren`

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Screens.Select
         {
             CarouselRoot newRoot = new CarouselRoot(this);
 
-            newRoot.AddChildren(beatmapSets.Select(s => createCarouselSet(s.Detach())).Where(g => g != null));
+            newRoot.AddItems(beatmapSets.Select(s => createCarouselSet(s.Detach())).Where(g => g != null));
 
             root = newRoot;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Select
 
         private readonly NoResultsPlaceholder noResultsPlaceholder;
 
-        private IEnumerable<CarouselBeatmapSet> beatmapSets => root.Children.OfType<CarouselBeatmapSet>();
+        private IEnumerable<CarouselBeatmapSet> beatmapSets => root.Items.OfType<CarouselBeatmapSet>();
 
         // todo: only used for testing, maybe remove.
         private bool loadedTestBeatmaps;
@@ -300,7 +300,7 @@ namespace osu.Game.Screens.Select
             if (!root.BeatmapSetsByID.TryGetValue(beatmapSetID, out var existingSet))
                 return;
 
-            root.RemoveChild(existingSet);
+            root.RemoveItem(existingSet);
             itemsCache.Invalidate();
 
             if (!Scroll.UserScrolling)
@@ -321,7 +321,7 @@ namespace osu.Game.Screens.Select
 
             if (newSet != null)
             {
-                root.AddChild(newSet);
+                root.AddItem(newSet);
 
                 // check if we can/need to maintain our current selection.
                 if (previouslySelectedID != null)
@@ -415,7 +415,7 @@ namespace osu.Game.Screens.Select
             if (selectedBeatmap == null)
                 return;
 
-            var unfilteredDifficulties = selectedBeatmapSet.Children.Where(s => !s.Filtered.Value).ToList();
+            var unfilteredDifficulties = selectedBeatmapSet.Items.Where(s => !s.Filtered.Value).ToList();
 
             int index = unfilteredDifficulties.IndexOf(selectedBeatmap);
 
@@ -798,7 +798,7 @@ namespace osu.Game.Screens.Select
 
             scrollTarget = null;
 
-            foreach (CarouselItem item in root.Children)
+            foreach (CarouselItem item in root.Items)
             {
                 if (item.Filtered.Value)
                     continue;
@@ -964,26 +964,26 @@ namespace osu.Game.Screens.Select
                 this.carousel = carousel;
             }
 
-            public override void AddChild(CarouselItem i)
+            public override void AddItem(CarouselItem i)
             {
                 CarouselBeatmapSet set = (CarouselBeatmapSet)i;
                 BeatmapSetsByID.Add(set.BeatmapSet.ID, set);
 
-                base.AddChild(i);
+                base.AddItem(i);
             }
 
             public void RemoveChild(Guid beatmapSetID)
             {
                 if (BeatmapSetsByID.TryGetValue(beatmapSetID, out var carouselBeatmapSet))
-                    RemoveChild(carouselBeatmapSet);
+                    RemoveItem(carouselBeatmapSet);
             }
 
-            public override void RemoveChild(CarouselItem i)
+            public override void RemoveItem(CarouselItem i)
             {
                 CarouselBeatmapSet set = (CarouselBeatmapSet)i;
                 BeatmapSetsByID.Remove(set.BeatmapSet.ID);
 
-                base.RemoveChild(i);
+                base.RemoveItem(i);
             }
 
             protected override void PerformSelection()

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Select.Carousel
                 switch (State.Value)
                 {
                     case CarouselItemState.Selected:
-                        return DrawableCarouselBeatmapSet.HEIGHT + Children.Count(c => c.Visible) * DrawableCarouselBeatmap.HEIGHT;
+                        return DrawableCarouselBeatmapSet.HEIGHT + Items.Count(c => c.Visible) * DrawableCarouselBeatmap.HEIGHT;
 
                     default:
                         return DrawableCarouselBeatmapSet.HEIGHT;
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
         }
 
-        public IEnumerable<CarouselBeatmap> Beatmaps => InternalChildren.OfType<CarouselBeatmap>();
+        public IEnumerable<CarouselBeatmap> Beatmaps => Items.OfType<CarouselBeatmap>();
 
         public BeatmapSetInfo BeatmapSet;
 
@@ -44,15 +44,15 @@ namespace osu.Game.Screens.Select.Carousel
                       .OrderBy(b => b.Ruleset)
                       .ThenBy(b => b.StarRating)
                       .Select(b => new CarouselBeatmap(b))
-                      .ForEach(AddChild);
+                      .ForEach(AddItem);
         }
 
         protected override CarouselItem GetNextToSelect()
         {
             if (LastSelected == null || LastSelected.Filtered.Value)
             {
-                if (GetRecommendedBeatmap?.Invoke(Children.OfType<CarouselBeatmap>().Where(b => !b.Filtered.Value).Select(b => b.BeatmapInfo)) is BeatmapInfo recommended)
-                    return Children.OfType<CarouselBeatmap>().First(b => b.BeatmapInfo.Equals(recommended));
+                if (GetRecommendedBeatmap?.Invoke(Items.OfType<CarouselBeatmap>().Where(b => !b.Filtered.Value).Select(b => b.BeatmapInfo)) is BeatmapInfo recommended)
+                    return Items.OfType<CarouselBeatmap>().First(b => b.BeatmapInfo.Equals(recommended));
             }
 
             return base.GetNextToSelect();
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Select.Carousel
         public override void Filter(FilterCriteria criteria)
         {
             base.Filter(criteria);
-            Filtered.Value = InternalChildren.All(i => i.Filtered.Value);
+            Filtered.Value = Items.All(i => i.Filtered.Value);
         }
 
         public override string ToString() => BeatmapSet.ToString();

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Screens.Select.Carousel
     {
         public override DrawableCarouselItem? CreateDrawableRepresentation() => null;
 
-        public IReadOnlyList<CarouselItem> Children => InternalChildren;
+        public IReadOnlyList<CarouselItem> Items => items;
 
-        protected List<CarouselItem> InternalChildren = new List<CarouselItem>();
+        private List<CarouselItem> items = new List<CarouselItem>();
 
         /// <summary>
         /// Used to assign a monotonically increasing ID to children as they are added. This member is
@@ -27,16 +27,18 @@ namespace osu.Game.Screens.Select.Carousel
 
         private FilterCriteria? lastCriteria;
 
-        public virtual void RemoveChild(CarouselItem i)
+        protected int GetIndexOfItem(CarouselItem lastSelected) => items.IndexOf(lastSelected);
+
+        public virtual void RemoveItem(CarouselItem i)
         {
-            InternalChildren.Remove(i);
+            items.Remove(i);
 
             // it's important we do the deselection after removing, so any further actions based on
             // State.ValueChanged make decisions post-removal.
             i.State.Value = CarouselItemState.Collapsed;
         }
 
-        public virtual void AddChild(CarouselItem i)
+        public virtual void AddItem(CarouselItem i)
         {
             i.State.ValueChanged += state => ChildItemStateChanged(i, state.NewValue);
             i.ChildID = ++currentChildID;
@@ -45,21 +47,21 @@ namespace osu.Game.Screens.Select.Carousel
             {
                 i.Filter(lastCriteria);
 
-                int index = InternalChildren.BinarySearch(i, criteriaComparer);
+                int index = items.BinarySearch(i, criteriaComparer);
                 if (index < 0) index = ~index; // BinarySearch hacks multiple return values with 2's complement.
 
-                InternalChildren.Insert(index, i);
+                items.Insert(index, i);
             }
             else
             {
                 // criteria may be null for initial population. the filtering will be applied post-add.
-                InternalChildren.Add(i);
+                items.Add(i);
             }
         }
 
         public CarouselGroup(List<CarouselItem>? items = null)
         {
-            if (items != null) InternalChildren = items;
+            if (items != null) this.items = items;
 
             State.ValueChanged += state =>
             {
@@ -67,11 +69,11 @@ namespace osu.Game.Screens.Select.Carousel
                 {
                     case CarouselItemState.Collapsed:
                     case CarouselItemState.NotSelected:
-                        InternalChildren.ForEach(c => c.State.Value = CarouselItemState.Collapsed);
+                        this.items.ForEach(c => c.State.Value = CarouselItemState.Collapsed);
                         break;
 
                     case CarouselItemState.Selected:
-                        InternalChildren.ForEach(c =>
+                        this.items.ForEach(c =>
                         {
                             if (c.State.Value == CarouselItemState.Collapsed) c.State.Value = CarouselItemState.NotSelected;
                         });
@@ -84,11 +86,11 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Filter(criteria);
 
-            InternalChildren.ForEach(c => c.Filter(criteria));
+            items.ForEach(c => c.Filter(criteria));
 
             // IEnumerable<T>.OrderBy() is used instead of List<T>.Sort() to ensure sorting stability
             criteriaComparer = Comparer<CarouselItem>.Create((x, y) => x.CompareTo(criteria, y));
-            InternalChildren = InternalChildren.OrderBy(c => c, criteriaComparer).ToList();
+            items = items.OrderBy(c => c, criteriaComparer).ToList();
 
             lastCriteria = criteria;
         }
@@ -98,7 +100,7 @@ namespace osu.Game.Screens.Select.Carousel
             // ensure we are the only item selected
             if (value == CarouselItemState.Selected)
             {
-                foreach (var b in InternalChildren)
+                foreach (var b in items)
                 {
                     if (item == b) continue;
 

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -49,9 +49,9 @@ namespace osu.Game.Screens.Select.Carousel
             attemptSelection();
         }
 
-        public override void RemoveChild(CarouselItem i)
+        public override void RemoveItem(CarouselItem i)
         {
-            base.RemoveChild(i);
+            base.RemoveItem(i);
 
             if (i != LastSelected)
                 updateSelectedIndex();
@@ -64,16 +64,16 @@ namespace osu.Game.Screens.Select.Carousel
             addingChildren = true;
 
             foreach (var i in items)
-                AddChild(i);
+                AddItem(i);
 
             addingChildren = false;
 
             attemptSelection();
         }
 
-        public override void AddChild(CarouselItem i)
+        public override void AddItem(CarouselItem i)
         {
-            base.AddChild(i);
+            base.AddItem(i);
             if (!addingChildren)
                 attemptSelection();
         }
@@ -103,15 +103,15 @@ namespace osu.Game.Screens.Select.Carousel
             if (State.Value != CarouselItemState.Selected) return;
 
             // we only perform eager selection if none of our children are in a selected state already.
-            if (Children.Any(i => i.State.Value == CarouselItemState.Selected)) return;
+            if (Items.Any(i => i.State.Value == CarouselItemState.Selected)) return;
 
             PerformSelection();
         }
 
         protected virtual CarouselItem GetNextToSelect()
         {
-            return Children.Skip(lastSelectedIndex).FirstOrDefault(i => !i.Filtered.Value) ??
-                   Children.Reverse().Skip(InternalChildren.Count - lastSelectedIndex).FirstOrDefault(i => !i.Filtered.Value);
+            return Items.Skip(lastSelectedIndex).FirstOrDefault(i => !i.Filtered.Value) ??
+                   Items.Reverse().Skip(Items.Count - lastSelectedIndex).FirstOrDefault(i => !i.Filtered.Value);
         }
 
         protected virtual void PerformSelection()
@@ -131,6 +131,6 @@ namespace osu.Game.Screens.Select.Carousel
             updateSelectedIndex();
         }
 
-        private void updateSelectedIndex() => lastSelectedIndex = LastSelected == null ? 0 : Math.Max(0, InternalChildren.IndexOf(LastSelected));
+        private void updateSelectedIndex() => lastSelectedIndex = LastSelected == null ? 0 : Math.Max(0, GetIndexOfItem(LastSelected));
     }
 }

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -57,16 +57,16 @@ namespace osu.Game.Screens.Select.Carousel
                 updateSelectedIndex();
         }
 
-        private bool addingChildren;
+        private bool addingItems;
 
-        public void AddChildren(IEnumerable<CarouselItem> items)
+        public void AddItems(IEnumerable<CarouselItem> items)
         {
-            addingChildren = true;
+            addingItems = true;
 
             foreach (var i in items)
                 AddItem(i);
 
-            addingChildren = false;
+            addingItems = false;
 
             attemptSelection();
         }
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.Select.Carousel
         public override void AddItem(CarouselItem i)
         {
             base.AddItem(i);
-            if (!addingChildren)
+            if (!addingItems)
                 attemptSelection();
         }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Select.Carousel
         {
             var carouselBeatmapSet = (CarouselBeatmapSet)Item;
 
-            var visibleBeatmaps = carouselBeatmapSet.Children.Where(c => c.Visible).ToArray();
+            var visibleBeatmaps = carouselBeatmapSet.Items.Where(c => c.Visible).ToArray();
 
             // if we are already displaying all the correct beatmaps, only run animation updates.
             // note that the displayed beatmaps may change due to the applied filter.

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Select.Carousel
 
                     if (item is CarouselGroup group)
                     {
-                        foreach (var c in group.Children)
+                        foreach (var c in group.Items)
                             c.Filtered.ValueChanged -= onStateChange;
                     }
                 }
@@ -117,7 +117,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (Item is CarouselGroup group)
             {
-                foreach (var c in group.Children)
+                foreach (var c in group.Items)
                     c.Filtered.ValueChanged += onStateChange;
             }
         }


### PR DESCRIPTION
Because I don't like being convinced that something is doing a drawable operation (like `InternalChildren.Remove(x)`) when it's actually a model class.

Doesn't change any functionality.