### PR TITLE
Fix intermittent timeline test failures

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
@@ -13,16 +13,6 @@ namespace osu.Game.Tests.Visual.Editing
         public override Drawable CreateTestComponent() => Empty();
 
         [Test]
-        [FlakyTest]
-        /*
-         * Fail rate around 0.3%
-         *
-         * TearDown : osu.Framework.Testing.Drawables.Steps.AssertButton+TracedException : range halved
-         *   --TearDown
-         *      at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
-         *      at osu.Framework.Threading.Scheduler.Update()
-         *      at osu.Framework.Graphics.Drawable.UpdateSubTree()
-         */
         public void TestVisibleRangeUpdatesOnZoomChange()
         {
             double initialVisibleRange = 0;

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Tests.Visual.Editing
         {
             double initialVisibleRange = 0;
 
+            AddUntilStep("wait for track load", () => Beatmap.Value.TrackLoaded);
+
             AddStep("reset zoom", () => TimelineArea.Timeline.Zoom = 100);
             AddStep("get initial range", () => initialVisibleRange = TimelineArea.Timeline.VisibleRange);
 
@@ -43,6 +45,8 @@ namespace osu.Game.Tests.Visual.Editing
         public void TestVisibleRangeConstantOnSizeChange()
         {
             double initialVisibleRange = 0;
+
+            AddUntilStep("wait for track load", () => Beatmap.Value.TrackLoaded);
 
             AddStep("reset timeline size", () => TimelineArea.Timeline.Width = 1);
             AddStep("get initial range", () => initialVisibleRange = TimelineArea.Timeline.VisibleRange);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -193,9 +193,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 trackWasLoaded = true;
 
+                defaultTimelineZoom = getZoomLevelForVisibleMilliseconds(6000);
                 MaxZoom = getZoomLevelForVisibleMilliseconds(500);
                 MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-                defaultTimelineZoom = getZoomLevelForVisibleMilliseconds(6000);
 
                 Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
             }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -196,8 +196,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 defaultTimelineZoom = getZoomLevelForVisibleMilliseconds(6000);
                 MaxZoom = getZoomLevelForVisibleMilliseconds(500);
                 MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-
                 Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
+
+                // The above zoom causes an initial seek to the middle of the track (since the focus point is the centre of the timeline).
+                // This seek, because it happens as a result of an interaction with the timeline, causes the track to seek to the timeline's position, which we don't want.
+                // To get around this, we'll finish the transform immediately and give the last scroll position an initial value.
+                FinishTransforms(targetMember: nameof(Zoom));
+                lastScrollPosition = Current;
             }
 
             // The extrema of track time should be positioned at the centre of the container when scrolled to the start or end

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 this.scrollOffset = scrollOffset;
             }
 
-            public override string TargetMember => nameof(currentZoom);
+            public override string TargetMember => nameof(Zoom);
 
             private float valueAt(double time)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// <summary>
         /// Gets or sets the content zoom level of this <see cref="ZoomableScrollContainer"/>.
         /// </summary>
-        public float Zoom
+        public virtual float Zoom
         {
             get => zoomTarget;
             set => updateZoom(value);
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             zoomedContentWidthCache.Validate();
         }
 
-        public void AdjustZoomRelatively(float change, float? focusPoint = null)
+        public virtual void AdjustZoomRelatively(float change, float? focusPoint = null)
         {
             const float zoom_change_sensitivity = 0.02f;
 


### PR DESCRIPTION
E.g. https://github.com/ppy/osu/runs/7463295786?check_suite_focus=true

Can be reproed with framework-side patch:
```diff
diff --git a/osu.Framework/Audio/Track/TrackBass.cs b/osu.Framework/Audio/Track/TrackBass.cs
index 104f0ca196..7a4c07582b 100644
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -96,6 +96,8 @@ internal TrackBass(Stream data, bool quick = false)

             EnqueueAction(() =>
             {
+                Thread.Sleep(1000);
+
                 Preview = quick;

                 activeStream = prepareStream(data, quick);

```

Note that the added `AddUntilStep`s are not enough to resolve the issue, since the issue is internal to `Timeline`. The `AddUntilSteps` were added to make sure that the timeline isn't operated on before the track is loaded, otherwise it blocks being able to set `Zoom`.