### PR TITLE
Fix editor not applying offsets

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/CatchSelectionBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/CatchSelectionBlueprintTestScene.cs
@@ -70,10 +70,17 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             [Cached]
             private readonly BindableBeatDivisor beatDivisor;
 
+            protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+
             public EditorBeatmapDependencyContainer(IBeatmap beatmap, BindableBeatDivisor beatDivisor)
             {
-                editorClock = new EditorClock(beatmap, beatDivisor);
                 this.beatDivisor = beatDivisor;
+
+                InternalChildren = new Drawable[]
+                {
+                    editorClock = new EditorClock(beatmap, beatDivisor),
+                    Content,
+                };
             }
         }
     }

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaHitObjectComposer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         public void Setup() => Schedule(() =>
         {
             BeatDivisor.Value = 8;
-            Clock.Seek(0);
+            EditorClock.Seek(0);
 
             Child = composer = new TestComposer { RelativeSizeAxes = Axes.Both };
         });
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
                 originalTime = lastObject.HitObject.StartTime;
-                Clock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
+                EditorClock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
             });
 
             AddStep("select all objects", () => composer.EditorBeatmap.SelectedHitObjects.AddRange(composer.EditorBeatmap.HitObjects));
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
                 originalTime = lastObject.HitObject.StartTime;
-                Clock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
+                EditorClock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
             });
 
             AddStep("select all objects", () => composer.EditorBeatmap.SelectedHitObjects.AddRange(composer.EditorBeatmap.HitObjects));
@@ -125,7 +125,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             AddStep("seek to last object", () =>
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
-                Clock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
+                EditorClock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
             });
 
             AddStep("select all objects", () => composer.EditorBeatmap.SelectedHitObjects.AddRange(composer.EditorBeatmap.HitObjects));

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -59,10 +59,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 }
             });
 
-            editorClock = new EditorClock(editorBeatmap);
-
             base.Content.Children = new Drawable[]
             {
+                editorClock = new EditorClock(editorBeatmap),
                 snapProvider,
                 Content
             };

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoHitObjectComposer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
         public void Setup() => Schedule(() =>
         {
             BeatDivisor.Value = 8;
-            Clock.Seek(0);
+            EditorClock.Seek(0);
 
             Child = new TestComposer { RelativeSizeAxes = Axes.Both };
         });

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -23,13 +21,13 @@ namespace osu.Game.Tests.Editing
     [HeadlessTest]
     public class TestSceneHitObjectComposerDistanceSnapping : EditorClockTestScene
     {
-        private TestHitObjectComposer composer;
+        private TestHitObjectComposer composer = null!;
 
         [Cached(typeof(EditorBeatmap))]
         [Cached(typeof(IBeatSnapProvider))]
         private readonly EditorBeatmap editorBeatmap;
 
-        protected override Container<Drawable> Content { get; }
+        protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
         public TestSceneHitObjectComposerDistanceSnapping()
         {
@@ -40,15 +38,9 @@ namespace osu.Game.Tests.Editing
                 {
                     editorBeatmap = new EditorBeatmap(new OsuBeatmap
                     {
-                        BeatmapInfo =
-                        {
-                            Ruleset = new OsuRuleset().RulesetInfo,
-                        },
+                        BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                     }),
-                    Content = new Container
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                    }
+                    Content
                 },
             });
         }
@@ -205,7 +197,7 @@ namespace osu.Game.Tests.Editing
             assertSnappedDistance(400, 400);
         }
 
