### PR TITLE
Fix two `Seek` operations being performed for a `Reset` which also starts the `GameplayClock`

### DIFF
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -136,9 +136,11 @@ namespace osu.Game.Screens.Play
 
             if (!IsPaused.Value || startClock)
                 Start();
-
-            ensureSourceClockSet();
-            Seek(StartTime ?? 0);
+            else
+            {
+                ensureSourceClockSet();
+                Seek(StartTime ?? 0);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The call to `Start` already does this logic. No need to do it twice (makes debugging harder, at very least).

This change may require https://github.com/ppy/osu/pull/19828/commits/11c7f61e49d18738cb94655da8fece08700a4a6d. Waiting to see CI results first.