### PR TITLE
Fix sorting mode not filling up to usable area in filter control

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -115,42 +115,53 @@ namespace osu.Game.Screens.Select
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                     },
-                                    new FillFlowContainer
+                                    new GridContainer
                                     {
                                         Anchor = Anchor.BottomRight,
                                         Origin = Anchor.BottomRight,
-                                        Direction = FillDirection.Horizontal,
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,
-                                        Spacing = new Vector2(OsuTabControl<SortMode>.HORIZONTAL_SPACING, 0),
-                                        Children = new Drawable[]
+                                        ColumnDimensions = new[]
                                         {
-                                            new OsuTabControlCheckbox
+                                            new Dimension(GridSizeMode.AutoSize),
+                                            new Dimension(GridSizeMode.Absolute, OsuTabControl<SortMode>.HORIZONTAL_SPACING),
+                                            new Dimension(),
+                                            new Dimension(GridSizeMode.Absolute, OsuTabControl<SortMode>.HORIZONTAL_SPACING),
+                                            new Dimension(GridSizeMode.AutoSize),
+                                        },
+                                        RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                                        Content = new[]
+                                        {
+                                            new[]
                                             {
-                                                Text = "Show converted",
-                                                Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
-                                                Anchor = Anchor.BottomRight,
-                                                Origin = Anchor.BottomRight,
-                                            },
-                                            sortTabs = new OsuTabControl<SortMode>
-                                            {
-                                                RelativeSizeAxes = Axes.X,
-                                                Width = 0.5f,
-                                                Height = 24,
-                                                AutoSort = true,
-                                                Anchor = Anchor.BottomRight,
-                                                Origin = Anchor.BottomRight,
-                                                AccentColour = colours.GreenLight,
-                                                Current = { BindTarget = sortMode }
-                                            },
-                                            new OsuSpriteText
-                                            {
-                                                Text = SortStrings.Default,
-                                                Font = OsuFont.GetFont(size: 14),
-                                                Margin = new MarginPadding(5),
-                                                Anchor = Anchor.BottomRight,
-                                                Origin = Anchor.BottomRight,
-                                            },
+                                                new OsuSpriteText
+                                                {
+                                                    Text = SortStrings.Default,
+                                                    Font = OsuFont.GetFont(size: 14),
+                                                    Margin = new MarginPadding(5),
+                                                    Anchor = Anchor.BottomRight,
+                                                    Origin = Anchor.BottomRight,
+                                                },
+                                                Empty(),
+                                                sortTabs = new OsuTabControl<SortMode>
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    Height = 24,
+                                                    AutoSort = true,
+                                                    Anchor = Anchor.BottomRight,
+                                                    Origin = Anchor.BottomRight,
+                                                    AccentColour = colours.GreenLight,
+                                                    Current = { BindTarget = sortMode }
+                                                },
+                                                Empty(),
+                                                new OsuTabControlCheckbox
+                                                {
+                                                    Text = "Show converted",
+                                                    Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
+                                                    Anchor = Anchor.BottomRight,
+                                                    Origin = Anchor.BottomRight,
+                                                },
+                                            }
                                         }
                                     },
                                 }


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/19276

Can't think of a better alternative than using `GridContainer`, since there are three different drawables with two of them being autosized (show converted toggle and "sorting mode" label) and one distributed (sorting mode tab control).

---

https://user-images.githubusercontent.com/22781491/180377486-2a292ba4-60a5-45a9-9afe-7b5bed3f5a82.mp4
