### PR TITLE
Add persistence of mod presets to realm

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestBasicAppearance()
+        public void TestBasicOperation()
         {
             AddStep("set osu! ruleset", () => Ruleset.Value = rulesets.GetRuleset(0));
             AddStep("create content", () => Child = new Container
@@ -65,6 +65,41 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("change ruleset to mania", () => Ruleset.Value = rulesets.GetRuleset(3));
             AddUntilStep("1 panel visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 1);
+
+            AddStep("add another mania preset", () => Realm.Write(r => r.Add(new ModPreset
+            {
+                Name = "and another one",
+                Mods = new Mod[]
+                {
+                    new ManiaModMirror(),
+                    new ManiaModNightcore(),
+                    new ManiaModHardRock()
+                },
+                Ruleset = rulesets.GetRuleset(3).AsNonNull()
+            })));
+            AddUntilStep("2 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 2);
+
+            AddStep("add another osu! preset", () => Realm.Write(r => r.Add(new ModPreset
+            {
+                Name = "hdhr",
+                Mods = new Mod[]
+                {
+                    new OsuModHidden(),
+                    new OsuModHardRock()
+                },
+                Ruleset = rulesets.GetRuleset(0).AsNonNull()
+            })));
+            AddUntilStep("2 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 2);
+
+            AddStep("remove mania preset", () => Realm.Write(r =>
+            {
+                var toRemove = r.All<ModPreset>().Single(preset => preset.Name == "Different ruleset");
+                r.Remove(toRemove);
+            }));
+            AddUntilStep("1 panel visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 1);
+
+            AddStep("set osu! ruleset", () => Ruleset.Value = rulesets.GetRuleset(0));
+            AddUntilStep("4 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 4);
         }
 
         private IEnumerable<ModPreset> createTestPresets() => new[]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
@@ -11,6 +11,7 @@ using osu.Game.Database;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osuTK;
 
@@ -46,7 +47,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                 {
                     new OsuModHardRock(),
                     new OsuModDoubleTime()
-                }
+                },
+                Ruleset = new OsuRuleset().RulesetInfo
             },
             new ModPreset
             {
@@ -58,7 +60,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         ApproachRate = { Value = 0 }
                     }
-                }
+                },
+                Ruleset = new OsuRuleset().RulesetInfo
             },
             new ModPreset
             {
@@ -68,7 +71,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                 {
                     new OsuModFlashlight(),
                     new OsuModSpinIn()
-                }
+                },
+                Ruleset = new OsuRuleset().RulesetInfo
             }
         };
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Database;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
@@ -31,7 +32,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Spacing = new Vector2(0, 5),
-                ChildrenEnumerable = createTestPresets().Select(preset => new ModPresetPanel(preset))
+                ChildrenEnumerable = createTestPresets().Select(preset => new ModPresetPanel(preset.ToLiveUnmanaged()))
             });
         }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -66,8 +66,9 @@ namespace osu.Game.Database
         /// 19   2022-07-19    Added DateSubmitted and DateRanked to BeatmapSetInfo.
         /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo, changed default value of BeatmapInfo.StarRating to -1.
         /// 21   2022-07-27    Migrate collections to realm (BeatmapCollection).
+        /// 22   2022-07-31    Added ModPreset.
         /// </summary>
