### PR TITLE
Add collection transfer logic to beatmap import-as-update flow

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -444,6 +444,8 @@ namespace osu.Game.Tests.Database
 
                 importAfterUpdate.PerformRead(updated =>
                 {
+                    updated.Realm.Refresh();
+
                     string[] hashes = updated.Realm.All<BeatmapCollection>().Single().BeatmapMD5Hashes.ToArray();
 
                     if (allOriginalBeatmapsInCollection)
@@ -506,6 +508,8 @@ namespace osu.Game.Tests.Database
 
                 importAfterUpdate.PerformRead(updated =>
                 {
+                    updated.Realm.Refresh();
+
                     string[] hashes = updated.Realm.All<BeatmapCollection>().Single().BeatmapMD5Hashes.ToArray();
                     string updatedHash = updated.Beatmaps.Single(b => b.DifficultyName == "Hard").MD5Hash;
 

--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -500,7 +500,7 @@ namespace osu.Game.Tests.Database
                     beatmapCollection.BeatmapMD5Hashes.Add(originalHash);
                 });
 
-                // Second import matches first but contains one extra .osu file.
+                // Second import matches first but contains a modified .osu file.
                 var importAfterUpdate = await importer.ImportAsUpdate(new ProgressNotification(), new ImportTask(pathModified), importBeforeUpdate.Value);
 
                 Assert.That(importAfterUpdate, Is.Not.Null);

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -14,6 +14,7 @@ using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;
@@ -71,6 +72,8 @@ namespace osu.Game.Beatmaps
                 // Transfer local values which should be persisted across a beatmap update.
                 updated.DateAdded = original.DateAdded;
 
+                transferCollectionReferences(realm, original, updated);
+
                 foreach (var beatmap in original.Beatmaps.ToArray())
                 {
                     var updatedBeatmap = updated.Beatmaps.FirstOrDefault(b => b.Hash == beatmap.Hash);
@@ -110,6 +113,40 @@ namespace osu.Game.Beatmaps
             });
 
             return first;
+        }
+
+        private static void transferCollectionReferences(Realm realm, BeatmapSetInfo original, BeatmapSetInfo updated)
+        {
+            // First check if every beatmap in the original set is in any collections.
+            // In this case, we will assume they also want any newly added difficulties added to the collection.
+            foreach (var c in realm.All<BeatmapCollection>())
+            {
+                if (original.Beatmaps.Select(b => b.MD5Hash).All(c.BeatmapMD5Hashes.Contains))
+                {
+                    foreach (var b in original.Beatmaps)
+                        c.BeatmapMD5Hashes.Remove(b.MD5Hash);
+
+                    foreach (var b in updated.Beatmaps)
+                        c.BeatmapMD5Hashes.Add(b.MD5Hash);
+                }
+            }
+
+            // Handle collections using permissive difficulty name to track difficulties.
+            foreach (var originalBeatmap in original.Beatmaps)
+            {
+                var updatedBeatmap = updated.Beatmaps.FirstOrDefault(b => b.DifficultyName == originalBeatmap.DifficultyName);
+
+                if (updatedBeatmap == null)
+                    continue;
+
+                var collections = realm.All<BeatmapCollection>().AsEnumerable().Where(c => c.BeatmapMD5Hashes.Contains(originalBeatmap.MD5Hash));
+
+                foreach (var c in collections)
+                {
+                    c.BeatmapMD5Hashes.Remove(originalBeatmap.MD5Hash);
+                    c.BeatmapMD5Hashes.Add(updatedBeatmap.MD5Hash);
+                }
+            }
         }
 
         protected override bool ShouldDeleteArchive(string path) => Path.GetExtension(path).ToLowerInvariant() == ".osz";

--- a/osu.Game/Database/Live.cs
+++ b/osu.Game/Database/Live.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 
 namespace osu.Game.Database
 {
@@ -18,19 +19,19 @@ namespace osu.Game.Database
         /// Perform a read operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        public abstract void PerformRead(Action<T> perform);
+        public abstract void PerformRead([InstantHandle] Action<T> perform);
 
         /// <summary>
         /// Perform a read operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        public abstract TReturn PerformRead<TReturn>(Func<T, TReturn> perform);
+        public abstract TReturn PerformRead<TReturn>([InstantHandle] Func<T, TReturn> perform);
 
         /// <summary>
         /// Perform a write operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
-        public abstract void PerformWrite(Action<T> perform);
+        public abstract void PerformWrite([InstantHandle] Action<T> perform);
 
         /// <summary>
         /// Whether this instance is tracking data which is managed by the database backing.


### PR DESCRIPTION
- If an updated difficulty is in a collection, its hash will be removed and replaced by the updated one (assuming difficulty name matches.
- If *all* difficulties in an updated beatmap set were in a collection, all difficulties post-update will be added to the same collection. This handles the case where a user has added a beatmap set to a collection (which is possible from the set header context menu).
- [ ] Depends on #19430

Closes https://github.com/ppy/osu/issues/19346

And to answer a question asked elsewhere "why was it necessary to move collections to realm to make this work?", the only answer I have is "i didn't want to pass a `CollectionManager` in to `BeatmapImporter`". Also because the deeper I got in beatmap collection code, the more I felt it required a refactor pass.