### PR TITLE
Move spectator begin/end playing to SubmittingPlayer

### DIFF
--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -14,7 +14,6 @@ using osu.Framework.Input.Events;
 using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Scoring;
-using osu.Game.Screens.Play;
 using osuTK;
 
 namespace osu.Game.Rulesets.UI
@@ -33,9 +32,6 @@ namespace osu.Game.Rulesets.UI
         [Resolved]
         private SpectatorClient spectatorClient { get; set; }
 
-        [Resolved]
-        private GameplayState gameplayState { get; set; }
-
         protected ReplayRecorder(Score target)
         {
             this.target = target;
@@ -48,15 +44,7 @@ namespace osu.Game.Rulesets.UI
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
             inputManager = GetContainingInputManager();
-            spectatorClient.BeginPlaying(gameplayState, target);
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-            spectatorClient?.EndPlaying(gameplayState);
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -26,7 +26,6 @@ using osu.Game.Extensions;
 using osu.Game.Graphics.Containers;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
-using osu.Game.Online.Spectator;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -100,9 +99,6 @@ namespace osu.Game.Screens.Play
 
         [Resolved]
         private MusicController musicController { get; set; }
-
-        [Resolved]
-        private SpectatorClient spectatorClient { get; set; }
 
         public GameplayState GameplayState { get; private set; }
 
@@ -1030,11 +1026,6 @@ namespace osu.Game.Screens.Play
                 // if arriving here and the results screen preparation task hasn't run, it's safe to say the user has not completed the beatmap.
                 if (prepareScoreForDisplayTask == null)
                     ScoreProcessor.FailScore(Score.ScoreInfo);
-
-                // EndPlaying() is typically called from ReplayRecorder.Dispose(). Disposal is currently asynchronous.
-                // To resolve test failures, forcefully end playing synchronously when this screen exits.
-                // Todo: Replace this with a more permanent solution once osu-framework has a synchronous cleanup method.
-                spectatorClient.EndPlaying(GameplayState);
             }
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -15,6 +15,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
+using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -32,6 +33,9 @@ namespace osu.Game.Screens.Play
 
         [Resolved]
         private IAPIProvider api { get; set; }
+
+        [Resolved]
+        private SpectatorClient spectatorClient { get; set; }
 
         private TaskCompletionSource<bool> scoreSubmissionSource;
 
@@ -134,6 +138,8 @@ namespace osu.Game.Screens.Play
                 if (realmBeatmap != null)
                     realmBeatmap.LastPlayed = DateTimeOffset.Now;
             });
+
+            spectatorClient.BeginPlaying(GameplayState, Score);
         }
 
         public override bool OnExiting(ScreenExitEvent e)
@@ -141,7 +147,10 @@ namespace osu.Game.Screens.Play
             bool exiting = base.OnExiting(e);
 
             if (LoadedBeatmapSuccessfully)
+            {
                 submitScore(Score.DeepClone());
+                spectatorClient.EndPlaying(GameplayState);
+            }
 
             return exiting;
         }


### PR DESCRIPTION
I noticed that sometimes `SpectatorClient.BeginPlaying()` could be called after an `SpectatorClient.EndPlaying()` from the same test.

The way this happens is if the player is exited on the same update frame that it loads in on:

- `Player.OnExiting()` occurs first, which calls `EndPlaying()`. The `Player` doesn't expire at point and still receives updates.
- In the very first update frame, after the `OnExiting()` call above, `Player` and all of its children transition into the `Loaded` state and `ReplayRecorder.LoadComplete()` is called which calls `BeginPlaying()`.

So by the end of this test, the spectator client remains in a playing state whilst the next test runs and tries to start playing again.

The fix I've come up with is to move the `BeginPlaying()`/`EndPlaying()` calls to `SubmittingPlayer`. I decided this way is best because `Player` already had logic to ensure `EndPlaying()` was called on exit, and `ReplayRecorder` should probably have nothing to do with `SpectatorClient` in the first place (it still submits frames to it with this PR, which is not ideal imo, but that can be refactored later).

Can be reproed spontaneously on `TestScenePlayerLoader` with the following diff, however removing the `EndPlaying()` call from `ReplayRecorder.Dispose()` can likely make the test fail more often.

```diff
diff --git a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
index 747f4d4a8a..f6f1018419 100644
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -5,6 +5,7 @@

 using System;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -74,6 +75,8 @@ public BarHitErrorMeter()
         [BackgroundDependencyLoader]
         private void load()
         {
+            Thread.Sleep(2000);
+
             const int bar_height = 200;
             const int bar_width = 2;
             const float chevron_size = 8;
```

I've run the tests several times to ensure no failures.