-        private const int schema_version = 21;
+        private const int schema_version = 22;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Overlays/Mods/ModPresetPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPresetPanel.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Cursor;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 
@@ -11,16 +12,16 @@ namespace osu.Game.Overlays.Mods
 {
     public class ModPresetPanel : ModSelectPanel, IHasCustomTooltip<ModPreset>
     {
-        public readonly ModPreset Preset;
+        public readonly Live<ModPreset> Preset;
 
         public override BindableBool Active { get; } = new BindableBool();
 
-        public ModPresetPanel(ModPreset preset)
+        public ModPresetPanel(Live<ModPreset> preset)
         {
             Preset = preset;
 
-            Title = preset.Name;
-            Description = preset.Description;
+            Title = preset.Value.Name;
+            Description = preset.Value.Description;
         }
 
         [BackgroundDependencyLoader]
@@ -29,7 +30,7 @@ namespace osu.Game.Overlays.Mods
             AccentColour = colours.Orange1;
         }
 
-        public ModPreset TooltipContent => Preset;
+        public ModPreset TooltipContent => Preset.Value;
         public ITooltip<ModPreset> GetCustomTooltip() => new ModPresetTooltip(ColourProvider);
     }
 }

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.Mods
 
         public void SetContent(ModPreset preset)
         {
-            if (preset == lastPreset)
+            if (ReferenceEquals(preset, lastPreset))
                 return;
 
             lastPreset = preset;

--- a/osu.Game/Rulesets/Mods/ModPreset.cs
+++ b/osu.Game/Rulesets/Mods/ModPreset.cs
@@ -3,6 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using Realms;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -10,12 +16,18 @@ namespace osu.Game.Rulesets.Mods
     /// A mod preset is a named collection of configured mods.
     /// Presets are presented to the user in the mod select overlay for convenience.
     /// </summary>
-    public class ModPreset
+    public class ModPreset : RealmObject, IHasGuidPrimaryKey, ISoftDelete
     {
+        /// <summary>
+        /// The internal database ID of the preset.
+        /// </summary>
+        [PrimaryKey]
+        public Guid ID { get; set; } = Guid.NewGuid();
+
         /// <summary>
         /// The ruleset that the preset is valid for.
         /// </summary>
-        public RulesetInfo RulesetInfo { get; set; } = null!;
+        public RulesetInfo Ruleset { get; set; } = null!;
 
         /// <summary>
         /// The name of the mod preset.
@@ -30,6 +42,34 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// The set of configured mods that are part of the preset.
         /// </summary>
-        public ICollection<Mod> Mods { get; set; } = Array.Empty<Mod>();
+        [Ignored]
+        public ICollection<Mod> Mods
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ModsJson))
+                    return Array.Empty<Mod>();
+
+                var apiMods = JsonConvert.DeserializeObject<IEnumerable<APIMod>>(ModsJson);
+                var ruleset = Ruleset.CreateInstance();
+                return apiMods.AsNonNull().Select(mod => mod.ToMod(ruleset)).ToArray();
+            }
+            set
+            {
+                var apiMods = value.Select(mod => new APIMod(mod)).ToArray();
+                ModsJson = JsonConvert.SerializeObject(apiMods);
+            }
+        }
+
+        /// <summary>
+        /// The set of configured mods that are part of the preset, serialised as a JSON blob.
+        /// </summary>
+        [MapTo("Mods")]
+        public string ModsJson { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether the preset has been soft-deleted by the user.
+        /// </summary>
+        public bool DeletePending { get; set; }
     }
 }


### PR DESCRIPTION
**Warning: This PR bumps the realm schema version. If you care about your local database, make backups before running it until it is merged, as there is a risk of data loss.**

As stated in title, the goal of this PR is to make `ModPreset` a `RealmObject`, add properties that are required for that to be possible, and also migrate the mod preset column to consume the database via a subscription. I've opted not to add any abstractions yet, the column operates on `RealmAccess` directly.

[As previously discussed on discord](https://discord.com/channels/188630481301012481/188630652340404224/999923478436257864), mod serialisation leverages the existing `APIMod`. A rename to `JsonMod` [was also put forward](https://discord.com/channels/188630481301012481/188630652340404224/999923980133736459) - I'll do it as a follow up if there is still agreement on this. Not in this diff, though, as it's going to be a huge one.

In order to be consistent with everything else, the presets are going to support soft deletion. For now I've just added the requisite interface spec and field. I'll add all the other pieces (restore, etc.) when everything else is ready to go.

The model generally has all it needs to be useful for the MVP at least - I've got a working branch that uses it as it is presented here. In the future I may be adding a `Type` field, to support different "user mod" and "free mod" presets, but I'm not sure about that yet. (The rationale for this, in short, would be that you could theoretically have a set of free mods as a "preset", but it'd be a different preset than a "user" preset, since it could potentially consist of incompatible mods.)