### PR TITLE
Add missing localisation for settings enums and mods tooltips

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.UI;
@@ -31,18 +32,18 @@ namespace osu.Game.Rulesets.Mania
             {
                 new SettingsEnumDropdown<ManiaScrollingDirection>
                 {
-                    LabelText = "Scrolling direction",
+                    LabelText = ManiaSettingsSubsectionStrings.ScrollingDirection,
                     Current = config.GetBindable<ManiaScrollingDirection>(ManiaRulesetSetting.ScrollDirection)
                 },
                 new SettingsSlider<double, TimeSlider>
                 {
-                    LabelText = "Scroll speed",
+                    LabelText = ManiaSettingsSubsectionStrings.ScrollSpeed,
                     Current = config.GetBindable<double>(ManiaRulesetSetting.ScrollTime),
                     KeyboardStep = 5
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Timing-based note colouring",
+                    LabelText = ManiaSettingsSubsectionStrings.TimingBasedNoteColouring,
                     Current = config.GetBindable<bool>(ManiaRulesetSetting.TimingBasedNoteColouring),
                 }
             };

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -9,6 +9,7 @@ using osu.Framework.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.UI;
+using osu.Game.Localisation;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -30,23 +31,23 @@ namespace osu.Game.Rulesets.Osu.UI
             {
                 new SettingsCheckbox
                 {
-                    LabelText = "Snaking in sliders",
+                    LabelText = OsuSettingsSubsectionStrings.SnakingInSliders,
                     Current = config.GetBindable<bool>(OsuRulesetSetting.SnakingInSliders)
                 },
                 new SettingsCheckbox
                 {
                     ClassicDefault = false,
-                    LabelText = "Snaking out sliders",
+                    LabelText = OsuSettingsSubsectionStrings.SnakingOutSliders,
                     Current = config.GetBindable<bool>(OsuRulesetSetting.SnakingOutSliders)
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Cursor trail",
+                    LabelText = OsuSettingsSubsectionStrings.CursorTrail,
                     Current = config.GetBindable<bool>(OsuRulesetSetting.ShowCursorTrail)
                 },
                 new SettingsEnumDropdown<PlayfieldBorderStyle>
                 {
-                    LabelText = "Playfield border style",
+                    LabelText = OsuSettingsSubsectionStrings.PlayfieldBorderStyle,
                     Current = config.GetBindable<PlayfieldBorderStyle>(OsuRulesetSetting.PlayfieldBorderStyle),
                 },
             };

--- a/osu.Game/Configuration/BackgroundSource.cs
+++ b/osu.Game/Configuration/BackgroundSource.cs
@@ -3,16 +3,20 @@
 
 #nullable disable
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Configuration
 {
     public enum BackgroundSource
     {
+        [LocalisableDescription(typeof(SkinSettingsStrings), nameof(SkinSettingsStrings.SkinSectionHeader))]
         Skin,
+
+        [LocalisableDescription(typeof(GameplaySettingsStrings), nameof(GameplaySettingsStrings.BeatmapHeader))]
         Beatmap,
 
-        [Description("Beatmap (with storyboard / video)")]
+        [LocalisableDescription(typeof(BackgroundSourceStrings), nameof(BackgroundSourceStrings.BeatmapWithStoryboard))]
         BeatmapWithStoryboard,
     }
 }

--- a/osu.Game/Configuration/DiscordRichPresenceMode.cs
+++ b/osu.Game/Configuration/DiscordRichPresenceMode.cs
@@ -10,13 +10,13 @@ namespace osu.Game.Configuration
 {
     public enum DiscordRichPresenceMode
     {
-        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Off))]
+        [LocalisableDescription(typeof(DiscordRichPresenceModeStrings), nameof(DiscordRichPresenceModeStrings.Off))]
         Off,
 
         [LocalisableDescription(typeof(DiscordRichPresenceModeStrings), nameof(DiscordRichPresenceModeStrings.HideIdentifiableInformation))]
         Limited,
 
-        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Full))]
+        [LocalisableDescription(typeof(DiscordRichPresenceModeStrings), nameof(DiscordRichPresenceModeStrings.Full))]
         Full
     }
 }