-        private void assertSnapDistance(float expectedDistance, HitObject hitObject = null)
+        private void assertSnapDistance(float expectedDistance, HitObject? hitObject = null)
             => AddAssert($"distance is {expectedDistance}", () => composer.GetBeatSnapDistanceAt(hitObject ?? new HitObject()), () => Is.EqualTo(expectedDistance));
 
         private void assertDurationToDistance(double duration, float expectedDistance)

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
@@ -55,51 +55,51 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestStopAtTrackEnd()
         {
-            AddStep("reset clock", () => Clock.Seek(0));
+            AddStep("reset clock", () => EditorClock.Seek(0));
 
-            AddStep("start clock", () => Clock.Start());
-            AddAssert("clock running", () => Clock.IsRunning);
+            AddStep("start clock", () => EditorClock.Start());
+            AddAssert("clock running", () => EditorClock.IsRunning);
 
-            AddStep("seek near end", () => Clock.Seek(Clock.TrackLength - 250));
-            AddUntilStep("clock stops", () => !Clock.IsRunning);
+            AddStep("seek near end", () => EditorClock.Seek(EditorClock.TrackLength - 250));
+            AddUntilStep("clock stops", () => !EditorClock.IsRunning);
 
-            AddUntilStep("clock stopped at end", () => Clock.CurrentTime, () => Is.EqualTo(Clock.TrackLength));
+            AddUntilStep("clock stopped at end", () => EditorClock.CurrentTime, () => Is.EqualTo(EditorClock.TrackLength));
 
-            AddStep("start clock again", () => Clock.Start());
-            AddAssert("clock looped to start", () => Clock.IsRunning && Clock.CurrentTime < 500);
+            AddStep("start clock again", () => EditorClock.Start());
+            AddAssert("clock looped to start", () => EditorClock.IsRunning && EditorClock.CurrentTime < 500);
         }
 
         [Test]
         public void TestWrapWhenStoppedAtTrackEnd()
         {
-            AddStep("reset clock", () => Clock.Seek(0));
+            AddStep("reset clock", () => EditorClock.Seek(0));
 
-            AddStep("stop clock", () => Clock.Stop());
-            AddAssert("clock stopped", () => !Clock.IsRunning);
+            AddStep("stop clock", () => EditorClock.Stop());
+            AddAssert("clock stopped", () => !EditorClock.IsRunning);
 
-            AddStep("seek exactly to end", () => Clock.Seek(Clock.TrackLength));
-            AddAssert("clock stopped at end", () => Clock.CurrentTime, () => Is.EqualTo(Clock.TrackLength));
+            AddStep("seek exactly to end", () => EditorClock.Seek(EditorClock.TrackLength));
+            AddAssert("clock stopped at end", () => EditorClock.CurrentTime, () => Is.EqualTo(EditorClock.TrackLength));
 
-            AddStep("start clock again", () => Clock.Start());
-            AddAssert("clock looped to start", () => Clock.IsRunning && Clock.CurrentTime < 500);
+            AddStep("start clock again", () => EditorClock.Start());
+            AddAssert("clock looped to start", () => EditorClock.IsRunning && EditorClock.CurrentTime < 500);
         }
 
         [Test]
         public void TestClampWhenSeekOutsideBeatmapBounds()
         {
-            AddStep("stop clock", () => Clock.Stop());
+            AddStep("stop clock", () => EditorClock.Stop());
 
-            AddStep("seek before start time", () => Clock.Seek(-1000));
-            AddAssert("time is clamped to 0", () => Clock.CurrentTime, () => Is.EqualTo(0));
+            AddStep("seek before start time", () => EditorClock.Seek(-1000));
+            AddAssert("time is clamped to 0", () => EditorClock.CurrentTime, () => Is.EqualTo(0));
 
-            AddStep("seek beyond track length", () => Clock.Seek(Clock.TrackLength + 1000));
-            AddAssert("time is clamped to track length", () => Clock.CurrentTime, () => Is.EqualTo(Clock.TrackLength));
+            AddStep("seek beyond track length", () => EditorClock.Seek(EditorClock.TrackLength + 1000));
+            AddAssert("time is clamped to track length", () => EditorClock.CurrentTime, () => Is.EqualTo(EditorClock.TrackLength));
 
-            AddStep("seek smoothly before start time", () => Clock.SeekSmoothlyTo(-1000));
-            AddUntilStep("time is clamped to 0", () => Clock.CurrentTime, () => Is.EqualTo(0));
+            AddStep("seek smoothly before start time", () => EditorClock.SeekSmoothlyTo(-1000));
+            AddUntilStep("time is clamped to 0", () => EditorClock.CurrentTime, () => Is.EqualTo(0));
 
-            AddStep("seek smoothly beyond track length", () => Clock.SeekSmoothlyTo(Clock.TrackLength + 1000));
-            AddUntilStep("time is clamped to track length", () => Clock.CurrentTime, () => Is.EqualTo(Clock.TrackLength));
+            AddStep("seek smoothly beyond track length", () => EditorClock.SeekSmoothlyTo(EditorClock.TrackLength + 1000));
+            AddUntilStep("time is clamped to track length", () => EditorClock.CurrentTime, () => Is.EqualTo(EditorClock.TrackLength));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("seek near end", () => EditorClock.Seek(EditorClock.TrackLength - 250));
             AddUntilStep("clock stops", () => !EditorClock.IsRunning);
 
-            AddUntilStep("clock stopped at end", () => EditorClock.CurrentTime, () => Is.EqualTo(EditorClock.TrackLength));
+            AddUntilStep("clock stopped at end", () => EditorClock.CurrentTime - EditorClock.TotalAppliedOffset, () => Is.EqualTo(EditorClock.TrackLength));
 
             AddStep("start clock again", () => EditorClock.Start());
             AddAssert("clock looped to start", () => EditorClock.IsRunning && EditorClock.CurrentTime < 500);

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSeekSnapping.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSeekSnapping.cs
@@ -28,6 +28,11 @@ namespace osu.Game.Tests.Visual.Editing
         {
             base.LoadComplete();
 
+            Child = new TimingPointVisualiser(Beatmap.Value.Beatmap, 5000) { Clock = EditorClock };
+        }
+
+        protected override Beatmap CreateEditorClockBeatmap()
+        {
             var testBeatmap = new Beatmap
             {
                 ControlPointInfo = new ControlPointInfo(),
@@ -45,9 +50,7 @@ namespace osu.Game.Tests.Visual.Editing
             testBeatmap.ControlPointInfo.Add(450, new TimingControlPoint { BeatLength = 100 });
             testBeatmap.ControlPointInfo.Add(500, new TimingControlPoint { BeatLength = 307.69230769230802 });
 
-            Beatmap.Value = CreateWorkingBeatmap(testBeatmap);
-
-            Child = new TimingPointVisualiser(testBeatmap, 5000) { Clock = Clock };
+            return testBeatmap;
         }
 
         /// <summary>
@@ -59,17 +62,17 @@ namespace osu.Game.Tests.Visual.Editing
             reset();
 
             // Forwards
-            AddStep("Seek(0)", () => Clock.Seek(0));
+            AddStep("Seek(0)", () => EditorClock.Seek(0));
             checkTime(0);
-            AddStep("Seek(33)", () => Clock.Seek(33));
+            AddStep("Seek(33)", () => EditorClock.Seek(33));
             checkTime(33);
-            AddStep("Seek(89)", () => Clock.Seek(89));
+            AddStep("Seek(89)", () => EditorClock.Seek(89));
             checkTime(89);
 
             // Backwards
-            AddStep("Seek(25)", () => Clock.Seek(25));
+            AddStep("Seek(25)", () => EditorClock.Seek(25));
             checkTime(25);
-            AddStep("Seek(0)", () => Clock.Seek(0));
+            AddStep("Seek(0)", () => EditorClock.Seek(0));
             checkTime(0);
         }
 
@@ -82,19 +85,19 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("Seek(0), Snap", () => Clock.SeekSnapped(0));
+            AddStep("Seek(0), Snap", () => EditorClock.SeekSnapped(0));
             checkTime(0);
-            AddStep("Seek(50), Snap", () => Clock.SeekSnapped(50));
+            AddStep("Seek(50), Snap", () => EditorClock.SeekSnapped(50));
             checkTime(50);
-            AddStep("Seek(100), Snap", () => Clock.SeekSnapped(100));
+            AddStep("Seek(100), Snap", () => EditorClock.SeekSnapped(100));
             checkTime(100);
-            AddStep("Seek(175), Snap", () => Clock.SeekSnapped(175));
+            AddStep("Seek(175), Snap", () => EditorClock.SeekSnapped(175));
             checkTime(175);
-            AddStep("Seek(350), Snap", () => Clock.SeekSnapped(350));
+            AddStep("Seek(350), Snap", () => EditorClock.SeekSnapped(350));
             checkTime(350);
-            AddStep("Seek(400), Snap", () => Clock.SeekSnapped(400));
+            AddStep("Seek(400), Snap", () => EditorClock.SeekSnapped(400));
             checkTime(400);
-            AddStep("Seek(450), Snap", () => Clock.SeekSnapped(450));
+            AddStep("Seek(450), Snap", () => EditorClock.SeekSnapped(450));
             checkTime(450);
         }
 
