### PR TITLE
Fix star ratings which are still being calculated showing as "-1" at song select

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneStarRatingDisplay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     AutoSizeAxes = Axes.Both,
                     Spacing = new Vector2(2f),
                     Direction = FillDirection.Horizontal,
-                    ChildrenEnumerable = Enumerable.Range(0, 15).Select(i => new FillFlowContainer
+                    ChildrenEnumerable = Enumerable.Range(-1, 15).Select(i => new FillFlowContainer
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Beatmaps.Drawables
 
             displayedStars.BindValueChanged(s =>
             {
-                starsText.Text = s.NewValue.ToLocalisableString("0.00");
+                starsText.Text = s.NewValue < 0 ? "-" : s.NewValue.ToLocalisableString("0.00");
 
                 background.Colour = colours.ForStarDifficulty(s.NewValue);
 


### PR DESCRIPTION
This fixes the display portion of, and closes https://github.com/ppy/osu/issues/19325. The actual processing is run on startup and will always fix any `-1` values, so the remainder of the issue will be resolved via #1934.

---

![osu! 2022-07-25 at 06 48 38](https://user-images.githubusercontent.com/191335/180715417-b093cc1b-6111-4080-a904-93457a5aa1ef.png)
