### PR TITLE
Maintain sort stability by using carousel item ID as a fallback

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -522,15 +522,15 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var sets = new List<BeatmapSetInfo>();
 
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < 10; i++)
             {
                 var set = TestResources.CreateTestBeatmapSetInfo();
 
                 // only need to set the first as they are a shared reference.
                 var beatmap = set.Beatmaps.First();
 
-                beatmap.Metadata.Artist = "same artist";
-                beatmap.Metadata.Title = "same title";
+                beatmap.Metadata.Artist = $"artist {i / 2}";
+                beatmap.Metadata.Title = $"title {9 - i}";
 
                 sets.Add(set);
             }
@@ -540,10 +540,13 @@ namespace osu.Game.Tests.Visual.SongSelect
             loadBeatmaps(sets);
 
             AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
-            AddAssert("Items remain in original order", () => carousel.BeatmapSets.Select((set, index) => set.OnlineID == index + idOffset).All(b => b));
+            AddAssert("Items remain in original order", () => carousel.BeatmapSets.Select((set, index) => set.OnlineID == idOffset + index).All(b => b));
 
             AddStep("Sort by title", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false));
-            AddAssert("Items remain in original order", () => carousel.BeatmapSets.Select((set, index) => set.OnlineID == index + idOffset).All(b => b));
+            AddAssert("Items are in reverse order", () => carousel.BeatmapSets.Select((set, index) => set.OnlineID == idOffset + sets.Count - index - 1).All(b => b));
+
+            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddAssert("Items reset to original order", () => carousel.BeatmapSets.Select((set, index) => set.OnlineID == idOffset + index).All(b => b));
         }
 
         [Test]

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Screens.Select.Carousel
         private ulong currentChildID;
 
         private Comparer<CarouselItem>? criteriaComparer;
+        private Comparer<CarouselItem>? itemIDComparer;
 
         private FilterCriteria? lastCriteria;
 
@@ -90,7 +91,8 @@ namespace osu.Game.Screens.Select.Carousel
 
             // IEnumerable<T>.OrderBy() is used instead of List<T>.Sort() to ensure sorting stability
             criteriaComparer = Comparer<CarouselItem>.Create((x, y) => x.CompareTo(criteria, y));
-            items = items.OrderBy(c => c, criteriaComparer).ToList();
+            itemIDComparer = Comparer<CarouselItem>.Create((x, y) => x.ChildID.CompareTo(y.ChildID));
+            items = items.OrderBy(c => c, criteriaComparer).ThenBy(c => c, itemIDComparer).ToList();
 
             lastCriteria = criteria;
         }

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Screens.Select.Carousel
         private ulong currentItemID;
 
         private Comparer<CarouselItem>? criteriaComparer;
-        private Comparer<CarouselItem>? itemIDComparer;
+
+        private static readonly Comparer<CarouselItem> item_id_comparer = Comparer<CarouselItem>.Create((x, y) => x.ItemID.CompareTo(y.ItemID));
 
         private FilterCriteria? lastCriteria;
 
@@ -91,8 +92,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             // IEnumerable<T>.OrderBy() is used instead of List<T>.Sort() to ensure sorting stability
             criteriaComparer = Comparer<CarouselItem>.Create((x, y) => x.CompareTo(criteria, y));