@@ -107,17 +110,17 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("Seek(24), Snap", () => Clock.SeekSnapped(24));
+            AddStep("Seek(24), Snap", () => EditorClock.SeekSnapped(24));
             checkTime(0);
-            AddStep("Seek(26), Snap", () => Clock.SeekSnapped(26));
+            AddStep("Seek(26), Snap", () => EditorClock.SeekSnapped(26));
             checkTime(50);
-            AddStep("Seek(150), Snap", () => Clock.SeekSnapped(150));
+            AddStep("Seek(150), Snap", () => EditorClock.SeekSnapped(150));
             checkTime(100);
-            AddStep("Seek(170), Snap", () => Clock.SeekSnapped(170));
+            AddStep("Seek(170), Snap", () => EditorClock.SeekSnapped(170));
             checkTime(175);
-            AddStep("Seek(274), Snap", () => Clock.SeekSnapped(274));
+            AddStep("Seek(274), Snap", () => EditorClock.SeekSnapped(274));
             checkTime(175);
-            AddStep("Seek(276), Snap", () => Clock.SeekSnapped(276));
+            AddStep("Seek(276), Snap", () => EditorClock.SeekSnapped(276));
             checkTime(350);
         }
 
@@ -129,15 +132,15 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("SeekForward", () => Clock.SeekForward());
+            AddStep("SeekForward", () => EditorClock.SeekForward());
             checkTime(50);
