### PR TITLE
Fix editor performance drop over time due to lingering nested object references

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("hit first hitobject", () =>
             {
                 InputManager.Click(MouseButton.Left);
-                return nextObjectEntry.Result.HasResult;
+                return nextObjectEntry.Result?.HasResult == true;
             });
 
             AddAssert("check correct object after hit", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[1]);

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Judgements;
@@ -24,7 +22,7 @@ namespace osu.Game.Rulesets.Objects
         /// The result that <see cref="HitObject"/> was judged with.
         /// This is set by the accompanying <see cref="DrawableHitObject"/>, and reused when required for rewinding.
         /// </summary>
-        internal JudgementResult Result;
+        internal JudgementResult? Result;
 
         private readonly IBindable<double> startTimeBindable = new BindableDouble();
 

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -55,9 +55,11 @@ namespace osu.Game.Rulesets.Objects.Pooling
             if (entryMap.ContainsKey(hitObject))
                 throw new InvalidOperationException($@"The {nameof(HitObjectLifetimeEntry)} is already added to this {nameof(HitObjectEntryManager)}.");
 
+            // Add the entry.
             entryMap[hitObject] = entry;
             childrenMap[hitObject] = new List<HitObjectLifetimeEntry>();
 
+            // If the entry has a parent, set it and add the entry to the parent's children.
             if (parent != null)
             {
                 parentMap[entry] = parent;
@@ -74,14 +76,15 @@ namespace osu.Game.Rulesets.Objects.Pooling
             HitObject hitObject = entry.HitObject;
 
             if (!entryMap.ContainsKey(hitObject))
-                throw new InvalidOperationException($@"The {nameof(HitObjectLifetimeEntry)} is not contained in this {nameof(HitObjectLifetimeEntry)}.");
+                throw new InvalidOperationException($@"The {nameof(HitObjectLifetimeEntry)} is not contained in this {nameof(HitObjectEntryManager)}.");
 
             entryMap.Remove(hitObject);
 
+            // If the entry has a parent, unset it and remove the entry from the parents' children.
             if (parentMap.Remove(entry, out var parent) && childrenMap.TryGetValue(parent, out var parentChildEntries))
                 parentChildEntries.Remove(entry);
 
-            // Remove all entries of the nested hit objects
+            // Remove all the entries' children.
             if (childrenMap.Remove(hitObject, out var childEntries))
             {
                 foreach (var childEntry in childEntries)
@@ -105,9 +108,11 @@ namespace osu.Game.Rulesets.Objects.Pooling
             if (!childrenMap.Remove(hitObject, out var childEntries))
                 return;
 
+            // Remove all the entries' children. At this point the parents' (this entries') children list has been removed from the map, so this does not cause upwards traversal.
             foreach (var entry in childEntries)
                 Remove(entry);
 
+            // The removed children list needs to be added back to the map for the entry to potentially receive children.
             childEntries.Clear();
             childrenMap[hitObject] = childEntries;
         }

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -50,10 +50,11 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
         public void Add(HitObjectLifetimeEntry entry, HitObject? parent)
         {
-            if (parentMap.ContainsKey(entry))
+            HitObject hitObject = entry.HitObject;
+
+            if (entryMap.ContainsKey(hitObject))
                 throw new InvalidOperationException($@"The {nameof(HitObjectLifetimeEntry)} is already added to this {nameof(HitObjectEntryManager)}.");
 
-            var hitObject = entry.HitObject;
             entryMap[hitObject] = entry;
             childrenMap[hitObject] = new List<HitObjectLifetimeEntry>();
 
@@ -70,17 +71,18 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
         public void Remove(HitObjectLifetimeEntry entry)
         {
-            if (!parentMap.ContainsKey(entry))
+            HitObject hitObject = entry.HitObject;
+
+            if (!entryMap.ContainsKey(hitObject))
                 throw new InvalidOperationException($@"The {nameof(HitObjectLifetimeEntry)} is not contained in this {nameof(HitObjectLifetimeEntry)}.");
 
-            var hitObject = entry.HitObject;
             entryMap.Remove(hitObject);
 
             if (parentMap.Remove(entry, out var parent) && childrenMap.TryGetValue(parent, out var parentChildEntries))
                 parentChildEntries.Remove(entry);
 
             // Remove all entries of the nested hit objects
-            if (childrenMap.Remove(entry.HitObject, out var childEntries))
+            if (childrenMap.Remove(hitObject, out var childEntries))
             {
                 foreach (var childEntry in childEntries)
                     Remove(childEntry);

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -19,13 +19,38 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </summary>
         public IEnumerable<HitObjectLifetimeEntry> AllEntries => entryMap.Values;
 
+        /// <summary>
+        /// Invoked when a new <see cref="HitObjectLifetimeEntry"/> is added to this <see cref="HitObjectEntryManager"/>..
+        /// The second parameter of the event is the parent hit object.
+        /// </summary>
         public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryAdded;
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObjectLifetimeEntry"/> is removed from this <see cref="HitObjectEntryManager"/>.
+        /// The second parameter of the event is the parent hit object.
+        /// </summary>
         public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryRemoved;
 
         private readonly Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry;
 
+        /// <summary>
+        /// Provides the reverse mapping of <see cref="HitObjectLifetimeEntry.HitObject"/> for each entry.
+        /// </summary>
         private readonly Dictionary<HitObject, HitObjectLifetimeEntry> entryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
+
+        /// <summary>
+        /// Stores the parent hit object for entries of the nested hit objects.
+        /// A <c>null</c> is stored for entries of the top-level hit objects.
+        /// </summary>
+        /// <remarks>
+        /// The parent hit object of a pooled hit object may be non-pooled.
+        /// In that case, no corresponding <see cref="HitObjectLifetimeEntry"/> is stored in this <see cref="HitObjectEntryManager"/>.
+        /// </remarks>
         private readonly Dictionary<HitObjectLifetimeEntry, HitObject?> parentMap = new Dictionary<HitObjectLifetimeEntry, HitObject?>();
+
+        /// <summary>
+        /// Stores the list of entries managed by this <see cref="HitObjectEntryManager"/> for each hit object managed by this <see cref="HitObjectEntryManager"/>.
+        /// </summary>
         private readonly Dictionary<HitObject, List<HitObjectLifetimeEntry>> childrenMap = new Dictionary<HitObject, List<HitObjectLifetimeEntry>>();
 
         public HitObjectEntryManager(Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry)

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
         private readonly Dictionary<HitObjectLifetimeEntry, HitObject> parentMap = new Dictionary<HitObjectLifetimeEntry, HitObject>();
 
         /// <summary>
-        /// Stores the list of entries managed by this <see cref="HitObjectEntryManager"/> for each hit object managed by this <see cref="HitObjectEntryManager"/>.
+        /// Stores the list of child entries for each hit object managed by this <see cref="HitObjectEntryManager"/>.
         /// </summary>
         private readonly Dictionary<HitObject, List<HitObjectLifetimeEntry>> childrenMap = new Dictionary<HitObject, List<HitObjectLifetimeEntry>>();
 

--- a/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/HitObjectEntryManager.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace osu.Game.Rulesets.Objects.Pooling
+{
+    /// <summary>
+    /// Manages a mapping between <see cref="HitObject"/> and <see cref="HitObjectLifetimeEntry"/>
+    /// </summary>
+    internal class HitObjectEntryManager
+    {
+        /// <summary>
+        /// All entries, including entries of the nested hit objects.
+        /// </summary>
+        public IEnumerable<HitObjectLifetimeEntry> AllEntries => entryMap.Values;
+
+        public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryAdded;
+        public event Action<HitObjectLifetimeEntry, HitObject?>? OnEntryRemoved;
+
+        private readonly Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry;
+
+        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> entryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
+        private readonly Dictionary<HitObject, HitObject> parentMap = new Dictionary<HitObject, HitObject>();
+
+        public HitObjectEntryManager(Func<HitObject, HitObjectLifetimeEntry> createLifetimeEntry)
+        {
+            this.createLifetimeEntry = createLifetimeEntry;
+        }
+
+        public HitObjectLifetimeEntry Add(HitObject hitObject, HitObject? parentHitObject)
+        {
+            if (parentHitObject != null && !entryMap.TryGetValue(parentHitObject, out var parentEntry))
+                throw new InvalidOperationException($@"The parent {nameof(HitObject)} must be added to this {nameof(HitObjectEntryManager)} before nested {nameof(HitObject)} is added.");
+
+            if (entryMap.ContainsKey(hitObject))
+                throw new InvalidOperationException($@"The {nameof(HitObject)} is already added to this {nameof(HitObjectEntryManager)}.");
+
+            if (parentHitObject != null)
+                parentMap[hitObject] = parentHitObject;
+
+            var entry = createLifetimeEntry(hitObject);
+            entryMap[hitObject] = entry;
+
+            OnEntryAdded?.Invoke(entry, parentHitObject);
+            return entry;
+        }
+
+        public bool Remove(HitObject hitObject)
+        {
+            if (!entryMap.TryGetValue(hitObject, out var entry))
+                return false;
+
+            parentMap.Remove(hitObject, out var parentHitObject);
+
+            OnEntryRemoved?.Invoke(entry, parentHitObject);
+            return true;
+        }
+
+        public bool TryGet(HitObject hitObject, [MaybeNullWhen(false)] out HitObjectLifetimeEntry entry)
+        {
+            return entryMap.TryGetValue(hitObject, out entry);
+        }
+    }
+}

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.UI
         [Resolved(CanBeNull = true)]
         private IReadOnlyList<Mod> mods { get; set; }
 
-        private readonly HitObjectEntryManager entryManager;
+        private readonly HitObjectEntryManager entryManager = new HitObjectEntryManager();
 
         /// <summary>
         /// Creates a new <see cref="Playfield"/>.
@@ -112,7 +112,6 @@ namespace osu.Game.Rulesets.UI
                 h.HitObjectUsageFinished += o => HitObjectUsageFinished?.Invoke(o);
             }));
 
-            entryManager = new HitObjectEntryManager(CreateLifetimeEntry);
             entryManager.OnEntryAdded += onEntryAdded;
             entryManager.OnEntryRemoved += onEntryRemoved;
         }
