### PR TITLE
Don't serialise `has_replay`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -18,9 +18,6 @@ namespace osu.Game.Online.API.Requests.Responses
     [Serializable]
     public class SoloScoreInfo : IHasOnlineID<long>
     {
-        [JsonProperty("has_replay")]
-        public bool HasReplay { get; set; }
-
         [JsonProperty("beatmap_id")]
         public int BeatmapID { get; set; }
 
@@ -114,12 +111,16 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("pp")]
         public double? PP { get; set; }
 
+        [JsonProperty("has_replay")]
+        public bool HasReplay { get; set; }
+
         public bool ShouldSerializeID() => false;
         public bool ShouldSerializeUser() => false;
         public bool ShouldSerializeBeatmap() => false;
         public bool ShouldSerializeBeatmapSet() => false;
         public bool ShouldSerializePP() => false;
         public bool ShouldSerializeOnlineID() => false;
+        public bool ShouldSerializeHasReplay() => false;
 
         #endregion
 


### PR DESCRIPTION
As it turns out, this is a read-only value and not actually part of the score data. osu!web will concatenate it from the table itself. It still needs to be here for client-side use.

This doesn't really change anything - `osu-queue-score-statistics` will be updated to not set this value and so it won't be serialised either way. More just for preventative measures.