### PR TITLE
Disable setting keys in the same ruleset with the same bindings

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -67,6 +67,26 @@ namespace osu.Game.Tests.Visual.Settings
         }
 
         [Test]
+        public void TestBindingLeftAndRightButtonWithTheSameKey()
+        {
+            scrollToAndStartBinding("Left button");
+            AddStep("bind z to left button", () => InputManager.Key(Key.Z));
+            scrollToAndStartBinding("Right button");
+            AddStep("bind z to right button", () => InputManager.Key(Key.Z));
+            compareBinding("Left button", "Right button");
+        }
+
+        [Test]
+        public void TestBindingLeftButtonAndRightAlternateButtonWithTheSameKey()
+        {
+            scrollToAndStartBinding("Left button");
+            AddStep("bind z to left button", () => InputManager.Key(Key.Z));
+            scrollToAndStartBindingAlternate("Right button");
+            AddStep("bind z to right button", () => InputManager.Key(Key.Z));
+            compareBindingAlternate("Left button", "Right button");
+        }
+
+        [Test]
         public void TestClickTwiceOnClearButton()
         {
             KeyBindingRow firstRow = null;
@@ -260,6 +280,34 @@ namespace osu.Game.Tests.Visual.Settings
             });
         }
 
+        private void compareBinding(string name1, string name2)
+        {
+            AddAssert($"Check if {name1} is not bound with the same key as {name2}", () =>
+            {
+                var firstRow = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == name1));
+                var firstButton = firstRow.ChildrenOfType<KeyBindingRow.KeyButton>().First();
+
+                var secondRow = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == name2));
+                var secondButton = secondRow.ChildrenOfType<KeyBindingRow.KeyButton>().First();
+
+                return firstButton.Text.Text != secondButton.Text.Text;
+            });
+        }
+
+        private void compareBindingAlternate(string name1, string name2)
+        {
+            AddAssert($"Check if {name1} is not bound with the same key as {name2}", () =>
+            {
+                var firstRow = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == name1));
+                var firstButton = firstRow.ChildrenOfType<KeyBindingRow.KeyButton>().First();
+
+                var secondRow = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == name2));
+                var secondButton = secondRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1);
+
+                return firstButton.Text.Text != secondButton.Text.Text;
+            });
+        }
+
         private void scrollToAndStartBinding(string name)
         {
             KeyBindingRow.KeyButton firstButton = null;
@@ -277,6 +325,27 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("click to bind", () =>
             {
                 InputManager.MoveMouseTo(firstButton);
+                InputManager.Click(MouseButton.Left);
+            });
+        }
+
+        private void scrollToAndStartBindingAlternate(string name)
+        {
+            KeyBindingRow.KeyButton secondButton = null;
+
+            AddStep($"Scroll to {name}", () =>
+            {
+                var firstRow = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == name));
+                secondButton = firstRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1);
+
+                panel.ChildrenOfType<SettingsPanel.SettingsSectionsContainer>().First().ScrollTo(secondButton);
+            });
+
+            AddWaitStep("wait for scroll", 5);
+
+            AddStep("click to bind", () =>
+            {
+                InputManager.MoveMouseTo(secondButton);
                 InputManager.Click(MouseButton.Left);
             });
         }

--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("click first row with two bindings", () =>
             {
                 multiBindingRow = panel.ChildrenOfType<KeyBindingRow>().First(row => row.Defaults.Count() > 1);
-                InputManager.MoveMouseTo(multiBindingRow);
+                InputManager.MoveMouseTo(multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First());
                 InputManager.Click(MouseButton.Left);
             });
 
@@ -229,7 +229,7 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("click first row with two bindings", () =>
             {
                 multiBindingRow = panel.ChildrenOfType<KeyBindingRow>().First(row => row.Defaults.Count() > 1);
-                InputManager.MoveMouseTo(multiBindingRow);
+                InputManager.MoveMouseTo(multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First());
                 InputManager.Click(MouseButton.Left);
             });
 
