### PR TITLE
Unify implementations of deletion dialogs

### DIFF
--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -200,10 +200,12 @@ namespace osu.Game.Tests.Visual.Collections
             AddStep("click confirmation", () =>
             {
                 InputManager.MoveMouseTo(dialogOverlay.CurrentDialog.ChildrenOfType<PopupDialogButton>().First());
-                InputManager.Click(MouseButton.Left);
+                InputManager.PressButton(MouseButton.Left);
             });
 
             assertCollectionCount(0);
+
+            AddStep("release mouse button", () => InputManager.ReleaseButton(MouseButton.Left));
         }
 
         [Test]

--- a/osu.Game/Collections/DeleteCollectionDialog.cs
+++ b/osu.Game/Collections/DeleteCollectionDialog.cs
@@ -3,33 +3,17 @@
 
 using System;
 using Humanizer;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Database;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Collections
 {
-    public class DeleteCollectionDialog : PopupDialog
+    public class DeleteCollectionDialog : DeleteConfirmationDialog
     {
         public DeleteCollectionDialog(Live<BeatmapCollection> collection, Action deleteAction)
         {
-            HeaderText = "Confirm deletion of";
             BodyText = collection.PerformRead(c => $"{c.Name} ({"beatmap".ToQuantity(c.BeatmapMD5Hashes.Count)})");
-
-            Icon = FontAwesome.Regular.TrashAlt;
-
-            Buttons = new PopupDialogButton[]
-            {
-                new PopupDialogOkButton
-                {
-                    Text = @"Yes. Go for it.",
-                    Action = deleteAction
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = @"No! Abort mission!",
-                },
-            };
+            DeleteAction = deleteAction;
         }
     }
 }

