### PR TITLE
Prevent capturing arrow keys in Playlist

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -204,7 +204,9 @@ namespace osu.Game.Screens.OnlinePlay
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (!allowSelection) return false;
+            if (!allowSelection) 
+                return false;
+            
             switch (e.Action)
             {
                 case GlobalAction.SelectNext:

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -204,6 +204,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
+            if (!allowSelection) return false;
             switch (e.Action)
             {
                 case GlobalAction.SelectNext:


### PR DESCRIPTION
Prevent capturing arrow keys in the playlist box when selection is disabled as they are used only for selection. Fixes issue mentioned in https://github.com/ppy/osu/discussions/19503 where you can't use arrow keys during the playlist creation.