### PR TITLE
Fix textbox sample playback potentially crashing if called before load

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -283,7 +283,7 @@ namespace osu.Game.Graphics.UserInterface
             return samples[RNG.Next(0, samples.Length)]?.GetChannel();
         }
 
-        private void playSample(FeedbackSampleType feedbackSample)
+        private void playSample(FeedbackSampleType feedbackSample) => Schedule(() =>
         {
             if (Time.Current < sampleLastPlaybackTime + 15) return;
 
@@ -300,7 +300,7 @@ namespace osu.Game.Graphics.UserInterface
             channel.Play();
 
             sampleLastPlaybackTime = Time.Current;
-        }
+        });
 
         private class OsuCaret : Caret
         {


### PR DESCRIPTION
Got crash while entering editor setup screen using F4 shortcut:

```csharp
[runtime] 2022-09-05 07:24:26 [verbose]: Unhandled exception has been denied .
Unhandled exception. [runtime] 2022-09-05 07:24:26 [verbose]: ⚠️ An unhandled error has occurred.
System.NullReferenceException: Object reference not set to an instance of an object.
   at osu.Framework.Graphics.Transforms.Transformable.get_Time()
   at osu.Game.Graphics.UserInterface.OsuTextBox.playSample(FeedbackSampleType feedbackSample)
   at osu.Game.Graphics.UserInterface.OsuTextBox.NotifyInputError()
   at osu.Framework.Graphics.UserInterface.TextBox.insertString(String value, Action`1 drawableCreationParameters)
   at osu.Framework.Graphics.UserInterface.TextBox.setText(String value)
   at osu.Framework.Graphics.UserInterface.TextBox.set_Text(String value)
   at osu.Framework.Graphics.UserInterface.TextBox.<.ctor>b__51_0(ValueChangedEvent`1 e)
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
   at osu.Framework.Bindables.Bindable`1.set_Value(T value)
   at osu.Game.Screens.Edit.Setup.MetadataSection.createTextBox[TTextBox](LocalisableString label, String initialValue)
```