### PR TITLE
Move all usage of `GameplayClock` to `IGameplayClock`

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDoubleTime.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDoubleTime.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 Mod = mod,
                 PassCondition = () => Player.ScoreProcessor.JudgedHits >= 2 &&
-                                      Precision.AlmostEquals(Player.GameplayClockContainer.GameplayClock.Rate, mod.SpeedChange.Value)
+                                      Precision.AlmostEquals(Player.GameplayClockContainer.Rate, mod.SpeedChange.Value)
             });
         }
     }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         private bool rotationTransferred;
 
         [Resolved(canBeNull: true)]
-        private GameplayClock gameplayClock { get; set; }
+        private IGameplayClock gameplayClock { get; set; }
 
         protected override void Update()
         {

--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Gameplay
             });
 
             AddStep("start clock", () => gameplayClockContainer.Start());
-            AddUntilStep("elapsed greater than zero", () => gameplayClockContainer.GameplayClock.ElapsedFrameTime > 0);
+            AddUntilStep("elapsed greater than zero", () => gameplayClockContainer.ElapsedFrameTime > 0);
         }
 
         [Test]
@@ -60,16 +60,16 @@ namespace osu.Game.Tests.Gameplay
             });
 
             AddStep("start clock", () => gameplayClockContainer.Start());
-            AddUntilStep("current time greater 2000", () => gameplayClockContainer.GameplayClock.CurrentTime > 2000);
+            AddUntilStep("current time greater 2000", () => gameplayClockContainer.CurrentTime > 2000);
 
             double timeAtReset = 0;
             AddStep("reset clock", () =>
             {
-                timeAtReset = gameplayClockContainer.GameplayClock.CurrentTime;
+                timeAtReset = gameplayClockContainer.CurrentTime;
                 gameplayClockContainer.Reset();
             });
 
-            AddAssert("current time < time at reset", () => gameplayClockContainer.GameplayClock.CurrentTime < timeAtReset);
+            AddAssert("current time < time at reset", () => gameplayClockContainer.CurrentTime < timeAtReset);
         }
 
         [Test]

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -77,7 +77,6 @@ namespace osu.Game.Tests.Gameplay
 
                 Add(gameplayContainer = new MasterGameplayClockContainer(working, 0)
                 {
-                    IsPaused = { Value = true },
                     Child = new FrameStabilityContainer
                     {
                         Child = sample = new DrawableStoryboardSample(new StoryboardSampleInfo(string.Empty, 0, 1))
@@ -106,7 +105,6 @@ namespace osu.Game.Tests.Gameplay
                 Add(gameplayContainer = new MasterGameplayClockContainer(working, start_time)
                 {
                     StartTime = start_time,
-                    IsPaused = { Value = true },
                     Child = new FrameStabilityContainer
                     {
                         Child = sample = new DrawableStoryboardSample(new StoryboardSampleInfo(string.Empty, 0, 1))

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Tests.Gameplay
 
                 beatmapSkinSourceContainer.Add(sample = new TestDrawableStoryboardSample(new StoryboardSampleInfo("test-sample", 1, 1))
                 {
-                    Clock = gameplayContainer.GameplayClock
+                    Clock = gameplayContainer
                 });
             });
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     (typeof(ScoreProcessor), actualComponentsContainer.Dependencies.Get<ScoreProcessor>()),
                     (typeof(HealthProcessor), actualComponentsContainer.Dependencies.Get<HealthProcessor>()),
                     (typeof(GameplayState), actualComponentsContainer.Dependencies.Get<GameplayState>()),
-                    (typeof(GameplayClock), actualComponentsContainer.Dependencies.Get<GameplayClock>())
+                    (typeof(IGameplayClock), actualComponentsContainer.Dependencies.Get<IGameplayClock>())
                 },
             };
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [Cached]
-        private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());
+        private readonly IGameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         // best way to check without exposing.
         private Drawable hideTarget => hudOverlay.KeyCounter;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached]
         private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
-        [Cached]
+        [Cached(typeof(IGameplayClock))]
         private readonly IGameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         // best way to check without exposing.

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public double FirstHitObjectTime => DrawableRuleset.Objects.First().StartTime;
 
