### PR TITLE
Fix possible null assignment inspection in `TestScenePreviewTrackManager`

### DIFF
--- a/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
+++ b/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Tests.Visual.Components
             AddAssert("track stopped", () => !track.IsRunning);
         }
 
-        private TestPreviewTrackManager.TestPreviewTrack getTrack() => (TestPreviewTrackManager.TestPreviewTrack)trackManager.Get(null);
+        private TestPreviewTrackManager.TestPreviewTrack getTrack() => (TestPreviewTrackManager.TestPreviewTrack)trackManager.Get(CreateAPIBeatmapSet());
 
         private TestPreviewTrackManager.TestPreviewTrack getOwnedTrack()
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22781491/183314372-3270749c-12e4-4120-9c12-2a356a8eb6b8.png)

Somehow CI skipped this. Possibly due to a stale cache.