### PR TITLE
Always reprocess beatmaps after a user update request

### DIFF
--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -55,7 +55,14 @@ namespace osu.Game.Beatmaps
 
             // If there were no changes, ensure we don't accidentally nuke ourselves.
             if (first.ID == original.ID)
+            {
+                first.PerformRead(s =>
+                {
+                    // Re-run processing even in this case. We might have outdated metadata.
+                    ProcessBeatmap?.Invoke((s, false));
+                });
                 return first;
+            }
 
             first.PerformWrite(updated =>
             {


### PR DESCRIPTION
This covers the rare case where metadata may have changed server-side but not the beatmap itself.

Tested with the provided user database to resolve the issue:

https://user-images.githubusercontent.com/191335/187168619-6d616032-1af2-45ad-a92d-590378dfda7b.mp4

Closes #19976.