### PR TITLE
Fix gameplay tests crashing when run multiple times

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -203,5 +203,15 @@ namespace osu.Game.Screens.Play
             api.Queue(request);
             return scoreSubmissionSource.Task;
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            // Specific to tests, the player can be disposed without OnExiting() ever being called.
+            // We should make sure that the gameplay session has finished even in this case.
+            if (LoadedBeatmapSuccessfully)
+                spectatorClient.EndPlaying(GameplayState);
+        }
     }
 }

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -203,15 +203,5 @@ namespace osu.Game.Screens.Play
             api.Queue(request);
             return scoreSubmissionSource.Task;
         }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            // Specific to tests, the player can be disposed without OnExiting() ever being called.
-            // We should make sure that the gameplay session has finished even in this case.
-            if (LoadedBeatmapSuccessfully)
-                spectatorClient.EndPlaying(GameplayState);
-        }
     }
 }

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
+using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -45,6 +46,9 @@ namespace osu.Game.Tests.Visual
         public new bool PauseCooldownActive => base.PauseCooldownActive;
 
         public readonly List<JudgementResult> Results = new List<JudgementResult>();
+
+        [Resolved]
+        private SpectatorClient spectatorClient { get; set; }
 
         public TestPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)
             : base(new PlayerConfiguration
@@ -97,6 +101,16 @@ namespace osu.Game.Tests.Visual
                 return;
 
             ScoreProcessor.NewJudgement += r => Results.Add(r);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            // Specific to tests, the player can be disposed without OnExiting() ever being called.
+            // We should make sure that the gameplay session has finished even in this case.
+            if (LoadedBeatmapSuccessfully)
+                spectatorClient.EndPlaying(GameplayState);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/19641

Regressed in https://github.com/ppy/osu/pull/19442

The previous test scene is disposed synchronously when a new one is loaded, so this doesn't come down to an async disposal.