### PR TITLE
Fix timeline `alt`+`scroll` zoom not correctly zooming to current mouse position

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
@@ -5,7 +5,6 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Utils;
 
 namespace osu.Game.Tests.Visual.Editing
 {
@@ -32,12 +31,12 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("get initial range", () => initialVisibleRange = TimelineArea.Timeline.VisibleRange);
 
             AddStep("scale zoom", () => TimelineArea.Timeline.Zoom = 200);
-            AddAssert("range halved", () => Precision.AlmostEquals(TimelineArea.Timeline.VisibleRange, initialVisibleRange / 2, 1));
+            AddStep("range halved", () => Assert.That(TimelineArea.Timeline.VisibleRange, Is.EqualTo(initialVisibleRange / 2).Within(1)));
             AddStep("descale zoom", () => TimelineArea.Timeline.Zoom = 50);
-            AddAssert("range doubled", () => Precision.AlmostEquals(TimelineArea.Timeline.VisibleRange, initialVisibleRange * 2, 1));
+            AddStep("range doubled", () => Assert.That(TimelineArea.Timeline.VisibleRange, Is.EqualTo(initialVisibleRange * 2).Within(1)));
 
             AddStep("restore zoom", () => TimelineArea.Timeline.Zoom = 100);
-            AddAssert("range restored", () => Precision.AlmostEquals(TimelineArea.Timeline.VisibleRange, initialVisibleRange, 1));
+            AddStep("range restored", () => Assert.That(TimelineArea.Timeline.VisibleRange, Is.EqualTo(initialVisibleRange).Within(1)));
         }
 
         [Test]

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -41,6 +41,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private EditorClock editorClock { get; set; }
 
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
         /// <summary>
         /// The timeline's scroll position in the last frame.
         /// </summary>
@@ -68,8 +71,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </summary>
         private float defaultTimelineZoom;
 
-        private readonly Bindable<double> timelineZoomScale = new BindableDouble(1.0);
-
         public Timeline(Drawable userContent)
         {
             this.userContent = userContent;
@@ -93,7 +94,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Bindable<float> waveformOpacity;
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, EditorBeatmap editorBeatmap, OsuColour colours, OsuConfigManager config)
+        private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours, OsuConfigManager config)
         {
             CentreMarker centreMarker;
 
@@ -154,12 +155,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 }
             }, true);
 
-            timelineZoomScale.Value = editorBeatmap.BeatmapInfo.TimelineZoom;
-            timelineZoomScale.BindValueChanged(scale =>
-            {
-                Zoom = (float)(defaultTimelineZoom * scale.NewValue);
-                editorBeatmap.BeatmapInfo.TimelineZoom = scale.NewValue;
-            }, true);
+            Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
         }
 
         protected override void LoadComplete()
@@ -221,7 +217,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         protected override void OnZoomChanged()
         {
             base.OnZoomChanged();
-            timelineZoomScale.Value = Zoom / defaultTimelineZoom;
+            editorBeatmap.BeatmapInfo.TimelineZoom = Zoom / defaultTimelineZoom;
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
This causes the focal point zooming to not work (as the focal point is lost). There's no need to handle ongoing changes to `BeatmapInfo.TimelineZoom` because it is not a property which is changed at runtime, so let's just nuke the bindable.