### PR TITLE
Fix some storyboard sprites still showing with zero `VectorScale`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -71,6 +69,17 @@ namespace osu.Game.Tests.Visual.Gameplay
                 s.FlipV = true;
             }));
             AddAssert("origin flipped", () => sprites.All(s => s.Origin == Anchor.BottomRight));
+        }
+
+        [Test]
+        public void TestZeroScale()
+        {
+            const string lookup_name = "hitcircleoverlay";
+
+            AddStep("allow skin lookup", () => storyboard.UseSkinSprites = true);
+            AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
+            AddStep("scale sprite", () => sprites.ForEach(s => s.VectorScale = new Vector2(0, 1)));
+            AddAssert("zero width", () => sprites.All(s => s.ScreenSpaceDrawQuad.Width == 0));
         }
 
         [Test]

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -56,11 +56,6 @@ namespace osu.Game.Storyboards.Drawables
             get => vectorScale;
             set
             {
-                if (Math.Abs(value.X) < Precision.FLOAT_EPSILON)
-                    value.X = Precision.FLOAT_EPSILON;
-                if (Math.Abs(value.Y) < Precision.FLOAT_EPSILON)
-                    value.Y = Precision.FLOAT_EPSILON;
-
                 if (vectorScale == value)
                     return;
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -55,11 +55,6 @@ namespace osu.Game.Storyboards.Drawables
             get => vectorScale;
             set
             {
-                if (Math.Abs(value.X) < Precision.FLOAT_EPSILON)
-                    value.X = Precision.FLOAT_EPSILON;
-                if (Math.Abs(value.Y) < Precision.FLOAT_EPSILON)
-                    value.Y = Precision.FLOAT_EPSILON;
-
                 if (vectorScale == value)
                     return;
 


### PR DESCRIPTION
The implementation of the local `VectorScale` was matching the [framework side implementation of scale](https://github.com/ppy/osu-framework/blob/16d1c2d3356b0f59271fb49cff5fe8373ae9cdf3/osu.Framework/Graphics/Drawable.cs#L973-L976) but I don't think it's required here.

I'm still not sure if the framework implementation is correct, but removing it locally does seem to fix broken storyboard cases.

Closes https://github.com/ppy/osu/issues/20155.