### PR TITLE
Fix potential nullref in `TestSceneAutoplay` check steps method

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -31,20 +31,20 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override void AddCheckSteps()
         {
-            // It doesn't matter which ruleset is used - this beatmap is only used for reference.
-            var beatmap = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
+            // we only want this beatmap for time reference.
+            var referenceBeatmap = CreateBeatmap(new OsuRuleset().RulesetInfo);
 
             AddUntilStep("score above zero", () => Player.ScoreProcessor.TotalScore.Value > 0);
             AddUntilStep("key counter counted keys", () => Player.HUDOverlay.KeyCounter.Children.Any(kc => kc.CountPresses > 2));
 
-            seekTo(beatmap.Beatmap.Breaks[0].StartTime);
+            seekTo(referenceBeatmap.Breaks[0].StartTime);
             AddAssert("keys not counting", () => !Player.HUDOverlay.KeyCounter.IsCounting);
             AddAssert("overlay displays 100% accuracy", () => Player.BreakOverlay.ChildrenOfType<BreakInfo>().Single().AccuracyDisplay.Current.Value == 1);
 
             AddStep("rewind", () => Player.GameplayClockContainer.Seek(-80000));
             AddUntilStep("key counter reset", () => Player.HUDOverlay.KeyCounter.Children.All(kc => kc.CountPresses == 0));
 
-            seekTo(beatmap.Beatmap.HitObjects[^1].GetEndTime());
+            seekTo(referenceBeatmap.HitObjects[^1].GetEndTime());
             AddUntilStep("results displayed", () => getResultsScreen()?.IsLoaded == true);
 
             AddAssert("score has combo", () => getResultsScreen().Score.Combo > 100);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
@@ -263,27 +263,30 @@ namespace osu.Game.Tests.Visual.Gameplay
             return beatmap;
         }
 
-        private void createTest(IBeatmap beatmap, Action<TestDrawableScrollingRuleset> overrideAction = null) => AddStep("create test", () =>
+        private void createTest(IBeatmap beatmap, Action<TestDrawableScrollingRuleset> overrideAction = null)
         {
-            var ruleset = new TestScrollingRuleset();
-
-            drawableRuleset = (TestDrawableScrollingRuleset)ruleset.CreateDrawableRulesetWith(CreateWorkingBeatmap(beatmap).GetPlayableBeatmap(ruleset.RulesetInfo));
-            drawableRuleset.FrameStablePlayback = false;
-
-            overrideAction?.Invoke(drawableRuleset);
-
-            Child = new Container
+            AddStep("create test", () =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Y,
-                Height = 0.75f,
-                Width = 400,
-                Masking = true,
-                Clock = new FramedClock(testClock),
-                Child = drawableRuleset
-            };
-        });
+                var ruleset = new TestScrollingRuleset();
+
+                drawableRuleset = (TestDrawableScrollingRuleset)ruleset.CreateDrawableRulesetWith(CreateWorkingBeatmap(beatmap).GetPlayableBeatmap(ruleset.RulesetInfo));
+                drawableRuleset.FrameStablePlayback = false;
+
+                overrideAction?.Invoke(drawableRuleset);
+
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Y,
+                    Height = 0.75f,
+                    Width = 400,
+                    Masking = true,
+                    Clock = new FramedClock(testClock),
+                    Child = drawableRuleset
+                };
+            });
+        }
 
         #region Ruleset
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -158,21 +158,24 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("clean up", () => drawableRuleset.NewResult -= onNewResult);
         }
 
-        private void createTest(IBeatmap beatmap, int poolSize, Func<IFrameBasedClock> createClock = null) => AddStep("create test", () =>
+        private void createTest(IBeatmap beatmap, int poolSize, Func<IFrameBasedClock> createClock = null)
         {
-            var ruleset = new TestPoolingRuleset();
-
-            drawableRuleset = (TestDrawablePoolingRuleset)ruleset.CreateDrawableRulesetWith(CreateWorkingBeatmap(beatmap).GetPlayableBeatmap(ruleset.RulesetInfo));
-            drawableRuleset.FrameStablePlayback = true;
-            drawableRuleset.PoolSize = poolSize;
-
-            Child = new Container
+            AddStep("create test", () =>
             {
-                RelativeSizeAxes = Axes.Both,
-                Clock = createClock?.Invoke() ?? new FramedOffsetClock(Clock, false) { Offset = -Clock.CurrentTime },
-                Child = drawableRuleset
-            };
-        });
+                var ruleset = new TestPoolingRuleset();
+
+                drawableRuleset = (TestDrawablePoolingRuleset)ruleset.CreateDrawableRulesetWith(CreateWorkingBeatmap(beatmap).GetPlayableBeatmap(ruleset.RulesetInfo));
+                drawableRuleset.FrameStablePlayback = true;
+                drawableRuleset.PoolSize = poolSize;
+
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Clock = createClock?.Invoke() ?? new FramedOffsetClock(Clock, false) { Offset = -Clock.CurrentTime },
+                    Child = drawableRuleset
+                };
+            });
+        }
 
         #region Ruleset
 


### PR DESCRIPTION

<img width="1528" alt="CleanShot 2022-07-30 at 10 10 22@2x" src="https://user-images.githubusercontent.com/22781491/181879281-b3df831e-79e4-4adb-97b0-5a7799efe963.png">

Since `LoadTrack` is now called on constructor in tests, the audio manager is necessary to have in order to construct a virtual track for the beatmap. `TestSceneAutoplay` however dodgily creates a working beatmap in a non-loaded context just to use it for time reference on the seek step descriptions. Have replaced by only creating the `IBeatmap`, which is enough for time reference.

I've also updated a few methods that combine the `AddStep` on the same line as the method declaration, which made it somewhat hard to tell that the code is being executed inside the step because of the indentation difference.