-            AddStep("SeekForward", () => Clock.SeekForward());
+            AddStep("SeekForward", () => EditorClock.SeekForward());
             checkTime(100);
-            AddStep("SeekForward", () => Clock.SeekForward());
+            AddStep("SeekForward", () => EditorClock.SeekForward());
             checkTime(200);
-            AddStep("SeekForward", () => Clock.SeekForward());
+            AddStep("SeekForward", () => EditorClock.SeekForward());
             checkTime(400);
-            AddStep("SeekForward", () => Clock.SeekForward());
+            AddStep("SeekForward", () => EditorClock.SeekForward());
             checkTime(450);
         }
 
@@ -149,17 +152,17 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(50);
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(100);
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(175);
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(350);
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(400);
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(450);
         }
 
@@ -172,30 +175,30 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("Seek(49)", () => Clock.Seek(49));
+            AddStep("Seek(49)", () => EditorClock.Seek(49));
             checkTime(49);
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(50);
-            AddStep("Seek(49.999)", () => Clock.Seek(49.999));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(49.999)", () => EditorClock.Seek(49.999));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(100);
-            AddStep("Seek(99)", () => Clock.Seek(99));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(99)", () => EditorClock.Seek(99));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(100);
-            AddStep("Seek(99.999)", () => Clock.Seek(99.999));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(99.999)", () => EditorClock.Seek(99.999));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(150);
-            AddStep("Seek(174)", () => Clock.Seek(174));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(174)", () => EditorClock.Seek(174));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(175);
-            AddStep("Seek(349)", () => Clock.Seek(349));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(349)", () => EditorClock.Seek(349));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(350);
-            AddStep("Seek(399)", () => Clock.Seek(399));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(399)", () => EditorClock.Seek(399));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(400);
-            AddStep("Seek(449)", () => Clock.Seek(449));
-            AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
+            AddStep("Seek(449)", () => EditorClock.Seek(449));
+            AddStep("SeekForward, Snap", () => EditorClock.SeekForward(true));
             checkTime(450);
         }
 
@@ -207,17 +210,17 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("Seek(450)", () => Clock.Seek(450));
+            AddStep("Seek(450)", () => EditorClock.Seek(450));
             checkTime(450);
-            AddStep("SeekBackward", () => Clock.SeekBackward());
+            AddStep("SeekBackward", () => EditorClock.SeekBackward());
             checkTime(400);
-            AddStep("SeekBackward", () => Clock.SeekBackward());
+            AddStep("SeekBackward", () => EditorClock.SeekBackward());
             checkTime(350);
-            AddStep("SeekBackward", () => Clock.SeekBackward());
+            AddStep("SeekBackward", () => EditorClock.SeekBackward());
             checkTime(150);
-            AddStep("SeekBackward", () => Clock.SeekBackward());
+            AddStep("SeekBackward", () => EditorClock.SeekBackward());
             checkTime(50);
-            AddStep("SeekBackward", () => Clock.SeekBackward());
+            AddStep("SeekBackward", () => EditorClock.SeekBackward());
             checkTime(0);
         }
 
@@ -229,19 +232,19 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("Seek(450)", () => Clock.Seek(450));
+            AddStep("Seek(450)", () => EditorClock.Seek(450));
             checkTime(450);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(400);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(350);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(175);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(100);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(50);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(0);
         }
 
