### PR TITLE
Remove weird seek call in `GameplayClockContainer`

### DIFF
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -93,13 +93,7 @@ namespace osu.Game.Screens.Play
             ensureSourceClockSet();
 
             if (!decoupledClock.IsRunning)
-            {
-                // Seeking the decoupled clock to its current time ensures that its source clock will be seeked to the same time
-                // This accounts for the clock source potentially taking time to enter a completely stopped state
-                Seek(FramedClock.CurrentTime);
-
                 decoupledClock.Start();
-            }
 
             isPaused.Value = false;
         }


### PR DESCRIPTION
Hopefully not required anymore. This can actually cause incorrect seeks to occur, at random, during actual game and test execution.

Split out from #19828 for isolated testing (and more test runs).