### PR TITLE
Add battery info / low battery warning for desktop platforms

### DIFF
--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -106,9 +106,9 @@ namespace osu.Android
 
         private class AndroidBatteryInfo : BatteryInfo
         {
-            public override double ChargeLevel => Battery.ChargeLevel;
+            public override double? ChargeLevel => Battery.ChargeLevel;
 
-            public override bool IsCharging => Battery.PowerSource != BatteryPowerSource.Battery;
+            public override bool OnBattery => Battery.PowerSource == BatteryPowerSource.Battery;
         }
     }
 }

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -29,6 +29,8 @@ using osu.Game.IPC;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Overlays.Settings.Sections.Input;
+using osu.Game.Utils;
+using SDL2;
 
 namespace osu.Desktop
 {
@@ -166,6 +168,8 @@ namespace osu.Desktop
             }
         }
 
+        protected override BatteryInfo CreateBatteryInfo() => new SDL2BatteryInfo();
+
         private readonly List<string> importableFiles = new List<string>();
         private ScheduledDelegate? importSchedule;
 
@@ -205,6 +209,24 @@ namespace osu.Desktop
         {
             base.Dispose(isDisposing);
             osuSchemeLinkIPCChannel?.Dispose();
+        }
+
+        private class SDL2BatteryInfo : BatteryInfo
+        {
+            public override double? ChargeLevel
+            {
+                get
+                {
+                    SDL.SDL_GetPowerInfo(out _, out int percentage);
+
+                    if (percentage == -1)
+                        return null;
+
+                    return percentage / 100.0;
+                }
+            }
+
+            public override bool OnBattery => SDL.SDL_GetPowerInfo(out _, out _) == SDL.SDL_PowerState.SDL_POWERSTATE_ON_BATTERY;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -308,17 +308,18 @@ namespace osu.Game.Tests.Visual.Gameplay
             }
         }
 
-        [TestCase(false, 1.0, false)] // not charging, above cutoff --> no warning
-        [TestCase(true, 0.1, false)] // charging, below cutoff --> no warning
-        [TestCase(false, 0.25, true)] // not charging, at cutoff --> warning
-        public void TestLowBatteryNotification(bool isCharging, double chargeLevel, bool shouldWarn)
+        [TestCase(true, 1.0, false)] // on battery, above cutoff --> no warning
+        [TestCase(false, 0.1, false)] // not on battery, below cutoff --> no warning
+        [TestCase(true, 0.25, true)] // on battery, at cutoff --> warning
+        [TestCase(true, null, false)] // on battery, level unknown --> no warning
+        public void TestLowBatteryNotification(bool onBattery, double? chargeLevel, bool shouldWarn)
         {
             AddStep("reset notification lock", () => sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).Value = false);
 
             // set charge status and level
             AddStep("load player", () => resetPlayer(false, () =>
             {
-                batteryInfo.SetCharging(isCharging);
+                batteryInfo.SetOnBattery(onBattery);
                 batteryInfo.SetChargeLevel(chargeLevel);
             }));
             AddUntilStep("wait for player", () => player?.LoadState == LoadState.Ready);
@@ -408,19 +409,19 @@ namespace osu.Game.Tests.Visual.Gameplay
         /// <inheritdoc/>
         private class LocalBatteryInfo : BatteryInfo
         {
-            private bool isCharging = true;
-            private double chargeLevel = 1;
+            private bool onBattery;
+            private double? chargeLevel;
 
-            public override bool IsCharging => isCharging;
+            public override bool OnBattery => onBattery;
 
-            public override double ChargeLevel => chargeLevel;
+            public override double? ChargeLevel => chargeLevel;
 
-            public void SetCharging(bool value)
+            public void SetOnBattery(bool value)
             {
-                isCharging = value;
+                onBattery = value;
             }
 
-            public void SetChargeLevel(double value)
+            public void SetChargeLevel(double? value)
             {
                 chargeLevel = value;
             }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -549,6 +549,8 @@ namespace osu.Game.Screens.Play
 
         #region Low battery warning
 
+        private const double low_battery_threshold = 0.25;
+
         private Bindable<bool> batteryWarningShownOnce = null!;
 
         private void showBatteryWarningIfNeeded()
@@ -557,7 +559,7 @@ namespace osu.Game.Screens.Play
 
             if (!batteryWarningShownOnce.Value)
             {
-                if (!batteryInfo.IsCharging && batteryInfo.ChargeLevel <= 0.25)
+                if (batteryInfo.OnBattery && batteryInfo.ChargeLevel <= low_battery_threshold)
                 {
                     notificationOverlay?.Post(new BatteryWarningNotification());
                     batteryWarningShownOnce.Value = true;

--- a/osu.Game/Utils/BatteryInfo.cs
+++ b/osu.Game/Utils/BatteryInfo.cs
@@ -9,10 +9,16 @@ namespace osu.Game.Utils
     public abstract class BatteryInfo
     {
         /// <summary>
-        /// The charge level of the battery, from 0 to 1.
+        /// The charge level of the battery, from <c>0</c> to <c>1</c>, or <c>null</c> if a battery isn't present.
         /// </summary>
-        public abstract double ChargeLevel { get; }
+        public abstract double? ChargeLevel { get; }
 
-        public abstract bool IsCharging { get; }
+        /// <summary>
+        /// Whether the current power source is the battery.
+        /// </summary>
+        /// <remarks>
+        /// This is <c>false</c> when the device is charging or doesn't have a battery.
+        /// </remarks>
+        public abstract bool OnBattery { get; }
     }
 }

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -43,9 +43,9 @@ namespace osu.iOS
 
         private class IOSBatteryInfo : BatteryInfo
         {
-            public override double ChargeLevel => Battery.ChargeLevel;
+            public override double? ChargeLevel => Battery.ChargeLevel;
 
-            public override bool IsCharging => Battery.PowerSource != BatteryPowerSource.Battery;
+            public override bool OnBattery => Battery.PowerSource == BatteryPowerSource.Battery;
         }
     }
 }

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -350,6 +350,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PM/@EntryIndexedValue">PM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RGB/@EntryIndexedValue">RGB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RNG/@EntryIndexedValue">RNG</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SDL/@EntryIndexedValue">SDL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SHA/@EntryIndexedValue">SHA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SRGB/@EntryIndexedValue">SRGB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=TK/@EntryIndexedValue">TK</s:String>


### PR DESCRIPTION
Tested on Windows on a laptop. Calling `SDL_GetPowerInfo` seems to work just fine from the update thread.

`ChargeLevel` has been made nullable to accommodate devices without a battery.
`IsCharging` has been flipped to `OnBattery` as charging doesn't make sense for devices without a battery.
