### PR TITLE
Fix selecting preset containing Difficulty Adjust automatically opening customisation panel

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -192,7 +192,11 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("select customisable mod", () => SelectedMods.Value = new[] { new OsuModDoubleTime() });
             assertCustomisationToggleState(disabled: false, active: false);
 
-            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            AddStep("select mod requiring configuration externally", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            assertCustomisationToggleState(disabled: false, active: false);
+
+            AddStep("reset mods", () => SelectedMods.SetDefault());
+            AddStep("select difficulty adjust via panel", () => getPanelForMod(typeof(OsuModDifficultyAdjust)).TriggerClick());
             assertCustomisationToggleState(disabled: false, active: true);
 
             AddStep("dismiss mod customisation via toggle", () =>
@@ -203,7 +207,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             assertCustomisationToggleState(disabled: false, active: false);
 
             AddStep("reset mods", () => SelectedMods.SetDefault());
-            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            AddStep("select difficulty adjust via panel", () => getPanelForMod(typeof(OsuModDifficultyAdjust)).TriggerClick());
             assertCustomisationToggleState(disabled: false, active: true);
 
             AddStep("dismiss mod customisation via keyboard", () => InputManager.Key(Key.Escape));
@@ -215,7 +219,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("select mod without configuration", () => SelectedMods.Value = new[] { new OsuModAutoplay() });
             assertCustomisationToggleState(disabled: true, active: false);
 
-            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            AddStep("select difficulty adjust via panel", () => getPanelForMod(typeof(OsuModDifficultyAdjust)).TriggerClick());
             assertCustomisationToggleState(disabled: false, active: true);
 
             AddStep("select mod without configuration", () => SelectedMods.Value = new[] { new OsuModAutoplay() });
@@ -235,7 +239,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             createScreen();
             assertCustomisationToggleState(disabled: true, active: false);
 
-            AddStep("select mod requiring configuration", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            AddStep("select difficulty adjust via panel", () => getPanelForMod(typeof(OsuModDifficultyAdjust)).TriggerClick());
             assertCustomisationToggleState(disabled: false, active: true);
 
             AddStep("move mouse to settings area", () => InputManager.MoveMouseTo(this.ChildrenOfType<ModSettingsArea>().Single()));
@@ -262,7 +266,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             ModSelectOverlay modSelectOverlay2 = null!;
 
             createScreen();
-            AddStep("select diff adjust", () => SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust() });
+            AddStep("select difficulty adjust via panel", () => getPanelForMod(typeof(OsuModDifficultyAdjust)).TriggerClick());
 
             AddStep("set setting", () => modSelectOverlay.ChildrenOfType<OsuSliderBar<float>>().First().Current.Value = 8);
 
@@ -492,7 +496,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             createScreen();
             changeRuleset(0);
 
-            AddStep("select difficulty adjust", () => SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust() });
+            AddStep("select difficulty adjust via panel", () => getPanelForMod(typeof(OsuModDifficultyAdjust)).TriggerClick());
             assertCustomisationToggleState(disabled: false, active: true);
             AddAssert("back button disabled", () => !modSelectOverlay.BackButton.Enabled.Value);
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -47,6 +47,26 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("clear contents", Clear);
             AddStep("reset ruleset", () => Ruleset.Value = rulesetStore.GetRuleset(0));
             AddStep("reset mods", () => SelectedMods.SetDefault());
+            AddStep("set up presets", () =>
+            {
+                Realm.Write(r =>
+                {
+                    r.RemoveAll<ModPreset>();
+                    r.Add(new ModPreset
+                    {
+                        Name = "AR0",
+                        Description = "Too... many... circles...",
+                        Ruleset = r.Find<RulesetInfo>(OsuRuleset.SHORT_NAME),
+                        Mods = new[]
+                        {
+                            new OsuModDifficultyAdjust
+                            {
+                                ApproachRate = { Value = 0 }
+                            }
+                        }
+                    });
+                });
+            });
         }
 
         private void createScreen()