--- a/osu.Game/Localisation/DeleteConfirmationDialogStrings.cs
+++ b/osu.Game/Localisation/DeleteConfirmationDialogStrings.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class DeleteConfirmationDialogStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.DeleteConfirmationDialog";
+
+        /// <summary>
+        /// "Confirm deletion of"
+        /// </summary>
+        public static LocalisableString HeaderText => new TranslatableString(getKey(@"header_text"), @"Confirm deletion of");
+
+        /// <summary>
+        /// "Yes. Go for it."
+        /// </summary>
+        public static LocalisableString Confirm => new TranslatableString(getKey(@"confirm"), @"Yes. Go for it.");
+
+        /// <summary>
+        /// "No! Abort mission"
+        /// </summary>
+        public static LocalisableString Cancel => new TranslatableString(getKey(@"cancel"), @"No! Abort mission");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Overlays/Dialog/DeleteConfirmationDialog.cs
+++ b/osu.Game/Overlays/Dialog/DeleteConfirmationDialog.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Localisation;
+
+namespace osu.Game.Overlays.Dialog
+{
+    /// <summary>
+    /// Base class for various confirmation dialogs that concern deletion actions.
+    /// Differs from <see cref="ConfirmDialog"/> in that the confirmation button is a "dangerous" one
+    /// (requires the confirm button to be held).
+    /// </summary>
+    public abstract class DeleteConfirmationDialog : PopupDialog
+    {
+        /// <summary>
+        /// The action which performs the deletion.
+        /// </summary>
+        protected Action? DeleteAction { get; set; }
+
+        protected DeleteConfirmationDialog()
+        {
+            HeaderText = DeleteConfirmationDialogStrings.HeaderText;
+
+            Icon = FontAwesome.Regular.TrashAlt;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogDangerousButton
+                {
+                    Text = DeleteConfirmationDialogStrings.Confirm,
+                    Action = () => DeleteAction?.Invoke()
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = DeleteConfirmationDialogStrings.Cancel
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MassDeleteConfirmationDialog.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MassDeleteConfirmationDialog.cs
@@ -1,34 +1,17 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Overlays.Settings.Sections.Maintenance
 {
-    public class MassDeleteConfirmationDialog : PopupDialog
+    public class MassDeleteConfirmationDialog : DeleteConfirmationDialog
     {
         public MassDeleteConfirmationDialog(Action deleteAction)
         {
             BodyText = "Everything?";
-
-            Icon = FontAwesome.Regular.TrashAlt;
-            HeaderText = @"Confirm deletion of";
-            Buttons = new PopupDialogButton[]
-            {
-                new PopupDialogDangerousButton
-                {
-                    Text = @"Yes. Go for it.",
-                    Action = deleteAction
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = @"No! Abort mission!",
-                },
-            };
+            DeleteAction = deleteAction;
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MassVideoDeleteConfirmationDialog.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MassVideoDeleteConfirmationDialog.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Game.Overlays.Settings.Sections.Maintenance

--- a/osu.Game/Screens/Select/BeatmapClearScoresDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapClearScoresDialog.cs
@@ -1,43 +1,27 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Select
 {
-    public class BeatmapClearScoresDialog : PopupDialog
+    public class BeatmapClearScoresDialog : DeleteConfirmationDialog
     {
         [Resolved]
-        private ScoreManager scoreManager { get; set; }
+        private ScoreManager scoreManager { get; set; } = null!;
 
         public BeatmapClearScoresDialog(BeatmapInfo beatmapInfo, Action onCompletion)
         {
-            BodyText = beatmapInfo.GetDisplayTitle();
-            Icon = FontAwesome.Solid.Eraser;
-            HeaderText = @"Clearing all local scores. Are you sure?";
-            Buttons = new PopupDialogButton[]
+            BodyText = $"All local scores on {beatmapInfo.GetDisplayTitle()}";
+            DeleteAction = () =>
             {
-                new PopupDialogOkButton
-                {
-                    Text = @"Yes. Please.",
-                    Action = () =>
-                    {
-                        Task.Run(() => scoreManager.Delete(beatmapInfo))
-                            .ContinueWith(_ => onCompletion);
-                    }
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = @"No, I'm still attached.",
-                },
+                Task.Run(() => scoreManager.Delete(beatmapInfo))
+                    .ContinueWith(_ => onCompletion);
             };
         }
     }

--- a/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
@@ -1,43 +1,26 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Screens.Select
 {
-    public class BeatmapDeleteDialog : PopupDialog
+    public class BeatmapDeleteDialog : DeleteConfirmationDialog
     {
-        private BeatmapManager manager;
+        private readonly BeatmapSetInfo beatmapSet;
+
+        public BeatmapDeleteDialog(BeatmapSetInfo beatmapSet)
+        {
+            this.beatmapSet = beatmapSet;
+            BodyText = $@"{beatmapSet.Metadata.Artist} - {beatmapSet.Metadata.Title}";
+        }
 
         [BackgroundDependencyLoader]
         private void load(BeatmapManager beatmapManager)
         {
-            manager = beatmapManager;
-        }
-
-        public BeatmapDeleteDialog(BeatmapSetInfo beatmap)
-        {
-            BodyText = $@"{beatmap.Metadata.Artist} - {beatmap.Metadata.Title}";
-
-            Icon = FontAwesome.Regular.TrashAlt;
-            HeaderText = @"Confirm deletion of";
-            Buttons = new PopupDialogButton[]
-            {
-                new PopupDialogDangerousButton
-                {
-                    Text = @"Yes. Totally. Delete it.",
-                    Action = () => manager?.Delete(beatmap),
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = @"Firetruck, I didn't mean to!",
-                },
-            };
+            DeleteAction = () => beatmapManager.Delete(beatmapSet);
         }
     }
 }

--- a/osu.Game/Screens/Select/LocalScoreDeleteDialog.cs
+++ b/osu.Game/Screens/Select/LocalScoreDeleteDialog.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Scoring;
@@ -12,44 +10,25 @@ using osu.Game.Beatmaps;
 
 namespace osu.Game.Screens.Select
 {
-    public class LocalScoreDeleteDialog : PopupDialog
+    public class LocalScoreDeleteDialog : DeleteConfirmationDialog
     {
         private readonly ScoreInfo score;
-
-        [Resolved]
-        private ScoreManager scoreManager { get; set; }
-
-        [Resolved]
-        private BeatmapManager beatmapManager { get; set; }
 
         public LocalScoreDeleteDialog(ScoreInfo score)
         {
             this.score = score;
-            Debug.Assert(score != null);
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(BeatmapManager beatmapManager, ScoreManager scoreManager)
         {
-            BeatmapInfo beatmapInfo = beatmapManager.QueryBeatmap(b => b.ID == score.BeatmapInfoID);
+            BeatmapInfo? beatmapInfo = beatmapManager.QueryBeatmap(b => b.ID == score.BeatmapInfoID);
             Debug.Assert(beatmapInfo != null);
 
             BodyText = $"{score.User} ({score.DisplayAccuracy}, {score.Rank})";
 
             Icon = FontAwesome.Regular.TrashAlt;
-            HeaderText = "Confirm deletion of local score";
-            Buttons = new PopupDialogButton[]
-            {
-                new PopupDialogDangerousButton
-                {
-                    Text = "Yes. Please.",
-                    Action = () => scoreManager?.Delete(score)
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = "No, I'm still attached.",
-                },
-            };
+            DeleteAction = () => scoreManager.Delete(score);
         }
     }
 }

--- a/osu.Game/Screens/Select/SkinDeleteDialog.cs
+++ b/osu.Game/Screens/Select/SkinDeleteDialog.cs
@@ -1,43 +1,29 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Skinning;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Screens.Select
 {
-    public class SkinDeleteDialog : PopupDialog
+    public class SkinDeleteDialog : DeleteConfirmationDialog
     {
-        [Resolved]
-        private SkinManager manager { get; set; }
+        private readonly Skin skin;
 
         public SkinDeleteDialog(Skin skin)
         {
+            this.skin = skin;
             BodyText = skin.SkinInfo.Value.Name;
-            Icon = FontAwesome.Regular.TrashAlt;
-            HeaderText = @"Confirm deletion of";
-            Buttons = new PopupDialogButton[]
-            {
-                new PopupDialogDangerousButton
-                {
-                    Text = @"Yes. Totally. Delete it.",
-                    Action = () =>
-                    {
-                        if (manager == null)
-                            return;
+        }
 
-                        manager.Delete(skin.SkinInfo.Value);
-                        manager.CurrentSkinInfo.SetDefault();
-                    },
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = @"Firetruck, I didn't mean to!",
-                },
+        [BackgroundDependencyLoader]
+        private void load(SkinManager manager)
+        {
+            DeleteAction = () =>
+            {
+                manager.Delete(skin.SkinInfo.Value);
+                manager.CurrentSkinInfo.SetDefault();
             };
         }
     }


### PR DESCRIPTION
This is a slight detour in the mod preset series.

To keep consistent UX with everything else, I wanted to add a deletion confirmation dialog for presets. However, as I went around looking at how other places did this, it quickly became apparent that they did this very haphazardly - aside from different copy, some places used a standard ok button for the confirmation, while others used the dangerous variant. The code of most of the variants was also copy paste.

So what this PR does is, it extracts a base deletion dialog to build upon, which causes most implementations to be reduced to only specifying the body text of the dialog (to name what is being deleted), and the actual deletion action. This reduces LoC (net 30 lines removed), unifies UX, and also adds localisation support to the base dialog.