### PR TITLE
Improve `IBeatSyncProvider` interface and reduce beatmap track dependence

### DIFF
--- a/osu.Game/Beatmaps/BeatSyncProviderExtensions.cs
+++ b/osu.Game/Beatmaps/BeatSyncProviderExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Beatmaps
+{
+    public static class BeatSyncProviderExtensions
+    {
+        /// <summary>
+        /// Check whether beat sync is currently available.
+        /// </summary>
+        public static bool CheckBeatSyncAvailable(this IBeatSyncProvider provider) => provider.Clock != null;
+
+        /// <summary>
+        /// Whether the beat sync provider is currently in a kiai section. Should make everything more epic.
+        /// </summary>
+        public static bool CheckIsKiaiTime(this IBeatSyncProvider provider) => provider.Clock != null && (provider.ControlPoints?.EffectPointAt(provider.Clock.CurrentTime).KiaiMode ?? false);
+    }
+}

--- a/osu.Game/Beatmaps/BeatSyncProviderExtensions.cs
+++ b/osu.Game/Beatmaps/BeatSyncProviderExtensions.cs
@@ -13,6 +13,6 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Whether the beat sync provider is currently in a kiai section. Should make everything more epic.
         /// </summary>
-        public static bool CheckIsKiaiTime(this IBeatSyncProvider provider) => provider.Clock != null && (provider.ControlPoints?.EffectPointAt(provider.Clock.CurrentTime).KiaiMode ?? false);
+        public static bool CheckIsKiaiTime(this IBeatSyncProvider provider) => provider.Clock != null && provider.ControlPoints?.EffectPointAt(provider.Clock.CurrentTime).KiaiMode == true;
     }
 }

--- a/osu.Game/Beatmaps/IBeatSyncProvider.cs
+++ b/osu.Game/Beatmaps/IBeatSyncProvider.cs
@@ -17,16 +17,6 @@ namespace osu.Game.Beatmaps
     public interface IBeatSyncProvider : IHasAmplitudes
     {
         /// <summary>
-        /// Check whether beat sync is currently available.
-        /// </summary>
-        public bool BeatSyncAvailable => Clock != null;
-
-        /// <summary>
-        /// Whether the beat sync provider is currently in a kiai section. Should make everything more epic.
-        /// </summary>
-        public bool IsKiaiTime => Clock != null && (ControlPoints?.EffectPointAt(Clock.CurrentTime).KiaiMode ?? false);
-
-        /// <summary>
         /// Access any available control points from a beatmap providing beat sync. If <c>null</c>, no current provider is available.
         /// </summary>
         ControlPointInfo? ControlPoints { get; }

--- a/osu.Game/Beatmaps/IBeatSyncProvider.cs
+++ b/osu.Game/Beatmaps/IBeatSyncProvider.cs
@@ -22,6 +22,11 @@ namespace osu.Game.Beatmaps
         public bool BeatSyncAvailable => Clock != null;
 
         /// <summary>
+        /// Whether the beat sync provider is currently in a kiai section. Should make everything more epic.
+        /// </summary>
+        public bool IsKiaiTime => Clock != null && (ControlPoints?.EffectPointAt(Clock.CurrentTime).KiaiMode ?? false);
+
+        /// <summary>
         /// Access any available control points from a beatmap providing beat sync. If <c>null</c>, no current provider is available.
         /// </summary>
         ControlPointInfo? ControlPoints { get; }

--- a/osu.Game/Beatmaps/IBeatSyncProvider.cs
+++ b/osu.Game/Beatmaps/IBeatSyncProvider.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
+using osu.Framework.Audio;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
@@ -14,12 +14,21 @@ namespace osu.Game.Beatmaps
     /// Primarily intended for use with <see cref="BeatSyncedContainer"/>.
     /// </summary>
     [Cached]
-    public interface IBeatSyncProvider
+    public interface IBeatSyncProvider : IHasAmplitudes
     {
+        /// <summary>
+        /// Check whether beat sync is currently available.
+        /// </summary>
+        public bool BeatSyncAvailable => Clock != null;
+
+        /// <summary>
+        /// Access any available control points from a beatmap providing beat sync. If <c>null</c>, no current provider is available.
+        /// </summary>
         ControlPointInfo? ControlPoints { get; }
 
+        /// <summary>
+        /// Access a clock currently responsible for providing beat sync. If <c>null</c>, no current provider is available.
+        /// </summary>
         IClock? Clock { get; }
-
-        ChannelAmplitudes? Amplitudes { get; }
     }
 }

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Graphics.Containers
         private TimingControlPoint? lastTimingPoint { get; set; }
         private EffectControlPoint? lastEffectPoint { get; set; }
 