@@ -200,6 +220,13 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("select mod without configuration", () => SelectedMods.Value = new[] { new OsuModAutoplay() });
             assertCustomisationToggleState(disabled: true, active: false); // config was dismissed without explicit user action.
+
+            AddStep("select mod preset with mod requiring configuration", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<ModPresetPanel>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            assertCustomisationToggleState(disabled: false, active: false);
         }
 
         [Test]

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -66,7 +66,10 @@ namespace osu.Game.Overlays.Mods
         private IModHotkeyHandler hotkeyHandler = null!;
 
         private Task? latestLoadTask;
-        internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true;
+        private bool itemsLoaded;
+        internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true && itemsLoaded;
+
+        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
 
         public ModColumn(ModType modType, bool allowIncompatibleSelection)
         {
@@ -132,10 +135,12 @@ namespace osu.Game.Overlays.Mods
 
             var panels = availableMods.Select(mod => CreateModPanel(mod).With(panel => panel.Shear = Vector2.Zero));
 
+            itemsLoaded = false;
             latestLoadTask = LoadComponentsAsync(panels, loaded =>
             {
                 ItemsFlow.ChildrenEnumerable = loaded;
                 updateState();
+                itemsLoaded = true;
             }, (cancellationTokenSource = new CancellationTokenSource()).Token);
         }
 

--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -66,8 +66,8 @@ namespace osu.Game.Overlays.Mods
         private IModHotkeyHandler hotkeyHandler = null!;
 
         private Task? latestLoadTask;
-        private bool itemsLoaded;
-        internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true && itemsLoaded;
+        private ICollection<ModPanel>? latestLoadedPanels;
+        internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true && latestLoadedPanels?.All(panel => panel.Parent != null) == true;
 
         public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
 
@@ -133,14 +133,13 @@ namespace osu.Game.Overlays.Mods
         {
             cancellationTokenSource?.Cancel();
 
-            var panels = availableMods.Select(mod => CreateModPanel(mod).With(panel => panel.Shear = Vector2.Zero));
+            var panels = availableMods.Select(mod => CreateModPanel(mod).With(panel => panel.Shear = Vector2.Zero)).ToArray();
+            latestLoadedPanels = panels;
 
-            itemsLoaded = false;
             latestLoadTask = LoadComponentsAsync(panels, loaded =>
             {
                 ItemsFlow.ChildrenEnumerable = loaded;
                 updateState();
-                itemsLoaded = true;
             }, (cancellationTokenSource = new CancellationTokenSource()).Token);
         }
 

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -59,13 +59,13 @@ namespace osu.Game.Overlays.Mods
 
         protected override void Select()
         {
-            modState.RequiresConfiguration = Mod.RequiresConfiguration;
+            modState.PendingConfiguration = Mod.RequiresConfiguration;
             Active.Value = true;
         }
 
         protected override void Deselect()
         {
-            modState.RequiresConfiguration = false;
+            modState.PendingConfiguration = false;
             Active.Value = false;
         }
 

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Overlays.Mods
                 Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
                 Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
             };
-
-            Action = select;
         }
 
         public ModPanel(Mod mod)
@@ -59,18 +57,16 @@ namespace osu.Game.Overlays.Mods
             Filtered.BindValueChanged(_ => updateFilterState(), true);
         }
 
-        private void select()
+        protected override void Select()
         {
-            if (!Active.Value)
-            {
-                modState.RequiresConfiguration = Mod.RequiresConfiguration;
-                Active.Value = true;
-            }
-            else
-            {
-                modState.RequiresConfiguration = false;
-                Active.Value = false;
-            }
+            modState.RequiresConfiguration = Mod.RequiresConfiguration;
+            Active.Value = true;
+        }
+
+        protected override void Deselect()
+        {
+            modState.RequiresConfiguration = false;
+            Active.Value = false;
         }
 
         #region Filtering support

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Overlays.Mods
                 Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
                 Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
             };
