### PR TITLE
Fix playlist overlay showing new imports when they don't match collection filter

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -128,6 +128,8 @@ namespace osu.Game.Tests.Resources
 
                     var rulesetInfo = getRuleset();
 
+                    string hash = Guid.NewGuid().ToString().ComputeMD5Hash();
+
                     yield return new BeatmapInfo
                     {
                         OnlineID = beatmapId,
@@ -136,7 +138,8 @@ namespace osu.Game.Tests.Resources
                         Length = length,
                         BeatmapSet = beatmapSet,
                         BPM = bpm,
-                        Hash = Guid.NewGuid().ToString().ComputeMD5Hash(),
+                        Hash = hash,
+                        MD5Hash = hash,
                         Ruleset = rulesetInfo,
                         Metadata = metadata.DeepClone(),
                         Difficulty = new BeatmapDifficulty

--- a/osu.Game/Overlays/Music/Playlist.cs
+++ b/osu.Game/Overlays/Music/Playlist.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using osu.Framework.Bindables;
@@ -17,9 +15,11 @@ namespace osu.Game.Overlays.Music
 {
     public class Playlist : OsuRearrangeableListContainer<Live<BeatmapSetInfo>>
     {
-        public Action<Live<BeatmapSetInfo>> RequestSelection;
+        public Action<Live<BeatmapSetInfo>>? RequestSelection;
 
         public readonly Bindable<Live<BeatmapSetInfo>> SelectedSet = new Bindable<Live<BeatmapSetInfo>>();
+
+        private FilterCriteria currentCriteria = new FilterCriteria();
 
         public new MarginPadding Padding
         {
@@ -31,26 +31,22 @@ namespace osu.Game.Overlays.Music
         {
             var items = (SearchContainer<RearrangeableListItem<Live<BeatmapSetInfo>>>)ListContainer;
 
-            string[] currentCollectionHashes = criteria.Collection?.PerformRead(c => c.BeatmapMD5Hashes.ToArray());
+            string[]? currentCollectionHashes = criteria.Collection?.PerformRead(c => c.BeatmapMD5Hashes.ToArray());
 
             foreach (var item in items.OfType<PlaylistItem>())
             {
-                if (currentCollectionHashes == null)
-                    item.InSelectedCollection = true;
-                else
-                {
-                    item.InSelectedCollection = item.Model.Value.Beatmaps.Select(b => b.MD5Hash)
-                                                    .Any(currentCollectionHashes.Contains);
-                }
+                item.InSelectedCollection = currentCollectionHashes == null || item.Model.Value.Beatmaps.Select(b => b.MD5Hash).Any(currentCollectionHashes.Contains);
             }
 
             items.SearchTerm = criteria.SearchText;
+            currentCriteria = criteria;
         }
 
-        public Live<BeatmapSetInfo> FirstVisibleSet => Items.FirstOrDefault(i => ((PlaylistItem)ItemMap[i]).MatchingFilter);
+        public Live<BeatmapSetInfo>? FirstVisibleSet => Items.FirstOrDefault(i => ((PlaylistItem)ItemMap[i]).MatchingFilter);
 
         protected override OsuRearrangeableListItem<Live<BeatmapSetInfo>> CreateOsuDrawable(Live<BeatmapSetInfo> item) => new PlaylistItem(item)
         {
+            InSelectedCollection = currentCriteria.Collection?.PerformRead(c => item.Value.Beatmaps.Select(b => b.MD5Hash).Any(c.BeatmapMD5Hashes.Contains)) != false,
             SelectedSet = { BindTarget = SelectedSet },
             RequestSelection = set => RequestSelection?.Invoke(set)
         };

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -26,8 +26,6 @@ namespace osu.Game.Overlays.Music
         private const float transition_duration = 600;
         private const float playlist_height = 510;
 
-        public IBindableList<Live<BeatmapSetInfo>> BeatmapSets => beatmapSets;
-
         private readonly BindableList<Live<BeatmapSetInfo>> beatmapSets = new BindableList<Live<BeatmapSetInfo>>();
 
         private readonly Bindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
@@ -104,9 +102,7 @@ namespace osu.Game.Overlays.Music
         {
             base.LoadComplete();
 
-            // tests might bind externally, in which case we don't want to involve realm.
-            if (beatmapSets.Count == 0)
-                beatmapSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => !s.DeletePending), beatmapsChanged);
+            beatmapSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => !s.DeletePending), beatmapsChanged);
 
             list.Items.BindTo(beatmapSets);
             beatmap.BindValueChanged(working => list.SelectedSet.Value = working.NewValue.BeatmapSetInfo.ToLive(realm), true);


### PR DESCRIPTION
Reported via email.

I also took this opportunity to tidy up the exposed `BindableList` in `PlaylistOverlay` that was only used for testing purposes.