### PR TITLE
Fix host room status showing ended after playing

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -196,6 +196,9 @@ namespace osu.Game.Online.Multiplayer
                     APIRoom.Playlist.AddRange(joinedRoom.Playlist.Select(createPlaylistItem));
                     APIRoom.CurrentPlaylistItem.Value = APIRoom.Playlist.Single(item => item.ID == joinedRoom.Settings.PlaylistItemId);
 
+                    // The server will null out the end date upon the host joining the room, but the null value is never communicated to the client.
+                    APIRoom.EndDate.Value = null;
+
                     Debug.Assert(LocalUser != null);
                     addUserToAPIRoom(LocalUser);
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/19602

Inline comment should be self explanatory - osu-web sets an end date and the host receives that at the point of joining the room. `osu-server-spectator` only nulls it out once the host joins.