### PR TITLE
Revert blocking call when sending spectator frames

### DIFF
--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Online.Spectator
 
             Debug.Assert(connection != null);
 
-            return connection.InvokeAsync(nameof(ISpectatorServer.SendFrameData), bundle);
+            return connection.SendAsync(nameof(ISpectatorServer.SendFrameData), bundle);
         }
 
         protected override Task EndPlayingInternal(SpectatorState state)

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -304,7 +304,7 @@ namespace osu.Game.Online.Spectator
 
             SendFramesInternal(bundle).ContinueWith(t =>
             {
-                // Handle exception outside of `Schedule` to ensure it doesn't go unovserved.
+                // Handle exception outside of `Schedule` to ensure it doesn't go unobserved.
                 bool wasSuccessful = t.Exception == null;
 
                 return Schedule(() =>


### PR DESCRIPTION
There are a lot of these requests, and we don't really care about
waiting on them to finish sending. This may have negatively affected
send performance for users with very high latency.

Reverts part of 0533249d11ac220e223369f774fafcabc3f30c51.

Addresses concerns in https://github.com/ppy/osu/discussions/19429#discussioncomment-3276400.