### PR TITLE
Fix slider rotation causing thousands of new drawables to be created

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             sliderVersion = slider.Path.Version.GetBoundCopy();
 
             // schedule ensure that updates are only applied after all operations from a single frame are applied.
-            // this avoids inadvertently changing the slider path type for bach operations.
+            // this avoids inadvertently changing the slider path type for batch operations.
             sliderVersion.BindValueChanged(_ => Scheduler.AddOnce(() =>
             {
                 cachePoints(slider);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -66,11 +66,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             cachePoints(slider);
 
             sliderVersion = slider.Path.Version.GetBoundCopy();
-            sliderVersion.BindValueChanged(_ =>
+
+            // schedule ensure that updates are only applied after all operations from a single frame are applied.
+            // this avoids inadvertently changing the slider path type for bach operations.
+            sliderVersion.BindValueChanged(_ => Scheduler.AddOnce(() =>
             {
                 cachePoints(slider);
                 updatePathType();
-            });
+            }));
 
             controlPoint.Changed += updateMarkerDisplay;
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -127,16 +127,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     didFlip = true;
 
-                    var controlPoints = slider.Path.ControlPoints.Select(p =>
-                        new PathControlPoint(new Vector2(
-                            (direction == Direction.Horizontal ? -1 : 1) * p.Position.X,
-                            (direction == Direction.Vertical ? -1 : 1) * p.Position.Y
-                        ), p.Type)).ToArray();
-
-                    // Importantly, update as a single operation so automatic adjustment of control points to different
-                    // curve types does not unexpectedly trigger and change the slider's shape.
-                    slider.Path.ControlPoints.Clear();
-                    slider.Path.ControlPoints.AddRange(controlPoints);
+                    foreach (var cp in slider.Path.ControlPoints)
+                    {
+                        cp.Position = new Vector2(
+                            (direction == Direction.Horizontal ? -1 : 1) * cp.Position.X,
+                            (direction == Direction.Vertical ? -1 : 1) * cp.Position.Y
+                        );
+                    }
                 }
             }
 
@@ -186,8 +183,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 if (h is IHasPath path)
                 {
-                    foreach (PathControlPoint t in path.Path.ControlPoints)
-                        t.Position = RotatePointAroundOrigin(t.Position, Vector2.Zero, delta);
+                    foreach (PathControlPoint cp in path.Path.ControlPoints)
+                        cp.Position = RotatePointAroundOrigin(cp.Position, Vector2.Zero, delta);
                 }
             }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -186,13 +186,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 if (h is IHasPath path)
                 {
-                    var controlPoints = path.Path.ControlPoints.Select(p =>
-                        new PathControlPoint(RotatePointAroundOrigin(p.Position, Vector2.Zero, delta), p.Type)).ToArray();
-
-                    // Importantly, update as a single operation so automatic adjustment of control points to different
-                    // curve types does not unexpectedly trigger and change the slider's shape.
-                    path.Path.ControlPoints.Clear();
-                    path.Path.ControlPoints.AddRange(controlPoints);
+                    foreach (PathControlPoint t in path.Path.ControlPoints)
+                        t.Position = RotatePointAroundOrigin(t.Position, Vector2.Zero, delta);
                 }
             }
 


### PR DESCRIPTION
It also avoids much of the `DrawableHitObject` churn, making https://github.com/ppy/osu/pull/20303 and https://github.com/ppy/osu-framework/pull/5409 much less relevant.

Closes #20208.

Of note, I'm still working through more issues I found which can be improved (surrounding mass drawable creation overheads), but this change *avoids* the drawable spam in the first place and thus should be considered a fix for the linked issue.