### PR TITLE
Add mod preset column to solo mod select overlay

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddUntilStep("any column dimmed", () => this.ChildrenOfType<ModColumn>().Any(column => !column.Active.Value));
 
-            ModColumn lastColumn = null;
+            ModSelectColumn lastColumn = null;
 
             AddAssert("last column dimmed", () => !this.ChildrenOfType<ModColumn>().Last().Active.Value);
             AddStep("request scroll to last column", () =>

--- a/osu.Game/Localisation/MaintenanceSettingsStrings.cs
+++ b/osu.Game/Localisation/MaintenanceSettingsStrings.cs
@@ -74,6 +74,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString RestoreAllRecentlyDeletedBeatmaps => new TranslatableString(getKey(@"restore_all_recently_deleted_beatmaps"), @"Restore all recently deleted beatmaps");
 
+        /// <summary>
+        /// "Delete ALL mod presets"
+        /// </summary>
+        public static LocalisableString DeleteAllModPresets => new TranslatableString(getKey(@"delete_all_mod_presets"), @"Delete ALL mod presets");
+
+        /// <summary>
+        /// "Restore all recently deleted mod presets"
+        /// </summary>
+        public static LocalisableString RestoreAllRecentlyDeletedModPresets => new TranslatableString(getKey(@"restore_all_recently_deleted_mod_presets"), @"Restore all recently deleted mod presets");
+
         private static string getKey(string key) => $"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -11,12 +11,14 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
@@ -71,6 +73,11 @@ namespace osu.Game.Overlays.Mods
         /// Whether per-mod customisation controls are visible.
         /// </summary>
         protected virtual bool AllowCustomisation => true;
+
+        /// <summary>
+        /// Whether the column with available mod presets should be shown.
+        /// </summary>
+        protected virtual bool ShowPresets => false;
 
         protected virtual ModColumn CreateModColumn(ModType modType) => new ModColumn(modType, false);
 
@@ -139,40 +146,37 @@ namespace osu.Game.Overlays.Mods
 
             MainAreaContent.AddRange(new Drawable[]
             {
-                new Container
+                new OsuContextMenuContainer
                 {
-                    Padding = new MarginPadding
-                    {
-                        Top = (ShowTotalMultiplier ? DifficultyMultiplierDisplay.HEIGHT : 0) + PADDING,
-                        Bottom = PADDING
-                    },
                     RelativeSizeAxes = Axes.Both,
-                    RelativePositionAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Child = new PopoverContainer
                     {
-                        columnScroll = new ColumnScrollContainer
+                        Padding = new MarginPadding
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Masking = false,
-                            ClampExtension = 100,
-                            ScrollbarOverlapsContent = false,
-                            Child = columnFlow = new ColumnFlowContainer
+                            Top = (ShowTotalMultiplier ? DifficultyMultiplierDisplay.HEIGHT : 0) + PADDING,
+                            Bottom = PADDING
+                        },
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            columnScroll = new ColumnScrollContainer
                             {
-                                Anchor = Anchor.BottomLeft,
-                                Origin = Anchor.BottomLeft,
-                                Direction = FillDirection.Horizontal,
-                                Shear = new Vector2(SHEAR, 0),
-                                RelativeSizeAxes = Axes.Y,
-                                AutoSizeAxes = Axes.X,
-                                Margin = new MarginPadding { Horizontal = 70 },
-                                Padding = new MarginPadding { Bottom = 10 },
-                                Children = new[]
+                                RelativeSizeAxes = Axes.Both,
+                                Masking = false,
+                                ClampExtension = 100,
+                                ScrollbarOverlapsContent = false,
+                                Child = columnFlow = new ColumnFlowContainer
                                 {
-                                    createModColumnContent(ModType.DifficultyReduction),
-                                    createModColumnContent(ModType.DifficultyIncrease),
-                                    createModColumnContent(ModType.Automation),
-                                    createModColumnContent(ModType.Conversion),
-                                    createModColumnContent(ModType.Fun)
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Direction = FillDirection.Horizontal,
+                                    Shear = new Vector2(SHEAR, 0),
+                                    RelativeSizeAxes = Axes.Y,
+                                    AutoSizeAxes = Axes.X,
+                                    Margin = new MarginPadding { Horizontal = 70 },
+                                    Padding = new MarginPadding { Bottom = 10 },
+                                    ChildrenEnumerable = createColumns()
                                 }
                             }
                         }
@@ -282,6 +286,23 @@ namespace osu.Game.Overlays.Mods
                 column.DeselectAll();
         }
 
+        private IEnumerable<ColumnDimContainer> createColumns()
+        {
+            if (ShowPresets)
+            {
+                yield return new ColumnDimContainer(new ModPresetColumn
+                {
+                    Margin = new MarginPadding { Right = 10 }
+                });
+            }
+
+            yield return createModColumnContent(ModType.DifficultyReduction);
+            yield return createModColumnContent(ModType.DifficultyIncrease);
+            yield return createModColumnContent(ModType.Automation);
+            yield return createModColumnContent(ModType.Conversion);
+            yield return createModColumnContent(ModType.Fun);
+        }
+
         private ColumnDimContainer createModColumnContent(ModType modType)
         {
             var column = CreateModColumn(modType).With(column =>
@@ -290,12 +311,7 @@ namespace osu.Game.Overlays.Mods
                 column.Margin = new MarginPadding { Right = 10 };
             });
 
-            return new ColumnDimContainer(column)
-            {
-                AutoSizeAxes = Axes.X,
-                RelativeSizeAxes = Axes.Y,
-                RequestScroll = col => columnScroll.ScrollIntoView(col, extraScroll: 140),
-            };
+            return new ColumnDimContainer(column);
         }
 
         private void createLocalMods()
@@ -594,6 +610,7 @@ namespace osu.Game.Overlays.Mods
         /// <summary>
         /// Manages horizontal scrolling of mod columns, along with the "active" states of each column based on visibility.
         /// </summary>
+        [Cached]
         internal class ColumnScrollContainer : OsuScrollContainer<ColumnFlowContainer>
         {
             public ColumnScrollContainer()
@@ -668,10 +685,19 @@ namespace osu.Game.Overlays.Mods
             [Resolved]
             private OsuColour colours { get; set; } = null!;
 
-            public ColumnDimContainer(ModColumn column)
+            public ColumnDimContainer(ModSelectColumn column)
             {
+                AutoSizeAxes = Axes.X;
+                RelativeSizeAxes = Axes.Y;
+
                 Child = Column = column;
                 column.Active.BindTo(Active);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(ColumnScrollContainer columnScroll)
+            {
+                RequestScroll = col => columnScroll.ScrollIntoView(col, extraScroll: 140);
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/ModPresetSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/ModPresetSettings.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Framework.Logging;
+using osu.Game.Database;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Localisation;
+
+namespace osu.Game.Overlays.Settings.Sections.Maintenance
+{
+    public class ModPresetSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => "Mod presets";
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private INotificationOverlay? notificationOverlay { get; set; }
+
+        private SettingsButton undeleteButton = null!;
+        private SettingsButton deleteAllButton = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(IDialogOverlay? dialogOverlay)
+        {
+            AddRange(new Drawable[]
+            {
+                deleteAllButton = new DangerousSettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.DeleteAllModPresets,
+                    Action = () =>
+                    {
+                        dialogOverlay?.Push(new MassDeleteConfirmationDialog(() =>
+                        {
+                            deleteAllButton.Enabled.Value = false;
+                            Task.Run(deleteAllModPresets).ContinueWith(t => Schedule(onAllModPresetsDeleted, t));
+                        }));
+                    }
+                },
+                undeleteButton = new SettingsButton
+                {
+                    Text = MaintenanceSettingsStrings.RestoreAllRecentlyDeletedModPresets,
+                    Action = () => Task.Run(undeleteModPresets).ContinueWith(t => Schedule(onModPresetsUndeleted, t))
+                }
+            });
+        }
+
+        private void deleteAllModPresets() =>
+            realm.Write(r =>
+            {
+                foreach (var preset in r.All<ModPreset>())
+                    preset.DeletePending = true;
+            });
+
+        private void onAllModPresetsDeleted(Task deletionTask)
+        {
+            deleteAllButton.Enabled.Value = true;
+
+            if (deletionTask.IsCompletedSuccessfully)
+                notificationOverlay?.Post(new ProgressCompletionNotification { Text = "Deleted all mod presets!" });
+            else if (deletionTask.IsFaulted)
+                Logger.Error(deletionTask.Exception, "Failed to delete all mod presets");
+        }
+
+        private void undeleteModPresets() =>
+            realm.Write(r =>
+            {
+                foreach (var preset in r.All<ModPreset>().Where(preset => preset.DeletePending))
+                    preset.DeletePending = false;
+            });
+
+        private void onModPresetsUndeleted(Task undeletionTask)
+        {
+            undeleteButton.Enabled.Value = true;
+
+            if (undeletionTask.IsCompletedSuccessfully)
+                notificationOverlay?.Post(new ProgressCompletionNotification { Text = "Restored all deleted mod presets!" });
+            else if (undeletionTask.IsFaulted)
+                Logger.Error(undeletionTask.Exception, "Failed to restore mod presets");
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -25,7 +25,8 @@ namespace osu.Game.Overlays.Settings.Sections
                 new BeatmapSettings(),
                 new SkinSettings(),
                 new CollectionsSettings(),
-                new ScoreSettings()
+                new ScoreSettings(),
+                new ModPresetSettings()
             };
         }
     }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -313,7 +313,7 @@ namespace osu.Game.Screens.Select
             (new FooterButtonOptions(), BeatmapOptions)
         };
 
-        protected virtual ModSelectOverlay CreateModSelectOverlay() => new UserModSelectOverlay();
+        protected virtual ModSelectOverlay CreateModSelectOverlay() => new SoloModSelectOverlay();
 
         protected virtual void ApplyFilterToCarousel(FilterCriteria criteria)
         {
@@ -926,6 +926,11 @@ namespace osu.Game.Screens.Select
                 onHoverAction?.Invoke();
                 return base.OnHover(e);
             }
+        }
+
+        private class SoloModSelectOverlay : UserModSelectOverlay
+        {
+            protected override bool ShowPresets => true;
         }
     }
 }


### PR DESCRIPTION
- [x] Depends on #19621

https://user-images.githubusercontent.com/20418176/183298198-9aef2309-7c59-45c6-96b6-8745fbed4177.mp4

PR also adds buttons for mod preset management to maintenance settings section.

This is only supported in solo for the time being, as it is the simplest case. The other three places where mod select screens are present cause issues that are not addressed with the current implementations, namely:

1. Supporting presets when selecting required mods for a playlist item in multiplayer is problematic because some mods are not playable in multiplayer at all. A way to filter out or dim inapplicable mod presets is required.
2. Supporting presets when selecting free mods for a playlist item in multiplayer is problematic because the notion of a "mod preset" changes.

    For instance, imagine that you may want to create a preset of optional mods that has Perfect and Sudden Death in it - this only makes sense when selecting optional mods, but does not make sense for individual user mod selection because the mods are... incompatible. Adding this support would likely entail adding a "preset type" enumeration (`UserModPreset`, `FreeModPreset`, etc.) - and even then, there are concerns about how to convey the distinction.
5. Supporting presets when selecting which of the free mods you want to choose as a user is problematic for pretty much the same reasons as case (1) - a way to filter inapplicable mod presets is required.