### PR TITLE
Fix incorrect FPS damping implementation

### DIFF
--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -177,15 +177,15 @@ namespace osu.Game.Graphics.UserInterface
             // use elapsed frame time rather then FramesPerSecond to better catch stutter frames.
             bool hasDrawSpike = displayedFpsCount > (1000 / spike_time_ms) && drawClock.ElapsedFrameTime > spike_time_ms;
 
-            // note that we use an elapsed time here of 1 intentionally.
-            // this weights all updates equally. if we passed in the elapsed time, longer frames would be weighted incorrectly lower.
-            displayedFrameTime = Interpolation.DampContinuously(displayedFrameTime, updateClock.ElapsedFrameTime, hasUpdateSpike ? 0 : 100, 1);
+            const float damp_time = 100;
+
+            displayedFrameTime = Interpolation.DampContinuously(displayedFrameTime, updateClock.ElapsedFrameTime, hasUpdateSpike ? 0 : damp_time, updateClock.ElapsedFrameTime);
 
             if (hasDrawSpike)
                 // show spike time using raw elapsed value, to account for `FramesPerSecond` being so averaged spike frames don't show.
                 displayedFpsCount = 1000 / drawClock.ElapsedFrameTime;
             else
-                displayedFpsCount = Interpolation.DampContinuously(displayedFpsCount, drawClock.FramesPerSecond, 100, Time.Elapsed);
+                displayedFpsCount = Interpolation.DampContinuously(displayedFpsCount, drawClock.FramesPerSecond, damp_time, Time.Elapsed);
 
             if (Time.Current - lastUpdate > min_time_between_updates)
             {

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -167,6 +167,11 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.Update();
 
+            // If the game goes into a suspended state (ie. debugger attached or backgrounded on a mobile device)
+            // we want to ignore really long periods of no processing.
+            if (updateClock.ElapsedFrameTime > 10000)
+                return;
+
             mainContent.Width = Math.Max(mainContent.Width, counters.DrawWidth);
 
             // Handle the case where the window has become inactive or the user changed the


### PR DESCRIPTION
I'm not sure what I was thinking with the weighting stuff. It wasn't correct. Can most easily be noticed if suspending the app on iOS for a considerable period, or pausing debugger.

If testing, make sure to revert 4f7d63. Even though the former commit fixes the number sticking at stupid values for minutes at a time, it's still beneficial to ignore them altogether, else the FPS counter can get wider than it needs to be (after displaying `60,000ms` or something for a single frame or two).

`master`:

https://user-images.githubusercontent.com/191335/183353085-0adfc4ed-79fa-44e0-8772-e27800415f8d.mp4

this PR (first commit only):

https://user-images.githubusercontent.com/191335/183353531-f44a7689-3b24-4026-8c7e-dc474a92fce8.mp4

this PR (both commits):

https://user-images.githubusercontent.com/191335/183354128-4903128d-e640-45c5-88ff-d6a9dff9ad21.mp4


