### PR TITLE
Show "locally modified" pill when local modifications have been made

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -294,7 +294,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("approach rate correctly copied", () => EditorBeatmap.Difficulty.ApproachRate == 4);
             AddAssert("combo colours correctly copied", () => EditorBeatmap.BeatmapSkin.AsNonNull().ComboColours.Count == 2);
 
-            AddAssert("status not copied", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.None);
+            AddAssert("status is modified", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified);
             AddAssert("online ID not copied", () => EditorBeatmap.BeatmapInfo.OnlineID == -1);
 
             AddStep("save beatmap", () => Editor.Save());

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -56,8 +56,10 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestCreateNewBeatmap()
         {
+            AddAssert("status is none", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.None);
             AddStep("save beatmap", () => Editor.Save());
             AddAssert("new beatmap in database", () => beatmapManager.QueryBeatmapSet(s => s.ID == currentBeatmapSetID)?.Value.DeletePending == false);
+            AddAssert("status is modified", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified);
         }
 
         [Test]
@@ -208,6 +210,8 @@ namespace osu.Game.Tests.Visual.Editing
             });
             AddAssert("created difficulty has no objects", () => EditorBeatmap.HitObjects.Count == 0);
 
+            AddAssert("status is modified", () => EditorBeatmap.BeatmapInfo.Status == BeatmapOnlineStatus.LocallyModified);
+
             AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = secondDifficultyName);
             AddStep("save beatmap", () => Editor.Save());
             AddAssert("new beatmap persisted", () =>
@@ -218,7 +222,7 @@ namespace osu.Game.Tests.Visual.Editing
                 return beatmap != null
                        && beatmap.DifficultyName == secondDifficultyName
                        && set != null
-                       && set.PerformRead(s => s.Beatmaps.Count == 2 && s.Beatmaps.Any(b => b.DifficultyName == secondDifficultyName));
+                       && set.PerformRead(s => s.Beatmaps.Count == 2 && s.Beatmaps.Any(b => b.DifficultyName == secondDifficultyName) && s.Beatmaps.All(b => s.Status == BeatmapOnlineStatus.LocallyModified));
             });
         }
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -121,7 +121,8 @@ namespace osu.Game.Beatmaps
             OnlineID = -1;
             LastOnlineUpdate = null;
             OnlineMD5Hash = string.Empty;
-            Status = BeatmapOnlineStatus.None;
+            if (Status != BeatmapOnlineStatus.LocallyModified)
+                Status = BeatmapOnlineStatus.None;
         }
 
         #region Properties we may not want persisted (but also maybe no harm?)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -312,14 +312,13 @@ namespace osu.Game.Beatmaps
 
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();
-                beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
 
-                if (setInfo.Beatmaps.All(b => b.Status == BeatmapOnlineStatus.LocallyModified))
-                    setInfo.Status = BeatmapOnlineStatus.LocallyModified;
+                beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
 
                 AddFile(setInfo, stream, createBeatmapFilenameFromMetadata(beatmapInfo));
 
                 setInfo.Hash = beatmapImporter.ComputeHash(setInfo);
