### PR TITLE
Fix right-clicking a non-selected match in ladder view dismissing context menu

### DIFF
--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
         protected override bool OnClick(ClickEvent e)
         {
-            if (editorInfo == null || Match is ConditionalTournamentMatch)
+            if (editorInfo == null || Match is ConditionalTournamentMatch || e.Button != MouseButton.Left)
                 return false;
 
             Selected = true;


### PR DESCRIPTION
Extracted from https://github.com/ppy/osu/pull/20087.

Fixes this:

https://user-images.githubusercontent.com/191335/188110982-d3c00bf0-71c5-4a93-b0f5-9f8ad82bef3e.mp4



