### PR TITLE
Refactor/merge `ScoreProcessor.ComputeScore()` methods

### DIFF
--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -307,7 +307,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
                 HitObjects = { new TestHitObject(result) }
             });
 
-            Assert.That(scoreProcessor.ComputeFinalScore(ScoringMode.Standardised, new ScoreInfo
+            Assert.That(scoreProcessor.ComputeScore(ScoringMode.Standardised, new ScoreInfo
             {
                 Ruleset = new TestRuleset().RulesetInfo,
                 MaxCombo = result.AffectsCombo() ? 1 : 0,
@@ -350,7 +350,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
                 }
             };
 
-            double totalScore = new TestScoreProcessor().ComputeFinalScore(ScoringMode.Standardised, testScore);
+            double totalScore = new TestScoreProcessor().ComputeScore(ScoringMode.Standardised, testScore);
             Assert.That(totalScore, Is.EqualTo(750_000)); // 500K from accuracy (100%), and 250K from combo (50%).
         }
 #pragma warning restore CS0618

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Difficulty
                 // calculate total score
                 ScoreProcessor scoreProcessor = ruleset.CreateScoreProcessor();
                 scoreProcessor.Mods.Value = perfectPlay.Mods;
-                perfectPlay.TotalScore = (long)scoreProcessor.ComputeFinalScore(ScoringMode.Standardised, perfectPlay);
+                perfectPlay.TotalScore = (long)scoreProcessor.ComputeScore(ScoringMode.Standardised, perfectPlay);
 
                 // compute rank achieved
                 // default to SS, then adjust the rank with mods

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Scoring
             var scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = score.Mods;
 
-            return (long)Math.Round(scoreProcessor.ComputeFinalLegacyScore(mode, score, beatmapMaxCombo.Value));
+            return (long)Math.Round(scoreProcessor.ComputeScore(mode, score));
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         {
             await base.PrepareScoreForResultsAsync(score).ConfigureAwait(false);
 
-            Score.ScoreInfo.TotalScore = (int)Math.Round(ScoreProcessor.ComputeFinalScore(ScoringMode.Standardised, Score.ScoreInfo));
+            Score.ScoreInfo.TotalScore = (int)Math.Round(ScoreProcessor.ComputeScore(ScoringMode.Standardised, Score.ScoreInfo));
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
`ScoreProcessor.ComputePartialScore()` wasn't used.

`ScoreProcessor.ComputeFinalLegacyScore()` was used to apply a different max combo for legacy scores. Since we're not displaying osu!stable scores in lazer, I think this is fine to be removed for the time being. There should be no difference for lazer scores.

This is intended for external use. There's more refactoring _specific to osu!_ that I'll do in a separate PR.