### PR TITLE
Fix completion toasts sometimes not displaying

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -301,7 +301,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddAssert("check for notification", () => notificationOverlay.UnreadCount.Value, () => Is.EqualTo(1));
 
-            clickNotificationIfAny();
+            clickNotification();
 
             AddAssert("check " + volumeName, assert);
 
@@ -370,8 +370,12 @@ namespace osu.Game.Tests.Visual.Gameplay
                 batteryInfo.SetChargeLevel(chargeLevel);
             }));
             AddUntilStep("wait for player", () => player?.LoadState == LoadState.Ready);
-            AddAssert($"notification {(shouldWarn ? "triggered" : "not triggered")}", () => notificationOverlay.UnreadCount.Value == (shouldWarn ? 1 : 0));
-            clickNotificationIfAny();
+
+            if (shouldWarn)
+                clickNotification();
+            else
+                AddAssert("notification not triggered", () => notificationOverlay.UnreadCount.Value == 0);
+
             AddUntilStep("wait for player load", () => player.IsLoaded);
         }
 
@@ -436,9 +440,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("skip button not visible", () => !checkSkipButtonVisible());
         }
 
-        private void clickNotificationIfAny()
+        private void clickNotification()
         {
-            AddStep("click notification", () => notificationOverlay.ChildrenOfType<Notification>().FirstOrDefault()?.TriggerClick());
+            Notification notification = null;
+
+            AddUntilStep("wait for notification", () => (notification = notificationOverlay.ChildrenOfType<Notification>().FirstOrDefault()) != null);
+            AddStep("open notification overlay", () => notificationOverlay.Show());
+            AddStep("click notification", () => notification.TriggerClick());
         }
 
         private EpilepsyWarning getWarning() => loader.ChildrenOfType<EpilepsyWarning>().SingleOrDefault();