+
+            Action = select;
         }
 
         public ModPanel(Mod mod)
@@ -55,6 +57,20 @@ namespace osu.Game.Overlays.Mods
             base.LoadComplete();
 
             Filtered.BindValueChanged(_ => updateFilterState(), true);
+        }
+
+        private void select()
+        {
+            if (!Active.Value)
+            {
+                modState.RequiresConfiguration = Mod.RequiresConfiguration;
+                Active.Value = true;
+            }
+            else
+            {
+                modState.RequiresConfiguration = false;
+                Active.Value = false;
+            }
         }
 
         #region Filtering support

--- a/osu.Game/Overlays/Mods/ModPresetPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPresetPanel.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Overlays.Mods
 
             Title = preset.Value.Name;
             Description = preset.Value.Description;
-
-            Action = toggleRequestedByUser;
         }
 
         [BackgroundDependencyLoader]
@@ -54,15 +52,19 @@ namespace osu.Game.Overlays.Mods
             selectedMods.BindValueChanged(_ => selectedModsChanged(), true);
         }
 
-        private void toggleRequestedByUser()
+        protected override void Select()
         {
-            // if the preset is not active at the point of the user click, then set the mods using the preset directly, discarding any previous selections.
+            // if the preset is not active at the point of the user click, then set the mods using the preset directly, discarding any previous selections,
+            // which will also have the side effect of activating the preset (see `updateActiveState()`).
+            selectedMods.Value = Preset.Value.Mods.ToArray();
+        }
+
+        protected override void Deselect()
+        {
             // if the preset is active when the user has clicked it, then it means that the set of active mods is exactly equal to the set of mods in the preset
             // (there are no other active mods than what the preset specifies, and the mod settings match exactly).
             // therefore it's safe to just clear selected mods, since it will have the effect of toggling the preset off.
-            selectedMods.Value = !Active.Value
-                ? Preset.Value.Mods.ToArray()
-                : Array.Empty<Mod>();
+            selectedMods.Value = Array.Empty<Mod>();
         }
 
         private void selectedModsChanged()

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -362,20 +362,20 @@ namespace osu.Game.Overlays.Mods
                 return;
 
             bool anyCustomisableModActive = false;
