### PR TITLE
Hide "Update" button if beatmap is unavailable online

### DIFF
--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public DateTimeOffset? DateRanked { get; set; }
 
+        public bool? OnlineDownloadDisabled { get; set; }
+
         [JsonIgnore]
         public IBeatmapMetadataInfo Metadata => Beatmaps.FirstOrDefault()?.Metadata ?? new BeatmapMetadata();
 

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -97,6 +97,7 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
                     beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
                     beatmapInfo.BeatmapSet.DateSubmitted = res.BeatmapSet?.Submitted;
+                    beatmapInfo.BeatmapSet.OnlineDownloadDisabled = res.BeatmapSet?.Availability.DownloadDisabled;
 
                     beatmapInfo.OnlineMD5Hash = res.MD5Hash;
                     beatmapInfo.LastOnlineUpdate = res.LastUpdated;

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -66,8 +66,9 @@ namespace osu.Game.Database
         /// 19   2022-07-19    Added DateSubmitted and DateRanked to BeatmapSetInfo.
         /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo, changed default value of BeatmapInfo.StarRating to -1.
         /// 21   2022-07-27    Migrate collections to realm (BeatmapCollection).
+        /// 22   2022-07-31    Added OnlineDownloadDisabled to BeatmapSetInfo.
         /// </summary>
-        private const int schema_version = 21;
+        private const int schema_version = 22;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -810,6 +811,14 @@ namespace osu.Game.Database
                     {
                         // can be removed 20221027 (just for initial safety).
                         Logger.Error(e, "Collections could not be migrated to realm. Please provide your \"collection.db\" to the dev team.");
+                    }
+
+                    break;
+
+                case 22:
+                    foreach (var beatmapSet in migration.NewRealm.All<BeatmapSetInfo>())
+                    {
+                        beatmapSet.OnlineDownloadDisabled = null;
                     }
 
                     break;

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Select.Carousel
                         Spacing = new Vector2(5),
                         Children = new[]
                         {
-                            beatmapSet.AllBeatmapsUpToDate
+                            beatmapSet.AllBeatmapsUpToDate || beatmapSet.OnlineDownloadDisabled == true
                                 ? Empty()
                                 : new Container
                                 {

--- a/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
@@ -100,17 +100,20 @@ namespace osu.Game.Screens.Select.Carousel
                 // We want to check that so reset online info for now, background processing will update the info
                 realm.Run(r =>
                 {
-                    using (var transaction = r.BeginWrite())
+                    var matchingSet = r.Find<BeatmapSetInfo>(beatmapSetInfo.ID);
+
+                    if (matchingSet != null)
                     {
-                        var matchingSet = r.Find<BeatmapSetInfo>(beatmapSetInfo.ID);
-
-                        foreach (BeatmapInfo beatmap in matchingSet.Beatmaps)
+                        using (var transaction = r.BeginWrite())
                         {
-                            // Background processing checks LastOnlineUpdate, that's the only field we need to null
-                            beatmap.LastOnlineUpdate = null;
-                        }
+                            foreach (BeatmapInfo beatmap in matchingSet.Beatmaps)
+                            {
+                                // Background processing checks LastOnlineUpdate, that's the only field we need to null
+                                beatmap.LastOnlineUpdate = null;
+                            }
 
-                        transaction.Commit();
+                            transaction.Commit();
+                        }
                     }
                 });
             };


### PR DESCRIPTION
I explored how one would fix #19475. I get that it's not a priority and this PR will probably not get merged, I was just curious about it for some reason.

While hiding the update button when download fails is easy, keeping it hidden is not. Something must persist to local database or the update button will appear again the next time song select is loaded because the beatmap is still not up-to-date. This PR adds `OnlineDownloadDisabled` to `BeatmapSetInfo` which is populated by background beatmap processing. There's also the case where a beatmap is already processed but this new field is null and the "Update" button will still appear. To solve this, beatmap online info is reset when download fails.