### PR TITLE
Fix follow point animations in legacy skins not always starting at correct point in time

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
@@ -21,32 +20,36 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         public const int SPACING = 32;
         public const double PREEMPT = 800;
 
-        public DrawablePool<FollowPoint> Pool;
+        public DrawablePool<FollowPoint>? Pool { private get; set; }
 
         protected override void OnApply(FollowPointLifetimeEntry entry)
         {
             base.OnApply(entry);
 
-            entry.Invalidated += onEntryInvalidated;
-            refreshPoints();
+            entry.Invalidated += scheduleRefresh;
+
+            // Our clock may not be correct at this point if `LoadComplete` has not run yet.
+            // Without a schedule, animations referencing FollowPoint's clock (see `IAnimationTimeReference`) would be incorrect on first pool usage.
+            scheduleRefresh();
         }
 
         protected override void OnFree(FollowPointLifetimeEntry entry)
         {
             base.OnFree(entry);
 
-            entry.Invalidated -= onEntryInvalidated;
+            entry.Invalidated -= scheduleRefresh;
             // Return points to the pool.
             ClearInternal(false);
         }
 
-        private void onEntryInvalidated() => Scheduler.AddOnce(refreshPoints);
-
-        private void refreshPoints()
+        private void scheduleRefresh() => Scheduler.AddOnce(() =>
         {
+            Debug.Assert(Pool != null);
+
             ClearInternal(false);
 
             var entry = Entry;
+
             if (entry?.End == null) return;
 
             OsuHitObject start = entry.Start;
@@ -95,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             }
 
             entry.LifetimeEnd = finalTransformEndTime;
-        }
+        });
 
         /// <summary>
         /// Computes the fade time of follow point positioned between two hitobjects.


### PR DESCRIPTION
Closes #20335.

I think we decided that using `Schedule` in these cases is best (and does not add any frame delay due to `LoadComplete`/`Update` being run immediately before first display usage).