### PR TITLE
Fix local scores potentially not being stable-sorted for leaderboard display

### DIFF
--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -58,7 +58,10 @@ namespace osu.Game.Scoring
         /// <param name="scores">The array of <see cref="ScoreInfo"/>s to reorder.</param>
         /// <returns>The given <paramref name="scores"/> ordered by decreasing total score.</returns>
         public IEnumerable<ScoreInfo> OrderByTotalScore(IEnumerable<ScoreInfo> scores)
-            => scores.OrderByDescending(s => GetTotalScore(s)).ThenBy(s => s.OnlineID);
+            => scores.OrderByDescending(s => GetTotalScore(s))
+                     .ThenBy(s => s.OnlineID)
+                     // Local scores may not have an online ID. Fall back to date in these cases.
+                     .ThenBy(s => s.Date);
 
         /// <summary>
         /// Retrieves a bindable that represents the total score of a <see cref="ScoreInfo"/>.


### PR DESCRIPTION
Noticed in passing.

We probably want test coverage of `ScoreManager`, but seems like a bit of work to setup..

Before:

![osu! 2022-09-14 at 05 29 40](https://user-images.githubusercontent.com/191335/190067140-bfdef4d6-e1ef-4536-b19d-e2d8320e07d8.png)

After:

![osu! 2022-09-14 at 05 27 18](https://user-images.githubusercontent.com/191335/190066858-f54c63e9-e186-42aa-a82b-26de17ca0d9b.png)


Of note, this won't happen in normal lazer-first local score scenarios as the order was already "guaranteed" by the order of insert into realm. But in a case of importing from stable it might be an issue.