### PR TITLE
Assert non-null in `ProfileHeader` to appease r#

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Diagnostics;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -36,6 +37,10 @@ namespace osu.Game.Overlays.Profile
 
             // todo: pending implementation.
             // TabControl.AddItem(LayoutStrings.HeaderUsersModding);
+
+            // Haphazardly guaranteed by OverlayHeader constructor (see CreateBackground / CreateContent).
+            Debug.Assert(centreHeaderContainer != null);
+            Debug.Assert(detailHeaderContainer != null);
 
             centreHeaderContainer.DetailsVisible.BindValueChanged(visible => detailHeaderContainer.Expanded = visible.NewValue, true);
         }


### PR DESCRIPTION
This started showing up for me today, not sure why it happened out of the blue, but probably worth adding these asserts to answer the "wtf" part of looking at this code.

![JetBrains Rider 2022-08-30 at 09 09 23](https://user-images.githubusercontent.com/191335/187397589-a7111943-765d-41dc-9639-63c152a76b62.png)
