### PR TITLE
Fix slider ticks playing back at infinite rate while making changes to a slider in the editor

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -225,8 +225,6 @@ namespace osu.Game.Screens.Edit
             dependencies.CacheAs(clock);
             AddInternal(clock);
 
-            clock.SeekingOrStopped.BindValueChanged(_ => updateSampleDisabledState());
-
             // todo: remove caching of this and consume via editorBeatmap?
             dependencies.Cache(beatDivisor);
 
@@ -428,7 +426,12 @@ namespace osu.Game.Screens.Edit
         protected override void Update()
         {
             base.Update();
+
             clock.ProcessFrame();
+
+            samplePlaybackDisabled.Value = clock.SeekingOrStopped.Value
+                                           || currentScreen is not ComposeScreen
+                                           || editorBeatmap.UpdateInProgress;
         }
 
         public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
@@ -822,14 +825,8 @@ namespace osu.Game.Screens.Edit
             }
             finally
             {
-                updateSampleDisabledState();
                 rebindClipboardBindables();
             }
-        }
-
-        private void updateSampleDisabledState()
-        {
-            samplePlaybackDisabled.Value = clock.SeekingOrStopped.Value || !(currentScreen is ComposeScreen);
         }
 
         private void seek(UIEvent e, int direction)
@@ -936,11 +933,7 @@ namespace osu.Game.Screens.Edit
 
         protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleSwitchToExistingDifficulty(nextBeatmap, GetState(nextBeatmap.Ruleset));
 
-        private void cancelExit()
-        {
-            updateSampleDisabledState();
-            loader?.CancelPendingDifficultySwitch();
-        }
+        private void cancelExit() => loader?.CancelPendingDifficultySwitch();
 
         public double SnapTime(double time, double? referenceTime) => editorBeatmap.SnapTime(time, referenceTime);
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Legacy;
@@ -24,13 +23,15 @@ namespace osu.Game.Screens.Edit
     public class EditorBeatmap : TransactionalCommitComponent, IBeatmap, IBeatSnapProvider
     {
         /// <summary>
-        /// While performing updates on hitobjects, this will momentarily become true.
+        /// Will become <c>true</c> when a new update is queued, and <c>false</c> when all updates have been applied.
         /// </summary>
         /// <remarks>
         /// This is intended to be used to avoid performing operations (like playback of samples)
         /// while mutating hitobjects.
         /// </remarks>
-        public bool UpdateInProgress { get; private set; }
+        public IBindable<bool> UpdateInProgress => updateInProgress;
+
+        private readonly BindableBool updateInProgress = new BindableBool();
 
         /// <summary>
         /// Invoked when a <see cref="HitObject"/> is added to this <see cref="EditorBeatmap"/>.
@@ -236,10 +237,8 @@ namespace osu.Game.Screens.Edit
             // updates are debounced regardless of whether a batch is active.
             batchPendingUpdates.Add(hitObject);
 
-            advertiseUpdateInProgress();
+            updateInProgress.Value = true;
         }
-
-        private ScheduledDelegate updateCompleteDelegate;
 
         /// <summary>
         /// Update all hit objects with potentially changed difficulty or control point data.
@@ -249,7 +248,7 @@ namespace osu.Game.Screens.Edit
             foreach (var h in HitObjects)
                 batchPendingUpdates.Add(h);
 
-            advertiseUpdateInProgress();
+            updateInProgress.Value = true;
         }
 
         /// <summary>
@@ -342,21 +341,14 @@ namespace osu.Game.Screens.Edit
             foreach (var h in deletes) HitObjectRemoved?.Invoke(h);
             foreach (var h in inserts) HitObjectAdded?.Invoke(h);
             foreach (var h in updates) HitObjectUpdated?.Invoke(h);
+
+            updateInProgress.Value = false;
         }
 
         /// <summary>
         /// Clears all <see cref="HitObjects"/> from this <see cref="EditorBeatmap"/>.
         /// </summary>
         public void Clear() => RemoveRange(HitObjects.ToArray());
-
-        private void advertiseUpdateInProgress()
-        {
-            UpdateInProgress = true;
-
-            // Debounce is arbitrarily high enough to avoid flip-flopping the value each other frame.
-            updateCompleteDelegate?.Cancel();
-            updateCompleteDelegate = Scheduler.AddDelayed(() => UpdateInProgress = false, 50);
-        }
 
         private void processHitObject(HitObject hitObject) => hitObject.ApplyDefaults(ControlPointInfo, PlayableBeatmap.Difficulty);
 


### PR DESCRIPTION
This is the easiest way I could think of fixing this. The good part is that this should also help with any other blueprints across all rulesets that are hitting a similar issue.

Addresses concerns raised in https://github.com/ppy/osu/discussions/19714.