### PR TITLE
Tournament Client MatchHeader fixes

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
         private readonly Bindable<string> teamName = new Bindable<string>("???");
 
-        private bool showScore;
+        private bool showScore = true;
 
         public bool ShowScore
         {
@@ -37,9 +37,11 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             }
         }
 
-        public TeamDisplay(TournamentTeam team, TeamColour colour, Bindable<int?> currentTeamScore, int pointsToWin)
+        public TeamDisplay(TournamentTeam team, TeamColour colour, Bindable<int?> currentTeamScore, int pointsToWin, bool showScore)
             : base(team)
         {
+            this.showScore = showScore;
+
             AutoSizeAxes = Axes.Both;
 
             bool flip = colour == TeamColour.Red;

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreDisplay.cs
@@ -61,7 +61,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
             if (match != null)
             {
-                match.StartMatch();
 
                 currentTeamScore.BindTo(teamColour == TeamColour.Red ? match.Team1Score : match.Team2Score);
                 currentTeam.BindTo(teamColour == TeamColour.Red ? match.Team1 : match.Team2);
@@ -92,9 +91,15 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
         private void teamChanged(ValueChangedEvent<TournamentTeam> team)
         {
+            bool showScore = true;
+
+            if (teamDisplay != null)
+            {
+                showScore = teamDisplay.ShowScore;
+            }
             InternalChildren = new Drawable[]
             {
-                teamDisplay = new TeamDisplay(team.NewValue, teamColour, currentTeamScore, currentMatch.Value?.PointsToWin ?? 0),
+                teamDisplay = new TeamDisplay(team.NewValue, teamColour, currentTeamScore, currentMatch.Value?.PointsToWin ?? 0, showScore),
             };
         }
     }

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -51,6 +51,12 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             if (ladderInfo.CurrentMatch.Value != null)
                 ladderInfo.CurrentMatch.Value.Current.Value = false;
 
+            if (match.Team1Score.Value == null || match.Team2Score.Value == null)
+            {
+                ladderInfo.CurrentMatch.Value.CancelMatchStart();
+                match.StartMatch();
+            }
+
             ladderInfo.CurrentMatch.Value = match;
             ladderInfo.CurrentMatch.Value.Current.Value = true;
         }
@@ -153,11 +159,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
             if (e.Button == MouseButton.Left)
             {
-                if (score.Value == null)
-                {
-                    match.StartMatch();
-                }
-                else if (!match.Completed.Value)
+                if (!match.Completed.Value)
                     score.Value++;
             }
             else
@@ -172,8 +174,6 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
                 if (score.Value > 0)
                     score.Value--;
-                else
-                    match.CancelMatchStart();
             }
 
             return false;

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -283,7 +283,10 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             if (editorInfo == null || Match is ConditionalTournamentMatch)
                 return false;
 
-            Selected = true;
+            if (e.Button == MouseButton.Left)
+            {
+                Selected = true;
+            }
             return true;
         }
 


### PR DESCRIPTION
* When a match in the bracket is selected, the team score in the MatchHeader doesn't show up in the Map Pool screen.
* When right-clicking a match that wasn't previously selected, the context menu automatically hides before the user can select an option.
* When selecting a completed match and showing the Gameplay screen, the score previously saved gets reset.
* When a match without points was selected, the warmup check was made before the match was started, leading to a null comparison.