### PR TITLE
Remove nested hit object lifetime entries from playfield when parent hit object is removed or edited

### DIFF
--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -19,13 +19,38 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </summary>
         public IEnumerable<HitObjectLifetimeEntry> AllEntries => entryMap.Values;
 
+        /// <summary>
+        /// Invoked when a new <see cref="HitObjectLifetimeEntry"/> is added to this <see cref="HitObjectEntryManager"/>..
+        /// The second parameter of the event is the parent hit object.
+        /// </summary>
         public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryAdded;
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObjectLifetimeEntry"/> is removed from this <see cref="HitObjectEntryManager"/>.
+        /// The second parameter of the event is the parent hit object.
+        /// </summary>
         public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryRemoved;
 
         private readonly Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry;
 
+        /// <summary>
+        /// Provides the reverse mapping of <see cref="HitObjectLifetimeEntry.HitObject"/> for each entry.
+        /// </summary>
         private readonly Dictionary<HitObject, HitObjectLifetimeEntry> entryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
+
+        /// <summary>
+        /// Stores the parent hit object for entries of the nested hit objects.
+        /// A <c>null</c> is stored for entries of the top-level hit objects.
+        /// </summary>
+        /// <remarks>
+        /// The parent hit object of a pooled hit object may be non-pooled.
+        /// In that case, no corresponding <see cref="HitObjectLifetimeEntry"/> is stored in this <see cref="HitObjectEntryManager"/>.
+        /// </remarks>
         private readonly Dictionary<HitObjectLifetimeEntry, HitObject?> parentMap = new Dictionary<HitObjectLifetimeEntry, HitObject?>();
+
+        /// <summary>
+        /// Stores the list of entries managed by this <see cref="HitObjectEntryManager"/> for each hit object managed by this <see cref="HitObjectEntryManager"/>.
+        /// </summary>
         private readonly Dictionary<HitObject, List<HitObjectLifetimeEntry>> childrenMap = new Dictionary<HitObject, List<HitObjectLifetimeEntry>>();
 
         public HitObjectEntryManager(Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry)

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace osu.Game.Rulesets.Objects.Pooling
+{
+    /// <summary>
+    /// Manages a mapping between <see cref="HitObject"/> and <see cref="HitObjectLifetimeEntry"/>
+    /// </summary>
+    internal class HitObjectEntryManager
+    {
+        /// <summary>
+        /// All entries, including entries of the nested hit objects.
+        /// </summary>
+        public IEnumerable<HitObjectLifetimeEntry> AllEntries => entryMap.Values;
+
+        public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryAdded;
+        public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryRemoved;
+
+        private readonly Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry;
+
+        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> entryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
+        private readonly Dictionary<HitObject, HitObject> parentMap = new Dictionary<HitObject, HitObject>();
+
+        public HitObjectEntryManager(Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry)
+        {
+            this.createLifetimeEntry = createLifetimeEntry;
+        }
+
+        public HitObjectLifetimeEntry Add(HitObject hitObject, HitObject? parentHitObject)
+        {
+            if (parentHitObject != null && !entryMap.TryGetValue(parentHitObject, out var parentEntry))
+                throw new InvalidOperationException($@"The parent {nameof(HitObject)} must be added to this {nameof(HitObjectEntryManager)} before nested {nameof(HitObject)} is added.");
+
+            if (entryMap.ContainsKey(hitObject))
+                throw new InvalidOperationException($@"The {nameof(HitObject)} is already added to this {nameof(HitObjectEntryManager)}.");
+
+            if (parentHitObject != null)
+                parentMap[hitObject] = parentHitObject;
+
+            var entry = createLifetimeEntry(hitObject);
+            entryMap[hitObject] = entry;
+
+            OnEntryAdded?.Invoke(entry, parentHitObject);
+            return entry;
+        }
+
+        public bool Remove(HitObject hitObject)
+        {
+            if (!entryMap.TryGetValue(hitObject, out var entry))
+                return false;
+
+            parentMap.Remove(hitObject, out var parentHitObject);
+
+            OnEntryRemoved?.Invoke(entry, parentHitObject);
+            return true;
+        }
+
+        public bool TryGet(HitObject hitObject, [MaybeNullWhen(false)] out HitObjectLifetimeEntry entry)
+        {
+            return entryMap.TryGetValue(hitObject, out entry);
+        }
+    }
+}

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -20,6 +20,7 @@ using osu.Game.Skinning;
 using osuTK;
 using System.Diagnostics;
 using osu.Framework.Audio.Sample;