--- a/osu.Game/Configuration/DiscordRichPresenceMode.cs
+++ b/osu.Game/Configuration/DiscordRichPresenceMode.cs
@@ -3,17 +3,20 @@
 
 #nullable disable
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Configuration
 {
     public enum DiscordRichPresenceMode
     {
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Off))]
         Off,
 
-        [Description("Hide identifiable information")]
+        [LocalisableDescription(typeof(DiscordRichPresenceModeStrings), nameof(DiscordRichPresenceModeStrings.HideIdentifiableInformation))]
         Limited,
 
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Full))]
         Full
     }
 }

--- a/osu.Game/Configuration/HUDVisibilityMode.cs
+++ b/osu.Game/Configuration/HUDVisibilityMode.cs
@@ -3,17 +3,20 @@
 
 #nullable disable
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Configuration
 {
     public enum HUDVisibilityMode
     {
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Never))]
         Never,
 
-        [Description("Hide during gameplay")]
+        [LocalisableDescription(typeof(HUDVisibilityModeStrings), nameof(HUDVisibilityModeStrings.HideDuringGameplay))]
         HideDuringGameplay,
 
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Always))]
         Always
     }
 }

--- a/osu.Game/Configuration/RandomSelectAlgorithm.cs
+++ b/osu.Game/Configuration/RandomSelectAlgorithm.cs
@@ -3,16 +3,17 @@
 
 #nullable disable
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Configuration
 {
     public enum RandomSelectAlgorithm
     {
-        [Description("Never repeat")]
+        [LocalisableDescription(typeof(RandomSelectAlgorithmStrings), nameof(RandomSelectAlgorithmStrings.NeverRepeat))]
         RandomPermutation,
 
-        [Description("True Random")]
+        [LocalisableDescription(typeof(RandomSelectAlgorithmStrings), nameof(RandomSelectAlgorithmStrings.TrueRandom))]
         Random
     }
 }

--- a/osu.Game/Configuration/ScalingMode.cs
+++ b/osu.Game/Configuration/ScalingMode.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Configuration
 {
     public enum ScalingMode
     {
-        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Off))]
+        [LocalisableDescription(typeof(ScalingModeStrings), nameof(ScalingModeStrings.Off))]
         Off,
 
         [LocalisableDescription(typeof(ScalingModeStrings), nameof(ScalingModeStrings.Everything))]

--- a/osu.Game/Configuration/ScalingMode.cs
+++ b/osu.Game/Configuration/ScalingMode.cs
@@ -3,17 +3,23 @@
 
 #nullable disable
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Configuration
 {
     public enum ScalingMode
     {
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Off))]
         Off,
+
+        [LocalisableDescription(typeof(ScalingModeStrings), nameof(ScalingModeStrings.Everything))]
         Everything,
 
-        [Description("Excluding overlays")]
+        [LocalisableDescription(typeof(ScalingModeStrings), nameof(ScalingModeStrings.ExcludingOverlays))]
         ExcludeOverlays,
+
+        [LocalisableDescription(typeof(ScalingModeStrings), nameof(ScalingModeStrings.Gameplay))]
         Gameplay,
     }
 }

--- a/osu.Game/Configuration/ScreenshotFormat.cs
+++ b/osu.Game/Configuration/ScreenshotFormat.cs
@@ -3,16 +3,17 @@
 
 #nullable disable
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Configuration
 {
     public enum ScreenshotFormat
     {
-        [Description("JPG (web-friendly)")]
+        [LocalisableDescription(typeof(ScreenshotFormatStrings), nameof(ScreenshotFormatStrings.JPGWebFriendly))]
         Jpg = 1,
 
-        [Description("PNG (lossless)")]
+        [LocalisableDescription(typeof(ScreenshotFormatStrings), nameof(ScreenshotFormatStrings.PNGLossless))]
         Png = 2
     }
 }

--- a/osu.Game/Configuration/SeasonalBackgroundMode.cs
+++ b/osu.Game/Configuration/SeasonalBackgroundMode.cs
@@ -3,6 +3,9 @@
 
 #nullable disable
 
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+
 namespace osu.Game.Configuration
 {
     public enum SeasonalBackgroundMode
@@ -10,16 +13,19 @@ namespace osu.Game.Configuration
         /// <summary>
         /// Seasonal backgrounds are shown regardless of season, if at all available.
         /// </summary>
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Always))]
         Always,
 
         /// <summary>
         /// Seasonal backgrounds are shown only during their corresponding season.
         /// </summary>
