### PR TITLE
Improve tablet error/warning notifications messaging

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.831.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.916.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.922.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1042,7 +1042,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(tablet_prefix, StringComparison.Ordinal))
+                if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(tablet_prefix, StringComparison.OrdinalIgnoreCase))
                     return;
 
                 string message = entry.Message.Replace(tablet_prefix, string.Empty);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1041,7 +1041,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.LoggerName != ITabletHandler.LOGGER_NAME)
+                if (entry.Level < LogLevel.Important || !entry.LoggerName.Equals(ITabletHandler.LOGGER_NAME, StringComparison.OrdinalIgnoreCase))
                     return;
 
                 if (entry.Level == LogLevel.Error)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1041,7 +1041,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || !entry.LoggerName.Equals(ITabletHandler.LOGGER_NAME, StringComparison.OrdinalIgnoreCase))
+                if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(@"[Tablet]", StringComparison.Ordinal))
                     return;
 
                 if (entry.Level == LogLevel.Error)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -188,7 +188,7 @@ namespace osu.Game
         {
             this.args = args;
 
-            forwardRuntimeLogsToNotifications();
+            forwardGeneralLogsToNotifications();
             forwardTabletLogsToNotifications();
 
             SentryLogger = new SentryLogger(this);
@@ -994,7 +994,7 @@ namespace osu.Game
                 overlay.Depth = (float)-Clock.CurrentTime;
         }
 
-        private void forwardRuntimeLogsToNotifications()
+        private void forwardGeneralLogsToNotifications()
         {
             int recentLogCount = 0;
 
@@ -1002,7 +1002,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.Target == null) return;
+                if (entry.Level < LogLevel.Important || entry.Target > LoggingTarget.Database) return;
 
                 const int short_term_display_limit = 3;
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1037,18 +1037,21 @@ namespace osu.Game
 
         private void forwardTabletLogsToNotifications()
         {
+            const string tablet_prefix = @"[Tablet] ";
             bool notifyOnWarning = true;
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(@"[Tablet]", StringComparison.Ordinal))
+                if (entry.Level < LogLevel.Important || entry.Target != LoggingTarget.Input || !entry.Message.StartsWith(tablet_prefix, StringComparison.Ordinal))
                     return;
+
+                string message = entry.Message.Replace(tablet_prefix, string.Empty);
 
                 if (entry.Level == LogLevel.Error)
                 {
                     Schedule(() => Notifications.Post(new SimpleNotification
                     {
-                        Text = $"Encountered tablet error: \"{entry.Message}\"",
+                        Text = $"Encountered tablet error: \"{message}\"",
                         Icon = FontAwesome.Solid.PenSquare,
                         IconColour = Colours.RedDark,
                     }));

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -124,6 +124,8 @@ namespace osu.Game
 
         protected SessionStatics SessionStatics { get; private set; }
 
+        protected OsuColour Colours { get; private set; }
+
         protected BeatmapManager BeatmapManager { get; private set; }
 
         protected BeatmapModelDownloader BeatmapDownloader { get; private set; }
@@ -308,7 +310,7 @@ namespace osu.Game
                 dependencies.CacheAs(powerStatus);
 
             dependencies.Cache(SessionStatics = new SessionStatics());
-            dependencies.Cache(new OsuColour());
+            dependencies.Cache(Colours = new OsuColour());
 
             RegisterImportHandler(BeatmapManager);
             RegisterImportHandler(ScoreManager);

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
@@ -39,6 +40,12 @@ namespace osu.Game.Overlays.Notifications
                 if (iconDrawable != null)
                     iconDrawable.Icon = icon;
             }
+        }
+
+        public ColourInfo IconColour
+        {
+            get => IconContent.Colour;
+            set => IconContent.Colour = value;
         }
 
         private TextFlowContainer? textDrawable;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.15.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.916.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.922.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.831.0" />
     <PackageReference Include="Sentry" Version="3.20.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.916.1" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.922.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.831.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -82,7 +82,7 @@
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.916.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.922.0" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/20324
- [x] Depends on https://github.com/ppy/osu-framework/pull/5421
- [x] Depends on framework bump

Haven't tested this in practice, but should work well.

---

![CleanShot 2022-09-16 at 16 28 39@2x](https://user-images.githubusercontent.com/22781491/190650205-44169900-e688-42ca-8b74-1dcea5daf3ba.png)
