### PR TITLE
Fix editor potentially playing a track post-disposal

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -136,6 +136,20 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddAssert("track is not virtual", () => Beatmap.Value.Track is not TrackVirtual);
             AddAssert("track length changed", () => Beatmap.Value.Track.Length > 60000);
+
+            AddStep("test play", () => Editor.TestGameplay());
+
+            AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog != null);
+            AddStep("confirm save", () => InputManager.Key(Key.Number1));
+
+            AddUntilStep("wait for return to editor", () => Editor.IsCurrentScreen());
+
+            AddAssert("track is still not virtual", () => Beatmap.Value.Track is not TrackVirtual);
+            AddAssert("track length correct", () => Beatmap.Value.Track.Length > 60000);
+
+            AddUntilStep("track not playing", () => !EditorClock.IsRunning);
+            AddStep("play track", () => InputManager.Key(Key.Space));
+            AddUntilStep("wait for track playing", () => EditorClock.IsRunning);
         }
 
         [Test]

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -70,7 +70,11 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Forcefully reload the current <see cref="WorkingBeatmap"/>'s track from disk.
         /// </summary>
-        public void ReloadCurrentTrack() => changeTrack();
+        public void ReloadCurrentTrack()
+        {
+            changeTrack();
+            TrackChanged?.Invoke(current, TrackChangeDirection.None);
+        }
 
         /// <summary>
         /// Returns whether the beatmap track is playing.

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -329,6 +329,9 @@ namespace osu.Game.Screens.Edit
             changeHandler?.CanRedo.BindValueChanged(v => redoMenuItem.Action.Disabled = !v.NewValue, true);
         }
 
+        [Resolved]
+        private MusicController musicController { get; set; }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -336,12 +339,18 @@ namespace osu.Game.Screens.Edit
 
             Mode.Value = isNewBeatmap ? EditorScreenMode.SongSetup : EditorScreenMode.Compose;
             Mode.BindValueChanged(onModeChanged, true);
+
+            musicController.TrackChanged += onTrackChanged;
         }
 
-        /// <summary>
-        /// If the beatmap's track has changed, this method must be called to keep the editor in a valid state.
-        /// </summary>
-        public void UpdateClockSource() => clock.ChangeSource(Beatmap.Value.Track);
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            musicController.TrackChanged -= onTrackChanged;
+        }
+
+        private void onTrackChanged(WorkingBeatmap working, TrackChangeDirection direction) => clock.ChangeSource(working.Track);
 
         /// <summary>
         /// Creates an <see cref="EditorState"/> instance representing the current state of the editor.

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -30,8 +30,8 @@ namespace osu.Game.Screens.Edit.Setup
         [Resolved]
         private IBindable<WorkingBeatmap> working { get; set; }
 
-        [Resolved(canBeNull: true)]
-        private Editor editor { get; set; }
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
 
         [Resolved]
         private SetupScreenHeader header { get; set; }
@@ -88,6 +88,8 @@ namespace osu.Game.Screens.Edit.Setup
                 beatmaps.AddFile(set, stream, destination.Name);
             }
 
+            editorBeatmap.SaveState();
+
             working.Value.Metadata.BackgroundFile = destination.Name;
             header.Background.UpdateBackground();
 
@@ -117,7 +119,9 @@ namespace osu.Game.Screens.Edit.Setup
 
             working.Value.Metadata.AudioFile = destination.Name;
 
+            editorBeatmap.SaveState();
             music.ReloadCurrentTrack();
+
             return true;
         }
 

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -118,8 +118,6 @@ namespace osu.Game.Screens.Edit.Setup
             working.Value.Metadata.AudioFile = destination.Name;
 
             music.ReloadCurrentTrack();
-
-            editor?.UpdateClockSource();
             return true;
         }
 


### PR DESCRIPTION
This changes the editor to track the current track as it is *loaded* by `MusicController`, rather than haphazardly following the current global `WorkingBeatmap` (with a potentially unloaded track) or relying on local immediate-load behaviour (as implemented in `ResourcesSection`).

It also fixes beatmaps not saving when audio/background are changed via 6e7c298aaf. Without this, changing the audio then hitting `F5` would cause the track to revert to virtual on returning to the editor, because it wasn't saved before the `WorkingBeatmap` re-fetch.

The issue was supposedly fixed by https://github.com/ppy/osu/issues/19081, but actually wasn't.