### PR TITLE
Version realm files for debug executions

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -173,7 +173,8 @@ namespace osu.Game.Database
                 Filename += realm_extension;
 
 #if DEBUG
-            applyFilenameSchemaSuffix(ref Filename);
+            if (!DebugUtils.IsNUnitRunning)
+                applyFilenameSchemaSuffix(ref Filename);
 #endif
 
             string newerVersionFilename = $"{Filename.Replace(realm_extension, string.Empty)}_newer_version{realm_extension}";


### PR DESCRIPTION
To make it easier for developers to test out pull requests which bump the realm schema version, realm files are now stored with the schema version in the filename.

Note that this means any changes made to a newer version will not be applied to previous ones.