### PR TITLE
Fix migration failing on single file copy failure

### DIFF
--- a/osu.Game/IO/MigratableStorage.cs
+++ b/osu.Game/IO/MigratableStorage.cs
@@ -7,7 +7,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using osu.Framework.Logging;
 using osu.Framework.Platform;
 
 namespace osu.Game.IO
@@ -17,12 +16,6 @@ namespace osu.Game.IO
     /// </summary>
     public abstract class MigratableStorage : WrappedStorage
     {
-        /// <summary>
-        /// The number of file copy failures before actually bailing on migration.
-        /// This allows some lenience to cover things like temporary files which could not be copied but are also not too important.
-        /// </summary>
-        private const int allowed_failures = 10;
-
         /// <summary>
         /// A relative list of directory paths which should not be migrated.
         /// </summary>
@@ -80,7 +73,7 @@ namespace osu.Game.IO
                 if (topLevelExcludes && IgnoreFiles.Contains(fi.Name))
                     continue;
 
-                allFilesDeleted &= AttemptOperation(() => fi.Delete());
+                allFilesDeleted &= AttemptOperation(() => fi.Delete(), throwOnFailure: false);
             }
 
             foreach (DirectoryInfo dir in target.GetDirectories())
@@ -88,16 +81,16 @@ namespace osu.Game.IO
                 if (topLevelExcludes && IgnoreDirectories.Contains(dir.Name))
                     continue;
 
-                allFilesDeleted &= AttemptOperation(() => dir.Delete(true));
+                allFilesDeleted &= AttemptOperation(() => dir.Delete(true), throwOnFailure: false);
             }
 
             if (target.GetFiles().Length == 0 && target.GetDirectories().Length == 0)
-                allFilesDeleted &= AttemptOperation(target.Delete);
+                allFilesDeleted &= AttemptOperation(target.Delete, throwOnFailure: false);
 
             return allFilesDeleted;
         }
 
-        protected void CopyRecursive(DirectoryInfo source, DirectoryInfo destination, bool topLevelExcludes = true, int totalFailedOperations = 0)
+        protected void CopyRecursive(DirectoryInfo source, DirectoryInfo destination, bool topLevelExcludes = true)
         {
             // based off example code https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo
             if (!destination.Exists)
@@ -108,14 +101,7 @@ namespace osu.Game.IO
                 if (topLevelExcludes && IgnoreFiles.Contains(fi.Name))
                     continue;
 
-                if (!AttemptOperation(() => fi.CopyTo(Path.Combine(destination.FullName, fi.Name), false)))
-                {
-                    Logger.Log($"Failed to copy file {fi.Name} during folder migration");
-                    totalFailedOperations++;
-
-                    if (totalFailedOperations > allowed_failures)
-                        throw new Exception("Aborting due to too many file copy failures during data migration");
-                }
+                AttemptOperation(() => fi.CopyTo(Path.Combine(destination.FullName, fi.Name), true));
             }
 
             foreach (DirectoryInfo dir in source.GetDirectories())
@@ -123,7 +109,7 @@ namespace osu.Game.IO
                 if (topLevelExcludes && IgnoreDirectories.Contains(dir.Name))
                     continue;
 
-                CopyRecursive(dir, destination.CreateSubdirectory(dir.Name), false, totalFailedOperations);
+                CopyRecursive(dir, destination.CreateSubdirectory(dir.Name), false);
             }
         }
 
@@ -132,7 +118,8 @@ namespace osu.Game.IO
         /// </summary>
         /// <param name="action">The action to perform.</param>
         /// <param name="attempts">The number of attempts (250ms wait between each).</param>
-        protected static bool AttemptOperation(Action action, int attempts = 10)
+        /// <param name="throwOnFailure">Whether to throw an exception on failure. If <c>false</c>, will silently fail.</param>
+        protected static bool AttemptOperation(Action action, int attempts = 10, bool throwOnFailure = true)
         {
             while (true)
             {
@@ -144,7 +131,12 @@ namespace osu.Game.IO
                 catch (Exception)
                 {
                     if (attempts-- == 0)
+                    {
+                        if (throwOnFailure)
+                            throw;
+
                         return false;
+                    }
                 }
 
                 Thread.Sleep(250);


### PR DESCRIPTION
No longer throw if copying of single files fails during data migration.

Aiming to fix https://github.com/ppy/osu/runs/7601653833?check_suite_focus=true, which could also affect end users. I've left a limit before an exception is still thrown, to handle cases like the user running out of disk space (where we probably *do* want to bail, so they can continue to use their still-intact original storage location).

If this isn't seen as a good direction, an alternative will be to make the migration code aware of the structure of the temporary files created by `Storage` (but doesn't guarantee this will cover all cases of such temporary files – there could for isntance be metadata files created by the host operating system).

Another option would be to mark those temporary files as hidden and skip any hidden files during iteration.