### PR TITLE
Add additional SFX to the results screen

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.716.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.722.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.720.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.722.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.720.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.722.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                     FillMode = FillMode.Fit,
                                 }
                             },
-                            scoreCounter = new TotalScoreCounter
+                            scoreCounter = new TotalScoreCounter(!withFlair)
                             {
                                 Margin = new MarginPadding { Top = 0, Bottom = 5 },
                                 Current = { Value = 0 },

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelTopContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelTopContent.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
@@ -21,13 +23,19 @@ namespace osu.Game.Screens.Ranking.Expanded
     {
         private readonly APIUser user;
 
+        private Sample appearanceSample;
+
+        private readonly bool playAppearanceSound;
+
         /// <summary>
         /// Creates a new <see cref="ExpandedPanelTopContent"/>.
         /// </summary>
         /// <param name="user">The <see cref="APIUser"/> to display.</param>
-        public ExpandedPanelTopContent(APIUser user)
+        /// <param name="playAppearanceSound">Whether the appearance sample should play</param>
+        public ExpandedPanelTopContent(APIUser user, bool playAppearanceSound = false)
         {
             this.user = user;
+            this.playAppearanceSound = playAppearanceSound;
             Anchor = Anchor.TopCentre;
             Origin = Anchor.Centre;
 
@@ -35,8 +43,10 @@ namespace osu.Game.Screens.Ranking.Expanded
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
+            appearanceSample = audio.Samples.Get(@"Results/score-panel-top-appear");
+
             InternalChild = new FillFlowContainer
             {
                 AutoSizeAxes = Axes.Both,
@@ -61,6 +71,14 @@ namespace osu.Game.Screens.Ranking.Expanded
                     }
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (playAppearanceSound)
+                appearanceSample?.Play();
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
+++ b/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
@@ -93,11 +93,9 @@ namespace osu.Game.Screens.Ranking.Expanded
             const double tick_volume_start = 0.5f;
             const double tick_volume_end = 1.0f;
 
-            double tickDuration = RollingDuration;
-
             this.TransformBindableTo(tickPlaybackRate, tick_debounce_rate_start);
-            this.TransformBindableTo(tickPlaybackRate, tick_debounce_rate_end, tickDuration, Easing.OutSine);
-            sampleTick.VolumeTo(tick_volume_start).Then().VolumeTo(tick_volume_end, tickDuration, Easing.OutSine);
+            this.TransformBindableTo(tickPlaybackRate, tick_debounce_rate_end, RollingDuration, Easing.OutSine);
+            sampleTick.VolumeTo(tick_volume_start).Then().VolumeTo(tick_volume_end, RollingDuration, Easing.OutSine);
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
+++ b/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
@@ -3,7 +3,11 @@
 
 #nullable disable
 
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -22,11 +26,32 @@ namespace osu.Game.Screens.Ranking.Expanded
 
         protected override Easing RollingEasing => AccuracyCircle.ACCURACY_TRANSFORM_EASING;
 
-        public TotalScoreCounter()
+        private readonly bool playSound;
+        private bool isTicking;
+        private readonly Bindable<double> tickPlaybackRate = new Bindable<double>();
+        private double lastSampleTime;
+        private DrawableSample sampleTick;
+
+        public TotalScoreCounter(bool playSound = false)
         {
             // Todo: AutoSize X removed here due to https://github.com/ppy/osu-framework/issues/3369
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
+            this.playSound = playSound;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            AddInternal(sampleTick = new DrawableSample(audio.Samples.Get(@"Results/score-tick-lesser")));
+            lastSampleTime = Time.Current;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Current.BindValueChanged(startTickingPlayback);
         }
 
         protected override LocalisableString FormatCount(long count) => count.ToString("N0");
@@ -39,5 +64,40 @@ namespace osu.Game.Screens.Ranking.Expanded
             s.Font = OsuFont.Torus.With(size: 60, weight: FontWeight.Light, fixedWidth: true);
             s.Spacing = new Vector2(-5, 0);
         });
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (playSound && isTicking) playTickSample();
+        }
+
+        private void startTickingPlayback(ValueChangedEvent<long> _)
+        {
+            const double tick_debounce_rate_start = 10f;
+            const double tick_debounce_rate_end = 100f;
+            const double tick_volume_start = 0.5f;
+            const double tick_volume_end = 1.0f;
+            double tickDuration = RollingDuration - AccuracyCircle.ACCURACY_TRANSFORM_DELAY - AccuracyCircle.RANK_CIRCLE_TRANSFORM_DELAY;
+
+            this.TransformBindableTo(tickPlaybackRate, tick_debounce_rate_start);
+            this.TransformBindableTo(tickPlaybackRate, tick_debounce_rate_end, tickDuration, Easing.OutSine);
+            sampleTick.VolumeTo(tick_volume_start).Then().VolumeTo(tick_volume_end, tickDuration, Easing.OutSine);
+
+            Scheduler.AddDelayed(stopTickingPlayback, tickDuration);
+
+            isTicking = true;
+        }
+
+        private void stopTickingPlayback() => isTicking = false;
+
+        private void playTickSample()
+        {
+            if (Time.Current > lastSampleTime + tickPlaybackRate.Value)
+            {
+                sampleTick?.Play();
+                lastSampleTime = Time.Current;
+            }
+        }
     }
 }

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -60,6 +62,8 @@ namespace osu.Game.Screens.Ranking
         private readonly bool allowRetry;
         private readonly bool allowWatchingReplay;
 
