### PR TITLE
Add background beatmap processing

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
         private float halfCatcherWidth;
 
+        public override int Version => 20220701;
+
         public CatchDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
             : base(ruleset, beatmap)
         {

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         private readonly bool isForCurrentRuleset;
         private readonly double originalOverallDifficulty;
 
+        public override int Version => 20220701;
+
         public ManiaDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
             : base(ruleset, beatmap)
         {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private const double difficulty_multiplier = 0.0675;
         private double hitWindowGreat;
 
+        public override int Version => 20220701;
+
         public OsuDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
             : base(ruleset, beatmap)
         {

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private const double colour_skill_multiplier = 0.01;
         private const double stamina_skill_multiplier = 0.021;
 
+        public override int Version => 20220701;
+
         public TaikoDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
             : base(ruleset, beatmap)
         {

--- a/osu.Game.Tests/Database/BackgroundBeatmapProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundBeatmapProcessorTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Beatmaps.IO;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Database
+{
+    [HeadlessTest]
+    public class BackgroundBeatmapProcessorTests : OsuTestScene, ILocalUserPlayInfo
+    {
+        public IBindable<bool> IsPlaying => isPlaying;
+
+        private readonly Bindable<bool> isPlaying = new Bindable<bool>();
+
+        private BeatmapSetInfo importedSet = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGameBase osu)
+        {
+            importedSet = BeatmapImportHelper.LoadQuickOszIntoOsu(osu).GetResultSafely();
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("Set not playing", () => isPlaying.Value = false);
+        }
+
+        [Test]
+        public void TestDifficultyProcessing()
+        {
+            AddAssert("Difficulty is initially set", () =>
+            {
+                return Realm.Run(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
+                });
+            });
+
+            AddStep("Reset difficulty", () =>
+            {
+                Realm.Write(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    foreach (var b in beatmapSetInfo.Beatmaps)
+                        b.StarRating = -1;
+                });
+            });
+
+            AddStep("Run background processor", () =>
+            {
+                Add(new TestBackgroundBeatmapProcessor());
+            });
+
+            AddUntilStep("wait for difficulties repopulated", () =>
+            {
+                return Realm.Run(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
+                });
+            });
+        }
+
+        [Test]
+        public void TestDifficultyProcessingWhilePlaying()
+        {
+            AddAssert("Difficulty is initially set", () =>
+            {
+                return Realm.Run(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
+                });
+            });
+
+            AddStep("Set playing", () => isPlaying.Value = true);
+
+            AddStep("Reset difficulty", () =>
+            {
+                Realm.Write(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    foreach (var b in beatmapSetInfo.Beatmaps)
+                        b.StarRating = -1;
+                });
+            });
+
+            AddStep("Run background processor", () =>
+            {
+                Add(new TestBackgroundBeatmapProcessor());
+            });
+
+            AddWaitStep("wait some", 500);
+
+            AddAssert("Difficulty still not populated", () =>
+            {
+                return Realm.Run(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    return beatmapSetInfo.Beatmaps.All(b => b.StarRating == -1);
+                });
+            });
+
+            AddStep("Set not playing", () => isPlaying.Value = false);
+
+            AddUntilStep("wait for difficulties repopulated", () =>
+            {
+                return Realm.Run(r =>
+                {
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
+                });
+            });
+        }
+
+        public class TestBackgroundBeatmapProcessor : BackgroundBeatmapProcessor
+        {
+            protected override int TimeToSleepDuringGameplay => 10;
+        }
+    }
+}

--- a/osu.Game/BackgroundBeatmapProcessor.cs
+++ b/osu.Game/BackgroundBeatmapProcessor.cs
@@ -35,6 +35,8 @@ namespace osu.Game
         [Resolved]
         private ILocalUserPlayInfo? localUserPlayInfo { get; set; }
 
