### PR TITLE
Fix `SliderPath.Version` bindings not being correctly cleaned up on path changes

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -142,9 +142,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 case NotifyCollectionChangedAction.Remove:
                     foreach (var point in e.OldItems.Cast<PathControlPoint>())
                     {
-                        foreach (var piece in Pieces.Where(p => p.ControlPoint == point))
+                        foreach (var piece in Pieces.Where(p => p.ControlPoint == point).ToArray())
                             piece.RemoveAndDisposeImmediately();
-                        foreach (var connection in Connections.Where(c => c.ControlPoint == point))
+                        foreach (var connection in Connections.Where(c => c.ControlPoint == point).ToArray())
                             connection.RemoveAndDisposeImmediately();
                     }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -142,8 +142,10 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 case NotifyCollectionChangedAction.Remove:
                     foreach (var point in e.OldItems.Cast<PathControlPoint>())
                     {
-                        Pieces.RemoveAll(p => p.ControlPoint == point);
-                        Connections.RemoveAll(c => c.ControlPoint == point);
+                        foreach (var piece in Pieces.Where(p => p.ControlPoint == point))
+                            piece.RemoveAndDisposeImmediately();
+                        foreach (var connection in Connections.Where(c => c.ControlPoint == point))
+                            connection.RemoveAndDisposeImmediately();
                     }
 
                     // If removing before the end of the path,


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/19864.

Ouch. Again.