### PR TITLE
Fix potential startup failures if sqlite cannot be loaded

### DIFF
--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -42,9 +42,16 @@ namespace osu.Game.Beatmaps
 
         public BeatmapUpdaterMetadataLookup(IAPIProvider api, Storage storage)
         {
-            // required to initialise native SQLite libraries on some platforms.
-            Batteries_V2.Init();
-            raw.sqlite3_config(2 /*SQLITE_CONFIG_MULTITHREAD*/);
+            try
+            {
+                // required to initialise native SQLite libraries on some platforms.
+                Batteries_V2.Init();
+                raw.sqlite3_config(2 /*SQLITE_CONFIG_MULTITHREAD*/);
+            }
+            catch
+            {
+                // may fail if platform not supported.
+            }
 
             this.api = api;
             this.storage = storage;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Sentry" Version="3.20.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />
   </ItemGroup>


### PR DESCRIPTION
With the recent library changes, I moved the call to `Batteries.Init`. It turns out that this call *can* fail if the platform is not supported properly.

The library bump adds support for more platforms, including arm64, so seems like a good idea as well.