### PR TITLE
Allow skin transformers to be created for all skins

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -182,7 +182,16 @@ namespace osu.Game.Rulesets.Catch
 
         public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap) => new CatchDifficultyCalculator(RulesetInfo, beatmap);
 
-        public override ISkin CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => new CatchLegacySkinTransformer(skin);
+        public override ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap)
+        {
+            switch (skin)
+            {
+                case LegacySkin:
+                    return new CatchLegacySkinTransformer(skin);
+            }
+
+            return null;
+        }
 
         public override PerformanceCalculator CreatePerformanceCalculator() => new CatchPerformanceCalculator();
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -62,7 +62,16 @@ namespace osu.Game.Rulesets.Mania
 
         public override HitObjectComposer CreateHitObjectComposer() => new ManiaHitObjectComposer(this);
 
-        public override ISkin CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => new ManiaLegacySkinTransformer(skin, beatmap);
+        public override ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap)
+        {
+            switch (skin)
+            {
+                case LegacySkin:
+                    return new ManiaLegacySkinTransformer(skin, beatmap);
+            }
+
+            return null;
+        }
 
         public override IEnumerable<Mod> ConvertFromLegacyMods(LegacyMods mods)
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 var tintingSkin = skinManager.GetSkin(DefaultLegacySkin.CreateInfo());
                 tintingSkin.Configuration.ConfigDictionary["AllowSliderBallTint"] = "1";
 
-                var provider = Ruleset.Value.CreateInstance().CreateLegacySkinProvider(tintingSkin, Beatmap.Value.Beatmap);
+                var provider = Ruleset.Value.CreateInstance().CreateSkinTransformer(tintingSkin, Beatmap.Value.Beatmap);
 
                 Child = new SkinProvidingContainer(provider)
                 {

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -231,7 +231,16 @@ namespace osu.Game.Rulesets.Osu
 
         public override RulesetSettingsSubsection CreateSettings() => new OsuSettingsSubsection(this);
 
-        public override ISkin CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => new OsuLegacySkinTransformer(skin);
+        public override ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap)
+        {
+            switch (skin)
+            {
+                case LegacySkin:
+                    return new OsuLegacySkinTransformer(skin);
+            }
+
+            return null;
+        }
 
         public int LegacyID => 0;
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -43,7 +43,16 @@ namespace osu.Game.Rulesets.Taiko
 
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new TaikoBeatmapConverter(beatmap, this);
 
-        public override ISkin CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => new TaikoLegacySkinTransformer(skin);
+        public override ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap)
+        {
+            switch (skin)
+            {
+                case LegacySkin:
+                    return new TaikoLegacySkinTransformer(skin);
+            }
+
+            return null;
+        }
 
         public const string SHORT_NAME = "taiko";
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private class TestOsuRuleset : OsuRuleset
         {
-            public override ISkin CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => new TestOsuLegacySkinTransformer(skin);
+            public override ISkin CreateSkinTransformer(ISkin skin, IBeatmap beatmap) => new TestOsuLegacySkinTransformer(skin);
 
             private class TestOsuLegacySkinTransformer : OsuLegacySkinTransformer
             {

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -200,7 +200,13 @@ namespace osu.Game.Rulesets
 
         public ModAutoplay? GetAutoplayMod() => CreateMod<ModAutoplay>();
 
-        public virtual ISkin? CreateLegacySkinProvider(ISkin skin, IBeatmap beatmap) => null;
+        /// <summary>
+        /// Create a transformer which adds lookups specific to a ruleset to skin sources.
+        /// </summary>
+        /// <param name="skin">The source skin.</param>
+        /// <param name="beatmap">The current beatmap.</param>
+        /// <returns>A skin with a transformer applied, or null if no transformation is provided by this ruleset.</returns>
+        public virtual ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap) => null;
 
         protected Ruleset()
         {

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Skinning
             Ruleset = ruleset;
             Beatmap = beatmap;
 
-            InternalChild = new BeatmapSkinProvidingContainer(beatmapSkin is LegacySkin ? GetLegacyRulesetTransformedSkin(beatmapSkin) : beatmapSkin)
+            InternalChild = new BeatmapSkinProvidingContainer(beatmapSkin is LegacySkin ? GetRulesetTransformedSkin(beatmapSkin) : beatmapSkin)
             {
                 Child = Content = new Container
                 {
@@ -67,16 +67,16 @@ namespace osu.Game.Skinning
 
             Debug.Assert(ParentSource != null);
 
-            foreach (var skin in ParentSource.AllSources)
+            foreach (var source in ParentSource.AllSources)
             {
-                switch (skin)
+                switch (source)
                 {
-                    case LegacySkin legacySkin:
-                        sources.Add(GetLegacyRulesetTransformedSkin(legacySkin));
+                    case Skin skin:
+                        sources.Add(GetRulesetTransformedSkin(skin));
                         break;
 
                     default:
-                        sources.Add(skin);
+                        sources.Add(source);
                         break;
                 }
             }
@@ -94,16 +94,16 @@ namespace osu.Game.Skinning
             SetSources(sources);
         }
 
-        protected ISkin GetLegacyRulesetTransformedSkin(ISkin legacySkin)
+        protected ISkin GetRulesetTransformedSkin(ISkin skin)
         {
-            if (legacySkin == null)
+            if (skin == null)
                 return null;
 
-            var rulesetTransformed = Ruleset.CreateLegacySkinProvider(legacySkin, Beatmap);
+            var rulesetTransformed = Ruleset.CreateSkinTransformer(skin, Beatmap);
             if (rulesetTransformed != null)
                 return rulesetTransformed;
 
-            return legacySkin;
+            return skin;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Tests.Visual
             ISkin provider = skin;
 
             if (provider is LegacySkin legacyProvider)
-                provider = Ruleset.Value.CreateInstance().CreateLegacySkinProvider(legacyProvider, beatmap);
+                provider = Ruleset.Value.CreateInstance().CreateSkinTransformer(legacyProvider, beatmap);
 
             var children = new Container
             {


### PR DESCRIPTION
Moving towards having multiple default skin implementations, we need a way to have rulesets provide contextually correct elements for more than one default. Until now we've used `SkinnableDrawable`'s `defaultImplementation`, but this only works for a single default.

Going forward usage of that will be phased out, with the potential for it being removed if the triangles skin is moved to be completely provided inside transformers (one per ruleset). That will not be (and doesn't need to be) an immediate focus though.

For an idea of how this works in practice, you can check [my branch](https://github.com/ppy/osu/compare/master...peppy:osu:more-default-skin?expand=1) which adds a new default skin and provides a (very not final) hit circle implementation.

I don't think any rulesets would be using this function, but if there are we can list it as a breaking change.