### PR TITLE
Reorganise global bindings and split out overlay bindings to make things easier to find

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -32,13 +32,13 @@ namespace osu.Game.Input.Bindings
         }
 
         // IMPORTANT: Do not change the order of key bindings in this list.
-        // It is used to decide the int values when storing settings in DatabasedKeyBindingContainer.
+        // It is used to decide the order of precedence (see note in DatabasedKeyBindingContainer).
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
+                                                                       .Concat(OverlayKeyBindings)
                                                                        .Concat(EditorKeyBindings)
                                                                        .Concat(InGameKeyBindings)
                                                                        .Concat(SongSelectKeyBindings)
-                                                                       .Concat(AudioControlKeyBindings)
-                                                                       .Concat(OverlayKeyBindings);
+                                                                       .Concat(AudioControlKeyBindings);
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
@@ -15,8 +13,9 @@ namespace osu.Game.Input.Bindings
 {
     public class GlobalActionContainer : DatabasedKeyBindingContainer<GlobalAction>, IHandleGlobalKeyboardInput
     {
-        private readonly Drawable handler;
-        private InputManager parentInputManager;
+        private readonly Drawable? handler;
+
+        private InputManager? parentInputManager;
 
         public GlobalActionContainer(OsuGameBase game)
             : base(matchingMode: KeyCombinationMatchingMode.Modifiers)
@@ -33,6 +32,7 @@ namespace osu.Game.Input.Bindings
         }
 
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
+                                                                       .Concat(OverlayKeyBindings)
                                                                        .Concat(EditorKeyBindings)
                                                                        .Concat(InGameKeyBindings)
                                                                        .Concat(SongSelectKeyBindings)
@@ -40,18 +40,11 @@ namespace osu.Game.Input.Bindings
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {
-            new KeyBinding(InputKey.F6, GlobalAction.ToggleNowPlaying),
-            new KeyBinding(InputKey.F8, GlobalAction.ToggleChat),
-            new KeyBinding(InputKey.F9, GlobalAction.ToggleSocial),
             new KeyBinding(InputKey.F10, GlobalAction.ToggleGameplayMouseButtons),
             new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, GlobalAction.ToggleFPSDisplay),
-
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.R }, GlobalAction.ResetInputSettings),
             new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
-            new KeyBinding(new[] { InputKey.Control, InputKey.O }, GlobalAction.ToggleSettings),
-            new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.ToggleBeatmapListing),
-            new KeyBinding(new[] { InputKey.Control, InputKey.N }, GlobalAction.ToggleNotifications),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, GlobalAction.ToggleSkinEditor),
 
             new KeyBinding(InputKey.Escape, GlobalAction.Back),
@@ -70,6 +63,16 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.KeypadEnter, GlobalAction.Select),
 
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.R }, GlobalAction.RandomSkin),
+        };
+
+        public IEnumerable<KeyBinding> OverlayKeyBindings => new[]
+        {
+            new KeyBinding(InputKey.F8, GlobalAction.ToggleChat),
+            new KeyBinding(InputKey.F6, GlobalAction.ToggleNowPlaying),
+            new KeyBinding(InputKey.F9, GlobalAction.ToggleSocial),
+            new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.ToggleBeatmapListing),
+            new KeyBinding(new[] { InputKey.Control, InputKey.O }, GlobalAction.ToggleSettings),
+            new KeyBinding(new[] { InputKey.Control, InputKey.N }, GlobalAction.ToggleNotifications),
         };
 
         public IEnumerable<KeyBinding> EditorKeyBindings => new[]

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -31,12 +31,14 @@ namespace osu.Game.Input.Bindings
             parentInputManager = GetContainingInputManager();
         }
 
+        // IMPORTANT: Do not change the order of key bindings in this list.
+        // It is used to decide the int values when storing settings in DatabasedKeyBindingContainer.
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
-                                                                       .Concat(OverlayKeyBindings)
                                                                        .Concat(EditorKeyBindings)
                                                                        .Concat(InGameKeyBindings)
                                                                        .Concat(SongSelectKeyBindings)
