### PR TITLE
Fix spurious sample playbacks from already-removed mod preset panels

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestSoftDeleteSupport()
         {
             AddStep("set osu! ruleset", () => Ruleset.Value = rulesets.GetRuleset(0));
+            AddStep("clear mods", () => SelectedMods.Value = Array.Empty<Mod>());
             AddStep("create content", () => Child = new ModPresetColumn
             {
                 Anchor = Anchor.Centre,
@@ -153,9 +154,11 @@ namespace osu.Game.Tests.Visual.UserInterface
                 foreach (var preset in r.All<ModPreset>())
                     preset.DeletePending = true;
             }));
-            AddUntilStep("no panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 0);
+            AddUntilStep("no panels visible", () => !this.ChildrenOfType<ModPresetPanel>().Any());
 
-            AddStep("undelete preset", () => Realm.Write(r =>
+            AddStep("select mods from first preset", () => SelectedMods.Value = new Mod[] { new OsuModDoubleTime(), new OsuModHardRock() });
+
+            AddStep("undelete presets", () => Realm.Write(r =>
             {
                 foreach (var preset in r.All<ModPreset>())
                     preset.DeletePending = false;

--- a/osu.Game/Overlays/Mods/ModPresetColumn.cs
+++ b/osu.Game/Overlays/Mods/ModPresetColumn.cs
@@ -82,16 +82,8 @@ namespace osu.Game.Overlays.Mods
 
             void removeAndDisposePresetPanels()
             {
-                int i = 0;
-
-                while (i < ItemsFlow.Count)
-                {
-                    var item = ItemsFlow[i];
-                    if (item is ModPresetPanel)
-                        item.RemoveAndDisposeImmediately();
-                    else
-                        i++;
-                }
+                foreach (var panel in ItemsFlow.OfType<ModPresetPanel>().ToArray())
+                    panel.RemoveAndDisposeImmediately();
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModPresetColumn.cs
+++ b/osu.Game/Overlays/Mods/ModPresetColumn.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
@@ -66,7 +67,7 @@ namespace osu.Game.Overlays.Mods
 
             if (!presets.Any())
             {
-                ItemsFlow.RemoveAll(panel => panel is ModPresetPanel);
+                removeAndDisposePresetPanels();
                 return;
             }
 
@@ -75,9 +76,23 @@ namespace osu.Game.Overlays.Mods
                 Shear = Vector2.Zero
             }), loaded =>
             {
-                ItemsFlow.RemoveAll(panel => panel is ModPresetPanel);
+                removeAndDisposePresetPanels();
                 ItemsFlow.AddRange(loaded);
             }, (cancellationTokenSource = new CancellationTokenSource()).Token);
+
+            void removeAndDisposePresetPanels()
+            {
+                int i = 0;
+
+                while (i < ItemsFlow.Count)
+                {
+                    var item = ItemsFlow[i];
+                    if (item is ModPresetPanel)
+                        item.RemoveAndDisposeImmediately();
+                    else
+                        i++;
+                }
+            }
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Closes #19625.

As stated in the issue, I can't see how `RemoveAndDisposeImmediately()` breaks here, works well for what it needs to do.

Some rather pitiful "test coverage" is also included in `TestSceneModPresetColumn.TestSoftDeleteSupport()` (this is hard to test, so the "test coverage" is 100% manual and auditory). On master, you should hear the `check-on` sound twice - once after the `SelectedMods` mutation, and once after the presets are undeleted. With this PR, you should hear only the last one sample. At least I do...