### PR TITLE
Fix several weird scenarios with online play song selection

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -19,7 +19,6 @@ using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
@@ -66,37 +65,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("create song select", () => LoadScreen(songSelect = new TestMultiplayerMatchSongSelect(SelectedRoom.Value)));
             AddUntilStep("wait for present", () => songSelect.IsCurrentScreen() && songSelect.BeatmapSetsLoaded);
-        }
-
-        [Test]
-        public void TestBeatmapRevertedOnExitIfNoSelection()
-        {
-            BeatmapInfo selectedBeatmap = null;
-
-            AddStep("select beatmap",
-                () => songSelect.Carousel.SelectBeatmap(selectedBeatmap = beatmaps.Where(beatmap => beatmap.Ruleset.OnlineID == new OsuRuleset().LegacyID).ElementAt(1)));
-            AddUntilStep("wait for selection", () => Beatmap.Value.BeatmapInfo.Equals(selectedBeatmap));
-
-            AddStep("exit song select", () => songSelect.Exit());
-            AddAssert("beatmap reverted", () => Beatmap.IsDefault);
-        }
-
-        [Test]
-        public void TestModsRevertedOnExitIfNoSelection()
-        {
-            AddStep("change mods", () => SelectedMods.Value = new[] { new OsuModDoubleTime() });
-
-            AddStep("exit song select", () => songSelect.Exit());
-            AddAssert("mods reverted", () => SelectedMods.Value.Count == 0);
-        }
-
-        [Test]
-        public void TestRulesetRevertedOnExitIfNoSelection()
-        {
-            AddStep("change ruleset", () => Ruleset.Value = new CatchRuleset().RulesetInfo);
-
-            AddStep("exit song select", () => songSelect.Exit());
-            AddAssert("ruleset reverted", () => Ruleset.Value.Equals(new OsuRuleset().RulesetInfo));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -152,8 +152,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             public new BeatmapCarousel Carousel => base.Carousel;
 
-            public TestMultiplayerMatchSongSelect(Room room, WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
-                : base(room, null, beatmap, ruleset)
+            public TestMultiplayerMatchSongSelect(Room room)
+                : base(room)
             {
             }
         }

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -433,6 +433,9 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         private void updateWorkingBeatmap()
         {
+            if (SelectedItem.Value == null || !this.IsCurrentScreen())
+                return;
+
             var beatmap = SelectedItem.Value?.Beatmap;
 
             // Retrieve the corresponding local beatmap, since we can't directly use the playlist's beatmap info

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -1,12 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using JetBrains.Annotations;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -15,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -30,12 +29,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 {
     public class MultiplayerMatchSettingsOverlay : RoomSettingsOverlay
     {
-        private MatchSettings settings;
+        private MatchSettings settings = null!;
 
         protected override OsuButton SubmitButton => settings.ApplyButton;
 
         [Resolved]
-        private OngoingOperationTracker ongoingOperationTracker { get; set; }
+        private OngoingOperationTracker ongoingOperationTracker { get; set; } = null!;
 
         protected override bool IsLoading => ongoingOperationTracker.InProgress.Value;
 
@@ -57,20 +56,24 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         {
             private const float disabled_alpha = 0.2f;
 
-            public Action SettingsApplied;
+            public Action? SettingsApplied;
 
-            public OsuTextBox NameField, MaxParticipantsField;
-            public MatchTypePicker TypePicker;
-            public OsuEnumDropdown<QueueMode> QueueModeDropdown;
-            public OsuTextBox PasswordTextBox;
-            public OsuCheckbox AutoSkipCheckbox;
-            public TriangleButton ApplyButton;
+            public OsuTextBox NameField = null!;
+            public OsuTextBox MaxParticipantsField = null!;
+            public MatchTypePicker TypePicker = null!;
+            public OsuEnumDropdown<QueueMode> QueueModeDropdown = null!;
+            public OsuTextBox PasswordTextBox = null!;
+            public OsuCheckbox AutoSkipCheckbox = null!;
+            public TriangleButton ApplyButton = null!;
 
-            public OsuSpriteText ErrorText;
+            public OsuSpriteText ErrorText = null!;
 
-            private OsuEnumDropdown<StartMode> startModeDropdown;
-            private OsuSpriteText typeLabel;
-            private LoadingLayer loadingLayer;
+            private OsuEnumDropdown<StartMode> startModeDropdown = null!;
+            private OsuSpriteText typeLabel = null!;
+            private LoadingLayer loadingLayer = null!;
+
+            [Resolved]
+            private BeatmapManager beatmapManager { get; set; } = null!;
 
             public void SelectBeatmap()
             {
@@ -79,26 +82,23 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             }
 
             [Resolved]
-            private MultiplayerMatchSubScreen matchSubScreen { get; set; }
+            private MultiplayerMatchSubScreen matchSubScreen { get; set; } = null!;
 
             [Resolved]
-            private IRoomManager manager { get; set; }
+            private IRoomManager manager { get; set; } = null!;
 
             [Resolved]
-            private MultiplayerClient client { get; set; }
+            private MultiplayerClient client { get; set; } = null!;
 
             [Resolved]
-            private OngoingOperationTracker ongoingOperationTracker { get; set; }
+            private OngoingOperationTracker ongoingOperationTracker { get; set; } = null!;
 
             private readonly IBindable<bool> operationInProgress = new BindableBool();
-
-            [CanBeNull]
-            private IDisposable applyingSettingsOperation;
-
             private readonly Room room;
 
-            private Drawable playlistContainer;
-            private DrawableRoomPlaylist drawablePlaylist;
+            private IDisposable? applyingSettingsOperation;
+            private Drawable playlistContainer = null!;
+            private DrawableRoomPlaylist drawablePlaylist = null!;
 
             public MatchSettings(Room room)
             {
@@ -423,7 +423,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     else
                         room.MaxParticipants.Value = null;
 
-                    manager?.CreateRoom(room, onSuccess, onError);
+                    manager.CreateRoom(room, onSuccess, onError);
                 }
             }
 
@@ -466,7 +466,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         public class CreateOrUpdateButton : TriangleButton
         {
             [Resolved(typeof(Room), nameof(Room.RoomID))]
-            private Bindable<long?> roomId { get; set; }
+            private Bindable<long?> roomId { get; set; } = null!;
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -13,7 +12,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -71,9 +69,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             private OsuEnumDropdown<StartMode> startModeDropdown = null!;
             private OsuSpriteText typeLabel = null!;
             private LoadingLayer loadingLayer = null!;
-
-            [Resolved]
-            private BeatmapManager beatmapManager { get; set; } = null!;
 
             public void SelectBeatmap()
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -8,11 +8,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
-using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 
@@ -27,7 +25,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private OngoingOperationTracker operationTracker { get; set; } = null!;
 
         private readonly IBindable<bool> operationInProgress = new Bindable<bool>();
-        private readonly long? itemToEdit;
+        private readonly PlaylistItem? itemToEdit;
 
         private LoadingLayer loadingLayer = null!;
         private IDisposable? selectionOperation;
@@ -37,21 +35,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// </summary>
         /// <param name="room">The room.</param>
         /// <param name="itemToEdit">The item to be edited. May be null, in which case a new item will be added to the playlist.</param>
-        /// <param name="beatmap">An optional initial beatmap selection to perform.</param>
-        /// <param name="ruleset">An optional initial ruleset selection to perform.</param>
-        public MultiplayerMatchSongSelect(Room room, long? itemToEdit = null, WorkingBeatmap? beatmap = null, RulesetInfo? ruleset = null)
-            : base(room)
+        public MultiplayerMatchSongSelect(Room room, PlaylistItem? itemToEdit = null)
+            : base(room, itemToEdit)
         {
             this.itemToEdit = itemToEdit;
-
-            if (beatmap != null || ruleset != null)
-            {
-                Schedule(() =>
-                {
-                    if (beatmap != null) Beatmap.Value = beatmap;
-                    if (ruleset != null) Ruleset.Value = ruleset;
-                });
-            }
         }
 
         [BackgroundDependencyLoader]
@@ -80,7 +67,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             if (operationInProgress.Value)
             {
-                Logger.Log($"{nameof(SelectedItem)} aborted due to {nameof(operationInProgress)}");
+                Logger.Log($"{nameof(SelectItem)} aborted due to {nameof(operationInProgress)}");
                 return false;
             }
 
@@ -92,7 +79,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
                 var multiplayerItem = new MultiplayerPlaylistItem
                 {
-                    ID = itemToEdit ?? 0,
+                    ID = itemToEdit?.ID ?? 0,
                     BeatmapID = item.Beatmap.OnlineID,
                     BeatmapChecksum = item.Beatmap.MD5Hash,
                     RulesetID = item.RulesetID,

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -49,11 +49,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
-        [Resolved]
-        private BeatmapManager beatmapManager { get; set; }
-
-        private readonly IBindable<bool> isConnected = new Bindable<bool>();
-
         private AddItemButton addItemButton;
 
         public MultiplayerMatchSubScreen(Room room)
@@ -227,12 +222,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!this.IsCurrentScreen())
                 return;
 
-            int id = itemToEdit?.Beatmap.OnlineID ?? Room.Playlist.Last().Beatmap.OnlineID;
-            var localBeatmap = beatmapManager.QueryBeatmap(b => b.OnlineID == id);
-
-            var workingBeatmap = localBeatmap == null ? null : beatmapManager.GetWorkingBeatmap(localBeatmap);
-
-            this.Push(new MultiplayerMatchSongSelect(Room, itemToEdit?.ID, workingBeatmap));
+            this.Push(new MultiplayerMatchSongSelect(Room, itemToEdit));
         }
 
         protected override Drawable CreateFooter() => new MultiplayerMatchFooter();
@@ -424,7 +414,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
             }
 
-            this.Push(new MultiplayerMatchSongSelect(Room, client.Room.Settings.PlaylistItemId, beatmap, ruleset));
+            this.Push(new MultiplayerMatchSongSelect(Room, Room.Playlist.Single(item => item.ID == client.Room.Settings.PlaylistItemId)));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -49,11 +49,6 @@ namespace osu.Game.Screens.OnlinePlay
         private readonly PlaylistItem? initialItem;
         private readonly FreeModSelectOverlay freeModSelectOverlay;
 
-        private WorkingBeatmap initialBeatmap = null!;
-        private RulesetInfo initialRuleset = null!;
-        private IReadOnlyList<Mod> initialMods = null!;
-        private bool itemSelected;
-
         private IDisposable? freeModSelectOverlayRegistration;
 
         /// <summary>
@@ -80,12 +75,6 @@ namespace osu.Game.Screens.OnlinePlay
         private void load()
         {
             LeftArea.Padding = new MarginPadding { Top = Header.HEIGHT };
-
-            // Store the initial beatmap/ruleset/mods at the point of entering song select, so they can be reverted to upon exit.
-            initialBeatmap = Beatmap.Value;
-            initialRuleset = Ruleset.Value;
-            initialMods = Mods.Value.ToList();
-
             LoadComponent(freeModSelectOverlay);
         }
 
@@ -152,13 +141,7 @@ namespace osu.Game.Screens.OnlinePlay
                 AllowedMods = FreeMods.Value.Select(m => new APIMod(m)).ToArray()
             };
 
-            if (SelectItem(item))
-            {
-                itemSelected = true;
-                return true;
-            }
-
-            return false;
+            return SelectItem(item);
         }
 
         /// <summary>
@@ -181,15 +164,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         public override bool OnExiting(ScreenExitEvent e)
         {
-            if (!itemSelected)
-            {
-                Beatmap.Value = initialBeatmap;
-                Ruleset.Value = initialRuleset;
-                Mods.Value = initialMods;
-            }
-
             freeModSelectOverlay.Hide();
-
             return base.OnExiting(e);
         }
 

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Humanizer;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -35,32 +33,39 @@ namespace osu.Game.Screens.OnlinePlay
         public override bool AllowEditing => false;
 
         [Resolved(typeof(Room), nameof(Room.Playlist))]
-        protected BindableList<PlaylistItem> Playlist { get; private set; }
-
-        [CanBeNull]
-        [Resolved(CanBeNull = true)]
-        protected IBindable<PlaylistItem> SelectedItem { get; private set; }
+        protected BindableList<PlaylistItem> Playlist { get; private set; } = null!;
 
         [Resolved]
-        private RulesetStore rulesets { get; set; }
+        private RulesetStore rulesets { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
 
         protected override UserActivity InitialActivity => new UserActivity.InLobby(room);
 
         protected readonly Bindable<IReadOnlyList<Mod>> FreeMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         private readonly Room room;
+        private readonly PlaylistItem? initialItem;
+        private readonly FreeModSelectOverlay freeModSelectOverlay;
 
-        private WorkingBeatmap initialBeatmap;
-        private RulesetInfo initialRuleset;
-        private IReadOnlyList<Mod> initialMods;
+        private WorkingBeatmap initialBeatmap = null!;
+        private RulesetInfo initialRuleset = null!;
+        private IReadOnlyList<Mod> initialMods = null!;
         private bool itemSelected;
 
-        private readonly FreeModSelectOverlay freeModSelectOverlay;
-        private IDisposable freeModSelectOverlayRegistration;
+        private IDisposable? freeModSelectOverlayRegistration;
 
-        protected OnlinePlaySongSelect(Room room)
+        /// <summary>
+        /// Creates a new <see cref="OnlinePlaySongSelect"/>.
+        /// </summary>
+        /// <param name="room">The room.</param>
+        /// <param name="initialItem">An optional initial <see cref="PlaylistItem"/> to use for the initial beatmap/ruleset/mods.
+        /// If <c>null</c>, the last <see cref="PlaylistItem"/> in the room will be used.</param>
+        protected OnlinePlaySongSelect(Room room, PlaylistItem? initialItem = null)
         {
             this.room = room;
+            this.initialItem = initialItem ?? room.Playlist.LastOrDefault();
 
             Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING };
 
@@ -76,6 +81,7 @@ namespace osu.Game.Screens.OnlinePlay
         {
             LeftArea.Padding = new MarginPadding { Top = Header.HEIGHT };
 
+            // Store the initial beatmap/ruleset/mods at the point of entering song select, so they can be reverted to upon exit.
             initialBeatmap = Beatmap.Value;
             initialRuleset = Ruleset.Value;
             initialMods = Mods.Value.ToList();
@@ -87,14 +93,35 @@ namespace osu.Game.Screens.OnlinePlay
         {
             base.LoadComplete();
 
-            var rulesetInstance = SelectedItem?.Value?.RulesetID == null ? null : rulesets.GetRuleset(SelectedItem.Value.RulesetID)?.CreateInstance();
-
-            if (rulesetInstance != null)
+            if (initialItem != null)
             {
-                // At this point, Mods contains both the required and allowed mods. For selection purposes, it should only contain the required mods.
-                // Similarly, freeMods is currently empty but should only contain the allowed mods.
-                Mods.Value = SelectedItem.Value.RequiredMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
-                FreeMods.Value = SelectedItem.Value.AllowedMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
+                // Prefer using a local databased beatmap lookup since OnlineId may be -1 for an invalid beatmap selection.
+                BeatmapInfo? beatmapInfo = initialItem.Beatmap as BeatmapInfo;
+
+                // And in the case that this isn't a local databased beatmap, query by online ID.
+                if (beatmapInfo == null)
+                {
+                    int onlineId = initialItem.Beatmap.OnlineID;
+                    beatmapInfo = beatmapManager.QueryBeatmap(b => b.OnlineID == onlineId);
+                }
+
+                if (beatmapInfo != null)
+                    Beatmap.Value = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+
+                RulesetInfo? ruleset = rulesets.GetRuleset(initialItem.RulesetID);
+
+                if (ruleset != null)
+                {
+                    Ruleset.Value = ruleset;
+
+                    var rulesetInstance = ruleset.CreateInstance();
+                    Debug.Assert(rulesetInstance != null);
+
+                    // At this point, Mods contains both the required and allowed mods. For selection purposes, it should only contain the required mods.
+                    // Similarly, freeMods is currently empty but should only contain the allowed mods.
+                    Mods.Value = initialItem.RequiredMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
+                    FreeMods.Value = initialItem.AllowedMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
+                }
             }
 
             Mods.BindValueChanged(onModsChanged);
@@ -199,7 +226,6 @@ namespace osu.Game.Screens.OnlinePlay
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-
             freeModSelectOverlayRegistration?.Dispose();
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Screens;
 using osu.Game.Online.API;


### PR DESCRIPTION
Several things were fixed here that I'll go through below. Selection should feel much better in several ways now.

### [Give OnlinePlaySongSelect a reference PlaylistItem](https://github.com/ppy/osu/commit/2d9db519feb4fb30effe2122b7d6d2258d7671cd)

Previously, the constructor of `MultiplayerMatchSongSelect` took in an optional beatmap and ruleset which served as the initial selection. This was used in https://github.com/ppy/osu/pull/19234 to fix the incorrect beatmap being selected every time song select was opened _from inside the match_ (i.e. editing a playlist item).

But this was quite raw and a lot of work for consumers to do. It also has problems, such as mods are not taken into account.

I've changed this to be a `PlaylistItem` and handled inside `OnlinePlaySongSelect` instead. Passing a `null` value means taking on the last playlist item in the room, which fixes the issue of the beatmap changing when entering song select from the create match overlay.

### [Remove initial selection restoration from OnlinePlaySongSelect](https://github.com/ppy/osu/commit/1f28443cbc025fac19ed6a2ad5c693629f44910a)

This stuff broke at some point, because `itemSelected` is usually set _after_ `this.Exit()` is called from inside overrides of `SelectItem()`. Which means it's always `false` inside `OnExiting()`. The logic is unnecessary anyway since the restoration is handled inside `RoomSubScreen` so I've removed it.

https://github.com/ppy/osu/blob/85ce1bcea9a7911d8769ea7be17b3a6c6378f2ca/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs#L330-L337

### [Fix beatmap set to null after exiting song select](https://github.com/ppy/osu/commit/ba898869cd03a1968937cb282d67d9ff66c17f32)

Following on from the above, the `RoomSubScreen` restoration logic resulted in the dummy beatmap being selected after exiting song select with or without a selection, while the room hadn't yet been created. This is because `SelectedItem.Value` is always null while the room is not yet created.

Other methods inside `RoomSubScreen.OnResuming()` already had appropriate null checks, but it was missing for the beatmap.