### PR TITLE
Fix FPS counter disappearing when hovered over

### DIFF
--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Graphics.UserInterface
 
             if (hasSignificantChanges)
                 requestDisplay();
-            else if (isDisplayed && Time.Current - lastDisplayRequiredTime > 2000)
+            else if (isDisplayed && Time.Current - lastDisplayRequiredTime > 2000 && !IsHovered)
             {
                 mainContent.FadeTo(0, 300, Easing.OutQuint);
                 isDisplayed = false;


### PR DESCRIPTION
This PR fixes issue #19629, where the FPS counter would disappear even if it's hovered over.