### PR TITLE
Fix `SongProgress` invalidating too often

### DIFF
--- a/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
@@ -47,7 +47,10 @@ namespace osu.Game.Screens.Play.HUD
             if (clock != null)
                 gameplayClock = clock;
 
-            AutoSizeAxes = Axes.Y;
+            // Lock height so changes in text autosize (if character height changes)
+            // don't cause parent invalidation.
+            Height = 14;
+
             Children = new Drawable[]
             {
                 new Container


### PR DESCRIPTION
This regressed with https://github.com/ppy/osu/pull/19556. Rather than try and figure whether that new container needs to handle size differently, this is a simple solution.

Height was taken from a runtime check (maxes out at about 14.5).

Closes #20235.