### PR TITLE
Fix potential test failures due to Setup/SetUpSteps ordering

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomParticipantsList.cs
@@ -19,29 +19,33 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         private DrawableRoomParticipantsList list;
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            SelectedRoom.Value = new Room
-            {
-                Name = { Value = "test room" },
-                Host =
-                {
-                    Value = new APIUser
-                    {
-                        Id = 2,
-                        Username = "peppy",
-                    }
-                }
-            };
+            base.SetUpSteps();
 
-            Child = list = new DrawableRoomParticipantsList
+            AddStep("create list", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                NumberOfCircles = 4
-            };
-        });
+                SelectedRoom.Value = new Room
+                {
+                    Name = { Value = "test room" },
+                    Host =
+                    {
+                        Value = new APIUser
+                        {
+                            Id = 2,
+                            Username = "peppy",
+                        }
+                    }
+                };
+
+                Child = list = new DrawableRoomParticipantsList
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    NumberOfCircles = 4
+                };
+            });
+        }
 
         [Test]
         public void TestCircleCountNearLimit()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
@@ -25,23 +25,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private RoomsContainer container;
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            Child = new PopoverContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Width = 0.5f,
+            base.SetUpSteps();
 
-                Child = container = new RoomsContainer
+            AddStep("create container", () =>
+            {
+                Child = new PopoverContainer
                 {
-                    SelectedRoom = { BindTarget = SelectedRoom }
-                }
-            };
-        });
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 0.5f,
+
+                    Child = container = new RoomsContainer
+                    {
+                        SelectedRoom = { BindTarget = SelectedRoom }
+                    }
+                };
+            });
+        }
 
         [Test]
         public void TestBasicListChanges()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchBeatmapDetailArea.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchBeatmapDetailArea.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
@@ -18,19 +17,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMatchBeatmapDetailArea : OnlinePlayTestScene
     {
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            SelectedRoom.Value = new Room();
+            base.SetUpSteps();
 
-            Child = new MatchBeatmapDetailArea
+            AddStep("create area", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Size = new Vector2(500),
-                CreateNewItem = createNewItem
-            };
-        });
+                SelectedRoom.Value = new Room();
+
+                Child = new MatchBeatmapDetailArea
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(500),
+                    CreateNewItem = createNewItem
+                };
+            });
+        }
 
         private void createNewItem()
         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchLeaderboard.cs
@@ -4,8 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -19,59 +17,62 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMatchLeaderboard : OnlinePlayTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        public override void SetUpSteps()
         {
-            ((DummyAPIAccess)API).HandleRequest = r =>
+            base.SetUpSteps();
+
+            AddStep("setup API", () =>
             {
-                switch (r)
+                ((DummyAPIAccess)API).HandleRequest = r =>
                 {
-                    case GetRoomLeaderboardRequest leaderboardRequest:
-                        leaderboardRequest.TriggerSuccess(new APILeaderboard
-                        {
-                            Leaderboard = new List<APIUserScoreAggregate>
+                    switch (r)
+                    {
+                        case GetRoomLeaderboardRequest leaderboardRequest:
+                            leaderboardRequest.TriggerSuccess(new APILeaderboard
                             {
-                                new APIUserScoreAggregate
+                                Leaderboard = new List<APIUserScoreAggregate>
                                 {
-                                    UserID = 2,
-                                    User = new APIUser { Id = 2, Username = "peppy" },
-                                    TotalScore = 995533,
-                                    RoomID = 3,
-                                    CompletedBeatmaps = 1,
-                                    TotalAttempts = 6,
-                                    Accuracy = 0.9851
-                                },
-                                new APIUserScoreAggregate
-                                {
-                                    UserID = 1040328,
-                                    User = new APIUser { Id = 1040328, Username = "smoogipoo" },
-                                    TotalScore = 981100,
-                                    RoomID = 3,
-                                    CompletedBeatmaps = 1,
-                                    TotalAttempts = 9,
-                                    Accuracy = 0.937
+                                    new APIUserScoreAggregate
+                                    {
+                                        UserID = 2,
+                                        User = new APIUser { Id = 2, Username = "peppy" },
+                                        TotalScore = 995533,
+                                        RoomID = 3,
+                                        CompletedBeatmaps = 1,
+                                        TotalAttempts = 6,
+                                        Accuracy = 0.9851
+                                    },
+                                    new APIUserScoreAggregate
+                                    {
+                                        UserID = 1040328,
+                                        User = new APIUser { Id = 1040328, Username = "smoogipoo" },
+                                        TotalScore = 981100,
+                                        RoomID = 3,
+                                        CompletedBeatmaps = 1,
+                                        TotalAttempts = 9,
+                                        Accuracy = 0.937
+                                    }
                                 }
-                            }
-                        });
-                        return true;
-                }
+                            });
+                            return true;
+                    }
 
-                return false;
-            };
-        }
+                    return false;
+                };
+            });
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
-        {
-            SelectedRoom.Value = new Room { RoomID = { Value = 3 } };
-
-            Child = new MatchLeaderboard
+            AddStep("create leaderboard", () =>
             {
-                Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-                Size = new Vector2(550f, 450f),
-                Scope = MatchLeaderboardScope.Overall,
-            };
-        });
+                SelectedRoom.Value = new Room { RoomID = { Value = 3 } };
+
+                Child = new MatchLeaderboard
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    Size = new Vector2(550f, 450f),
+                    Scope = MatchLeaderboardScope.Overall,
+                };
+            });
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorLeaderboard.cs
@@ -22,8 +22,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private MultiSpectatorLeaderboard leaderboard;
 
         [SetUpSteps]
