### PR TITLE
Wraps "repel" and "magnetized" mods into a base class

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/CursorBasedHitObjectPositionMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/CursorBasedHitObjectPositionMod.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Timing;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.UI;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    internal abstract class CursorBasedHitObjectPositionMod : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+    {
+        public override ModType Type => ModType.Fun;
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay) };
+
+        protected abstract double GetDampLength(DrawableHitObject hitObject, Vector2 cursorPos);
+
+        protected abstract Vector2 GetBaseDestination(DrawableHitObject drawable, Vector2 cursorPos);
+
+        private void easeTo(DrawableHitObject hitObject, Vector2 destination, Vector2 cursorPos, IFrameBasedClock clock)
+        {
+            double dampLength = GetDampLength(hitObject, cursorPos);
+
+            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, clock.ElapsedFrameTime);
+            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, clock.ElapsedFrameTime);
+
+            hitObject.Position = new Vector2(x, y);
+        }
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
+        {
+            // Hide judgment displays and follow points as they won't make any sense.
+            // Judgements can potentially be turned on in a future where they display at a position relative to their drawable counterpart.
+            drawableRuleset.Playfield.DisplayJudgements.Value = false;
+            (drawableRuleset.Playfield as OsuPlayfield)?.FollowPoints.Hide();
+        }
+
+        public void Update(Playfield playfield)
+        {
+            var cursorPos = playfield.Cursor.ActiveCursor.DrawPosition;
+
+            foreach (var drawable in playfield.HitObjectContainer.AliveObjects)
+            {
+                var destination = GetBaseDestination(drawable, cursorPos);
+
+                switch (drawable)
+                {
+                    case DrawableSlider slider:
+                        destination = slider.HeadCircle.Result.HasResult ? destination - slider.Ball.DrawPosition : cursorPos;
+                        break;
+                }
+
+                easeTo(drawable, destination, cursorPos, playfield.Clock);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -2,31 +2,27 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osu.Game.Rulesets.Osu.UI;
-using osu.Game.Rulesets.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModMagnetised : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+    internal class OsuModMagnetised : CursorBasedHitObjectPositionMod, IApplicableToDrawableRuleset<OsuHitObject>
     {
         public override string Name => "Magnetised";
         public override string Acronym => "MG";
         public override IconUsage? Icon => FontAwesome.Solid.Magnet;
-        public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
         public override double ScoreMultiplier => 0.5;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModRelax), typeof(OsuModRepel) }).ToArray();
 
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]
         public BindableFloat AttractionStrength { get; } = new BindableFloat(0.5f)
@@ -36,46 +32,14 @@ namespace osu.Game.Rulesets.Osu.Mods
             MaxValue = 1.0f,
         };
 
-        public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
+        protected override double GetDampLength(DrawableHitObject hitObject, Vector2 cursorPos)
         {
-            // Hide judgment displays and follow points as they won't make any sense.
-            // Judgements can potentially be turned on in a future where they display at a position relative to their drawable counterpart.
-            drawableRuleset.Playfield.DisplayJudgements.Value = false;
-            (drawableRuleset.Playfield as OsuPlayfield)?.FollowPoints.Hide();
+            return Interpolation.Lerp(3000, 40, AttractionStrength.Value);
         }
 