+        private Sample popInSample;
+
         protected ResultsScreen(ScoreInfo score, bool allowRetry, bool allowWatchingReplay = true)
         {
             Score = score;
@@ -70,9 +74,11 @@ namespace osu.Game.Screens.Ranking
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             FillFlowContainer buttons;
+
+            popInSample = audio.Samples.Get(@"UI/overlay-pop-in");
 
             InternalChild = new GridContainer
             {
@@ -244,6 +250,8 @@ namespace osu.Game.Screens.Ranking
             });
 
             bottomPanel.FadeTo(1, 250);
+
+            popInSample?.Play();
         }
 
         public override bool OnExiting(ScreenExitEvent e)

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -96,7 +96,10 @@ namespace osu.Game.Screens.Ranking
 
         public readonly ScoreInfo Score;
 
-        public DrawableAudioMixer Mixer;
+        [Resolved]
+        private OsuGame game { get; set; }
+
+        private DrawableAudioMixer mixer;
 
         private bool displayWithFlair;
 
@@ -127,7 +130,7 @@ namespace osu.Game.Screens.Ranking
             // Adding a manual offset here allows the expanded version to take on an "acceptable" vertical centre when at 100% UI scale.
             const float vertical_fudge = 20;
 
-            InternalChild = Mixer = new DrawableAudioMixer
+            InternalChild = mixer = new DrawableAudioMixer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -219,6 +222,12 @@ namespace osu.Game.Screens.Ranking
             }
         }
 
+        protected override void Update()
+        {
+            base.Update();
+            mixer.Balance.Value = (ScreenSpaceDrawQuad.Centre.X / game.ScreenSpaceDrawQuad.Width) * 2 - 1;
+        }
+
         private void playAppearSample()
         {
             var channel = samplePanelFocus?.GetChannel();
@@ -265,7 +274,7 @@ namespace osu.Game.Screens.Ranking
                     break;
             }
 
-            Mixer.ResizeTo(Size, RESIZE_DURATION, Easing.OutQuint);
+            mixer.ResizeTo(Size, RESIZE_DURATION, Easing.OutQuint);
 
             bool topLayerExpanded = topLayerContainer.Y < 0;
 

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Ranking
         public readonly ScoreInfo Score;
 
         [Resolved]
-        private OsuGame game { get; set; }
+        private OsuGameBase game { get; set; }
 
         private DrawableAudioMixer mixer;
 

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -6,13 +6,16 @@
 using System;
 using osu.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Contracted;
 using osu.Game.Screens.Ranking.Expanded;
@@ -107,6 +110,8 @@ namespace osu.Game.Screens.Ranking
         private Container middleLayerContentContainer;
         private Drawable middleLayerContent;
 
