### PR TITLE
Fix taiko blueprints displaying incorrectly for drum rolls

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
@@ -29,6 +30,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// Number of rolling hits required to reach the dark/final colour.
         /// </summary>
         private const int rolling_hits_for_engaged_colour = 5;
+
+        public override Quad ScreenSpaceDrawQuad => MainPiece.Drawable.ScreenSpaceDrawQuad;
 
         /// <summary>
         /// Rolling number of tick hits. This increases for hits and decreases for misses.

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -19,6 +20,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     public class LegacyCirclePiece : CompositeDrawable, IHasAccentColour
     {
         private Drawable backgroundLayer;
+
+        // required for editor blueprints (not sure why these circle pieces are zero size).
+        public override Quad ScreenSpaceDrawQuad => backgroundLayer.ScreenSpaceDrawQuad;
 
         public LegacyCirclePiece()
         {

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyDrumRoll.cs
@@ -6,6 +6,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Graphics;
@@ -16,11 +17,22 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     public class LegacyDrumRoll : CompositeDrawable, IHasAccentColour
     {
+        public override Quad ScreenSpaceDrawQuad
+        {
+            get
+            {
+                var headDrawQuad = headCircle.ScreenSpaceDrawQuad;
+                var tailDrawQuad = tailCircle.ScreenSpaceDrawQuad;
+
+                return new Quad(headDrawQuad.TopLeft, tailDrawQuad.TopRight, headDrawQuad.BottomLeft, tailDrawQuad.BottomRight);
+            }
+        }
+
         private LegacyCirclePiece headCircle;
 
         private Sprite body;
 
-        private Sprite end;
+        private Sprite tailCircle;
 
         public LegacyDrumRoll()
         {
@@ -32,7 +44,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         {
             InternalChildren = new Drawable[]
             {
-                end = new Sprite
+                tailCircle = new Sprite
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreLeft,
@@ -82,7 +94,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
             headCircle.AccentColour = colour;
             body.Colour = colour;
-            end.Colour = colour;
+            tailCircle.Colour = colour;
         }
     }
 }


### PR DESCRIPTION
Before:

![osu! 2022-08-18 at 08 08 06](https://user-images.githubusercontent.com/191335/185343925-8d855412-0fab-4b75-ae2c-aec7b8e2fbf6.png)


After:

![osu! 2022-08-18 at 08 08 16](https://user-images.githubusercontent.com/191335/185343977-02f643f1-1819-49dd-8417-e4cc6cf654ed.png)

With classic skin:

Before:

![osu! 2022-08-18 at 08 17 50](https://user-images.githubusercontent.com/191335/185346060-ba85bab7-21d5-46be-a7e4-f63d9d607202.png)

After:

![osu! 2022-08-18 at 08 17 01](https://user-images.githubusercontent.com/191335/185345926-f1f9da2a-02d6-4852-b18f-2e716fc4195f.png)


Closes #19810.

