### PR TITLE
Fix `OsuSliderBar` throwing on negative draw width

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
@@ -8,8 +8,10 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 
@@ -17,11 +19,26 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public class TestSceneLabelledSliderBar : OsuTestScene
     {
-        [TestCase(false)]
-        [TestCase(true)]
-        public void TestSliderBar(bool hasDescription) => createSliderBar(hasDescription);
+        [Test]
+        public void TestBasic() => createSliderBar();
 
-        private void createSliderBar(bool hasDescription = false)
+        [Test]
+        public void TestDescription()
+        {
+            createSliderBar();
+            AddStep("set description", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.Description = "this text describes the component"));
+        }
+
+        [Test]
+        public void TestSize()
+        {
+            createSliderBar();
+            AddStep("set zero width", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.ResizeWidthTo(0, 200, Easing.OutQuint)));
+            AddStep("set negative width", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.ResizeWidthTo(-1, 200, Easing.OutQuint)));
+            AddStep("revert back", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.ResizeWidthTo(1, 200, Easing.OutQuint)));
+        }
+
+        private void createSliderBar()
         {
             AddStep("create component", () =>
             {
@@ -38,6 +55,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         new LabelledSliderBar<double>
                         {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
                             Current = new BindableDouble(5)
                             {
                                 MinValue = 0,
@@ -45,7 +64,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                                 Precision = 1,
                             },
                             Label = "a sample component",
-                            Description = hasDescription ? "this text describes the component" : string.Empty,
                         },
                     },
                 };
@@ -54,10 +72,14 @@ namespace osu.Game.Tests.Visual.UserInterface
                 {
                     flow.Add(new OverlayColourContainer(colour)
                     {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Child = new LabelledSliderBar<double>
                         {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
                             Current = new BindableDouble(5)
                             {
                                 MinValue = 0,
@@ -65,7 +87,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                                 Precision = 1,
                             },
                             Label = "a sample component",
-                            Description = hasDescription ? "this text describes the component" : string.Empty,
                         }
                     });
                 }

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -228,10 +228,8 @@ namespace osu.Game.Graphics.UserInterface
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
-            LeftBox.Scale = new Vector2(Math.Clamp(
-                RangePadding + Nub.DrawPosition.X - Nub.DrawWidth / 2, 0, DrawWidth), 1);
-            RightBox.Scale = new Vector2(Math.Clamp(
-                DrawWidth - Nub.DrawPosition.X - RangePadding - Nub.DrawWidth / 2, 0, DrawWidth), 1);
+            LeftBox.Scale = new Vector2(Math.Clamp(RangePadding + Nub.DrawPosition.X - Nub.DrawWidth / 2, 0, Math.Max(0, DrawWidth)), 1);
+            RightBox.Scale = new Vector2(Math.Clamp(DrawWidth - Nub.DrawPosition.X - RangePadding - Nub.DrawWidth / 2, 0, Math.Max(0, DrawWidth)), 1);
         }
 
         protected override void UpdateValue(float value)


### PR DESCRIPTION
As noticed in https://github.com/ppy/osu/runs/7484675169?check_suite_focus=true (see second test failure).

Drawables generally shouldn't fail on negative size, as the negative size could happen as a result of the parent resizing from zero or anything of the sorts.