-        public bool IsKiaiTime { get; private set; }
+        protected bool IsKiaiTime { get; private set; }
 
         /// <summary>
         /// The amount of time before a beat we should fire <see cref="OnNewBeat(int, TimingControlPoint, EffectControlPoint, ChannelAmplitudes)"/>.
@@ -142,7 +142,7 @@ namespace osu.Game.Graphics.Containers
             lastTimingPoint = timingPoint;
             lastEffectPoint = effectPoint;
 
-            IsKiaiTime = lastEffectPoint?.KiaiMode ?? false;
+            IsKiaiTime = effectPoint?.KiaiMode ?? false;
         }
     }
 }

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Graphics.Containers
         private int lastBeat;
 
         private TimingControlPoint? lastTimingPoint { get; set; }
-        private EffectControlPoint? lastEffectPoint { get; set; }
 
         protected bool IsKiaiTime { get; private set; }
 
@@ -87,7 +86,7 @@ namespace osu.Game.Graphics.Containers
             TimingControlPoint timingPoint;
             EffectControlPoint effectPoint;
 
-            IsBeatSyncedWithTrack = BeatSyncSource.BeatSyncAvailable && BeatSyncSource.Clock?.IsRunning == true;
+            IsBeatSyncedWithTrack = BeatSyncSource.CheckBeatSyncAvailable() && BeatSyncSource.Clock?.IsRunning == true;
 
             double currentTrackTime;
 
@@ -140,9 +139,8 @@ namespace osu.Game.Graphics.Containers
 
             lastBeat = beatIndex;
             lastTimingPoint = timingPoint;
-            lastEffectPoint = effectPoint;
 
-            IsKiaiTime = effectPoint?.KiaiMode ?? false;
+            IsKiaiTime = effectPoint.KiaiMode;
         }
     }
 }

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -26,8 +26,10 @@ namespace osu.Game.Graphics.Containers
     {
         private int lastBeat;
 
-        protected TimingControlPoint? LastTimingPoint { get; private set; }
-        protected EffectControlPoint? LastEffectPoint { get; private set; }
+        private TimingControlPoint? lastTimingPoint { get; set; }
+        private EffectControlPoint? lastEffectPoint { get; set; }
+
+        public bool IsKiaiTime { get; private set; }
 
         /// <summary>
         /// The amount of time before a beat we should fire <see cref="OnNewBeat(int, TimingControlPoint, EffectControlPoint, ChannelAmplitudes)"/>.
@@ -125,7 +127,7 @@ namespace osu.Game.Graphics.Containers
 
             TimeSinceLastBeat = beatLength - TimeUntilNextBeat;
 
-            if (ReferenceEquals(timingPoint, LastTimingPoint) && beatIndex == lastBeat)
+            if (ReferenceEquals(timingPoint, lastTimingPoint) && beatIndex == lastBeat)
                 return;
 
             // as this event is sometimes used for sound triggers where `BeginDelayedSequence` has no effect, avoid firing it if too far away from the beat.
@@ -137,8 +139,10 @@ namespace osu.Game.Graphics.Containers
             }
 
             lastBeat = beatIndex;
-            LastTimingPoint = timingPoint;
-            LastEffectPoint = effectPoint;
+            lastTimingPoint = timingPoint;
+            lastEffectPoint = effectPoint;
+
+            IsKiaiTime = lastEffectPoint?.KiaiMode ?? false;
         }
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -588,6 +588,6 @@ namespace osu.Game
 
         ControlPointInfo IBeatSyncProvider.ControlPoints => Beatmap.Value.BeatmapLoaded ? Beatmap.Value.Beatmap.ControlPointInfo : null;
         IClock IBeatSyncProvider.Clock => Beatmap.Value.TrackLoaded ? Beatmap.Value.Track : (IClock)null;
-        ChannelAmplitudes? IBeatSyncProvider.Amplitudes => Beatmap.Value.TrackLoaded ? Beatmap.Value.Track.CurrentAmplitudes : null;
+        ChannelAmplitudes IHasAmplitudes.CurrentAmplitudes => Beatmap.Value.TrackLoaded ? Beatmap.Value.Track.CurrentAmplitudes : ChannelAmplitudes.Empty;
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -949,7 +950,7 @@ namespace osu.Game.Screens.Edit
 
         ControlPointInfo IBeatSyncProvider.ControlPoints => editorBeatmap.ControlPointInfo;
         IClock IBeatSyncProvider.Clock => clock;
