### PR TITLE
Change all filter control button state test to until steps

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -227,7 +227,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             => AddUntilStep($"collection dropdown header displays '{collectionName}'",
                 () => shouldDisplay == (control.ChildrenOfType<CollectionDropdown.CollectionDropdownHeader>().Single().ChildrenOfType<SpriteText>().First().Text == collectionName));
 
-        private void assertFirstButtonIs(IconUsage icon) => AddUntilStep($"button is {icon.ToString()}", () => getAddOrRemoveButton(1).Icon.Equals(icon));
+        private void assertFirstButtonIs(IconUsage icon) => AddUntilStep($"button is {icon.Icon.ToString()}", () => getAddOrRemoveButton(1).Icon.Equals(icon));
 
         private void assertCollectionDropdownContains(string collectionName, bool shouldContain = true) =>
             AddUntilStep($"collection dropdown {(shouldContain ? "contains" : "does not contain")} '{collectionName}'",

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -150,13 +150,14 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "1"))));
             assertCollectionDropdownContains("1");
-            AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
+
+            assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
 
             AddStep("add beatmap to collection", () => writeAndRefresh(r => getFirstCollection().BeatmapMD5Hashes.Add(Beatmap.Value.BeatmapInfo.MD5Hash)));
-            AddAssert("button is minus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.MinusSquare));
+            assertFirstButtonIs(FontAwesome.Solid.MinusSquare);
 
             AddStep("remove beatmap from collection", () => writeAndRefresh(r => getFirstCollection().BeatmapMD5Hashes.Clear()));
-            AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
+            assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
         }
 
         [Test]
@@ -168,15 +169,15 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("add collection", () => writeAndRefresh(r => r.Add(new BeatmapCollection(name: "1"))));
             assertCollectionDropdownContains("1");
-            AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
+            assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
 
             addClickAddOrRemoveButtonStep(1);
             AddAssert("collection contains beatmap", () => getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
-            AddAssert("button is minus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.MinusSquare));
+            assertFirstButtonIs(FontAwesome.Solid.MinusSquare);
 
             addClickAddOrRemoveButtonStep(1);
             AddAssert("collection does not contain beatmap", () => !getFirstCollection().BeatmapMD5Hashes.Contains(Beatmap.Value.BeatmapInfo.MD5Hash));
-            AddAssert("button is plus", () => getAddOrRemoveButton(1).Icon.Equals(FontAwesome.Solid.PlusSquare));
+            assertFirstButtonIs(FontAwesome.Solid.PlusSquare);
         }
 
         [Test]
@@ -225,6 +226,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void assertCollectionHeaderDisplays(string collectionName, bool shouldDisplay = true)
             => AddUntilStep($"collection dropdown header displays '{collectionName}'",
                 () => shouldDisplay == (control.ChildrenOfType<CollectionDropdown.CollectionDropdownHeader>().Single().ChildrenOfType<SpriteText>().First().Text == collectionName));
+
+        private void assertFirstButtonIs(IconUsage icon) => AddUntilStep($"button is {icon.ToString()}", () => getAddOrRemoveButton(1).Icon.Equals(icon));
 
         private void assertCollectionDropdownContains(string collectionName, bool shouldContain = true) =>
             AddUntilStep($"collection dropdown {(shouldContain ? "contains" : "does not contain")} '{collectionName}'",


### PR DESCRIPTION
There's multiple schedules at play which could be adding multi-frame delays. let's play it safe and try and fix flaky tests.

Example of `Schedule` which could cause an issue:
https://github.com/ppy/osu/blob/392cb352cc71da8b0f82aa0877ea6a7febfc54b1/osu.Game/Collections/CollectionDropdown.cs#L77-L78

Example of test failure:
https://github.com/ppy/osu/runs/7648118894?check_suite_focus=true