### PR TITLE
Basic touch device detection implementation

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -29,13 +29,11 @@ namespace osu.Game.Rulesets.Osu.Tests
                 touchPosition = touchInputHandler.ScreenSpaceDrawQuad.Centre;
             });
         }
-
         [Test]
+
         public void TestTouchInput()
         {
-            var cursorTouch = new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, touchPosition);
-
-            AddStep("Touch", () => InputManager.BeginTouch(cursorTouch));
+            AddStep("Touch", () => new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, touchPosition));
 
             AddAssert("Pressed", () => osuInputManager.CurrentState.Touch.IsActive(OsuDrawableTouchInputHandler.CURSOR_TOUCH));
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu.UI;
+using osuTK;
+
+#nullable disable
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public class TestSceneTouchInput : TestSceneOsuPlayer
+    {
+        private OsuInputManager osuInputManager;
+        private OsuDrawableTouchInputHandler touchInputHandler;
+
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+            AddStep("Setup touch", () =>
+            {
+                var drawableRuleset = (DrawableOsuRuleset)Player.DrawableRuleset;
+                osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
+                touchInputHandler = drawableRuleset.TouchInputHandler;
+            });
+        }
+
+        [Test]
+        public void TestTouchInput()
+        {
+            var position = new Vector2(200);
+
+            var cursorTouch = new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, position);
+
+            AddStep("Touch", () => InputManager.BeginTouch(cursorTouch));
+
+            AddAssert("Pressed", () => osuInputManager.CurrentState.Touch.IsActive(OsuDrawableTouchInputHandler.CURSOR_TOUCH));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Input;
 using osu.Framework.Testing;
@@ -30,12 +31,36 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
         }
 
+        private void touch(TouchSource source)
+        {
+            InputManager.BeginTouch(new Touch(source, touchPosition));
+        }
+
+        private void release(TouchSource source)
+        {
+            InputManager.EndTouch(new Touch(source, touchPosition));
+        }
+
         [Test]
         public void TestTouchInput()
         {
-            AddStep("Touch", () => InputManager.BeginTouch(new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, touchPosition)));
+            AddStep("Touch", () => touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH));
 
             AddAssert("Pressed", () => osuInputManager.CurrentState.Touch.IsActive(OsuDrawableTouchInputHandler.CURSOR_TOUCH));
+
+            AddStep("Touch with other finger", () => touch(TouchSource.Touch2));
+
+            AddAssert("Pressed other key", () => osuInputManager.PressedActions.Contains(OsuAction.RightButton));
+
+            AddStep("Touch with another finger (Doubletapping)...", () => touch(TouchSource.Touch3));
+
+            AddAssert("Is dragging", () => osuInputManager.DragMode);
+
+            AddStep("Release", () =>
+            {
+                foreach (var source in touchInputHandler.AllowedTouchSources)
+                    release(source);
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         private OsuInputManager osuInputManager;
         private OsuDrawableTouchInputHandler touchInputHandler;
+        private Vector2 touchPosition;
 
         [SetUpSteps]
         public override void SetUpSteps()
@@ -25,15 +26,14 @@ namespace osu.Game.Rulesets.Osu.Tests
                 var drawableRuleset = (DrawableOsuRuleset)Player.DrawableRuleset;
                 osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
                 touchInputHandler = drawableRuleset.TouchInputHandler;
+                touchPosition = touchInputHandler.ScreenSpaceDrawQuad.Centre;
             });
         }
 
         [Test]
         public void TestTouchInput()
         {
-            var position = new Vector2(200);
-
-            var cursorTouch = new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, position);
+            var cursorTouch = new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, touchPosition);
 
             AddStep("Touch", () => InputManager.BeginTouch(cursorTouch));
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -29,11 +29,11 @@ namespace osu.Game.Rulesets.Osu.Tests
                 touchPosition = touchInputHandler.ScreenSpaceDrawQuad.Centre;
             });
         }
-        [Test]
 
+        [Test]
         public void TestTouchInput()
         {
-            AddStep("Touch", () => new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, touchPosition));
+            AddStep("Touch", () => InputManager.BeginTouch(new Touch(OsuDrawableTouchInputHandler.CURSOR_TOUCH, touchPosition)));
 
             AddAssert("Pressed", () => osuInputManager.CurrentState.Touch.IsActive(OsuDrawableTouchInputHandler.CURSOR_TOUCH));
         }

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -32,7 +32,10 @@ namespace osu.Game.Rulesets.Osu
         /// </summary>
         public bool AllowUserCursorMovement { get; set; } = true;
 