-            public double GameplayClockTime => GameplayClockContainer.GameplayClock.CurrentTime;
+            public double GameplayClockTime => GameplayClockContainer.CurrentTime;
 
             protected override void UpdateAfterChildren()
             {
@@ -138,7 +138,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 if (!FirstFrameClockTime.HasValue)
                 {
-                    FirstFrameClockTime = GameplayClockContainer.GameplayClock.CurrentTime;
+                    FirstFrameClockTime = GameplayClockContainer.CurrentTime;
                     AddInternal(new OsuSpriteText
                     {
                         Text = $"GameplayStartTime: {DrawableRuleset.GameplayStartTime} "

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneOverlayActivation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneOverlayActivation.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             base.SetUpSteps();
 
             AddUntilStep("gameplay has started",
-                () => Player.GameplayClockContainer.GameplayClock.CurrentTime > Player.DrawableRuleset.GameplayStartTime);
+                () => Player.GameplayClockContainer.CurrentTime > Player.DrawableRuleset.GameplayStartTime);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -313,7 +313,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("pause again", () =>
             {
                 Player.Pause();
-                return !Player.GameplayClockContainer.GameplayClock.IsRunning;
+                return !Player.GameplayClockContainer.IsRunning;
             });
 
             AddAssert("loop is playing", () => getLoop().IsPlaying);
@@ -378,7 +378,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("pause overlay " + (isShown ? "shown" : "hidden"), () => Player.PauseOverlayVisible == isShown);
 
         private void confirmClockRunning(bool isRunning) =>
-            AddUntilStep("clock " + (isRunning ? "running" : "stopped"), () => Player.GameplayClockContainer.GameplayClock.IsRunning == isRunning);
+            AddUntilStep("clock " + (isRunning ? "running" : "stopped"), () => Player.GameplayClockContainer.IsRunning == isRunning);
 
         protected override bool AllowFail => true;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached]
         private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
-        [Cached]
+        [Cached(typeof(IGameplayClock))]
         private readonly IGameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorMultipleSkins.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [Cached]
-        private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());
+        private readonly IGameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         [Cached]
-        private readonly GameplayClock gameplayClock = new GameplayClock(new FramedClock());
+        private readonly IGameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         private IEnumerable<HUDOverlay> hudOverlays => CreatedDrawables.OfType<HUDOverlay>();
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached]
         private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
-        [Cached]
+        [Cached(typeof(IGameplayClock))]
         private readonly IGameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
         private IEnumerable<HUDOverlay> hudOverlays => CreatedDrawables.OfType<HUDOverlay>();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -6,6 +6,7 @@
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
 using osuTK;
@@ -22,7 +23,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private double increment;
 
         private GameplayClockContainer gameplayClockContainer;
-        private GameplayClock gameplayClock;
+        private IFrameBasedClock gameplayClock;
 
         private const double skip_time = 6000;
 
@@ -51,7 +52,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             };
 
             gameplayClockContainer.Start();
-            gameplayClock = gameplayClockContainer.GameplayClock;
+            gameplayClock = gameplayClockContainer;
         });
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             Add(gameplayClockContainer = new MasterGameplayClockContainer(Beatmap.Value, skip_target_time));
 
-            Dependencies.CacheAs(gameplayClockContainer.GameplayClock);
+            Dependencies.CacheAs(gameplayClockContainer);
         }
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             Add(gameplayClockContainer = new MasterGameplayClockContainer(Beatmap.Value, skip_target_time));
 
-            Dependencies.CacheAs(gameplayClockContainer);
+            Dependencies.CacheAs<IGameplayClock>(gameplayClockContainer);
         }
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestStoryboardNoSkipOutro()
         {
             CreateTest();
-            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
+            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.CurrentTime >= currentStoryboardDuration);
             AddUntilStep("wait for score shown", () => Player.IsScoreShown);
         }
 
@@ -100,7 +100,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
-            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
+            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.CurrentTime >= currentStoryboardDuration);
             AddUntilStep("wait for fail overlay", () => Player.FailOverlay.State.Value == Visibility.Visible);
         }
 
