### PR TITLE
Adjust visuals of osu!mania barlines to be less present

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneBarLine.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneBarLine.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.UI;
+
+namespace osu.Game.Rulesets.Mania.Tests.Skinning
+{
+    public class TestSceneBarLine : ManiaSkinnableTestScene
+    {
+        [Test]
+        public void TestMinor()
+        {
+            AddStep("Create barlines", () => recreate());
+        }
+
+        private void recreate(Func<IEnumerable<BarLine>>? createBarLines = null)
+        {
+            var stageDefinitions = new List<StageDefinition>
+            {
+                new StageDefinition { Columns = 4 },
+            };
+
+            SetContents(_ => new ManiaPlayfield(stageDefinitions).With(s =>
+            {
+                if (createBarLines != null)
+                {
+                    var barLines = createBarLines();
+
+                    foreach (var b in barLines)
+                        s.Add(b);
+
+                    return;
+                }
+
+                for (int i = 0; i < 64; i++)
+                {
+                    s.Add(new BarLine
+                    {
+                        StartTime = Time.Current + i * 500,
+                        Major = i % 4 == 0,
+                    });
+                }
+            }));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
@@ -16,21 +13,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public class DrawableBarLine : DrawableManiaHitObject<BarLine>
     {
-        /// <summary>
-        /// Height of major bar line triangles.
-        /// </summary>
-        private const float triangle_height = 12;
-
-        /// <summary>
-        /// Offset of the major bar line triangles from the sides of the bar line.
-        /// </summary>
-        private const float triangle_offset = 9;
-
         public DrawableBarLine(BarLine barLine)
             : base(barLine)
         {
             RelativeSizeAxes = Axes.X;
-            Height = 2f;
+            Height = barLine.Major ? 1.7f : 1.2f;
 
             AddInternal(new Box
             {
@@ -38,34 +25,33 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 Anchor = Anchor.BottomCentre,
                 Origin = Anchor.BottomCentre,
                 RelativeSizeAxes = Axes.Both,
-                Colour = new Color4(255, 204, 33, 255),
+                Alpha = barLine.Major ? 0.5f : 0.2f
             });
 
             if (barLine.Major)
             {
-                AddInternal(new EquilateralTriangle
+                Vector2 size = new Vector2(22, 6);
+                const float triangle_offset = 4;
+
+                AddInternal(new Circle
                 {
-                    Name = "Left triangle",
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.TopCentre,
-                    Size = new Vector2(triangle_height),
+                    Name = "Left line",
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreRight,
+
+                    Size = size,
                     X = -triangle_offset,
-                    Rotation = 90
                 });
 
-                AddInternal(new EquilateralTriangle
+                AddInternal(new Circle
                 {
-                    Name = "Right triangle",
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.TopCentre,
-                    Size = new Vector2(triangle_height),
+                    Name = "Right line",
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreLeft,
+                    Size = size,
                     X = triangle_offset,
-                    Rotation = -90
                 });
             }
-
-            if (!barLine.Major)
-                Alpha = 0.2f;
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (barLine.Major)
             {
                 Vector2 size = new Vector2(22, 6);
-                const float triangle_offset = 4;
+                const float line_offset = 4;
 
                 AddInternal(new Circle
                 {
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     Origin = Anchor.CentreRight,
 
                     Size = size,
-                    X = -triangle_offset,
+                    X = -line_offset,
                 });
 
                 AddInternal(new Circle
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreLeft,
                     Size = size,
-                    X = triangle_offset,
+                    X = line_offset,
                 });
             }
         }


### PR DESCRIPTION
Roughly matches the new design. Metrics adjusted to fit with the existing design.

Closes #19611 maybe?

Before:

![osu Game Rulesets Mania Tests 2022-08-08 at 08 41 05](https://user-images.githubusercontent.com/191335/183376996-d1d235a6-a159-4306-b285-da2a5a89f794.png)

After:

![osu Game Rulesets Mania Tests 2022-08-08 at 08 40 49](https://user-images.githubusercontent.com/191335/183376945-7964ec58-0228-4d3d-aeb2-1e47f491bfc0.png)

