### PR TITLE
Ensure fail animation sequence isn't run after the player exit sequence has started

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -146,6 +146,7 @@ namespace osu.Game.Beatmaps
         /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.
         /// This generally happens via MusicController when changing the global beatmap.
         /// </summary>
+        [NotNull]
         public Track Track
         {
             get

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -1,14 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.UI;
 using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using ManagedBass.Fx;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
@@ -34,27 +31,27 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public class FailAnimation : Container
     {
-        public Action OnComplete;
+        public Action? OnComplete;
 
         private readonly DrawableRuleset drawableRuleset;
         private readonly BindableDouble trackFreq = new BindableDouble(1);
         private readonly BindableDouble volumeAdjustment = new BindableDouble(0.5);
 
-        private Container filters;
+        private Container filters = null!;
 
-        private Box redFlashLayer;
+        private Box redFlashLayer = null!;
 
-        private Track track;
+        private Track? track;
 
-        private AudioFilter failLowPassFilter;
-        private AudioFilter failHighPassFilter;
+        private AudioFilter failLowPassFilter = null!;
+        private AudioFilter failHighPassFilter = null!;
 
         private const float duration = 2500;
 
-        private Sample failSample;
+        private Sample? failSample;
 
         [Resolved]
-        private OsuConfigManager config { get; set; }
+        private OsuConfigManager config { get; set; } = null!;
 
         protected override Container<Drawable> Content { get; } = new Container
         {
@@ -66,8 +63,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// The player screen background, used to adjust appearance on failing.
         /// </summary>
-        [CanBeNull]
-        public BackgroundScreen Background { private get; set; }
+        public BackgroundScreen? Background { private get; set; }
 
         public FailAnimation(DrawableRuleset drawableRuleset)
         {
@@ -127,7 +123,7 @@ namespace osu.Game.Screens.Play
 
             failHighPassFilter.CutoffTo(300);
             failLowPassFilter.CutoffTo(300, duration, Easing.OutCubic);
-            failSample.Play();
+            failSample?.Play();
 
             track.AddAdjustment(AdjustableProperty.Frequency, trackFreq);
             track.AddAdjustment(AdjustableProperty.Volume, volumeAdjustment);

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -153,8 +153,6 @@ namespace osu.Game.Screens.Play
 
         public void RemoveFilters(bool resetTrackFrequency = true)
         {
-            if (filtersRemoved) return;
-
             filtersRemoved = true;
 
             if (!started)

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Screens.Play
         }
 
         private bool started;
+        private bool filtersRemoved;
 
         /// <summary>
         /// Start the fail animation playing.
@@ -113,6 +114,7 @@ namespace osu.Game.Screens.Play
         public void Start()
         {
             if (started) throw new InvalidOperationException("Animation cannot be started more than once.");
+            if (filtersRemoved) throw new InvalidOperationException("Animation cannot be started after filters have been removed.");
 
             started = true;
 
@@ -155,6 +157,11 @@ namespace osu.Game.Screens.Play
 
         public void RemoveFilters(bool resetTrackFrequency = true)
         {
+            if (filtersRemoved)
+                return;
+
+            filtersRemoved = true;
+
             if (resetTrackFrequency)
                 track?.RemoveAdjustment(AdjustableProperty.Frequency, trackFreq);
 

--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play
 
         private Box redFlashLayer = null!;
 
-        private Track? track;
+        private Track track = null!;
 
         private AudioFilter failLowPassFilter = null!;
         private AudioFilter failHighPassFilter = null!;
@@ -153,15 +153,17 @@ namespace osu.Game.Screens.Play
 
         public void RemoveFilters(bool resetTrackFrequency = true)
         {
-            if (filtersRemoved)
-                return;
+            if (filtersRemoved) return;
 
             filtersRemoved = true;
 
-            if (resetTrackFrequency)
-                track?.RemoveAdjustment(AdjustableProperty.Frequency, trackFreq);
+            if (!started)
+                return;
 
-            track?.RemoveAdjustment(AdjustableProperty.Volume, volumeAdjustment);
+            if (resetTrackFrequency)
+                track.RemoveAdjustment(AdjustableProperty.Frequency, trackFreq);
+
+            track.RemoveAdjustment(AdjustableProperty.Volume, volumeAdjustment);
 
             if (filters.Parent == null)
                 return;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -828,8 +829,16 @@ namespace osu.Game.Screens.Play
 
         private bool onFail()
         {
+            // Failing after the quit sequence has started may cause weird side effects with the fail animation / effects.
+            if (GameplayState.HasQuit)
+                return false;
+
             if (!CheckModsAllowFailure())
                 return false;
+
+            Debug.Assert(!GameplayState.HasFailed);
+            Debug.Assert(!GameplayState.HasPassed);
+            Debug.Assert(!GameplayState.HasQuit);
 
             GameplayState.HasFailed = true;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/19835.

I'd like to add a test for this but can't immediately think of how to do so, due to the tight timing requirements (need to call `Player.Exit` and then fail immediately after). If we could easily slot in a mock `HealthProcessor` it wouldn't be too hard.