@@ -111,7 +111,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 AddStep("set ShowResults = false", () => showResults = false);
             });
-            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
+            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.CurrentTime >= currentStoryboardDuration);
             AddWaitStep("wait", 10);
             AddAssert("no score shown", () => !Player.IsScoreShown);
         }
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestStoryboardEndsBeforeCompletion()
         {
             CreateTest(() => AddStep("set storyboard duration to .1s", () => currentStoryboardDuration = 100));
-            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
+            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.CurrentTime >= currentStoryboardDuration);
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddUntilStep("wait for score shown", () => Player.IsScoreShown);
         }
@@ -138,7 +138,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("skip overlay content not visible", () => fadeContainer().State == Visibility.Hidden);
 
             AddUntilStep("skip overlay content becomes visible", () => fadeContainer().State == Visibility.Visible);
-            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
+            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.CurrentTime >= currentStoryboardDuration);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -451,7 +451,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         private void checkPaused(int userId, bool state)
-            => AddUntilStep($"{userId} is {(state ? "paused" : "playing")}", () => getPlayer(userId).ChildrenOfType<GameplayClockContainer>().First().GameplayClock.IsRunning != state);
+            => AddUntilStep($"{userId} is {(state ? "paused" : "playing")}", () => getPlayer(userId).ChildrenOfType<GameplayClockContainer>().First().IsRunning != state);
 
         private void checkPausedInstant(int userId, bool state)
         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -671,7 +671,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             for (double i = 1000; i < TestResources.QUICK_BEATMAP_LENGTH; i += 1000)
             {
                 double time = i;
-                AddUntilStep($"wait for time > {i}", () => this.ChildrenOfType<GameplayClockContainer>().SingleOrDefault()?.GameplayClock.CurrentTime > time);
+                AddUntilStep($"wait for time > {i}", () => this.ChildrenOfType<GameplayClockContainer>().SingleOrDefault()?.CurrentTime > time);
             }
 
             AddUntilStep("wait for results", () => multiplayerComponents.CurrentScreen is ResultsScreen);

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.UI
 
         public IFrameStableClock FrameStableClock => frameStableClock;
 
-        [Cached(typeof(GameplayClock))]
+        [Cached(typeof(IGameplayClock))]
         private readonly FrameStabilityClock frameStableClock;
 
         public FrameStabilityContainer(double gameplayStartTime = double.MinValue)
@@ -64,12 +64,12 @@ namespace osu.Game.Rulesets.UI
         private int direction = 1;
 
         [BackgroundDependencyLoader(true)]
-        private void load(GameplayClock clock)
+        private void load(IGameplayClock clock)
         {
             if (clock != null)
             {
                 parentGameplayClock = frameStableClock.ParentGameplayClock = clock;
-                frameStableClock.IsPaused.BindTo(clock.IsPaused);
+                ((IBindable<bool>)frameStableClock.IsPaused).BindTo(clock.IsPaused);
             }
         }
 
