### PR TITLE
Update ReSharper CLI to 2022.2.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2022.1.1",
+      "version": "2022.2.3",
       "commands": [
         "jb"
       ]


### PR DESCRIPTION
Should contain a fix for this: https://youtrack.jetbrains.com/issue/RSRP-489541/InspectCode-caches-inconsistent-after-turning-on-NRT