### PR TITLE
Adjust weirdly back-to-front fallback comparison in `HitObjectOrderedSelectionContainer`

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (result != 0) return result;
             }
 
-            return CompareReverseChildID(y, x);
+            return CompareReverseChildID(x, y);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Noticed on passing. This also indirectly (fixes) https://github.com/ppy/osu/issues/19922, but this is not meant to be a fix for that issue in any way and the feature is already unreliable on such scenarios that it's better to disable it instead.