### PR TITLE
Turn score ids into `ulong`s

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneScoresContainer.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Tests.Visual.Online
             });
         }
 
-        private int onlineID = 1;
+        private ulong onlineID = 1;
 
         private APIScoresCollection createScores()
         {

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -81,12 +81,12 @@ namespace osu.Game.Online.API.Requests.Responses
         public int? LegacyTotalScore { get; set; }
 
         [JsonProperty("legacy_score_id")]
-        public uint? LegacyScoreId { get; set; }
+        public ulong? LegacyScoreId { get; set; }
 
         #region osu-web API additions (not stored to database).
 
         [JsonProperty("id")]
-        public long? ID { get; set; }
+        public ulong? ID { get; set; }
 
         [JsonProperty("user")]
         public APIUser? User { get; set; }
@@ -190,6 +190,6 @@ namespace osu.Game.Online.API.Requests.Responses
             MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
         };
 
-        public long OnlineID => ID ?? -1;
+        public long OnlineID => (long?)ID ?? -1;
     }
 }


### PR DESCRIPTION
Of particular importance, since we're upgrading the highscore tables to `BIGINT`, `LegacyScoreID` needs to be a `ulong` for the highscore importer.

`OnlineID` remains a `long` because uh... yeah. >_<