### PR TITLE
Fix div-by-zero in `SongProgress` when no object duration could be calculated

### DIFF
--- a/osu.Game/Screens/Play/HUD/SongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgress.cs
@@ -94,7 +94,10 @@ namespace osu.Game.Screens.Play.HUD
                 double objectOffsetCurrent = currentTime - FirstHitTime;
 
                 double objectDuration = LastHitTime - FirstHitTime;
-                UpdateProgress(objectOffsetCurrent / objectDuration, false);
+                if (objectDuration == 0)
+                    UpdateProgress(0, false);
+                else
+                    UpdateProgress(objectOffsetCurrent / objectDuration, false);
             }
         }
     }


### PR DESCRIPTION
Fixes test failures with next framework release (due to new exception in https://github.com/ppy/osu-framework/pull/5349).