### PR TITLE
Update Bracket Editor behaviour

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreDisplay.cs
@@ -61,7 +61,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
             if (match != null)
             {
-                match.StartMatch();
 
                 currentTeamScore.BindTo(teamColour == TeamColour.Red ? match.Team1Score : match.Team2Score);
                 currentTeam.BindTo(teamColour == TeamColour.Red ? match.Team1 : match.Team2);

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -51,6 +51,14 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             if (ladderInfo.CurrentMatch.Value != null)
                 ladderInfo.CurrentMatch.Value.Current.Value = false;
 
+            if (match.Team1Score.Value == null || match.Team2Score.Value == null)
+            {
+                match.StartMatch();
+            }
+            if (ladderInfo.CurrentMatch.Value.Team1Score.Value.GetValueOrDefault() == 0 && ladderInfo.CurrentMatch.Value.Team2Score.Value.GetValueOrDefault() == 0)
+            {
+                ladderInfo.CurrentMatch.Value.CancelMatchStart();
+            }
             ladderInfo.CurrentMatch.Value = match;
             ladderInfo.CurrentMatch.Value.Current.Value = true;
         }
@@ -153,11 +161,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
             if (e.Button == MouseButton.Left)
             {
-                if (score.Value == null)
-                {
-                    match.StartMatch();
-                }
-                else if (!match.Completed.Value)
+                if (!match.Completed.Value)
                     score.Value++;
             }
             else
@@ -172,8 +176,6 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
                 if (score.Value > 0)
                     score.Value--;
-                else
-                    match.CancelMatchStart();
             }
 
             return false;


### PR DESCRIPTION
Currently, when selecting matches in the bracket, `ladderInfo` would receive the selected match, and `match.StartMatch()` would always be called when updating `TeamScoreDisplay`, setting the match score to 0-0, even if it was already completed.

My suggestion would be to start the match right after selecting the match, in cases where the match wasn't started yet, and when selecting other matches, check if the previously selected match was actually started, and if not, cancel it.
As the `match.StartMatch()` is now only called after selecting a match that hasn't started, it also fixes the issue where previously completed matches would be reset if selected.

Here is an example of the old behaviour:
https://user-images.githubusercontent.com/41023844/188152778-968ce556-8a06-4b2f-82e2-eca772e2ea29.mp4

And the new behaviour:
https://user-images.githubusercontent.com/41023844/188152837-6da39d4e-936b-4fb2-b5a3-96ad3b9c14ee.mp4




