### PR TITLE
Don't include misses in failed score statistics

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -124,14 +124,19 @@ namespace osu.Game.Tests.Gameplay
 
             Assert.That(score.Rank, Is.EqualTo(ScoreRank.F));
             Assert.That(score.Passed, Is.False);
-            Assert.That(score.Statistics.Count(kvp => kvp.Value > 0), Is.EqualTo(7));
+            Assert.That(score.Statistics.Sum(kvp => kvp.Value), Is.EqualTo(4));
+            Assert.That(score.MaximumStatistics.Sum(kvp => kvp.Value), Is.EqualTo(8));
+
             Assert.That(score.Statistics[HitResult.Ok], Is.EqualTo(1));
-            Assert.That(score.Statistics[HitResult.Miss], Is.EqualTo(1));
             Assert.That(score.Statistics[HitResult.LargeTickHit], Is.EqualTo(1));
-            Assert.That(score.Statistics[HitResult.LargeTickMiss], Is.EqualTo(1));
-            Assert.That(score.Statistics[HitResult.SmallTickMiss], Is.EqualTo(2));
+            Assert.That(score.Statistics[HitResult.SmallTickMiss], Is.EqualTo(1));
             Assert.That(score.Statistics[HitResult.SmallBonus], Is.EqualTo(1));
-            Assert.That(score.Statistics[HitResult.IgnoreMiss], Is.EqualTo(1));
+
+            Assert.That(score.MaximumStatistics[HitResult.Perfect], Is.EqualTo(2));
+            Assert.That(score.MaximumStatistics[HitResult.LargeTickHit], Is.EqualTo(2));
+            Assert.That(score.MaximumStatistics[HitResult.SmallTickHit], Is.EqualTo(2));
+            Assert.That(score.MaximumStatistics[HitResult.SmallBonus], Is.EqualTo(1));
+            Assert.That(score.MaximumStatistics[HitResult.LargeBonus], Is.EqualTo(1));
         }
 
         private class TestJudgement : Judgement

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -458,7 +458,7 @@ namespace osu.Game.Rulesets.Scoring
         }
 
         /// <summary>
-        /// Populates the given score with remaining statistics as "missed" and marks it with <see cref="ScoreRank.F"/> rank.
+        /// Populates a failed score, marking it with the <see cref="ScoreRank.F"/> rank.
         /// </summary>
         public void FailScore(ScoreInfo score)
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -468,22 +468,6 @@ namespace osu.Game.Rulesets.Scoring
             score.Passed = false;
             Rank.Value = ScoreRank.F;
 
-            Debug.Assert(maximumResultCounts != null);
-
-            if (maximumResultCounts.TryGetValue(HitResult.LargeTickHit, out int maximumLargeTick))
-                scoreResultCounts[HitResult.LargeTickMiss] = maximumLargeTick - scoreResultCounts.GetValueOrDefault(HitResult.LargeTickHit);
-
-            if (maximumResultCounts.TryGetValue(HitResult.SmallTickHit, out int maximumSmallTick))
-                scoreResultCounts[HitResult.SmallTickMiss] = maximumSmallTick - scoreResultCounts.GetValueOrDefault(HitResult.SmallTickHit);
-
-            int maximumBonusOrIgnore = maximumResultCounts.Where(kvp => kvp.Key.IsBonus() || kvp.Key == HitResult.IgnoreHit).Sum(kvp => kvp.Value);
-            int currentBonusOrIgnore = scoreResultCounts.Where(kvp => kvp.Key.IsBonus() || kvp.Key == HitResult.IgnoreHit).Sum(kvp => kvp.Value);
-            scoreResultCounts[HitResult.IgnoreMiss] = maximumBonusOrIgnore - currentBonusOrIgnore;
-
-            int maximumBasic = maximumResultCounts.SingleOrDefault(kvp => kvp.Key.IsBasic()).Value;
-            int currentBasic = scoreResultCounts.Where(kvp => kvp.Key.IsBasic() && kvp.Key != HitResult.Miss).Sum(kvp => kvp.Value);
-            scoreResultCounts[HitResult.Miss] = maximumBasic - currentBasic;
-
             PopulateScore(score);
         }
 


### PR DESCRIPTION
This isn't required after https://github.com/ppy/osu/pull/19939, and actually leads to incorrect data for failed scores (since we want to display e.g. tick counts at the time of fail). I intended to remove this in that PR, but forgot about it.