### PR TITLE
Fix timeline zoom focus point when using zoom buttons

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -157,7 +157,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private void setZoomTarget(float newZoom, float? focusPoint = null)
         {
             zoomTarget = Math.Clamp(newZoom, MinZoom, MaxZoom);
-            transformZoomTo(zoomTarget, focusPoint ?? DrawWidth / 2, ZoomDuration, ZoomEasing);
+            focusPoint ??= zoomedContent.ToLocalSpace(ToScreenSpace(new Vector2(DrawWidth / 2, 0))).X;
+
+            transformZoomTo(zoomTarget, focusPoint.Value, ZoomDuration, ZoomEasing);
 
             OnZoomChanged();
         }


### PR DESCRIPTION
Technically regressed in https://github.com/ppy/osu/pull/19294 however this logic has been wrong for quite a while.

Master:

https://user-images.githubusercontent.com/1329837/180393263-c1630864-b2dd-4b7f-85bc-d2d9f5cb9e43.mp4

This PR:

https://user-images.githubusercontent.com/1329837/180393476-8be7588b-33c0-4b28-bdeb-e60e7fb6304a.mp4