### PR TITLE
Add realm refresh calls to fix intermittent test failures on new update tests

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Tests.Database
                 Assert.That(importBeforeUpdate, Is.Not.Null);
                 Debug.Assert(importBeforeUpdate != null);
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<BeatmapSetInfo>(realm, 1, s => !s.DeletePending);
                 Assert.That(importBeforeUpdate.Value.Beatmaps, Has.Count.EqualTo(count_beatmaps - 1));
 
@@ -59,6 +61,8 @@ namespace osu.Game.Tests.Database
 
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
+
+                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapInfo>(realm, count_beatmaps);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps);
@@ -103,6 +107,8 @@ namespace osu.Game.Tests.Database
                         beatmap.ResetOnlineInfo();
                 });
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<BeatmapSetInfo>(realm, 1, s => !s.DeletePending);
                 Assert.That(importBeforeUpdate.Value.Beatmaps, Has.Count.EqualTo(count_beatmaps - 1));
 
@@ -111,6 +117,8 @@ namespace osu.Game.Tests.Database
 
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
+
+                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapInfo>(realm, count_beatmaps);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps);
@@ -148,6 +156,8 @@ namespace osu.Game.Tests.Database
                 Assert.That(importBeforeUpdate, Is.Not.Null);
                 Debug.Assert(importBeforeUpdate != null);
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<BeatmapSetInfo>(realm, 1, s => !s.DeletePending);
                 Assert.That(importBeforeUpdate.Value.Beatmaps, Has.Count.EqualTo(count_beatmaps));
 
@@ -160,6 +170,8 @@ namespace osu.Game.Tests.Database
                 // should only contain the modified beatmap (others purged).
                 Assert.That(importBeforeUpdate.Value.Beatmaps, Has.Count.EqualTo(1));
                 Assert.That(importAfterUpdate.Value.Beatmaps, Has.Count.EqualTo(count_beatmaps));
+
+                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapInfo>(realm, count_beatmaps + 1);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps + 1);
@@ -198,6 +210,8 @@ namespace osu.Game.Tests.Database
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<BeatmapInfo>(realm, count_beatmaps);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps);
                 checkCount<BeatmapSetInfo>(realm, 2);
@@ -234,6 +248,8 @@ namespace osu.Game.Tests.Database
                 var importAfterUpdate = await importer.ImportAsUpdate(new ProgressNotification(), new ImportTask(pathEmpty), importBeforeUpdate.Value);
                 Assert.That(importAfterUpdate, Is.Null);
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<BeatmapSetInfo>(realm, 1);
                 checkCount<BeatmapInfo>(realm, count_beatmaps);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps);
@@ -262,6 +278,8 @@ namespace osu.Game.Tests.Database
 
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
+
+                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapSetInfo>(realm, 1);
                 checkCount<BeatmapInfo>(realm, count_beatmaps);
@@ -307,12 +325,16 @@ namespace osu.Game.Tests.Database
                     s.Realm.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
                 });
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<ScoreInfo>(realm, 1);
 
                 var importAfterUpdate = await importer.ImportAsUpdate(new ProgressNotification(), new ImportTask(pathMissingOneBeatmap), importBeforeUpdate.Value);
 
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
+
+                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapInfo>(realm, count_beatmaps);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps);
@@ -348,6 +370,8 @@ namespace osu.Game.Tests.Database
                     s.Realm.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
                 });
 
+                realm.Run(r => r.Refresh());
+
                 checkCount<ScoreInfo>(realm, 1);
 
                 using var _ = getBeatmapArchiveWithModifications(out string pathModified, directory =>
@@ -364,6 +388,8 @@ namespace osu.Game.Tests.Database
 
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
+
+                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapInfo>(realm, count_beatmaps + 1);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps + 1);


### PR DESCRIPTION
As seen at
- https://teamcity.ppy.sh/buildConfiguration/Osu_Build/4275?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true
- https://teamcity.ppy.sh/buildConfiguration/Osu_Build/4265?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true
- https://teamcity.ppy.sh/buildConfiguration/Osu_Build/4294?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&isReloaded=true

If preferred, the refresh call could be placed within `checkCount()`, but this felt better to me.