@@ -254,18 +257,18 @@ namespace osu.Game.Tests.Visual.Editing
         {
             reset();
 
-            AddStep("Seek(451)", () => Clock.Seek(451));
+            AddStep("Seek(451)", () => EditorClock.Seek(451));
             checkTime(451);
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(450);
-            AddStep("Seek(450.999)", () => Clock.Seek(450.999));
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("Seek(450.999)", () => EditorClock.Seek(450.999));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(450);
-            AddStep("Seek(401)", () => Clock.Seek(401));
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("Seek(401)", () => EditorClock.Seek(401));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(400);
-            AddStep("Seek(401.999)", () => Clock.Seek(401.999));
-            AddStep("SeekBackward, Snap", () => Clock.SeekBackward(true));
+            AddStep("Seek(401.999)", () => EditorClock.Seek(401.999));
+            AddStep("SeekBackward, Snap", () => EditorClock.SeekBackward(true));
             checkTime(400);
         }
 
@@ -279,37 +282,37 @@ namespace osu.Game.Tests.Visual.Editing
 
             double lastTime = 0;
 
-            AddStep("Seek(0)", () => Clock.Seek(0));
+            AddStep("Seek(0)", () => EditorClock.Seek(0));
             checkTime(0);
 
             for (int i = 0; i < 9; i++)
             {
                 AddStep("SeekForward, Snap", () =>
                 {
-                    lastTime = Clock.CurrentTime;
-                    Clock.SeekForward(true);
+                    lastTime = EditorClock.CurrentTime;
+                    EditorClock.SeekForward(true);
                 });
-                AddAssert("Time > lastTime", () => Clock.CurrentTime > lastTime);
+                AddAssert("Time > lastTime", () => EditorClock.CurrentTime > lastTime);
             }
 
             for (int i = 0; i < 9; i++)
             {
                 AddStep("SeekBackward, Snap", () =>
                 {
-                    lastTime = Clock.CurrentTime;
-                    Clock.SeekBackward(true);
+                    lastTime = EditorClock.CurrentTime;
+                    EditorClock.SeekBackward(true);
                 });
-                AddAssert("Time < lastTime", () => Clock.CurrentTime < lastTime);
+                AddAssert("Time < lastTime", () => EditorClock.CurrentTime < lastTime);
             }
 
             checkTime(0);
         }
 
-        private void checkTime(double expectedTime) => AddAssert($"Current time is {expectedTime}", () => Clock.CurrentTime, () => Is.EqualTo(expectedTime));
+        private void checkTime(double expectedTime) => AddUntilStep($"Current time is {expectedTime}", () => EditorClock.CurrentTime, () => Is.EqualTo(expectedTime));
 
         private void reset()
         {
-            AddStep("Reset", () => Clock.Seek(0));
+            AddStep("Reset", () => EditorClock.Seek(0));
         }
 
         private class TimingPointVisualiser : CompositeDrawable

--- a/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Tests.Visual.Editing
                        .TriggerClick();
             });
 
-            AddUntilStep("wait for track playing", () => Clock.IsRunning);
+            AddUntilStep("wait for track playing", () => EditorClock.IsRunning);
 
             AddStep("click reset button", () =>
             {
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.Editing
                        .TriggerClick();
             });
 
-            AddUntilStep("wait for track stopped", () => !Clock.IsRunning);
+            AddUntilStep("wait for track stopped", () => !EditorClock.IsRunning);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineBlueprintContainer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineBlueprintContainer.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual.Editing
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            Clock.Seek(10000);
+            EditorClock.Seek(10000);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineZoom.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Tests.Visual.Editing
         {
             double initialVisibleRange = 0;
 
-            AddUntilStep("wait for load", () => MusicController.TrackLoaded);
-
             AddStep("reset zoom", () => TimelineArea.Timeline.Zoom = 100);
             AddStep("get initial range", () => initialVisibleRange = TimelineArea.Timeline.VisibleRange);
 
@@ -35,8 +33,6 @@ namespace osu.Game.Tests.Visual.Editing
         public void TestVisibleRangeConstantOnSizeChange()
         {
             double initialVisibleRange = 0;
-
-            AddUntilStep("wait for load", () => MusicController.TrackLoaded);
 
             AddStep("reset timeline size", () => TimelineArea.Timeline.Width = 1);
             AddStep("get initial range", () => initialVisibleRange = TimelineArea.Timeline.VisibleRange);

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Editing
         [SetUpSteps]
         public void SetUpSteps()
         {
-            AddStep("Stop clock", () => Clock.Stop());
+            AddStep("Stop clock", () => EditorClock.Stop());
 
             AddUntilStep("wait for rows to load", () => Child.ChildrenOfType<EffectRowAttribute>().Any());
         }
@@ -68,10 +68,10 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 54670);
-            AddUntilStep("Ensure seeked to correct time", () => Clock.CurrentTimeAccurate == 54670);
+            AddUntilStep("Ensure seeked to correct time", () => EditorClock.CurrentTimeAccurate == 54670);
 
-            AddStep("Seek to just before next point", () => Clock.Seek(69000));
-            AddStep("Start clock", () => Clock.Start());
+            AddStep("Seek to just before next point", () => EditorClock.Seek(69000));
+            AddStep("Start clock", () => EditorClock.Start());
 
             AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 69670);
         }