-        public void Update(Playfield playfield)
+        protected override Vector2 GetBaseDestination(DrawableHitObject drawable, Vector2 cursorPos)
         {
-            var cursorPos = playfield.Cursor.ActiveCursor.DrawPosition;
-
-            foreach (var drawable in playfield.HitObjectContainer.AliveObjects)
-            {
-                switch (drawable)
-                {
-                    case DrawableHitCircle circle:
-                        easeTo(playfield.Clock, circle, cursorPos);
-                        break;
-
-                    case DrawableSlider slider:
-
-                        if (!slider.HeadCircle.Result.HasResult)
-                            easeTo(playfield.Clock, slider, cursorPos);
-                        else
-                            easeTo(playfield.Clock, slider, cursorPos - slider.Ball.DrawPosition);
-
-                        break;
-                }
-            }
-        }
-
-        private void easeTo(IFrameBasedClock clock, DrawableHitObject hitObject, Vector2 destination)
-        {
-            double dampLength = Interpolation.Lerp(3000, 40, AttractionStrength.Value);
-
-            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, clock.ElapsedFrameTime);
-            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, clock.ElapsedFrameTime);
-
-            hitObject.Position = new Vector2(x, y);
+            return cursorPos;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -8,14 +8,12 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModMagnetised : CursorBasedHitObjectPositionMod, IApplicableToDrawableRuleset<OsuHitObject>
+    internal class OsuModMagnetised : CursorBasedHitObjectPositionMod
     {
         public override string Name => "Magnetised";
         public override string Acronym => "MG";

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -2,30 +2,26 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
-using osu.Framework.Timing;
-using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Osu.Utils;
-using osu.Game.Rulesets.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModRepel : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+    internal class OsuModRepel : CursorBasedHitObjectPositionMod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
     {
         public override string Name => "Repel";
         public override string Acronym => "RP";
-        public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Hit objects run away!";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModMagnetised) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModMagnetised) }).ToArray();
 
         [SettingSource("Repulsion strength", "How strong the repulsion is.", 0)]
         public BindableFloat RepulsionStrength { get; } = new BindableFloat(0.5f)
@@ -35,59 +31,30 @@ namespace osu.Game.Rulesets.Osu.Mods
             MaxValue = 1.0f,
         };
 
-        public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
+        protected override double GetDampLength(DrawableHitObject hitObject, Vector2 cursorPos)
         {
-            // Hide judgment displays and follow points as they won't make any sense.
-            // Judgements can potentially be turned on in a future where they display at a position relative to their drawable counterpart.
-            drawableRuleset.Playfield.DisplayJudgements.Value = false;
-            (drawableRuleset.Playfield as OsuPlayfield)?.FollowPoints.Hide();
+            return Vector2.Distance(hitObject.Position, cursorPos) / (0.04 * RepulsionStrength.Value + 0.04);
         }
 
-        public void Update(Playfield playfield)
+        protected override Vector2 GetBaseDestination(DrawableHitObject drawable, Vector2 cursorPos)
         {
-            var cursorPos = playfield.Cursor.ActiveCursor.DrawPosition;
+            var destination = Vector2.Clamp(2 * drawable.Position - cursorPos, Vector2.Zero, OsuPlayfield.BASE_SIZE);
 
-            foreach (var drawable in playfield.HitObjectContainer.AliveObjects)
+            switch (drawable.HitObject)
             {
-                var destination = Vector2.Clamp(2 * drawable.Position - cursorPos, Vector2.Zero, OsuPlayfield.BASE_SIZE);
-
-                if (drawable.HitObject is Slider thisSlider)
-                {
-                    var possibleMovementBounds = OsuHitObjectGenerationUtils.CalculatePossibleMovementBounds(thisSlider);
+                case Slider slider:
+                    var possibleMovementBounds = OsuHitObjectGenerationUtils.CalculatePossibleMovementBounds(slider);
 
                     destination = Vector2.Clamp(
                         destination,
                         new Vector2(possibleMovementBounds.Left, possibleMovementBounds.Top),
                         new Vector2(possibleMovementBounds.Right, possibleMovementBounds.Bottom)
                     );
-                }
 
-                switch (drawable)
-                {
-                    case DrawableHitCircle circle:
-                        easeTo(playfield.Clock, circle, destination, cursorPos);
-                        break;
-
-                    case DrawableSlider slider:
-
-                        if (!slider.HeadCircle.Result.HasResult)
-                            easeTo(playfield.Clock, slider, destination, cursorPos);
-                        else
-                            easeTo(playfield.Clock, slider, destination - slider.Ball.DrawPosition, cursorPos);
-
-                        break;
-                }
+                    break;
             }
-        }
 
-        private void easeTo(IFrameBasedClock clock, DrawableHitObject hitObject, Vector2 destination, Vector2 cursorPos)
-        {
-            double dampLength = Vector2.Distance(hitObject.Position, cursorPos) / (0.04 * RepulsionStrength.Value + 0.04);
-
-            float x = (float)Interpolation.DampContinuously(hitObject.X, destination.X, dampLength, clock.ElapsedFrameTime);
-            float y = (float)Interpolation.DampContinuously(hitObject.Y, destination.Y, dampLength, clock.ElapsedFrameTime);
-
-            hitObject.Position = new Vector2(x, y);
+            return destination;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
@@ -15,7 +14,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModRepel : CursorBasedHitObjectPositionMod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+    internal class OsuModRepel : CursorBasedHitObjectPositionMod
     {
         public override string Name => "Repel";
         public override string Acronym => "RP";


### PR DESCRIPTION
This pull request aims to address code repetition between `OsuModRepel` and `OsuModMagnetized` mods by creating a base class `CursorBasedHitObjectPositionMod` (This naming seens odd but i couldn't think of anything else) which both mods inherit from.