### PR TITLE
Fix crash when attempting to watch a replay when the storage file doesn't exist

### DIFF
--- a/osu.Game/Scoring/LegacyDatabasedScore.cs
+++ b/osu.Game/Scoring/LegacyDatabasedScore.cs
@@ -25,7 +25,12 @@ namespace osu.Game.Scoring
                 return;
 
             using (var stream = store.GetStream(replayFilename))
+            {
+                if (stream == null)
+                    return;
+
                 Replay = new DatabasedLegacyScoreDecoder(rulesets, beatmaps).Parse(stream).Replay;
+            }
         }
     }
 }


### PR DESCRIPTION
As mentioned at https://github.com/ppy/osu/discussions/20021#discussioncomment-3506757.

This will cause the button to be disabled (in most cases) when the file is missing on disk. This is really a higher level fail case (we probably need some degree of integrity checking on the user's storage to detect when all/most files are missing), but no harm in fixing the local failure.

Would be nice to have NRT turned on in the resource store classes...