### PR TITLE
Tidy up and document `FrameStabilityContainer`

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.UI
     /// </summary>
     [Cached(typeof(IGameplayClock))]
     [Cached(typeof(IFrameStableClock))]
-    public class FrameStabilityContainer : Container, IHasReplayHandler, IFrameStableClock, IGameplayClock
+    public sealed class FrameStabilityContainer : Container, IHasReplayHandler, IFrameStableClock, IGameplayClock
     {
         public ReplayInputHandler? ReplayInputHandler { get; set; }
 


### PR DESCRIPTION
Split out from #19776 because it reorders a lot of the file and will make the actual changes harder to see.

- [x] Depends on #19776.