### PR TITLE
Add thread safety to `APIAccess.LocalUser`

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -142,10 +142,10 @@ namespace osu.Game.Online.API
                             // Show a placeholder user if saved credentials are available.
                             // This is useful for storing local scores and showing a placeholder username after starting the game,
                             // until a valid connection has been established.
-                            localUser.Value = new APIUser
+                            setLocalUser(new APIUser
                             {
                                 Username = ProvidedUsername,
-                            };
+                            });
                         }
 
                         // save the username at this point, if the user requested for it to be.
@@ -188,12 +188,12 @@ namespace osu.Game.Online.API
                             else
                                 failConnectionProcess();
                         };
-                        userReq.Success += u =>
+                        userReq.Success += user =>
                         {
-                            localUser.Value = u;
-
                             // todo: save/pull from settings
-                            localUser.Value.Status.Value = new UserStatusOnline();
+                            user.Status.Value = new UserStatusOnline();
+
+                            setLocalUser(user);
 
                             failureCount = 0;
                         };
@@ -453,7 +453,7 @@ namespace osu.Game.Online.API
             // Scheduled prior to state change such that the state changed event is invoked with the correct user and their friends present
             Schedule(() =>
             {
-                localUser.Value = createGuestUser();
+                setLocalUser(createGuestUser());
                 friends.Clear();
             });
 
@@ -462,6 +462,8 @@ namespace osu.Game.Online.API
         }
 
         private static APIUser createGuestUser() => new GuestUser();
+
+        private void setLocalUser(APIUser user) => Scheduler.Add(() => localUser.Value = user, false);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -13,19 +13,16 @@ namespace osu.Game.Online.API
     {
         /// <summary>
         /// The local user.
-        /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>
         IBindable<APIUser> LocalUser { get; }
 
         /// <summary>
         /// The user's friends.
-        /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>
         IBindableList<APIUser> Friends { get; }
 
         /// <summary>
         /// The current user's activity.
-        /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>
         IBindable<UserActivity> Activity { get; }
 


### PR DESCRIPTION
Following up from https://github.com/ppy/osu/pull/19658, there are many other unsafe cases of usage.

Rather than attempt to guard each one, let's just make `LocalUser` safe itself.

Note that I'm not removing the local `Schedule` calls because it's probably best to have them at a component level to avoid calls after drawable disposal, as usual. Just wanting to stop game crashes from this silly stuff.

There were around 9 different stacks for failures surrounding this, triggered by the user now being modified more often at startup, whereas previously it would have only happened on login/logout (and likely guarded by accident by `APIRequest` doing its own scheduling).

https://sentry.ppy.sh/organizations/ppy/issues/5685/?end=2022-08-11T03%3A10%3A59&project=2&query=firstRelease%3Aosu%402022.810.2+InvalidThreadFor&sort=freq&start=2022-08-10T08%3A52%3A00