### PR TITLE
Hide F rank from the beatmap overlay

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchScoreFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchScoreFilterRow.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.BeatmapListing
         {
             protected override MultipleSelectionFilterTabItem CreateTabItem(ScoreRank value) => new RankItem(value);
 
-            protected override IEnumerable<ScoreRank> GetValues() => base.GetValues().Reverse();
+            protected override IEnumerable<ScoreRank> GetValues() => base.GetValues().Where(r => r > ScoreRank.F).Reverse();
         }
 
         private class RankItem : MultipleSelectionFilterTabItem


### PR DESCRIPTION
Closes #19525
Simple `Where` to only show ranks with value higher than `ScoreRank.F`. `ScoreRank.F` is explicitly set to `-1`.