+        [LocalisableDescription(typeof(SeasonalBackgroundModeStrings), nameof(SeasonalBackgroundModeStrings.Sometimes))]
         Sometimes,
 
         /// <summary>
         /// Seasonal backgrounds are never shown.
         /// </summary>
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Never))]
         Never
     }
 }

--- a/osu.Game/Input/OsuConfineMouseMode.cs
+++ b/osu.Game/Input/OsuConfineMouseMode.cs
@@ -3,8 +3,9 @@
 
 #nullable disable
 
-using System.ComponentModel;
 using osu.Framework.Input;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Input
 {
@@ -17,18 +18,20 @@ namespace osu.Game.Input
         /// <summary>
         /// The mouse cursor will be free to move outside the game window.
         /// </summary>
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Never))]
         Never,
 
         /// <summary>
         /// The mouse cursor will be locked to the window bounds during gameplay,
         /// but may otherwise move freely.
         /// </summary>
-        [Description("During Gameplay")]
+        [LocalisableDescription(typeof(OsuConfineMouseModeStrings), nameof(OsuConfineMouseModeStrings.DuringGameplay))]
         DuringGameplay,
 
         /// <summary>
         /// The mouse cursor will always be locked to the window bounds while the game has focus.
         /// </summary>
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Always))]
         Always
     }
 }

--- a/osu.Game/Localisation/BackgroundSourceStrings.cs
+++ b/osu.Game/Localisation/BackgroundSourceStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class BackgroundSourceStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.BackgroundSource";
+
+        /// <summary>
+        /// "Beatmap (with storyboard / video)"
+        /// </summary>
+        public static LocalisableString BeatmapWithStoryboard => new TranslatableString(getKey(@"beatmap_with_storyboard"), @"Beatmap (with storyboard / video)");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -99,6 +99,31 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Description => new TranslatableString(getKey(@"description"), @"Description");
 
+        /// <summary>
+        /// "Always"
+        /// </summary>
+        public static LocalisableString Always => new TranslatableString(getKey(@"always"), @"Always");
+
+        /// <summary>
+        /// "Never"
+        /// </summary>
+        public static LocalisableString Never => new TranslatableString(getKey(@"never"), @"Never");
+
+        /// <summary>
+        /// "None"
+        /// </summary>
+        public static LocalisableString None => new TranslatableString(getKey(@"none"), @"None");
+
+        /// <summary>
+        /// "Full"
+        /// </summary>
+        public static LocalisableString Full => new TranslatableString(getKey(@"full"), @"Full");
+
+        /// <summary>
+        /// "Off"
+        /// </summary>
+        public static LocalisableString Off => new TranslatableString(getKey(@"off"), @"Off");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/DiscordRichPresenceModeStrings.cs
+++ b/osu.Game/Localisation/DiscordRichPresenceModeStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class DiscordRichPresenceModeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.DiscordRichPresenceMode";
+
+        /// <summary>
+        /// "Hide identifiable information"
+        /// </summary>
+        public static LocalisableString HideIdentifiableInformation => new TranslatableString(getKey(@"hide_identifiable_information"), @"Hide identifiable information");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/DiscordRichPresenceModeStrings.cs
+++ b/osu.Game/Localisation/DiscordRichPresenceModeStrings.cs
@@ -14,6 +14,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString HideIdentifiableInformation => new TranslatableString(getKey(@"hide_identifiable_information"), @"Hide identifiable information");
 
