### PR TITLE
Implement selection logic for mod preset panels

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetPanel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Database;
@@ -35,6 +36,48 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Spacing = new Vector2(0, 5),
                 ChildrenEnumerable = createTestPresets().Select(preset => new ModPresetPanel(preset.ToLiveUnmanaged()))
             });
+        }
+
+        [Test]
+        public void TestPresetSelectionStateAfterExternalModChanges()
+        {
+            ModPresetPanel? panel = null;
+
+            AddStep("create panel", () => Child = panel = new ModPresetPanel(createTestPresets().First().ToLiveUnmanaged())
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 0.5f
+            });
+            AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
+
+            AddStep("set mods to HR", () => SelectedMods.Value = new[] { new OsuModHardRock() });
+            AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
+
+            AddStep("set mods to DT", () => SelectedMods.Value = new[] { new OsuModDoubleTime() });
+            AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
+
+            AddStep("set mods to HR+DT", () => SelectedMods.Value = new Mod[] { new OsuModHardRock(), new OsuModDoubleTime() });
+            AddAssert("panel is active", () => panel.AsNonNull().Active.Value);
+
+            AddStep("set mods to HR+customised DT", () => SelectedMods.Value = new Mod[]
+            {
+                new OsuModHardRock(),
+                new OsuModDoubleTime
+                {
+                    SpeedChange = { Value = 1.25 }
+                }
+            });
+            AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
+
+            AddStep("set mods to HR+DT", () => SelectedMods.Value = new Mod[] { new OsuModHardRock(), new OsuModDoubleTime() });
+            AddAssert("panel is active", () => panel.AsNonNull().Active.Value);
+
+            AddStep("customise mod in place", () => SelectedMods.Value.OfType<OsuModDoubleTime>().Single().SpeedChange.Value = 1.33);
+            AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
+
+            AddStep("set mods to HD+HR+DT", () => SelectedMods.Value = new Mod[] { new OsuModHidden(), new OsuModHardRock(), new OsuModDoubleTime() });
+            AddAssert("panel is not active", () => !panel.AsNonNull().Active.Value);
         }
 
         private static IEnumerable<ModPreset> createTestPresets() => new[]


### PR DESCRIPTION
Up until now, clicking the mod preset panels didn't do anything but change the visual state of the panel. This changes with this PR.

While things aren't integrated it's a bit hard to convey what my intent was with these changes. I recommend reading the test cases, but the general gist of it is:

- Clicking an inactive mod preset panel causes current `SelectedMods` to change to the preset as it is given. Any and all previous mods are discarded regardless of compatibility.
- Because of the above, clicking an active mod preset panel to toggle it off just clears selected mods.
- The selection state is coupled to `SelectedMods` rather being an internal property of the mod panel. This has the following implications:
  - If you add or delete a mod after selecting a preset, the preset will automatically deselect, since the current mod selection no longer matches the preset.
  - If you manually select the exact set of mods that make up a preset one-by-one via the normal mod panels, the preset panel will automatically select when an exact match is detected. This feels nice, and avoids situations where you select the mods that make up a preset, then click the preset panel, and nothing other than the visual state of the mod preset panel changes.
  - As an aside, this also helps deal with the infamous mod reference replacement logic of the mod overlay.
- All of the above also takes mod settings into account. If you select a mod preset and then change settings of one of the mods, the preset panel will deactivate as the active mods no longer match the preset. But if you change the settings back to what's stored in the preset, the panel will reactivate.