### PR TITLE
Fix Progress bar info text overlapping with progress graph

### DIFF
--- a/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgressInfo.cs
@@ -47,10 +47,7 @@ namespace osu.Game.Screens.Play.HUD
             if (clock != null)
                 gameplayClock = clock;
 
-            // Lock height so changes in text autosize (if character height changes)
-            // don't cause parent invalidation.
-            Height = 14;
-
+            AutoSizeAxes = Axes.Y;
             Children = new Drawable[]
             {
                 new Container

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
+        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize, InvalidationSource.Self);
         private ScheduledDelegate scheduledCreate;
 
         protected override void Update()

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -78,11 +78,13 @@ namespace osu.Game.Screens.Play
         private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
         private ScheduledDelegate scheduledCreate;
 
+        private Vector2 previousDrawSize;
+
         protected override void Update()
         {
             base.Update();
 
-            if (values != null && !layout.IsValid)
+            if (values != null && !layout.IsValid && DrawSize != previousDrawSize)
             {
                 columns?.FadeOut(500, Easing.OutQuint).Expire();
 
@@ -90,6 +92,7 @@ namespace osu.Game.Screens.Play
                 scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
 
                 layout.Validate();
+                previousDrawSize = DrawSize;
             }
         }
 

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize, InvalidationSource.Self);
+        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
         private ScheduledDelegate scheduledCreate;
 
         protected override void Update()

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Play
 
         private ScheduledDelegate scheduledCreate;
 
-        private bool graphNeedsUpdate = false;
+        private bool graphNeedsUpdate;
 
         private Vector2 previousDrawSize;
 

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -15,7 +15,6 @@ using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Allocation;
-using osu.Framework.Layout;
 using osu.Framework.Threading;
 
 namespace osu.Game.Screens.Play
@@ -23,11 +22,6 @@ namespace osu.Game.Screens.Play
     public class SquareGraph : Container
     {
         private BufferedContainer<Column> columns;
-
-        public SquareGraph()
-        {
-            AddLayout(layout);
-        }
 
         public int ColumnCount => columns?.Children.Count ?? 0;
 
@@ -57,7 +51,7 @@ namespace osu.Game.Screens.Play
                 if (value == values) return;
 
                 values = value;
-                layout.Invalidate();
+                graphNeedsUpdate = true;
             }
         }
 
@@ -75,8 +69,9 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
         private ScheduledDelegate scheduledCreate;
+
+        private bool graphNeedsUpdate = false;
 
         private Vector2 previousDrawSize;
 
@@ -84,15 +79,15 @@ namespace osu.Game.Screens.Play
         {
             base.Update();
 
-            if (values != null && !layout.IsValid && DrawSize != previousDrawSize)
+            if (graphNeedsUpdate || (values != null && DrawSize != previousDrawSize))
             {
                 columns?.FadeOut(500, Easing.OutQuint).Expire();
 
                 scheduledCreate?.Cancel();
                 scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
 
-                layout.Validate();
                 previousDrawSize = DrawSize;
+                graphNeedsUpdate = false;
             }
         }
 


### PR DESCRIPTION
When the progress bar is rotated 90 degrees, the text in the progress bar will overlap with the graph.

![Screenshot (4)](https://user-images.githubusercontent.com/101936124/190399835-79389684-1ace-4c0d-a3f2-0921a2137b65.png)

This overlap is caused by #20265.
This pr is intended to replace #20265 as a solution to #20235.