### PR TITLE
Fix new hit distribution graph didn't account for size changes

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -19,14 +20,24 @@ namespace osu.Game.Tests.Visual.Ranking
     public class TestSceneHitEventTimingDistributionGraph : OsuTestScene
     {
         private HitEventTimingDistributionGraph graph = null!;
+        private readonly BindableFloat width = new BindableFloat(600);
+        private readonly BindableFloat height = new BindableFloat(130);
 
         private static readonly HitObject placeholder_object = new HitCircle();
+
+        public TestSceneHitEventTimingDistributionGraph()
+        {
+            width.BindValueChanged(e => graph.Width = e.NewValue);
+            height.BindValueChanged(e => graph.Height = e.NewValue);
+        }
 
         [Test]
         public void TestManyDistributedEvents()
         {
             createTest(CreateDistributedHitEvents());
             AddStep("add adjustment", () => graph.UpdateOffset(10));
+            AddSliderStep("width", 0.0f, 1000.0f, width.Value, width.Set);
+            AddSliderStep("height", 0.0f, 1000.0f, height.Value, height.Set);
         }
 
         [Test]
@@ -137,7 +148,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(600, 130)
+                    Size = new Vector2(width.Value, height.Value)
                 }
             };
         });

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -278,7 +278,10 @@ namespace osu.Game.Screens.Ranking.Statistics
                 updateBasalHeight();
 
                 foreach (var boxOriginal in boxOriginals)
+                {
+                    boxOriginal.Y = 0;
                     boxOriginal.Height = basalHeight;
+                }
 
                 float offsetValue = 0;
 

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -323,7 +323,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             private void updateBasalHeight()
             {
-                float newBasalHeight = DrawHeight == 0 ? 0 : DrawWidth / DrawHeight;
+                float newBasalHeight = DrawHeight > DrawWidth ? DrawWidth / DrawHeight : 1;
 
                 if (newBasalHeight == basalHeight)
                     return;
@@ -353,7 +353,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                 for (int i = 0; i < values.Count; i++)
                 {
-                    boxOriginals[i].Y = offsetForValue(offsetValue) * BoundingBox.Height;
+                    boxOriginals[i].Y = offsetForValue(offsetValue) * DrawHeight;
                     boxOriginals[i].Height = heightForValue(values[i].Value);
                     offsetValue -= values[i].Value;
                 }


### PR DESCRIPTION
Cosmetic bugfix that related to #20143.

The new hit distribution graph depends on the size of the drawing size when rendering, but on the other hand it didn't observe the resizing of the drawing size.
This PR fixes the code to observe the resizing of the drawing size.

base
--
https://user-images.githubusercontent.com/20679825/189546855-f9878159-6ee8-490d-b9f4-956efbbbe2c2.mp4

head
--

https://user-images.githubusercontent.com/20679825/189546944-7b26d66e-016c-40f9-bd76-3a3e83d5a816.mp4



