### PR TITLE
osu!taiko performance point adjustments & effective misses

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceAttributes.cs
@@ -17,6 +17,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("accuracy")]
         public double Accuracy { get; set; }
 
+        [JsonProperty("effective_miss_count")]
+        public double EffectiveMissCount { get; set; }
+
         public override IEnumerable<PerformanceDisplayAttribute> GetAttributesForDisplay()
         {
             foreach (var attribute in base.GetAttributesForDisplay())

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -38,7 +38,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
 
             // The effectiveMissCount is calculated by gaining a ratio for totalSuccessfulHits and increasing the miss penalty for shorter object counts lower than 1000.
-            effectiveMissCount = Math.Max(1.0, Math.Min(0, 1000.0 / totalSuccessfulHits)) * countMiss;
+            if (totalSuccessfulHits > 0)
+                effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
 
             double multiplier = 1.13;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 difficultyValue *= 1.050;
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
-                difficultyValue *= 1.05 * lengthBonus;
+                difficultyValue *= 1.050 * lengthBonus;
 
             return difficultyValue * Math.Pow(score.Accuracy, 2.0);
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
 
             // The effectiveMissCount is calculated by gaining a ratio for totalSuccessfulHits and increasing the miss penalty for shorter object counts lower than 1000.
-            effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
+            effectiveMissCount = Math.Max(1.0, Math.Min(0, 1000.0 / totalSuccessfulHits)) * countMiss;
 
             double multiplier = 1.13;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private int countMeh;
         private int countMiss;
 
+        private double effectiveMissCount;
+
         public TaikoPerformanceCalculator()
             : base(new TaikoRuleset())
         {
@@ -35,7 +37,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
             countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
 
-            double multiplier = 1.12; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things
+            // The effectiveMissCount is calculated by gaining a ratio for totalSuccessfulHits and increasing the misspenalty for shorter object counts lower than 1000, past 1000 is 1:1.
+            effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
+
+            double multiplier = 1.13;
 
             if (score.Mods.Any(m => m is ModHidden))
                 multiplier *= 1.075;
@@ -55,6 +60,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             {
                 Difficulty = difficultyValue,
                 Accuracy = accuracyValue,
+                EffectiveMissCount = effectiveMissCount,
                 Total = totalValue
             };
         }
@@ -66,18 +72,21 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double lengthBonus = 1 + 0.1 * Math.Min(1.0, totalHits / 1500.0);
             difficultyValue *= lengthBonus;
 
-            difficultyValue *= Math.Pow(0.986, countMiss);
+            difficultyValue *= Math.Pow(0.986, effectiveMissCount);
 
             if (score.Mods.Any(m => m is ModEasy))
-                difficultyValue *= 0.980;
+                difficultyValue *= 0.985;
 
             if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= 1.025;
 
+            if (score.Mods.Any(m => m is ModHardRock))
+                difficultyValue *= 1.050;
+
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= 1.05 * lengthBonus;
 
-            return difficultyValue * Math.Pow(score.Accuracy, 1.5);
+            return difficultyValue * Math.Pow(score.Accuracy, 2.0);
         }
 
         private double computeAccuracyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
@@ -85,18 +94,20 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (attributes.GreatHitWindow <= 0)
                 return 0;
 
-            double accuracyValue = Math.Pow(140.0 / attributes.GreatHitWindow, 1.1) * Math.Pow(score.Accuracy, 12.0) * 27;
+            double accuracyValue = Math.Pow(60.0 / attributes.GreatHitWindow, 1.1) * Math.Pow(score.Accuracy, 8.0) * Math.Pow(attributes.StarRating, 0.4) * 27.0;
 
             double lengthBonus = Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
             accuracyValue *= lengthBonus;
 
-            // Slight HDFL Bonus for accuracy.
+            // Slight HDFL Bonus for accuracy. A clamp is used to prevent against negative values
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>) && score.Mods.Any(m => m is ModHidden))
-                accuracyValue *= 1.10 * lengthBonus;
+                accuracyValue *= Math.Max(1.050, 1.075 * lengthBonus);
 
             return accuracyValue;
         }
 
         private int totalHits => countGreat + countOk + countMeh + countMiss;
+
+        private int totalSuccessfulHits => countGreat + countOk + countMeh;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
             countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
 
-            // The effectiveMissCount is calculated by gaining a ratio for totalSuccessfulHits and increasing the misspenalty for shorter object counts lower than 1000, past 1000 is 1:1.
+            // The effectiveMissCount is calculated by gaining a ratio for totalSuccessfulHits and increasing the miss penalty for shorter object counts lower than 1000.
             effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
 
             double multiplier = 1.13;


### PR DESCRIPTION
Based on sentiments and feedback from the community and committee members. Changes are:
- GreatHitWindow's (300s) impact on Accuracy PP has been significantly reduced.
- An SR component has been added to Accuracy PP, which replaces most of the scaling seen within GreatHitWindow. As a tradeoff, HR and EZ now each have their respective buff and nerf within difficulty PP.
- The HDFL Bonus has been clamped to ensure that negative accuracy PP isn't given
- Addition of effective misses - this calculated as a ratio, with maps below 1000 combo receiving a multiplier to their misscount. This is able to be viewed via an attribute.

Values are up [here](https://pp.huismetbenen.nl/rankings/players/ltca2), and have been up for public testing for a number of days now.

---

SR/PP sheet: https://docs.google.com/spreadsheets/d/1whakV2tDv4haWs9uETbSOCDQt1x9UP35dvDHWwy7wwU/edit

As of c1da5091191bfac75eb2b5b3294f58addd1b64a5