### PR TITLE
Fix avatar potentially not loading in `LoginOverlay` due to misordered events

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -195,6 +195,8 @@ namespace osu.Game.Online.API
 
                             setLocalUser(user);
 
+                            //we're connected!
+                            state.Value = APIState.Online;
                             failureCount = 0;
                         };
 
@@ -208,13 +210,7 @@ namespace osu.Game.Online.API
                         var friendsReq = new GetFriendsRequest();
 
                         friendsReq.Failure += _ => failConnectionProcess();
-                        friendsReq.Success += res =>
-                        {
-                            friends.AddRange(res);
-
-                            //we're connected!
-                            state.Value = APIState.Online;
-                        };
+                        friendsReq.Success += res => friends.AddRange(res);
 
                         if (!handleRequest(friendsReq))
                         {

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -334,8 +334,7 @@ namespace osu.Game.Online.API
                 if (req.CompletionState != APIRequestCompletionState.Completed)
                     return false;
 
-                // we could still be in initialisation, at which point we don't want to say we're Online yet.
-                if (IsLoggedIn) state.Value = APIState.Online;
+                // Reset failure count if this request succeeded.
                 failureCount = 0;
                 return true;
             }


### PR DESCRIPTION
Previously, it was guaranteed that the local user was in a final state at the point of state change to `Online`. With the introduction of the placeholder user, this was no longer guaranteed (the state change to `Online` could trigger at the end of `handleRequest`, which precedes the `LocalUser` change due to the latter being `Scheduled` via `APIRequest` logic). The main fix is covered by the first commit:

## 47196b19a5 Stop setting `Online` state in `handleRequest`

This is already handled amicably by the `Failing` -> `Connecting` flow.  Having this set in `handleRequest` throws things off, potentially leading to the `Online` state change before the user has been populated.

## 7ec67c28b9 Set `Online` state sooner in connection process

This isn't really required as such, but feels more correct. There was no reason for it to wait for the friend population to complete before deeming things to be "online".

Closes #19701.

Can also add `ValueChanged` handling on `LocalUser` in the `LoginOverlay` if deemed necessary. Currently it is 100% reliant on `APIState` changes.