### PR TITLE
Allow osu!taiko hitsounds to fall back to classic skin rather than use non-taiko samples

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Taiko.Tests
         protected override IResourceStore<byte[]> RulesetResources => new DllResourceStore(Assembly.GetAssembly(typeof(TestSceneTaikoHitObjectSamples)));
 
         [TestCase("taiko-normal-hitnormal")]
-        [TestCase("normal-hitnormal")]
         [TestCase("hitnormal")]
         public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
         {
@@ -29,7 +28,6 @@ namespace osu.Game.Rulesets.Taiko.Tests
         }
 
         [TestCase("taiko-normal-hitnormal")]
-        [TestCase("normal-hitnormal")]
         [TestCase("hitnormal")]
         public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
         {
@@ -41,7 +39,6 @@ namespace osu.Game.Rulesets.Taiko.Tests
         }
 
         [TestCase("taiko-normal-hitnormal2")]
-        [TestCase("normal-hitnormal2")]
         public void TestUserSkinLookupIgnoresSampleBank(string unwantedSample)
         {
             SetupSkins(string.Empty, unwantedSample);

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Reflection;
 using NUnit.Framework;
 using osu.Framework.IO.Stores;

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using osu.Framework.Audio.Sample;
@@ -24,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             hasExplosion = new Lazy<bool>(() => GetTexture(getHitName(TaikoSkinComponents.TaikoExplosionGreat)) != null);
         }
 
-        public override Drawable GetDrawableComponent(ISkinComponent component)
+        public override Drawable? GetDrawableComponent(ISkinComponent component)
         {
             if (component is GameplaySkinComponent<HitResult>)
             {
@@ -151,7 +149,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             throw new ArgumentOutOfRangeException(nameof(component), $"Invalid component type: {component}");
         }
 
-        public override ISample GetSample(ISampleInfo sampleInfo)
+        public override ISample? GetSample(ISampleInfo sampleInfo)
         {
             if (sampleInfo is HitSampleInfo hitSampleInfo)
                 return base.GetSample(new LegacyTaikoSampleInfo(hitSampleInfo));

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -173,9 +173,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 {
                     foreach (string name in base.LookupNames)
                         yield return name.Insert(name.LastIndexOf('/') + 1, "taiko-");
-
-                    foreach (string name in base.LookupNames)
-                        yield return name;
                 }
             }
         }


### PR DESCRIPTION
- Closes #19436 

Upon checking with osu!(stable) and its code, there are no signs of falling back to the non-taiko hitsound samples when the current skin/beatmap doesn't provide one. In the code, the taiko prefix is always assigned at the beginning of the sample lookup method.

There is only one special thing that osu!(stable) does which I plan to solve differently, which is mapping `taiko-drum` hitsound samples to `taiko-normal` when falling back all the way to the classic skin. Rather than play around with the default skin lookup methods, I'll open a PR at osu-resources copying the normal variants as "drum" samples.