### PR TITLE
Nerf repeated angles in Flashlight skill

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -7,7 +7,6 @@ using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Framework.Utils;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             OsuDifficultyHitObject lastObj = osuCurrent;
 
-            int angleRepeatCount = 0;
+            double angleRepeatCount = 0.0;
 
             // We want to round angles to make abusing the nerf a bit harder.
             double initialRoundedAngle = 0.0;
@@ -82,8 +82,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     {
                         double roundedAngle = Math.Round(MathUtils.RadiansToDegrees(currentObj.Angle.Value) / 2.0) * 2.0;
 
+                        // Objects further back in time should count less for the nerf.
                         if (roundedAngle == initialRoundedAngle)
-                            angleRepeatCount++;
+                            angleRepeatCount += 1.0 - 0.1 * i;
                     }
                 }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -49,11 +49,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             double angleRepeatCount = 0.0;
 
-            // We want to round angles to make abusing the nerf a bit harder.
-            double initialRoundedAngle = 0.0;
-            if (osuCurrent.Angle != null)
-                initialRoundedAngle = Math.Round(MathUtils.RadiansToDegrees(osuCurrent.Angle.Value) / 2.0) * 2.0;
-
             // This is iterating backwards in time from the current object.
             for (int i = 0; i < Math.Min(current.Index, 10); i++)
             {
@@ -80,10 +75,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                     if (currentObj.Angle != null && osuCurrent.Angle != null)
                     {
-                        double roundedAngle = Math.Round(MathUtils.RadiansToDegrees(currentObj.Angle.Value) / 2.0) * 2.0;
-
                         // Objects further back in time should count less for the nerf.
-                        if (roundedAngle == initialRoundedAngle)
+                        if (Math.Abs(currentObj.Angle.Value - osuCurrent.Angle.Value) < 0.02)
                             angleRepeatCount += Math.Max(1.0 - 0.1 * i, 0.0);
                     }
                 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -85,9 +85,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // 0 deg, 45 deg, 90 deg, 135 deg and 180 deg are commonly used in squaregrid maps.
             if (osuCurrent.Angle != null)
             {
-                double hexgrid_multiplier = 1.0 - Math.Pow(Math.Cos((180 / 60.0) * (double)(osuCurrent.Angle)), 20.0);
-                double squaregrid_multiplier = 1.0 - Math.Pow(Math.Cos((180 / 45.0) * (double)(osuCurrent.Angle)), 20.0);
-                result *= (1.0 - min_grid_multiplier) * hexgrid_multiplier * squaregrid_multiplier + min_grid_multiplier;
+                double hexgridMultiplier = 1.0 - Math.Pow(Math.Cos((180 / 60.0) * (double)(osuCurrent.Angle)), 20.0);
+                double squaregridMultiplier = 1.0 - Math.Pow(Math.Cos((180 / 45.0) * (double)(osuCurrent.Angle)), 20.0);
+                result *= (1.0 - min_grid_multiplier) * hexgridMultiplier * squaregridMultiplier + min_grid_multiplier;
             }
 
             double sliderBonus = 0.0;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                         // Objects further back in time should count less for the nerf.
                         if (roundedAngle == initialRoundedAngle)
-                            angleRepeatCount += 1.0 - 0.1 * i;
+                            angleRepeatCount += Math.Max(1.0 - 0.1 * i, 0.0);
                     }
                 }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -78,7 +78,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                     result += stackNerf * opacityBonus * scalingFactor * jumpDistance / cumulativeStrainTime;
 
