### PR TITLE
Fix `UpdateBeatmapSetButton` intermittent test failure

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -71,6 +71,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 carousel.UpdateBeatmapSet(testBeatmapSetInfo);
             });
 
+            AddUntilStep("only one set visible", () => carousel.ChildrenOfType<DrawableCarouselBeatmapSet>().Count() == 1);
             AddUntilStep("update button visible", () => getUpdateButton() != null);
 
             AddStep("click button", () => getUpdateButton()?.TriggerClick());
@@ -120,6 +121,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 carousel.UpdateBeatmapSet(testBeatmapSetInfo);
             });
 
+            AddUntilStep("only one set visible", () => carousel.ChildrenOfType<DrawableCarouselBeatmapSet>().Count() == 1);
             AddUntilStep("update button visible", () => getUpdateButton() != null);
 
             AddStep("click button", () => getUpdateButton()?.TriggerClick());


### PR DESCRIPTION
As seen [here](https://github.com/ppy/osu/runs/7441792335?check_suite_focus=true). Carousel would only expire items when off-screen. This meant that for a case (like a test) where items are generally always on-screen, `UpdateBeatmapSet` calls would result in panels remaining hidden but not cleaned up.

- [x] Depends on #19268,