### PR TITLE
Platform exclusive mods

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -327,7 +326,7 @@ namespace osu.Game.Overlays.Mods
                                         switch (mod)
                                         {
                                             case IPlatformExclusiveMod platformMod:
-                                                return platformMod.AllowedPlatforms.Contains(RuntimeInfo.OS);
+                                                return platformMod.AcceptPlatform();
                                             default:
                                                 return true;
                                         }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -321,6 +322,16 @@ namespace osu.Game.Overlays.Mods
             foreach (var (modType, mods) in globalAvailableMods.Value)
             {
                 var modStates = mods.SelectMany(ModUtils.FlattenMod)
+                                    .Where(mod =>
+                                    {
+                                        switch (mod)
+                                        {
+                                            case IPlatformExclusiveMod platformMod:
+                                                return platformMod.AllowedPlatforms.Contains(RuntimeInfo.OS);
+                                            default:
+                                                return true;
+                                        }
+                                    })
                                     .Select(mod => new ModState(mod.DeepClone()))
                                     .ToArray();
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -327,6 +327,7 @@ namespace osu.Game.Overlays.Mods
                                         {
                                             case IPlatformExclusiveMod platformMod:
                                                 return platformMod.AcceptPlatform();
+
                                             default:
                                                 return true;
                                         }

--- a/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
+++ b/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
@@ -5,7 +5,7 @@ using static osu.Framework.RuntimeInfo;
 
 namespace osu.Game.Rulesets.Mods
 {
-    internal interface IPlatformExclusiveMod
+    public interface IPlatformExclusiveMod
     {
         Platform[] AllowedPlatforms { get; }
     }

--- a/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
+++ b/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using static osu.Framework.RuntimeInfo;
+
+namespace osu.Game.Rulesets.Mods
+{
+    internal interface IPlatformExclusiveMod
+    {
+        Platform[] AllowedPlatforms { get; }
+    }
+}

--- a/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
+++ b/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using static osu.Framework.RuntimeInfo;
-
 namespace osu.Game.Rulesets.Mods
 {
     public interface IPlatformExclusiveMod
     {
-        Platform[] AllowedPlatforms { get; }
+        bool AcceptPlatform();
     }
 }

--- a/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
+++ b/osu.Game/Rulesets/Mods/IPlatformExclusiveMod.cs
@@ -3,6 +3,9 @@
 
 namespace osu.Game.Rulesets.Mods
 {
+    /// <summary>
+    /// Interface for any mod that should only be selectable on specific platforms.
+    /// </summary>
     public interface IPlatformExclusiveMod
     {
         bool AcceptPlatform();


### PR DESCRIPTION
This pull request provides a way to make platform exclusive mods, such mods being mods that shouldn't normally be selectable on desktop or mobile this is useful for mods that aim to exclusively provide another experience for a specific platform.

this pull request is part of another that will be referenced.