### PR TITLE
Fix beat sync components stopping after beatmap change

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -390,6 +390,11 @@ namespace osu.Game
             var framedClock = new FramedClock(beatmap.Track);
 
             beatmapClock.ChangeSource(framedClock);
+
+            // Normally the internal decoupled clock will seek the *track* to the decoupled time, but we blocked this.
+            // It won't behave nicely unless we also set it to the track's time.
+            // Probably another thing which should be fixed in the decoupled mess (or just replaced).
+            beatmapClock.Seek(beatmap.Track.CurrentTime);
         }
 
         protected virtual void InitialiseFonts()


### PR DESCRIPTION
Not an amazing fix, but it seems to work and would rather get this in ASAP rather than trying to fix at a framework level.

Closes #20059.