### PR TITLE
Prevent capturing arrow keys on playlist creation. 

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -204,6 +204,9 @@ namespace osu.Game.Screens.OnlinePlay
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
+            if (!AllowSelection)
+                return false;
+
             switch (e.Action)
             {
                 case GlobalAction.SelectNext:

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -227,9 +227,6 @@ namespace osu.Game.Screens.OnlinePlay
 
         private void selectNext(int direction)
         {
-            if (!AllowSelection)
-                return;
-
             var visibleItems = ListContainer.AsEnumerable().Where(r => r.IsPresent);
 
             PlaylistItem item;


### PR DESCRIPTION
Prevent capturing arrow keys in the playlist box when selection is disabled as they are used only for selection. Fixes issue mentioned in https://github.com/ppy/osu/discussions/19503 where you can't use arrow keys during the playlist creation.