@@ -86,9 +86,9 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 54670);
-            AddUntilStep("Ensure seeked to correct time", () => Clock.CurrentTimeAccurate == 54670);
+            AddUntilStep("Ensure seeked to correct time", () => EditorClock.CurrentTimeAccurate == 54670);
 
-            AddStep("Seek to later", () => Clock.Seek(80000));
+            AddStep("Seek to later", () => EditorClock.Seek(80000));
             AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 69670);
         }
 

--- a/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
+++ b/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Visual.Editing
         {
             base.LoadComplete();
 
-            Clock.Seek(2500);
+            EditorClock.Seek(2500);
         }
 
         public abstract Drawable CreateTestComponent();

--- a/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
+++ b/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
@@ -9,12 +9,14 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osu.Game.Storyboards;
 using osuTK;
 using osuTK.Graphics;
 
@@ -28,10 +30,14 @@ namespace osu.Game.Tests.Visual.Editing
 
         protected EditorBeatmap EditorBeatmap { get; private set; }
 
-        [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        [Resolved]
+        private AudioManager audio { get; set; }
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null) => new WaveformTestBeatmap(audio);
+
+        protected override void LoadComplete()
         {
-            Beatmap.Value = new WaveformTestBeatmap(audio);
+            base.LoadComplete();
 
             var playable = Beatmap.Value.GetPlayableBeatmap(Beatmap.Value.BeatmapInfo.Ruleset);
             EditorBeatmap = new EditorBeatmap(playable);
@@ -68,11 +74,11 @@ namespace osu.Game.Tests.Visual.Editing
             });
         }
 
-        protected override void LoadComplete()
+        [SetUpSteps]
+        public void SetUpSteps()
         {
-            base.LoadComplete();
-
-            EditorClock.Seek(2500);
+            AddUntilStep("wait for track loaded", () => MusicController.TrackLoaded);
+            AddStep("seek forward", () => EditorClock.Seek(2500));
         }
 
         public abstract Drawable CreateTestComponent();

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Beatmaps
             finalClockSource.ProcessFrame();
         }
 
