### PR TITLE
Implement mod preset panels for mod select overlay

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestSceneModPresetPanel : OsuTestScene
+    {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
+
+        [Test]
+        public void TestVariousModPresets()
+        {
+            AddStep("create content", () => Child = new FillFlowContainer
+            {
+                Width = 300,
+                AutoSizeAxes = Axes.Y,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Spacing = new Vector2(0, 5),
+                ChildrenEnumerable = createTestPresets().Select(preset => new ModPresetPanel(preset))
+            });
+        }
+
+        private static IEnumerable<ModPreset> createTestPresets() => new[]
+        {
+            new ModPreset
+            {
+                Name = "First preset",
+                Description = "Please ignore",
+                Mods = new Mod[]
+                {
+                    new OsuModHardRock(),
+                    new OsuModDoubleTime()
+                }
+            },
+            new ModPreset
+            {
+                Name = "AR0",
+                Description = "For good readers",
+                Mods = new Mod[]
+                {
+                    new OsuModDifficultyAdjust
+                    {
+                        ApproachRate = { Value = 0 }
+                    }
+                }
+            },
+            new ModPreset
+            {
+                Name = "This preset is going to have an extraordinarily long name",
+                Description = "This is done so that the capability to truncate overlong texts may be demonstrated",
+                Mods = new Mod[]
+                {
+                    new OsuModFlashlight(),
+                    new OsuModSpinIn()
+                }
+            }
+        };
+    }
+}

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays.Mods
                 RelativeSizeAxes = Axes.Y,
                 AutoSizeAxes = Axes.X,
                 Masking = true,
