### PR TITLE
Remove `FrameStableClock` (and redirect usages to `FrameStabilityContainer`)

### DIFF
--- a/osu.Game.Tests/NonVisual/GameplayClockTest.cs
+++ b/osu.Game.Tests/NonVisual/GameplayClockTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Timing;
@@ -30,7 +31,7 @@ namespace osu.Game.Tests.NonVisual
         {
             public List<Bindable<double>> MutableNonGameplayAdjustments { get; } = new List<Bindable<double>>();
 
-            public override IEnumerable<Bindable<double>> NonGameplayAdjustments => MutableNonGameplayAdjustments;
+            public override IEnumerable<double> NonGameplayAdjustments => MutableNonGameplayAdjustments.Select(b => b.Value);
 
             public TestGameplayClock(IFrameBasedClock underlyingClock)
                 : base(underlyingClock)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFrameStabilityContainer.cs
@@ -137,13 +137,13 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void seekManualTo(double time) => AddStep($"seek manual clock to {time}", () => manualClock.CurrentTime = time);
 
-        private void confirmSeek(double time) => AddUntilStep($"wait for seek to {time}", () => consumer.Clock.CurrentTime == time);
+        private void confirmSeek(double time) => AddUntilStep($"wait for seek to {time}", () => consumer.Clock.CurrentTime, () => Is.EqualTo(time));
 
         private void checkFrameCount(int frames) =>
-            AddAssert($"elapsed frames is {frames}", () => consumer.ElapsedFrames == frames);
+            AddAssert($"elapsed frames is {frames}", () => consumer.ElapsedFrames, () => Is.EqualTo(frames));
 
         private void checkRate(double rate) =>
-            AddAssert($"clock rate is {rate}", () => consumer.Clock.Rate == rate);
+            AddAssert($"clock rate is {rate}", () => consumer.Clock.Rate, () => Is.EqualTo(rate));
 
         public class ClockConsumingChild : CompositeDrawable
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySamplePlayback.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -21,22 +19,22 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestAllSamplesStopDuringSeek()
         {
-            DrawableSlider slider = null;
-            PoolableSkinnableSample[] samples = null;
-            ISamplePlaybackDisabler sampleDisabler = null;
+            DrawableSlider? slider = null;
+            PoolableSkinnableSample[] samples = null!;
+            ISamplePlaybackDisabler sampleDisabler = null!;
 
             AddUntilStep("get variables", () =>
             {
                 sampleDisabler = Player;
                 slider = Player.ChildrenOfType<DrawableSlider>().MinBy(s => s.HitObject.StartTime);
-                samples = slider?.ChildrenOfType<PoolableSkinnableSample>().ToArray();
+                samples = slider.ChildrenOfType<PoolableSkinnableSample>().ToArray();
 
                 return slider != null;
             });
 
             AddUntilStep("wait for slider sliding then seek", () =>
             {
-                if (!slider.Tracking.Value)
+                if (slider?.Tracking.Value != true)
                     return false;
 
                 if (!samples.Any(s => s.Playing))

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -363,7 +363,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private Player player => Stack.CurrentScreen as Player;
 
         private double currentFrameStableTime
-            => player.ChildrenOfType<FrameStabilityContainer>().First().FrameStableClock.CurrentTime;
+            => player.ChildrenOfType<FrameStabilityContainer>().First().CurrentTime;
 
         private void waitForPlayer() => AddUntilStep("wait for player", () => (Stack.CurrentScreen as Player)?.IsLoaded == true);
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.UI
 
         public override Container FrameStableComponents { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
-        public override IFrameStableClock FrameStableClock => frameStabilityContainer.FrameStableClock;
+        public override IFrameStableClock FrameStableClock => frameStabilityContainer;
 
         private bool frameStablePlayback = true;
 

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.UI
             if (state == PlaybackState.Valid && proposedTime != manualClock.CurrentTime)
                 direction = proposedTime >= manualClock.CurrentTime ? 1 : -1;
 
-            double timeBehind = Math.Abs(proposedTime - CurrentTime);
+            double timeBehind = Math.Abs(proposedTime - referenceClock.CurrentTime);
 
             IsCatchingUp.Value = timeBehind > 200;
             WaitingOnFrames.Value = state == PlaybackState.NotValid;

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.UI
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            setClock();
+            Clock = this;
         }
 
         private PlaybackState state;
@@ -128,12 +128,7 @@ namespace osu.Game.Rulesets.UI
                 state = PlaybackState.Valid;
             }
 
-            if (parentGameplayClock == null)
-                setClock(); // LoadComplete may not be run yet, but we still want the clock.
-
-            Debug.Assert(parentGameplayClock != null);
-
-            double proposedTime = parentGameplayClock.CurrentTime;
+            double proposedTime = Clock.CurrentTime;
 
             if (FrameStablePlayback)
                 // if we require frame stability, the proposed time will be adjusted to move at most one known
@@ -153,14 +148,14 @@ namespace osu.Game.Rulesets.UI
             if (state == PlaybackState.Valid && proposedTime != manualClock.CurrentTime)
                 direction = proposedTime >= manualClock.CurrentTime ? 1 : -1;
 
-            double timeBehind = Math.Abs(proposedTime - parentGameplayClock.CurrentTime);
+            double timeBehind = Math.Abs(proposedTime - Clock.CurrentTime);
 
             IsCatchingUp.Value = timeBehind > 200;
             WaitingOnFrames.Value = state == PlaybackState.NotValid;
 
             manualClock.CurrentTime = proposedTime;
-            manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;
-            manualClock.IsRunning = parentGameplayClock.IsRunning;
+            manualClock.Rate = Math.Abs(Clock.Rate) * direction;
+            manualClock.IsRunning = Clock.IsRunning;
 
             // determine whether catch-up is required.
             if (state == PlaybackState.Valid && timeBehind > 0)
@@ -237,12 +232,6 @@ namespace osu.Game.Rulesets.UI
                     ? Math.Min(proposedTime, manualClock.CurrentTime + sixty_frame_time)
                     : Math.Max(proposedTime, manualClock.CurrentTime - sixty_frame_time);
             }
-        }
-
-        private void setClock()
-        {
-            if (parentGameplayClock != null)
-                Clock = this;
         }
 
         public ReplayInputHandler? ReplayInputHandler { get; set; }

--- a/osu.Game/Rulesets/UI/IFrameStableClock.cs
+++ b/osu.Game/Rulesets/UI/IFrameStableClock.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Timing;
 

--- a/osu.Game/Screens/Play/GameplayClock.cs
+++ b/osu.Game/Screens/Play/GameplayClock.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Play
 
         IBindable<bool> IGameplayClock.IsPaused => IsPaused;
 
-        public virtual IEnumerable<Bindable<double>> NonGameplayAdjustments => Enumerable.Empty<Bindable<double>>();
+        public virtual IEnumerable<double> NonGameplayAdjustments => Enumerable.Empty<double>();
 
         public GameplayClock(IFrameBasedClock underlyingClock)
         {
@@ -46,12 +46,12 @@ namespace osu.Game.Screens.Play
             {
                 double baseRate = Rate;
 
-                foreach (var adjustment in NonGameplayAdjustments)
+                foreach (double adjustment in NonGameplayAdjustments)
                 {
-                    if (Precision.AlmostEquals(adjustment.Value, 0))
+                    if (Precision.AlmostEquals(adjustment, 0))
                         return 0;
 
-                    baseRate /= adjustment.Value;
+                    baseRate /= adjustment;
                 }
 
                 return baseRate;

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        public IEnumerable<Bindable<double>> NonGameplayAdjustments => GameplayClock.NonGameplayAdjustments;
+        public IEnumerable<double> NonGameplayAdjustments => GameplayClock.NonGameplayAdjustments;
 
         /// <summary>
         /// The final clock which is exposed to gameplay components.

--- a/osu.Game/Screens/Play/IGameplayClock.cs
+++ b/osu.Game/Screens/Play/IGameplayClock.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// All adjustments applied to this clock which don't come from gameplay or mods.
         /// </summary>
-        IEnumerable<Bindable<double>> NonGameplayAdjustments { get; }
+        IEnumerable<double> NonGameplayAdjustments { get; }
 
         IBindable<bool> IsPaused { get; }
     }

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -303,7 +303,7 @@ namespace osu.Game.Screens.Play
         private class MasterGameplayClock : GameplayClock
         {
             public readonly List<Bindable<double>> MutableNonGameplayAdjustments = new List<Bindable<double>>();
-            public override IEnumerable<Bindable<double>> NonGameplayAdjustments => MutableNonGameplayAdjustments;
+            public override IEnumerable<double> NonGameplayAdjustments => MutableNonGameplayAdjustments.Select(b => b.Value);
 
             public MasterGameplayClock(FramedOffsetClock underlyingClock)
                 : base(underlyingClock)


### PR DESCRIPTION
- [x] Depends on #19775.