### PR TITLE
Use a placeholder user with the correct username during login process

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -402,7 +402,7 @@ namespace osu.Game.Online.API
             }
         }
 
-        public bool IsLoggedIn => localUser.Value.Id > 1; // TODO: should this also be true if attempting to connect?
+        public bool IsLoggedIn => State.Value > APIState.Offline;
 
         public void Queue(APIRequest request)
         {

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -137,6 +137,17 @@ namespace osu.Game.Online.API
 
                         state.Value = APIState.Connecting;
 
+                        if (localUser.IsDefault)
+                        {
+                            // Show a placeholder user if saved credentials are available.
+                            // This is useful for storing local scores and showing a placeholder username after starting the game,
+                            // until a valid connection has been established.
+                            localUser.Value = new APIUser
+                            {
+                                Username = ProvidedUsername,
+                            };
+                        }
+
                         // save the username at this point, if the user requested for it to be.
                         config.SetValue(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);
 

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -104,11 +104,11 @@ namespace osu.Game.Overlays
             filterControl.CardSize.BindValueChanged(_ => onCardSizeChanged());
 
             apiUser = api.LocalUser.GetBoundCopy();
-            apiUser.BindValueChanged(_ =>
+            apiUser.BindValueChanged(_ => Schedule(() =>
             {
                 if (api.IsLoggedIn)
                     addContentToResultsArea(Drawable.Empty());
-            });
+            }));
         }
 
         public void ShowWithSearch(string query)


### PR DESCRIPTION
This allows for various components (like gameplay) to obtain a correct username even if the API is not yet in a connected state. The most common case is during startup, where a connection may not have been established yet, but the user's username was restored from their config file.

By making the change, local scores will now have the correct username (although avatar etc. will be missing, which I think it fine) even if the API is not yet connected. Previously, they would show up as "Guest".

Also fixes an unsafe usage of `LocalUser` in beb3d41, and changes the behaviour of `IsLoggedIn` to better match expectations in f9d0cc3. I've tested this manually in all the locations I could find which was using `IsLoggedIn` and it seems to handle correctly.

(Probably) addresses https://github.com/ppy/osu/discussions/19584.

The easiest way to test this is to add a `Thread.Sleep` at line 138 of `APIAccess` to delay login some.