### PR TITLE
Fix collection migration potentially deleting the database before finishing migration

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -802,8 +802,8 @@ namespace osu.Game.Database
 
                         if (legacyCollectionImporter.GetAvailableCount(storage).GetResultSafely() > 0)
                         {
-                            storage.Delete("collection.db");
                             legacyCollectionImporter.ImportFromStorage(storage).WaitSafely();
+                            storage.Move("collection.db", "collection.db.migrated");
                         }
                     }
                     catch (Exception e)

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -802,8 +802,8 @@ namespace osu.Game.Database
 
                         if (legacyCollectionImporter.GetAvailableCount(storage).GetResultSafely() > 0)
                         {
-                            legacyCollectionImporter.ImportFromStorage(storage);
                             storage.Delete("collection.db");
+                            legacyCollectionImporter.ImportFromStorage(storage).WaitSafely();
                         }
                     }
                     catch (Exception e)


### PR DESCRIPTION
Asynchronous import was not waited on correctly...

I've left commit history here, but it turns out async execution is required to avoid deadlocking. I've made it safe by moving the deletion to `ContinueWith`, and making it a `Move` for extra safety.