### PR TITLE
Clean up SoloScoreInfo serialised output

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -102,6 +102,14 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("pp")]
         public double? PP { get; set; }
 
+        public bool ShouldSerializeID() => false;
+        public bool ShouldSerializeUser() => false;
+        public bool ShouldSerializeBeatmap() => false;
+        public bool ShouldSerializeBeatmapSet() => false;
+        public bool ShouldSerializePP() => false;
+        public bool ShouldSerializeOnlineID() => false;
+        public bool ShouldSerializeHasReplay() => false;
+
         #endregion
 
         public override string ToString() => $"score_id: {ID} user_id: {UserID}";

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Online.API.Requests.Responses
             RulesetID = score.RulesetID,
             Passed = score.Passed,
             Mods = score.APIMods,
-            Statistics = score.Statistics,
+            Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
         };
 
         public long OnlineID => ID ?? -1;


### PR DESCRIPTION
Some values were getting submitted and stored to the database, when they don't need to/shouldn't be. Inclusive of https://github.com/ppy/osu/pull/19380, this is the new data:

```json
{
    "mods": [
        {
            "acronym": "HR",
            "settings": {}
        },
        {
            "acronym": "HD",
            "settings": {}
        }
    ],
    "rank": "SH",
    "passed": true,
    "user_id": 124493,
    "accuracy": 0.9983190452176836,
    "build_id": null,
    "ended_at": "2016-09-20T01:51:49+00:00",
    "max_combo": 2385,
    "base_score": 593900,
    "beatmap_id": 129891,
    "ruleset_id": 0,
    "started_at": null,
    "statistics": {
        "ok": 5,
        "meh": 0,
        "miss": 0,
        "great": 1978
    },
    "bonus_score": 0,
    "total_score": 132408001,
    "maximum_scoring_values": {
        "max_combo": 2385,
        "base_score": 594900,
        "bonus_score": 0,
        "large_ticks_count": 0,
        "small_ticks_count": 0,
        "basic_objects_count": 1983
    }
}
```
These are just surefire things, I haven't removed `started_at`, `ended_at`, `build_id`, `ruleset_id` or `beatmap_id` because I'm not 100% sure on them and they're serialised by the highscore importer.

Ignore:
- `0` values in `maximum_scoring_values` object.
- Empty mod settings.
- `accuracy` and `total_score`