### PR TITLE
Fix multi-spectator potentially getting stuck for passed players

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -219,19 +219,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         protected override void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState)
             => instances.Single(i => i.UserId == userId).LoadScore(spectatorGameplayState.Score);
 
-        protected override void EndGameplay(int userId, SpectatorState state)
+        protected override void QuitGameplay(int userId)
         {
-            // Allowed passed/failed users to complete their remaining replay frames.
-            // The failed state isn't really possible in multiplayer (yet?) but is added here just for safety in case it starts being used.
-            if (state.State == SpectatedUserState.Passed || state.State == SpectatedUserState.Failed)
-                return;
-
-            // we could also potentially receive EndGameplay with "Playing" state, at which point we can only early-return and hope it's a passing player.
-            // todo: this shouldn't exist, but it's here as a hotfix for an issue with multi-spectator screen not proceeding to results screen.
-            // see: https://github.com/ppy/osu/issues/19593
-            if (state.State == SpectatedUserState.Playing)
-                return;
-
             RemoveUser(userId);
 
             var instance = instances.Single(i => i.UserId == userId);

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Screens.Play
             scheduleStart(spectatorGameplayState);
         }
 
-        protected override void EndGameplay(int userId, SpectatorState state)
+        protected override void QuitGameplay(int userId)
         {
             scheduledStart?.Cancel();
             immediateSpectatorGameplayState = null;

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -118,11 +118,6 @@ namespace osu.Game.Screens.Spectate
                     foreach ((int userId, SpectatorState state) in e.NewItems.AsNonNull())
                         onUserStateChanged(userId, state);
                     break;
-
-                case NotifyDictionaryChangedAction.Remove:
-                    foreach ((int userId, SpectatorState state) in e.OldItems.AsNonNull())
-                        onUserStateChanged(userId, state);
-                    break;
             }
         }
 


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/19593
- Reverts https://github.com/ppy/osu/pull/19597

RFC. The issue is mainly occurring due to `SpectatorClient` not supporting multiple components watching/stop-watching the same user, potentially causing one component calling `StopWatchingUser` to corrupt another component's state.

After fixing that issue, it turns out that `SpectatorScreen` actually *depends* on that "bug" as it only calls `EndGameplay` once the user is no longer watched, which means waiting until another component (`MultiplayerGameplayLeaderboard` in this case) to stop watching the user. 

This felt quite awkward, so I've went ahead and refactored part of the logic to no longer rely on that bug (and also change and rename `EndGameplay` to no longer be called on pass/fail state).