### PR TITLE
Adjust pooling to reduce stutters during gameplay on unique hit objects

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         {
             InternalChildren = new Drawable[]
             {
-                connectionPool = new DrawablePool<FollowPointConnection>(1, 200),
+                connectionPool = new DrawablePool<FollowPointConnection>(10, 200),
                 pointPool = new DrawablePool<FollowPoint>(50, 1000)
             };
         }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -118,9 +118,9 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             config?.BindWith(OsuRulesetSetting.PlayfieldBorderStyle, playfieldBorder.PlayfieldBorderStyle);
 
-            RegisterPool<HitCircle, DrawableHitCircle>(10, 100);
             var osuBeatmap = (OsuBeatmap)beatmap;
 
+            RegisterPool<HitCircle, DrawableHitCircle>(20, 100);
 
             var sliders = osuBeatmap.HitObjects.OfType<Slider>();
 
@@ -138,8 +138,8 @@ namespace osu.Game.Rulesets.Osu.UI
             }
 
             RegisterPool<Spinner, DrawableSpinner>(2, 20);
-            RegisterPool<SpinnerTick, DrawableSpinnerTick>(10, 100);
-            RegisterPool<SpinnerBonusTick, DrawableSpinnerBonusTick>(10, 100);
+            RegisterPool<SpinnerTick, DrawableSpinnerTick>(10, 200);
+            RegisterPool<SpinnerBonusTick, DrawableSpinnerBonusTick>(10, 200);
         }
 
         protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new OsuHitObjectLifetimeEntry(hitObject);
@@ -186,7 +186,7 @@ namespace osu.Game.Rulesets.Osu.UI
             private readonly Action<DrawableOsuJudgement> onLoaded;
 
             public DrawableJudgementPool(HitResult result, Action<DrawableOsuJudgement> onLoaded)
-                : base(10)
+                : base(20)
             {
                 this.result = result;
                 this.onLoaded = onLoaded;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -122,20 +122,23 @@ namespace osu.Game.Rulesets.Osu.UI
 
             RegisterPool<HitCircle, DrawableHitCircle>(20, 100);
 
-            var sliders = osuBeatmap.HitObjects.OfType<Slider>();
+            int maxRepeatsOnOneSlider = 0;
+            int maxTicksOnOneSlider = 0;
 
-            if (sliders.Any())
+            var sliders = osuBeatmap?.HitObjects.OfType<Slider>();
+
+            if (sliders?.Any() == true)
             {
                 // handle edge cases where a beatmap has a slider with many repeats.
-                int maxRepeatsOnOneSlider = osuBeatmap.HitObjects.OfType<Slider>().Max(s => s.RepeatCount);
-                int maxTicksOnOneSlider = osuBeatmap.HitObjects.OfType<Slider>().Max(s => s.NestedHitObjects.OfType<SliderTick>().Count());
-
-                RegisterPool<Slider, DrawableSlider>(20, 100);
-                RegisterPool<SliderHeadCircle, DrawableSliderHead>(20, 100);
-                RegisterPool<SliderTailCircle, DrawableSliderTail>(20, 100);
-                RegisterPool<SliderTick, DrawableSliderTick>(Math.Max(maxTicksOnOneSlider, 20), Math.Max(maxTicksOnOneSlider, 200));
-                RegisterPool<SliderRepeat, DrawableSliderRepeat>(Math.Max(maxRepeatsOnOneSlider, 20), Math.Max(maxRepeatsOnOneSlider, 200));
+                maxRepeatsOnOneSlider = sliders?.Max(s => s.RepeatCount) ?? 0;
+                maxTicksOnOneSlider = sliders?.Max(s => s.NestedHitObjects.OfType<SliderTick>().Count()) ?? 0;
             }
+
+            RegisterPool<Slider, DrawableSlider>(20, 100);
+            RegisterPool<SliderHeadCircle, DrawableSliderHead>(20, 100);
+            RegisterPool<SliderTailCircle, DrawableSliderTail>(20, 100);
+            RegisterPool<SliderTick, DrawableSliderTick>(Math.Max(maxTicksOnOneSlider, 20), Math.Max(maxTicksOnOneSlider, 200));
+            RegisterPool<SliderRepeat, DrawableSliderRepeat>(Math.Max(maxRepeatsOnOneSlider, 20), Math.Max(maxRepeatsOnOneSlider, 200));
 
             RegisterPool<Spinner, DrawableSpinner>(2, 20);
             RegisterPool<SpinnerTick, DrawableSpinnerTick>(10, 200);

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -122,16 +122,17 @@ namespace osu.Game.Rulesets.Osu.UI
 
             RegisterPool<HitCircle, DrawableHitCircle>(20, 100);
 
+            // handle edge cases where a beatmap has a slider with many repeats.
             int maxRepeatsOnOneSlider = 0;
             int maxTicksOnOneSlider = 0;
 
-            var sliders = osuBeatmap?.HitObjects.OfType<Slider>();
-
-            if (sliders?.Any() == true)
+            if (osuBeatmap != null)
             {
-                // handle edge cases where a beatmap has a slider with many repeats.
-                maxRepeatsOnOneSlider = sliders?.Max(s => s.RepeatCount) ?? 0;
-                maxTicksOnOneSlider = sliders?.Max(s => s.NestedHitObjects.OfType<SliderTick>().Count()) ?? 0;
+                foreach (var slider in osuBeatmap.HitObjects.OfType<Slider>())
+                {
+                    maxRepeatsOnOneSlider = Math.Max(maxRepeatsOnOneSlider, slider.RepeatCount);
+                    maxTicksOnOneSlider = Math.Max(maxTicksOnOneSlider, slider.NestedHitObjects.OfType<SliderTick>().Count());
+                }
             }
 
             RegisterPool<Slider, DrawableSlider>(20, 100);


### PR DESCRIPTION
Closes #19585.

Note that this does not fix pooling of `PoolableSkinnableSample`s, which is not so simple to address (but seemingly lower overhead).

---

### Slider pooling is now based on the sliders contained within the beatmap.

I chose this because it's very hard to set good defaults. Some beatmaps just have insane numbers per sliders and the overhead from setting the pool sizes high enough to cater for them is non-negligible (~10ms -> 100ms to handle the reported beatmap).

### Pools have been increased in general

I noticed while testing various insane/extra beatmaps that some pools were too small. I made adjustments until they were large enough. I'd encourage testing with any beatmaps you think might still hit limits. There's still room to adjust these numbers upwards.