@@ -271,7 +270,8 @@ namespace osu.Game.Rulesets.UI
         /// <param name="hitObject"></param>
         public virtual void Add(HitObject hitObject)
         {
-            entryManager.Add(hitObject, null);
+            var entry = CreateLifetimeEntry(hitObject);
+            entryManager.Add(entry, null);
         }
 
         private void preloadSamples(HitObject hitObject)
@@ -294,7 +294,13 @@ namespace osu.Game.Rulesets.UI
         /// <returns>Whether the <see cref="HitObject"/> was successfully removed.</returns>
         public virtual bool Remove(HitObject hitObject)
         {
-            return entryManager.Remove(hitObject) || nestedPlayfields.Any(p => p.Remove(hitObject));
+            if (entryManager.TryGet(hitObject, out var entry))
+            {
+                entryManager.Remove(entry);
+                return true;
+            }
+
+            return nestedPlayfields.Any(p => p.Remove(hitObject));
         }
 
         private void onEntryAdded(HitObjectLifetimeEntry entry, [CanBeNull] HitObject parentHitObject)
@@ -378,7 +384,10 @@ namespace osu.Game.Rulesets.UI
                 }
 
                 if (!entryManager.TryGet(hitObject, out var entry))
-                    entry = entryManager.Add(hitObject, parent?.HitObject);
+                {
+                    entry = CreateLifetimeEntry(hitObject);
+                    entryManager.Add(entry, parent?.HitObject);
+                }
 
                 dho.ParentHitObject = parent;
                 dho.Apply(entry);


### PR DESCRIPTION
Supersedes #11262
Closes #11261

PRing on behalf of @ekrctb to continue with review (rebased commits from https://github.com/ppy/osu/compare/master...ekrctb:hitobject-entry-nesting?expand=1)
