### PR TITLE
Isolate development builds' storage from release builds

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -21,7 +21,11 @@ namespace osu.Desktop
 {
     public static class Program
     {
+#if DEBUG
+        private const string base_game_name = @"osu-development";
+#else
         private const string base_game_name = @"osu";
+#endif
 
         private static LegacyTcpIpcProvider legacyIpc;
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -212,6 +212,10 @@ namespace osu.Game
         {
             Name = @"osu!";
 
+#if DEBUG
+            Name += " (development)";
+#endif
+
             allowableExceptions = UnhandledExceptionsBeforeCrash;
         }
 


### PR DESCRIPTION
The main reason for doing this is to avoid users from accidentally one-way upgrading their game's database to a newer version unexpetedly, but should also make developers feel more at-ease in general when performing other dangerous actions around the game.

I've also updated the game title/name to better know when an instance is running in development mode.