### PR TITLE
Clamp effective miss count to maximum amount of possible breaks

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -270,8 +270,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                     comboBasedMissCount = fullComboThreshold / Math.Max(1.0, scoreMaxCombo);
             }
 
-            // Clamp miss count since it's derived from combo and can be higher than total hits and that breaks some calculations
-            comboBasedMissCount = Math.Min(comboBasedMissCount, totalHits);
+            // Clamp miss count to maximum amount of possible breaks
+            comboBasedMissCount = Math.Min(comboBasedMissCount, countOk + countMeh + countMiss);
 
             return Math.Max(countMiss, comboBasedMissCount);
         }


### PR DESCRIPTION
Minimal change to fix 1x100 scores having >1 miss count

**Before:**  
![image](https://user-images.githubusercontent.com/8269193/184888971-a16bf3bb-1b8f-407e-9c53-eb9e2d4109eb.png)
**After:**  
![image](https://user-images.githubusercontent.com/8269193/184888887-9a1f8f50-082f-481e-ab29-ca2f3e2c2d19.png)

---

SR/PP changes sheet: https://docs.google.com/spreadsheets/d/1q8Q-dvUCchnvd2rNTqz_mvLRnwNyq_NaH3FWxaxcHcc/edit
As of 43e471c2a5832621ca91a4eea98650511a678bff