@@ -246,7 +246,7 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("click back binding row", () =>
             {
                 multiBindingRow = panel.ChildrenOfType<KeyBindingRow>().ElementAt(10);
-                InputManager.MoveMouseTo(multiBindingRow);
+                InputManager.MoveMouseTo(multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First());
                 InputManager.Click(MouseButton.Left);
             });
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -527,8 +527,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Text.FadeColour(Color4.White, transition_time, Easing.OutQuint);
                     box.FadeColour(Color4.Red, transition_time, Easing.OutQuint).Then()
-                    .FadeColour(colourProvider.Background6, transition_time, Easing.OutQuint)
-                    .Loop(0, 3);
+                       .FadeColour(colourProvider.Background6, transition_time, Easing.OutQuint)
+                       .Loop(0, 3);
 
                     isBindingInvalid = false;
                 }
@@ -541,9 +541,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             public void CheckAndUpdateKeyCombination(KeyCombination newCombination)
             {
-                var rulesetBindings = realm.Run(r => r.All<RealmKeyBinding>()
-                                      .Where(b => b.RulesetName == KeyBinding.RulesetName && b.Variant == KeyBinding.Variant)
-                                      .Detach());
+                var rulesetBindings = realm.Run(r => r.All<RealmKeyBinding>().Where(b => b.RulesetName == KeyBinding.RulesetName && b.Variant == KeyBinding.Variant).Detach());
 
                 if (KeyBinding.RulesetName != null && rulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
                 {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -206,7 +206,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         public bool AllowMainMouseButtons;
 
         public IEnumerable<KeyCombination> Defaults;
-        
+
         private bool isModifier(Key k) => k < Key.F1;
 
         protected override bool OnClick(ClickEvent e) => true;
@@ -556,7 +556,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 if (KeyBinding.RulesetName != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
                     return;
-                
+
                 KeyBinding.KeyCombination = newCombination;
                 updateKeyCombinationText();
             }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -436,6 +436,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             private bool isBinding;
 
+            private bool isBindingInvalid = false;
+
             public bool IsBinding
             {
                 get => isBinding;
@@ -522,9 +524,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     box.FadeColour(colourProvider.Light2, transition_time, Easing.OutQuint);
                     Text.FadeColour(Color4.Black, transition_time, Easing.OutQuint);
                 }
+                else if (isBindingInvalid)
+                {
+                    box.FadeColour(Color4.Red, transition_time, Easing.OutQuint);
+                }
                 else
                 {
-                    box.FadeColour(IsHovered ? colourProvider.Light4 : colourProvider.Background6, transition_time, Easing.OutQuint);
+                    box.FadeColour(IsHovered ? colourProvider.Light4 : colourProvider.Background6, transition_time, Easing.InOutBounce);
                     Text.FadeColour(IsHovered ? Color4.Black : Color4.White, transition_time, Easing.OutQuint);
                 }
             }
@@ -534,9 +540,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 if (KeyBinding.RulesetName != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
                     return;
 
-                if (RulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
+                if (KeyBinding.RulesetName != null && RulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
+                {
+                    isBindingInvalid = true;
                     return;
+                }
 
+                isBindingInvalid = false;
                 KeyBinding.KeyCombination = newCombination;
                 updateKeyCombinationText();
             }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             };
 
             foreach (var b in bindings)
-                buttons.Add(new KeyButton(b));
+                buttons.Add(new KeyButton(b) { RulesetBindings = RulesetBindings });
 
             updateIsDefaultValue();
         }
@@ -206,6 +206,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         public bool AllowMainMouseButtons;
 
         public IEnumerable<KeyCombination> Defaults;
+
+        public List<RealmKeyBinding> RulesetBindings;
 
         private bool isModifier(Key k) => k < Key.F1;
 
@@ -447,6 +449,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             }
 
+            public List<RealmKeyBinding> RulesetBindings;
+
             public KeyButton(RealmKeyBinding keyBinding)
             {
                 if (keyBinding.IsManaged)
@@ -528,6 +532,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public void UpdateKeyCombination(KeyCombination newCombination)
             {
                 if (KeyBinding.RulesetName != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
+                    return;
+
+                if (RulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
                     return;
 
                 KeyBinding.KeyCombination = newCombination;

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -525,7 +525,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
                 else if (isBindingInvalid)
                 {
-                    box.FlashColour(Color4.Red, 800, Easing.InElastic).Loop(0, 5);
+                    Text.FadeColour(Color4.White, transition_time, Easing.OutQuint);
+                    box.FadeColour(Color4.Red, transition_time, Easing.OutQuint).Then()
+                       .FadeColour(colourProvider.Background6, transition_time, Easing.OutQuint)
+                       .Loop(0, 3);
+
                     isBindingInvalid = false;
                 }
                 else

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -527,8 +527,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Text.FadeColour(Color4.White, transition_time, Easing.OutQuint);
                     box.FadeColour(Color4.Red, transition_time, Easing.OutQuint).Then()
-                       .FadeColour(colourProvider.Background6, transition_time, Easing.OutQuint)
-                       .Loop(0, 3);
+                    .FadeColour(colourProvider.Background6, transition_time, Easing.OutQuint)
+                    .Loop(0, 3);
 
                     isBindingInvalid = false;
                 }
@@ -542,8 +542,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public void CheckAndUpdateKeyCombination(KeyCombination newCombination)
             {
                 var rulesetBindings = realm.Run(r => r.All<RealmKeyBinding>()
-                                           .Where(b => b.RulesetName == KeyBinding.RulesetName && b.Variant == KeyBinding.Variant)
-                                           .Detach());
+                                      .Where(b => b.RulesetName == KeyBinding.RulesetName && b.Variant == KeyBinding.Variant)
+                                      .Detach());
 
                 if (KeyBinding.RulesetName != null && rulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
                 {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             };
 
             foreach (var b in bindings)
-                buttons.Add(new KeyButton(b) { RulesetBindings = RulesetBindings });
+                buttons.Add(new KeyButton(b));
 
             updateIsDefaultValue();
         }
@@ -206,9 +206,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         public bool AllowMainMouseButtons;
 
         public IEnumerable<KeyCombination> Defaults;
-
-        public List<RealmKeyBinding> RulesetBindings;
-
+        
         private bool isModifier(Key k) => k < Key.F1;
 
         protected override bool OnClick(ClickEvent e) => true;
@@ -436,8 +434,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             private bool isBinding;
 
-            private bool isBindingInvalid = false;
-
             public bool IsBinding
             {
                 get => isBinding;
@@ -451,7 +447,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             }
 
-            public List<RealmKeyBinding> RulesetBindings;
+            private bool isBindingInvalid = false;
+
+            [Resolved]
+            private RealmAccess realm { get; set; }
+
+            private List<RealmKeyBinding> rulesetBindings;
 
             public KeyButton(RealmKeyBinding keyBinding)
             {
@@ -502,6 +503,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             [BackgroundDependencyLoader]
             private void load()
             {
+                rulesetBindings = realm.Run(r => r.All<RealmKeyBinding>()
+                                           .Where(b => b.RulesetName == KeyBinding.RulesetName && b.Variant == KeyBinding.Variant)
+                                           .Detach());
+
                 updateHoverState();
             }
 
@@ -540,7 +545,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 if (KeyBinding.RulesetName != null && !RealmKeyBindingStore.CheckValidForGameplay(newCombination))
                     return;
 
-                if (KeyBinding.RulesetName != null && RulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
+                if (KeyBinding.RulesetName != null && rulesetBindings.Select(k => k.KeyCombination).Contains(newCombination))
                 {
                     isBindingInvalid = true;
                     return;

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             string rulesetName = Ruleset?.ShortName;
 
+            var className = this.GetType().Name;
+
             var bindings = realm.Run(r => r.All<RealmKeyBinding>()
                                            .Where(b => b.RulesetName == rulesetName && b.Variant == variant)
                                            .Detach());
@@ -50,7 +52,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     AllowMainMouseButtons = Ruleset != null,
                     Defaults = defaultGroup.Select(d => d.KeyCombination),
-                    RulesetBindings = bindings
+                    RulesetBindings = className == "VariantBindingsSubsection" ? bindings : new List<RealmKeyBinding>()
                 });
             }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -49,7 +49,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 Add(new KeyBindingRow(defaultGroup.Key, bindings.Where(b => b.ActionInt.Equals(intKey)).ToList())
                 {
                     AllowMainMouseButtons = Ruleset != null,
-                    Defaults = defaultGroup.Select(d => d.KeyCombination)
+                    Defaults = defaultGroup.Select(d => d.KeyCombination),
+                    RulesetBindings = bindings
                 });
             }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             string rulesetName = Ruleset?.ShortName;
 
-            var className = GetType().Name;
-
             var bindings = realm.Run(r => r.All<RealmKeyBinding>()
                                            .Where(b => b.RulesetName == rulesetName && b.Variant == variant)
                                            .Detach());
@@ -52,7 +50,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     AllowMainMouseButtons = Ruleset != null,
                     Defaults = defaultGroup.Select(d => d.KeyCombination),
-                    RulesetBindings = className == "VariantBindingsSubsection" ? bindings : new List<RealmKeyBinding>()
+                    RulesetBindings = bindings
                 });
             }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -49,8 +49,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 Add(new KeyBindingRow(defaultGroup.Key, bindings.Where(b => b.ActionInt.Equals(intKey)).ToList())
                 {
                     AllowMainMouseButtons = Ruleset != null,
-                    Defaults = defaultGroup.Select(d => d.KeyCombination),
-                    RulesetBindings = bindings
+                    Defaults = defaultGroup.Select(d => d.KeyCombination)
                 });
             }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             string rulesetName = Ruleset?.ShortName;
 
