### PR TITLE
Add auto skip for multiplayer rooms

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -265,8 +265,9 @@ namespace osu.Game.Online.Multiplayer
         /// <param name="matchType">The type of the match, if any.</param>
         /// <param name="queueMode">The new queue mode, if any.</param>
         /// <param name="autoStartDuration">The new auto-start countdown duration, if any.</param>
+        /// <param name="autoSkip">The new auto-skip setting.</param>
         public Task ChangeSettings(Optional<string> name = default, Optional<string> password = default, Optional<MatchType> matchType = default, Optional<QueueMode> queueMode = default,
-                                   Optional<TimeSpan> autoStartDuration = default)
+                                   Optional<TimeSpan> autoStartDuration = default, Optional<bool> autoSkip = default)
         {
             if (Room == null)
                 throw new InvalidOperationException("Must be joined to a match to change settings.");
@@ -278,6 +279,7 @@ namespace osu.Game.Online.Multiplayer
                 MatchType = matchType.GetOr(Room.Settings.MatchType),
                 QueueMode = queueMode.GetOr(Room.Settings.QueueMode),
                 AutoStartDuration = autoStartDuration.GetOr(Room.Settings.AutoStartDuration),
+                AutoSkip = autoSkip.GetOr(Room.Settings.AutoSkip)
             });
         }
 
@@ -739,6 +741,7 @@ namespace osu.Game.Online.Multiplayer
             APIRoom.QueueMode.Value = Room.Settings.QueueMode;
             APIRoom.AutoStartDuration.Value = Room.Settings.AutoStartDuration;
             APIRoom.CurrentPlaylistItem.Value = APIRoom.Playlist.Single(item => item.ID == settings.PlaylistItemId);
+            APIRoom.AutoSkip.Value = Room.Settings.AutoSkip;
 
             RoomUpdated?.Invoke();
         }

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -29,6 +29,9 @@ namespace osu.Game.Online.Multiplayer
         [Key(5)]
         public TimeSpan AutoStartDuration { get; set; }
 
+        [Key(6)]
+        public bool AutoSkip { get; set; }
+
         [IgnoreMember]
         public bool AutoStartEnabled => AutoStartDuration != TimeSpan.Zero;
 
@@ -42,7 +45,8 @@ namespace osu.Game.Online.Multiplayer
                    && PlaylistItemId == other.PlaylistItemId
                    && MatchType == other.MatchType
                    && QueueMode == other.QueueMode
-                   && AutoStartDuration == other.AutoStartDuration;
+                   && AutoStartDuration == other.AutoStartDuration
+                   && AutoSkip == other.AutoSkip;
         }
 
         public override string ToString() => $"Name:{Name}"
@@ -50,6 +54,7 @@ namespace osu.Game.Online.Multiplayer
                                              + $" Type:{MatchType}"
                                              + $" Item:{PlaylistItemId}"
                                              + $" Queue:{QueueMode}"
-                                             + $" Start:{AutoStartDuration}";
+                                             + $" Start:{AutoStartDuration}"
+                                             + $" AutoSkip:{AutoSkip}";
     }
 }

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Online.Rooms
 
         [Cached]
         [JsonProperty("auto_skip")]
-        public readonly Bindable<bool> AutoSkip = new Bindable<bool>(true);
+        public readonly Bindable<bool> AutoSkip = new Bindable<bool>();
 
         public Room()
         {

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -159,6 +159,10 @@ namespace osu.Game.Online.Rooms
             set => MaxAttempts.Value = value;
         }
 
+        [Cached]
+        [JsonProperty("auto_skip")]
+        public readonly Bindable<bool> AutoSkip = new Bindable<bool>(true);
+
         public Room()
         {
             Password.BindValueChanged(p => HasPassword.Value = !string.IsNullOrEmpty(p.NewValue));
@@ -195,6 +199,7 @@ namespace osu.Game.Online.Rooms
             DifficultyRange.Value = other.DifficultyRange.Value;
             PlaylistItemStats.Value = other.PlaylistItemStats.Value;
             CurrentPlaylistItem.Value = other.CurrentPlaylistItem.Value;
+            AutoSkip.Value = other.AutoSkip.Value;
 
             if (EndDate.Value != null && DateTimeOffset.Now >= EndDate.Value)
                 Status.Value = new RoomStatusEnded();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             public MatchTypePicker TypePicker;
             public OsuEnumDropdown<QueueMode> QueueModeDropdown;
             public OsuTextBox PasswordTextBox;
+            public OsuCheckbox AutoSkipCheckbox;
             public TriangleButton ApplyButton;
 
             public OsuSpriteText ErrorText;
@@ -249,6 +250,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                                         LengthLimit = 255,
                                                                     },
                                                                 },
