### PR TITLE
Add flow for creating new mod presets

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
@@ -22,6 +23,9 @@ namespace osu.Game.Tests.Visual.UserInterface
     {
         protected override bool UseFreshStoragePerRun => true;
 
+        private Container<Drawable> content = null!;
+        protected override Container<Drawable> Content => content;
+
         private RulesetStore rulesets = null!;
 
         [Cached]
@@ -32,6 +36,12 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(Realm);
+
+            base.Content.Add(content = new PopoverContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding(30),
+            });
         }
 
         [SetUpSteps]
@@ -57,15 +67,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestBasicOperation()
         {
             AddStep("set osu! ruleset", () => Ruleset.Value = rulesets.GetRuleset(0));
-            AddStep("create content", () => Child = new Container
+            AddStep("create content", () => Child = new ModPresetColumn
             {
-                RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(30),
-                Child = new ModPresetColumn
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
             });
             AddUntilStep("3 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 3);
 
@@ -112,15 +117,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestSoftDeleteSupport()
         {
             AddStep("set osu! ruleset", () => Ruleset.Value = rulesets.GetRuleset(0));
-            AddStep("create content", () => Child = new Container
+            AddStep("create content", () => Child = new ModPresetColumn
             {
-                RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(30),
-                Child = new ModPresetColumn
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
             });
             AddUntilStep("3 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 3);
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -10,16 +11,19 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Graphics.Cursor;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public class TestSceneModPresetColumn : OsuTestScene
+    public class TestSceneModPresetColumn : OsuManualInputManagerTestScene
     {
         protected override bool UseFreshStoragePerRun => true;
 
@@ -144,6 +148,61 @@ namespace osu.Game.Tests.Visual.UserInterface
                     preset.DeletePending = false;
             }));
             AddUntilStep("3 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 3);
+        }
+
+        [Test]
+        public void TestAddingFlow()
+        {
+            ModPresetColumn modPresetColumn = null!;
+
+            AddStep("clear mods", () => SelectedMods.Value = Array.Empty<Mod>());
+            AddStep("create content", () => Child = modPresetColumn = new ModPresetColumn
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            });
+
+            AddUntilStep("items loaded", () => modPresetColumn.IsLoaded && modPresetColumn.ItemsLoaded);
+            AddAssert("add preset button disabled", () => !this.ChildrenOfType<AddPresetButton>().Single().Enabled.Value);
+
+            AddStep("set mods", () => SelectedMods.Value = new Mod[] { new OsuModDaycore(), new OsuModClassic() });
+            AddAssert("add preset button enabled", () => this.ChildrenOfType<AddPresetButton>().Single().Enabled.Value);
+
+            AddStep("click add preset button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<AddPresetButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            OsuPopover? popover = null;
+            AddUntilStep("wait for popover", () => (popover = this.ChildrenOfType<OsuPopover>().FirstOrDefault()) != null);
+            AddStep("attempt preset creation", () =>
+            {
+                InputManager.MoveMouseTo(popover.ChildrenOfType<ShearedButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddWaitStep("wait some", 3);
+            AddAssert("preset creation did not occur", () => this.ChildrenOfType<ModPresetPanel>().Count() == 3);
+            AddUntilStep("popover is unchanged", () => this.ChildrenOfType<OsuPopover>().FirstOrDefault() == popover);
+
+            AddStep("fill preset name", () => popover.ChildrenOfType<LabelledTextBox>().First().Current.Value = "new preset");
+            AddStep("attempt preset creation", () =>
+            {
+                InputManager.MoveMouseTo(popover.ChildrenOfType<ShearedButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("popover closed", () => !this.ChildrenOfType<OsuPopover>().Any());
+            AddUntilStep("preset creation occurred", () => this.ChildrenOfType<ModPresetPanel>().Count() == 4);
+
+            AddStep("click add preset button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<AddPresetButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("wait for popover", () => (popover = this.ChildrenOfType<OsuPopover>().FirstOrDefault()) != null);
+            AddStep("clear mods", () => SelectedMods.Value = Array.Empty<Mod>());
+            AddUntilStep("popover closed", () => !this.ChildrenOfType<OsuPopover>().Any());
         }
 
         private ICollection<ModPreset> createTestPresets() => new[]

--- a/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
@@ -49,15 +49,15 @@ namespace osu.Game.Graphics.UserInterface
             Active.BindDisabledChanged(disabled => Action = disabled ? null : Active.Toggle, true);
             Active.BindValueChanged(_ =>
             {
-                updateActiveState();
+                UpdateActiveState();
                 playSample();
             });
 
-            updateActiveState();
+            UpdateActiveState();
             base.LoadComplete();
         }
 
-        private void updateActiveState()
+        protected virtual void UpdateActiveState()
         {
             DarkerColour = Active.Value ? ColourProvider.Highlight1 : ColourProvider.Background3;
             LighterColour = Active.Value ? ColourProvider.Colour0 : ColourProvider.Background1;

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
@@ -88,6 +88,16 @@ namespace osu.Game.Localisation
         /// "Collections"
         /// </summary>
         public static LocalisableString Collections => new TranslatableString(getKey(@"collections"), @"Collections");
+
+        /// <summary>
+        /// "Name"
+        /// </summary>
+        public static LocalisableString Name => new TranslatableString(getKey(@"name"), @"Name");
+
+        /// <summary>
+        /// "Description"
+        /// </summary>
+        public static LocalisableString Description => new TranslatableString(getKey(@"description"), @"Description");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/ModSelectOverlayStrings.cs
+++ b/osu.Game/Localisation/ModSelectOverlayStrings.cs
@@ -29,6 +29,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString PersonalPresets => new TranslatableString(getKey(@"personal_presets"), @"Personal Presets");
 
+        /// <summary>
+        /// "Add preset"
+        /// </summary>
+        public static LocalisableString AddPreset => new TranslatableString(getKey(@"add_preset"), @"Add preset");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -7,18 +7,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Database;
-using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osuTK;
-using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -69,96 +63,5 @@ namespace osu.Game.Overlays.Mods
         }
 
         public Popover GetPopover() => new AddPresetPopover(this);
-
-        private class AddPresetPopover : OsuPopover
-        {
-            private readonly AddPresetButton button;
-
-            private readonly LabelledTextBox nameTextBox;
-            private readonly LabelledTextBox descriptionTextBox;
-            private readonly ShearedButton createButton;
-
-            [Resolved]
-            private Bindable<RulesetInfo> ruleset { get; set; } = null!;
-
-            [Resolved]
-            private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
-
-            [Resolved]
-            private RealmAccess realm { get; set; } = null!;
-
-            public AddPresetPopover(AddPresetButton addPresetButton)
-            {
-                button = addPresetButton;
-
-                Child = new FillFlowContainer
-                {
-                    Width = 300,
-                    AutoSizeAxes = Axes.Y,
-                    Spacing = new Vector2(7),
-                    Children = new Drawable[]
-                    {
-                        nameTextBox = new LabelledTextBox
-                        {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Label = CommonStrings.Name,
-                            TabbableContentContainer = this
-                        },
-                        descriptionTextBox = new LabelledTextBox
-                        {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Label = CommonStrings.Description,
-                            TabbableContentContainer = this
-                        },
-                        createButton = new ShearedButton
-                        {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Text = ModSelectOverlayStrings.AddPreset,
-                            Action = tryCreatePreset
-                        }
-                    }
-                };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider, OsuColour colours)
-            {
-                Body.BorderThickness = 3;
-                Body.BorderColour = colours.Orange1;
-
-                createButton.DarkerColour = colours.Orange1;
-                createButton.LighterColour = colours.Orange0;
-                createButton.TextColour = colourProvider.Background6;
-            }
-
-            private void tryCreatePreset()
-            {
-                if (string.IsNullOrWhiteSpace(nameTextBox.Current.Value))
-                {
-                    Body.Shake();
-                    return;
-                }
-
-                realm.Write(r => r.Add(new ModPreset
-                {
-                    Name = nameTextBox.Current.Value,
-                    Description = descriptionTextBox.Current.Value,
-                    Mods = selectedMods.Value.ToArray(),
-                    Ruleset = r.Find<RulesetInfo>(ruleset.Value.ShortName)
-                }));
-
-                this.HidePopover();
-            }
-
-            protected override void UpdateState(ValueChangedEvent<Visibility> state)
-            {
-                base.UpdateState(state);
-                if (state.NewValue == Visibility.Hidden)
-                    button.Active.Value = false;
-            }
-        }
     }
 }

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -42,10 +42,10 @@ namespace osu.Game.Overlays.Mods
         {
             base.LoadComplete();
 
-            selectedMods.BindValueChanged(val => Enabled.Value = val.NewValue.Any(), true);
-            Enabled.BindValueChanged(val =>
+            selectedMods.BindValueChanged(mods => Enabled.Value = mods.NewValue.Any(), true);
+            Enabled.BindValueChanged(enabled =>
             {
-                if (!val.NewValue)
+                if (!enabled.NewValue)
                     Active.Value = false;
             });
         }

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -2,14 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
 
 namespace osu.Game.Overlays.Mods
 {
-    public class AddPresetButton : ShearedToggleButton
+    public class AddPresetButton : ShearedToggleButton, IHasPopover
     {
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -33,6 +39,73 @@ namespace osu.Game.Overlays.Mods
             DarkerColour = Active.Value ? colours.Orange1 : ColourProvider.Background3;
             LighterColour = Active.Value ? colours.Orange0 : ColourProvider.Background1;
             TextColour = Active.Value ? ColourProvider.Background6 : ColourProvider.Content1;
+
+            if (Active.Value)
+                this.ShowPopover();
+            else
+                this.HidePopover();
+        }
+
+        public Popover GetPopover() => new AddPresetPopover(this);
+
+        private class AddPresetPopover : OsuPopover
+        {
+            private readonly AddPresetButton button;
+
+            private readonly LabelledTextBox nameTextBox;
+            private readonly LabelledTextBox descriptionTextBox;
+            private readonly ShearedButton createButton;
+
+            public AddPresetPopover(AddPresetButton addPresetButton)
+            {
+                button = addPresetButton;
+
+                Child = new FillFlowContainer
+                {
+                    Width = 300,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(7),
+                    Children = new Drawable[]
+                    {
+                        nameTextBox = new LabelledTextBox
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Label = "Name",
+                            TabbableContentContainer = this
+                        },
+                        descriptionTextBox = new LabelledTextBox
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Label = "Description",
+                            TabbableContentContainer = this
+                        },
+                        createButton = new ShearedButton
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Text = "Create preset",
+                            Action = this.HidePopover
+                        }
+                    }
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider, OsuColour colours)
+            {
+                createButton.DarkerColour = colours.Orange1;
+                createButton.LighterColour = colours.Orange0;
+                createButton.TextColour = colourProvider.Background6;
+            }
+
+            protected override void UpdateState(ValueChangedEvent<Visibility> state)
+            {
+                base.UpdateState(state);
+                if (state.NewValue == Visibility.Hidden)
+                    button.Active.Value = false;
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Game.Overlays.Mods
+{
+    public class AddPresetButton : ShearedToggleButton
+    {
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public AddPresetButton()
+            : base(1)
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = ModSelectPanel.HEIGHT;
+
+            // shear will be applied at a higher level in `ModPresetColumn`.
+            Content.Shear = Vector2.Zero;
+            Padding = new MarginPadding();
+
+            Text = "+";
+            TextSize = 30;
+        }
+
+        protected override void UpdateActiveState()
+        {
+            DarkerColour = Active.Value ? colours.Orange1 : ColourProvider.Background3;
+            LighterColour = Active.Value ? colours.Orange0 : ColourProvider.Background1;
+            TextColour = Active.Value ? ColourProvider.Background6 : ColourProvider.Content1;
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -71,21 +72,21 @@ namespace osu.Game.Overlays.Mods
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
-                            Label = "Name",
+                            Label = CommonStrings.Name,
                             TabbableContentContainer = this
                         },
                         descriptionTextBox = new LabelledTextBox
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
-                            Label = "Description",
+                            Label = CommonStrings.Description,
                             TabbableContentContainer = this
                         },
                         createButton = new ShearedButton
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
-                            Text = "Create preset",
+                            Text = ModSelectOverlayStrings.AddPreset,
                             Action = this.HidePopover
                         }
                     }

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -95,6 +95,9 @@ namespace osu.Game.Overlays.Mods
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider, OsuColour colours)
             {
+                Body.BorderThickness = 3;
+                Body.BorderColour = colours.Orange1;
+
                 createButton.DarkerColour = colours.Orange1;
                 createButton.LighterColour = colours.Orange0;
                 createButton.TextColour = colourProvider.Background6;

--- a/osu.Game/Overlays/Mods/AddPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/AddPresetPopover.cs
@@ -84,6 +84,13 @@ namespace osu.Game.Overlays.Mods
             createButton.TextColour = colourProvider.Background6;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ScheduleAfterChildren(() => GetContainingInputManager().ChangeFocus(nameTextBox));
+        }
+
         private void tryCreatePreset()
         {
             if (string.IsNullOrWhiteSpace(nameTextBox.Current.Value))

--- a/osu.Game/Overlays/Mods/AddPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/AddPresetPopover.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Database;
+using osu.Game.Extensions;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osuTK;
+
+namespace osu.Game.Overlays.Mods
+{
+    internal class AddPresetPopover : OsuPopover
+    {
+        private readonly AddPresetButton button;
+
+        private readonly LabelledTextBox nameTextBox;
+        private readonly LabelledTextBox descriptionTextBox;
+        private readonly ShearedButton createButton;
+
+        [Resolved]
+        private Bindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        [Resolved]
+        private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        public AddPresetPopover(AddPresetButton addPresetButton)
+        {
+            button = addPresetButton;
+
+            Child = new FillFlowContainer
+            {
+                Width = 300,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(7),
+                Children = new Drawable[]
+                {
+                    nameTextBox = new LabelledTextBox
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Label = CommonStrings.Name,
+                        TabbableContentContainer = this
+                    },
+                    descriptionTextBox = new LabelledTextBox
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Label = CommonStrings.Description,
+                        TabbableContentContainer = this
+                    },
+                    createButton = new ShearedButton
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Text = ModSelectOverlayStrings.AddPreset,
+                        Action = tryCreatePreset
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider, OsuColour colours)
+        {
+            Body.BorderThickness = 3;
+            Body.BorderColour = colours.Orange1;
+
+            createButton.DarkerColour = colours.Orange1;
+            createButton.LighterColour = colours.Orange0;
+            createButton.TextColour = colourProvider.Background6;
+        }
+
+        private void tryCreatePreset()
+        {
+            if (string.IsNullOrWhiteSpace(nameTextBox.Current.Value))
+            {
+                Body.Shake();
+                return;
+            }
+
+            realm.Write(r => r.Add(new ModPreset
+            {
+                Name = nameTextBox.Current.Value,
+                Description = descriptionTextBox.Current.Value,
+                Mods = selectedMods.Value.ToArray(),
+                Ruleset = r.Find<RulesetInfo>(ruleset.Value.ShortName)
+            }));
+
+            this.HidePopover();
+        }
+
+        protected override void UpdateState(ValueChangedEvent<Visibility> state)
+        {
+            base.UpdateState(state);
+            if (state.NewValue == Visibility.Hidden)
+                button.Active.Value = false;
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/ModPresetColumn.cs
+++ b/osu.Game/Overlays/Mods/ModPresetColumn.cs
@@ -31,6 +31,10 @@ namespace osu.Game.Overlays.Mods
         {
             AccentColour = colours.Orange1;
             HeaderText = ModSelectOverlayStrings.PersonalPresets;
+
+            AddPresetButton addPresetButton;
+            ItemsFlow.Add(addPresetButton = new AddPresetButton());
+            ItemsFlow.SetLayoutPosition(addPresetButton, float.PositiveInfinity);
         }
 
         protected override void LoadComplete()
@@ -64,7 +68,7 @@ namespace osu.Game.Overlays.Mods
 
             if (!presets.Any())
             {
-                ItemsFlow.Clear();
+                ItemsFlow.RemoveAll(panel => panel is ModPresetPanel);
                 return;
             }
 
@@ -77,7 +81,8 @@ namespace osu.Game.Overlays.Mods
 
             latestLoadTask = loadTask = LoadComponentsAsync(panels, loaded =>
             {
-                ItemsFlow.ChildrenEnumerable = loaded;
+                ItemsFlow.RemoveAll(panel => panel is ModPresetPanel);
+                ItemsFlow.AddRange(loaded);
             }, (cancellationTokenSource = new CancellationTokenSource()).Token);
             loadTask.ContinueWith(_ =>
             {

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -43,8 +43,7 @@ namespace osu.Game.Overlays.Mods
         }
 
         public const float CORNER_RADIUS = 7;
-
-        protected const float HEIGHT = 42;
+        public const float HEIGHT = 42;
 
         protected virtual float IdleSwitchWidth => 14;
         protected virtual float ExpandedSwitchWidth => 30;


### PR DESCRIPTION
https://user-images.githubusercontent.com/20418176/182475442-2d7c643c-c0b8-48e5-bbac-584fc745f44e.mp4

As an explanation, the way that the button is set up is that it always uses the ambient global `SelectedMods` to create the preset. This looks kinda bad in this test but works better in the full overlay itself. I also made the button disable if no mods are selected to prevent empty presets from being created.

The design of the popover is seat-of-the-pants and can be tweaked to preference. Probably the most controversial part will be the border on it - it's there so that the popover doesn't blend in with the background content. I tried bumping the background shade up and down a level but it still looked bad to me regardless, so I did a border. There sort of is precedent for this [on the beatmap editor designs](https://www.figma.com/file/ytnnne2TH8Z956Jxhiypqq/Beatmap-Editor-2?node-id=1%3A364).