+using osu.Game.Rulesets.Objects.Pooling;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -91,6 +92,8 @@ namespace osu.Game.Rulesets.UI
         [Resolved]
         private ISampleStore sampleStore { get; set; }
 
+        private readonly HitObjectEntryManager entryManager;
+
         /// <summary>
         /// Creates a new <see cref="Playfield"/>.
         /// </summary>
@@ -105,6 +108,10 @@ namespace osu.Game.Rulesets.UI
                 h.HitObjectUsageBegan += o => HitObjectUsageBegan?.Invoke(o);
                 h.HitObjectUsageFinished += o => HitObjectUsageFinished?.Invoke(o);
             }));
+
+            entryManager = new HitObjectEntryManager(CreateLifetimeEntry);
+            entryManager.OnEntryAdded += onEntryAdded;
+            entryManager.OnEntryRemoved += onEntryRemoved;
         }
 
         [BackgroundDependencyLoader]
@@ -258,11 +265,7 @@ namespace osu.Game.Rulesets.UI
         /// <param name="hitObject"></param>
         public virtual void Add(HitObject hitObject)
         {
-            var entry = CreateLifetimeEntry(hitObject);
-            lifetimeEntryMap[entry.HitObject] = entry;
-
-            HitObjectContainer.Add(entry);
-            OnHitObjectAdded(entry.HitObject);
+            entryManager.Add(hitObject, null);
         }
 
         /// <summary>
@@ -272,14 +275,23 @@ namespace osu.Game.Rulesets.UI
         /// <returns>Whether the <see cref="HitObject"/> was successfully removed.</returns>
         public virtual bool Remove(HitObject hitObject)
         {
-            if (lifetimeEntryMap.Remove(hitObject, out var entry))
-            {
-                HitObjectContainer.Remove(entry);
-                OnHitObjectRemoved(hitObject);
-                return true;
-            }
+            return entryManager.Remove(hitObject) || nestedPlayfields.Any(p => p.Remove(hitObject));
+        }
 
-            return nestedPlayfields.Any(p => p.Remove(hitObject));
+        private void onEntryAdded(HitObjectLifetimeEntry entry, [CanBeNull] HitObject parentHitObject)
+        {
+            if (parentHitObject != null) return;
+
+            HitObjectContainer.Add(entry);
+            OnHitObjectAdded(entry.HitObject);
+        }
+
+        private void onEntryRemoved(HitObjectLifetimeEntry entry, [CanBeNull] HitObject parentHitObject)
+        {
+            if (parentHitObject != null) return;
+
+            HitObjectContainer.Remove(entry);
+            OnHitObjectRemoved(entry.HitObject);
         }
 
         /// <summary>
@@ -361,8 +373,8 @@ namespace osu.Game.Rulesets.UI
                     }
                 }
 
-                if (!lifetimeEntryMap.TryGetValue(hitObject, out var entry))
-                    lifetimeEntryMap[hitObject] = entry = CreateLifetimeEntry(hitObject);
+                if (!entryManager.TryGet(hitObject, out var entry))
+                    entry = entryManager.Add(hitObject, parent?.HitObject);
 
                 dho.ParentHitObject = parent;
                 dho.Apply(entry);
@@ -412,8 +424,6 @@ namespace osu.Game.Rulesets.UI
         /// </remarks>
         internal event Action<HitObject> HitObjectUsageFinished;
 
-        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> lifetimeEntryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
-
         /// <summary>
         /// Sets whether to keep a given <see cref="HitObject"/> always alive within this or any nested <see cref="Playfield"/>.
         /// </summary>
@@ -421,7 +431,7 @@ namespace osu.Game.Rulesets.UI
         /// <param name="keepAlive">Whether to keep <paramref name="hitObject"/> always alive.</param>
         internal void SetKeepAlive(HitObject hitObject, bool keepAlive)
         {
-            if (lifetimeEntryMap.TryGetValue(hitObject, out var entry))
+            if (entryManager.TryGet(hitObject, out var entry))
             {
                 entry.KeepAlive = keepAlive;
                 return;
@@ -436,7 +446,7 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         internal void KeepAllAlive()
         {
-            foreach (var (_, entry) in lifetimeEntryMap)
+            foreach (var entry in entryManager.AllEntries)
                 entry.KeepAlive = true;
 
             foreach (var p in nestedPlayfields)


### PR DESCRIPTION
Supersedes #11262
Closes #11261