### PR TITLE
Upgrade LocalisationAnalyser and disable warning

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "ppy.localisationanalyser.tools": {
-      "version": "2022.607.0",
+      "version": "2022.809.0",
       "commands": [
         "localisation"
       ]

--- a/.globalconfig
+++ b/.globalconfig
@@ -53,3 +53,7 @@ dotnet_diagnostic.CA2225.severity = none
 
 # Banned APIs
 dotnet_diagnostic.RS0030.severity = error
+
+# Temporarily disable analysing CanBeNull = true in NRT contexts due to mobile issues.
+# See: https://github.com/ppy/osu/pull/19677
+dotnet_diagnostic.OSUF001.severity = none

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.LocalisationAnalyser" Version="2022.607.0">
+    <PackageReference Include="ppy.LocalisationAnalyser" Version="2022.809.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
I don't see us merging mobile .NET 6 for the next two months minimum with the current rate of progress on that front, but I want to take advantage of the latest fixes in this analyser (VSCode)