### PR TITLE
Adjust various mod multipliers to avoid competition with normal scores

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstantSpeed.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override string Acronym => "CS";
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.9;
 
         public override string Description => "No more tricky speed changes!";
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModAutopilot;
         public override ModType Type => ModType.Automation;
         public override string Description => @"Automatic cursor movement - just follow the rhythm.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModSpunOut), typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail), typeof(ModAutoplay), typeof(OsuModMagnetised), typeof(OsuModRepel) };
 
         public bool PerformFail() => false;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => FontAwesome.Solid.Magnet;
         public override ModType Type => ModType.Fun;
         public override string Description => "No need to chase the circles – your cursor is a magnet!";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel) };
 
         private IFrameStableClock gameplayClock = null!;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.5;
 
         public override bool ValidForMultiplayer => false;
         public override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override IconUsage? Icon => FontAwesome.Solid.Hammer;
 
-        public sealed override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier => 0.5;
 
         public override bool RequiresConfiguration => true;
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override IconUsage? Icon => FontAwesome.Solid.Hammer;
 
-        public override double ScoreMultiplier => 1.0;
+        public sealed override double ScoreMultiplier => 0.5;
 
         public override bool RequiresConfiguration => true;
 

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RX";
         public override IconUsage? Icon => OsuIcon.ModRelax;
         public override ModType Type => ModType.Automation;
-        public override double ScoreMultiplier => 0.5;
+        public sealed override double ScoreMultiplier => 0.1;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModNoFail), typeof(ModFailCondition) };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RX";
         public override IconUsage? Icon => OsuIcon.ModRelax;
         public override ModType Type => ModType.Automation;
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModNoFail), typeof(ModFailCondition) };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "RX";
         public override IconUsage? Icon => OsuIcon.ModRelax;
         public override ModType Type => ModType.Automation;
-        public sealed override double ScoreMultiplier => 0.1;
+        public override double ScoreMultiplier => 0.1;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModNoFail), typeof(ModFailCondition) };
     }
 }


### PR DESCRIPTION
Has previously been discussed internally. Probably good to get this out before the next full reprocess of scores server-side.

The multiplier here was @smoogipoo's suggested value. I'd be willing to go lower if this is seen at too high, but it should be a round number to make it easy for users to understand the max score available to them.

We should probably also cover any other similar mods in this PR.

---

While we have leaderboards still showing all mods next to each other, we've decided to devalue new (lazer-first) mods which are seen as making the game easier. The multipliers decided here are **placeholder** and mainly meant to reduce competition of unworthy scores that were previously showing at the top of the leaderboards. We will continue to adjust these (and make them dynamic based on settings) going forward.

Relax 1.0x -> 0.1x
Autopilot 1.0x -> 0.1x
Magnetised 1.0x -> 0.5x
Adaptive Speed 1.0x -> 0.5x
Difficulty Adjust 1.0x -> 0.5x
Constant Speed  1.0x -> 0.9x