### PR TITLE
Hide volume overlay when in-game

### DIFF
--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -36,10 +36,12 @@ namespace osu.Game.Overlays
 
         public Bindable<bool> IsMuted { get; } = new Bindable<bool>();
 
+        protected readonly IBindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
+
         private SelectionCycleFillFlowContainer<VolumeMeter> volumeMeters;
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio, OsuColour colours)
+        private void load(AudioManager audio, OsuColour colours, OsuGame osuGame)
         {
             AutoSizeAxes = Axes.X;
             RelativeSizeAxes = Axes.Y;
@@ -87,6 +89,9 @@ namespace osu.Game.Overlays
                 else
                     audio.RemoveAdjustment(AdjustableProperty.Volume, muteAdjustment);
             });
+
+            if (osuGame != null)
+                OverlayActivationMode.BindTo(osuGame.OverlayActivationMode);
         }
 
         protected override void LoadComplete()
@@ -97,6 +102,12 @@ namespace osu.Game.Overlays
                 volumeMeter.Bindable.ValueChanged += _ => Show();
 
             muteButton.Current.ValueChanged += _ => Show();
+
+            OverlayActivationMode.BindValueChanged(val =>
+            {
+                if (val.NewValue == OverlayActivation.Disabled)
+                    Hide();
+            });
         }
 
         public bool Adjust(GlobalAction action, float amount = 1, bool isPrecise = false)

--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -20,6 +20,7 @@ using osu.Game.Overlays.Volume;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
+using JetBrains.Annotations;
 
 namespace osu.Game.Overlays
 {
@@ -36,12 +37,13 @@ namespace osu.Game.Overlays
 
         public Bindable<bool> IsMuted { get; } = new Bindable<bool>();
 
+        [CanBeNull]
         protected readonly IBindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         private SelectionCycleFillFlowContainer<VolumeMeter> volumeMeters;
 
-        [BackgroundDependencyLoader]
-        private void load(AudioManager audio, OsuColour colours, OsuGame osuGame)
+        [BackgroundDependencyLoader(true)]
+        private void load(AudioManager audio, OsuColour colours, [CanBeNull] OsuGame osuGame)
         {
             AutoSizeAxes = Axes.X;
             RelativeSizeAxes = Axes.Y;
@@ -103,7 +105,7 @@ namespace osu.Game.Overlays
 
             muteButton.Current.ValueChanged += _ => Show();
 
-            OverlayActivationMode.BindValueChanged(val =>
+            OverlayActivationMode?.BindValueChanged(val =>
             {
                 if (val.NewValue == OverlayActivation.Disabled)
                     Hide();

--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Overlays
 
         public Bindable<bool> IsMuted { get; } = new Bindable<bool>();
 
-        [CanBeNull]
         protected readonly IBindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         private SelectionCycleFillFlowContainer<VolumeMeter> volumeMeters;
@@ -104,12 +103,6 @@ namespace osu.Game.Overlays
                 volumeMeter.Bindable.ValueChanged += _ => Show();
 
             muteButton.Current.ValueChanged += _ => Show();
-
-            OverlayActivationMode?.BindValueChanged(val =>
-            {
-                if (val.NewValue == OverlayActivation.Disabled)
-                    Hide();
-            });
         }
 
         public bool Adjust(GlobalAction action, float amount = 1, bool isPrecise = false)
@@ -194,6 +187,9 @@ namespace osu.Game.Overlays
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            if (OverlayActivationMode.Value == OverlayActivation.Disabled)
+                return false;
+
             switch (e.Key)
             {
                 case Key.Left:

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -100,7 +100,6 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private MusicController musicController { get; set; }
 
-
         public GameplayState GameplayState { get; private set; }
 
         private Ruleset ruleset;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -100,8 +100,6 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private MusicController musicController { get; set; }
 
-        [Resolved]
-        private VolumeOverlay volumeOverlay { get; set; }
 
         public GameplayState GameplayState { get; private set; }
 
@@ -368,12 +366,6 @@ namespace osu.Game.Screens.Play
 
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
-
-            LocalUserPlaying.BindValueChanged(val =>
-            {
-                if (val.NewValue)
-                    volumeOverlay.Hide();
-            });
         }
 
         protected virtual GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -100,6 +100,9 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private MusicController musicController { get; set; }
 
+        [Resolved]
+        private VolumeOverlay volumeOverlay { get; set; }
+
         public GameplayState GameplayState { get; private set; }
 
         private Ruleset ruleset;
@@ -365,6 +368,12 @@ namespace osu.Game.Screens.Play
 
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
+
+            LocalUserPlaying.BindValueChanged(val =>
+            {
+                if (val.NewValue)
+                    volumeOverlay.Hide();
+            });
         }
 
         protected virtual GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart);


### PR DESCRIPTION
Closes #19362 
Uses `LocalUserPlaying` to hide `VolumeOverlay` on the start of the game and when a break ends. Overlay stays open when playing replays and autoplay.