### PR TITLE
Fix background beatmap processor resetting star ratings in tests

### DIFF
--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -171,6 +171,11 @@ namespace osu.Game.Tests.Visual
                 API.Login("Rhythm Champion", "osu!");
 
                 Dependencies.Get<SessionStatics>().SetValue(Static.MutedAudioNotificationShownOnce, true);
+
+                // set applied version to latest so that the BackgroundBeatmapProcessor doesn't consider
+                // beatmap star ratings as outdated and reset them throughout the test.
+                foreach (var ruleset in RulesetStore.AvailableRulesets)
+                    ruleset.LastAppliedDifficultyVersion = ruleset.CreateInstance().CreateDifficultyCalculator(Beatmap.Default).Version;
             }
 
             protected override void Update()


### PR DESCRIPTION
As seen in this [test failure](https://github.com/ppy/osu/runs/7479339630?check_suite_focus=true).

The recently added `BackgroundBeatmapProcessor` reprocesses all beatmaps of a ruleset which doesn't have `LastAppliedDifficultyVersion` set (in order to update them with latest star rating).

This could happen in the middle of the test asynchronously, corrupting the state of the test and therefore falsely fail.

Given that this is local to `OsuGameTestScene`s, I've fixed this by updating `LastAppliedDifficultyVersion` on all rulesets explicitly at the test scene, all for simplicity.

To reproduce the test failure above, I've made the test case wait until `BackgroundBeatmapProcessor` is loaded after the save step:
```diff
diff --git a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
index d7e9cc1bc0..f730b4212a 100644
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -151,6 +151,8 @@ public void TestLengthAndStarRatingUpdated()
             AddAssert("One hitobject placed", () => EditorBeatmap.HitObjects.Count == 1);
 
             SaveEditor();
+            AddUntilStep("wait for something", () => Game.ChildrenOfType<BackgroundBeatmapProcessor>().SingleOrDefault()?.IsLoaded == true);
+
             AddStep("Get working beatmap", () => working = Game.BeatmapManager.GetWorkingBeatmap(EditorBeatmap.BeatmapInfo, true));
 
             AddAssert("Beatmap length is zero", () => working.BeatmapInfo.Length == 0);
```