### PR TITLE
Fix intermittent HUD tests

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -159,6 +159,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for hud load", () => hudOverlay.IsLoaded);
             AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().Alpha == 0);
+            AddUntilStep("wait for hud load", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
 
             AddStep("bind on update", () =>
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -14,6 +14,7 @@ using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play.HUD.HitErrorMeters;
+using osu.Game.Skinning;
 using osu.Game.Skinning.Editor;
 using osuTK.Input;
 
@@ -32,6 +33,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         public override void SetUpSteps()
         {
             base.SetUpSteps();
+
+            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
 
             AddStep("reload skin editor", () =>
             {


### PR DESCRIPTION
See: https://github.com/ppy/osu/runs/7555304502?check_suite_focus=true

Can be reproed with:
```diff
diff --git a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
index 747f4d4a8a..f6f1018419 100644
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -5,6 +5,7 @@

 using System;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -74,6 +75,8 @@ public BarHitErrorMeter()
         [BackgroundDependencyLoader]
         private void load()
         {
+            Thread.Sleep(2000);
+
             const int bar_height = 200;
             const int bar_width = 2;
             const float chevron_size = 8;
```