### PR TITLE
Fix broken sheared button autosizing logic

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
@@ -3,9 +3,13 @@
 
 #nullable disable
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK.Input;
@@ -99,7 +103,10 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Origin = Anchor.Centre,
                 Text = "Fixed width"
             });
+            AddAssert("draw width is 200", () => toggleButton.DrawWidth, () => Is.EqualTo(200).Within(Precision.FLOAT_EPSILON));
+
             AddStep("change text", () => toggleButton.Text = "New text");
+            AddAssert("draw width is 200", () => toggleButton.DrawWidth, () => Is.EqualTo(200).Within(Precision.FLOAT_EPSILON));
 
             AddStep("create auto-sizing button", () => Child = toggleButton = new ShearedToggleButton
             {
@@ -107,7 +114,14 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Origin = Anchor.Centre,
                 Text = "This button autosizes to its text!"
             });
+            AddAssert("button is wider than text", () => toggleButton.DrawWidth, () => Is.GreaterThan(toggleButton.ChildrenOfType<SpriteText>().Single().DrawWidth));
+
+            float originalDrawWidth = 0;
+            AddStep("store button width", () => originalDrawWidth = toggleButton.DrawWidth);
+
             AddStep("change text", () => toggleButton.Text = "New text");
+            AddAssert("button is wider than text", () => toggleButton.DrawWidth, () => Is.GreaterThan(toggleButton.ChildrenOfType<SpriteText>().Single().DrawWidth));
+            AddAssert("button width decreased", () => toggleButton.DrawWidth, () => Is.LessThan(originalDrawWidth));
         }
 
         [Test]

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 backgroundLayer = new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.Y,
                     CornerRadius = corner_radius,
                     Masking = true,
                     BorderThickness = 2,
@@ -128,10 +128,12 @@ namespace osu.Game.Graphics.UserInterface
             if (width != null)
             {
                 Width = width.Value;
+                backgroundLayer.RelativeSizeAxes = Axes.Both;
             }
             else
             {
                 AutoSizeAxes = Axes.X;
+                backgroundLayer.AutoSizeAxes = Axes.X;
                 text.Margin = new MarginPadding { Horizontal = 15 };
             }
         }


### PR DESCRIPTION
Small one for today. Noticed that the `ShearedButton` autosize logic got broken somewhere along the way with refactors when trying to use it for the mod preset stuff.

Current master:

https://user-images.githubusercontent.com/20418176/182244001-753c0bcb-6919-44ca-a1be-e7f94d10baf9.mp4

This PR:

https://user-images.githubusercontent.com/20418176/182244019-38d54633-5b23-4a34-ab9a-31ffdb4c2075.mp4

Some assertions to the requisite test are also added in this pull to (hopefully) prevent this from happening again.