### PR TITLE
Fix multiple cases of mutations at editor setup screen not triggering a state save

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaSetupSection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaSetupSection.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
         private void updateBeatmap()
         {
             Beatmap.BeatmapInfo.SpecialStyle = specialStyle.Current.Value;
+            Beatmap.SaveState();
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Setup/OsuSetupSection.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Setup/OsuSetupSection.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Setup
         private void updateBeatmap()
         {
             Beatmap.BeatmapInfo.StackLeniency = stackLeniency.Current.Value;
+            Beatmap.SaveState();
         }
     }
 }

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -78,7 +78,10 @@ namespace osu.Game.Screens.Edit
             this.beatmapInfo = beatmapInfo ?? playableBeatmap.BeatmapInfo;
 
             if (beatmapSkin is Skin skin)
+            {
                 BeatmapSkin = new EditorBeatmapSkin(skin);
+                BeatmapSkin.BeatmapSkinChanged += SaveState;
+            }
 
             beatmapProcessor = playableBeatmap.BeatmapInfo.Ruleset.CreateInstance().CreateBeatmapProcessor(PlayableBeatmap);
 

--- a/osu.Game/Screens/Edit/Setup/DesignSection.cs
+++ b/osu.Game/Screens/Edit/Setup/DesignSection.cs
@@ -126,6 +126,8 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.BeatmapInfo.EpilepsyWarning = epilepsyWarning.Current.Value;
             Beatmap.BeatmapInfo.LetterboxInBreaks = letterboxDuringBreaks.Current.Value;
             Beatmap.BeatmapInfo.SamplesMatchPlaybackRate = samplesMatchPlaybackRate.Current.Value;
+
+            Beatmap.SaveState();
         }
     }
 }

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.Difficulty.OverallDifficulty = overallDifficultySlider.Current.Value;
 
             Beatmap.UpdateAllHitObjects();
+            Beatmap.SaveState();
         }
     }
 }

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Edit.Setup
                 target.Current.Value = value;
 
             updateReadOnlyState();
-            updateMetadata();
+            Scheduler.AddOnce(updateMetadata);
         }
 
         private void updateReadOnlyState()
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Edit.Setup
 
             // for now, update on commit rather than making BeatmapMetadata bindables.
             // after switching database engines we can reconsider if switching to bindables is a good direction.
-            updateMetadata();
+            Scheduler.AddOnce(updateMetadata);
         }
 
         private void updateMetadata()

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -117,6 +117,8 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.BeatmapInfo.DifficultyName = difficultyTextBox.Current.Value;
             Beatmap.Metadata.Source = sourceTextBox.Current.Value;
             Beatmap.Metadata.Tags = tagsTextBox.Current.Value;
+
+            Beatmap.SaveState();
         }
     }
 }


### PR DESCRIPTION
Reproduction:
- Enter editor and change title, then hit escape to exit
- Note that prompt to save will not appear
- [x] Depends on https://github.com/ppy/osu-framework/pull/5331
- [x] Depends on framework bump

This has the side-effect of creating undo state, which is fine, but the setup screens don't support restoring previous states' content. So actually performing an undo looks invisible currently. I'm not sure this is a deal-breaker to get the more important issue fixed (dirty state not being recognised), but it's definitely not an easy one. Will involve figuring out if we want to use bindable flow, switching the editor to use live realm data, etc.