### PR TITLE
Adjust rounding in mod select difficulty multiplier to match song select footer

### DIFF
--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -31,10 +31,7 @@ namespace osu.Game.Overlays.Mods
             set => current.Current = value;
         }
 
-        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1)
-        {
-            Precision = 0.01
-        };
+        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1);
 
         private readonly Box underlayBackground;
         private readonly Box contentBackground;


### PR DESCRIPTION
The 0.01 `Precision` spec on `DifficultyMultiplierDisplay.Current` would cause the difficulty multiplier to use a different midpoint rounding strategy than `double.ToString()`, which is the one that the song select footer relies on. For example, a value of 0.015 would be rounded down to 0.01 by `double.ToString()`, but rounded up to 0.02 by `BindableDouble`.

Fix the discrepancy by just deleting the `Precision` spec. Since the value of the bindable would go through `ToLocalisableString(@"N2")` anyway, it was redundant as is.

Fixes #19889.

Note:  Whether `BindableDouble`'s midpoint rounding strategy should be changed to match `double.ToString()`, I don't have a strong opinion on - but I consider that mostly irrelevant to this fix as the `Precision` spec is redundant, generally not correct (as it is potentially interfering with correct operation of the `RollingCounter`), and I'm looking to not complicate things too much here if it can be avoided, as I have a feeling that fixing `BindableDouble` is not trivial.