### PR TITLE
Test editor `ComposeScreen` tests not adding beatmap to hierarchy

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Database;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
@@ -34,10 +35,14 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             AddStep("setup compose screen", () =>
             {
-                var editorBeatmap = new EditorBeatmap(new ManiaBeatmap(new StageDefinition { Columns = 4 })
+                var beatmap = new ManiaBeatmap(new StageDefinition { Columns = 4 })
                 {
                     BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
-                });
+                };
+
+                beatmap.ControlPointInfo.Add(0, new TimingControlPoint());
+
+                var editorBeatmap = new EditorBeatmap(beatmap, new LegacyBeatmapSkin(beatmap.BeatmapInfo, null));
 
                 Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
 
@@ -50,7 +55,11 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                         (typeof(IBeatSnapProvider), editorBeatmap),
                         (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Green)),
                     },
-                    Child = new ComposeScreen { State = { Value = Visibility.Visible } },
+                    Children = new Drawable[]
+                    {
+                        editorBeatmap,
+                        new ComposeScreen { State = { Value = Visibility.Visible } },
+                    }
                 };
             });
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
@@ -34,8 +35,10 @@ namespace osu.Game.Tests.Visual.Editing
             {
                 var beatmap = new OsuBeatmap
                 {
-                    BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo }
+                    BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 };
+
+                beatmap.ControlPointInfo.Add(0, new TimingControlPoint());
 
                 editorBeatmap = new EditorBeatmap(beatmap, new LegacyBeatmapSkin(beatmap.BeatmapInfo, null));
 
@@ -50,7 +53,11 @@ namespace osu.Game.Tests.Visual.Editing
                         (typeof(IBeatSnapProvider), editorBeatmap),
                         (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Green)),
                     },
-                    Child = new ComposeScreen { State = { Value = Visibility.Visible } },
+                    Children = new Drawable[]
+                    {
+                        editorBeatmap,
+                        new ComposeScreen { State = { Value = Visibility.Visible } },
+                    }
                 };
             });
 


### PR DESCRIPTION
Makes it hard to test anything because `EditorBeatmap`'s `Update` method updates whether a beatmap has timing or not (enabling the placement controls).

Also adds a basic timing point to allow for better testing.