### PR TITLE
Add ability to merge hit objects in osu! editor to create sliders

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Utils;
@@ -19,8 +17,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestSimpleMerge()
         {
-            HitCircle circle1 = null;
-            HitCircle circle2 = null;
+            HitCircle? circle1 = null;
+            HitCircle? circle2 = null;
 
             AddStep("select first two circles", () =>
             {
@@ -33,20 +31,20 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             mergeSelection();
 
-            AddAssert("slider created", () => sliderCreatedFor(
+            AddAssert("slider created", () => circle1 is not null && circle2 is not null && sliderCreatedFor(
                 (pos: circle1.Position, pathType: PathType.Linear),
                 (pos: circle2.Position, pathType: null)));
 
             AddStep("undo", () => Editor.Undo());
-            AddAssert("merged objects restored", () => objectsRestored(circle1, circle2));
+            AddAssert("merged objects restored", () => circle1 is not null && circle2 is not null && objectsRestored(circle1, circle2));
         }
 
         [Test]
         public void TestMergeCircleSlider()
         {
-            HitCircle circle1 = null;
-            Slider slider = null;
-            HitCircle circle2 = null;
+            HitCircle? circle1 = null;
+            Slider? slider = null;
+            HitCircle? circle2 = null;
 
             AddStep("select a circle, slider, circle", () =>
             {
@@ -63,6 +61,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddAssert("slider created", () =>
             {
+                if (circle1 is null || circle2 is null || slider is null)
+                    return false;
+
                 var controlPoints = slider.Path.ControlPoints;
                 (Vector2, PathType?)[] args = new (Vector2, PathType?)[controlPoints.Count + 2];
                 args[0] = (circle1.Position, PathType.Linear);
@@ -77,15 +78,15 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
 
             AddStep("undo", () => Editor.Undo());
-            AddAssert("merged objects restored", () => objectsRestored(circle1, slider, circle2));
+            AddAssert("merged objects restored", () => circle1 is not null && circle2 is not null && slider is not null && objectsRestored(circle1, slider, circle2));
         }
 
         [Test]
         public void TestMergeSliderSlider()
         {
-            Slider slider1 = null;
-            SliderPath slider1Path = null;
-            Slider slider2 = null;
+            Slider? slider1 = null;
+            SliderPath? slider1Path = null;
+            Slider? slider2 = null;
 
             AddStep("select two sliders", () =>
             {
@@ -101,6 +102,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddAssert("slider created", () =>
             {
+                if (slider1 is null || slider2 is null || slider1Path is null)
+                    return false;
+
                 var controlPoints1 = slider1Path.ControlPoints;
                 var controlPoints2 = slider2.Path.ControlPoints;
                 (Vector2, PathType?)[] args = new (Vector2, PathType?)[controlPoints1.Count + controlPoints2.Count - 1];
@@ -121,14 +125,17 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddAssert("merged slider matches first slider", () =>
             {
                 var mergedSlider = (Slider)EditorBeatmap.SelectedHitObjects.First();
-                return mergedSlider.HeadCircle.Samples.SequenceEqual(slider1.HeadCircle.Samples)
-                       && mergedSlider.TailCircle.Samples.SequenceEqual(slider1.TailCircle.Samples)
-                       && mergedSlider.Samples.SequenceEqual(slider1.Samples)
-                       && mergedSlider.SampleControlPoint.IsRedundant(slider1.SampleControlPoint);
+                return slider1 is not null && mergedSlider.HeadCircle.Samples.SequenceEqual(slider1.HeadCircle.Samples)
+                                           && mergedSlider.TailCircle.Samples.SequenceEqual(slider1.TailCircle.Samples)
+                                           && mergedSlider.Samples.SequenceEqual(slider1.Samples)
+                                           && mergedSlider.SampleControlPoint.IsRedundant(slider1.SampleControlPoint);
             });
 
             AddAssert("slider end is at same completion for last slider", () =>
             {
+                if (slider1Path is null || slider2 is null)
+                    return false;
+
                 var mergedSlider = (Slider)EditorBeatmap.SelectedHitObjects.First();
                 return Precision.AlmostEquals(mergedSlider.Path.Distance, slider1Path.CalculatedDistance + slider2.Path.Distance);
             });

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 #nullable disable
 
 using System.Linq;

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
@@ -1,6 +1,3 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 #nullable disable
 
 using System.Linq;

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
@@ -141,6 +141,33 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
         }
 
+        [Test]
+        public void TestNonMerge()
+        {
+            HitCircle? circle1 = null;
+            HitCircle? circle2 = null;
+            Spinner? spinner = null;
+
+            AddStep("select first two circles and spinner", () =>
+            {
+                circle1 = (HitCircle)EditorBeatmap.HitObjects.First(h => h is HitCircle);
+                circle2 = (HitCircle)EditorBeatmap.HitObjects.First(h => h is HitCircle && h != circle1);
+                spinner = (Spinner)EditorBeatmap.HitObjects.First(h => h is Spinner);
+                EditorClock.Seek(spinner.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(circle1);
+                EditorBeatmap.SelectedHitObjects.Add(circle2);
+                EditorBeatmap.SelectedHitObjects.Add(spinner);
+            });
+
+            mergeSelection();
+
+            AddAssert("slider created", () => circle1 is not null && circle2 is not null && sliderCreatedFor(
+                (pos: circle1.Position, pathType: PathType.Linear),
+                (pos: circle2.Position, pathType: null)));
+
+            AddAssert("spinner not merged", () => EditorBeatmap.HitObjects.Contains(spinner));
+        }
+
         private void mergeSelection()
         {
             AddStep("merge selection", () =>

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
@@ -1,0 +1,179 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public class TestSceneObjectMerging : TestSceneOsuEditor
+    {
+        [Test]
+        public void TestSimpleMerge()
+        {
+            HitCircle circle1 = null;
+            HitCircle circle2 = null;
+
+            AddStep("select first two circles", () =>
+            {
+                circle1 = (HitCircle)EditorBeatmap.HitObjects.First(h => h is HitCircle);
+                circle2 = (HitCircle)EditorBeatmap.HitObjects.First(h => h is HitCircle && h != circle1);
+                EditorClock.Seek(circle1.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(circle1);
+                EditorBeatmap.SelectedHitObjects.Add(circle2);
+            });
+
+            mergeSelection();
+
+            AddAssert("slider created", () => sliderCreatedFor(
+                (pos: circle1.Position, pathType: PathType.Linear),
+                (pos: circle2.Position, pathType: null)));
+
+            AddStep("undo", () => Editor.Undo());
+            AddAssert("merged objects restored", () => objectsRestored(circle1, circle2));
+        }
+
+        [Test]
+        public void TestMergeCircleSlider()
+        {
+            HitCircle circle1 = null;
+            Slider slider = null;
+            HitCircle circle2 = null;
+
+            AddStep("select a circle, slider, circle", () =>
+            {
+                circle1 = (HitCircle)EditorBeatmap.HitObjects.First(h => h is HitCircle);
+                slider = (Slider)EditorBeatmap.HitObjects.First(h => h is Slider && h.StartTime > circle1.StartTime);
+                circle2 = (HitCircle)EditorBeatmap.HitObjects.First(h => h is HitCircle && h.StartTime > slider.StartTime);
+                EditorClock.Seek(circle1.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(circle1);
+                EditorBeatmap.SelectedHitObjects.Add(slider);
+                EditorBeatmap.SelectedHitObjects.Add(circle2);
+            });
+
+            mergeSelection();
+
+            AddAssert("slider created", () =>
+            {
+                var controlPoints = slider.Path.ControlPoints;
+                (Vector2, PathType?)[] args = new (Vector2, PathType?)[controlPoints.Count + 2];
+                args[0] = (circle1.Position, PathType.Linear);
+
+                for (int i = 0; i < controlPoints.Count; i++)
+                {
+                    args[i + 1] = (controlPoints[i].Position + slider.Position, i == controlPoints.Count - 1 ? PathType.Linear : controlPoints[i].Type);
+                }
+
+                args[^1] = (circle2.Position, null);
+                return sliderCreatedFor(args);
+            });
+
+            AddStep("undo", () => Editor.Undo());
+            AddAssert("merged objects restored", () => objectsRestored(circle1, slider, circle2));
+        }
+
+        [Test]
+        public void TestMergeSliderSlider()
+        {
+            Slider slider1 = null;
+            SliderPath slider1Path = null;
+            Slider slider2 = null;
+
+            AddStep("select two sliders", () =>
+            {
+                slider1 = (Slider)EditorBeatmap.HitObjects.First(h => h is Slider);
+                slider1Path = new SliderPath(slider1.Path.ControlPoints.Select(p => new PathControlPoint(p.Position, p.Type)).ToArray(), slider1.Path.ExpectedDistance.Value);
+                slider2 = (Slider)EditorBeatmap.HitObjects.First(h => h is Slider && h.StartTime > slider1.StartTime);
+                EditorClock.Seek(slider1.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(slider1);
+                EditorBeatmap.SelectedHitObjects.Add(slider2);
+            });
+
+            mergeSelection();
+
+            AddAssert("slider created", () =>
+            {
+                var controlPoints1 = slider1Path.ControlPoints;
+                var controlPoints2 = slider2.Path.ControlPoints;
+                (Vector2, PathType?)[] args = new (Vector2, PathType?)[controlPoints1.Count + controlPoints2.Count - 1];
+
+                for (int i = 0; i < controlPoints1.Count - 1; i++)
+                {
+                    args[i] = (controlPoints1[i].Position + slider1.Position, controlPoints1[i].Type);
+                }
+
+                for (int i = 0; i < controlPoints2.Count; i++)
+                {
+                    args[i + controlPoints1.Count - 1] = (controlPoints2[i].Position + controlPoints1[^1].Position + slider1.Position, controlPoints2[i].Type);
+                }
+
+                return sliderCreatedFor(args);
+            });
+
+            AddAssert("merged slider matches first slider", () =>
+            {
+                var mergedSlider = (Slider)EditorBeatmap.SelectedHitObjects.First();
+                return mergedSlider.HeadCircle.Samples.SequenceEqual(slider1.HeadCircle.Samples)
+                       && mergedSlider.TailCircle.Samples.SequenceEqual(slider1.TailCircle.Samples)
+                       && mergedSlider.Samples.SequenceEqual(slider1.Samples)
+                       && mergedSlider.SampleControlPoint.IsRedundant(slider1.SampleControlPoint);
+            });
+
+            AddAssert("slider end is at same completion for last slider", () =>
+            {
+                var mergedSlider = (Slider)EditorBeatmap.SelectedHitObjects.First();
+                return Precision.AlmostEquals(mergedSlider.Path.Distance, slider1Path.CalculatedDistance + slider2.Path.Distance);
+            });
+        }
+
+        private void mergeSelection()
+        {
+            AddStep("merge selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.PressKey(Key.LShift);
+                InputManager.Key(Key.M);
+                InputManager.ReleaseKey(Key.LShift);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+        }
+
+        private bool sliderCreatedFor(params (Vector2 pos, PathType? pathType)[] expectedControlPoints)
+        {
+            if (EditorBeatmap.SelectedHitObjects.Count != 1)
+                return false;
+
+            var mergedSlider = (Slider)EditorBeatmap.SelectedHitObjects.First();
+            int i = 0;
+
+            foreach ((Vector2 pos, PathType? pathType) in expectedControlPoints)
+            {
+                var controlPoint = mergedSlider.Path.ControlPoints[i++];
+
+                if (!Precision.AlmostEquals(controlPoint.Position + mergedSlider.Position, pos) || controlPoint.Type != pathType)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool objectsRestored(params HitObject[] objects)
+        {
+            foreach (var hitObject in objects)
+            {
+                if (EditorBeatmap.HitObjects.Contains(hitObject))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -251,13 +251,13 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void convertToStream()
         {
-            if (editorBeatmap == null || changeHandler == null || beatDivisor == null)
+            if (editorBeatmap == null || beatDivisor == null)
                 return;
 
             var timingPoint = editorBeatmap.ControlPointInfo.TimingPointAt(HitObject.StartTime);
             double streamSpacing = timingPoint.BeatLength / beatDivisor.Value;
 
-            changeHandler.BeginChange();
+            changeHandler?.BeginChange();
 
             int i = 0;
             double time = HitObject.StartTime;
@@ -292,7 +292,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             editorBeatmap.Remove(HitObject);
 
-            changeHandler.EndChange();
+            changeHandler?.EndChange();
         }
 
         public override MenuItem[] ContextMenuItems => new MenuItem[]

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -348,13 +348,15 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void mergeSelection()
         {
-            if (selectedMergeableObjects.Length < 2)
+            var mergeableObjects = selectedMergeableObjects;
+
+            if (mergeableObjects.Length < 2)
                 return;
 
             ChangeHandler?.BeginChange();
 
             // Have an initial slider object.
-            var firstHitObject = selectedMergeableObjects[0];
+            var firstHitObject = mergeableObjects[0];
             var mergedHitObject = firstHitObject as Slider ?? new Slider
             {
                 StartTime = firstHitObject.StartTime,
@@ -371,7 +373,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             // Merge all the selected hit objects into one slider path.
             bool lastCircle = firstHitObject is HitCircle;
 
-            foreach (var selectedMergeableObject in selectedMergeableObjects.Skip(1))
+            foreach (var selectedMergeableObject in mergeableObjects.Skip(1))
             {
                 if (selectedMergeableObject is IHasPath hasPath)
                 {
@@ -407,14 +409,14 @@ namespace osu.Game.Rulesets.Osu.Edit
             // Make sure only the merged hit object is in the beatmap.
             if (firstHitObject is Slider)
             {
-                foreach (var selectedMergeableObject in selectedMergeableObjects.Skip(1))
+                foreach (var selectedMergeableObject in mergeableObjects.Skip(1))
                 {
                     EditorBeatmap.Remove(selectedMergeableObject);
                 }
             }
             else
             {
-                foreach (var selectedMergeableObject in selectedMergeableObjects)
+                foreach (var selectedMergeableObject in mergeableObjects)
                 {
                     EditorBeatmap.Remove(selectedMergeableObject);
                 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -348,10 +348,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void mergeSelection()
         {
-            if (EditorBeatmap == null || ChangeHandler == null || selectedMergeableObjects.Length < 2)
+            if (selectedMergeableObjects.Length < 2)
                 return;
 
-            ChangeHandler.BeginChange();
+            ChangeHandler?.BeginChange();
 
             // Have an initial slider object.
             var firstHitObject = selectedMergeableObjects[0];
@@ -426,7 +426,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             SelectedItems.Clear();
             SelectedItems.Add(mergedHitObject);
 
-            ChangeHandler.EndChange();
+            ChangeHandler?.EndChange();
         }
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterface;
@@ -18,6 +19,7 @@ using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -60,6 +62,17 @@ namespace osu.Game.Rulesets.Osu.Edit
             base.OnOperationEnded();
             referenceOrigin = null;
             referencePathTypes = null;
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Key == Key.M && e.ControlPressed && e.ShiftPressed)
+            {
+                mergeSelection();
+                return true;
+            }
+
+            return false;
         }
 
         public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent)

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -335,7 +335,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// All osu! hitobjects which can be moved/rotated/scaled.
         /// </summary>
         private OsuHitObject[] selectedMovableObjects => SelectedItems.OfType<OsuHitObject>()
-                                                                      .Where(h => !(h is Spinner))
+                                                                      .Where(h => h is not Spinner)
                                                                       .ToArray();
 
         /// <summary>
@@ -434,7 +434,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             foreach (var item in base.GetContextMenuItemsForSelection(selection))
                 yield return item;
 
-            if (selection.Count() > 1 && selection.All(o => o.Item is HitCircle or Slider))
+            if (selectedMergeableObjects.Length > 1)
                 yield return new OsuMenuItem("Merge selection", MenuItemType.Destructive, mergeSelection);
         }
     }

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -16,7 +16,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
-using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 using osuTK.Input;
@@ -27,12 +26,6 @@ namespace osu.Game.Rulesets.Osu.Edit
     {
         [Resolved(CanBeNull = true)]
         private IDistanceSnapProvider? snapProvider { get; set; }
-
-        [Resolved(CanBeNull = true)]
-        private EditorBeatmap? editorBeatmap { get; set; }
-
-        [Resolved(CanBeNull = true)]
-        private IEditorChangeHandler? changeHandler { get; set; }
 
         /// <summary>
         /// During a transform, the initial origin is stored so it can be used throughout the operation.
@@ -355,10 +348,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void mergeSelection()
         {
-            if (editorBeatmap == null || changeHandler == null || selectedMergeableObjects.Length < 2)
+            if (EditorBeatmap == null || ChangeHandler == null || selectedMergeableObjects.Length < 2)
                 return;
 
-            changeHandler.BeginChange();
+            ChangeHandler.BeginChange();
 
             // Have an initial slider object.
             var firstHitObject = selectedMergeableObjects[0];
@@ -416,24 +409,24 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 foreach (var selectedMergeableObject in selectedMergeableObjects.Skip(1))
                 {
-                    editorBeatmap.Remove(selectedMergeableObject);
+                    EditorBeatmap.Remove(selectedMergeableObject);
                 }
             }
             else
             {
                 foreach (var selectedMergeableObject in selectedMergeableObjects)
                 {
-                    editorBeatmap.Remove(selectedMergeableObject);
+                    EditorBeatmap.Remove(selectedMergeableObject);
                 }
 
-                editorBeatmap.Add(mergedHitObject);
+                EditorBeatmap.Add(mergedHitObject);
             }
 
             // Make sure the merged hitobject is selected.
             SelectedItems.Clear();
             SelectedItems.Add(mergedHitObject);
 
-            changeHandler.EndChange();
+            ChangeHandler.EndChange();
         }
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)


### PR DESCRIPTION
I added a feature to the osu editor which lets you merge multiple objects into one big slider. You can use it by selecting multiple sliders and then pressing the 'Merge selection' in the context menu or pressing Ctrl+Shift+M.

https://user-images.githubusercontent.com/17460441/184664631-decf2530-d119-4198-94ac-250091470893.mp4

 