### PR TITLE
Update notification overlay design

### DIFF
--- a/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
+++ b/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
@@ -76,7 +76,7 @@ namespace osu.Desktop.Security
             private void load(OsuColour colours)
             {
                 Icon = FontAwesome.Solid.ShieldAlt;
-                IconBackground.Colour = colours.YellowDark;
+                IconContent.Colour = colours.YellowDark;
             }
         }
     }

--- a/osu.Game/Database/TooManyDownloadsNotification.cs
+++ b/osu.Game/Database/TooManyDownloadsNotification.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Database
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            IconBackground.Colour = colours.RedDark;
+            IconContent.Colour = colours.RedDark;
         }
     }
 }

--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Online.Chat
             [BackgroundDependencyLoader]
             private void load(OsuColour colours, ChatOverlay chatOverlay, INotificationOverlay notificationOverlay)
             {
-                IconBackground.Colour = colours.PurpleDark;
+                IconContent.Colour = colours.PurpleDark;
 
                 Activated = delegate
                 {

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Resources.Localisation.Web;
@@ -35,6 +34,9 @@ namespace osu.Game.Overlays
         [Resolved]
         private AudioManager audio { get; set; } = null!;
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
         private readonly IBindable<Visibility> firstRunSetupVisibility = new Bindable<Visibility>();
 
         [BackgroundDependencyLoader]
@@ -49,7 +51,7 @@ namespace osu.Game.Overlays
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = OsuColour.Gray(0.05f),
+                    Colour = colourProvider.Background4,
                 },
                 new OsuScrollContainer
                 {

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -58,6 +58,11 @@ namespace osu.Game.Overlays.Notifications
 
         protected virtual IconUsage CloseButtonIcon => FontAwesome.Solid.Check;
 
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private Box background = null!;
+
         protected Notification()
         {
             RelativeSizeAxes = Axes.X;
@@ -73,7 +78,7 @@ namespace osu.Game.Overlays.Notifications
                 },
                 MainContent = new Container
                 {
-                    CornerRadius = 8,
+                    CornerRadius = 6,
                     Masking = true,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
@@ -133,14 +138,26 @@ namespace osu.Game.Overlays.Notifications
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load()
         {
-            MainContent.Add(new Box
+            MainContent.Add(background = new Box
             {
                 RelativeSizeAxes = Axes.Both,
                 Colour = colourProvider.Background3,
                 Depth = float.MaxValue
             });
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            background.FadeColour(colourProvider.Background2, 200, Easing.OutQuint);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            background.FadeColour(colourProvider.Background3, 200, Easing.OutQuint);
+            base.OnHoverLost(e);
         }
 
         protected override bool OnClick(ClickEvent e)
@@ -193,7 +210,7 @@ namespace osu.Game.Overlays.Notifications
             private void load()
             {
                 RelativeSizeAxes = Axes.Y;
-                Width = 24;
+                Width = 28;
 
                 Children = new Drawable[]
                 {
@@ -216,15 +233,15 @@ namespace osu.Game.Overlays.Notifications
 
             protected override bool OnHover(HoverEvent e)
             {
-                background.FadeIn(200);
-                icon.FadeColour(colourProvider.Content1, 200);
+                background.FadeIn(200, Easing.OutQuint);
+                icon.FadeColour(colourProvider.Content1, 200, Easing.OutQuint);
                 return base.OnHover(e);
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                background.FadeOut(200);
-                icon.FadeColour(colourProvider.Foreground1, 200);
+                background.FadeOut(200, Easing.OutQuint);
+                icon.FadeColour(colourProvider.Foreground1, 200, Easing.OutQuint);
                 base.OnHoverLost(e);
             }
         }

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Overlays.Notifications
 
         protected override Container<Drawable> Content => content;
 
-        protected Container NotificationContent;
+        protected Container MainContent;
 
         public virtual bool Read { get; set; }
 
@@ -71,7 +71,7 @@ namespace osu.Game.Overlays.Notifications
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreRight,
                 },
-                NotificationContent = new Container
+                MainContent = new Container
                 {
                     CornerRadius = 8,
                     Masking = true,
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays.Notifications
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            NotificationContent.Add(new Box
+            MainContent.Add(new Box
             {
                 RelativeSizeAxes = Axes.Both,
                 Colour = colourProvider.Background3,
@@ -157,8 +157,8 @@ namespace osu.Game.Overlays.Notifications
 
             this.FadeInFromZero(200);
 
-            NotificationContent.MoveToX(DrawSize.X);
-            NotificationContent.MoveToX(0, 500, Easing.OutQuint);
+            MainContent.MoveToX(DrawSize.X);
+            MainContent.MoveToX(0, 500, Easing.OutQuint);
         }
 
         public bool WasClosed;

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osuTK;
 using osuTK.Graphics;
@@ -217,7 +218,7 @@ namespace osu.Game.Overlays.Notifications
                 {
                     background = new Box
                     {
-                        Colour = colourProvider.Background4,
+                        Colour = OsuColour.Gray(0).Opacity(0.15f),
                         Alpha = 0,
                         RelativeSizeAxes = Axes.Both,
                     },

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -118,6 +118,7 @@ namespace osu.Game.Overlays.Notifications
                                         {
                                             content = new Container
                                             {
+                                                Masking = true,
                                                 RelativeSizeAxes = Axes.X,
                                                 AutoSizeAxes = Axes.Y,
                                             },

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Overlays.Notifications
 
         public virtual bool Read { get; set; }
 
+        protected virtual IconUsage CloseButtonIcon => FontAwesome.Solid.Check;
+
         protected Notification()
         {
             RelativeSizeAxes = Axes.X;
@@ -116,7 +118,7 @@ namespace osu.Game.Overlays.Notifications
                                             },
                                         }
                                     },
-                                    new CloseButton
+                                    new CloseButton(CloseButtonIcon)
                                     {
                                         Action = Close,
                                         Anchor = Anchor.TopRight,
@@ -177,8 +179,15 @@ namespace osu.Game.Overlays.Notifications
             private SpriteIcon icon = null!;
             private Box background = null!;
 
+            private readonly IconUsage iconUsage;
+
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            public CloseButton(IconUsage iconUsage)
+            {
+                this.iconUsage = iconUsage;
+            }
 
             [BackgroundDependencyLoader]
             private void load()
@@ -198,7 +207,7 @@ namespace osu.Game.Overlays.Notifications
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Icon = FontAwesome.Solid.Check,
+                        Icon = iconUsage,
                         Size = new Vector2(12),
                         Colour = colourProvider.Foreground1,
                     }

--- a/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays.Notifications
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            IconBackground.Colour = ColourInfo.GradientVertical(colours.GreenDark, colours.GreenLight);
+            IconContent.Colour = ColourInfo.GradientVertical(colours.GreenDark, colours.GreenLight);
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -141,8 +141,7 @@ namespace osu.Game.Overlays.Notifications
 
                 case ProgressNotificationState.Completed:
                     loadingSpinner.Hide();
-                    MainContent.MoveToY(-DrawSize.Y / 2, 200, Easing.OutQuint);
-                    this.FadeOut(200).Finally(_ => Completed());
+                    Completed();
                     break;
             }
         }

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -61,7 +61,10 @@ namespace osu.Game.Overlays.Notifications
             }
         }
 
-        private void updateProgress(float progress) => progressBar.Progress = progress;
+        protected override IconUsage CloseButtonIcon => FontAwesome.Solid.Times;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Overlays.Notifications
 
         public ProgressNotification()
         {
-            Content.Add(textDrawable = new OsuTextFlowContainer
+            Content.Add(textDrawable = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14, weight: FontWeight.Medium))
             {
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Overlays.Notifications
             set
             {
                 progress = value;
-                Scheduler.AddOnce(updateProgress, progress);
+                Scheduler.AddOnce(p => progressBar.Progress = p, progress);
             }
         }
 
@@ -174,7 +174,6 @@ namespace osu.Game.Overlays.Notifications
         {
             Content.Add(textDrawable = new OsuTextFlowContainer
             {
-                Colour = OsuColour.Gray(128),
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
             });

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Overlays.Notifications
                     Light.Pulsate = false;
                     progressBar.Active = false;
 
-                    iconBackground.FadeColour(ColourInfo.GradientVertical(colourQueued, colourQueued.Lighten(0.5f)), colour_fade_duration);
+                    IconContent.FadeColour(ColourInfo.GradientVertical(colourQueued, colourQueued.Lighten(0.5f)), colour_fade_duration);
                     loadingSpinner.Show();
                     break;
 
@@ -112,14 +112,14 @@ namespace osu.Game.Overlays.Notifications
                     Light.Pulsate = true;
                     progressBar.Active = true;
 
-                    iconBackground.FadeColour(ColourInfo.GradientVertical(colourActive, colourActive.Lighten(0.5f)), colour_fade_duration);
+                    IconContent.FadeColour(ColourInfo.GradientVertical(colourActive, colourActive.Lighten(0.5f)), colour_fade_duration);
                     loadingSpinner.Show();
                     break;
 
                 case ProgressNotificationState.Cancelled:
                     cancellationTokenSource.Cancel();
 
-                    iconBackground.FadeColour(ColourInfo.GradientVertical(Color4.Gray, Color4.Gray.Lighten(0.5f)), colour_fade_duration);
+                    IconContent.FadeColour(ColourInfo.GradientVertical(Color4.Gray, Color4.Gray.Lighten(0.5f)), colour_fade_duration);
                     loadingSpinner.Hide();
 
                     var icon = new SpriteIcon
@@ -168,7 +168,6 @@ namespace osu.Game.Overlays.Notifications
         private Color4 colourActive;
         private Color4 colourCancelled;
 
-        private Box iconBackground = null!;
         private LoadingSpinner loadingSpinner = null!;
 
         private readonly TextFlowContainer textDrawable;
@@ -206,10 +205,10 @@ namespace osu.Game.Overlays.Notifications
 
             IconContent.AddRange(new Drawable[]
             {
-                iconBackground = new Box
+                new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.White,
+                    Colour = colourProvider.Background5,
                 },
                 loadingSpinner = new LoadingSpinner
                 {

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Overlays.Notifications
 
                 case ProgressNotificationState.Completed:
                     loadingSpinner.Hide();
-                    NotificationContent.MoveToY(-DrawSize.Y / 2, 200, Easing.OutQuint);
+                    MainContent.MoveToY(-DrawSize.Y / 2, 200, Easing.OutQuint);
                     this.FadeOut(200).Finally(_ => Completed());
                     break;
             }
@@ -180,7 +180,7 @@ namespace osu.Game.Overlays.Notifications
                 RelativeSizeAxes = Axes.X,
             });
 
-            NotificationContent.Add(progressBar = new ProgressBar
+            MainContent.Add(progressBar = new ProgressBar
             {
                 Origin = Anchor.BottomLeft,
                 Anchor = Anchor.BottomLeft,

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -41,8 +41,6 @@ namespace osu.Game.Overlays.Notifications
             }
         }
 
-        protected Box IconBackground = null!;
-
         private TextFlowContainer? textDrawable;
 
         private SpriteIcon? iconDrawable;
@@ -54,7 +52,7 @@ namespace osu.Game.Overlays.Notifications
 
             IconContent.AddRange(new Drawable[]
             {
-                IconBackground = new Box
+                new Box
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = colourProvider.Background5,

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
@@ -24,7 +23,8 @@ namespace osu.Game.Overlays.Notifications
             set
             {
                 text = value;
-                textDrawable.Text = text;
+                if (textDrawable != null)
+                    textDrawable.Text = text;
             }
         }
 
@@ -36,46 +36,44 @@ namespace osu.Game.Overlays.Notifications
             set
             {
                 icon = value;
-                iconDrawable.Icon = icon;
+                if (iconDrawable != null)
+                    iconDrawable.Icon = icon;
             }
         }
 
-        private readonly TextFlowContainer textDrawable;
-        private readonly SpriteIcon iconDrawable;
+        protected Box IconBackground = null!;
 
-        protected Box IconBackground;
+        private TextFlowContainer? textDrawable;
 
-        public SimpleNotification()
+        private SpriteIcon? iconDrawable;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, OverlayColourProvider colourProvider)
         {
+            Light.Colour = colours.Green;
+
             IconContent.AddRange(new Drawable[]
             {
                 IconBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.6f))
+                    Colour = colourProvider.Background5,
                 },
                 iconDrawable = new SpriteIcon
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Icon = icon,
-                    Size = new Vector2(20),
+                    Size = new Vector2(16),
                 }
             });
 
-            Content.Add(textDrawable = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14))
+            Content.Add(textDrawable = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 14, weight: FontWeight.Medium))
             {
-                Colour = OsuColour.Gray(128),
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
                 Text = text
             });
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            Light.Colour = colours.Green;
         }
 
         public override bool Read

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -530,7 +530,7 @@ namespace osu.Game.Screens.Play
             private void load(OsuColour colours, AudioManager audioManager, INotificationOverlay notificationOverlay, VolumeOverlay volumeOverlay)
             {
                 Icon = FontAwesome.Solid.VolumeMute;
-                IconBackground.Colour = colours.RedDark;
+                IconContent.Colour = colours.RedDark;
 
                 Activated = delegate
                 {
@@ -584,7 +584,7 @@ namespace osu.Game.Screens.Play
             private void load(OsuColour colours, INotificationOverlay notificationOverlay)
             {
                 Icon = FontAwesome.Solid.BatteryQuarter;
-                IconBackground.Colour = colours.RedDark;
+                IconContent.Colour = colours.RedDark;
 
                 Activated = delegate
                 {

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Updater
             private void load(OsuColour colours, ChangelogOverlay changelog, INotificationOverlay notificationOverlay)
             {
                 Icon = FontAwesome.Solid.CheckSquare;
-                IconBackground.Colour = colours.BlueDark;
+                IconContent.Colour = colours.BlueDark;
 
                 Activated = delegate
                 {


### PR DESCRIPTION
Roughly matches web. Not interested in getting metrics perfect or removing the light. Just wanted to get ballpark visuals correct to make sure any subsequent changes don't feel too out-of-place against the rest of the game ecosystem.

Before:

![osu Game Tests 2022-08-30 at 09 06 13](https://user-images.githubusercontent.com/191335/187396881-316ea889-3350-43a0-8c1a-93b23bd6d2c7.png)


After:

![osu Game Tests 2022-08-30 at 09 04 35](https://user-images.githubusercontent.com/191335/187396722-2ea9c37d-bbdc-4f93-9c8b-fd00c086dc02.png)