-        private double totalAppliedOffset
+        public double TotalAppliedOffset
         {
             get
             {
@@ -169,7 +169,7 @@ namespace osu.Game.Beatmaps
 
         public bool Seek(double position)
         {
-            bool success = decoupledClock.Seek(position - totalAppliedOffset);
+            bool success = decoupledClock.Seek(position - TotalAppliedOffset);
             finalClockSource.ProcessFrame();
 
             return success;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -5,7 +5,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -64,8 +63,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </summary>
         private bool trackWasPlaying;
 
-        private Track track;
-
         /// <summary>
         /// The timeline zoom level at a 1x zoom scale.
         /// </summary>
@@ -92,6 +89,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Container mainContent;
 
         private Bindable<float> waveformOpacity;
+
+        private double trackLengthForZoom;
 
         [BackgroundDependencyLoader]
         private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours, OsuConfigManager config)
@@ -144,9 +143,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             Beatmap.BindValueChanged(b =>
             {
                 waveform.Waveform = b.NewValue.Waveform;
-                track = b.NewValue.Track;
-
-                setupTimelineZoom();
             }, true);
 
             Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
@@ -185,8 +181,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private void updateWaveformOpacity() =>
             waveform.FadeTo(WaveformVisible.Value ? waveformOpacity.Value : 0, 200, Easing.OutQuint);
 
-        private float getZoomLevelForVisibleMilliseconds(double milliseconds) => Math.Max(1, (float)(track.Length / milliseconds));
-
         protected override void Update()
         {
             base.Update();
@@ -197,20 +191,21 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             // This needs to happen after transforms are updated, but before the scroll position is updated in base.UpdateAfterChildren
             if (editorClock.IsRunning)
                 scrollToTrackTime();
-        }
 
-        private void setupTimelineZoom()
-        {
-            if (!track.IsLoaded)
+            if (editorClock.TrackLength != trackLengthForZoom)
             {
-                Scheduler.AddOnce(setupTimelineZoom);
-                return;
+                defaultTimelineZoom = getZoomLevelForVisibleMilliseconds(6000);
+
+                float initialZoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
+                float minimumZoom = getZoomLevelForVisibleMilliseconds(10000);
+                float maximumZoom = getZoomLevelForVisibleMilliseconds(500);
+
+                SetupZoom(initialZoom, minimumZoom, maximumZoom);
+
+                float getZoomLevelForVisibleMilliseconds(double milliseconds) => Math.Max(1, (float)(editorClock.TrackLength / milliseconds));
+
+                trackLengthForZoom = editorClock.TrackLength;
             }
-
-            defaultTimelineZoom = getZoomLevelForVisibleMilliseconds(6000);
-
-            float initialZoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
-            SetupZoom(initialZoom, getZoomLevelForVisibleMilliseconds(10000), getZoomLevelForVisibleMilliseconds(500));
         }
 
         protected override bool OnScroll(ScrollEvent e)
@@ -255,16 +250,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void seekTrackToCurrent()
         {
-            if (!track.IsLoaded)
-                return;
-
-            double target = Current / Content.DrawWidth * track.Length;
-            editorClock.Seek(Math.Min(track.Length, target));
+            double target = Current / Content.DrawWidth * editorClock.TrackLength;
+            editorClock.Seek(Math.Min(editorClock.TrackLength, target));
         }
 
         private void scrollToTrackTime()
         {
-            if (!track.IsLoaded || track.Length == 0)
+            if (editorClock.TrackLength == 0)
                 return;
 
             // covers the case where the user starts playback after a drag is in progress.
@@ -272,7 +264,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             if (handlingDragInput)
                 editorClock.Stop();
 
-            ScrollTo((float)(editorClock.CurrentTime / track.Length) * Content.DrawWidth, false);
+            ScrollTo((float)(editorClock.CurrentTime / editorClock.TrackLength) * Content.DrawWidth, false);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)
@@ -310,12 +302,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// <summary>
         /// The total amount of time visible on the timeline.
         /// </summary>
-        public double VisibleRange => track.Length / Zoom;
+        public double VisibleRange => editorClock.TrackLength / Zoom;
 
         public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All) =>
             new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(screenSpacePosition))));
 
         private double getTimeFromPosition(Vector2 localPosition) =>
-            (localPosition.X / Content.DrawWidth) * track.Length;
+            (localPosition.X / Content.DrawWidth) * editorClock.TrackLength;
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -220,7 +220,7 @@ namespace osu.Game.Screens.Edit
             }
 
             // Todo: should probably be done at a DrawableRuleset level to share logic with Player.
-            clock = new EditorClock(playableBeatmap, beatDivisor) { IsCoupled = false };
+            clock = new EditorClock(playableBeatmap, beatDivisor);
             clock.ChangeSource(loadableBeatmap.Track);
 
             dependencies.CacheAs(clock);

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -158,6 +158,8 @@ namespace osu.Game.Screens.Edit
 
         public double CurrentTime => underlyingClock.CurrentTime;
 