-            itemIDComparer = Comparer<CarouselItem>.Create((x, y) => x.ItemID.CompareTo(y.ItemID));
-            items = items.OrderBy(c => c, criteriaComparer).ThenBy(c => c, itemIDComparer).ToList();
+            items = items.OrderBy(c => c, criteriaComparer).ThenBy(c => c, item_id_comparer).ToList();
 
             lastCriteria = criteria;
         }

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace osu.Game.Screens.Select.Carousel
 {
     /// <summary>
-    /// A group which ensures only one child is selected.
+    /// A group which ensures only one item is selected.
     /// </summary>
     public class CarouselGroup : CarouselItem
     {
@@ -18,10 +18,10 @@ namespace osu.Game.Screens.Select.Carousel
         private List<CarouselItem> items = new List<CarouselItem>();
 
         /// <summary>
-        /// Used to assign a monotonically increasing ID to children as they are added. This member is
-        /// incremented whenever a child is added.
+        /// Used to assign a monotonically increasing ID to items as they are added. This member is
+        /// incremented whenever an item is added.
         /// </summary>
-        private ulong currentChildID;
+        private ulong currentItemID;
 
         private Comparer<CarouselItem>? criteriaComparer;
         private Comparer<CarouselItem>? itemIDComparer;
@@ -42,7 +42,7 @@ namespace osu.Game.Screens.Select.Carousel
         public virtual void AddItem(CarouselItem i)
         {
             i.State.ValueChanged += state => ChildItemStateChanged(i, state.NewValue);
-            i.ChildID = ++currentChildID;
+            i.ItemID = ++currentItemID;
 
             if (lastCriteria != null)
             {
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             // IEnumerable<T>.OrderBy() is used instead of List<T>.Sort() to ensure sorting stability
             criteriaComparer = Comparer<CarouselItem>.Create((x, y) => x.CompareTo(criteria, y));
-            itemIDComparer = Comparer<CarouselItem>.Create((x, y) => x.ChildID.CompareTo(y.ChildID));
+            itemIDComparer = Comparer<CarouselItem>.Create((x, y) => x.ItemID.CompareTo(y.ItemID));
             items = items.OrderBy(c => c, criteriaComparer).ThenBy(c => c, itemIDComparer).ToList();
 
             lastCriteria = criteria;

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace osu.Game.Screens.Select.Carousel
 {
     /// <summary>
-    /// A group which ensures at least one child is selected (if the group itself is selected).
+    /// A group which ensures at least one item is selected (if the group itself is selected).
     /// </summary>
     public class CarouselGroupEagerSelect : CarouselGroup
     {
@@ -35,16 +35,16 @@ namespace osu.Game.Screens.Select.Carousel
 
         /// <summary>
         /// To avoid overhead during filter operations, we don't attempt any selections until after all
-        /// children have been filtered. This bool will be true during the base <see cref="Filter(FilterCriteria)"/>
+        /// items have been filtered. This bool will be true during the base <see cref="Filter(FilterCriteria)"/>
         /// operation.
         /// </summary>
-        private bool filteringChildren;
+        private bool filteringItems;
 
         public override void Filter(FilterCriteria criteria)
         {
-            filteringChildren = true;
+            filteringItems = true;
             base.Filter(criteria);
-            filteringChildren = false;
+            filteringItems = false;
 
             attemptSelection();
         }
@@ -97,12 +97,12 @@ namespace osu.Game.Screens.Select.Carousel
 
         private void attemptSelection()
         {
-            if (filteringChildren) return;
+            if (filteringItems) return;
 
             // we only perform eager selection if we are a currently selected group.
             if (State.Value != CarouselItemState.Selected) return;
 
-            // we only perform eager selection if none of our children are in a selected state already.
+            // we only perform eager selection if none of our items are in a selected state already.
             if (Items.Any(i => i.State.Value == CarouselItemState.Selected)) return;
 
             PerformSelection();

--- a/osu.Game/Screens/Select/Carousel/CarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselItem.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Select.Carousel
         /// <summary>
         /// Used as a default sort method for <see cref="CarouselItem"/>s of differing types.
         /// </summary>
-        internal ulong ChildID;
+        internal ulong ItemID;
 
         /// <summary>
         /// Create a fresh drawable version of this item.
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Select.Carousel
         {
         }
 
-        public virtual int CompareTo(FilterCriteria criteria, CarouselItem other) => ChildID.CompareTo(other.ChildID);
+        public virtual int CompareTo(FilterCriteria criteria, CarouselItem other) => ItemID.CompareTo(other.ItemID);
 
         public int CompareTo(CarouselItem other) => CarouselYPosition.CompareTo(other.CarouselYPosition);
     }


### PR DESCRIPTION
- Closes #19382 

I haven't checked how stable does it, but I've changed this so that the ID associated with the carousel item is used as a final fallback value when two items are matching (which can essentially be described as "when the beatmap was added to the database"), such that switching between sort modes doesn't result in different permutations.

Before:

https://user-images.githubusercontent.com/22781491/180948722-63372664-bb7b-40f5-b27e-435a83a8bd50.mp4

(notice how switching from "Length" to "Last Played" displayed a different permutation than from "Author" to "Last Played")

After:

https://user-images.githubusercontent.com/22781491/180948706-0fb2c738-ca76-4f0d-bd93-c0704bf89d81.mp4