@@ -272,7 +272,7 @@ namespace osu.Game.Rulesets.UI
 
         private class FrameStabilityClock : GameplayClock, IFrameStableClock
         {
-            public GameplayClock ParentGameplayClock;
+            public IGameplayClock ParentGameplayClock;
 
             public readonly Bindable<bool> IsCatchingUp = new Bindable<bool>();
 

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -128,6 +129,8 @@ namespace osu.Game.Rulesets.UI
 
             if (parentGameplayClock == null)
                 setClock(); // LoadComplete may not be run yet, but we still want the clock.
+
+            Debug.Assert(parentGameplayClock != null);
 
             double proposedTime = parentGameplayClock.CurrentTime;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             for (int i = 0; i < Users.Count; i++)
             {
-                grid.Add(instances[i] = new PlayerArea(Users[i], masterClockContainer.GameplayClock));
+                grid.Add(instances[i] = new PlayerArea(Users[i], masterClockContainer));
                 syncManager.AddPlayerClock(instances[i].GameplayClock);
             }
 

--- a/osu.Game/Screens/Play/ComboEffects.cs
+++ b/osu.Game/Screens/Play/ComboEffects.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Play
         private ISamplePlaybackDisabler samplePlaybackDisabler { get; set; }
 
         [Resolved]
-        private GameplayClock gameplayClock { get; set; }
+        private IGameplayClock gameplayClock { get; set; }
 
         private void onComboChange(ValueChangedEvent<int> combo)
         {

--- a/osu.Game/Screens/Play/GameplayClock.cs
+++ b/osu.Game/Screens/Play/GameplayClock.cs
@@ -19,15 +19,14 @@ namespace osu.Game.Screens.Play
     /// <see cref="IFrameBasedClock"/>, as this should only be done once to ensure accuracy.
     /// </remarks>
     /// </summary>
-    public class GameplayClock : IFrameBasedClock
+    public class GameplayClock : IGameplayClock
     {
         internal readonly IFrameBasedClock UnderlyingClock;
 
         public readonly BindableBool IsPaused = new BindableBool();
 
-        /// <summary>
-        /// All adjustments applied to this clock which don't come from gameplay or mods.
-        /// </summary>
+        IBindable<bool> IGameplayClock.IsPaused => IsPaused;
+
         public virtual IEnumerable<Bindable<double>> NonGameplayAdjustments => Enumerable.Empty<Bindable<double>>();
 
         public GameplayClock(IFrameBasedClock underlyingClock)
@@ -35,23 +34,12 @@ namespace osu.Game.Screens.Play
             UnderlyingClock = underlyingClock;
         }
 
-        /// <summary>
-        /// The time from which the clock should start. Will be seeked to on calling <see cref="GameplayClockContainer.Reset"/>.
-        /// </summary>
-        /// <remarks>
-        /// If not set, a value of zero will be used.
-        /// Importantly, the value will be inferred from the current ruleset in <see cref="MasterGameplayClockContainer"/> unless specified.
-        /// </remarks>
         public double? StartTime { get; internal set; }
 
         public double CurrentTime => UnderlyingClock.CurrentTime;
 
         public double Rate => UnderlyingClock.Rate;
 
-        /// <summary>
-        /// The rate of gameplay when playback is at 100%.
-        /// This excludes any seeking / user adjustments.
-        /// </summary>
         public double TrueGameplayRate
         {
             get

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Play
     /// <summary>
     /// Encapsulates gameplay timing logic and provides a <see cref="GameplayClock"/> via DI for gameplay components to use.
     /// </summary>
-    public abstract class GameplayClockContainer : Container, IAdjustableClock
+    public class GameplayClockContainer : Container, IAdjustableClock
     {
         /// <summary>
         /// The final clock which is exposed to gameplay components.
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// The source clock.
         /// </summary>
-        protected IClock SourceClock { get; private set; }
+        public IClock SourceClock { get; private set; }
 
         /// <summary>
         /// Invoked when a seek has been performed via <see cref="Seek"/>
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Play
         /// Creates a new <see cref="GameplayClockContainer"/>.
         /// </summary>
         /// <param name="sourceClock">The source <see cref="IClock"/> used for timing.</param>
-        protected GameplayClockContainer(IClock sourceClock)
+        public GameplayClockContainer(IClock sourceClock)
         {
             SourceClock = sourceClock;
 
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Play
         /// </remarks>
         /// <param name="source">The <see cref="IFrameBasedClock"/> providing the source time.</param>
         /// <returns>The final <see cref="GameplayClock"/>.</returns>
-        protected abstract GameplayClock CreateGameplayClock(IFrameBasedClock source);
+        protected virtual GameplayClock CreateGameplayClock(IFrameBasedClock source) => new GameplayClock(source);
 
         #region IAdjustableClock
 

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -15,12 +16,14 @@ namespace osu.Game.Screens.Play
     /// <summary>
     /// Encapsulates gameplay timing logic and provides a <see cref="GameplayClock"/> via DI for gameplay components to use.
     /// </summary>
-    public class GameplayClockContainer : Container, IAdjustableClock, IFrameBasedClock
+    public class GameplayClockContainer : Container, IAdjustableClock, IGameplayClock
     {
         /// <summary>
         /// Whether gameplay is paused.
         /// </summary>
-        public readonly BindableBool IsPaused = new BindableBool(true);
+        public IBindable<bool> IsPaused => isPaused;
+
+        private readonly BindableBool isPaused = new BindableBool(true);
 
         /// <summary>
         /// The adjustable source clock used for gameplay. Should be used for seeks and clock control.
@@ -58,6 +61,8 @@ namespace osu.Game.Screens.Play
             }
         }
 
+        public IEnumerable<Bindable<double>> NonGameplayAdjustments => GameplayClock.NonGameplayAdjustments;
+
         /// <summary>
         /// The final clock which is exposed to gameplay components.
         /// </summary>
@@ -84,7 +89,7 @@ namespace osu.Game.Screens.Play
             dependencies.CacheAs<IGameplayClock>(GameplayClock = CreateGameplayClock(AdjustableSource));
 
             GameplayClock.StartTime = StartTime;
-            GameplayClock.IsPaused.BindTo(IsPaused);
+            GameplayClock.IsPaused.BindTo(isPaused);
 
             return dependencies;
         }
@@ -105,7 +110,7 @@ namespace osu.Game.Screens.Play
                 AdjustableSource.Start();
             }
 
-            IsPaused.Value = false;
+            isPaused.Value = false;
         }
 
         /// <summary>
@@ -127,7 +132,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Stops gameplay.
         /// </summary>
-        public void Stop() => IsPaused.Value = true;
+        public void Stop() => isPaused.Value = true;
 
         /// <summary>
         /// Resets this <see cref="GameplayClockContainer"/> and the source to an initial state ready for gameplay.
@@ -232,5 +237,7 @@ namespace osu.Game.Screens.Play
         public double FramesPerSecond => GameplayClock.FramesPerSecond;
 
         public FrameTimeInfo TimeInfo => GameplayClock.TimeInfo;
+
+        public double TrueGameplayRate => GameplayClock.TrueGameplayRate;
     }
 }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Play
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.CacheAs(GameplayClock = CreateGameplayClock(AdjustableSource));
+            dependencies.CacheAs<IGameplayClock>(GameplayClock = CreateGameplayClock(AdjustableSource));
 
             GameplayClock.StartTime = StartTime;
             GameplayClock.IsPaused.BindTo(IsPaused);

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -86,7 +86,9 @@ namespace osu.Game.Screens.Play
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.CacheAs<IGameplayClock>(GameplayClock = CreateGameplayClock(AdjustableSource));
+            GameplayClock = CreateGameplayClock(AdjustableSource);
+
+            dependencies.CacheAs<IGameplayClock>(this);
 
             GameplayClock.StartTime = StartTime;
             GameplayClock.IsPaused.BindTo(isPaused);

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -209,9 +209,7 @@ namespace osu.Game.Screens.Play
 
         void IAdjustableClock.Reset() => Reset();
 
