### PR TITLE
Fix notification overlay toast tray background absorbing input from behind

### DIFF
--- a/osu.Game/Overlays/NotificationOverlayToastTray.cs
+++ b/osu.Game/Overlays/NotificationOverlayToastTray.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Overlays
     {
         public override bool IsPresent => toastContentBackground.Height > 0 || toastFlow.Count > 0;
 
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => toastFlow.ReceivePositionalInputAt(screenSpacePos);
+
         public bool IsDisplayingToasts => toastFlow.Count > 0;
 
         private FillFlowContainer<Notification> toastFlow = null!;


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![osu!_SzL03kPWgq](https://user-images.githubusercontent.com/35318437/190057859-6e394adf-746b-4f77-ab57-c558993b42c6.gif) | ![osu!_Jc5Ltm0owg](https://user-images.githubusercontent.com/35318437/190057719-5ae79d3f-38d2-41cb-abd8-afd90f4182ff.gif) |