### PR TITLE
Quality of Life - Added Keybinds to interact with the pause/fail overlay using the keyboard

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -109,6 +109,21 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestResumeWithResumeKeybindOverlay()
+        {
+            AddUntilStep("wait for hitobjects", () => Player.HealthProcessor.Health.Value < 1);
+
+            pauseAndConfirm();
+
+            AddStep("press default continue keybind", () => InputManager.PressKey(Key.C));
+
+            confirmPausedWithNoOverlay();
+            AddStep("click to resume", () => InputManager.Click(MouseButton.Left));
+
+            confirmClockRunning(true);
+        }
+
+        [Test]
         public void TestPauseWithResumeOverlay()
         {
             AddStep("move cursor to center", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.Centre));
@@ -284,6 +299,16 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             pauseAndConfirm();
             exitAndConfirm();
+        }
+
+        [Test]
+        public void TestExitKeybindFromPause()
+        {
+            pauseAndConfirm();
+
+            confirmNotExited();
+            AddStep("exit using default keybind", () => InputManager.PressKey(Key.Q));
+            confirmExited();
         }
 
         [Test]

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Input.Bindings
         {
             new KeyBinding(InputKey.Up, GlobalAction.SelectPrevious),
             new KeyBinding(InputKey.Down, GlobalAction.SelectNext),
+            new KeyBinding(InputKey.C, GlobalAction.SelectContinue),
+            new KeyBinding(InputKey.R, GlobalAction.SelectRetry),
+            new KeyBinding(InputKey.Q, GlobalAction.SelectQuit),
 
             new KeyBinding(InputKey.Left, GlobalAction.SelectPreviousGroup),
             new KeyBinding(InputKey.Right, GlobalAction.SelectNextGroup),
@@ -233,6 +236,15 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectNext))]
         SelectNext,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectContinue))]
+        SelectContinue,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectRetry))]
+        SelectRetry,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SelectQuit))]
+        SelectQuit,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.Home))]
         Home,

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -130,6 +130,21 @@ namespace osu.Game.Localisation
         public static LocalisableString SelectNext => new TranslatableString(getKey(@"select_next"), @"Next selection");
 
         /// <summary>
+        /// "Select continue"
+        /// </summary>
+        public static LocalisableString SelectContinue => new TranslatableString(getKey(@"select_continue"), @"Select continue");
+
+        /// <summary>
+        /// "Select retry"
+        /// </summary>
+        public static LocalisableString SelectRetry => new TranslatableString(getKey(@"select_retry"), @"Select retry");
+
+        /// <summary>
+        /// "Select quit"
+        /// </summary>
+        public static LocalisableString SelectQuit => new TranslatableString(getKey(@"select_quit"), @"Select quit");
+
+        /// <summary>
         /// "Select previous group"
         /// </summary>
         public static LocalisableString SelectPreviousGroup => new TranslatableString(getKey(@"select_previous_group"), @"Select previous group");

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -175,6 +175,7 @@ namespace osu.Game.Screens.Play
             var button = new Button
             {
                 Text = text,
+                Name = text,
                 ButtonColour = colour,
                 Origin = Anchor.TopCentre,
                 Anchor = Anchor.TopCentre,
@@ -201,6 +202,15 @@ namespace osu.Game.Screens.Play
                     InternalButtons.SelectNext();
                     return true;
 
+                case GlobalAction.SelectContinue:
+                    return useButtonKeybind("Continue");
+
+                case GlobalAction.SelectRetry:
+                    return useButtonKeybind("Retry");
+
+                case GlobalAction.SelectQuit:
+                    return useButtonKeybind("Quit");
+
                 case GlobalAction.Back:
                     BackAction.Invoke();
                     return true;
@@ -215,6 +225,21 @@ namespace osu.Game.Screens.Play
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
+        }
+
+        private bool useButtonKeybind(string id)
+        {
+            for (int i = 0; i < InternalButtons.Count; i++)
+            {
+                if (InternalButtons[i].Name == id)
+                {
+                    InternalButtons.Select(InternalButtons[i]);
+                    SelectAction.Invoke();
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void updateRetryCount()


### PR DESCRIPTION
Added 3 new keys with changable binds
- Select Continue (c)
- Select Retry (r)
- Select Quit (q)

With these, the player is able to quickly interact with one of the overlay buttons instead of moving the mouse or using the arrow keys and enter. Useful for Keyboard heavy Rulesets (Taiko, Catch, Mania)

Hopefully easy to expand on in case the buttons get localised or more overlays are added