-        ChannelAmplitudes? IBeatSyncProvider.Amplitudes => Beatmap.Value.TrackLoaded ? Beatmap.Value.Track.CurrentAmplitudes : null;
+        ChannelAmplitudes IHasAmplitudes.CurrentAmplitudes => Beatmap.Value.TrackLoaded ? Beatmap.Value.Track.CurrentAmplitudes : ChannelAmplitudes.Empty;
 
         private class BeatmapEditorToast : Toast
         {

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using osuTK;
-using osuTK.Graphics;
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Colour;
@@ -12,16 +14,10 @@ using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Beatmaps;
-using System;
-using System.Collections.Generic;
-using JetBrains.Annotations;
-using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Track;
-using osu.Framework.Bindables;
 using osu.Framework.Utils;
-using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Beatmaps;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Menu
 {
@@ -30,8 +26,6 @@ namespace osu.Game.Screens.Menu
     /// </summary>
     public class LogoVisualisation : Drawable
     {
-        private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
-
         /// <summary>
         /// The number of bars to jump each update iteration.
         /// </summary>
@@ -76,7 +70,8 @@ namespace osu.Game.Screens.Menu
 
         private readonly float[] frequencyAmplitudes = new float[256];
 
-        private IShader shader;
+        private IShader shader = null!;
+
         private readonly Texture texture;
 
         public LogoVisualisation()
@@ -93,32 +88,35 @@ namespace osu.Game.Screens.Menu
         }
 
         [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap)
+        private void load(ShaderManager shaders)
         {
-            this.beatmap.BindTo(beatmap);
             shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
         }
 
         private readonly float[] temporalAmplitudes = new float[ChannelAmplitudes.AMPLITUDES_SIZE];
 
+        [Resolved]
+        private IBeatSyncProvider beatSyncProvider { get; set; } = null!;
+
         private void updateAmplitudes()
         {
-            var effect = beatmap.Value.BeatmapLoaded && beatmap.Value.TrackLoaded
-                ? beatmap.Value.Beatmap?.ControlPointInfo.EffectPointAt(beatmap.Value.Track.CurrentTime)
-                : null;
+            bool isKiaiTime = false;
 
             for (int i = 0; i < temporalAmplitudes.Length; i++)
                 temporalAmplitudes[i] = 0;
 
-            if (beatmap.Value.TrackLoaded)
-                addAmplitudesFromSource(beatmap.Value.Track);
+            if (beatSyncProvider.Clock != null)
+            {
+                isKiaiTime = beatSyncProvider.ControlPoints?.EffectPointAt(beatSyncProvider.Clock.CurrentTime).KiaiMode ?? false;
+                addAmplitudesFromSource(beatSyncProvider);
+            }
 
             foreach (var source in amplitudeSources)
                 addAmplitudesFromSource(source);
 
             for (int i = 0; i < bars_per_visualiser; i++)
             {
-                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * (effect?.KiaiMode == true ? 1 : 0.5f);
+                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * (isKiaiTime ? 1 : 0.5f);
                 if (targetAmplitude > frequencyAmplitudes[i])
                     frequencyAmplitudes[i] = targetAmplitude;
             }
@@ -153,7 +151,7 @@ namespace osu.Game.Screens.Menu
 
         protected override DrawNode CreateDrawNode() => new VisualisationDrawNode(this);
 
-        private void addAmplitudesFromSource([NotNull] IHasAmplitudes source)
+        private void addAmplitudesFromSource(IHasAmplitudes source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
@@ -170,8 +168,8 @@ namespace osu.Game.Screens.Menu
         {
             protected new LogoVisualisation Source => (LogoVisualisation)base.Source;
 
-            private IShader shader;
-            private Texture texture;
+            private IShader shader = null!;
+            private Texture texture = null!;
 
             // Assuming the logo is a circle, we don't need a second dimension.
             private float size;
@@ -209,43 +207,40 @@ namespace osu.Game.Screens.Menu
                 ColourInfo colourInfo = DrawColourInfo.Colour;
                 colourInfo.ApplyChild(transparent_white);
 
-                if (audioData != null)
+                for (int j = 0; j < visualiser_rounds; j++)
                 {
-                    for (int j = 0; j < visualiser_rounds; j++)
+                    for (int i = 0; i < bars_per_visualiser; i++)
                     {
-                        for (int i = 0; i < bars_per_visualiser; i++)
-                        {
-                            if (audioData[i] < amplitude_dead_zone)
-                                continue;
+                        if (audioData[i] < amplitude_dead_zone)
+                            continue;
 
-                            float rotation = MathUtils.DegreesToRadians(i / (float)bars_per_visualiser * 360 + j * 360 / visualiser_rounds);
-                            float rotationCos = MathF.Cos(rotation);
-                            float rotationSin = MathF.Sin(rotation);
-                            // taking the cos and sin to the 0..1 range
-                            var barPosition = new Vector2(rotationCos / 2 + 0.5f, rotationSin / 2 + 0.5f) * size;
+                        float rotation = MathUtils.DegreesToRadians(i / (float)bars_per_visualiser * 360 + j * 360 / visualiser_rounds);
+                        float rotationCos = MathF.Cos(rotation);
+                        float rotationSin = MathF.Sin(rotation);
+                        // taking the cos and sin to the 0..1 range
+                        var barPosition = new Vector2(rotationCos / 2 + 0.5f, rotationSin / 2 + 0.5f) * size;
 
-                            var barSize = new Vector2(size * MathF.Sqrt(2 * (1 - MathF.Cos(MathUtils.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, bar_length * audioData[i]);
-                            // The distance between the position and the sides of the bar.
-                            var bottomOffset = new Vector2(-rotationSin * barSize.X / 2, rotationCos * barSize.X / 2);
-                            // The distance between the bottom side of the bar and the top side.
-                            var amplitudeOffset = new Vector2(rotationCos * barSize.Y, rotationSin * barSize.Y);
+                        var barSize = new Vector2(size * MathF.Sqrt(2 * (1 - MathF.Cos(MathUtils.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, bar_length * audioData[i]);
+                        // The distance between the position and the sides of the bar.
+                        var bottomOffset = new Vector2(-rotationSin * barSize.X / 2, rotationCos * barSize.X / 2);
+                        // The distance between the bottom side of the bar and the top side.
+                        var amplitudeOffset = new Vector2(rotationCos * barSize.Y, rotationSin * barSize.Y);
 
-                            var rectangle = new Quad(
-                                Vector2Extensions.Transform(barPosition - bottomOffset, DrawInfo.Matrix),
-                                Vector2Extensions.Transform(barPosition - bottomOffset + amplitudeOffset, DrawInfo.Matrix),
-                                Vector2Extensions.Transform(barPosition + bottomOffset, DrawInfo.Matrix),
-                                Vector2Extensions.Transform(barPosition + bottomOffset + amplitudeOffset, DrawInfo.Matrix)
-                            );
+                        var rectangle = new Quad(
+                            Vector2Extensions.Transform(barPosition - bottomOffset, DrawInfo.Matrix),
+                            Vector2Extensions.Transform(barPosition - bottomOffset + amplitudeOffset, DrawInfo.Matrix),
+                            Vector2Extensions.Transform(barPosition + bottomOffset, DrawInfo.Matrix),
+                            Vector2Extensions.Transform(barPosition + bottomOffset + amplitudeOffset, DrawInfo.Matrix)
+                        );
 
-                            DrawQuad(
-                                texture,
-                                rectangle,
-                                colourInfo,
-                                null,
-                                vertexBatch.AddAction,
-                                // barSize by itself will make it smooth more in the X axis than in the Y axis, this reverts that.
-                                Vector2.Divide(inflation, barSize.Yx));
-                        }
+                        DrawQuad(
+                            texture,
+                            rectangle,
+                            colourInfo,
+                            null,
+                            vertexBatch.AddAction,
+                            // barSize by itself will make it smooth more in the X axis than in the Y axis, this reverts that.
+                            Vector2.Divide(inflation, barSize.Yx));
                     }
                 }
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -100,23 +100,18 @@ namespace osu.Game.Screens.Menu
 
         private void updateAmplitudes()
         {
-            bool isKiaiTime = false;
-
             for (int i = 0; i < temporalAmplitudes.Length; i++)
                 temporalAmplitudes[i] = 0;
 
             if (beatSyncProvider.Clock != null)
-            {
-                isKiaiTime = beatSyncProvider.ControlPoints?.EffectPointAt(beatSyncProvider.Clock.CurrentTime).KiaiMode ?? false;
                 addAmplitudesFromSource(beatSyncProvider);
-            }
 
             foreach (var source in amplitudeSources)
                 addAmplitudesFromSource(source);
 
             for (int i = 0; i < bars_per_visualiser; i++)
             {
-                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * (isKiaiTime ? 1 : 0.5f);
+                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * (beatSyncProvider.IsKiaiTime ? 1 : 0.5f);
                 if (targetAmplitude > frequencyAmplitudes[i])
                     frequencyAmplitudes[i] = targetAmplitude;
             }

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Screens.Menu
 
             for (int i = 0; i < bars_per_visualiser; i++)
             {
-                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * (beatSyncProvider.IsKiaiTime ? 1 : 0.5f);
+                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * (beatSyncProvider.CheckIsKiaiTime() ? 1 : 0.5f);
                 if (targetAmplitude > frequencyAmplitudes[i])
                     frequencyAmplitudes[i] = targetAmplitude;
             }

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -353,7 +353,7 @@ namespace osu.Game.Screens.Menu
                 float maxAmplitude = lastBeatIndex >= 0 ? musicController.CurrentTrack.CurrentAmplitudes.Maximum : 0;
                 logoAmplitudeContainer.Scale = new Vector2((float)Interpolation.Damp(logoAmplitudeContainer.Scale.X, 1 - Math.Max(0, maxAmplitude - scale_adjust_cutoff) * 0.04f, 0.9f, Time.Elapsed));
 
-                triangles.Velocity = (float)Interpolation.Damp(triangles.Velocity, triangles_paused_velocity * (LastEffectPoint.KiaiMode ? 4 : 2), 0.995f, Time.Elapsed);
+                triangles.Velocity = (float)Interpolation.Damp(triangles.Velocity, triangles_paused_velocity * (IsKiaiTime ? 4 : 2), 0.995f, Time.Elapsed);
             }
             else
             {

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -53,21 +51,21 @@ namespace osu.Game.Screens.Play
 
         private readonly WorkingBeatmap beatmap;
 
-        private HardwareCorrectionOffsetClock userGlobalOffsetClock;
-        private HardwareCorrectionOffsetClock userBeatmapOffsetClock;
-        private HardwareCorrectionOffsetClock platformOffsetClock;
-        private MasterGameplayClock masterGameplayClock;
-        private Bindable<double> userAudioOffset;
+        private HardwareCorrectionOffsetClock userGlobalOffsetClock = null!;
+        private HardwareCorrectionOffsetClock userBeatmapOffsetClock = null!;
+        private HardwareCorrectionOffsetClock platformOffsetClock = null!;
+        private MasterGameplayClock masterGameplayClock = null!;
+        private Bindable<double> userAudioOffset = null!;
 
-        private IDisposable beatmapOffsetSubscription;
+        private IDisposable? beatmapOffsetSubscription;
 
         private readonly double skipTargetTime;
 
         [Resolved]
-        private RealmAccess realm { get; set; }
+        private RealmAccess realm { get; set; } = null!;
 
         [Resolved]
-        private OsuConfigManager config { get; set; }
+        private OsuConfigManager config { get; set; } = null!;
 
         /// <summary>
         /// Create a new master gameplay clock container.
@@ -255,7 +253,7 @@ namespace osu.Game.Screens.Play
 
         ControlPointInfo IBeatSyncProvider.ControlPoints => beatmap.Beatmap.ControlPointInfo;
         IClock IBeatSyncProvider.Clock => GameplayClock;
-        ChannelAmplitudes? IBeatSyncProvider.Amplitudes => beatmap.TrackLoaded ? beatmap.Track.CurrentAmplitudes : null;
+        ChannelAmplitudes IHasAmplitudes.CurrentAmplitudes => beatmap.TrackLoaded ? beatmap.Track.CurrentAmplitudes : ChannelAmplitudes.Empty;
 
         private class HardwareCorrectionOffsetClock : FramedOffsetClock
         {


### PR DESCRIPTION
As a preliminary step to moving out more of the clock/offset logic to a higher level, I want to start by reducing dependence on `WorkingBeatmap.Track`. Most of the usages outside of editor/player are for beat sync purposes (ie. animating various components), so I've gone through each of these usages and removed any references to the beatmap itself.