-        public new void SetUpSteps()
+        public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
             AddStep("reset", () =>
             {
                 leaderboard?.RemoveAndDisposeImmediately();

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -56,8 +56,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             importedBeatmapId = importedBeatmap.OnlineID;
         }
 
-        [SetUp]
-        public new void Setup() => Schedule(() => playingUsers.Clear());
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("clear playing users", () => playingUsers.Clear());
+        }
 
         [Test]
         public void TestDelayedStart()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -13,23 +12,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerMatchFooter : MultiplayerTestScene
     {
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            Child = new PopoverContainer
+            base.SetUpSteps();
+
+            AddStep("create footer", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Both,
-                Child = new Container
+                Child = new PopoverContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.X,
-                    Height = 50,
-                    Child = new MultiplayerMatchFooter()
-                }
-            };
-        });
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new Container
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.X,
+                        Height = 50,
+                        Child = new MultiplayerMatchFooter()
+                    }
+                };
+            });
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -59,16 +59,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             importedSet = beatmaps.GetAllUsableBeatmapSets().First();
         }
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
-        {
-            SelectedRoom.Value = new Room { Name = { Value = "Test Room" } };
-        });
-
         [SetUpSteps]
         public void SetupSteps()
         {
-            AddStep("load match", () => LoadScreen(screen = new MultiplayerMatchSubScreen(SelectedRoom.Value)));
+            AddStep("load match", () =>
+            {
+                SelectedRoom.Value = new Room { Name = { Value = "Test Room" } };
+                LoadScreen(screen = new MultiplayerMatchSubScreen(SelectedRoom.Value));
+            });
+
             AddUntilStep("wait for load", () => screen.IsCurrentScreen());
         }
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlaylist.cs
@@ -42,21 +42,22 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(Realm);
         }
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
-        {
-            Child = list = new MultiplayerPlaylist
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Both,
-                Size = new Vector2(0.4f, 0.8f)
-            };
-        });
-
         [SetUpSteps]
-        public new void SetUpSteps()
+        public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
+            AddStep("create list", () =>
+            {
+                Child = list = new MultiplayerPlaylist
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(0.4f, 0.8f)
+                };
+            });
+
             AddStep("import beatmap", () =>
             {
                 beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -46,43 +46,47 @@ namespace osu.Game.Tests.Visual.Multiplayer
             beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
         }
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            AvailabilityTracker.SelectedItem.BindTo(selectedItem);
+            base.SetUpSteps();
 
-            importedSet = beatmaps.GetAllUsableBeatmapSets().First();
-            Beatmap.Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First());
-            selectedItem.Value = new PlaylistItem(Beatmap.Value.BeatmapInfo)
+            AddStep("create button", () =>
             {
-                RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID,
-            };
+                AvailabilityTracker.SelectedItem.BindTo(selectedItem);
 
-            Child = new PopoverContainer
-            {
-                RelativeSizeAxes = Axes.Both,
-                Child = new FillFlowContainer
+                importedSet = beatmaps.GetAllUsableBeatmapSets().First();
+                Beatmap.Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First());
+                selectedItem.Value = new PlaylistItem(Beatmap.Value.BeatmapInfo)
                 {
-                    AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Children = new Drawable[]
+                    RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID,
+                };
+
+                Child = new PopoverContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new FillFlowContainer
                     {
-                        spectateButton = new MultiplayerSpectateButton
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Children = new Drawable[]
                         {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Size = new Vector2(200, 50),
-                        },
-                        startControl = new MatchStartControl
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Size = new Vector2(200, 50),
+                            spectateButton = new MultiplayerSpectateButton
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Size = new Vector2(200, 50),
+                            },
+                            startControl = new MatchStartControl
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Size = new Vector2(200, 50),
+                            }
                         }
                     }