+        /// <summary>
+        /// "Full"
+        /// </summary>
+        public static LocalisableString Full => new TranslatableString(getKey(@"rich_presence.full"), @"Full");
+
+        /// <summary>
+        /// "Off"
+        /// </summary>
+        public static LocalisableString Off => new TranslatableString(getKey(@"rich_presence.off"), @"Off");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/HUDVisibilityModeStrings.cs
+++ b/osu.Game/Localisation/HUDVisibilityModeStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class HUDVisibilityModeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.HUDVisibilityMode";
+
+        /// <summary>
+        /// "Hide during gameplay"
+        /// </summary>
+        public static LocalisableString HideDuringGameplay => new TranslatableString(getKey(@"hide_during_gameplay"), @"Hide during gameplay");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/IncompatibilityDisplayingTooltipStrings.cs
+++ b/osu.Game/Localisation/IncompatibilityDisplayingTooltipStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class IncompatibilityDisplayingTooltipStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.IncompatibilityDisplayingTooltip";
+
+        /// <summary>
+        /// "Incompatible with:"
+        /// </summary>
+        public static LocalisableString IncompatibleWith => new TranslatableString(getKey(@"incompatible_with"), @"Incompatible with:");
+
+        /// <summary>
+        /// "Compatible with all mods"
+        /// </summary>
+        public static LocalisableString CompatibleWithAllMods => new TranslatableString(getKey(@"compatible_with_all_mods"), @"Compatible with all mods");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/ManiaSettingsSubsectionStrings.cs
+++ b/osu.Game/Localisation/ManiaSettingsSubsectionStrings.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ManiaSettingsSubsectionStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ManiaSettingsSubsection";
+
+        /// <summary>
+        /// "Scrolling direction"
+        /// </summary>
+        public static LocalisableString ScrollingDirection => new TranslatableString(getKey(@"scrolling_direction"), @"Scrolling direction");
+
+        /// <summary>
+        /// "Scroll speed"
+        /// </summary>
+        public static LocalisableString ScrollSpeed => new TranslatableString(getKey(@"scroll_speed"), @"Scroll speed");
+
+        /// <summary>
+        /// "Timing-based note colouring"
+        /// </summary>
+        public static LocalisableString TimingBasedNoteColouring => new TranslatableString(getKey(@"timing_based_note_colouring"), @"Timing-based note colouring");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/ModSelectHotkeyStyleStrings.cs
+++ b/osu.Game/Localisation/ModSelectHotkeyStyleStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ModSelectHotkeyStyleStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ModSelectHotkeyStyle";
+
+        /// <summary>
+        /// "Sequential"
+        /// </summary>
+        public static LocalisableString Sequential => new TranslatableString(getKey(@"sequential"), @"Sequential");
+
+        /// <summary>
+        /// "Classic"
+        /// </summary>
+        public static LocalisableString Classic => new TranslatableString(getKey(@"classic"), @"Classic");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/OsuConfineMouseModeStrings.cs
+++ b/osu.Game/Localisation/OsuConfineMouseModeStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class OsuConfineMouseModeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.OsuConfineMouseMode";
+
+        /// <summary>
+        /// "During Gameplay"
+        /// </summary>
+        public static LocalisableString DuringGameplay => new TranslatableString(getKey(@"during_gameplay"), @"During Gameplay");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/OsuSettingsSubsectionStrings.cs
+++ b/osu.Game/Localisation/OsuSettingsSubsectionStrings.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class OsuSettingsSubsectionStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.OsuSettingsSubsection";
+
+        /// <summary>
+        /// "Snaking in sliders"
+        /// </summary>
+        public static LocalisableString SnakingInSliders => new TranslatableString(getKey(@"snaking_in_sliders"), @"Snaking in sliders");
+
+        /// <summary>
+        /// "Snaking out sliders"
+        /// </summary>
+        public static LocalisableString SnakingOutSliders => new TranslatableString(getKey(@"snaking_out_sliders"), @"Snaking out sliders");
+
+        /// <summary>
+        /// "Cursor trail"
+        /// </summary>
+        public static LocalisableString CursorTrail => new TranslatableString(getKey(@"cursor_trail"), @"Cursor trail");
+
+        /// <summary>
+        /// "Playfield border style"
+        /// </summary>
+        public static LocalisableString PlayfieldBorderStyle => new TranslatableString(getKey(@"playfield_border_style"), @"Playfield border style");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/PlayfieldBorderStyleStrings.cs
+++ b/osu.Game/Localisation/PlayfieldBorderStyleStrings.cs
@@ -14,6 +14,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Corners => new TranslatableString(getKey(@"corners"), @"Corners");
 
