### PR TITLE
Change migration logic to ignore realm pipe files regardless of database filename

### DIFF
--- a/osu.Game/IO/MigratableStorage.cs
+++ b/osu.Game/IO/MigratableStorage.cs
@@ -26,6 +26,11 @@ namespace osu.Game.IO
         /// </summary>
         public virtual string[] IgnoreFiles => Array.Empty<string>();
 
+        /// <summary>
+        /// A list of file/directory suffixes which should not be migrated.
+        /// </summary>
+        public virtual string[] IgnoreSuffixes => Array.Empty<string>();
+
         protected MigratableStorage(Storage storage, string subPath = null)
             : base(storage, subPath)
         {
@@ -73,12 +78,18 @@ namespace osu.Game.IO
                 if (topLevelExcludes && IgnoreFiles.Contains(fi.Name))
                     continue;
 
+                if (IgnoreSuffixes.Any(suffix => fi.Name.EndsWith(suffix, StringComparison.Ordinal)))
+                    continue;
+
                 allFilesDeleted &= AttemptOperation(() => fi.Delete(), throwOnFailure: false);
             }
 
             foreach (DirectoryInfo dir in target.GetDirectories())
             {
                 if (topLevelExcludes && IgnoreDirectories.Contains(dir.Name))
+                    continue;
+
+                if (IgnoreSuffixes.Any(suffix => dir.Name.EndsWith(suffix, StringComparison.Ordinal)))
                     continue;
 
                 allFilesDeleted &= AttemptOperation(() => dir.Delete(true), throwOnFailure: false);
@@ -101,6 +112,9 @@ namespace osu.Game.IO
                 if (topLevelExcludes && IgnoreFiles.Contains(fileInfo.Name))
                     continue;
 
+                if (IgnoreSuffixes.Any(suffix => fileInfo.Name.EndsWith(suffix, StringComparison.Ordinal)))
+                    continue;
+
                 AttemptOperation(() =>
                 {
                     fileInfo.Refresh();
@@ -117,6 +131,9 @@ namespace osu.Game.IO
             foreach (DirectoryInfo dir in source.GetDirectories())
             {
                 if (topLevelExcludes && IgnoreDirectories.Contains(dir.Name))
+                    continue;
+
+                if (IgnoreSuffixes.Any(suffix => dir.Name.EndsWith(suffix, StringComparison.Ordinal)))
                     continue;
 
                 CopyRecursive(dir, destination.CreateSubdirectory(dir.Name), false);

--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -38,15 +38,20 @@ namespace osu.Game.IO
         public override string[] IgnoreDirectories => new[]
         {
             "cache",
-            $"{OsuGameBase.CLIENT_DATABASE_FILENAME}.management",
         };
 
         public override string[] IgnoreFiles => new[]
         {
             "framework.ini",
             "storage.ini",
-            $"{OsuGameBase.CLIENT_DATABASE_FILENAME}.note",
-            $"{OsuGameBase.CLIENT_DATABASE_FILENAME}.lock",
+        };
+
+        public override string[] IgnoreSuffixes => new[]
+        {
+            // Realm pipe files don't play well with copy operations
+            ".note",
+            ".lock",
+            ".management",
         };
 
         public OsuStorage(GameHost host, Storage defaultStorage)


### PR DESCRIPTION
Without this, migration would get stuck for me on `client_newer_version.lock` and the likes.

macOS issues.