-        private readonly List<TouchSource> allTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().ToList();
+        private readonly Dictionary<TouchSource, int> indexedTouchSources = Enum.GetValues(typeof(TouchSource))
+            .Cast<TouchSource>()
+            .Select((v, i) => new { v, i })
+            .ToDictionary(entry => entry.v, entry => entry.i);
 
         protected override KeyBindingContainer<OsuAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
             => new OsuKeyBindingContainer(ruleset, variant, unique);
@@ -51,7 +54,7 @@ namespace osu.Game.Rulesets.Osu
 
         private OsuAction getActionForTouchSource(TouchSource source)
         {
-            int sourceIndex = allTouchSources.IndexOf(source);
+            int sourceIndex = indexedTouchSources[source];
             return sourceIndex % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton;
         }
 

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Rulesets.Osu
         public bool AllowUserCursorMovement { get; set; } = true;
 
         private readonly Dictionary<TouchSource, int> numberedTouchSources = Enum.GetValues(typeof(TouchSource))
-            .Cast<TouchSource>()
-            .Select((v, i) => new { v, i })
-            .ToDictionary(entry => entry.v, entry => entry.i + 1);
+                                                                                 .Cast<TouchSource>()
+                                                                                 .Select((v, i) => new { v, i })
+                                                                                 .ToDictionary(entry => entry.v, entry => entry.i + 1);
 
         protected override KeyBindingContainer<OsuAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
             => new OsuKeyBindingContainer(ruleset, variant, unique);
@@ -75,13 +75,11 @@ namespace osu.Game.Rulesets.Osu
             var activeTapTouches = AllowUserCursorMovement ? activeSources.Skip(1) : activeSources;
             var limitedActiveTapTouches = activeTapTouches.Take(tap_touches_limit);
 
-            bool isCursorTouch = source == cursorTouch;
-            bool isTapTouch = !isCursorTouch;
-
-            bool dragMode = limitedActiveTapTouches.Count() == tap_touches_limit;
-
             var newActiveTapActions = limitedActiveTapTouches.Select(getActionForTouchSource);
             var newInactiveTapActions = PressedActions.Where(a => !newActiveTapActions.Contains(a)).ToList();
+
+            bool isCursorTouch = source == cursorTouch;
+            bool isTapTouch = !isCursorTouch;
 
             foreach (var action in newInactiveTapActions)
                 KeyBindingContainer.TriggerReleased(action);
@@ -93,8 +91,9 @@ namespace osu.Game.Rulesets.Osu
                     KeyBindingContainer.TriggerPressed(action);
             }
 
-            // Allows doubletap when streaming by making the main cursor not be pressed
-            if (dragMode)
+            bool doubletapping = limitedActiveTapTouches.Count() == tap_touches_limit;
+
+            if (doubletapping)
             {
                 e = new TouchStateChangeEvent(e.State, e.Input, e.Touch, false, e.LastPosition);
             }

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Osu
 
             bool dragMode = limitedActiveTapTouches.Count() >= tap_touches_limit;
 