+        private DrawableSample samplePanelFocus;
+
         public ScorePanel(ScoreInfo score, bool isNewLocalScore = false)
         {
             Score = score;
@@ -116,7 +121,7 @@ namespace osu.Game.Screens.Ranking
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             // ScorePanel doesn't include the top extruding area in its own size.
             // Adding a manual offset here allows the expanded version to take on an "acceptable" vertical centre when at 100% UI scale.
@@ -174,7 +179,8 @@ namespace osu.Game.Screens.Ranking
                             },
                             middleLayerContentContainer = new Container { RelativeSizeAxes = Axes.Both }
                         }
-                    }
+                    },
+                    samplePanelFocus = new DrawableSample(audio.Samples.Get(@"Results/score-panel-focus"))
                 }
             };
         }
@@ -202,10 +208,24 @@ namespace osu.Game.Screens.Ranking
                 state = value;
 
                 if (IsLoaded)
+                {
                     updateState();
+
+                    if (value == PanelState.Expanded)
+                        playAppearSample();
+                }
 
                 StateChanged?.Invoke(value);
             }
+        }
+
+        private void playAppearSample()
+        {
+            var channel = samplePanelFocus?.GetChannel();
+            if (channel == null) return;
+
+            channel.Frequency.Value = 0.99 + RNG.NextDouble(0.2);
+            channel.Play();
         }
 
         private void updateState()
@@ -221,7 +241,8 @@ namespace osu.Game.Screens.Ranking
                     topLayerBackground.FadeColour(expanded_top_layer_colour, RESIZE_DURATION, Easing.OutQuint);
                     middleLayerBackground.FadeColour(expanded_middle_layer_colour, RESIZE_DURATION, Easing.OutQuint);
 
-                    topLayerContentContainer.Add(topLayerContent = new ExpandedPanelTopContent(Score.User) { Alpha = 0 });
+                    bool firstLoad = topLayerContent == null;
+                    topLayerContentContainer.Add(topLayerContent = new ExpandedPanelTopContent(Score.User, firstLoad) { Alpha = 0 });
                     middleLayerContentContainer.Add(middleLayerContent = new ExpandedPanelMiddleContent(Score, displayWithFlair) { Alpha = 0 });
 
                     // only the first expanded display should happen with flair.

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -96,9 +96,9 @@ namespace osu.Game.Screens.Ranking
 
         public readonly ScoreInfo Score;
 
-        private bool displayWithFlair;
+        public DrawableAudioMixer Mixer;
 
-        private Container content;
+        private bool displayWithFlair;
 
         private Container topLayerContainer;
         private Drawable topLayerBackground;
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.Ranking
             // Adding a manual offset here allows the expanded version to take on an "acceptable" vertical centre when at 100% UI scale.
             const float vertical_fudge = 20;
 
-            InternalChild = content = new Container
+            InternalChild = Mixer = new DrawableAudioMixer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -265,7 +265,7 @@ namespace osu.Game.Screens.Ranking
                     break;
             }
 
-            content.ResizeTo(Size, RESIZE_DURATION, Easing.OutQuint);
+            Mixer.ResizeTo(Size, RESIZE_DURATION, Easing.OutQuint);
 
             bool topLayerExpanded = topLayerContainer.Y < 0;
 

--- a/osu.Game/Screens/Ranking/ScorePanelList.cs
+++ b/osu.Game/Screens/Ranking/ScorePanelList.cs
@@ -344,23 +344,6 @@ namespace osu.Game.Screens.Ranking
             private IEnumerable<ScorePanelTrackingContainer> applySorting(IEnumerable<Drawable> drawables) => drawables.OfType<ScorePanelTrackingContainer>()
                                                                                                                        .OrderByDescending(GetLayoutPosition)
                                                                                                                        .ThenBy(s => s.Panel.Score.OnlineID);
