### PR TITLE
Update more places to support displaying unprocessed PP placeholder

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -141,6 +141,19 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("best score not displayed", () => scoresContainer.ChildrenOfType<DrawableTopScore>().Count() == 1);
         }
 
+        [Test]
+        public void TestUnprocessedPP()
+        {
+            AddStep("Load scores with unprocessed PP", () =>
+            {
+                var allScores = createScores();
+                allScores.Scores[0].PP = null;
+                allScores.UserScore = createUserBest();
+                allScores.UserScore.Score.PP = null;
+                scoresContainer.Scores = allScores;
+            });
+        }
+
         private int onlineID = 1;
 
         private APIScoresCollection createScores()
@@ -210,7 +223,7 @@ namespace osu.Game.Tests.Visual.Online
                             new APIMod { Acronym = new OsuModHidden().Acronym },
                         },
                         Rank = ScoreRank.B,
-                        PP = null,
+                        PP = 180,
                         MaxCombo = 1234,
                         TotalScore = 12345678,
                         Accuracy = 0.9854,

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileScores.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileScores.cs
@@ -7,6 +7,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
@@ -99,6 +100,23 @@ namespace osu.Game.Tests.Visual.Online
                 Accuracy = 0.55879
             };
 
+            var unprocessedPPScore = new SoloScoreInfo
+            {
+                Rank = ScoreRank.B,
+                Beatmap = new APIBeatmap
+                {
+                    BeatmapSet = new APIBeatmapSet
+                    {
+                        Title = "C18H27NO3(extend)",
+                        Artist = "Team Grimoire",
+                    },
+                    DifficultyName = "[4K] Cataclysmic Hypernova",
+                    Status = BeatmapOnlineStatus.Ranked,
+                },
+                EndedAt = DateTimeOffset.Now,
+                Accuracy = 0.55879
+            };
+
             Add(new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
@@ -112,6 +130,7 @@ namespace osu.Game.Tests.Visual.Online
                     new ColourProvidedContainer(OverlayColourScheme.Green, new DrawableProfileScore(firstScore)),
                     new ColourProvidedContainer(OverlayColourScheme.Green, new DrawableProfileScore(secondScore)),
                     new ColourProvidedContainer(OverlayColourScheme.Pink, new DrawableProfileScore(noPPScore)),
+                    new ColourProvidedContainer(OverlayColourScheme.Pink, new DrawableProfileScore(unprocessedPPScore)),
                     new ColourProvidedContainer(OverlayColourScheme.Pink, new DrawableProfileWeightedScore(firstScore, 0.97)),
                     new ColourProvidedContainer(OverlayColourScheme.Pink, new DrawableProfileWeightedScore(secondScore, 0.85)),
                     new ColourProvidedContainer(OverlayColourScheme.Pink, new DrawableProfileWeightedScore(thirdScore, 0.66)),

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -23,8 +23,8 @@ using osuTK.Graphics;
 using osu.Framework.Localisation;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Scoring.Drawables;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -182,7 +182,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 if (score.PP != null)
                     content.Add(new StatisticText(score.PP, format: @"N0"));
                 else
-                    content.Add(new ProcessingPPIcon());
+                    content.Add(new UnprocessedPerformancePointsPlaceholder { Size = new Vector2(text_size) });
             }
 
             content.Add(new ScoreboardTime(score.Date, text_size)
@@ -245,19 +245,6 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             {
                 if (count == maxCount)
                     Colour = colours.GreenLight;
-            }
-        }
-
-        private class ProcessingPPIcon : SpriteIcon, IHasTooltip
-        {
-            public LocalisableString TooltipText => ScoresStrings.StatusProcessing;
-
-            public ProcessingPPIcon()
-            {
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                Size = new Vector2(text_size);
-                Icon = FontAwesome.Solid.ExclamationTriangle;
             }
         }
     }

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -219,42 +219,42 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
 
         private Drawable createDrawablePerformance()
         {
-            if (Score.PP.HasValue)
+            if (!Score.PP.HasValue)
             {
-                return new FillFlowContainer
+                if (Score.Beatmap?.Status.GrantsPerformancePoints() == true)
+                    return new UnprocessedPerformancePointsPlaceholder { Size = new Vector2(16), Colour = colourProvider.Highlight1 };
+
+                return new OsuSpriteText
                 {
-                    AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Horizontal,
-                    Children = new[]
-                    {
-                        new OsuSpriteText
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
-                            Font = OsuFont.GetFont(weight: FontWeight.Bold),
-                            Text = $"{Score.PP:0}",
-                            Colour = colourProvider.Highlight1
-                        },
-                        new OsuSpriteText
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
-                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                            Text = "pp",
-                            Colour = colourProvider.Light3
-                        }
-                    }
+                    Font = OsuFont.GetFont(weight: FontWeight.Bold),
+                    Text = "-",
+                    Colour = colourProvider.Highlight1
                 };
             }
 