-                                                                       .Concat(AudioControlKeyBindings);
+                                                                       .Concat(AudioControlKeyBindings)
+                                                                       .Concat(OverlayKeyBindings);
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -40,18 +40,6 @@ namespace osu.Game.Input.Bindings
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {
-            new KeyBinding(InputKey.F10, GlobalAction.ToggleGameplayMouseButtons),
-            new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, GlobalAction.ToggleFPSDisplay),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.R }, GlobalAction.ResetInputSettings),
-            new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, GlobalAction.ToggleSkinEditor),
-
-            new KeyBinding(InputKey.Escape, GlobalAction.Back),
-            new KeyBinding(InputKey.ExtraMouseButton1, GlobalAction.Back),
-
-            new KeyBinding(new[] { InputKey.Alt, InputKey.Home }, GlobalAction.Home),
-
             new KeyBinding(InputKey.Up, GlobalAction.SelectPrevious),
             new KeyBinding(InputKey.Down, GlobalAction.SelectNext),
 
@@ -62,7 +50,21 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Enter, GlobalAction.Select),
             new KeyBinding(InputKey.KeypadEnter, GlobalAction.Select),
 
+            new KeyBinding(InputKey.Escape, GlobalAction.Back),
+            new KeyBinding(InputKey.ExtraMouseButton1, GlobalAction.Back),
+
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Home }, GlobalAction.Home),
+
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, GlobalAction.ToggleFPSDisplay),
+            new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, GlobalAction.ToggleSkinEditor),
+
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.R }, GlobalAction.ResetInputSettings),
+
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.R }, GlobalAction.RandomSkin),
+
+            new KeyBinding(InputKey.F10, GlobalAction.ToggleGameplayMouseButtons),
+            new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
         };
 
         public IEnumerable<KeyBinding> OverlayKeyBindings => new[]

--- a/osu.Game/Localisation/InputSettingsStrings.cs
+++ b/osu.Game/Localisation/InputSettingsStrings.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Localisation
         public static LocalisableString GlobalKeyBindingHeader => new TranslatableString(getKey(@"global_key_binding_header"), @"Global");
 
         /// <summary>
+        /// "Overlays"
+        /// </summary>
+        public static LocalisableString OverlaysSection => new TranslatableString(getKey(@"overlays_section"), @"Overlays");
+
+        /// <summary>
         /// "Song Select"
         /// </summary>
         public static LocalisableString SongSelectSection => new TranslatableString(getKey(@"song_select_section"), @"Song Select");

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -23,6 +21,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         public GlobalKeyBindingsSection(GlobalActionContainer manager)
         {
             Add(new DefaultBindingsSubsection(manager));
+            Add(new OverlayBindingsSubsection(manager));
             Add(new AudioControlKeyBindingsSubsection(manager));
             Add(new SongSelectKeyBindingSubsection(manager));
             Add(new InGameKeyBindingsSubsection(manager));
@@ -37,6 +36,17 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 : base(null)
             {
                 Defaults = manager.GlobalKeyBindings;
+            }
+        }
+
+        private class OverlayBindingsSubsection : KeyBindingsSubsection
+        {
+            protected override LocalisableString Header => InputSettingsStrings.OverlaysSection;
+
+            public OverlayBindingsSubsection(GlobalActionContainer manager)
+                : base(null)
+            {
+                Defaults = manager.OverlayKeyBindings;
             }
         }
 

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Visual
             // Specific to tests, the player can be disposed without OnExiting() ever being called.
             // We should make sure that the gameplay session has finished even in this case.
             if (LoadedBeatmapSuccessfully)
-                spectatorClient.EndPlaying(GameplayState);
+                spectatorClient?.EndPlaying(GameplayState);
         }
     }
 }


### PR DESCRIPTION
Before:

![osu! 2022-08-09 at 08 09 37](https://user-images.githubusercontent.com/191335/183598471-334dc6b9-2a0b-4bb2-8750-aee1d38b7097.png)

After:

![osu! 2022-08-09 at 08 02 56](https://user-images.githubusercontent.com/191335/183598326-75df6ce2-6aea-4f4d-a631-1ec1d52ec5e6.png)
