### PR TITLE
Avoid leaving left-over files after test run completes

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -142,7 +142,6 @@ namespace osu.Game.Tests.Database
                 {
                     Task.Run(async () =>
                     {
-                        // ReSharper disable once AccessToDisposedClosure
                         var beatmapSet = await importer.Import(new ImportTask(TestResources.GetTestBeatmapStream(), "renatus.osz"));
 
                         Assert.NotNull(beatmapSet);

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -310,6 +310,7 @@ namespace osu.Game.Tests.Database
                 }
                 finally
                 {
+                    File.Delete(temp);
                     Directory.Delete(extractedFolder, true);
                 }
             });

--- a/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -27,7 +28,6 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 {
                     var osu = new TestTournament(runOnLoadComplete: () =>
                     {
-                        // ReSharper disable once AccessToDisposedClosure
                         var storage = host.Storage.GetStorageForDirectory(Path.Combine("tournaments", "default"));
 
                         using (var stream = storage.CreateFileSafely("bracket.json"))
@@ -85,7 +85,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
 
             public new Task BracketLoadTask => base.BracketLoadTask;
 
-            public TestTournament(bool resetRuleset = false, Action runOnLoadComplete = null)
+            public TestTournament(bool resetRuleset = false, [InstantHandle] Action runOnLoadComplete = null)
             {
                 this.resetRuleset = resetRuleset;
                 this.runOnLoadComplete = runOnLoadComplete;


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/191335/180933988-f60b9d9c-2800-4688-afa1-873537cc61aa.mp4

After:

https://user-images.githubusercontent.com/191335/180935228-2a0c6418-fd0e-496a-af50-b70737a3fa78.mp4

Not sure why realm tests were using their own storage (I think it was mostly to let me debug realm issues in the early days?).

