### PR TITLE
Invert creation of clocks in multi-spectator

### DIFF
--- a/osu.Game.Tests/OnlinePlay/TestSceneCatchUpSyncManager.cs
+++ b/osu.Game.Tests/OnlinePlay/TestSceneCatchUpSyncManager.cs
@@ -29,8 +29,8 @@ namespace osu.Game.Tests.OnlinePlay
         public void Setup()
         {
             syncManager = new CatchUpSyncManager(master = new GameplayClockContainer(new TestManualClock()));
-            player1 = syncManager.AddClock();
-            player2 = syncManager.AddClock();
+            player1 = syncManager.CreateManagedClock();
+            player2 = syncManager.CreateManagedClock();
 
             clocksById = new Dictionary<ISpectatorPlayerClock, int>
             {

--- a/osu.Game.Tests/OnlinePlay/TestSceneCatchUpSyncManager.cs
+++ b/osu.Game.Tests/OnlinePlay/TestSceneCatchUpSyncManager.cs
@@ -4,11 +4,13 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
-using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
+using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Tests.OnlinePlay
@@ -16,20 +18,34 @@ namespace osu.Game.Tests.OnlinePlay
     [HeadlessTest]
     public class TestSceneCatchUpSyncManager : OsuTestScene
     {
-        private TestManualClock master;
+        private GameplayClockContainer master;
         private CatchUpSyncManager syncManager;
 
-        private TestSpectatorPlayerClock player1;
-        private TestSpectatorPlayerClock player2;
+        private Dictionary<ISpectatorPlayerClock, int> clocksById;
+        private ISpectatorPlayerClock player1;
+        private ISpectatorPlayerClock player2;
 
         [SetUp]
         public void Setup()
         {
-            syncManager = new CatchUpSyncManager(master = new TestManualClock());
-            syncManager.AddPlayerClock(player1 = new TestSpectatorPlayerClock(1));
-            syncManager.AddPlayerClock(player2 = new TestSpectatorPlayerClock(2));
+            syncManager = new CatchUpSyncManager(master = new GameplayClockContainer(new TestManualClock()));
+            player1 = syncManager.AddClock();
+            player2 = syncManager.AddClock();
 
-            Schedule(() => Child = syncManager);
+            clocksById = new Dictionary<ISpectatorPlayerClock, int>
+            {
+                { player1, 1 },
+                { player2, 2 }
+            };
+
+            Schedule(() =>
+            {
+                Children = new Drawable[]
+                {
+                    syncManager,
+                    master
+                };
+            });
         }
 
         [Test]
@@ -129,8 +145,8 @@ namespace osu.Game.Tests.OnlinePlay
             assertPlayerClockState(() => player1, false);
         }
 
-        private void setWaiting(Func<TestSpectatorPlayerClock> playerClock, bool waiting)
-            => AddStep($"set player clock {playerClock().Id} waiting = {waiting}", () => playerClock().WaitingOnFrames.Value = waiting);
+        private void setWaiting(Func<ISpectatorPlayerClock> playerClock, bool waiting)
+            => AddStep($"set player clock {clocksById[playerClock()]} waiting = {waiting}", () => playerClock().WaitingOnFrames.Value = waiting);
 
         private void setAllWaiting(bool waiting) => AddStep($"set all player clocks waiting = {waiting}", () =>
         {
@@ -144,51 +160,14 @@ namespace osu.Game.Tests.OnlinePlay
         /// <summary>
         /// clock.Time = master.Time - offsetFromMaster
         /// </summary>
-        private void setPlayerClockTime(Func<TestSpectatorPlayerClock> playerClock, double offsetFromMaster)
-            => AddStep($"set player clock {playerClock().Id} = master - {offsetFromMaster}", () => playerClock().Seek(master.CurrentTime - offsetFromMaster));
+        private void setPlayerClockTime(Func<ISpectatorPlayerClock> playerClock, double offsetFromMaster)
+            => AddStep($"set player clock {clocksById[playerClock()]} = master - {offsetFromMaster}", () => playerClock().Seek(master.CurrentTime - offsetFromMaster));
 
-        private void assertCatchingUp(Func<TestSpectatorPlayerClock> playerClock, bool catchingUp) =>
-            AddAssert($"player clock {playerClock().Id} {(catchingUp ? "is" : "is not")} catching up", () => playerClock().IsCatchingUp == catchingUp);
+        private void assertCatchingUp(Func<ISpectatorPlayerClock> playerClock, bool catchingUp) =>
+            AddAssert($"player clock {clocksById[playerClock()]} {(catchingUp ? "is" : "is not")} catching up", () => playerClock().IsCatchingUp == catchingUp);
 
-        private void assertPlayerClockState(Func<TestSpectatorPlayerClock> playerClock, bool running)
-            => AddAssert($"player clock {playerClock().Id} {(running ? "is" : "is not")} running", () => playerClock().IsRunning == running);
-
-        private class TestSpectatorPlayerClock : TestManualClock, ISpectatorPlayerClock
-        {
-            public Bindable<bool> WaitingOnFrames { get; } = new Bindable<bool>(true);
-
-            public bool IsCatchingUp { get; set; }
-
-            public IFrameBasedClock Source
-            {
-                set => throw new NotImplementedException();
-            }
-
-            public readonly int Id;
-
-            public TestSpectatorPlayerClock(int id)
-            {
-                Id = id;
-
-                WaitingOnFrames.BindValueChanged(waiting =>
-                {
-                    if (waiting.NewValue)
-                        Stop();
-                    else
-                        Start();
-                });
-            }
-
-            public void ProcessFrame()
-            {
-            }
-
-            public double ElapsedFrameTime => 0;
-
-            public double FramesPerSecond => 0;
-
-            public FrameTimeInfo TimeInfo => default;
-        }
+        private void assertPlayerClockState(Func<ISpectatorPlayerClock> playerClock, bool running)
+            => AddAssert($"player clock {clocksById[playerClock()]} {(running ? "is" : "is not")} running", () => playerClock().IsRunning == running);
 
         private class TestManualClock : ManualClock, IAdjustableClock
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
@@ -17,14 +17,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public const double CATCHUP_RATE = 2;
 
-        /// <summary>
-        /// The source clock.
-        /// </summary>
-        public IFrameBasedClock? Source { get; set; }
+        public IFrameBasedClock Source { get; set; }
 
         public double CurrentTime { get; private set; }
 
         public bool IsRunning { get; private set; }
+
+        public CatchUpSpectatorPlayerClock(IFrameBasedClock source)
+        {
+            Source = source;
+        }
 
         public void Reset() => CurrentTime = 0;
 
@@ -66,9 +68,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
             ElapsedFrameTime = 0;
             FramesPerSecond = 0;
-
-            if (Source == null)
-                return;
 
             Source.ProcessFrame();
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSpectatorPlayerClock.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public const double CATCHUP_RATE = 2;
 
-        public IFrameBasedClock Source { get; set; }
+        public readonly IFrameBasedClock Source;
 
         public double CurrentTime { get; private set; }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
@@ -5,11 +5,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Timing;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 {
@@ -38,7 +37,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// The master clock which is used to control the timing of all player clocks clocks.
         /// </summary>
-        public IAdjustableClock MasterClock { get; }
+        public GameplayClockContainer MasterClock { get; }
 
         public IBindable<MasterClockState> MasterState => masterState;
 
@@ -52,18 +51,19 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private bool hasStarted;
         private double? firstStartAttemptTime;
 
-        public CatchUpSyncManager(IAdjustableClock master)
+        public CatchUpSyncManager(GameplayClockContainer master)
         {
             MasterClock = master;
         }
 
-        public void AddPlayerClock(ISpectatorPlayerClock clock)
+        public ISpectatorPlayerClock AddClock()
         {
-            Debug.Assert(!playerClocks.Contains(clock));
+            var clock = new CatchUpSpectatorPlayerClock { Source = MasterClock };
             playerClocks.Add(clock);
+            return clock;
         }
 
-        public void RemovePlayerClock(ISpectatorPlayerClock clock)
+        public void RemoveClock(ISpectatorPlayerClock clock)
         {
             playerClocks.Remove(clock);
             clock.Stop();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             MasterClock = master;
         }
 
-        public ISpectatorPlayerClock AddClock()
+        public ISpectatorPlayerClock CreateManagedClock()
         {
             var clock = new CatchUpSpectatorPlayerClock(MasterClock);
             playerClocks.Add(clock);
             return clock;
         }
 
-        public void RemoveClock(ISpectatorPlayerClock clock)
+        public void RemoveManagedClock(ISpectatorPlayerClock clock)
         {
             playerClocks.Remove(clock);
             clock.Stop();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/CatchUpSyncManager.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public const double MAXIMUM_START_DELAY = 15000;
 
-        public event Action ReadyToStart;
+        public event Action? ReadyToStart;
 
         /// <summary>
         /// The master clock which is used to control the timing of all player clocks clocks.
@@ -58,7 +56,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         public ISpectatorPlayerClock AddClock()
         {
-            var clock = new CatchUpSpectatorPlayerClock { Source = MasterClock };
+            var clock = new CatchUpSpectatorPlayerClock(MasterClock);
             playerClocks.Add(clock);
             return clock;
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Timing;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISpectatorPlayerClock.cs
@@ -33,10 +33,5 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// Of note, this will be false if this clock is *ahead* of the master clock.
         /// </remarks>
         bool IsCatchingUp { get; set; }
-
-        /// <summary>
-        /// The source clock
-        /// </summary>
-        IFrameBasedClock Source { set; }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISyncManager.cs
@@ -5,7 +5,7 @@
 
 using System;
 using osu.Framework.Bindables;
-using osu.Framework.Timing;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 {
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// The master clock which player clocks should synchronise to.
         /// </summary>
-        IAdjustableClock MasterClock { get; }
+        GameplayClockContainer MasterClock { get; }
 
         /// <summary>
         /// An event which is invoked when the state of <see cref="MasterClock"/> is changed.
@@ -30,15 +30,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         IBindable<MasterClockState> MasterState { get; }
 
         /// <summary>
-        /// Adds an <see cref="ISpectatorPlayerClock"/> to manage.
+        /// Adds a new managed <see cref="ISpectatorPlayerClock"/>.
         /// </summary>
-        /// <param name="clock">The <see cref="ISpectatorPlayerClock"/> to add.</param>
-        void AddPlayerClock(ISpectatorPlayerClock clock);
+        /// <returns>The added <see cref="ISpectatorPlayerClock"/>.</returns>
+        ISpectatorPlayerClock AddClock();
 
         /// <summary>
         /// Removes an <see cref="ISpectatorPlayerClock"/>, stopping it from being managed by this <see cref="ISyncManager"/>.
         /// </summary>
         /// <param name="clock">The <see cref="ISpectatorPlayerClock"/> to remove.</param>
-        void RemovePlayerClock(ISpectatorPlayerClock clock);
+        void RemoveClock(ISpectatorPlayerClock clock);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISyncManager.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Bindables;
 using osu.Game.Screens.Play;
@@ -17,7 +15,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// An event which is invoked when gameplay is ready to start.
         /// </summary>
-        event Action ReadyToStart;
+        event Action? ReadyToStart;
 
         /// <summary>
         /// The master clock which player clocks should synchronise to.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/ISyncManager.cs
@@ -28,15 +28,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         IBindable<MasterClockState> MasterState { get; }
 
         /// <summary>
-        /// Adds a new managed <see cref="ISpectatorPlayerClock"/>.
+        /// Create a new managed <see cref="ISpectatorPlayerClock"/>.
         /// </summary>
-        /// <returns>The added <see cref="ISpectatorPlayerClock"/>.</returns>
-        ISpectatorPlayerClock AddClock();
+        /// <returns>The newly created <see cref="ISpectatorPlayerClock"/>.</returns>
+        ISpectatorPlayerClock CreateManagedClock();
 
         /// <summary>
         /// Removes an <see cref="ISpectatorPlayerClock"/>, stopping it from being managed by this <see cref="ISyncManager"/>.
         /// </summary>
         /// <param name="clock">The <see cref="ISpectatorPlayerClock"/> to remove.</param>
-        void RemoveClock(ISpectatorPlayerClock clock);
+        void RemoveManagedClock(ISpectatorPlayerClock clock);
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             };
 
             for (int i = 0; i < Users.Count; i++)
-                grid.Add(instances[i] = new PlayerArea(Users[i], syncManager.AddClock()));
+                grid.Add(instances[i] = new PlayerArea(Users[i], syncManager.CreateManagedClock()));
 
             LoadComponentAsync(leaderboard = new MultiSpectatorLeaderboard(users)
             {
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             var instance = instances.Single(i => i.UserId == userId);
 
             instance.FadeColour(colours.Gray4, 400, Easing.OutQuint);
-            syncManager.RemoveClock(instance.GameplayClock);
+            syncManager.RemoveManagedClock(instance.GameplayClock);
         }
 
         public override bool OnBackButton()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -125,10 +125,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             };
 
             for (int i = 0; i < Users.Count; i++)
-            {
-                grid.Add(instances[i] = new PlayerArea(Users[i], masterClockContainer));
-                syncManager.AddPlayerClock(instances[i].GameplayClock);
-            }
+                grid.Add(instances[i] = new PlayerArea(Users[i], syncManager.AddClock()));
 
             LoadComponentAsync(leaderboard = new MultiSpectatorLeaderboard(users)
             {
@@ -242,7 +239,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             var instance = instances.Single(i => i.UserId == userId);
 
             instance.FadeColour(colours.Gray4, 400, Easing.OutQuint);
-            syncManager.RemovePlayerClock(instance.GameplayClock);
+            syncManager.RemoveClock(instance.GameplayClock);
         }
 
         public override bool OnBackButton()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -42,17 +40,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         protected override UserActivity InitialActivity => new UserActivity.SpectatingMultiplayerGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         [Resolved]
-        private MultiplayerClient multiplayerClient { get; set; }
+        private MultiplayerClient multiplayerClient { get; set; } = null!;
 
         private readonly PlayerArea[] instances;
-        private MasterGameplayClockContainer masterClockContainer;
-        private ISyncManager syncManager;
-        private PlayerGrid grid;
-        private MultiSpectatorLeaderboard leaderboard;
-        private PlayerArea currentAudioSource;
+        private MasterGameplayClockContainer masterClockContainer = null!;
+        private ISyncManager syncManager = null!;
+        private PlayerGrid grid = null!;
+        private MultiSpectatorLeaderboard leaderboard = null!;
+        private PlayerArea? currentAudioSource;
         private bool canStartMasterClock;
 
         private readonly Room room;
@@ -178,7 +176,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             }
         }
 
-        private bool isCandidateAudioSource([CanBeNull] ISpectatorPlayerClock clock)
+        private bool isCandidateAudioSource(ISpectatorPlayerClock? clock)
             => clock?.IsRunning == true && !clock.IsCatchingUp && !clock.WaitingOnFrames.Value;
 
         private void onReadyToStart()
@@ -186,7 +184,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             // Seek the master clock to the gameplay time.
             // This is chosen as the first available frame in the players' replays, which matches the seek by each individual SpectatorPlayer.
             double startTime = instances.Where(i => i.Score != null)
-                                        .SelectMany(i => i.Score.Replay.Frames)
+                                        .SelectMany(i => i.Score.AsNonNull().Replay.Frames)
                                         .Select(f => f.Time)
                                         .DefaultIfEmpty(0)
                                         .Min();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -1,11 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -28,7 +25,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// Raised after <see cref="Player.StartGameplay"/> is called on <see cref="Player"/>.
         /// </summary>
-        public event Action OnGameplayStarted;
+        public event Action? OnGameplayStarted;
 
         /// <summary>
         /// Whether a <see cref="Player"/> is loaded in the area.
@@ -43,21 +40,22 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// The <see cref="ISpectatorPlayerClock"/> used to control the gameplay running state of a loaded <see cref="Player"/>.
         /// </summary>
-        [NotNull]
         public readonly ISpectatorPlayerClock GameplayClock;
 
         /// <summary>
         /// The currently-loaded score.
         /// </summary>
-        [CanBeNull]
-        public Score Score { get; private set; }
+        public Score? Score { get; private set; }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
         private readonly BindableDouble volumeAdjustment = new BindableDouble();
         private readonly Container gameplayContent;
         private readonly LoadingLayer loadingLayer;
-        private OsuScreenStack stack;
+        private OsuScreenStack? stack;
 
-        public PlayerArea(int userId, [NotNull] ISpectatorPlayerClock clock)
+        public PlayerArea(int userId, ISpectatorPlayerClock clock)
         {
             UserId = userId;
             GameplayClock = clock;
@@ -79,10 +77,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             audioContainer.AddAdjustment(AdjustableProperty.Volume, volumeAdjustment);
         }
 
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; }
-
-        public void LoadScore([NotNull] Score score)
+        public void LoadScore(Score score)
         {
             if (Score != null)
                 throw new InvalidOperationException($"Cannot load a new score on a {nameof(PlayerArea)} that has an existing score.");

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerArea.cs
@@ -11,7 +11,6 @@ using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
@@ -45,7 +44,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// The <see cref="ISpectatorPlayerClock"/> used to control the gameplay running state of a loaded <see cref="Player"/>.
         /// </summary>
         [NotNull]
-        public readonly ISpectatorPlayerClock GameplayClock = new CatchUpSpectatorPlayerClock();
+        public readonly ISpectatorPlayerClock GameplayClock;
 
         /// <summary>
         /// The currently-loaded score.
@@ -58,9 +57,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         private readonly LoadingLayer loadingLayer;
         private OsuScreenStack stack;
 
-        public PlayerArea(int userId, IFrameBasedClock masterClock)
+        public PlayerArea(int userId, [NotNull] ISpectatorPlayerClock clock)
         {
             UserId = userId;
+            GameplayClock = clock;
 
             RelativeSizeAxes = Axes.Both;
             Masking = true;
@@ -77,8 +77,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             };
 
             audioContainer.AddAdjustment(AdjustableProperty.Volume, volumeAdjustment);
-
-            GameplayClock.Source = masterClock;
         }
 
         [Resolved]


### PR DESCRIPTION
Inspired by the confusion around how multi-spectator clocks work, I think it's more obvious what's going on if `CatchUpSyncManager` is the one creating clocks, and those clocks are passed to the individual `PlayerArea`s.