-                    if (currentObj.Angle != null && osuCurrent.Angle != null) {
+                    if (currentObj.Angle != null && osuCurrent.Angle != null)
+                    {
                         double roundedAngle = Math.Round(MathUtils.RadiansToDegrees(currentObj.Angle.Value) / 2.0) * 2.0;
 
                         if (roundedAngle == initialRoundedAngle)

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -18,11 +18,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double min_velocity = 0.5;
         private const double slider_multiplier = 1.3;
 
+        private const double min_grid_multiplier = 0.35;
+
         /// <summary>
         /// Evaluates the difficulty of memorising and hitting an object, based on:
         /// <list type="bullet">
         /// <item><description>distance between a number of previous objects and the current object,</description></item>
         /// <item><description>the visual opacity of the current object,</description></item>
+        /// <item><description>the angle made by the current object,</description></item>
         /// <item><description>length and speed of the current object (for sliders),</description></item>
         /// <item><description>and whether the hidden mod is enabled.</description></item>
         /// </list>
@@ -76,6 +79,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Additional bonus for Hidden due to there being no approach circles.
             if (hidden)
                 result *= 1.0 + hidden_bonus;
+
+            // Nerf patterns with angles that are commonly used in grid maps.
+            // 0 deg, 60 deg, 120 deg and 180 deg are commonly used in hexgrid maps.
+            // 0 deg, 45 deg, 90 deg, 135 deg and 180 deg are commonly used in squaregrid maps.
+            if (osuCurrent.Angle != null) {
+                double hexgrid_multiplier = 1.0 - Math.Pow(Math.Cos((180 / 60.0) * (double)(osuCurrent.Angle)), 20.0);
+                double squaregrid_multiplier = 1.0 - Math.Pow(Math.Cos((180 / 45.0) * (double)(osuCurrent.Angle)), 20.0);
+                result *= (1.0 - min_grid_multiplier) * hexgrid_multiplier * squaregrid_multiplier + min_grid_multiplier;
+            }
 
             double sliderBonus = 0.0;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                     if (currentObj.Angle != null && osuCurrent.Angle != null) {
                         double roundedAngle = Math.Round(MathUtils.RadiansToDegrees(currentObj.Angle.Value) / 2.0) * 2.0;
-                        
+
                         if (roundedAngle == initialRoundedAngle)
                             angleRepeatCount++;
                     }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -83,7 +83,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Nerf patterns with angles that are commonly used in grid maps.
             // 0 deg, 60 deg, 120 deg and 180 deg are commonly used in hexgrid maps.
             // 0 deg, 45 deg, 90 deg, 135 deg and 180 deg are commonly used in squaregrid maps.
-            if (osuCurrent.Angle != null) {
+            if (osuCurrent.Angle != null)
+            {
                 double hexgrid_multiplier = 1.0 - Math.Pow(Math.Cos((180 / 60.0) * (double)(osuCurrent.Angle)), 20.0);
                 double squaregrid_multiplier = 1.0 - Math.Pow(Math.Cos((180 / 45.0) * (double)(osuCurrent.Angle)), 20.0);
                 result *= (1.0 - min_grid_multiplier) * hexgrid_multiplier * squaregrid_multiplier + min_grid_multiplier;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             hasHiddenMod = mods.Any(m => m is OsuModHidden);
         }
 
-        private double skillMultiplier => 0.05;
+        private double skillMultiplier => 0.052;
         private double strainDecayBase => 0.15;
 
         private double currentStrain;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             hasHiddenMod = mods.Any(m => m is OsuModHidden);
         }
 
-        private double skillMultiplier => 0.05;
+        private double skillMultiplier => 0.06;
         private double strainDecayBase => 0.15;
 
         private double currentStrain;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Flashlight.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             hasHiddenMod = mods.Any(m => m is OsuModHidden);
         }
 
-        private double skillMultiplier => 0.06;
+        private double skillMultiplier => 0.05;
         private double strainDecayBase => 0.15;
 
         private double currentStrain;


### PR DESCRIPTION
Originally this PR aimed to nerf grid style mapping, however the method used to do it wasn't ideal, and it would take a lot of work to properly consider the difficulty of grid style mapping.

Now it simply nerfs repeated angles, which are generally easy to read and make the placement of objects predictable. This indirectly nerfs grid style maps.

Nerf examples:
[Night of Knights [SOLO] (DJPop)](https://osu.ppy.sh/beatmapsets/15920#osu/58063) +HDHRFL: 837pp -> 689pp
[Kakenukeru Anime Song Medley [TWO DIMENSIONS] (Monstrata)](https://osu.ppy.sh/beatmapsets/297110#osu/667021) +FL: 847pp -> 753pp
[Cross Over [Ultra] (Sonnyc)](https://osu.ppy.sh/beatmapsets/1270122#osu/2639521) +FL: 547pp -> 510pp

---

Spreadsheet of SR/PP changes: https://docs.google.com/spreadsheets/d/1TKGEQSsG0-Wbkz6bRi_6hOW2fg5uxXxa2xXDIexRlk4/edit

As of https://github.com/ppy/osu/pull/19716/commits/b082dc1fe47f30662d7f2f81a3ac5766371a1bf9