-
-            protected override void Update()
-            {
-                foreach (ScorePanelTrackingContainer trackingContainer in FlowingChildren.OfType<ScorePanelTrackingContainer>())
-                {
-                    var panel = trackingContainer.Panel;
-
-                    if (panel.State != PanelState.Expanded) continue;
-
-                    var scrollContainer = Parent.Parent;
-                    float balance = scrollContainer.ToLocalSpace(panel.ToScreenSpace(panel.BoundingBox.Centre)).X / scrollContainer.RelativeToAbsoluteFactor.X;
-
-                    panel.Mixer.Balance.Value = Math.Clamp(-1 + balance * 2, -1, 1);
-                }
-
-                base.Update();
-            }
         }
 
         private class Scroll : OsuScrollContainer

--- a/osu.Game/Screens/Ranking/ScorePanelList.cs
+++ b/osu.Game/Screens/Ranking/ScorePanelList.cs
@@ -344,6 +344,23 @@ namespace osu.Game.Screens.Ranking
             private IEnumerable<ScorePanelTrackingContainer> applySorting(IEnumerable<Drawable> drawables) => drawables.OfType<ScorePanelTrackingContainer>()
                                                                                                                        .OrderByDescending(GetLayoutPosition)
                                                                                                                        .ThenBy(s => s.Panel.Score.OnlineID);
+
+            protected override void Update()
+            {
+                foreach (ScorePanelTrackingContainer trackingContainer in FlowingChildren.OfType<ScorePanelTrackingContainer>())
+                {
+                    var panel = trackingContainer.Panel;
+
+                    if (panel.State != PanelState.Expanded) continue;
+
+                    var scrollContainer = Parent.Parent;
+                    float balance = scrollContainer.ToLocalSpace(panel.ToScreenSpace(panel.BoundingBox.Centre)).X / scrollContainer.RelativeToAbsoluteFactor.X;
+
+                    panel.Mixer.Balance.Value = Math.Clamp(-1 + balance * 2, -1, 1);
+                }
+
+                base.Update();
+            }
         }
 
         private class Scroll : OsuScrollContainer

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -35,6 +37,10 @@ namespace osu.Game.Screens.Ranking.Statistics
         private readonly Container content;
         private readonly LoadingSpinner spinner;
 
+        private bool wasOpened;
+        private Sample popInSample;
+        private Sample popOutSample;
+
         public StatisticsPanel()
         {
             InternalChild = new Container
@@ -56,9 +62,12 @@ namespace osu.Game.Screens.Ranking.Statistics
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             Score.BindValueChanged(populateStatistics, true);
+
+            popInSample = audio.Samples.Get(@"Results/statistics-panel-pop-in");
+            popOutSample = audio.Samples.Get(@"Results/statistics-panel-pop-out");
         }
 
         private CancellationTokenSource loadCancellation;
@@ -216,9 +225,21 @@ namespace osu.Game.Screens.Ranking.Statistics
             return true;
         }
 
-        protected override void PopIn() => this.FadeIn(150, Easing.OutQuint);
+        protected override void PopIn()
+        {
+            this.FadeIn(150, Easing.OutQuint);
 
-        protected override void PopOut() => this.FadeOut(150, Easing.OutQuint);
+            popInSample?.Play();
+            wasOpened = true;
+        }
+
+        protected override void PopOut()
+        {
+            this.FadeOut(150, Easing.OutQuint);
+
+            if (wasOpened)
+                popOutSample?.Play();
+        }
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.14.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.720.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.716.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.722.0" />
     <PackageReference Include="Sentry" Version="3.19.0" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.14.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.720.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.722.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.722.0" />
     <PackageReference Include="Sentry" Version="3.19.0" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.720.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.716.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.722.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
   <PropertyGroup>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.720.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.722.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.722.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.720.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.722.0" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Adds panel appearance+transition sounds, score rolling/ticking effects and additionally some dynamic panning to make the results screen a bit more interesting.

Dynamic panning also affecting the `AccuracyCircle`/ranking SFX was a side-effect of implementation, but it feels kinda cool so I left it in?

https://user-images.githubusercontent.com/272140/180435636-a9f11c11-3590-4ea5-9dcc-56b359d225de.mov

- [x] depends on ppy/osu-resources#204