### PR TITLE
No "gameplayClock" usage with playfield update mods

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private OsuInputManager inputManager = null!;
 
-        private IFrameStableClock gameplayClock = null!;
-
         private List<OsuReplayFrame> replayFrames = null!;
 
         private int currentFrame;
@@ -41,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             if (currentFrame == replayFrames.Count - 1) return;
 
-            double time = gameplayClock.CurrentTime;
+            double time = playfield.Clock.CurrentTime;
 
             // Very naive implementation of autopilot based on proximity to replay frames.
             // TODO: this needs to be based on user interactions to better match stable (pausing until judgement is registered).
@@ -56,8 +54,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
-            gameplayClock = drawableRuleset.FrameStableClock;
-
             // Grab the input manager to disable the user's cursor, and for future use
             inputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
             inputManager.AllowUserCursorMovement = false;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
@@ -27,8 +28,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel) };
 
-        private IFrameStableClock gameplayClock = null!;
-
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]
         public BindableFloat AttractionStrength { get; } = new BindableFloat(0.5f)
         {
@@ -39,8 +38,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
-            gameplayClock = drawableRuleset.FrameStableClock;
-
             // Hide judgment displays and follow points as they won't make any sense.
             // Judgements can potentially be turned on in a future where they display at a position relative to their drawable counterpart.
             drawableRuleset.Playfield.DisplayJudgements.Value = false;
@@ -56,27 +53,27 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (drawable)
                 {
                     case DrawableHitCircle circle:
-                        easeTo(circle, cursorPos);
+                        easeTo(playfield.Clock, circle, cursorPos);
                         break;
 
                     case DrawableSlider slider:
 
                         if (!slider.HeadCircle.Result.HasResult)
-                            easeTo(slider, cursorPos);
+                            easeTo(playfield.Clock, slider, cursorPos);
                         else
-                            easeTo(slider, cursorPos - slider.Ball.DrawPosition);
+                            easeTo(playfield.Clock, slider, cursorPos - slider.Ball.DrawPosition);
 
                         break;
                 }
             }
         }
 
-        private void easeTo(DrawableHitObject hitObject, Vector2 destination)
+        private void easeTo(IFrameBasedClock clock, DrawableHitObject hitObject, Vector2 destination)
         {
             double dampLength = Interpolation.Lerp(3000, 40, AttractionStrength.Value);
 
-            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, gameplayClock.ElapsedFrameTime);
-            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, gameplayClock.ElapsedFrameTime);
+            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, clock.ElapsedFrameTime);
+            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, clock.ElapsedFrameTime);
 
             hitObject.Position = new Vector2(x, y);
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
+using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
@@ -27,8 +27,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModMagnetised) };
 
-        private IFrameStableClock? gameplayClock;
-
         [SettingSource("Repulsion strength", "How strong the repulsion is.", 0)]
         public BindableFloat RepulsionStrength { get; } = new BindableFloat(0.5f)
         {
@@ -39,8 +37,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
-            gameplayClock = drawableRuleset.FrameStableClock;
-
             // Hide judgment displays and follow points as they won't make any sense.
             // Judgements can potentially be turned on in a future where they display at a position relative to their drawable counterpart.
             drawableRuleset.Playfield.DisplayJudgements.Value = false;
@@ -69,29 +65,27 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (drawable)
                 {
                     case DrawableHitCircle circle:
-                        easeTo(circle, destination, cursorPos);
+                        easeTo(playfield.Clock, circle, destination, cursorPos);
                         break;
 
                     case DrawableSlider slider:
 
                         if (!slider.HeadCircle.Result.HasResult)
-                            easeTo(slider, destination, cursorPos);
+                            easeTo(playfield.Clock, slider, destination, cursorPos);
                         else
-                            easeTo(slider, destination - slider.Ball.DrawPosition, cursorPos);
+                            easeTo(playfield.Clock, slider, destination - slider.Ball.DrawPosition, cursorPos);
 
                         break;
                 }
             }
         }
 
-        private void easeTo(DrawableHitObject hitObject, Vector2 destination, Vector2 cursorPos)
+        private void easeTo(IFrameBasedClock clock, DrawableHitObject hitObject, Vector2 destination, Vector2 cursorPos)
         {
-            Debug.Assert(gameplayClock != null);
-
             double dampLength = Vector2.Distance(hitObject.Position, cursorPos) / (0.04 * RepulsionStrength.Value + 0.04);
 
-            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, gameplayClock.ElapsedFrameTime);
-            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, gameplayClock.ElapsedFrameTime);
+            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, clock.ElapsedFrameTime);
+            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, clock.ElapsedFrameTime);
 
             hitObject.Position = new Vector2(x, y);
         }


### PR DESCRIPTION
Since all children of a  `FrameStabilityContainer` inherit the same clock, these usages are no longer necessary, because these mods all have access to the `DrawableRuleset` clock by it's playfield
![image](https://user-images.githubusercontent.com/88356162/186550520-b3ad27d8-e350-462f-8f50-c3a174dd671d.png)
(Playfield is a child of a `FrameStabilityContainer`)