-            bool anyModRequiresCustomisation = false;
+            bool anyModPendingConfiguration = false;
 
             foreach (var modState in allAvailableMods)
             {
                 anyCustomisableModActive |= modState.Active.Value && modState.Mod.GetSettingsSourceProperties().Any();
-                anyModRequiresCustomisation |= modState.RequiresConfiguration;
-                modState.RequiresConfiguration = false;
+                anyModPendingConfiguration |= modState.PendingConfiguration;
+                modState.PendingConfiguration = false;
             }
 
             if (anyCustomisableModActive)
             {
                 customisationVisible.Disabled = false;
 
-                if (anyModRequiresCustomisation && !customisationVisible.Value)
+                if (anyModPendingConfiguration && !customisationVisible.Value)
                     customisationVisible.Value = true;
             }
             else

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Overlays.Mods
         {
             if (AllowCustomisation)
             {
-                yield return customisationButton = new ShearedToggleButton(BUTTON_WIDTH)
+                yield return CustomisationButton = new ShearedToggleButton(BUTTON_WIDTH)
                 {
                     Text = ModSelectOverlayStrings.ModCustomisation,
                     Active = { BindTarget = customisationVisible }
@@ -107,11 +107,11 @@ namespace osu.Game.Overlays.Mods
         private ColumnScrollContainer columnScroll = null!;
         private ColumnFlowContainer columnFlow = null!;
         private FillFlowContainer<ShearedButton> footerButtonFlow = null!;
-        private ShearedButton backButton = null!;
 
         private DifficultyMultiplierDisplay? multiplierDisplay;
 
-        private ShearedToggleButton? customisationButton;
+        protected ShearedButton BackButton { get; private set; } = null!;
+        protected ShearedToggleButton? CustomisationButton { get; private set; }
 
         private Sample? columnAppearSample;
 
@@ -214,7 +214,7 @@ namespace osu.Game.Overlays.Mods
                     Horizontal = 70
                 },
                 Spacing = new Vector2(10),
-                ChildrenEnumerable = CreateFooterButtons().Prepend(backButton = new ShearedButton(BUTTON_WIDTH)
+                ChildrenEnumerable = CreateFooterButtons().Prepend(BackButton = new ShearedButton(BUTTON_WIDTH)
                 {
                     Text = CommonStrings.Back,
                     Action = Hide,
@@ -358,7 +358,7 @@ namespace osu.Game.Overlays.Mods
 
         private void updateCustomisation(ValueChangedEvent<IReadOnlyList<Mod>> valueChangedEvent)
         {
-            if (customisationButton == null)
+            if (CustomisationButton == null)
                 return;
 
             bool anyCustomisableMod = false;
@@ -394,7 +394,7 @@ namespace osu.Game.Overlays.Mods
 
             foreach (var button in footerButtonFlow)
             {
-                if (button != customisationButton)
+                if (button != CustomisationButton)
                     button.Enabled.Value = !customisationVisible.Value;
             }
 
@@ -587,14 +587,14 @@ namespace osu.Game.Overlays.Mods
             {
                 if (customisationVisible.Value)
                 {
-                    Debug.Assert(customisationButton != null);
-                    customisationButton.TriggerClick();
+                    Debug.Assert(CustomisationButton != null);
+                    CustomisationButton.TriggerClick();
 
                     if (!immediate)
                         return;
                 }
 
-                backButton.TriggerClick();
+                BackButton.TriggerClick();
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -708,7 +708,18 @@ namespace osu.Game.Overlays.Mods
                 FinishTransforms();
             }
 
-            protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate || (Column as ModColumn)?.SelectionAnimationRunning == true;
+            protected override bool RequiresChildrenUpdate
+            {
+                get
+                {
+                    bool result = base.RequiresChildrenUpdate;
+
+                    if (Column is ModColumn modColumn)
+                        result |= !modColumn.ItemsLoaded || modColumn.SelectionAnimationRunning;
+
+                    return result;
+                }
+            }
 
             private void updateState()
             {

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -247,8 +247,8 @@ namespace osu.Game.Overlays.Mods
                 modSettingChangeTracker?.Dispose();
 
                 updateMultiplier();
-                updateCustomisation(val);
                 updateFromExternalSelection();
+                updateCustomisation();
 
                 if (AllowCustomisation)
                 {
@@ -356,25 +356,26 @@ namespace osu.Game.Overlays.Mods
             multiplierDisplay.Current.Value = multiplier;
         }
 
-        private void updateCustomisation(ValueChangedEvent<IReadOnlyList<Mod>> valueChangedEvent)
+        private void updateCustomisation()
         {
             if (CustomisationButton == null)
                 return;
 
-            bool anyCustomisableMod = false;
-            bool anyModWithRequiredCustomisationAdded = false;
+            bool anyCustomisableModActive = false;
+            bool anyModRequiresCustomisation = false;
 
-            foreach (var mod in SelectedMods.Value)
+            foreach (var modState in allAvailableMods)
             {
-                anyCustomisableMod |= mod.GetSettingsSourceProperties().Any();
-                anyModWithRequiredCustomisationAdded |= valueChangedEvent.OldValue.All(m => m.GetType() != mod.GetType()) && mod.RequiresConfiguration;
+                anyCustomisableModActive |= modState.Active.Value && modState.Mod.GetSettingsSourceProperties().Any();
+                anyModRequiresCustomisation |= modState.RequiresConfiguration;
+                modState.RequiresConfiguration = false;
             }
 
-            if (anyCustomisableMod)
+            if (anyCustomisableModActive)
             {
                 customisationVisible.Disabled = false;
 
-                if (anyModWithRequiredCustomisationAdded && !customisationVisible.Value)
+                if (anyModRequiresCustomisation && !customisationVisible.Value)
                     customisationVisible.Value = true;
             }
             else

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -143,8 +143,24 @@ namespace osu.Game.Overlays.Mods
                 }
             };
 
-            Action = () => Active.Toggle();
+            Action = () =>
+            {
+                if (!Active.Value)
+                    Select();
+                else
+                    Deselect();
+            };
         }
+
+        /// <summary>
+        /// Performs all actions necessary to select this <see cref="ModSelectPanel"/>.
+        /// </summary>
+        protected abstract void Select();
+
+        /// <summary>
+        /// Performs all actions necessary to deselect this <see cref="ModSelectPanel"/>.
+        /// </summary>
+        protected abstract void Deselect();
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, ISamplePlaybackDisabler? samplePlaybackDisabler)

--- a/osu.Game/Overlays/Mods/ModState.cs
+++ b/osu.Game/Overlays/Mods/ModState.cs
@@ -25,6 +25,13 @@ namespace osu.Game.Overlays.Mods
         public BindableBool Active { get; } = new BindableBool();
 
         /// <summary>
+        /// Whether the mod requires further customisation.
+        /// This flag is read by the <see cref="ModSelectOverlay"/> to determine if the customisation panel should be opened after a mod change
+        /// and cleared after reading.
+        /// </summary>
+        public bool RequiresConfiguration { get; set; }
+
+        /// <summary>
         /// Whether the mod is currently filtered out due to not matching imposed criteria.
         /// </summary>
         public BindableBool Filtered { get; } = new BindableBool();

--- a/osu.Game/Overlays/Mods/ModState.cs
+++ b/osu.Game/Overlays/Mods/ModState.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.Mods
         /// This flag is read by the <see cref="ModSelectOverlay"/> to determine if the customisation panel should be opened after a mod change
         /// and cleared after reading.
         /// </summary>
-        public bool RequiresConfiguration { get; set; }
+        public bool PendingConfiguration { get; set; }
 
         /// <summary>
         /// Whether the mod is currently filtered out due to not matching imposed criteria.

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -928,7 +928,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private class SoloModSelectOverlay : UserModSelectOverlay
+        internal class SoloModSelectOverlay : UserModSelectOverlay
         {
             protected override bool ShowPresets => true;
         }


### PR DESCRIPTION
Closes #19720.

Opening primarily as a request for comments, as I'm not very sure of this diff. The reasons why not are twofold:

### Async loads throw spanner in works

This section is sponsored by the entirety of f860bc11. The gist of the issue which spurred this commit is, basically, that *only* adding the mod preset column to visual tests caused a bunch of them to fail. This was in turn a consequence of async load semantics - the callback that is fired when the load completes is scheduled onto the mod column that loads them, which becomes a problem when the column is either offscreen (as in, _masked away_) or not present due to all mods within being filtered out. Tests, in turn, depend on the panels being present and in the hierarchy to execute actions, which means they depend on the load complete callbacks executing, hence the failures.

The aforementioned commit attempts to make sure that all the callbacks complete regardless of column position or the filtered state, at the cost of being quite horrid.

### `ModState.RequiresConfiguration` is... meh

Because of the complicated data flow in the mod overlay, the easiest method to pass information from each mod panel that the customisation panel should open is to basically add another flag in `ModState`, which is read and cleared by the overlay. I don't much like this, but I don't see many better options, either. The primary obstacle is the mod reference replacement logic that I keep calling back to, which this solution conveniently bypasses.

I don't think it's too bad, and this implementation allows a near-instant implementation of another behaviour that users requested, namely having right-click instantly open the customisation panel regardless of whether the mod requires configuration or not, but I can see this design of the feature being rejected for not being up to scratch.