### PR TITLE
Fix song select not updating selected beatmap card on editor resume

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
@@ -280,6 +281,28 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("return", () => songSelect.MakeCurrent());
             AddUntilStep("wait for current", () => songSelect.IsCurrentScreen());
             AddAssert("filter count is 2", () => songSelect.FilterCount == 2);
+        }
+
+        [Test]
+        public void TestCarouselSelectionUpdatesOnResume()
+        {
+            addRulesetImportStep(0);
+
+            createSongSelect();
+
+            AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
+            AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
+
+            AddStep("update beatmap", () =>
+            {
+                var selectedBeatmap = Beatmap.Value.BeatmapInfo;
+                var anotherBeatmap = Beatmap.Value.BeatmapSetInfo.Beatmaps.Except(selectedBeatmap.Yield()).First();
+                Beatmap.Value = manager.GetWorkingBeatmap(anotherBeatmap);
+            });
+
+            AddStep("return", () => songSelect.MakeCurrent());
+            AddUntilStep("wait for current", () => songSelect.IsCurrentScreen());
+            AddAssert("carousel updated", () => songSelect.Carousel.SelectedBeatmapInfo.Equals(Beatmap.Value.BeatmapInfo));
         }
 
         [Test]

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -405,20 +405,21 @@ namespace osu.Game.Screens.Select
 
         private ScheduledDelegate selectionChangedDebounce;
 
-        private void workingBeatmapChanged(ValueChangedEvent<WorkingBeatmap> e)
+        private void updateCarouselSelection(ValueChangedEvent<WorkingBeatmap> e = null)
         {
-            if (e.NewValue is DummyWorkingBeatmap || !this.IsCurrentScreen()) return;
+            var beatmap = e?.NewValue ?? Beatmap.Value;
+            if (beatmap is DummyWorkingBeatmap || !this.IsCurrentScreen()) return;
 
-            Logger.Log($"Song select working beatmap updated to {e.NewValue}");
+            Logger.Log($"Song select working beatmap updated to {beatmap}");
 
-            if (!Carousel.SelectBeatmap(e.NewValue.BeatmapInfo, false))
+            if (!Carousel.SelectBeatmap(beatmap.BeatmapInfo, false))
             {
                 // A selection may not have been possible with filters applied.
 
                 // There was possibly a ruleset mismatch. This is a case we can help things along by updating the game-wide ruleset to match.
-                if (!e.NewValue.BeatmapInfo.Ruleset.Equals(decoupledRuleset.Value))
+                if (!beatmap.BeatmapInfo.Ruleset.Equals(decoupledRuleset.Value))
                 {
-                    Ruleset.Value = e.NewValue.BeatmapInfo.Ruleset;
+                    Ruleset.Value = beatmap.BeatmapInfo.Ruleset;
                     transferRulesetValue();
                 }
 
@@ -426,10 +427,10 @@ namespace osu.Game.Screens.Select
                 // we still want to temporarily show the new beatmap, bypassing filters.
                 // This will be undone the next time the user changes the filter.
                 var criteria = FilterControl.CreateCriteria();
-                criteria.SelectedBeatmapSet = e.NewValue.BeatmapInfo.BeatmapSet;
+                criteria.SelectedBeatmapSet = beatmap.BeatmapInfo.BeatmapSet;
                 Carousel.Filter(criteria);
 
-                Carousel.SelectBeatmap(e.NewValue.BeatmapInfo);
+                Carousel.SelectBeatmap(beatmap.BeatmapInfo);
             }
         }
 
@@ -597,6 +598,8 @@ namespace osu.Game.Screens.Select
 
             if (Beatmap != null && !Beatmap.Value.BeatmapSetInfo.DeletePending)
             {
+                updateCarouselSelection();
+
                 updateComponentFromBeatmap(Beatmap.Value);
 
                 if (ControlGlobalMusic)
@@ -805,7 +808,7 @@ namespace osu.Game.Screens.Select
             };
             decoupledRuleset.DisabledChanged += r => Ruleset.Disabled = r;
 
-            Beatmap.BindValueChanged(workingBeatmapChanged);
+            Beatmap.BindValueChanged(updateCarouselSelection);
 
             boundLocalBindables = true;
         }


### PR DESCRIPTION
- Closes #19476

Along with all other components, selected beatmap card will get refreshed on screen resume to ensure it doesn't become out of sync.

Hopes would be that we don't do this kind of stuff and let `workingBeatmapChanged` always invoke regardless of whether song select is current, but I'm not willing to spend too much time on this.