### PR TITLE
Reduce calls to `LoadTrack` by implicitly running on test/dummy classes

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -41,8 +41,6 @@ namespace osu.Game.Tests.Gameplay
             AddStep("create container", () =>
             {
                 var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
-                working.LoadTrack();
-
                 Child = gameplayClockContainer = new MasterGameplayClockContainer(working, 0);
             });
 
@@ -58,8 +56,6 @@ namespace osu.Game.Tests.Gameplay
             AddStep("create container", () =>
             {
                 var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
-                working.LoadTrack();
-
                 Child = gameplayClockContainer = new MasterGameplayClockContainer(working, 0);
             });
 
@@ -102,8 +98,6 @@ namespace osu.Game.Tests.Gameplay
             AddStep("create container", () =>
             {
                 working = new ClockBackedTestWorkingBeatmap(new OsuRuleset().RulesetInfo, new FramedClock(new ManualClock()), Audio);
-                working.LoadTrack();
-
                 Child = gameplayClockContainer = new MasterGameplayClockContainer(working, 0);
 
                 gameplayClockContainer.Reset(startClock: !whileStopped);

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -69,7 +69,6 @@ namespace osu.Game.Tests.Gameplay
             AddStep("create container", () =>
             {
                 var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
-                working.LoadTrack();
 
                 Add(gameplayContainer = new MasterGameplayClockContainer(working, 0)
                 {
@@ -96,7 +95,6 @@ namespace osu.Game.Tests.Gameplay
             AddStep("create container", () =>
             {
                 var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
-                working.LoadTrack();
 
                 const double start_time = 1000;
 

--- a/osu.Game.Tests/Skins/TestSceneBeatmapSkinResources.cs
+++ b/osu.Game.Tests/Skins/TestSceneBeatmapSkinResources.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Tests.Skins
             imported?.PerformRead(s =>
             {
                 beatmap = beatmaps.GetWorkingBeatmap(s.Beatmaps[0]);
-                beatmap.LoadTrack();
             });
         }
 
@@ -40,6 +39,10 @@ namespace osu.Game.Tests.Skins
         public void TestRetrieveOggSample() => AddAssert("sample is non-null", () => beatmap.Skin.GetSample(new SampleInfo("sample")) != null);
 
         [Test]
-        public void TestRetrieveOggTrack() => AddAssert("track is non-null", () => !(beatmap.Track is TrackVirtual));
+        public void TestRetrieveOggTrack() => AddAssert("track is non-null", () =>
+        {
+            using (var track = beatmap.LoadTrack())
+                return track is not TrackVirtual;
+        });
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             increment = skip_time;
 
             var working = CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
-            working.LoadTrack();
 
             Child = gameplayClockContainer = new MasterGameplayClockContainer(working, 0)
             {

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -44,6 +44,10 @@ namespace osu.Game.Beatmaps
             }, audio)
         {
             this.textures = textures;
+
+            // We are guaranteed to have a virtual track.
+            // To ease usability, ensure the track is available from point of construction.
+            LoadTrack();
         }
 
         protected override IBeatmap GetBeatmap() => new Beatmap();

--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -161,7 +161,6 @@ namespace osu.Game.Overlays.FirstRunSetup
             private void load(AudioManager audio, TextureStore textures, RulesetStore rulesets)
             {
                 Beatmap.Value = new DummyWorkingBeatmap(audio, textures);
-                Beatmap.Value.LoadTrack();
 
                 Ruleset.Value = rulesets.AvailableRulesets.First();
 

--- a/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Tests.Beatmaps
             this.storyboard = storyboard;
         }
 
-        public override bool TrackLoaded => true;
-
         public override bool BeatmapLoaded => true;
 
         protected override IBeatmap GetBeatmap() => beatmap;

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -365,6 +365,11 @@ namespace osu.Game.Tests.Visual
                 }
                 else
                     track = audio?.Tracks.GetVirtual(trackLength);
+
+                // We are guaranteed to have a virtual track.
+                // To ease testability, ensure the track is available from point of construction.
+                // (Usually this would be done by MusicController for us).
+                LoadTrack();
             }
 
             ~ClockBackedTestWorkingBeatmap()


### PR DESCRIPTION
I feel really uneasy about having this call all over test scenes.

Came up during review of https://github.com/ppy/osu/pull/19408.