### PR TITLE
Add `BeatmapInfo.LastUpdate` to track the time of local changes

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -102,6 +102,14 @@ namespace osu.Game.Beatmaps
 
         public string OnlineMD5Hash { get; set; } = string.Empty;
 
+        /// <summary>
+        /// The last time of a local modification (via the editor).
+        /// </summary>
+        public DateTimeOffset? LastUpdated { get; set; }
+
+        /// <summary>
+        /// The last time online metadata was applied to this beatmap.
+        /// </summary>
         public DateTimeOffset? LastOnlineUpdate { get; set; }
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The last time of a local modification (via the editor).
         /// </summary>
-        public DateTimeOffset? LastUpdated { get; set; }
+        public DateTimeOffset? LastLocalUpdate { get; set; }
 
         /// <summary>
         /// The last time online metadata was applied to this beatmap.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Beatmaps
 
             var beatmapSet = new BeatmapSetInfo
             {
+                DateAdded = DateTimeOffset.UtcNow,
                 Beatmaps =
                 {
                     new BeatmapInfo(ruleset, new BeatmapDifficulty(), metadata)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -314,6 +314,7 @@ namespace osu.Game.Beatmaps
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();
                 beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
+                beatmapInfo.LastUpdated = DateTimeOffset.Now;
 
                 if (setInfo.Beatmaps.All(b => b.Status == BeatmapOnlineStatus.LocallyModified))
                     setInfo.Status = BeatmapOnlineStatus.LocallyModified;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -314,7 +314,7 @@ namespace osu.Game.Beatmaps
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();
 
-                beatmapInfo.LastUpdated = DateTimeOffset.Now;
+                beatmapInfo.LastLocalUpdate = DateTimeOffset.Now;
                 beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
 
                 AddFile(setInfo, stream, createBeatmapFilenameFromMetadata(beatmapInfo));

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Database
         /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo, changed default value of BeatmapInfo.StarRating to -1.
         /// 21   2022-07-27    Migrate collections to realm (BeatmapCollection).
         /// 22   2022-07-31    Added ModPreset.
-        /// 23   2022-08-01    Added LastUpdated to BeatmapInfo.
+        /// 23   2022-08-01    Added LastLocalUpdate to BeatmapInfo.
         /// </summary>
         private const int schema_version = 23;
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -67,8 +67,9 @@ namespace osu.Game.Database
         /// 20   2022-07-21    Added LastAppliedDifficultyVersion to RulesetInfo, changed default value of BeatmapInfo.StarRating to -1.
         /// 21   2022-07-27    Migrate collections to realm (BeatmapCollection).
         /// 22   2022-07-31    Added ModPreset.
+        /// 23   2022-08-01    Added LastUpdated to BeatmapInfo.
         /// </summary>
-        private const int schema_version = 22;
+        private const int schema_version = 23;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.


### PR DESCRIPTION
Also fix `DateAdded` not being set to a sane value when creating a new beatmap in the editor.

Note that this date is not currently used, but I figure it will be useful for showing a user's own creations (which would default to "last modified" for sure).

- [x] Depends on #19529 for conflict avoidance.