+        public double TotalAppliedOffset => underlyingClock.TotalAppliedOffset;
+
         public void Reset()
         {
             ClearTransforms();

--- a/osu.Game/Tests/Visual/EditorClockTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorClockTestScene.cs
@@ -6,6 +6,8 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -24,30 +26,39 @@ namespace osu.Game.Tests.Visual
 
         protected readonly BindableBeatDivisor BeatDivisor = new BindableBeatDivisor();
 
-        [Cached]
-        protected new readonly EditorClock Clock;
+        protected EditorClock EditorClock;
 
         private readonly Bindable<double> frequencyAdjustment = new BindableDouble(1);
 
+        private IBeatmap editorClockBeatmap;
         protected virtual bool ScrollUsingMouseWheel => true;
 
-        protected EditorClockTestScene()
-        {
-            Clock = new EditorClock(new Beatmap(), BeatDivisor) { IsCoupled = false };
-        }
+        protected override Container<Drawable> Content => content;
+
+        private readonly Container<Drawable> content = new Container { RelativeSizeAxes = Axes.Both };
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
+            editorClockBeatmap = CreateEditorClockBeatmap();
+
+            base.Content.AddRange(new Drawable[]
+            {
+                EditorClock = new EditorClock(editorClockBeatmap, BeatDivisor),
+                content
+            });
+
             dependencies.Cache(BeatDivisor);
-            dependencies.CacheAs(Clock);
+            dependencies.CacheAs(EditorClock);
 
             return dependencies;
         }
 
         protected override void LoadComplete()
         {
+            Beatmap.Value = CreateWorkingBeatmap(editorClockBeatmap);
+
             base.LoadComplete();
 
             Beatmap.BindValueChanged(beatmapChanged, true);
@@ -55,22 +66,13 @@ namespace osu.Game.Tests.Visual
             AddSliderStep("editor clock rate", 0.0, 2.0, 1.0, v => frequencyAdjustment.Value = v);
         }
 
+        protected virtual IBeatmap CreateEditorClockBeatmap() => new Beatmap();
+
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> e)
         {
             e.OldValue?.Track.RemoveAdjustment(AdjustableProperty.Frequency, frequencyAdjustment);
-
-            Clock.Beatmap = e.NewValue.Beatmap;
-            Clock.ChangeSource(e.NewValue.Track);
-            Clock.ProcessFrame();
-
             e.NewValue.Track.AddAdjustment(AdjustableProperty.Frequency, frequencyAdjustment);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            Clock.ProcessFrame();
+            EditorClock.ChangeSource(e.NewValue.Track);
         }
 
         protected override bool OnScroll(ScrollEvent e)
@@ -79,9 +81,9 @@ namespace osu.Game.Tests.Visual
                 return false;
 
             if (e.ScrollDelta.Y > 0)
-                Clock.SeekBackward(true);
+                EditorClock.SeekBackward(true);
             else
-                Clock.SeekForward(true);
+                EditorClock.SeekForward(true);
 
             return true;
         }

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -30,10 +30,15 @@ namespace osu.Game.Tests.Visual
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            dependencies.CacheAs(new EditorClock());
-
             var playable = GetPlayableBeatmap();
-            dependencies.CacheAs(new EditorBeatmap(playable));
+
+            var editorClock = new EditorClock();
+            base.Content.Add(editorClock);
+            dependencies.CacheAs(editorClock);
+
+            var editorBeatmap = new EditorBeatmap(playable);
+            // Not adding to hierarchy as we don't satisfy its dependencies. Probably not good.
+            dependencies.CacheAs(editorBeatmap);
 
             return dependencies;
         }

--- a/osu.Game/Tests/Visual/SelectionBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/SelectionBlueprintTestScene.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -19,19 +16,23 @@ namespace osu.Game.Tests.Visual
         [Cached]
         private readonly EditorClock editorClock = new EditorClock();
 
-        protected override Container<Drawable> Content => content ?? base.Content;
+        protected override Container<Drawable> Content => content;
         private readonly Container content;
 
         protected SelectionBlueprintTestScene()
         {
-            base.Content.Add(content = new Container
+            base.Content.AddRange(new Drawable[]
             {
-                Clock = new FramedClock(new StopwatchClock()),
-                RelativeSizeAxes = Axes.Both
+                editorClock,
+                content = new Container
+                {
+                    Clock = new FramedClock(new StopwatchClock()),
+                    RelativeSizeAxes = Axes.Both
+                }
             });
         }
 
-        protected void AddBlueprint(HitObjectSelectionBlueprint blueprint, [CanBeNull] DrawableHitObject drawableObject = null)
+        protected void AddBlueprint(HitObjectSelectionBlueprint blueprint, DrawableHitObject? drawableObject = null)
         {
             Add(blueprint.With(d =>
             {


### PR DESCRIPTION
Finally. Notably, this cleans up a lot of weird logic surrounding track access / loaded state. Apart from that, I've tried to make as few changes as possible. As with other clock changes, disclaimer that this is likely not the final picture, but is made to be flexible to future changes.

- [x] Depends on #19828.