### PR TITLE
Display readable error message when reaching download limit

### DIFF
--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Humanizer;
 using osu.Framework.Logging;
@@ -107,7 +108,15 @@ namespace osu.Game.Database
                 notification.State = ProgressNotificationState.Cancelled;
 
                 if (!(error is OperationCanceledException))
-                    Logger.Error(error, $"{importer.HumanisedModelName.Titleize()} download failed!");
+                {
+                    if (error is WebException webException && webException.Message == @"TooManyRequests")
+                    {
+                        notification.Close();
+                        PostNotification?.Invoke(new TooManyDownloadsNotification(importer.HumanisedModelName));
+                    }
+                    else
+                        Logger.Error(error, $"{importer.HumanisedModelName.Titleize()} download failed!");
+                }
             }
         }
 

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Database
                     if (error is WebException webException && webException.Message == @"TooManyRequests")
                     {
                         notification.Close();
-                        PostNotification?.Invoke(new TooManyDownloadsNotification(importer.HumanisedModelName));
+                        PostNotification?.Invoke(new TooManyDownloadsNotification());
                     }
                     else
                         Logger.Error(error, $"{importer.HumanisedModelName.Titleize()} download failed!");

--- a/osu.Game/Database/TooManyDownloadsNotification.cs
+++ b/osu.Game/Database/TooManyDownloadsNotification.cs
@@ -5,14 +5,15 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Database
 {
     public class TooManyDownloadsNotification : SimpleNotification
     {
-        public TooManyDownloadsNotification(string humanisedModelName)
+        public TooManyDownloadsNotification()
         {
-            Text = $"You have downloaded too many {humanisedModelName}s! Please try again later.";
+            Text = BeatmapsetsStrings.DownloadLimitExceeded;
             Icon = FontAwesome.Solid.ExclamationCircle;
         }
 

--- a/osu.Game/Database/TooManyDownloadsNotification.cs
+++ b/osu.Game/Database/TooManyDownloadsNotification.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Database
+{
+    public class TooManyDownloadsNotification : SimpleNotification
+    {
+        public TooManyDownloadsNotification(string humanisedModelName)
+        {
+            Text = CommonStrings.TooManyDownloaded(humanisedModelName);
+            Icon = FontAwesome.Solid.ExclamationCircle;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            IconBackground.Colour = colours.RedDark;
+        }
+    }
+}

--- a/osu.Game/Database/TooManyDownloadsNotification.cs
+++ b/osu.Game/Database/TooManyDownloadsNotification.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
-using osu.Game.Localisation;
 using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Database
@@ -13,7 +12,7 @@ namespace osu.Game.Database
     {
         public TooManyDownloadsNotification(string humanisedModelName)
         {
-            Text = CommonStrings.TooManyDownloaded(humanisedModelName);
+            Text = $"You have downloaded too many {humanisedModelName}s! Please try again later.";
             Icon = FontAwesome.Solid.ExclamationCircle;
         }
 

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
@@ -53,6 +53,11 @@ namespace osu.Game.Localisation
         /// "Downloading..."
         /// </summary>
         public static LocalisableString Downloading => new TranslatableString(getKey(@"downloading"), @"Downloading...");
+
+        /// <summary>
+        /// "You have downloaded too many {0}s! Please try again later."
+        /// </summary>
+        public static LocalisableString TooManyDownloaded(string humanisedModelName) => new TranslatableString(getKey(@"too_many_downloaded"), @"You have downloaded too many {0}s! Please try again later.", humanisedModelName);
 
         /// <summary>
         /// "Importing..."

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -55,11 +55,6 @@ namespace osu.Game.Localisation
         public static LocalisableString Downloading => new TranslatableString(getKey(@"downloading"), @"Downloading...");
 
         /// <summary>
-        /// "You have downloaded too many {0}s! Please try again later."
-        /// </summary>
-        public static LocalisableString TooManyDownloaded(string humanisedModelName) => new TranslatableString(getKey(@"too_many_downloaded"), @"You have downloaded too many {0}s! Please try again later.", humanisedModelName);
-
-        /// <summary>
         /// "Importing..."
         /// </summary>
         public static LocalisableString Importing => new TranslatableString(getKey(@"importing"), @"Importing...");


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/19518

The error code 429 usually contains a `Retry-After` response to let the user know when they'll become able to download, but that doesn't look to be available on the web requests here.

I was concerned with the icon choice between a triangle and a circle exclamation, but I've went with the latter since the user has already been restricted from downloading at that point, so it doesn't make sense to show a triangle. The notification may have been a bit more exaggerated though.

Will also note that osu-web provides a localised string for 429, but it doesn't look to be displayable ([`errors.codes.http-429`](https://github.com/ppy/osu-web/blob/51ab390e2d9aa1f3f7ea5fac94fd7d3a6ed3281b/resources/lang/en/errors.php#L16)), so I opted for a new readable and flexible definition instead.

---

<img width="427" alt="CleanShot 2022-08-01 at 14 20 32@2x" src="https://user-images.githubusercontent.com/22781491/182137599-d42ebd65-0143-41db-b9b2-0ecffa4cffe3.png">