+        /// <summary>
+        /// "Full"
+        /// </summary>
+        public static LocalisableString Full => new TranslatableString(getKey(@"play_field_border_style.full"), @"Full");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/PlayfieldBorderStyleStrings.cs
+++ b/osu.Game/Localisation/PlayfieldBorderStyleStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class PlayfieldBorderStyleStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.PlayfieldBorderStyle";
+
+        /// <summary>
+        /// "Corners"
+        /// </summary>
+        public static LocalisableString Corners => new TranslatableString(getKey(@"corners"), @"Corners");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/RandomSelectAlgorithmStrings.cs
+++ b/osu.Game/Localisation/RandomSelectAlgorithmStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class RandomSelectAlgorithmStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.RandomSelectAlgorithm";
+
+        /// <summary>
+        /// "Never repeat"
+        /// </summary>
+        public static LocalisableString NeverRepeat => new TranslatableString(getKey(@"never_repeat"), @"Never repeat");
+
+        /// <summary>
+        /// "True Random"
+        /// </summary>
+        public static LocalisableString TrueRandom => new TranslatableString(getKey(@"true_random"), @"True Random");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/ScalingModeStrings.cs
+++ b/osu.Game/Localisation/ScalingModeStrings.cs
@@ -24,6 +24,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Gameplay => new TranslatableString(getKey(@"gameplay"), @"Gameplay");
 
+        /// <summary>
+        /// "Off"
+        /// </summary>
+        public static LocalisableString Off => new TranslatableString(getKey(@"scaling_mode.off"), @"Off");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/ScalingModeStrings.cs
+++ b/osu.Game/Localisation/ScalingModeStrings.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ScalingModeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ScalingMode";
+
+        /// <summary>
+        /// "Excluding overlays"
+        /// </summary>
+        public static LocalisableString ExcludingOverlays => new TranslatableString(getKey(@"excluding_overlays"), @"Excluding overlays");
+
+        /// <summary>
+        /// "Everything"
+        /// </summary>
+        public static LocalisableString Everything => new TranslatableString(getKey(@"everything"), @"Everything");
+
+        /// <summary>
+        /// "Gameplay"
+        /// </summary>
+        public static LocalisableString Gameplay => new TranslatableString(getKey(@"gameplay"), @"Gameplay");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/ScoringModeStrings.cs
+++ b/osu.Game/Localisation/ScoringModeStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ScoringModeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ScoringMode";
+
+        /// <summary>
+        /// "Standardised"
+        /// </summary>
+        public static LocalisableString Standardised => new TranslatableString(getKey(@"standardised"), @"Standardised");
+
+        /// <summary>
+        /// "Classic"
+        /// </summary>
+        public static LocalisableString Classic => new TranslatableString(getKey(@"classic"), @"Classic");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/ScreenshotFormatStrings.cs
+++ b/osu.Game/Localisation/ScreenshotFormatStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ScreenshotFormatStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ScreenshotFormat";
+
+        /// <summary>
+        /// "JPG (web-friendly)"
+        /// </summary>
+        public static LocalisableString JPGWebFriendly => new TranslatableString(getKey(@"jpgweb_friendly"), @"JPG (web-friendly)");
+
+        /// <summary>
+        /// "PNG (lossless)"
+        /// </summary>
+        public static LocalisableString PNGLossless => new TranslatableString(getKey(@"pnglossless"), @"PNG (lossless)");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/SeasonalBackgroundModeStrings.cs
+++ b/osu.Game/Localisation/SeasonalBackgroundModeStrings.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class SeasonalBackgroundModeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.SeasonalBackgroundMode";
+
+        /// <summary>
+        /// "Sometimes"
+        /// </summary>
+        public static LocalisableString Sometimes => new TranslatableString(getKey(@"sometimes"), @"Sometimes");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingTooltip.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingTooltip.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -34,7 +35,7 @@ namespace osu.Game.Overlays.Mods
                 {
                     Margin = new MarginPadding { Top = 5 },
                     Font = OsuFont.GetFont(weight: FontWeight.Regular),
-                    Text = "Incompatible with:"
+                    Text = IncompatibilityDisplayingTooltipStrings.IncompatibleWith
                 },
                 new ModDisplay
                 {
@@ -60,7 +61,7 @@ namespace osu.Game.Overlays.Mods
             var allMods = ruleset.Value.CreateInstance().AllMods;
 
             incompatibleMods.Value = allMods.Where(m => m.GetType() != mod.GetType() && incompatibleTypes.Any(t => t.IsInstanceOfType(m))).Select(m => m.CreateInstance()).ToList();
-            incompatibleText.Text = incompatibleMods.Value.Any() ? "Incompatible with:" : "Compatible with all mods";
+            incompatibleText.Text = incompatibleMods.Value.Any() ? IncompatibilityDisplayingTooltipStrings.IncompatibleWith : IncompatibilityDisplayingTooltipStrings.CompatibleWithAllMods;
         }
     }
 }

