### PR TITLE
Fix some storyboard elements displaying too late due to incorrect start time allowances

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -118,6 +118,23 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
+        public void TestEarliestStartTimeWithLoopAlphas()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using (var resStream = TestResources.OpenResource("loop-containing-earlier-non-zero-fade.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var storyboard = decoder.Decode(stream);
+
+                StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
+                Assert.AreEqual(1, background.Elements.Count);
+                Assert.AreEqual(1000, background.Elements[0].StartTime);
+                Assert.AreEqual(1000, storyboard.EarliestEventTime);
+            }
+        }
+
+        [Test]
         public void TestDecodeVariableWithSuffix()
         {
             var decoder = new LegacyStoryboardDecoder();

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -128,8 +128,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
-                Assert.AreEqual(1, background.Elements.Count);
+                Assert.AreEqual(2, background.Elements.Count);
+
                 Assert.AreEqual(1000, background.Elements[0].StartTime);
+                Assert.AreEqual(1000, background.Elements[1].StartTime);
+
                 Assert.AreEqual(1000, storyboard.EarliestEventTime);
             }
         }

--- a/osu.Game.Tests/Resources/loop-containing-earlier-non-zero-fade.osb
+++ b/osu.Game.Tests/Resources/loop-containing-earlier-non-zero-fade.osb
@@ -1,0 +1,8 @@
+osu file format v14
+
+[Events]
+//Storyboard Layer 0 (Background)
+Sprite,Background,TopCentre,"img.jpg",320,240
+ L,1000,1
+  F,0,0,,1       // fade inside a loop with non-zero alpha and an earlier start time should be the true start time..
+ F,0,2000,,0     // ..not a zero alpha fade with a later start time

--- a/osu.Game.Tests/Resources/loop-containing-earlier-non-zero-fade.osb
+++ b/osu.Game.Tests/Resources/loop-containing-earlier-non-zero-fade.osb
@@ -6,3 +6,9 @@ Sprite,Background,TopCentre,"img.jpg",320,240
  L,1000,1
   F,0,0,,1       // fade inside a loop with non-zero alpha and an earlier start time should be the true start time..
  F,0,2000,,0     // ..not a zero alpha fade with a later start time
+
+Sprite,Background,TopCentre,"img.jpg",320,240
+ L,2000,1
+  F,0,0,24,0     // fade inside a loop with zero alpha but later start time than the top-level zero alpha start time.
+  F,0,24,48,1
+ F,0,1000,,1     // ..so this should be the true start time

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneLeadIn.cs
@@ -66,18 +66,20 @@ namespace osu.Game.Tests.Visual.Gameplay
         [TestCase(-10000, -10000, true)]
         public void TestStoryboardProducesCorrectStartTimeFadeInAfterOtherEvents(double firstStoryboardEvent, double expectedStartTime, bool addEventToLoop)
         {
+            const double loop_start_time = -20000;
+
             var storyboard = new Storyboard();
 
             var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
 
             // these should be ignored as we have an alpha visibility blocker proceeding this command.
-            sprite.TimelineGroup.Scale.Add(Easing.None, -20000, -18000, 0, 1);
-            var loopGroup = sprite.AddLoop(-20000, 50);
-            loopGroup.Scale.Add(Easing.None, -20000, -18000, 0, 1);
+            sprite.TimelineGroup.Scale.Add(Easing.None, loop_start_time, -18000, 0, 1);
+            var loopGroup = sprite.AddLoop(loop_start_time, 50);
+            loopGroup.Scale.Add(Easing.None, loop_start_time, -18000, 0, 1);
 
             var target = addEventToLoop ? loopGroup : sprite.TimelineGroup;
-            double targetTime = addEventToLoop ? 20000 : 0;
-            target.Alpha.Add(Easing.None, targetTime + firstStoryboardEvent, targetTime + firstStoryboardEvent + 500, 0, 1);
+            double loopRelativeOffset = addEventToLoop ? -loop_start_time : 0;
+            target.Alpha.Add(Easing.None, loopRelativeOffset + firstStoryboardEvent, loopRelativeOffset + firstStoryboardEvent + 500, 0, 1);
 
             // these should be ignored due to being in the future.
             sprite.TimelineGroup.Alpha.Add(Easing.None, 18000, 20000, 0, 1);

--- a/osu.Game/Storyboards/CommandTimelineGroup.cs
+++ b/osu.Game/Storyboards/CommandTimelineGroup.cs
@@ -47,30 +47,11 @@ namespace osu.Game.Storyboards
             };
         }
 
-        /// <summary>
-        /// Returns the earliest visible time. Will be null unless this group's first <see cref="Alpha"/> command has a start value of zero.
-        /// </summary>
-        public double? EarliestDisplayedTime
-        {
-            get
-            {
-                var first = Alpha.Commands.FirstOrDefault();
-
-                return first?.StartValue == 0 ? first.StartTime : null;
-            }
-        }
-
         [JsonIgnore]
         public double CommandsStartTime
         {
             get
             {
-                // if the first alpha command starts at zero it should be given priority over anything else.
-                // this is due to it creating a state where the target is not present before that time, causing any other events to not be visible.
-                double? earliestDisplay = EarliestDisplayedTime;
-                if (earliestDisplay != null)
-                    return earliestDisplay.Value;
-
                 double min = double.MaxValue;
 
                 for (int i = 0; i < timelines.Length; i++)

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Storyboards
                 foreach (var loop in loops)
                 {
                     command = loop.Alpha.Commands.FirstOrDefault();
-                    if (command != null) alphaCommands.Add((command.StartTime + loop.StartTime, command.StartValue == 0));
+                    if (command != null) alphaCommands.Add((command.StartTime + loop.LoopStartTime, command.StartValue == 0));
                 }
 
                 if (alphaCommands.Count > 0)


### PR DESCRIPTION
Closes #20125.

I hope I've done a good job explaining this in commit messages and inline comments, but the gist of it is that until now we were checking `EarliestStartTime` on each loop in isolation, which turns out to be incorrect. We instead need to check the earliest alpha command after flattening all commands owned by the sprite.

I'd encourage testing with other storyboards to make sure nothing has regressed, but I'm pretty confident in this change.

Of note, 677708c5e4 refactors the start time computation logic to use a temporary `List`. I think this makes it more legible, but please check on the diff of that commit alone and make your own judgement. The previous version avoids the list allocation but is a bit harder to follow.