-            var newActiveTapActions = limitedActiveTapTouches.Select(s => getActionForTouchSource(s));
+            var newActiveTapActions = limitedActiveTapTouches.Select(getActionForTouchSource);
             var newInactiveTapActions = PressedActions.Where(a => !newActiveTapActions.Contains(a)).ToList();
 
             foreach (var action in newInactiveTapActions)

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Osu
 {
     public class OsuInputManager : RulesetInputManager<OsuAction>
     {
+        private const int tap_touches_limit = 2;
+
         public IEnumerable<OsuAction> PressedActions => KeyBindingContainer.PressedActions;
 
         public bool AllowUserPresses
@@ -30,7 +32,7 @@ namespace osu.Game.Rulesets.Osu
         /// </summary>
         public bool AllowUserCursorMovement { get; set; } = true;
 
-        private List<TouchSource> allTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().ToList();
+        private readonly List<TouchSource> allTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().ToList();
 
         protected override KeyBindingContainer<OsuAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
             => new OsuKeyBindingContainer(ruleset, variant, unique);
@@ -55,13 +57,12 @@ namespace osu.Game.Rulesets.Osu
 
         protected override bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
         {
-            int tapTouchesLimit = 2;
             var source = e.Touch.Source;
 
             var cursorTouch = CurrentState.Touch.ActiveSources.Any() ? CurrentState.Touch.ActiveSources.First() : source;
 
             var activeTapTouches = AllowUserCursorMovement ? CurrentState.Touch.ActiveSources.Skip(1) : CurrentState.Touch.ActiveSources;
-            var limitedActiveTapTouches = activeTapTouches.Take(tapTouchesLimit);
+            var limitedActiveTapTouches = activeTapTouches.Take(tap_touches_limit);
 
             bool isTapTouch = activeTapTouches.Contains(source);
 
@@ -69,7 +70,7 @@ namespace osu.Game.Rulesets.Osu
             if (isTapTouch && !limitedActiveTapTouches.Contains(source))
                 return false;
 
-            bool dragMode = limitedActiveTapTouches.Count() >= tapTouchesLimit;
+            bool dragMode = limitedActiveTapTouches.Count() >= tap_touches_limit;
 
             var newActiveTapActions = limitedActiveTapTouches.Select(s => getActionForTouchSource(s));
             var newInactiveTapActions = PressedActions.Where(a => !newActiveTapActions.Contains(a)).ToList();

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -69,17 +69,12 @@ namespace osu.Game.Rulesets.Osu
             bool isTapTouch = source != cursor_touch || !AllowUserCursorMovement;
             bool isCursorTouch = !isTapTouch;
 
-            if (isTapTouch)
+            if (isTapTouch && !activeTapTouches.Contains(source))
             {
-                var action = touchTapActionsDictionary[source];
-                if (!activeTapTouches.Contains(source))
-                {
-                    activeTapTouches.Add(source);
-                    KeyBindingContainer.TriggerPressed(action);
-                }
+                activeTapTouches.Add(source);
+                KeyBindingContainer.TriggerPressed(touchTapActionsDictionary[source]);
             }
 
-            var activeSources = CurrentState.Touch.ActiveSources;
             var disabledTapTouches = activeTapTouches.Where(tap => !CurrentState.Touch.IsActive(tap));
 
             if (disabledTapTouches.Any())

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -78,14 +78,15 @@ namespace osu.Game.Rulesets.Osu
             var disabledTapTouches = activeTapTouches.Where(tap => !CurrentState.Touch.IsActive(tap));
 
             if (disabledTapTouches.Any())
+            {
                 foreach (var tap in disabledTapTouches.ToList())
                 {
                     activeTapTouches.Remove(tap);
                     KeyBindingContainer.TriggerReleased(touchTapActionsDictionary[tap]);
                 }
+            }
 
-            // HashSet count implementation is o(1) so this is fine.
-            bool doubletapping = activeTapTouches.Count() == tap_touches_limit;
+            bool doubletapping = activeTapTouches.Count == tap_touches_limit;
 
             if (doubletapping)
             {

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Rulesets.Osu
                     KeyBindingContainer.TriggerPressed(action);
             }
 
+            // Allows doubletap when streaming by making the main cursor not be pressed
             if (dragMode)
             {
                 e = new TouchStateChangeEvent(e.State, e.Input, e.Touch, false, e.LastPosition);

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -64,10 +64,12 @@ namespace osu.Game.Rulesets.Osu
             var activeTapTouches = AllowUserCursorMovement ? CurrentState.Touch.ActiveSources.Skip(1) : CurrentState.Touch.ActiveSources;
             var limitedActiveTapTouches = activeTapTouches.Take(tap_touches_limit);
 
-            bool isTapTouch = activeTapTouches.Contains(source);
+            bool isCursorTouch = source == cursorTouch;
+            bool isTapTouch = !isCursorTouch;
 
-            // Limits amount of simultaneous clicks
-            if (isTapTouch && !limitedActiveTapTouches.Contains(source))
+            bool isInvalidTap = isTapTouch && !limitedActiveTapTouches.Contains(source);
+
+            if (isInvalidTap)
                 return false;
 
             bool dragMode = limitedActiveTapTouches.Count() >= tap_touches_limit;
@@ -91,7 +93,7 @@ namespace osu.Game.Rulesets.Osu
                 e = new TouchStateChangeEvent(e.State, e.Input, e.Touch, false, e.LastPosition);
             }
 
-            return AllowUserCursorMovement && source == cursorTouch && base.HandleMouseTouchStateChange(e);
+            return AllowUserCursorMovement && isCursorTouch && base.HandleMouseTouchStateChange(e);
         }
 
         private class OsuKeyBindingContainer : RulesetKeyBindingContainer

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu
         /// </summary>
         public bool AllowUserCursorMovement { get; set; } = true;
 
-        private readonly List<TouchSource> allTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().ToList();
+        private readonly List<TouchSource> allTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().ToList();
 
         protected override KeyBindingContainer<OsuAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
             => new OsuKeyBindingContainer(ruleset, variant, unique);
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu
 
         private OsuAction getActionForTouchSource(TouchSource source)
         {
-            int sourceIndex = allTapTouchSources.IndexOf(source);
+            int sourceIndex = allTouchSources.IndexOf(source);
             return sourceIndex % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton;
         }
 

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Rulesets.Osu
         private const int tap_touches_limit = 2;
         private const int simultaneous_touches_limit = tap_touches_limit + 1;
 
-        private IEnumerable<TouchSource> possibleTapTouches;
-
         private HashSet<TouchSource> activeTapTouches = new HashSet<TouchSource>();
 
         public IEnumerable<OsuAction> PressedActions => KeyBindingContainer.PressedActions;
@@ -72,10 +70,8 @@ namespace osu.Game.Rulesets.Osu
             if (touchNumber > simultaneous_touches_limit)
                 return false;
 
-            possibleTapTouches ??= AllowUserCursorMovement ? new TouchSource[] { TouchSource.Touch2, TouchSource.Touch3 } : new TouchSource[] { TouchSource.Touch1, TouchSource.Touch2 };
-
-            bool isCursorTouch = source == cursor_touch;
-            bool isTapTouch = !isCursorTouch;
+            bool isTapTouch = source != cursor_touch || !AllowUserCursorMovement;
+            bool isCursorTouch = !isTapTouch;
 
             if (isTapTouch)
             {

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public new OsuPlayfield Playfield => (OsuPlayfield)base.Playfield;
 
+        public OsuDrawableTouchInputHandler TouchInputHandler;
+
         public DrawableOsuRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
             : base(ruleset, beatmap, mods)
         {
@@ -38,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            KeyBindingInputManager.Add(new OsuDrawableTouchInputHandler(this) { RelativeSizeAxes = Axes.Both });
+            KeyBindingInputManager.Add(TouchInputHandler = new OsuDrawableTouchInputHandler((OsuInputManager)KeyBindingInputManager) { RelativeSizeAxes = Axes.Both });
         }
 
         public override DrawableHitObject<OsuHitObject> CreateDrawableRepresentation(OsuHitObject h) => null;

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
@@ -31,6 +33,12 @@ namespace osu.Game.Rulesets.Osu.UI
         public DrawableOsuRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
             : base(ruleset, beatmap, mods)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            KeyBindingInputManager.Add(new OsuDrawableTouchInputHandler(this) { RelativeSizeAxes = Axes.Both });
         }
 
         public override DrawableHitObject<OsuHitObject> CreateDrawableRepresentation(OsuHitObject h) => null;

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -1,12 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -35,6 +41,16 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private readonly OsuInputManager osuInputManager;
 
+        [Resolved(canBeNull: true)]
+        private Player player { get; set; }
+
+        private bool detectedTouchscreen;
+
+        private readonly BindableInt detectedTouches = new BindableInt
+        {
+            MaxValue = 25
+        };
+
         private int getTouchIndex(TouchSource source) => source - TouchSource.Touch1;
 
         public OsuDrawableTouchInputHandler(OsuInputManager inputManager)
@@ -59,6 +75,12 @@ namespace osu.Game.Rulesets.Osu.UI
                 return false;
 
             osuInputManager.DragMode = sourceIndex == last_concurrent_touch_index;
+
+            if (!detectedTouchscreen && ++detectedTouches.Value == detectedTouches.MaxValue)
+            {
+                detectedTouchscreen = true;
+                player.Score.ScoreInfo.Mods = player.Score.ScoreInfo.Mods.Append(new OsuModTouchDevice()).ToArray();
+            }
 
             if (isCursorTouch(source))
                 return base.OnTouchDown(e);

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private readonly BindableInt detectedTouches = new BindableInt
         {
-            MaxValue = 25
+            MaxValue = 10
         };
 
         private int getTouchIndex(TouchSource source) => source - TouchSource.Touch1;

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -32,7 +32,9 @@ namespace osu.Game.Rulesets.Osu.UI
         /// </summary>
         public const int CONCURRENT_TOUCHES_LIMIT = LAST_CONCURRENT_TOUCH_INDEX + 1;
 
-        public readonly HashSet<TouchSource> PossibleTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().Take(CONCURRENT_TOUCHES_LIMIT).ToHashSet();
+        public readonly HashSet<TouchSource> PossibleTapTouchSources;
+
+        public readonly IEnumerable<TouchSource> AllTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>();
 
         private readonly Dictionary<TouchSource, OsuAction> touchTapActionsDictionary = new Dictionary<TouchSource, OsuAction>();
 
@@ -46,6 +48,7 @@ namespace osu.Game.Rulesets.Osu.UI
         public OsuDrawableTouchInputHandler(OsuInputManager inputManager)
         {
             osuInputManager = inputManager;
+            PossibleTapTouchSources = AllTouchSources.Take(CONCURRENT_TOUCHES_LIMIT).ToHashSet();
             foreach (var source in PossibleTapTouchSources)
                 touchTapActionsDictionary.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
         }

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -15,23 +15,24 @@ namespace osu.Game.Rulesets.Osu.UI
     public class OsuDrawableTouchInputHandler : Drawable
     {
         public const TouchSource CURSOR_TOUCH = TouchSource.Touch1;
+        public const OsuAction CURSOR_TOUCH_ACTION = OsuAction.LeftButton;
 
         /// <summary>
         /// How many taps (taps referring as streaming touch input) can be registered.
         /// </summary>
-        private const int tap_touches_limit = 2;
+        public const int TAP_TOUCHES_LIMIT = 2;
 
         /// <summary>
         /// The index for the last concurrent able touch.
         /// </summary>
-        private const int last_concurrent_touch_index = tap_touches_limit;
+        public const int LAST_CONCURRENT_TOUCH_INDEX = TAP_TOUCHES_LIMIT;
 
         /// <summary>
         /// How many concurrent touches can be registered.
         /// </summary>
-        private const int concurrent_touches_limit = last_concurrent_touch_index + 1;
+        public const int CONCURRENT_TOUCHES_LIMIT = LAST_CONCURRENT_TOUCH_INDEX + 1;
 
-        private readonly HashSet<TouchSource> possibleTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().Take(concurrent_touches_limit).ToHashSet();
+        public readonly HashSet<TouchSource> PossibleTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().Take(CONCURRENT_TOUCHES_LIMIT).ToHashSet();
 
         private readonly Dictionary<TouchSource, OsuAction> touchTapActionsDictionary = new Dictionary<TouchSource, OsuAction>();
 
@@ -42,10 +43,10 @@ namespace osu.Game.Rulesets.Osu.UI
             return source - TouchSource.Touch1;
         }
 
-        public OsuDrawableTouchInputHandler(DrawableOsuRuleset drawableRuleset)
+        public OsuDrawableTouchInputHandler(OsuInputManager inputManager)
         {
-            osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
-            foreach (var source in possibleTapTouchSources)
+            osuInputManager = inputManager;
+            foreach (var source in PossibleTapTouchSources)
                 touchTapActionsDictionary.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
         }
 
@@ -61,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private bool isValidTouchInput(TouchSource source, int index)
         {
-            return index <= last_concurrent_touch_index;
+            return index <= LAST_CONCURRENT_TOUCH_INDEX;
         }
 
         protected override bool OnTouchDown(TouchDownEvent e)
@@ -69,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.UI
             var source = e.Touch.Source;
             int sourceIndex = getTouchIndex(source);
 
-            osuInputManager.DragMode = sourceIndex >= last_concurrent_touch_index;
+            osuInputManager.DragMode = sourceIndex >= LAST_CONCURRENT_TOUCH_INDEX;
 
             if (!isValidTouchInput(source, sourceIndex))
                 return false;

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.UI
         private const int tap_touches_limit = 2;
 
         /// <summary>
-        /// The index for the last concurrent able touch. 
+        /// The index for the last concurrent able touch.
         /// </summary>
         private const int last_concurrent_touch_index = tap_touches_limit;
 

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -76,13 +76,20 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private bool isValidTouchInput(int index) => index <= last_concurrent_touch_index;
 
+        /// <summary>
+        /// Detects the touchscreen and applies the Touch Device mod for the current score.
+        /// <remarks>
+        /// We wait till some value of detected touches to be detected regardless if the input was surely made from a touch device,
+        /// this because we don't want to penalize players that barely used their touch device with the touch device mod.
+        /// although in a near future we probably must use some kind of metadata on how many touch inputs were detected to properly
+        /// nerf pp according to that, rather than nerfing every play made with a touch device the same.
+        /// </remarks>
+        /// </summary>
         private void detectTouchScreen()
         {
-            if (++detectedTouches.Value == detectedTouches.MaxValue)
-            {
-                detectedTouchscreen = true;
+            detectedTouchscreen = ++detectedTouches.Value == detectedTouches.MaxValue;
+            if (detectedTouchscreen)
                 player.Score.ScoreInfo.Mods = player.Score.ScoreInfo.Mods.Append(new OsuModTouchDevice()).ToArray();
-            }
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -35,10 +35,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private readonly OsuInputManager osuInputManager;
 
-        private int getTouchIndex(TouchSource source)
-        {
-            return source - TouchSource.Touch1;
-        }
+        private int getTouchIndex(TouchSource source) => source - TouchSource.Touch1;
 
         public OsuDrawableTouchInputHandler(OsuInputManager inputManager)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -67,14 +67,13 @@ namespace osu.Game.Rulesets.Osu.UI
             var source = e.Touch.Source;
             int sourceIndex = getTouchIndex(source);
 
-            osuInputManager.DragMode = sourceIndex >= last_concurrent_touch_index;
-
-            // A cursor touch is always a valid touch.
-            if (isCursorTouch(source))
-                return base.OnTouchDown(e);
-
             if (!isValidTouchInput(sourceIndex))
                 return false;
+
+            osuInputManager.DragMode = sourceIndex == last_concurrent_touch_index;
+
+            if (isCursorTouch(source))
+                return base.OnTouchDown(e);
 
             osuInputManager.KeyBindingContainer.TriggerPressed(touchActions[source]);
 

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -31,9 +31,7 @@ namespace osu.Game.Rulesets.Osu.UI
         /// </summary>
         private const int concurrent_touches_limit = last_concurrent_touch_index + 1;
 
-        public readonly HashSet<TouchSource> AllowedTouchSources;
-
-        private readonly IEnumerable<TouchSource> allTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>();
+        public readonly HashSet<TouchSource> AllowedTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().Take(concurrent_touches_limit).ToHashSet();
 
         private readonly Dictionary<TouchSource, OsuAction> touchTapActionsDictionary = new Dictionary<TouchSource, OsuAction>();
 
@@ -47,7 +45,6 @@ namespace osu.Game.Rulesets.Osu.UI
         public OsuDrawableTouchInputHandler(OsuInputManager inputManager)
         {
             osuInputManager = inputManager;
-            AllowedTouchSources = allTouchSources.Take(concurrent_touches_limit).ToHashSet();
             foreach (var source in AllowedTouchSources)
                 touchTapActionsDictionary.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
         }

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -71,11 +71,12 @@ namespace osu.Game.Rulesets.Osu.UI
 
             osuInputManager.DragMode = sourceIndex >= last_concurrent_touch_index;
 
-            if (!isValidTouchInput(sourceIndex))
-                return false;
-
+            // A cursor touch is always a valid touch.
             if (isCursorTouch(source))
                 return base.OnTouchDown(e);
+
+            if (!isValidTouchInput(sourceIndex))
+                return false;
 
             var touchAction = touchTapActionsDictionary[source];
 

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -8,8 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 
-#nullable disable
-
 namespace osu.Game.Rulesets.Osu.UI
 {
     public class OsuDrawableTouchInputHandler : Drawable

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+
+#nullable disable
+
+namespace osu.Game.Rulesets.Osu.UI
+{
+    public class OsuDrawableTouchInputHandler : Drawable
+    {
+        public const TouchSource CURSOR_TOUCH = TouchSource.Touch1;
+
+        /// <summary>
+        /// How many taps (taps referring as streaming touch input) can be registered.
+        /// </summary>
+        private const int tap_touches_limit = 2;
+
+        /// <summary>
+        /// The index for the last concurrent able touch. 
+        /// </summary>
+        private const int last_concurrent_touch_index = tap_touches_limit;
+
+        /// <summary>
+        /// How many concurrent touches can be registered.
+        /// </summary>
+        private const int concurrent_touches_limit = last_concurrent_touch_index + 1;
+
+        private readonly HashSet<TouchSource> possibleTapTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().Take(concurrent_touches_limit).ToHashSet();
+
+        private readonly Dictionary<TouchSource, OsuAction> touchTapActionsDictionary = new Dictionary<TouchSource, OsuAction>();
+
+        private readonly OsuInputManager osuInputManager;
+
+        private int getTouchIndex(TouchSource source)
+        {
+            return source - TouchSource.Touch1;
+        }
+
+        public OsuDrawableTouchInputHandler(DrawableOsuRuleset drawableRuleset)
+        {
+            osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
+            foreach (var source in possibleTapTouchSources)
+                touchTapActionsDictionary.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
+        }
+
+        private bool isTapTouch(TouchSource source)
+        {
+            return CURSOR_TOUCH != source || !osuInputManager.AllowUserCursorMovement;
+        }
+
+        private bool isCursorTouch(TouchSource source)
+        {
+            return !isTapTouch(source);
+        }
+
+        private bool isValidTouchInput(TouchSource source, int index)
+        {
+            return index <= last_concurrent_touch_index;
+        }
+
+        protected override bool OnTouchDown(TouchDownEvent e)
+        {
+            var source = e.Touch.Source;
+            int sourceIndex = getTouchIndex(source);
+
+            osuInputManager.DragMode = sourceIndex >= last_concurrent_touch_index;
+
+            if (!isValidTouchInput(source, sourceIndex))
+                return false;
+
+            if (isCursorTouch(source))
+                return base.OnTouchDown(e);
+
+            var touchAction = touchTapActionsDictionary[source];
+
+            osuInputManager.KeyBindingContainer.TriggerPressed(touchAction);
+
+            return true;
+        }
+
+        protected override void OnTouchUp(TouchUpEvent e)
+        {
+            var source = e.Touch.Source;
+            int sourceIndex = getTouchIndex(source);
+
+            if (!isValidTouchInput(source, sourceIndex))
+                return;
+
+            if (isTapTouch(source))
+            {
+                var touchAction = touchTapActionsDictionary[source];
+                osuInputManager.KeyBindingContainer.TriggerReleased(touchAction);
+            }
+
+            base.OnTouchUp(e);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -76,14 +76,15 @@ namespace osu.Game.Rulesets.Osu.UI
 
             osuInputManager.DragMode = sourceIndex == last_concurrent_touch_index;
 
-            if (!detectedTouchscreen && ++detectedTouches.Value == detectedTouches.MaxValue)
-            {
-                detectedTouchscreen = true;
-                player.Score.ScoreInfo.Mods = player.Score.ScoreInfo.Mods.Append(new OsuModTouchDevice()).ToArray();
-            }
-
             if (isCursorTouch(source))
+            {
+                if (!detectedTouchscreen && ++detectedTouches.Value == detectedTouches.MaxValue)
+                {
+                    detectedTouchscreen = true;
+                    player.Score.ScoreInfo.Mods = player.Score.ScoreInfo.Mods.Append(new OsuModTouchDevice()).ToArray();
+                }
                 return base.OnTouchDown(e);
+            }
 
             osuInputManager.KeyBindingContainer.TriggerPressed(touchActions[source]);
 

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -47,20 +47,11 @@ namespace osu.Game.Rulesets.Osu.UI
                 touchActions.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
         }
 
-        private bool isTapTouch(TouchSource source)
-        {
-            return CURSOR_TOUCH != source || !osuInputManager.AllowUserCursorMovement;
-        }
+        private bool isTapTouch(TouchSource source) => source != CURSOR_TOUCH || !osuInputManager.AllowUserCursorMovement;
 
-        private bool isCursorTouch(TouchSource source)
-        {
-            return !isTapTouch(source);
-        }
+        private bool isCursorTouch(TouchSource source) => !isTapTouch(source);
 
-        private bool isValidTouchInput(int index)
-        {
-            return index <= last_concurrent_touch_index;
-        }
+        private bool isValidTouchInput(int index) => index <= last_concurrent_touch_index;
 
         protected override bool OnTouchDown(TouchDownEvent e)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -83,6 +83,7 @@ namespace osu.Game.Rulesets.Osu.UI
                     detectedTouchscreen = true;
                     player.Score.ScoreInfo.Mods = player.Score.ScoreInfo.Mods.Append(new OsuModTouchDevice()).ToArray();
                 }
+
                 return base.OnTouchDown(e);
             }
 

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -57,9 +57,7 @@ namespace osu.Game.Rulesets.Osu.UI
             MaxValue = 10
         };
 
-        private Vector2 previousMousePosition;
-
-        private bool firstMouseDownApplied;
+        private Vector2? previousMousePosition;
 
         private int getTouchIndex(TouchSource source) => source - TouchSource.Touch1;
 
@@ -100,12 +98,10 @@ namespace osu.Game.Rulesets.Osu.UI
             var currentMousePosition = e.MousePosition;
 
             // We ignore the first input since we don't have a proper previousMousePosition
-            if (firstMouseDownApplied && Vector2.Distance(currentMousePosition, previousMousePosition) > mouse_input_touchscreen_distance)
+            if (previousMousePosition != null && Vector2.Distance(currentMousePosition, previousMousePosition.Value) > mouse_input_touchscreen_distance)
                 detectTouchScreen();
 
             previousMousePosition = currentMousePosition;
-
-            firstMouseDownApplied = true;
 
             return base.OnMouseDown(e);
         }

--- a/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuDrawableTouchInputHandler.cs
@@ -20,18 +20,18 @@ namespace osu.Game.Rulesets.Osu.UI
         private const int tap_touches_limit = 2;
 
         /// <summary>
-        /// The index for the last concurrent able touch.
-        /// </summary>
-        private const int last_concurrent_touch_index = tap_touches_limit;
-
-        /// <summary>
         /// How many concurrent touches can be registered.
         /// </summary>
-        private const int concurrent_touches_limit = last_concurrent_touch_index + 1;
+        private const int concurrent_touches_limit = tap_touches_limit + 1;
+
+        /// <summary>
+        /// The index for the last concurrent able touch.
+        /// </summary>
+        private const int last_concurrent_touch_index = concurrent_touches_limit - 1;
 
         public readonly HashSet<TouchSource> AllowedTouchSources = Enum.GetValues(typeof(TouchSource)).Cast<TouchSource>().Take(concurrent_touches_limit).ToHashSet();
 
-        private readonly Dictionary<TouchSource, OsuAction> touchTapActionsDictionary = new Dictionary<TouchSource, OsuAction>();
+        private readonly Dictionary<TouchSource, OsuAction> touchActions = new Dictionary<TouchSource, OsuAction>();
 
         private readonly OsuInputManager osuInputManager;
 
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             osuInputManager = inputManager;
             foreach (var source in AllowedTouchSources)
-                touchTapActionsDictionary.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
+                touchActions.Add(source, getTouchIndex(source) % 2 == 0 ? OsuAction.LeftButton : OsuAction.RightButton);
         }
 
         private bool isTapTouch(TouchSource source)
@@ -76,9 +76,7 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!isValidTouchInput(sourceIndex))
                 return false;
 
-            var touchAction = touchTapActionsDictionary[source];
-
-            osuInputManager.KeyBindingContainer.TriggerPressed(touchAction);
+            osuInputManager.KeyBindingContainer.TriggerPressed(touchActions[source]);
 
             return true;
         }
@@ -92,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.UI
                 return;
 
             if (isTapTouch(source))
-                osuInputManager.KeyBindingContainer.TriggerReleased(touchTapActionsDictionary[source]);
+                osuInputManager.KeyBindingContainer.TriggerReleased(touchActions[source]);
 
             base.OnTouchUp(e);
         }


### PR DESCRIPTION
 * [x] Depends on [osu! ruleset simple touch input implementation #19977](https://github.com/ppy/osu/pull/19977).

This is a basic implementation that aims to provide touch device detection atleast when submitting a score, this does not account for in-gameplay things that are affected by the touch device mod, such as a skin pp counter.

But i still believe this should be accounted for when submitting scores as of now, since multiple scores are being sent without being flagged as TD, so it's a starting point.