-                CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
+                CornerRadius = ModSelectPanel.CORNER_RADIUS,
                 Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0),
                 Children = new Drawable[]
                 {
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays.Mods
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                         RelativeSizeAxes = Axes.Y,
-                        Width = multiplier_value_area_width + ModSelectOverlayPanel.CORNER_RADIUS
+                        Width = multiplier_value_area_width + ModSelectPanel.CORNER_RADIUS
                     },
                     new GridContainer
                     {
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.Mods
                                     RelativeSizeAxes = Axes.Y,
                                     AutoSizeAxes = Axes.X,
                                     Masking = true,
-                                    CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
+                                    CornerRadius = ModSelectPanel.CORNER_RADIUS,
                                     Children = new Drawable[]
                                     {
                                         contentBackground = new Box

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays.Mods
                 RelativeSizeAxes = Axes.Y,
                 AutoSizeAxes = Axes.X,
                 Masking = true,
-                CornerRadius = ModPanel.CORNER_RADIUS,
+                CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
                 Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0),
                 Children = new Drawable[]
                 {
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays.Mods
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                         RelativeSizeAxes = Axes.Y,
-                        Width = multiplier_value_area_width + ModPanel.CORNER_RADIUS
+                        Width = multiplier_value_area_width + ModSelectOverlayPanel.CORNER_RADIUS
                     },
                     new GridContainer
                     {
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.Mods
                                     RelativeSizeAxes = Axes.Y,
                                     AutoSizeAxes = Axes.X,
                                     Masking = true,
-                                    CornerRadius = ModPanel.CORNER_RADIUS,
+                                    CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
                                     Children = new Drawable[]
                                     {
                                         contentBackground = new Box

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -105,20 +105,20 @@ namespace osu.Game.Overlays.Mods
                 TopLevelContent = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    CornerRadius = ModPanel.CORNER_RADIUS,
+                    CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
                     Masking = true,
                     Children = new Drawable[]
                     {
                         new Container
                         {
                             RelativeSizeAxes = Axes.X,
-                            Height = header_height + ModPanel.CORNER_RADIUS,
+                            Height = header_height + ModSelectOverlayPanel.CORNER_RADIUS,
                             Children = new Drawable[]
                             {
                                 headerBackground = new Box
                                 {
                                     RelativeSizeAxes = Axes.X,
-                                    Height = header_height + ModPanel.CORNER_RADIUS
+                                    Height = header_height + ModSelectOverlayPanel.CORNER_RADIUS
                                 },
                                 headerText = new OsuTextFlowContainer(t =>
                                 {
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays.Mods
                                     Padding = new MarginPadding
                                     {
                                         Horizontal = 17,
-                                        Bottom = ModPanel.CORNER_RADIUS
+                                        Bottom = ModSelectOverlayPanel.CORNER_RADIUS
                                     }
                                 }
                             }
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.Mods
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Masking = true,
-                                CornerRadius = ModPanel.CORNER_RADIUS,
+                                CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
                                 BorderThickness = 3,
                                 Children = new Drawable[]
                                 {

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -105,20 +105,20 @@ namespace osu.Game.Overlays.Mods
                 TopLevelContent = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
+                    CornerRadius = ModSelectPanel.CORNER_RADIUS,
                     Masking = true,
                     Children = new Drawable[]
                     {
                         new Container
                         {
                             RelativeSizeAxes = Axes.X,
-                            Height = header_height + ModSelectOverlayPanel.CORNER_RADIUS,
+                            Height = header_height + ModSelectPanel.CORNER_RADIUS,
                             Children = new Drawable[]
                             {
                                 headerBackground = new Box
                                 {
                                     RelativeSizeAxes = Axes.X,
-                                    Height = header_height + ModSelectOverlayPanel.CORNER_RADIUS
+                                    Height = header_height + ModSelectPanel.CORNER_RADIUS
                                 },
                                 headerText = new OsuTextFlowContainer(t =>
                                 {
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays.Mods
                                     Padding = new MarginPadding
                                     {
                                         Horizontal = 17,
-                                        Bottom = ModSelectOverlayPanel.CORNER_RADIUS
+                                        Bottom = ModSelectPanel.CORNER_RADIUS
                                     }
                                 }
                             }
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.Mods
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Masking = true,
-                                CornerRadius = ModSelectOverlayPanel.CORNER_RADIUS,
+                                CornerRadius = ModSelectPanel.CORNER_RADIUS,
                                 BorderThickness = 3,
                                 Children = new Drawable[]
                                 {

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -1,144 +1,42 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input.Events;
-using osu.Framework.Utils;
-using osu.Game.Audio;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Overlays.Mods
 {
-    public class ModPanel : OsuClickableContainer
+    public class ModPanel : ModSelectOverlayPanel
     {
         public Mod Mod => modState.Mod;
-        public BindableBool Active => modState.Active;
+        public override BindableBool Active => modState.Active;
         public BindableBool Filtered => modState.Filtered;
 
+        protected override float IdleSwitchWidth => 54;
+        protected override float ExpandedSwitchWidth => 70;
+
         private readonly ModState modState;
-
-        protected readonly Box Background;
-        protected readonly Container SwitchContainer;
-        protected readonly Container MainContentContainer;
-        protected readonly Box TextBackground;
-        protected readonly FillFlowContainer TextFlow;
-
-        [Resolved]
-        protected OverlayColourProvider ColourProvider { get; private set; } = null!;
-
-        protected const double TRANSITION_DURATION = 150;
-
-        public const float CORNER_RADIUS = 7;
-
-        protected const float HEIGHT = 42;
-        protected const float IDLE_SWITCH_WIDTH = 54;
-        protected const float EXPANDED_SWITCH_WIDTH = 70;
-
-        private Colour4 activeColour;
-
-        private readonly Bindable<bool> samplePlaybackDisabled = new BindableBool();
-        private Sample? sampleOff;
-        private Sample? sampleOn;
 
         public ModPanel(ModState modState)
         {
             this.modState = modState;
 
-            RelativeSizeAxes = Axes.X;
-            Height = 42;
+            Title = Mod.Name;
+            Description = Mod.Description;
 
-            // all below properties are applied to `Content` rather than the `ModPanel` in its entirety
-            // to allow external components to set these properties on the panel without affecting
-            // its "internal" appearance.
-            Content.Masking = true;
-            Content.CornerRadius = CORNER_RADIUS;
-            Content.BorderThickness = 2;
-            Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
-
-            Children = new Drawable[]
+            SwitchContainer.Child = new ModSwitchSmall(Mod)
             {
-                Background = new Box
-                {
-                    RelativeSizeAxes = Axes.Both
-                },
-                SwitchContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.Y,
-                    Child = new ModSwitchSmall(Mod)
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Active = { BindTarget = Active },
-                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                        Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
-                    }
-                },
-                MainContentContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = new Container
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Masking = true,
-                        CornerRadius = CORNER_RADIUS,
-                        Children = new Drawable[]
-                        {
-                            TextBackground = new Box
-                            {
-                                RelativeSizeAxes = Axes.Both
-                            },
-                            TextFlow = new FillFlowContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding
-                                {
-                                    Horizontal = 17.5f,
-                                    Vertical = 4
-                                },
-                                Direction = FillDirection.Vertical,
-                                Children = new[]
-                                {
-                                    new OsuSpriteText
-                                    {
-                                        Text = Mod.Name,
-                                        Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                        Margin = new MarginPadding
-                                        {
-                                            Left = -18 * ShearedOverlayContainer.SHEAR
-                                        }
-                                    },
-                                    new OsuSpriteText
-                                    {
-                                        Text = Mod.Description,
-                                        Font = OsuFont.Default.With(size: 12),
-                                        RelativeSizeAxes = Axes.X,
-                                        Truncate = true,
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Active = { BindTarget = Active },
+                Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
+                Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
             };
-
-            Action = Active.Toggle;
         }
 
         public ModPanel(Mod mod)
@@ -146,121 +44,20 @@ namespace osu.Game.Overlays.Mods
         {
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, OsuColour colours, ISamplePlaybackDisabler? samplePlaybackDisabler)
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
         {
-            sampleOn = audio.Samples.Get(@"UI/check-on");
-            sampleOff = audio.Samples.Get(@"UI/check-off");
-
-            activeColour = colours.ForModType(Mod.Type);
-
-            if (samplePlaybackDisabler != null)
-                ((IBindable<bool>)samplePlaybackDisabled).BindTo(samplePlaybackDisabler.SamplePlaybackDisabled);
+            AccentColour = colours.ForModType(Mod.Type);
         }
-
-        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds(sampleSet);
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            Active.BindValueChanged(_ =>
-            {
-                playStateChangeSamples();
-                UpdateState();
-            });
+
             Filtered.BindValueChanged(_ => updateFilterState(), true);
-
-            UpdateState();
-            FinishTransforms(true);
-        }
-
-        private void playStateChangeSamples()
-        {
-            if (samplePlaybackDisabled.Value)
-                return;
-
-            if (Active.Value)
-                sampleOn?.Play();
-            else
-                sampleOff?.Play();
-        }
-
-        protected override bool OnHover(HoverEvent e)
-        {
-            UpdateState();
-            return base.OnHover(e);
-        }
-
-        protected override void OnHoverLost(HoverLostEvent e)
-        {
-            UpdateState();
-            base.OnHoverLost(e);
-        }
-
-        private bool mouseDown;
-
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            if (e.Button == MouseButton.Left)
-                mouseDown = true;
-
-            UpdateState();
-            return false;
-        }
-
-        protected override void OnMouseUp(MouseUpEvent e)
-        {
-            mouseDown = false;
-
-            UpdateState();
-            base.OnMouseUp(e);
-        }
-
-        protected virtual Colour4 BackgroundColour => Active.Value ? activeColour.Darken(0.3f) : ColourProvider.Background3;
-        protected virtual Colour4 ForegroundColour => Active.Value ? activeColour : ColourProvider.Background2;
-        protected virtual Colour4 TextColour => Active.Value ? ColourProvider.Background6 : Colour4.White;
-
-        protected virtual void UpdateState()
-        {
-            float targetWidth = Active.Value ? EXPANDED_SWITCH_WIDTH : IDLE_SWITCH_WIDTH;
-            double transitionDuration = TRANSITION_DURATION;
-
-            Colour4 backgroundColour = BackgroundColour;
-            Colour4 foregroundColour = ForegroundColour;
-            Colour4 textColour = TextColour;
-
-            // Hover affects colour of button background
-            if (IsHovered)
-            {
-                backgroundColour = backgroundColour.Lighten(0.1f);
-                foregroundColour = foregroundColour.Lighten(0.1f);
-            }
-
-            // Mouse down adds a halfway tween of the movement
-            if (mouseDown)
-            {
-                targetWidth = (float)Interpolation.Lerp(IDLE_SWITCH_WIDTH, EXPANDED_SWITCH_WIDTH, 0.5f);
-                transitionDuration *= 4;
-            }
-
-            Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, foregroundColour), transitionDuration, Easing.OutQuint);
-            Background.FadeColour(backgroundColour, transitionDuration, Easing.OutQuint);
-            SwitchContainer.ResizeWidthTo(targetWidth, transitionDuration, Easing.OutQuint);
-            MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
-            {
-                Left = targetWidth,
-                Right = CORNER_RADIUS
-            }, transitionDuration, Easing.OutQuint);
-            TextBackground.FadeColour(foregroundColour, transitionDuration, Easing.OutQuint);
-            TextFlow.FadeColour(textColour, transitionDuration, Easing.OutQuint);
         }
 
         #region Filtering support
-
-        public void ApplyFilter(Func<Mod, bool>? filter)
-        {
-            Filtered.Value = filter != null && !filter.Invoke(Mod);
-        }
 
         private void updateFilterState()
         {

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -11,7 +11,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Mods
 {
-    public class ModPanel : ModSelectOverlayPanel
+    public class ModPanel : ModSelectPanel
     {
         public Mod Mod => modState.Mod;
         public override BindableBool Active => modState.Active;

--- a/osu.Game/Overlays/Mods/ModPresetPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPresetPanel.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class ModPresetPanel : ModSelectOverlayPanel
+    {
+        public override BindableBool Active { get; } = new BindableBool();
+
+        public ModPresetPanel(ModPreset preset)
+        {
+            Title = preset.Name;
+            Description = preset.Description;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            AccentColour = colours.Orange1;
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModPresetPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPresetPanel.cs
@@ -3,17 +3,22 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Overlays.Mods
 {
-    public class ModPresetPanel : ModSelectOverlayPanel
+    public class ModPresetPanel : ModSelectOverlayPanel, IHasCustomTooltip<ModPreset>
     {
+        public readonly ModPreset Preset;
+
         public override BindableBool Active { get; } = new BindableBool();
 
         public ModPresetPanel(ModPreset preset)
         {
+            Preset = preset;
+
             Title = preset.Name;
             Description = preset.Description;
         }
@@ -23,5 +28,8 @@ namespace osu.Game.Overlays.Mods
         {
             AccentColour = colours.Orange1;
         }
+
+        public ModPreset TooltipContent => Preset;
+        public ITooltip<ModPreset> GetCustomTooltip() => new ModPresetTooltip(ColourProvider);
     }
 }

--- a/osu.Game/Overlays/Mods/ModPresetPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPresetPanel.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Overlays.Mods
 {
-    public class ModPresetPanel : ModSelectOverlayPanel, IHasCustomTooltip<ModPreset>
+    public class ModPresetPanel : ModSelectPanel, IHasCustomTooltip<ModPreset>
     {
         public readonly ModPreset Preset;
 

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osuTK;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class ModPresetTooltip : VisibilityContainer, ITooltip<ModPreset>
+    {
+        protected override Container<Drawable> Content { get; }
+
+        private const double transition_duration = 200;
+
+        public ModPresetTooltip(OverlayColourProvider colourProvider)
+        {
+            Width = 250;
+            AutoSizeAxes = Axes.Y;
+
+            Masking = true;
+            CornerRadius = 7;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background6
+                },
+                Content = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding(7),
+                    Spacing = new Vector2(7)
+                }
+            };
+        }
+
+        private ModPreset? lastPreset;
+
+        public void SetContent(ModPreset preset)
+        {
+            if (preset == lastPreset)
+                return;
+
+            lastPreset = preset;
+            Content.ChildrenEnumerable = preset.Mods.Select(mod => new ModPresetRow(mod));
+        }
+
+        protected override void PopIn() => this.FadeIn(transition_duration, Easing.OutQuint);
+        protected override void PopOut() => this.FadeOut(transition_duration, Easing.OutQuint);
+
+        public void Move(Vector2 pos) => Position = pos;
+
+        private class ModPresetRow : FillFlowContainer
+        {
+            public ModPresetRow(Mod mod)
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                Direction = FillDirection.Vertical;
+                Spacing = new Vector2(4);
+                InternalChildren = new Drawable[]
+                {
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(7),
+                        Children = new Drawable[]
+                        {
+                            new ModSwitchTiny(mod)
+                            {
+                                Active = { Value = true },
+                                Scale = new Vector2(0.6f),
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = mod.Name,
+                                Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold),
+                                Origin = Anchor.CentreLeft,
+                                Anchor = Anchor.CentreLeft,
+                                Margin = new MarginPadding { Bottom = 2 }
+                            }
+                        }
+                    }
+                };
+
+                if (!string.IsNullOrEmpty(mod.SettingDescription))
+                {
+                    AddInternal(new OsuTextFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding { Left = 14 },
+                        Text = mod.SettingDescription
+                    });
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModSelectOverlayPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlayPanel.cs
@@ -122,6 +122,8 @@ namespace osu.Game.Overlays.Mods
                                     titleText = new OsuSpriteText
                                     {
                                         Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
+                                        RelativeSizeAxes = Axes.X,
+                                        Truncate = true,
                                         Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
                                         Margin = new MarginPadding
                                         {

--- a/osu.Game/Overlays/Mods/ModSelectOverlayPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlayPanel.cs
@@ -1,0 +1,250 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Framework.Utils;
+using osu.Game.Audio;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Overlays.Mods
+{
+    public abstract class ModSelectOverlayPanel : OsuClickableContainer, IHasAccentColour
+    {
+        public abstract BindableBool Active { get; }
+
+        public Color4 AccentColour { get; set; }
+
+        public LocalisableString Title
+        {
+            get => titleText.Text;
+            set => titleText.Text = value;
+        }
+
+        public LocalisableString Description
+        {
+            get => descriptionText.Text;
+            set => descriptionText.Text = value;
+        }
+
+        public const float CORNER_RADIUS = 7;
+
+        protected const float HEIGHT = 42;
+
+        protected virtual float IdleSwitchWidth => 14;
+        protected virtual float ExpandedSwitchWidth => 30;
+        protected virtual Colour4 BackgroundColour => Active.Value ? AccentColour.Darken(0.3f) : ColourProvider.Background3;
+        protected virtual Colour4 ForegroundColour => Active.Value ? AccentColour : ColourProvider.Background2;
+        protected virtual Colour4 TextColour => Active.Value ? ColourProvider.Background6 : Colour4.White;
+
+        protected const double TRANSITION_DURATION = 150;
+
+        protected readonly Box Background;
+        protected readonly Container SwitchContainer;
+        protected readonly Container MainContentContainer;
+        protected readonly Box TextBackground;
+        protected readonly FillFlowContainer TextFlow;
+
+        [Resolved]
+        protected OverlayColourProvider ColourProvider { get; private set; } = null!;
+
+        private readonly OsuSpriteText titleText;
+        private readonly OsuSpriteText descriptionText;
+
+        private readonly Bindable<bool> samplePlaybackDisabled = new BindableBool();
+        private Sample? sampleOff;
+        private Sample? sampleOn;
+
+        protected ModSelectOverlayPanel()
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = HEIGHT;
+
+            // all below properties are applied to `Content` rather than the `ModPanel` in its entirety
+            // to allow external components to set these properties on the panel without affecting
+            // its "internal" appearance.
+            Content.Masking = true;
+            Content.CornerRadius = CORNER_RADIUS;
+            Content.BorderThickness = 2;
+
+            Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
+
+            Children = new Drawable[]
+            {
+                Background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                SwitchContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Y,
+                },
+                MainContentContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = CORNER_RADIUS,
+                        Children = new Drawable[]
+                        {
+                            TextBackground = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both
+                            },
+                            TextFlow = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding
+                                {
+                                    Horizontal = 17.5f,
+                                    Vertical = 4
+                                },
+                                Direction = FillDirection.Vertical,
+                                Children = new[]
+                                {
+                                    titleText = new OsuSpriteText
+                                    {
+                                        Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
+                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
+                                        Margin = new MarginPadding
+                                        {
+                                            Left = -18 * ShearedOverlayContainer.SHEAR
+                                        }
+                                    },
+                                    descriptionText = new OsuSpriteText
+                                    {
+                                        Font = OsuFont.Default.With(size: 12),
+                                        RelativeSizeAxes = Axes.X,
+                                        Truncate = true,
+                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Action = () => Active.Toggle();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio, ISamplePlaybackDisabler? samplePlaybackDisabler)
+        {
+            sampleOn = audio.Samples.Get(@"UI/check-on");
+            sampleOff = audio.Samples.Get(@"UI/check-off");
+
+            if (samplePlaybackDisabler != null)
+                ((IBindable<bool>)samplePlaybackDisabled).BindTo(samplePlaybackDisabler.SamplePlaybackDisabled);
+        }
+
+        protected sealed override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds(sampleSet);
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Active.BindValueChanged(_ =>
+            {
+                playStateChangeSamples();
+                UpdateState();
+            });
+
+            UpdateState();
+            FinishTransforms(true);
+        }
+
+        private void playStateChangeSamples()
+        {
+            if (samplePlaybackDisabled.Value)
+                return;
+
+            if (Active.Value)
+                sampleOn?.Play();
+            else
+                sampleOff?.Play();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            UpdateState();
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            UpdateState();
+            base.OnHoverLost(e);
+        }
+
+        private bool mouseDown;
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (e.Button == MouseButton.Left)
+                mouseDown = true;
+
+            UpdateState();
+            return false;
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            mouseDown = false;
+
+            UpdateState();
+            base.OnMouseUp(e);
+        }
+
+        protected virtual void UpdateState()
+        {
+            float targetWidth = Active.Value ? ExpandedSwitchWidth : IdleSwitchWidth;
+            double transitionDuration = TRANSITION_DURATION;
+
+            Colour4 backgroundColour = BackgroundColour;
+            Colour4 foregroundColour = ForegroundColour;
+            Colour4 textColour = TextColour;
+
+            // Hover affects colour of button background
+            if (IsHovered)
+            {
+                backgroundColour = backgroundColour.Lighten(0.1f);
+                foregroundColour = foregroundColour.Lighten(0.1f);
+            }
+
+            // Mouse down adds a halfway tween of the movement
+            if (mouseDown)
+            {
+                targetWidth = (float)Interpolation.Lerp(IdleSwitchWidth, ExpandedSwitchWidth, 0.5f);
+                transitionDuration *= 4;
+            }
+
+            Content.TransformTo(nameof(BorderColour), ColourInfo.GradientVertical(backgroundColour, foregroundColour), transitionDuration, Easing.OutQuint);
+            Background.FadeColour(backgroundColour, transitionDuration, Easing.OutQuint);
+            SwitchContainer.ResizeWidthTo(targetWidth, transitionDuration, Easing.OutQuint);
+            MainContentContainer.TransformTo(nameof(Padding), new MarginPadding
+            {
+                Left = targetWidth,
+                Right = CORNER_RADIUS
+            }, transitionDuration, Easing.OutQuint);
+            TextBackground.FadeColour(foregroundColour, transitionDuration, Easing.OutQuint);
+            TextFlow.FadeColour(textColour, transitionDuration, Easing.OutQuint);
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -24,7 +24,7 @@ using osuTK.Input;
 
 namespace osu.Game.Overlays.Mods
 {
-    public abstract class ModSelectOverlayPanel : OsuClickableContainer, IHasAccentColour
+    public abstract class ModSelectPanel : OsuClickableContainer, IHasAccentColour
     {
         public abstract BindableBool Active { get; }
 
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays.Mods
         private Sample? sampleOff;
         private Sample? sampleOn;
 
-        protected ModSelectOverlayPanel()
+        protected ModSelectPanel()
         {
             RelativeSizeAxes = Axes.X;
             Height = HEIGHT;

--- a/osu.Game/Rulesets/Mods/ModPreset.cs
+++ b/osu.Game/Rulesets/Mods/ModPreset.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.Rulesets.Mods
+{
+    /// <summary>
+    /// A mod preset is a named collection of configured mods.
+    /// Presets are presented to the user in the mod select overlay for convenience.
+    /// </summary>
+    public class ModPreset
+    {
+        /// <summary>
+        /// The ruleset that the preset is valid for.
+        /// </summary>
+        public RulesetInfo RulesetInfo { get; set; } = null!;
+
+        /// <summary>
+        /// The name of the mod preset.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The description of the mod preset.
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The set of configured mods that are part of the preset.
+        /// </summary>
+        public ICollection<Mod> Mods { get; set; } = Array.Empty<Mod>();
+    }
+}


### PR DESCRIPTION
This is the start of a series of pulls whose end goal is to add a mod preset column to the mod select overlay, [as foreshadowed by the designs on figma](https://www.figma.com/file/NkdREXr6wFkA99oLw8PnBv/Client%2FMod-Selection?node-id=2292%3A373).

While I have a few decently-formed thoughts as to where I want to take the implementation of this feature, I have not fully completed it yet. This branch is all I have for now; I expect there to be some figuring out of the details as we go.

For now, what this PR is offering is a simple start - a baseline model class for presets and a new panel type for displaying them:

https://user-images.githubusercontent.com/20418176/180319257-10d311c6-412f-4c5a-b49c-20e9742e93d1.mp4

The diff is large because most of it is abstractifying `ModPanel` so that I can reuse presentation logic for this panel too, to ensure visual consistency. The actual implementation is almost barebones, only augmented by the addition of the tooltip - I figure it will be a convenient thing to be able to check what is in the preset at a glance if the user forgets, for whatever reason.

I don't expect the model class to change much, but I am not considering serialisation or storage concerns yet. Likely there will be a guid primary key and the mods will be likely serialised to json (not sure if I want to hijack `APIMod` for this, or create some other structure). I figure that bridge can be crossed when need be.