### PR TITLE
Test ruleset compatibility during initial startup to avoid runtime errors

### DIFF
--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
@@ -21,8 +21,11 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
         public PippidonBeatmapConverter(IBeatmap beatmap, Ruleset ruleset)
             : base(beatmap, ruleset)
         {
-            minPosition = beatmap.HitObjects.Min(getUsablePosition);
-            maxPosition = beatmap.HitObjects.Max(getUsablePosition);
+            if (beatmap.HitObjects.Any())
+            {
+                minPosition = beatmap.HitObjects.Min(getUsablePosition);
+                maxPosition = beatmap.HitObjects.Max(getUsablePosition);
+            }
         }
 
         public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasXPosition && h is IHasYPosition);

--- a/osu.Game/Rulesets/RealmRulesetStore.cs
+++ b/osu.Game/Rulesets/RealmRulesetStore.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -91,8 +90,7 @@ namespace osu.Game.Rulesets
                     catch (Exception ex)
                     {
                         r.Available = false;
-                        Logger.Log($"Could not load ruleset {r.Name}. Please check for an update from the developer.", level: LogLevel.Error);
-                        Logger.Log($"Ruleset load failed with {ex.Message}");
+                        LogFailedLoad(r.Name, ex);
                     }
                 }
 

--- a/osu.Game/Rulesets/RealmRulesetStore.cs
+++ b/osu.Game/Rulesets/RealmRulesetStore.cs
@@ -68,8 +68,14 @@ namespace osu.Game.Rulesets
                 {
                     try
                     {
-                        var resolvedType = Type.GetType(r.InstantiationInfo)
-                                           ?? throw new RulesetLoadException(@"Type could not be resolved");
+                        var resolvedType = Type.GetType(r.InstantiationInfo);
+
+                        if (resolvedType == null)
+                        {
+                            // ruleset DLL was probably deleted.
+                            r.Available = false;
+                            continue;
+                        }
 
                         var instanceInfo = (Activator.CreateInstance(resolvedType) as Ruleset)?.RulesetInfo
                                            ?? throw new RulesetLoadException(@"Instantiation failure");

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Rulesets
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Failed to load ruleset {filename}");
+                LogFailedLoad(filename, e);
             }
         }
 
@@ -158,7 +158,7 @@ namespace osu.Game.Rulesets
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Failed to add ruleset {assembly}");
+                LogFailedLoad(assembly.FullName, e);
             }
         }
 
@@ -171,6 +171,12 @@ namespace osu.Game.Rulesets
         protected virtual void Dispose(bool disposing)
         {
             AppDomain.CurrentDomain.AssemblyResolve -= resolveRulesetDependencyAssembly;
+        }
+
+        protected void LogFailedLoad(string name, Exception exception)
+        {
+            Logger.Log($"Could not load ruleset {name}. Please check for an update from the developer.", level: LogLevel.Error);
+            Logger.Log($"Ruleset load failed: {exception}");
         }
 
         #region Implementation of IRulesetStore


### PR DESCRIPTION
As we continue to break the ruleset API, it makes more sense to proactively check known changes and bail early during ruleset loading to avoid a user experiencing a crash at a random point during execution.

This is a RFC and needs to be tested against known broken (and working) rulesets. There might be some other calls we want to add in addition to the ones I've listed. Also I'm not 100% sure on running conversion (may need to check the `CanConvert()` flag first?).

Should hopefully cover the new breakage in #19695 via mod instantiation alone.