### PR TITLE
Update nullability specifications in osu!catch and osu!taiko mods

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Catch.Objects;
@@ -36,9 +35,9 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         public override float DefaultFlashlightSize => 350;
 
-        protected override Flashlight CreateFlashlight() => new CatchFlashlight(this, playfield.AsNonNull());
+        protected override Flashlight CreateFlashlight() => new CatchFlashlight(this, playfield);
 
-        private CatchPlayfield? playfield;
+        private CatchPlayfield playfield = null!;
 
         public override void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModRelax.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
@@ -19,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Mods
     {
         public override string Description => @"Use the mouse to control the catcher.";
 
-        private DrawableRuleset<CatchHitObject>? drawableRuleset;
+        private DrawableRuleset<CatchHitObject> drawableRuleset = null!;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)
         {
@@ -28,8 +27,6 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         public void ApplyToPlayer(Player player)
         {
-            Debug.Assert(drawableRuleset != null);
-
             if (!drawableRuleset.HasReplayLoaded.Value)
                 drawableRuleset.Cursor.Add(new MouseInputHelper((CatchPlayfield)drawableRuleset.Playfield));
         }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
 using osu.Game.Configuration;
@@ -37,9 +36,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
         public override float DefaultFlashlightSize => 250;
 
-        protected override Flashlight CreateFlashlight() => new TaikoFlashlight(this, playfield.AsNonNull());
+        protected override Flashlight CreateFlashlight() => new TaikoFlashlight(this, playfield);
 
-        private TaikoPlayfield? playfield;
+        private TaikoPlayfield playfield = null!;
 
         public override void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         /// </summary>
         private const float fade_out_duration = 0.375f;
 
-        private DrawableTaikoRuleset? drawableRuleset;
+        private DrawableTaikoRuleset drawableRuleset = null!;
 
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
@@ -45,8 +45,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            Debug.Assert(drawableRuleset != null);
-
             switch (hitObject)
             {
                 case DrawableDrumRollTick:


### PR DESCRIPTION
Fix remaining issue in the #19249 and #19419.
Mark some properties as non-nullable in the catch and taiko ruleset.
