### PR TITLE
Always allow selecting the top-most button using the select binding

### DIFF
--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -121,7 +121,11 @@ namespace osu.Game.Overlays
             switch (e.Action)
             {
                 case GlobalAction.Select:
-                    CurrentDialog?.Buttons.OfType<PopupDialogOkButton>().FirstOrDefault()?.TriggerClick();
+                    var clickableButton =
+                        CurrentDialog?.Buttons.OfType<PopupDialogOkButton>().FirstOrDefault() ??
+                        CurrentDialog?.Buttons.First();
+
+                    clickableButton?.TriggerClick();
                     return true;
             }
 


### PR DESCRIPTION
Defaulting to the "OK" type still seems correct, but let's allow selecting the top-most failing that.

Eventually proper keyboard navigation should be implemented for this dialog (similar to the pause screen).