### PR TITLE
Add safeties to avoid deadlock in `SubmittingPlayer`

### DIFF
--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -128,5 +128,13 @@ namespace osu.Game.Online.API
         IBindable<UserActivity> IAPIProvider.Activity => Activity;
 
         public void FailNextLogin() => shouldFailNextLogin = true;
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            // Ensure (as much as we can) that any pending tasks are run.
+            Scheduler.Update();
+        }
     }
 }

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
@@ -84,7 +83,10 @@ namespace osu.Game.Screens.Play
 
             api.Queue(req);
 
-            tcs.Task.WaitSafely();
+            // Generally a timeout would not happen here as APIAccess will timeout first.
+            if (!tcs.Task.Wait(60000))
+                handleTokenFailure(new InvalidOperationException("Token retrieval timed out (request never run)"));
+
             return true;
 
             void handleTokenFailure(Exception exception)


### PR DESCRIPTION
Aims to avoid the deadlock discovered in #19855.

Of note, I'm still not sure about the stack trace in that issue which shows `Dispose` calling `CacheAs`. I believe we should understand how that happens before closing the issue completely.