+                                                                new Section("Other")
+                                                                {
+                                                                    Child = AutoSkipCheckbox = new OsuCheckbox
+                                                                    {
+                                                                        LabelText = "Automatically skip the beatmap intro"
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     },
@@ -343,6 +351,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 Password.BindValueChanged(password => PasswordTextBox.Text = password.NewValue ?? string.Empty, true);
                 QueueMode.BindValueChanged(mode => QueueModeDropdown.Current.Value = mode.NewValue, true);
                 AutoStartDuration.BindValueChanged(duration => startModeDropdown.Current.Value = (StartMode)(int)duration.NewValue.TotalSeconds, true);
+                AutoSkip.BindValueChanged(autoSkip => AutoSkipCheckbox.Current.Value = autoSkip.NewValue, true);
 
                 operationInProgress.BindTo(ongoingOperationTracker.InProgress);
                 operationInProgress.BindValueChanged(v =>
@@ -390,7 +399,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                               password: PasswordTextBox.Text,
                               matchType: TypePicker.Current.Value,
                               queueMode: QueueModeDropdown.Current.Value,
-                              autoStartDuration: autoStartDuration)
+                              autoStartDuration: autoStartDuration,
+                              autoSkip: AutoSkipCheckbox.Current.Value)
                           .ContinueWith(t => Schedule(() =>
                           {
                               if (t.IsCompletedSuccessfully)
@@ -406,6 +416,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     room.Password.Value = PasswordTextBox.Current.Value;
                     room.QueueMode.Value = QueueModeDropdown.Current.Value;
                     room.AutoStartDuration.Value = autoStartDuration;
+                    room.AutoSkip.Value = AutoSkipCheckbox.Current.Value;
 
                     if (int.TryParse(MaxParticipantsField.Text, out int max))
                         room.MaxParticipants.Value = max;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -61,7 +61,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             {
                 AllowPause = false,
                 AllowRestart = false,
-                AllowSkipping = false,
+                AllowSkipping = room.AutoSkip.Value,
+                AutomaticallySkipIntro = room.AutoSkip.Value
             })
         {
             this.users = users;

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -86,6 +86,9 @@ namespace osu.Game.Screens.OnlinePlay
         [Resolved(typeof(Room))]
         protected Bindable<TimeSpan> AutoStartDuration { get; private set; }
 
+        [Resolved(typeof(Room))]
+        protected Bindable<bool> AutoSkip { get; private set; }
+
         [Resolved(CanBeNull = true)]
         private IBindable<PlaylistItem> subScreenSelectedItem { get; set; }
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -363,7 +363,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             CurrentPlayer = createPlayer();
-            CurrentPlayer.Configuration.AutomaticallySkipIntro = quickRestart;
+            CurrentPlayer.Configuration.AutomaticallySkipIntro |= quickRestart;
             CurrentPlayer.RestartCount = restartCount++;
             CurrentPlayer.RestartRequested = restartRequested;
 


### PR DESCRIPTION
Soft prereqs:
- https://github.com/ppy/osu-web/pull/9235
- `osu-server-spectator` deploy with https://github.com/ppy/osu-server-spectator/pull/141.

Resolves https://github.com/ppy/osu/issues/14260. Or most of it. I've defaulted to `true` because I believe this is likely going to be the more common setting. Support for skipping with `false` will come later.

|         | Old Server           | New Server  |
| ------------- |:-------------:| :-----:|
| Old Client      | :green_circle:  | :orange_circle: (old clients won't auto skip)  |
| New Client      | :orange_circle: (auto skip will have no effect) | :green_circle: |