+                setInfo.Status = BeatmapOnlineStatus.LocallyModified;
 
                 Realm.Write(r =>
                 {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -312,6 +312,10 @@ namespace osu.Game.Beatmaps
 
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();
+                beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
+
+                if (setInfo.Beatmaps.All(b => b.Status == BeatmapOnlineStatus.LocallyModified))
+                    setInfo.Status = BeatmapOnlineStatus.LocallyModified;
 
                 AddFile(setInfo, stream, createBeatmapFilenameFromMetadata(beatmapInfo));
 

--- a/osu.Game/Beatmaps/BeatmapOnlineStatus.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineStatus.cs
@@ -5,6 +5,7 @@
 
 using System.ComponentModel;
 using osu.Framework.Localisation;
+using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Beatmaps
@@ -16,6 +17,7 @@ namespace osu.Game.Beatmaps
         /// Once in this state, online status changes should be ignored unless the beatmap is reverted or submitted.
         /// </summary>
         [Description("Local")]
+        [LocalisableDescription(typeof(SongSelectStrings), nameof(SongSelectStrings.LocallyModified))]
         LocallyModified = -4,
 
         None = -3,

--- a/osu.Game/Beatmaps/BeatmapOnlineStatus.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineStatus.cs
@@ -11,6 +11,10 @@ namespace osu.Game.Beatmaps
 {
     public enum BeatmapOnlineStatus
     {
+        /// <summary>
+        /// This is a special status given when local changes are made via the editor.
+        /// Once in this state, online status changes should be ignored unless the beatmap is reverted or submitted.
+        /// </summary>
         [Description("Local")]
         LocallyModified = -4,
 

--- a/osu.Game/Beatmaps/BeatmapOnlineStatus.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineStatus.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.ComponentModel;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -10,6 +11,9 @@ namespace osu.Game.Beatmaps
 {
     public enum BeatmapOnlineStatus
     {
+        [Description("Local")]
+        LocallyModified = -4,
+
         None = -3,
 
         [LocalisableDescription(typeof(BeatmapsetsStrings), nameof(BeatmapsetsStrings.ShowStatusGraveyard))]

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -101,13 +101,13 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
 
                     // Some metadata should only be applied if there's no local changes.
-                    if (beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified)
+                    if (shouldSaveOnlineMetadata(beatmapInfo))
                     {
                         beatmapInfo.Status = res.Status;
                         beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
                     }
 
-                    if (beatmapInfo.BeatmapSet.Beatmaps.All(b => b.MatchesOnlineVersion || b.Status != BeatmapOnlineStatus.LocallyModified))
+                    if (beatmapInfo.BeatmapSet.Beatmaps.All(shouldSaveOnlineMetadata))
                     {
                         beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
                         beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
@@ -212,7 +212,7 @@ namespace osu.Game.Beatmaps
                                 var status = (BeatmapOnlineStatus)reader.GetByte(2);
 
                                 // Some metadata should only be applied if there's no local changes.
-                                if (beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified)
+                                if (shouldSaveOnlineMetadata(beatmapInfo))
                                 {
                                     beatmapInfo.Status = status;
                                     beatmapInfo.Metadata.Author.OnlineID = reader.GetInt32(3);
@@ -226,7 +226,7 @@ namespace osu.Game.Beatmaps
                                 Debug.Assert(beatmapInfo.BeatmapSet != null);
                                 beatmapInfo.BeatmapSet.OnlineID = reader.GetInt32(0);
 
-                                if (beatmapInfo.BeatmapSet.Beatmaps.All(b => b.MatchesOnlineVersion || b.Status != BeatmapOnlineStatus.LocallyModified))
+                                if (beatmapInfo.BeatmapSet.Beatmaps.All(shouldSaveOnlineMetadata))
                                 {
                                     beatmapInfo.BeatmapSet.Status = status;
                                 }
@@ -248,6 +248,12 @@ namespace osu.Game.Beatmaps
 
         private void logForModel(BeatmapSetInfo set, string message) =>
             RealmArchiveModelImporter<BeatmapSetInfo>.LogForModel(set, $"[{nameof(BeatmapUpdaterMetadataLookup)}] {message}");
+
+        /// <summary>
+        /// Check whether the provided beatmap is in a state where online "ranked" status metadata should be saved against it.
+        /// Handles the case where a user may have locally modified a beatmap in the editor and expects the local status to stick.
+        /// </summary>
+        private static bool shouldSaveOnlineMetadata(BeatmapInfo beatmapInfo) => beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified;
 
         public void Dispose()
         {

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Queue an update for a beatmap set.
         /// </summary>
+        /// <remarks>
+        /// This may happen during initial import, or at a later stage in response to a user action or server event.
+        /// </remarks>
         /// <param name="beatmapSet">The beatmap set to update. Updates will be applied directly (so a transaction should be started if this instance is managed).</param>
         /// <param name="preferOnlineFetch">Whether metadata from an online source should be preferred. If <c>true</c>, the local cache will be skipped to ensure the freshest data state possible.</param>
         public void Update(BeatmapSetInfo beatmapSet, bool preferOnlineFetch)
@@ -94,15 +97,15 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.LastOnlineUpdate = res.LastUpdated;
                     beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
 
+                    Debug.Assert(beatmapInfo.BeatmapSet != null);
+
                     // In the case local changes have been applied, don't reset the status.
                     if (beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified)
                     {
                         beatmapInfo.Status = res.Status;
+                        beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
                     }
 
-                    Debug.Assert(beatmapInfo.BeatmapSet != null);
-
-                    beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
                     beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
                     beatmapInfo.BeatmapSet.DateSubmitted = res.BeatmapSet?.Submitted;

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -95,20 +95,21 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.OnlineID = res.OnlineID;
                     beatmapInfo.OnlineMD5Hash = res.MD5Hash;
                     beatmapInfo.LastOnlineUpdate = res.LastUpdated;
-                    beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
 
                     Debug.Assert(beatmapInfo.BeatmapSet != null);
+                    beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
 
-                    // In the case local changes have been applied, don't reset the status.
+                    // Some metadata should only be applied if there's no local changes.
                     if (beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified)
                     {
                         beatmapInfo.Status = res.Status;
-                        beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
-                    }
 
-                    beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
-                    beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
-                    beatmapInfo.BeatmapSet.DateSubmitted = res.BeatmapSet?.Submitted;
+                        beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
+
+                        beatmapInfo.BeatmapSet.Status = res.BeatmapSet?.Status ?? BeatmapOnlineStatus.None;
+                        beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
+                        beatmapInfo.BeatmapSet.DateSubmitted = res.BeatmapSet?.Submitted;
+                    }
 
                     logForModel(set, $"Online retrieval mapped {beatmapInfo} to {res.OnlineBeatmapSetID} / {res.OnlineID}.");
                 }
@@ -209,16 +210,20 @@ namespace osu.Game.Beatmaps
 
                                 beatmapInfo.Status = status;
 
-                                Debug.Assert(beatmapInfo.BeatmapSet != null);
-
-                                beatmapInfo.BeatmapSet.Status = status;
-                                beatmapInfo.BeatmapSet.OnlineID = reader.GetInt32(0);
                                 // TODO: DateSubmitted and DateRanked are not provided by local cache.
                                 beatmapInfo.OnlineID = reader.GetInt32(1);
-                                beatmapInfo.Metadata.Author.OnlineID = reader.GetInt32(3);
-
                                 beatmapInfo.OnlineMD5Hash = reader.GetString(4);
                                 beatmapInfo.LastOnlineUpdate = reader.GetDateTimeOffset(5);
+
+                                Debug.Assert(beatmapInfo.BeatmapSet != null);
+                                beatmapInfo.BeatmapSet.OnlineID = reader.GetInt32(0);
+
+                                // Some metadata should only be applied if there's no local changes.
+                                if (beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified)
+                                {
+                                    beatmapInfo.BeatmapSet.Status = status;
+                                    beatmapInfo.Metadata.Author.OnlineID = reader.GetInt32(3);
+                                }
 
                                 logForModel(set, $"Cached local retrieval for {beatmapInfo}.");
                                 return true;

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -89,7 +89,16 @@ namespace osu.Game.Beatmaps
 
                 if (res != null)
                 {
-                    beatmapInfo.Status = res.Status;
+                    beatmapInfo.OnlineID = res.OnlineID;
+                    beatmapInfo.OnlineMD5Hash = res.MD5Hash;
+                    beatmapInfo.LastOnlineUpdate = res.LastUpdated;
+                    beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
+
+                    // In the case local changes have been applied, don't reset the status.
+                    if (beatmapInfo.MatchesOnlineVersion || beatmapInfo.Status != BeatmapOnlineStatus.LocallyModified)
+                    {
+                        beatmapInfo.Status = res.Status;
+                    }
 
                     Debug.Assert(beatmapInfo.BeatmapSet != null);
 
@@ -97,13 +106,6 @@ namespace osu.Game.Beatmaps
                     beatmapInfo.BeatmapSet.OnlineID = res.OnlineBeatmapSetID;
                     beatmapInfo.BeatmapSet.DateRanked = res.BeatmapSet?.Ranked;
                     beatmapInfo.BeatmapSet.DateSubmitted = res.BeatmapSet?.Submitted;
-
-                    beatmapInfo.OnlineMD5Hash = res.MD5Hash;
-                    beatmapInfo.LastOnlineUpdate = res.LastUpdated;
-
-                    beatmapInfo.OnlineID = res.OnlineID;
-
-                    beatmapInfo.Metadata.Author.OnlineID = res.AuthorID;
 
                     logForModel(set, $"Online retrieval mapped {beatmapInfo} to {res.OnlineBeatmapSetID} / {res.OnlineID}.");
                 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetOnlineStatusPill.cs
@@ -6,15 +6,18 @@ using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    public class BeatmapSetOnlineStatusPill : CircularContainer
+    public class BeatmapSetOnlineStatusPill : CircularContainer, IHasTooltip
     {
         private BeatmapOnlineStatus status;
 
@@ -95,6 +98,20 @@ namespace osu.Game.Beatmaps.Drawables
                 statusText.Colour = status == BeatmapOnlineStatus.Graveyard ? colours.GreySeaFoamLight : Color4.Black;
 
             background.Colour = OsuColour.ForBeatmapSetOnlineStatus(Status) ?? colourProvider?.Light1 ?? colours.GreySeaFoamLighter;
+        }
+
+        public LocalisableString TooltipText
+        {
+            get
+            {
+                switch (Status)
+                {
+                    case BeatmapOnlineStatus.LocallyModified:
+                        return SongSelectStrings.LocallyModifiedTooltip;
+                }
+
+                return string.Empty;
+            }
         }
     }
 }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -137,6 +137,9 @@ namespace osu.Game.Graphics
         {
             switch (status)
             {
+                case BeatmapOnlineStatus.LocallyModified:
+                    return Color4.OrangeRed;
+
                 case BeatmapOnlineStatus.Ranked:
                 case BeatmapOnlineStatus.Approved:
                     return Color4Extensions.FromHex(@"b3ff66");

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class SongSelectStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.SongSelect";
+
+        /// <summary>
+        /// "Local"
+        /// </summary>
+        public static LocalisableString LocallyModified => new TranslatableString(getKey(@"locally_modified"), @"Local");
+
+        /// <summary>
+        /// "Has been locally modified"
+        /// </summary>
+        public static LocalisableString LocallyModifiedTooltip => new TranslatableString(getKey(@"locally_modified_tooltip"), @"Has been locally modified");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}


### PR DESCRIPTION
Addresses issue mentioned in https://github.com/ppy/osu/discussions/19306#discussioncomment-3290649 by changing the ranked status to imply that local changes have been made.

I'm not sure this is the final solution for this, but it seems to work well for now, and helps with visibility for the user.

https://user-images.githubusercontent.com/191335/182189128-3e82d551-2278-4854-b01d-e78971c216b8.mp4


