### PR TITLE
Assign team labels for pull requests

### DIFF
--- a/.github/workflows/pr-team-labels.yml
+++ b/.github/workflows/pr-team-labels.yml
@@ -1,0 +1,15 @@
+name: Assign PR team labels
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  team-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: equitybee/team-label-action@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          organization-name: ppy

--- a/.github/workflows/pr-team-labels.yml
+++ b/.github/workflows/pr-team-labels.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: equitybee/team-label-action@v1.0.2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.PR_WRITE_TOKEN }}
           organization-name: ppy

--- a/.github/workflows/pr-team-labels.yml
+++ b/.github/workflows/pr-team-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: equitybee/team-label-action@main
+      - uses: equitybee/team-label-action@v1.0.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           organization-name: ppy


### PR DESCRIPTION
In theory. https://github.com/marketplace/actions/team-label-action

May have to make labels for it to work, we'll see.