+        protected virtual int TimeToSleepDuringGameplay => 30000;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -107,8 +109,8 @@ namespace osu.Game
             {
                 while (localUserPlayInfo?.IsPlaying.Value == true)
                 {
-                    Logger.Log("Background processing sleeping 30s due to active gameplay...");
-                    Thread.Sleep(30000);
+                    Logger.Log("Background processing sleeping due to active gameplay...");
+                    Thread.Sleep(TimeToSleepDuringGameplay);
                 }
 
                 realmAccess.Run(r =>

--- a/osu.Game/BackgroundBeatmapProcessor.cs
+++ b/osu.Game/BackgroundBeatmapProcessor.cs
@@ -71,7 +71,7 @@ namespace osu.Game
                         {
                             if (b.Ruleset.ShortName == ruleset.ShortName)
                             {
-                                b.StarRating = 0;
+                                b.StarRating = -1;
                                 countReset++;
                             }
                         }
@@ -92,7 +92,7 @@ namespace osu.Game
 
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.StarRating == 0 || (b.OnlineID > 0 && b.LastOnlineUpdate == null)))
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.StarRating < 0 || (b.OnlineID > 0 && b.LastOnlineUpdate == null)))
                 {
                     Debug.Assert(b.BeatmapSet != null);
                     beatmapSetIds.Add(b.BeatmapSet.ID);

--- a/osu.Game/BackgroundBeatmapProcessor.cs
+++ b/osu.Game/BackgroundBeatmapProcessor.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets;
+
+namespace osu.Game
+{
+    public class BackgroundBeatmapProcessor : Component
+    {
+        [Resolved]
+        private RulesetStore rulesetStore { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realmAccess { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapUpdater beatmapUpdater { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> gameBeatmap { get; set; } = null!;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Task.Run(() =>
+            {
+                Logger.Log("Beginning background beatmap processing..");
+                checkForOutdatedStarRatings();
+                processBeatmapSetsWithMissingMetrics();
+                Logger.Log("Finished background beatmap processing!");
+            });
+        }
+
+        /// <summary>
+        /// Check whether the databased difficulty calculation version matches the latest ruleset provided version.
+        /// If it doesn't, clear out any existing difficulties so they can be incrementally recalculated.
+        /// </summary>
+        private void checkForOutdatedStarRatings()
+        {
+            foreach (var ruleset in rulesetStore.AvailableRulesets)
+            {
+                // beatmap being passed in is arbitrary here. just needs to be non-null.
+                int currentVersion = ruleset.CreateInstance().CreateDifficultyCalculator(gameBeatmap.Value).Version;
+
+                if (ruleset.LastAppliedDifficultyVersion < currentVersion)
+                {
+                    Logger.Log($"Resetting star ratings for {ruleset.Name} (difficulty calculation version updated from {ruleset.LastAppliedDifficultyVersion} to {currentVersion})");
+
+                    int countReset = 0;
+
+                    realmAccess.Write(r =>
+                    {
+                        foreach (var b in r.All<BeatmapInfo>())
+                        {
+                            if (b.Ruleset.ShortName == ruleset.ShortName)
+                            {
+                                b.StarRating = 0;
+                                countReset++;
+                            }
+                        }
+
+                        r.Find<RulesetInfo>(ruleset.ShortName).LastAppliedDifficultyVersion = currentVersion;
+                    });
+
+                    Logger.Log($"Finished resetting {countReset} beatmap sets for {ruleset.Name}");
+                }
+            }
+        }
+
+        private void processBeatmapSetsWithMissingMetrics()
+        {
+            // TODO: rate limit and pause processing during gameplay.
+
+            HashSet<Guid> beatmapSetIds = new HashSet<Guid>();
+
+            realmAccess.Run(r =>
+            {
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.StarRating == 0 || (b.OnlineID > 0 && b.LastOnlineUpdate == null)))
+                {
+                    Debug.Assert(b.BeatmapSet != null);
+                    beatmapSetIds.Add(b.BeatmapSet.ID);
+                }
+            });
+
+            foreach (var id in beatmapSetIds)
+            {
+                realmAccess.Run(r =>
+                {
+                    var set = r.Find<BeatmapSetInfo>(id);
+
+                    if (set != null)
+                    {
+                        Logger.Log($"Background processing {set}");
+                        beatmapUpdater.Process(set);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/osu.Game/BackgroundBeatmapProcessor.cs
+++ b/osu.Game/BackgroundBeatmapProcessor.cs
@@ -46,6 +46,14 @@ namespace osu.Game
                 Logger.Log("Beginning background beatmap processing..");
                 checkForOutdatedStarRatings();
                 processBeatmapSetsWithMissingMetrics();
+            }).ContinueWith(t =>
+            {
+                if (t.Exception?.InnerException is ObjectDisposedException)
+                {
+                    Logger.Log("Finished background aborted during shutdown");
+                    return;
+                }
+
                 Logger.Log("Finished background beatmap processing!");
             });
         }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -87,7 +87,11 @@ namespace osu.Game.Beatmaps
 
         public string Hash { get; set; } = string.Empty;
 
-        public double StarRating { get; set; }
+        /// <summary>
+        /// Defaults to -1 (meaning not-yet-calculated).
+        /// Will likely be superseded with a better storage considering ruleset/mods.
+        /// </summary>
+        public double StarRating { get; set; } = -1;
 
         [Indexed]
         public string MD5Hash { get; set; } = string.Empty;

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Database
         /// 17   2022-07-16    Added CountryCode to RealmUser.
         /// 18   2022-07-19    Added OnlineMD5Hash and LastOnlineUpdate to BeatmapInfo.
         /// 19   2022-07-19    Added DateSubmitted and DateRanked to BeatmapSetInfo.
-        /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo.
+        /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo, changed default value of BeatmapInfo.StarRating to -1.
         /// </summary>
         private const int schema_version = 20;
 
@@ -781,6 +781,16 @@ namespace osu.Game.Database
                 case 14:
                     foreach (var beatmap in migration.NewRealm.All<BeatmapInfo>())
                         beatmap.UserSettings = new BeatmapUserSettings();
+
+                    break;
+
+                case 20:
+                    foreach (var beatmap in migration.NewRealm.All<BeatmapInfo>())
+                    {
+                        if (beatmap.StarRating == 0)
+                            beatmap.StarRating = -1;
+                    }
+
                     break;
             }
         }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -785,11 +785,10 @@ namespace osu.Game.Database
                     break;
 
                 case 20:
+                    // As we now have versioned difficulty calculations, let's reset
+                    // all star ratings and have `BackgroundBeatmapProcessor` recalculate them.
                     foreach (var beatmap in migration.NewRealm.All<BeatmapInfo>())
-                    {
-                        if (beatmap.StarRating == 0)
-                            beatmap.StarRating = -1;
-                    }
+                        beatmap.StarRating = -1;
 
                     break;
             }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -63,8 +63,9 @@ namespace osu.Game.Database
         /// 17   2022-07-16    Added CountryCode to RealmUser.
         /// 18   2022-07-19    Added OnlineMD5Hash and LastOnlineUpdate to BeatmapInfo.
         /// 19   2022-07-19    Added DateSubmitted and DateRanked to BeatmapSetInfo.
+        /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo.
         /// </summary>
-        private const int schema_version = 19;
+        private const int schema_version = 20;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -904,6 +904,8 @@ namespace osu.Game
 
             loadComponentSingleFile(CreateHighPerformanceSession(), Add);
 
+            loadComponentSingleFile(new BackgroundBeatmapProcessor(), Add);
+
             chatOverlay.State.BindValueChanged(_ => updateChatPollRate());
             // Multiplayer modes need to increase poll rate temporarily.
             API.Activity.BindValueChanged(_ => updateChatPollRate(), true);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -280,8 +280,7 @@ namespace osu.Game
             AddInternal(difficultyCache);
 
             // TODO: OsuGame or OsuGameBase?
-            beatmapUpdater = new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage);
-
+            dependencies.CacheAs(beatmapUpdater = new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage));
             dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(multiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -34,6 +34,11 @@ namespace osu.Game.Rulesets.Difficulty
         private readonly IRulesetInfo ruleset;
         private readonly IWorkingBeatmap beatmap;
 
+        /// <summary>
+        /// A yymmdd version which is used to discern when reprocessing is required.
+        /// </summary>
+        public virtual int Version => 0;
+
         protected DifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
         {
             this.ruleset = ruleset;

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using JetBrains.Annotations;
 using osu.Framework.Testing;
+using osu.Game.Rulesets.Difficulty;
 using Realms;
 
 namespace osu.Game.Rulesets
@@ -21,6 +22,11 @@ namespace osu.Game.Rulesets
         public string Name { get; set; } = string.Empty;
 
         public string InstantiationInfo { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Stores the last applied <see cref="DifficultyCalculator.Version"/>
+        /// </summary>
+        public int LastAppliedDifficultyVersion { get; set; }
 
         public RulesetInfo(string shortName, string name, string instantiationInfo, int onlineID)
         {
@@ -86,7 +92,8 @@ namespace osu.Game.Rulesets
             Name = Name,
             ShortName = ShortName,
             InstantiationInfo = InstantiationInfo,
-            Available = Available
+            Available = Available,
+            LastAppliedDifficultyVersion = LastAppliedDifficultyVersion,
         };
 
         public Ruleset CreateInstance()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10242.

As discussed, this is intended to be a stepping stone towards better storage/processing of star ratings locally. The focus here is on the invalidation flow when difficulty algorithm changes occur, so I didn't put too much thought into the `BeatmapInfo` / realm storage of the star rating.

Of note, the default value is now `-1` to differentiate for "zero stars" and "not processed".

Also note that this will nuke all local beatmaps' difficulties once. Seems like a good move to get everything in a consistent state. This will also handle legacy issues like "length" not being calculated, for users with very old databases.

As previously mentioned, the online lookup / diff calc portions may eventually be split out (ie. "I only want to recalculate difficulty, not do an online lookup") but in name of simplicity I've left them bundled for now.

I haven't tested with a large database yet, so help there would be appreciated. I'll look to do that today or tomorrow.