### PR TITLE
Fix multi-spectator potentially getting stuck for passed players (hotfix)

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -432,8 +432,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 var user = playingUsers.Single(u => u.UserID == userId);
 
-                OnlinePlayDependencies.MultiplayerClient.RemoveUser(user.User.AsNonNull());
                 SpectatorClient.SendEndPlay(userId);
+                OnlinePlayDependencies.MultiplayerClient.RemoveUser(user.User.AsNonNull());
 
                 playingUsers.Remove(user);
             });

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -231,6 +231,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             if (state.State == SpectatedUserState.Passed || state.State == SpectatedUserState.Failed)
                 return;
 
+            // we could also potentially receive EndGameplay with "Playing" state, at which point we can only early-return and hope it's a passing player.
+            // todo: this shouldn't exist, but it's here as a hotfix for an issue with multi-spectator screen not proceeding to results screen.
+            // see: https://github.com/ppy/osu/issues/19593
+            if (state.State == SpectatedUserState.Playing)
+                return;
+
             RemoveUser(userId);
 
             var instance = instances.Single(i => i.UserId == userId);


### PR DESCRIPTION
- Closes #19593 

On a multi-spectator session, both `SpectatorScreen` and `MultiplayerGameplayLeaderboard` are watching the users via `SpectatorClient.WatchUser`, and once the match ends, the leaderboard may get signalled first from the server that the users have transitioned to the `Results` state, causing the leaderboard to stop watching said users.

Once that happens, `SpectatorScreen` will be signalled to abruptly invoke `EndGameplay` with the current state (`Playing`), which will grey out the players as if they have actually quitted, and therefore not proceed to the results screen.

This aims to be a hotfix for the issue, as the underlying problem requires a bit of rethought on the general flow of watching users (see [discord](https://discord.com/channels/188630481301012481/188630652340404224/1005293821006971011)).