### PR TITLE
Fixed merging circles at the same time causing a crash

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneObjectMerging.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("add two circles on the same position", () =>
             {
                 circle1 = new HitCircle();
-                circle2 = new HitCircle { Position = circle1.Position + Vector2.UnitX, StartTime = 1 };
+                circle2 = new HitCircle { Position = circle1.Position + Vector2.UnitX };
                 EditorClock.Seek(0);
                 EditorBeatmap.Add(circle1);
                 EditorBeatmap.Add(circle2);
@@ -203,6 +203,33 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             mergeSelection();
             AddAssert("circles not merged", () => circle1 is not null && circle2 is not null
                                                                       && EditorBeatmap.HitObjects.Contains(circle1) && EditorBeatmap.HitObjects.Contains(circle2));
+        }
+
+        [Test]
+        public void TestSameStartTimeMerge()
+        {
+            HitCircle? circle1 = null;
+            HitCircle? circle2 = null;
+
+            AddStep("add two circles at the same time", () =>
+            {
+                circle1 = new HitCircle();
+                circle2 = new HitCircle { Position = circle1.Position + 100 * Vector2.UnitX };
+                EditorClock.Seek(0);
+                EditorBeatmap.Add(circle1);
+                EditorBeatmap.Add(circle2);
+                EditorBeatmap.SelectedHitObjects.Add(circle1);
+                EditorBeatmap.SelectedHitObjects.Add(circle2);
+            });
+
+            moveMouseToHitObject(1);
+            AddAssert("merge option available", () => selectionHandler.ContextMenuItems.Any(o => o.Text.Value == "Merge selection"));
+
+            mergeSelection();
+
+            AddAssert("slider created", () => circle1 is not null && circle2 is not null && sliderCreatedFor(
+                (pos: circle1.Position, pathType: PathType.Linear),
+                (pos: circle2.Position, pathType: null)));
         }
 
         private void mergeSelection()

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -362,7 +362,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                                                 && Precision.AlmostBigger(1, Vector2.DistanceSquared(mergeableObjects[0].Position, mergeableObjects[1].Position))))
                 return;
 
-            ChangeHandler?.BeginChange();
             EditorBeatmap.BeginChange();
 
             // Have an initial slider object.
@@ -440,7 +439,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             SelectedItems.Add(mergedHitObject);
 
             EditorBeatmap.EndChange();
-            ChangeHandler?.EndChange();
         }
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -363,6 +363,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 return;
 
             ChangeHandler?.BeginChange();
+            EditorBeatmap.BeginChange();
 
             // Have an initial slider object.
             var firstHitObject = mergeableObjects[0];
@@ -438,6 +439,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             SelectedItems.Clear();
             SelectedItems.Add(mergedHitObject);
 
+            EditorBeatmap.EndChange();
             ChangeHandler?.EndChange();
         }
 


### PR DESCRIPTION
closes #19922 

- [x] Depends on https://github.com/ppy/osu/pull/19982

We might want to make a new issue for the underlying issue? If there are two circles at the same time and both selected and then you remove the first circle (somehow without deleting the second circle aswell), then the game crashes. Not sure if this is intented because you currently cant cause this behaviour in the editor.