### PR TITLE
Fix countdown serialisation

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerCountdown.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerCountdown.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// Whether only a single instance of this <see cref="MultiplayerCountdown"/> type may be active at any one time.
         /// </summary>
+        [IgnoreMember]
         public virtual bool IsExclusive => true;
     }
 }


### PR DESCRIPTION
Need both `osu` and `osu-server-spectator` redeploys with this change.
```
[multiplayer] 2022-09-11 09:49:15 [verbose]: [user:???] [room:2] Room state changing from Open to WaitingForLoad
fail: Microsoft.AspNetCore.SignalR.HubConnectionContext[6]
      Failed writing message. Aborting connection.
      MessagePack.MessagePackSerializationException: Failed to serialize osu.Game.Online.Multiplayer.Countdown.CountdownStartedEvent value.
       ---> System.TypeInitializationException: The type initializer for 'FormatterCache`1' threw an exception.
       ---> MessagePack.Internal.MessagePackDynamicObjectResolverException: all public members must mark KeyAttribute or IgnoreMemberAttribute. type:osu.Game.Online.Multiplayer.ForceGameplayStartCountdown member:IsExclusive
         at MessagePack.Internal.ObjectSerializationInfo.CreateOrNull(Type type, Boolean forceStringKey, Boolean contractless, Boolean allowPrivate, Boolean dynamicMethod)
         at MessagePack.Internal.DynamicObjectTypeBuilder.BuildType(DynamicAssembly assembly, Type type, Boolean forceStringKey, Boolean contractless)
         at MessagePack.Resolvers.DynamicObjectResolver.FormatterCache`1..cctor()
         --- End of inner exception stack trace ---
```
Root cause is this member was added as an afterthought, and was only tested server-side.