### PR TITLE
Fix notification count not always updating when it should

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 displayedCount = new OsuSpriteText()
             };
 
-            notificationOverlay.UnreadCount.ValueChanged += count => { displayedCount.Text = $"displayed count: {count.NewValue}"; };
+            notificationOverlay.UnreadCount.ValueChanged += count => { displayedCount.Text = $"unread count: {count.NewValue}"; };
         });
 
         [Test]
@@ -270,6 +270,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddUntilStep("wait completion", () => notification.State == ProgressNotificationState.Completed);
 
             AddAssert("Completion toast shown", () => notificationOverlay.ToastCount == 1);
+            AddUntilStep("wait forwarded", () => notificationOverlay.ToastCount == 0);
+            AddAssert("only one unread", () => notificationOverlay.UnreadCount.Value == 1);
         }
 
         [Test]

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -210,14 +210,14 @@ namespace osu.Game.Overlays
             mainContent.FadeTo(0, TRANSITION_LENGTH, Easing.OutQuint);
         }
 
-        private void notificationClosed()
+        private void notificationClosed() => Schedule(() =>
         {
             updateCounts();
 
             // this debounce is currently shared between popin/popout sounds, which means one could potentially not play when the user is expecting it.
             // popout is constant across all notification types, and should therefore be handled using playback concurrency instead, but seems broken at the moment.
             playDebouncedSample("UI/overlay-pop-out");
-        }
+        });
 
         private void playDebouncedSample(string sampleName)
         {

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -26,7 +26,8 @@ namespace osu.Game.Overlays.Notifications
     public abstract class Notification : Container
     {
         /// <summary>
-        /// User requested close.
+        /// Notification was closed, either by user or otherwise.
+        /// Importantly, this event may be fired from a non-update thread.
         /// </summary>
         public event Action? Closed;
 
@@ -54,6 +55,8 @@ namespace osu.Game.Overlays.Notifications
         protected NotificationLight Light;
 
         protected Container IconContent;
+
+        public bool WasClosed { get; private set; }
 
         private readonly Container content;
 
@@ -245,21 +248,23 @@ namespace osu.Game.Overlays.Notifications
             initialFlash.FadeOutFromOne(2000, Easing.OutQuart);
         }
 
-        public bool WasClosed;
-
         public virtual void Close(bool runFlingAnimation)
         {
             if (WasClosed) return;
 
             WasClosed = true;
 
-            if (runFlingAnimation && dragContainer.FlingLeft())
-                this.FadeOut(600, Easing.In);
-            else
-                this.FadeOut(100);
-
             Closed?.Invoke();
-            Expire();
+
+            Schedule(() =>
+            {
+                if (runFlingAnimation && dragContainer.FlingLeft())
+                    this.FadeOut(600, Easing.In);
+                else
+                    this.FadeOut(100);
+
+                Expire();
+            });
         }
 
         private class DragContainer : Container

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -141,6 +141,7 @@ namespace osu.Game.Overlays.Notifications
 
                 case ProgressNotificationState.Completed:
                     loadingSpinner.Hide();
+                    attemptPostCompletion();
                     break;
             }
         }

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -141,8 +141,6 @@ namespace osu.Game.Overlays.Notifications
 
                 case ProgressNotificationState.Completed:
                     loadingSpinner.Hide();
-                    attemptPostCompletion();
-                    base.Close(false);
                     break;
             }
         }
@@ -166,6 +164,8 @@ namespace osu.Game.Overlays.Notifications
 
             CompletionTarget.Invoke(CreateCompletionNotification());
             completionSent = true;
+
+            Close(false);
         }
 
         private ProgressNotificationState state;
@@ -239,6 +239,7 @@ namespace osu.Game.Overlays.Notifications
         {
             switch (State)
             {
+                case ProgressNotificationState.Completed:
                 case ProgressNotificationState.Cancelled:
                     base.Close(runFlingAnimation);
                     break;


### PR DESCRIPTION
Part two of fixing progress notifications completing off-screen (ie. while the overlay is hidden) not correctly updating the unread count.

Addresses https://github.com/ppy/osu/discussions/20330