### PR TITLE
Fix relevant note count summation in osu!'s Speed skill

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (maxStrain == 0)
                 return 0;
 
-            return objectStrains.Aggregate((total, next) => total + (1.0 / (1.0 + Math.Exp(-(next / maxStrain * 12.0 - 6.0)))));
+            return objectStrains.Sum(strain => 1.0 / (1.0 + Math.Exp(-(strain / maxStrain * 12.0 - 6.0))));
         }
     }
 }


### PR DESCRIPTION
Sneaky bug that was spotted in pp dev: [the speed note count could be potentially larger than the number of objects in the map.](https://cdn.discordapp.com/attachments/757615676310552598/1014213897563160607/unknown.png). This is unintended of course, so this PR ships a fix.

The reason why the live version was wrong becomes evident once you (automatically) convert the code from LINQ into something actually digestible by human beings - the initial value is not scaled by the `maxStrain`:

![image](https://user-images.githubusercontent.com/83023433/187497573-30fab90c-0cd6-44cf-913c-cf46dce3d782.png)

The problem would have only affected super short maps, but it's necessary to get right. Definitely should be fixed before the deployment.

---

SR/PP sheet: https://docs.google.com/spreadsheets/d/1aI3ToxNut3BJBvfRb5ex8wMBjkryh4qNGG1tis484Uk/edit

As of ad650adab0b9ea2b226b10523193f96439265c6c