-        public void ResetSpeedAdjustments()
-        {
-        }
+        public void ResetSpeedAdjustments() => throw new NotImplementedException();
 
         double IAdjustableClock.Rate
         {

--- a/osu.Game/Screens/Play/HUD/SongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgress.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Play.HUD
         public bool UsesFixedAnchor { get; set; }
 
         [Resolved]
-        protected GameplayClock GameplayClock { get; private set; } = null!;
+        protected IGameplayClock GameplayClock { get; private set; } = null!;
 
         [Resolved(canBeNull: true)]
         private DrawableRuleset? drawableRuleset { get; set; }

--- a/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
@@ -38,10 +38,10 @@ namespace osu.Game.Screens.Play.HUD
             set => endTime = value;
         }
 
-        private GameplayClock gameplayClock;
+        private IGameplayClock gameplayClock;
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, GameplayClock clock)
+        private void load(OsuColour colours, IGameplayClock clock)
         {
             if (clock != null)
                 gameplayClock = clock;

--- a/osu.Game/Screens/Play/IGameplayClock.cs
+++ b/osu.Game/Screens/Play/IGameplayClock.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Timing;
+
+namespace osu.Game.Screens.Play
+{
+    public interface IGameplayClock : IFrameBasedClock
+    {
+        /// <summary>
+        /// The rate of gameplay when playback is at 100%.
+        /// This excludes any seeking / user adjustments.
+        /// </summary>
+        double TrueGameplayRate { get; }
+
+        /// <summary>
+        /// The time from which the clock should start. Will be seeked to on calling <see cref="GameplayClockContainer.Reset"/>.
+        /// </summary>
+        /// <remarks>
+        /// If not set, a value of zero will be used.
+        /// Importantly, the value will be inferred from the current ruleset in <see cref="MasterGameplayClockContainer"/> unless specified.
+        /// </remarks>
+        double? StartTime { get; }
+
+        /// <summary>
+        /// All adjustments applied to this clock which don't come from gameplay or mods.
+        /// </summary>
+        IEnumerable<Bindable<double>> NonGameplayAdjustments { get; }
+
+        IBindable<bool> IsPaused { get; }
+    }
+}

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -330,7 +330,7 @@ namespace osu.Game.Screens.Play
             DrawableRuleset.HasReplayLoaded.BindValueChanged(_ => updateGameplayState());
 
             // bind clock into components that require it
-            DrawableRuleset.IsPaused.BindTo(GameplayClockContainer.IsPaused);
+            ((IBindable<bool>)DrawableRuleset.IsPaused).BindTo(GameplayClockContainer.IsPaused);
 
             DrawableRuleset.NewResult += r =>
             {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -475,7 +475,7 @@ namespace osu.Game.Screens.Play
 
         private void updateSampleDisabledState()
         {
-            samplePlaybackDisabled.Value = DrawableRuleset.FrameStableClock.IsCatchingUp.Value || GameplayClockContainer.GameplayClock.IsPaused.Value;
+            samplePlaybackDisabled.Value = DrawableRuleset.FrameStableClock.IsCatchingUp.Value || GameplayClockContainer.IsPaused.Value;
         }
 
         private void updatePauseOnFocusLostState()
@@ -877,7 +877,7 @@ namespace osu.Game.Screens.Play
         private double? lastPauseActionTime;
 
         protected bool PauseCooldownActive =>
-            lastPauseActionTime.HasValue && GameplayClockContainer.GameplayClock.CurrentTime < lastPauseActionTime + pause_cooldown;
+            lastPauseActionTime.HasValue && GameplayClockContainer.CurrentTime < lastPauseActionTime + pause_cooldown;
 
         /// <summary>
         /// A set of conditionals which defines whether the current game state and configuration allows for
@@ -915,7 +915,7 @@ namespace osu.Game.Screens.Play
 
             GameplayClockContainer.Stop();
             PauseOverlay.Show();
-            lastPauseActionTime = GameplayClockContainer.GameplayClock.CurrentTime;
+            lastPauseActionTime = GameplayClockContainer.CurrentTime;
             return true;
         }
 
@@ -1005,7 +1005,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual void StartGameplay()
         {
-            if (GameplayClockContainer.GameplayClock.IsRunning)
+            if (GameplayClockContainer.IsRunning)
                 throw new InvalidOperationException($"{nameof(StartGameplay)} should not be called when the gameplay clock is already running");
 
             GameplayClockContainer.Reset(true);

--- a/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
+++ b/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Play
     public class ScreenSuspensionHandler : Component
     {
         private readonly GameplayClockContainer gameplayClockContainer;
-        private Bindable<bool> isPaused;
+        private IBindable<bool> isPaused;
 
         private readonly Bindable<bool> disableSuspensionBindable = new Bindable<bool>();
 

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play
         private bool isClickable;
 
         [Resolved]
-        private GameplayClock gameplayClock { get; set; }
+        private IGameplayClock gameplayClock { get; set; }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(GameplayClock clock, CancellationToken? cancellationToken, GameHost host, RealmAccess realm)
+        private void load(IGameplayClock clock, CancellationToken? cancellationToken, GameHost host, RealmAccess realm)
         {
             if (clock != null)
                 Clock = clock;


### PR DESCRIPTION
As a first step towards tidying up the structure of clocks in gameplay usages, I want to remove all usage of `GameplayClock` via DI.

The next step would be to attempt to remove `GameplayClock` itself.