-            if (Score.Beatmap?.Status.GrantsPerformancePoints() == true)
-                return new UnprocessedPerformancePointsPlaceholder { Size = new Vector2(16), Colour = colourProvider.Highlight1 };
-
-            return new OsuSpriteText
+            return new FillFlowContainer
             {
-                Font = OsuFont.GetFont(weight: FontWeight.Bold),
-                Text = "-",
-                Colour = colourProvider.Highlight1
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Children = new[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Font = OsuFont.GetFont(weight: FontWeight.Bold),
+                        Text = $"{Score.PP:0}",
+                        Colour = colourProvider.Highlight1
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Text = "pp",
+                        Colour = colourProvider.Light3
+                    }
+                }
             };
         }
 

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -19,6 +19,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.UI;
+using osu.Game.Scoring.Drawables;
 using osu.Game.Utils;
 using osuTK;
 
@@ -245,6 +246,9 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                     }
                 };
             }
+
+            if (Score.Beatmap?.Status.GrantsPerformancePoints() == true)
+                return new UnprocessedPerformancePointsPlaceholder { Size = new Vector2(16), Colour = colourProvider.Highlight1 };
 
             return new OsuSpriteText
             {

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
@@ -42,12 +42,11 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                         CreateDrawableAccuracy(),
                         new Container
                         {
-                            AutoSizeAxes = Axes.Y,
-                            Width = 50,
+                            Size = new Vector2(50, 14),
                             Child = new OsuSpriteText
                             {
                                 Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold, italics: true),
-                                Text = $"{Score.PP * weight:0}pp",
+                                Text = Score.PP.HasValue ? $"{Score.PP * weight:0}pp" : string.Empty,
                             },
                         }
                     }

--- a/osu.Game/Scoring/Drawables/UnprocessedPerformancePointsPlaceholder.cs
+++ b/osu.Game/Scoring/Drawables/UnprocessedPerformancePointsPlaceholder.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Scoring.Drawables
+{
+    /// <summary>
+    /// A placeholder used in PP columns for scores with unprocessed PP value.
+    /// </summary>
+    public class UnprocessedPerformancePointsPlaceholder : SpriteIcon, IHasTooltip
+    {
+        public LocalisableString TooltipText => ScoresStrings.StatusProcessing;
+
+        public UnprocessedPerformancePointsPlaceholder()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Icon = FontAwesome.Solid.ExclamationTriangle;
+        }
+    }
+}


### PR DESCRIPTION

Handles remaining places that https://github.com/ppy/osu/pull/19343 didn't cover. For visual comparisons:

| web | lazer |
|-----|-------|
| <img width="464" alt="CleanShot 2022-07-25 at 09 42 18@2x" src="https://user-images.githubusercontent.com/22781491/180714445-f16592c4-2d41-42c4-946c-dc9531bd9f9e.png"> | <img width="464" src="https://user-images.githubusercontent.com/22781491/180714263-054e00ac-d575-4357-a77a-aeb796189ae3.png"> |
| <img width="582" alt="CleanShot 2022-07-25 at 09 42 04@2x" src="https://user-images.githubusercontent.com/22781491/180714497-add67572-8c81-45dc-acdc-875edaf8ade3.png"> | <img width="582" alt="CleanShot 2022-07-25 at 09 39 24@2x" src="https://user-images.githubusercontent.com/22781491/180714276-b033427b-134b-487a-8d31-9187e7b36d17.png"> |