### PR TITLE
Avoid clearing chat overlay textbox when pressing "back" key binding

### DIFF
--- a/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
@@ -21,6 +21,11 @@ namespace osu.Game.Graphics.UserInterface
 
         private bool allowImmediateFocus => host?.OnScreenKeyboardOverlapsGameWindow != true;
 
+        /// <summary>
+        /// Whether the content of the text box should be cleared on the first "back" key press.
+        /// </summary>
+        protected virtual bool ClearTextOnBackKey => true;
+
         public void TakeFocus()
         {
             if (!allowImmediateFocus)
@@ -78,7 +83,7 @@ namespace osu.Game.Graphics.UserInterface
 
             if (!HasFocus) return false;
 
-            if (e.Action == GlobalAction.Back)
+            if (ClearTextOnBackKey && e.Action == GlobalAction.Back)
             {
                 if (Text.Length > 0)
                 {

--- a/osu.Game/Overlays/Chat/ChatTextBox.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBox.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Overlays.Chat
 
         public override bool HandleLeftRightArrows => !ShowSearch.Value;
 
+        protected override bool ClearTextOnBackKey => false;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();


### PR DESCRIPTION
Generally this is expected behaviour for usages of focused text boxes (ie. to clear search content), but not so much here.

Addresses https://github.com/ppy/osu/discussions/19403#discussioncomment-3230395.