-                }
-            };
-        });
+                };
+            });
+        }
 
         [TestCase(MultiplayerRoomState.Open)]
         [TestCase(MultiplayerRoomState.WaitingForLoad)]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -14,17 +14,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneStarRatingRangeDisplay : OnlinePlayTestScene
     {
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            SelectedRoom.Value = new Room();
+            base.SetUpSteps();
 
-            Child = new StarRatingRangeDisplay
+            AddStep("create display", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre
-            };
-        });
+                SelectedRoom.Value = new Room();
+
+                Child = new StarRatingRangeDisplay
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                };
+            });
+        }
 
         [Test]
         public void TestRange([Values(0, 2, 3, 4, 6, 7)] double min, [Values(0, 2, 3, 4, 6, 7)] double max)

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsMatchSettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsMatchSettingsOverlay.cs
@@ -25,17 +25,21 @@ namespace osu.Game.Tests.Visual.Playlists
 
         protected override OnlinePlayTestSceneDependencies CreateOnlinePlayDependencies() => new TestDependencies();
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            SelectedRoom.Value = new Room();
+            base.SetUpSteps();
 
-            Child = settings = new TestRoomSettings(SelectedRoom.Value)
+            AddStep("create overlay", () =>
             {
-                RelativeSizeAxes = Axes.Both,
-                State = { Value = Visibility.Visible }
-            };
-        });
+                SelectedRoom.Value = new Room();
+
+                Child = settings = new TestRoomSettings(SelectedRoom.Value)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    State = { Value = Visibility.Visible }
+                };
+            });
+        }
 
         [Test]
         public void TestButtonEnabledOnlyWithNameAndBeatmap()

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsParticipantsList.cs
@@ -15,21 +15,25 @@ namespace osu.Game.Tests.Visual.Playlists
 {
     public class TestScenePlaylistsParticipantsList : OnlinePlayTestScene
     {
-        [SetUp]
-        public new void Setup() => Schedule(() =>
+        public override void SetUpSteps()
         {
-            SelectedRoom.Value = new Room { RoomID = { Value = 7 } };
+            base.SetUpSteps();
 
-            for (int i = 0; i < 50; i++)
+            AddStep("create list", () =>
             {
-                SelectedRoom.Value.RecentParticipants.Add(new APIUser
+                SelectedRoom.Value = new Room { RoomID = { Value = 7 } };
+
+                for (int i = 0; i < 50; i++)
                 {
-                    Username = "peppy",
-                    Statistics = new UserStatistics { GlobalRank = 1234 },
-                    Id = 2
-                });
-            }
-        });
+                    SelectedRoom.Value.RecentParticipants.Add(new APIUser
+                    {
+                        Username = "peppy",
+                        Statistics = new UserStatistics { GlobalRank = 1234 },
+                        Id = 2
+                    });
+                }
+            });
+        }
 
         [Test]
         public void TestHorizontalLayout()

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using NUnit.Framework;
 using osu.Game.Online.Rooms;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Visual.OnlinePlay;
@@ -34,13 +33,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             this.joinRoom = joinRoom;
         }
 
-        [SetUp]
-        public new void Setup() => Schedule(() =>
-        {
-            if (joinRoom)
-                SelectedRoom.Value = CreateRoom();
-        });
-
         protected virtual Room CreateRoom()
         {
             return new Room
@@ -63,7 +55,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             if (joinRoom)
             {
-                AddStep("join room", () => RoomManager.CreateRoom(SelectedRoom.Value));
+                AddStep("join room", () =>
+                {
+                    SelectedRoom.Value = CreateRoom();
+                    RoomManager.CreateRoom(SelectedRoom.Value);
+                });
+
                 AddUntilStep("wait for room join", () => RoomJoined);
             }
         }


### PR DESCRIPTION
Fixes https://teamcity.ppy.sh/buildConfiguration/Osu_Build/4290?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

`Setup` runs before `SetUpSteps`, and is used to reconstruct the testscene's dependencies, but the current screen hasn't been exited by this point. The above failure can be reproed in visual tests by running the test two times with:
```diff
diff --git a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
index 228ecd4bf3..a24b1c44b9 100644
--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -54,6 +54,12 @@ private void load([CanBeNull] IdleTracker idleTracker)
             AddInternal(selectionPollingComponent = new SelectionPollingComponent(Room));
         }

+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            selectionPollingComponent.PollImmediately();
+            return base.OnExiting(e);
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
```

The fix is to move all of this code to `SetUpSteps`. This may also fix other intermittent multiplayer tests, but unsure.