### PR TITLE
Fix beat sync stopping after returning to menu from a failed play

### DIFF
--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -131,8 +131,8 @@ namespace osu.Game.Beatmaps
                 // Rather than trying to get around this by fixing the framework clock stack, let's work around it for now.
                 Seek(Source.CurrentTime);
             }
-
-            finalClockSource.ProcessFrame();
+            else
+                finalClockSource.ProcessFrame();
         }
 
         public double TotalAppliedOffset

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -121,6 +121,17 @@ namespace osu.Game.Beatmaps
         protected override void Update()
         {
             base.Update();
+
+            if (Source != null && Source is not IAdjustableClock && Source.CurrentTime < finalClockSource.CurrentTime)
+            {
+                // InterpolatingFramedClock won't interpolate backwards unless its source has an ElapsedFrameTime.
+                // See https://github.com/ppy/osu-framework/blob/ba1385330cc501f34937e08257e586c84e35d772/osu.Framework/Timing/InterpolatingFramedClock.cs#L91-L93
+                // This is not always the case here when doing large seeks.
+                // (Of note, this is not an issue if the source is adjustable, as the source is seeked to be in time by DecoupleableInterpolatingFramedClock).
+                // Rather than trying to get around this by fixing the framework clock stack, let's work around it for now.
+                Seek(Source.CurrentTime);
+            }
+
             finalClockSource.ProcessFrame();
         }
 

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Beatmaps
         {
             base.Update();
 
-            if (Source != null && Source is not IAdjustableClock && Source.CurrentTime < finalClockSource.CurrentTime)
+            if (Source != null && Source is not IAdjustableClock && Source.CurrentTime < decoupledClock.CurrentTime)
             {
                 // InterpolatingFramedClock won't interpolate backwards unless its source has an ElapsedFrameTime.
                 // See https://github.com/ppy/osu-framework/blob/ba1385330cc501f34937e08257e586c84e35d772/osu.Framework/Timing/InterpolatingFramedClock.cs#L91-L93

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -390,11 +390,6 @@ namespace osu.Game
             var framedClock = new FramedClock(beatmap.Track);
 
             beatmapClock.ChangeSource(framedClock);
-
-            // Normally the internal decoupled clock will seek the *track* to the decoupled time, but we blocked this.
-            // It won't behave nicely unless we also set it to the track's time.
-            // Probably another thing which should be fixed in the decoupled mess (or just replaced).
-            beatmapClock.Seek(beatmap.Track.CurrentTime);
         }
 
         protected virtual void InitialiseFonts()


### PR DESCRIPTION
Closes #20193.

Explanation is inline comment.