--- a/osu.Game/Overlays/Mods/Input/ModSelectHotkeyStyle.cs
+++ b/osu.Game/Overlays/Mods/Input/ModSelectHotkeyStyle.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods.Input
 {
@@ -15,6 +17,7 @@ namespace osu.Game.Overlays.Mods.Input
         /// Individual letters in a row trigger the mods in a sequential fashion.
         /// Uses <see cref="SequentialModHotkeyHandler"/>.
         /// </summary>
+        [LocalisableDescription(typeof(ModSelectHotkeyStyleStrings), nameof(ModSelectHotkeyStyleStrings.Sequential))]
         Sequential,
 
         /// <summary>
@@ -22,6 +25,7 @@ namespace osu.Game.Overlays.Mods.Input
         /// One keybinding can toggle between what used to be <see cref="MultiMod"/>s on stable,
         /// and some mods in a column may not have any hotkeys at all.
         /// </summary>
+        [LocalisableDescription(typeof(ModSelectHotkeyStyleStrings), nameof(ModSelectHotkeyStyleStrings.Classic))]
         Classic
     }
 }

--- a/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
+++ b/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Overlays.Music
                                 break;
 
                             case PreviousTrackResult.Previous:
-                                onScreenDisplay?.Display(new MusicActionToast(GlobalActionKeyBindingStrings.MusicPrev, e.Action));
+                                onScreenDisplay?.Display(new MusicActionToast("Test", e.Action));
                                 break;
                         }
                     });

--- a/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
+++ b/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Overlays.Music
                                 break;
 
                             case PreviousTrackResult.Previous:
-                                onScreenDisplay?.Display(new MusicActionToast("Test", e.Action));
+                                onScreenDisplay?.Display(new MusicActionToast(GlobalActionKeyBindingStrings.MusicPrev, e.Action));
                                 break;
                         }
                     });

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -16,6 +16,8 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Scoring;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Rulesets.Scoring
 {
@@ -636,7 +638,10 @@ namespace osu.Game.Rulesets.Scoring
 
     public enum ScoringMode
     {
+        [LocalisableDescription(typeof(ScoringModeStrings), nameof(ScoringModeStrings.Standardised))]
         Standardised,
+
+        [LocalisableDescription(typeof(ScoringModeStrings), nameof(ScoringModeStrings.Classic))]
         Classic
     }
 }

--- a/osu.Game/Rulesets/UI/PlayfieldBorderStyle.cs
+++ b/osu.Game/Rulesets/UI/PlayfieldBorderStyle.cs
@@ -3,12 +3,20 @@
 
 #nullable disable
 
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+
 namespace osu.Game.Rulesets.UI
 {
     public enum PlayfieldBorderStyle
     {
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.None))]
         None,
+
+        [LocalisableDescription(typeof(PlayfieldBorderStyleStrings), nameof(PlayfieldBorderStyleStrings.Corners))]
         Corners,
+
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Full))]
         Full
     }
 }

--- a/osu.Game/Rulesets/UI/PlayfieldBorderStyle.cs
+++ b/osu.Game/Rulesets/UI/PlayfieldBorderStyle.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.UI
         [LocalisableDescription(typeof(PlayfieldBorderStyleStrings), nameof(PlayfieldBorderStyleStrings.Corners))]
         Corners,
 
-        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Full))]
+        [LocalisableDescription(typeof(PlayfieldBorderStyleStrings), nameof(PlayfieldBorderStyleStrings.Full))]
         Full
     }
 }


### PR DESCRIPTION
I've added localisation support for some settings labels and enums, so the settings are 99% localised.