### PR TITLE
Fix playlist items showing download button briefly during initial display

### DIFF
--- a/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Beatmaps/TestSceneBeatmapCardDownloadButton.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables.Cards.Buttons;
 using osu.Game.Configuration;
+using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
@@ -58,6 +59,7 @@ namespace osu.Game.Tests.Visual.Beatmaps
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    State = { Value = DownloadState.NotDownloaded },
                     Scale = new Vector2(2)
                 };
             });

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -81,9 +81,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             CreateTest();
 
             AddUntilStep("fail screen displayed", () => Player.ChildrenOfType<FailOverlay>().First().State.Value == Visibility.Visible);
+            AddUntilStep("wait for button clickable", () => Player.ChildrenOfType<SaveFailedScoreButton>().First().ChildrenOfType<OsuClickableContainer>().First().Enabled.Value);
+
             AddUntilStep("score not in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) == null));
             AddStep("click save button", () => Player.ChildrenOfType<SaveFailedScoreButton>().First().ChildrenOfType<OsuClickableContainer>().First().TriggerClick());
-            AddUntilStep("score not in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
+            AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for load", () => downloadButton.IsLoaded);
 
-            AddAssert("state is not downloaded", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            AddAssert("state is unknown", () => downloadButton.State.Value == DownloadState.Unknown);
             AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
         }
 

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/DownloadButton.cs
@@ -17,8 +17,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 {
     public class DownloadButton : BeatmapCardIconButton
     {
-        public IBindable<DownloadState> State => state;
-        private readonly Bindable<DownloadState> state = new Bindable<DownloadState>();
+        public Bindable<DownloadState> State { get; } = new Bindable<DownloadState>();
 
         private readonly APIBeatmapSet beatmapSet;
 
@@ -48,14 +47,19 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
         {
             base.LoadComplete();
             preferNoVideo.BindValueChanged(_ => updateState());
-            state.BindValueChanged(_ => updateState(), true);
+            State.BindValueChanged(_ => updateState(), true);
             FinishTransforms(true);
         }
 
         private void updateState()
         {
-            switch (state.Value)
+            switch (State.Value)
             {
+                case DownloadState.Unknown:
+                    Action = null;
+                    TooltipText = string.Empty;
+                    break;
+
                 case DownloadState.Downloading:
                 case DownloadState.Importing:
                     Action = null;

--- a/osu.Game/Online/DownloadState.cs
+++ b/osu.Game/Online/DownloadState.cs
@@ -5,6 +5,7 @@ namespace osu.Game.Online
 {
     public enum DownloadState
     {
+        Unknown,
         NotDownloaded,
         Downloading,
         Importing,

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -114,6 +114,7 @@ namespace osu.Game.Online.Rooms
 
             switch (downloadTracker.State.Value)
             {
+                case DownloadState.Unknown:
                 case DownloadState.NotDownloaded:
                     availability.Value = BeatmapAvailability.NotDownloaded();
                     break;

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -561,6 +561,10 @@ namespace osu.Game.Screens.OnlinePlay
             {
                 switch (state.NewValue)
                 {
+                    case DownloadState.Unknown:
+                        // Ignore initial state to ensure the button doesn't briefly appear.
+                        break;
+
                     case DownloadState.LocallyAvailable:
                         // Perform a local query of the beatmap by beatmap checksum, and reset the state if not matching.
                         if (beatmapManager.QueryBeatmap(b => b.MD5Hash == beatmap.MD5Hash) == null)

--- a/osu.Game/Screens/Play/SaveFailedScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveFailedScoreButton.cs
@@ -63,8 +63,7 @@ namespace osu.Game.Screens.Play
             if (player != null)
             {
                 importedScore = realm.Run(r => r.Find<ScoreInfo>(player.Score.ScoreInfo.ID)?.Detach());
-                if (importedScore != null)
-                    state.Value = DownloadState.LocallyAvailable;
+                state.Value = importedScore != null ? DownloadState.LocallyAvailable : DownloadState.NotDownloaded;
             }
 
             state.BindValueChanged(state =>


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/191335/189071695-efdedade-4e79-4077-a6c6-54327f7c10b2.mp4

After:

https://user-images.githubusercontent.com/191335/189071498-07d2fb87-13ce-4d77-869f-3cc4fbc05564.mp4

A bit hard to add test coverage for due to timing considerations.

Note that I haven't updated every usage of `DownloadState`. I figure we can add this where required as situations come up (going through each usage immediately is quite involved, as it requires making conscious decisions on the UX in the unknown state). Just wanted to fix this one I noticed in multiplayer as it happens every time for me and is visually distracting.