### PR TITLE
Log beatmap difficulty retrieval failures during score calculation

### DIFF
--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
@@ -172,6 +173,10 @@ namespace osu.Game.Scoring
 
                 // We can compute the max combo locally after the async beatmap difficulty computation.
                 var difficulty = await difficultyCache.GetDifficultyAsync(score.BeatmapInfo, score.Ruleset, score.Mods, cancellationToken).ConfigureAwait(false);
+
+                if (difficulty == null)
+                    Logger.Log($"Couldn't get beatmap difficulty for beatmap {score.BeatmapInfo.OnlineID}");
+
                 return difficulty?.MaxCombo;
             }
 


### PR DESCRIPTION
In attempt to investigate https://github.com/ppy/osu/issues/19356

I have a theory as to why this is happening, but want some output here to confirm.