### PR TITLE
Fix beatmap overlay leaderboard not handling lazer score max combo

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -162,9 +162,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     ShowPlaceholderOnUnknown = false,
                 },
                 username,
-#pragma warning disable 618
-                new StatisticText(score.MaxCombo, score.BeatmapInfo.MaxCombo, @"0\x"),
-#pragma warning restore 618
+                new StatisticText(score.MaxCombo, scoreManager.GetMaximumAchievableComboAsync(score).GetResultSafely(), @"0\x"),
             };
 
             var availableStatistics = score.GetStatisticsForDisplay().ToDictionary(tuple => tuple.Result);


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/19321

I was also hoping to remove `BeatmapInfo.MaxCombo` once and for all, but it appears that's not feasible due to the [`APIBeatmap` -> `BeatmapInfo`](https://github.com/ppy/osu/blob/f956955d4d66a6955cafdf066d1c4034b46c64ec/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs#L80-L88) conversion in `ScoresContainer`, which makes `GetDifficultyAsync` [unable to pick the online max combo provided by `APIBeatmap`](https://github.com/ppy/osu/blob/98938821e5debc1f9d0470c51bc6fff63a626f79/osu.Game/Beatmaps/BeatmapDifficultyCache.cs#L131-L132).

I plan to attempt looking at what's required to switch to `IScoreInfo` given that the statistics serialisation change should now be done with the new `SoloScoreInfo` structure.

Before:
<img width="1360" alt="CleanShot 2022-07-24 at 04 42 00@2x" src="https://user-images.githubusercontent.com/22781491/180628787-7d7b05a3-0d37-4fad-b635-072f2338d176.png">

After:
![CleanShot 2022-07-24 at 04 46 41@2x](https://user-images.githubusercontent.com/22781491/180628793-56a1ead9-8565-45ba-b718-d8994a84444f.png)
