### PR TITLE
Display 0 stars instead of infinity for the minimum star slider

### DIFF
--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -65,7 +65,10 @@ namespace osu.Game.Screens.Select
 
         private class MinimumStarsSlider : StarsSlider
         {
-            public MinimumStarsSlider() : base("0") { }
+            public MinimumStarsSlider()
+                : base("0")
+            {
+            }
 
             public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
 
@@ -86,7 +89,10 @@ namespace osu.Game.Screens.Select
 
         private class MaximumStarsSlider : StarsSlider
         {
-            public MaximumStarsSlider() : base("∞") { }
+            public MaximumStarsSlider()
+                : base("∞")
+            {
+            }
 
             protected override void LoadComplete()
             {
@@ -102,15 +108,15 @@ namespace osu.Game.Screens.Select
 
         private class StarsSlider : OsuSliderBar<double>
         {
+            private readonly string defaultString;
+
             public override LocalisableString TooltipText => Current.IsDefault
                 ? UserInterfaceStrings.NoLimit
                 : Current.Value.ToString(@"0.## stars");
 
-            protected readonly string DefaultValue;
-
-            public StarsSlider(string defaultValue)
+            protected StarsSlider(string defaultString)
             {
-                DefaultValue = defaultValue;
+                this.defaultString = defaultString;
             }
 
             protected override bool OnHover(HoverEvent e)
@@ -138,7 +144,7 @@ namespace osu.Game.Screens.Select
 
                 Current.BindValueChanged(current =>
                 {
-                    currentDisplay.Text = current.NewValue != Current.Default ? current.NewValue.ToString("N1") : DefaultValue;
+                    currentDisplay.Text = current.NewValue != Current.Default ? current.NewValue.ToString("N1") : defaultString;
                 }, true);
             }
         }

--- a/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
+++ b/osu.Game/Screens/Select/DifficultyRangeFilterControl.cs
@@ -65,6 +65,10 @@ namespace osu.Game.Screens.Select
 
         private class MinimumStarsSlider : StarsSlider
         {
+            public MinimumStarsSlider() : base("0") { }
+
+            public override LocalisableString TooltipText => Current.Value.ToString(@"0.## stars");
+
             protected override void LoadComplete()
             {
                 base.LoadComplete();
@@ -82,6 +86,8 @@ namespace osu.Game.Screens.Select
 
         private class MaximumStarsSlider : StarsSlider
         {
+            public MaximumStarsSlider() : base("∞") { }
+
             protected override void LoadComplete()
             {
                 base.LoadComplete();
@@ -99,6 +105,13 @@ namespace osu.Game.Screens.Select
             public override LocalisableString TooltipText => Current.IsDefault
                 ? UserInterfaceStrings.NoLimit
                 : Current.Value.ToString(@"0.## stars");
+
+            protected readonly string DefaultValue;
+
+            public StarsSlider(string defaultValue)
+            {
+                DefaultValue = defaultValue;
+            }
 
             protected override bool OnHover(HoverEvent e)
             {
@@ -125,7 +138,7 @@ namespace osu.Game.Screens.Select
 
                 Current.BindValueChanged(current =>
                 {
-                    currentDisplay.Text = current.NewValue != Current.Default ? current.NewValue.ToString("N1") : "∞";
+                    currentDisplay.Text = current.NewValue != Current.Default ? current.NewValue.ToString("N1") : DefaultValue;
                 }, true);
             }
         }

--- a/osu.Game/Screens/Select/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/Select/NoResultsPlaceholder.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.Select
                         config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1);
                     });
 
-                    string lowerStar = filter.UserStarDifficulty.Min == null ? "0,0" : $"{filter.UserStarDifficulty.Min:N1}";
+                    string lowerStar = $"{filter.UserStarDifficulty.Min ?? 0:N1}";
                     string upperStar = filter.UserStarDifficulty.Max == null ? "∞" : $"{filter.UserStarDifficulty.Max:N1}";
 
                     textFlow.AddText($" the {lowerStar} - {upperStar} star difficulty filter.");

--- a/osu.Game/Screens/Select/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/Select/NoResultsPlaceholder.cs
@@ -127,10 +127,10 @@ namespace osu.Game.Screens.Select
                         config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1);
                     });
 
-                    string lowerStar = filter.UserStarDifficulty.Min == null ? "∞" : $"{filter.UserStarDifficulty.Min:N1}";
+                    string lowerStar = filter.UserStarDifficulty.Min == null ? "0,0" : $"{filter.UserStarDifficulty.Min:N1}";
                     string upperStar = filter.UserStarDifficulty.Max == null ? "∞" : $"{filter.UserStarDifficulty.Max:N1}";
 
-                    textFlow.AddText($" the {lowerStar}-{upperStar} star difficulty filter.");
+                    textFlow.AddText($" the {lowerStar} - {upperStar} star difficulty filter.");
                 }
 
                 // TODO: Add realm queries to hint at which ruleset results are available in (and allow clicking to switch).


### PR DESCRIPTION
This is only a proposition but I think it feels more natural to have the MinimumStarsSlider display "0" instead of "∞".

 - MinimumStarsSlider now shows "0" when at it's minimum
 - Modified the tooltip and NoResultsPlaceholder to stay consistent with the changes

![image](https://user-images.githubusercontent.com/43091560/188335717-6eaf59dd-990a-47c5-a753-912d28bd2892.png)
![image](https://user-images.githubusercontent.com/43091560/188335732-bdab2082-6855-4e87-8950-bde216d800f4.png)
![image](https://user-images.githubusercontent.com/43091560/188335738-3f9fc83a-b8ea-48e9-bddc-4c061b9d637b.png)
