### PR TITLE
Remove logging of "failing" web requests

### DIFF
--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -212,7 +212,6 @@ namespace osu.Game.Online.API
                     }
                 }
 
-                Logger.Log($@"Failing request {this} ({e})", LoggingTarget.Network);
                 TriggerFailure(e);
             }
         }


### PR DESCRIPTION
There's already enough context for failing requrests. This adds nothing, especially since the call stack is most usually just `WebRequest` calling the method.

Before:

```csharp
[network] 2022-07-21 08:36:02 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapRequest
[network] 2022-07-21 08:36:02 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/channels successfully completed!
[network] 2022-07-21 08:36:02 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmaps/lookup failed with System.Net.WebException: NotFound.
[network] 2022-07-21 08:36:02 [verbose]: Response was: {"error":null}
[network] 2022-07-21 08:36:02 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (osu.Game.Online.API.APIException: Exception of type 'osu.Game.Online.API.APIException' was thrown.
[network] 2022-07-21 08:36:02 [verbose]: ---> System.Net.WebException: NotFound
[network] 2022-07-21 08:36:02 [verbose]: --- End of inner exception stack trace ---)
```

After:

```csharp
[network] 2022-07-21 08:30:59 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapRequest
[network] 2022-07-21 08:30:59 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmaps/lookup failed with System.Net.WebException: NotFound.
[network] 2022-07-21 08:30:59 [verbose]: Response was: {"error":null}
```