--- a/osu.Game.Tests/Visual/Navigation/TestSceneStartupImport.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneStartupImport.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
@@ -13,7 +11,7 @@ namespace osu.Game.Tests.Visual.Navigation
 {
     public class TestSceneStartupImport : OsuGameTestScene
     {
-        private string importFilename;
+        private string? importFilename;
 
         protected override TestOsuGame CreateTestGame() => new TestOsuGame(LocalStorage, API, new[] { importFilename });
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -58,6 +58,19 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestPresenceWithManualDismiss()
+        {
+            AddAssert("tray not present", () => !notificationOverlay.ChildrenOfType<NotificationOverlayToastTray>().Single().IsPresent);
+            AddAssert("overlay not present", () => !notificationOverlay.IsPresent);
+
+            AddStep(@"post notification", sendBackgroundNotification);
+            AddStep("click notification", () => notificationOverlay.ChildrenOfType<Notification>().Single().TriggerClick());
+
+            AddUntilStep("wait tray not present", () => !notificationOverlay.ChildrenOfType<NotificationOverlayToastTray>().Single().IsPresent);
+            AddUntilStep("wait overlay not present", () => !notificationOverlay.IsPresent);
+        }
+
+        [Test]
         public void TestCompleteProgress()
         {
             ProgressNotification notification = null!;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -45,6 +46,18 @@ namespace osu.Game.Tests.Visual.UserInterface
         });
 
         [Test]
+        public void TestPresence()
+        {
+            AddAssert("tray not present", () => !notificationOverlay.ChildrenOfType<NotificationOverlayToastTray>().Single().IsPresent);
+            AddAssert("overlay not present", () => !notificationOverlay.IsPresent);
+
+            AddStep(@"post notification", sendBackgroundNotification);
+
+            AddUntilStep("wait tray not present", () => !notificationOverlay.ChildrenOfType<NotificationOverlayToastTray>().Single().IsPresent);
+            AddUntilStep("wait overlay not present", () => !notificationOverlay.IsPresent);
+        }
+
+        [Test]
         public void TestCompleteProgress()
         {
             ProgressNotification notification = null!;
@@ -63,6 +76,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("wait completion", () => notification.State == ProgressNotificationState.Completed);
 
             AddAssert("Completion toast shown", () => notificationOverlay.ToastCount == 1);
+            AddUntilStep("wait forwarded", () => notificationOverlay.ToastCount == 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -23,9 +23,12 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private SpriteText displayedCount = null!;
 
+        public double TimeToCompleteProgress { get; set; } = 2000;
+
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
+            TimeToCompleteProgress = 2000;
             progressingNotifications.Clear();
 
             Content.Children = new Drawable[]
@@ -45,6 +48,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestCompleteProgress()
         {
             ProgressNotification notification = null!;
+
             AddStep("add progress notification", () =>
             {
                 notification = new ProgressNotification
@@ -57,6 +61,30 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddUntilStep("wait completion", () => notification.State == ProgressNotificationState.Completed);
+
+            AddAssert("Completion toast shown", () => notificationOverlay.ToastCount == 1);
+        }
+
+        [Test]
+        public void TestCompleteProgressSlow()
+        {
+            ProgressNotification notification = null!;
+
+            AddStep("Set progress slow", () => TimeToCompleteProgress *= 2);
+            AddStep("add progress notification", () =>
+            {
+                notification = new ProgressNotification
+                {
+                    Text = @"Uploading to BSS...",
+                    CompletionText = "Uploaded to BSS!",
+                };
+                notificationOverlay.Post(notification);
+                progressingNotifications.Add(notification);
+            });
+
+            AddUntilStep("wait completion", () => notification.State == ProgressNotificationState.Completed);
+
+            AddAssert("Completion toast shown", () => notificationOverlay.ToastCount == 1);
         }
 
         [Test]
@@ -177,7 +205,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             foreach (var n in progressingNotifications.FindAll(n => n.State == ProgressNotificationState.Active))
             {
                 if (n.Progress < 1)
-                    n.Progress += (float)(Time.Elapsed / 2000);
+                    n.Progress += (float)(Time.Elapsed / TimeToCompleteProgress);
                 else
                     n.State = ProgressNotificationState.Completed;
             }

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -71,7 +71,6 @@ namespace osu.Game.Overlays
                 },
                 mainContent = new Container
                 {
-                    AlwaysPresent = true,
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
@@ -137,9 +136,9 @@ namespace osu.Game.Overlays
 
         private readonly Scheduler postScheduler = new Scheduler();
 
-        public override bool IsPresent => base.IsPresent
-                                          || postScheduler.HasPendingTasks
-                                          || toastTray.IsDisplayingToasts;
+        public override bool IsPresent =>
+            // Delegate presence as we need to consider the toast tray in addition to the main overlay.
+            State.Value == Visibility.Visible || mainContent.IsPresent || toastTray.IsPresent || postScheduler.HasPendingTasks;
 
         private bool processingPosts = true;
 

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -137,7 +137,9 @@ namespace osu.Game.Overlays
 
         private readonly Scheduler postScheduler = new Scheduler();
 
-        public override bool IsPresent => base.IsPresent || postScheduler.HasPendingTasks;
+        public override bool IsPresent => base.IsPresent
+                                          || postScheduler.HasPendingTasks
+                                          || toastTray.IsDisplayingToasts;
 
         private bool processingPosts = true;
 

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Overlays
     /// </summary>
     public class NotificationOverlayToastTray : CompositeDrawable
     {
+        public override bool IsPresent => IsDisplayingToasts;
+
         public bool IsDisplayingToasts => displayedCount > 0;
 
         private FillFlowContainer<Notification> toastFlow = null!;

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays
                     postEffectDrawable.AutoSizeAxes = Axes.None;
                     postEffectDrawable.RelativeSizeAxes = Axes.X;
                 })),
-                toastFlow = new AlwaysUpdateFillFlowContainer<Notification>
+                toastFlow = new FillFlowContainer<Notification>
                 {
                     LayoutDuration = 150,
                     LayoutEasing = Easing.OutQuart,

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays
     {
         public override bool IsPresent => toastContentBackground.Height > 0 || toastFlow.Count > 0;
 
-        public bool IsDisplayingToasts => allNotifications.Any();
+        public bool IsDisplayingToasts => toastFlow.Count > 0;
 
         private FillFlowContainer<Notification> toastFlow = null!;
         private BufferedContainer toastContentBackground = null!;
@@ -36,9 +36,12 @@ namespace osu.Game.Overlays
 
         public Action<Notification>? ForwardNotificationToPermanentStore { get; set; }
 
-        public int UnreadCount => allNotifications.Count(n => !n.WasClosed && !n.Read);
+        public int UnreadCount => allDisplayedNotifications.Count(n => !n.WasClosed && !n.Read);
 
-        private IEnumerable<Notification> allNotifications => toastFlow.Concat(InternalChildren.OfType<Notification>());
+        /// <summary>
+        /// Notifications contained in the toast flow, or in a detached state while they animate during forwarding to the main overlay.
+        /// </summary>
+        private IEnumerable<Notification> allDisplayedNotifications => toastFlow.Concat(InternalChildren.OfType<Notification>());
 
         private int runningDepth;
 

--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -97,6 +97,8 @@ namespace osu.Game.Overlays
 
         public void Post(Notification notification)
         {
+            notification.Closed += stopTrackingNotification;
+
             ++runningDepth;
             displayedCount++;
 
@@ -139,12 +141,21 @@ namespace osu.Game.Overlays
             notification.MoveToOffset(new Vector2(400, 0), NotificationOverlay.TRANSITION_LENGTH, Easing.OutQuint);
             notification.FadeOut(NotificationOverlay.TRANSITION_LENGTH, Easing.OutQuint).OnComplete(_ =>
             {
+                notification.Closed -= stopTrackingNotification;
+                if (!notification.WasClosed)
+                    stopTrackingNotification();
+
                 RemoveInternal(notification, false);
-                displayedCount--;
                 ForwardNotificationToPermanentStore?.Invoke(notification);
 
                 notification.FadeIn(300, Easing.OutQuint);
             });
+        }
+
+        private void stopTrackingNotification()
+        {
+            Debug.Assert(displayedCount > 0);
+            displayedCount--;
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Game.Graphics;
 using osu.Framework.Graphics.Colour;

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -162,6 +162,8 @@ namespace osu.Game.Overlays.Notifications
 
         public override bool DisplayOnTop => false;
 
+        public override bool IsImportant => false;
+
         private readonly ProgressBar progressBar;
         private Color4 colourQueued;
         private Color4 colourActive;

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -88,7 +88,12 @@ namespace osu.Game.Overlays.Notifications
                 state = value;
 
                 if (IsLoaded)
+                {
                     Schedule(updateState);
+
+                    if (state == ProgressNotificationState.Completed)
+                        CompletionTarget?.Invoke(CreateCompletionNotification());
+                }
             }
         }
 
@@ -141,7 +146,7 @@ namespace osu.Game.Overlays.Notifications
 
                 case ProgressNotificationState.Completed:
                     loadingSpinner.Hide();
-                    Completed();
+                    base.Close();
                     break;
             }
         }
@@ -153,12 +158,6 @@ namespace osu.Game.Overlays.Notifications
             Activated = CompletionClickAction,
             Text = CompletionText
         };
-
-        protected void Completed()
-        {
-            CompletionTarget?.Invoke(CreateCompletionNotification());
-            base.Close();
-        }
 
         public override bool DisplayOnTop => false;
 


### PR DESCRIPTION
Until now, the `NotificationOverlay` class has had some pretty zany logic to ensure that any `ProgressNotification`s correctly `Post` their completion notification (which was scheduled locally inside the notification class). This was pretty hard to maintain, so I've moved the posting of completion out of the `Schedule` call. `NotificationOverlay.Post` is already quite thread-safe, so this should not be an issue.

This fixes an issue I only experience in very specific conditions (I think a high or low fps is required to trigger it), where completion notifications would not get the overlay into a present state, therefore not displaying the toasts.

In the process, I also restored sanity to the overall presence of `NotificationOverlay` itself, which as of the recent changes was always present, even when not required.