-            var className = this.GetType().Name;
+            var className = GetType().Name;
 
             var bindings = realm.Run(r => r.All<RealmKeyBinding>()
                                            .Where(b => b.RulesetName == rulesetName && b.Variant == variant)

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -202,7 +202,9 @@ namespace osu.Game.Rulesets.UI
             {
                 base.ReloadMappings();
 
-                KeyBindings = KeyBindings.Where(b => RealmKeyBindingStore.CheckValidForGameplay(b.KeyCombination)).ToList();
+                KeyBindings = KeyBindings.Where(b => RealmKeyBindingStore.CheckValidForGameplay(b.KeyCombination))
+                              .GroupBy(b => b.KeyCombination)
+                              .Select(g => g.First()).ToList();
             }
         }
     }

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -203,8 +203,8 @@ namespace osu.Game.Rulesets.UI
                 base.ReloadMappings();
 
                 KeyBindings = KeyBindings.Where(b => RealmKeyBindingStore.CheckValidForGameplay(b.KeyCombination))
-                         .GroupBy(b => b.KeyCombination)
-                         .Select(g => g.First()).ToList();
+                                         .GroupBy(b => b.KeyCombination)
+                                         .Select(g => g.First()).ToList();
             }
         }
     }

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -203,8 +203,8 @@ namespace osu.Game.Rulesets.UI
                 base.ReloadMappings();
 
                 KeyBindings = KeyBindings.Where(b => RealmKeyBindingStore.CheckValidForGameplay(b.KeyCombination))
-                              .GroupBy(b => b.KeyCombination)
-                              .Select(g => g.First()).ToList();
+                         .GroupBy(b => b.KeyCombination)
+                         .Select(g => g.First()).ToList();
             }
         }
     }


### PR DESCRIPTION
- Addresses #20107 

Can no longer set keys in the same ruleset with the same bindings but it may need feedback like a toast or an animation.