### PR TITLE
Fix incorrect slider length in timeline when non-default velocity is inherited from previous object

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -89,6 +89,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
                     HitObject.DifficultyControlPoint = nearestDifficultyPoint ?? new DifficultyControlPoint();
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
+
+                    // Replacing the DifficultyControlPoint above doesn't trigger any kind of invalidation.
+                    // Without re-applying defaults, velocity won't be updated.
+                    // If this causes further issues, it may be better to copy the velocity p
+                    ApplyDefaultsToHitObject();
                     break;
 
                 case SliderPlacementState.Body:

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -92,7 +92,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
                     // Replacing the DifficultyControlPoint above doesn't trigger any kind of invalidation.
                     // Without re-applying defaults, velocity won't be updated.
-                    // If this causes further issues, it may be better to copy the velocity p
                     ApplyDefaultsToHitObject();
                     break;
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -33,19 +31,19 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     {
         private const float circle_size = 38;
 
-        private Container repeatsContainer;
+        private Container? repeatsContainer;
 
-        public Action<DragEvent> OnDragHandled;
+        public Action<DragEvent?>? OnDragHandled = null!;
 
         [UsedImplicitly]
         private readonly Bindable<double> startTime;
 
-        private Bindable<int> indexInCurrentComboBindable;
+        private Bindable<int>? indexInCurrentComboBindable;
 
-        private Bindable<int> comboIndexBindable;
-        private Bindable<int> comboIndexWithOffsetsBindable;
+        private Bindable<int>? comboIndexBindable;
+        private Bindable<int>? comboIndexWithOffsetsBindable;
 
-        private Bindable<Color4> displayColourBindable;
+        private Bindable<Color4> displayColourBindable = null!;
 
         private readonly ExtendableCircle circle;
         private readonly Border border;
@@ -54,7 +52,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private readonly OsuSpriteText comboIndexText;
 
         [Resolved]
-        private ISkinSource skin { get; set; }
+        private ISkinSource skin { get; set; } = null!;
 
         public TimelineHitObjectBlueprint(HitObject item)
             : base(item)
@@ -124,7 +122,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 case IHasComboInformation comboInfo:
                     indexInCurrentComboBindable = comboInfo.IndexInCurrentComboBindable.GetBoundCopy();
-                    indexInCurrentComboBindable.BindValueChanged(_ => updateComboIndex(), true);
+                    indexInCurrentComboBindable.BindValueChanged(_ =>
+                    {
+                        comboIndexText.Text = (indexInCurrentComboBindable.Value + 1).ToString();
+                    }, true);
 
                     comboIndexBindable = comboInfo.ComboIndexBindable.GetBoundCopy();
                     comboIndexWithOffsetsBindable = comboInfo.ComboIndexWithOffsetsBindable.GetBoundCopy();
@@ -148,8 +149,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             // base logic hides selected blueprints when not selected, but timeline doesn't do that.
             updateColour();
         }
-
-        private void updateComboIndex() => comboIndexText.Text = (indexInCurrentComboBindable.Value + 1).ToString();
 
         private void updateColour()
         {
@@ -183,11 +182,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             colouredComponents.Colour = OsuColour.ForegroundTextColourFor(averageColour);
         }
 
-        private SamplePointPiece sampleOverrideDisplay;
-        private DifficultyPointPiece difficultyOverrideDisplay;
+        private SamplePointPiece? sampleOverrideDisplay;
+        private DifficultyPointPiece? difficultyOverrideDisplay;
 
-        private DifficultyControlPoint difficultyControlPoint;
-        private SampleControlPoint sampleControlPoint;
+        private DifficultyControlPoint difficultyControlPoint = null!;
+        private SampleControlPoint sampleControlPoint = null!;
 
         protected override void Update()
         {
@@ -276,16 +275,27 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         public class DragArea : Circle
         {
-            private readonly HitObject hitObject;
+            private readonly HitObject? hitObject;
 
             [Resolved]
-            private Timeline timeline { get; set; }
+            private EditorBeatmap beatmap { get; set; } = null!;
 
-            public Action<DragEvent> OnDragHandled;
+            [Resolved]
+            private IBeatSnapProvider beatSnapProvider { get; set; } = null!;
+
+            [Resolved]
+            private Timeline timeline { get; set; } = null!;
+
+            [Resolved(CanBeNull = true)]
+            private IEditorChangeHandler? changeHandler { get; set; }
+
+            private ScheduledDelegate? dragOperation;
+
+            public Action<DragEvent?>? OnDragHandled;
 
             public override bool HandlePositionalInput => hitObject != null;
 
-            public DragArea(HitObject hitObject)
+            public DragArea(HitObject? hitObject)
             {
                 this.hitObject = hitObject;
 
@@ -356,22 +366,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 this.FadeTo(IsHovered || hasMouseDown ? 1f : 0.9f, 200, Easing.OutQuint);
             }
 
-            [Resolved]
-            private EditorBeatmap beatmap { get; set; }
-
-            [Resolved]
-            private IBeatSnapProvider beatSnapProvider { get; set; }
-
-            [Resolved(CanBeNull = true)]
-            private IEditorChangeHandler changeHandler { get; set; }
-
             protected override bool OnDragStart(DragStartEvent e)
             {
                 changeHandler?.BeginChange();
                 return true;
             }
-
-            private ScheduledDelegate dragOperation;
 
             protected override void OnDrag(DragEvent e)
             {


### PR DESCRIPTION
Quite an ordeal to investigate this one, but mostly because I started on the wrong trail.

I'm not sure if there's a better way to handle this. Probably find to just forcefully reapply defaults for now?

Closes #20133.