### PR TITLE
Fixed Leaderboard tooltip not following time format setting

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
@@ -15,6 +15,8 @@ using osu.Framework.Localisation;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
 
 namespace osu.Game.Online.Leaderboards
 {
@@ -24,7 +26,7 @@ namespace osu.Game.Online.Leaderboards
         private FillFlowContainer<HitResultCell> topScoreStatistics = null!;
         private FillFlowContainer<HitResultCell> bottomScoreStatistics = null!;
         private FillFlowContainer<ModCell> modStatistics = null!;
-
+        private readonly Bindable<bool> prefer24HourTime = new Bindable<bool>();
         public LeaderboardScoreTooltip()
         {
             AutoSizeAxes = Axes.Both;
@@ -36,8 +38,9 @@ namespace osu.Game.Online.Leaderboards
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, OsuConfigManager configManager)
         {
+            configManager.BindWith(OsuSetting.Prefer24HourTime, prefer24HourTime);
             InternalChildren = new Drawable[]
             {
                 new Box
@@ -92,6 +95,13 @@ namespace osu.Game.Online.Leaderboards
             };
         }
 
+        private void updateDisplay()
+        {
+            if (displayedScore != null)
+            {
+                timestampLabel.Text = prefer24HourTime.Value ? $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy HH:mm}" : $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy h:mm tt}";
+            }
+        }
         private ScoreInfo? displayedScore;
 
         public void SetContent(ScoreInfo score)
@@ -101,7 +111,7 @@ namespace osu.Game.Online.Leaderboards
 
             displayedScore = score;
 
-            timestampLabel.Text = $"Played on {score.Date.ToLocalTime():d MMMM yyyy HH:mm}";
+            prefer24HourTime.BindValueChanged(_ => updateDisplay(), true);
 
             modStatistics.Clear();
             topScoreStatistics.Clear();

--- a/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
@@ -94,13 +94,11 @@ namespace osu.Game.Online.Leaderboards
                 }
             };
         }
-
-        private void updateDisplay()
+        protected override void LoadComplete()
         {
-            if (displayedScore != null)
-            {
-                timestampLabel.Text = prefer24HourTime.Value ? $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy HH:mm}" : $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy h:mm tt}";
-            }
+            base.LoadComplete();
+
+            prefer24HourTime.BindValueChanged(_ => updateTimestampLabel(), true);
         }
         private ScoreInfo? displayedScore;
 
@@ -111,7 +109,7 @@ namespace osu.Game.Online.Leaderboards
 
             displayedScore = score;
 
-            prefer24HourTime.BindValueChanged(_ => updateDisplay(), true);
+            updateTimestampLabel();
 
             modStatistics.Clear();
             topScoreStatistics.Clear();
@@ -128,6 +126,13 @@ namespace osu.Game.Online.Leaderboards
                     bottomScoreStatistics.Add(new HitResultCell(result));
                 else
                     topScoreStatistics.Add(new HitResultCell(result));
+            }
+        }
+        private void updateTimestampLabel()
+        {
+            if (displayedScore != null)
+            {
+                timestampLabel.Text = prefer24HourTime.Value ? $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy HH:mm}" : $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy h:mm tt}";
             }
         }
 

--- a/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Online.Leaderboards
         private FillFlowContainer<HitResultCell> bottomScoreStatistics = null!;
         private FillFlowContainer<ModCell> modStatistics = null!;
         private readonly Bindable<bool> prefer24HourTime = new Bindable<bool>();
+
         public LeaderboardScoreTooltip()
         {
             AutoSizeAxes = Axes.Both;
@@ -94,12 +95,14 @@ namespace osu.Game.Online.Leaderboards
                 }
             };
         }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
             prefer24HourTime.BindValueChanged(_ => updateTimestampLabel(), true);
         }
+
         private ScoreInfo? displayedScore;
 
         public void SetContent(ScoreInfo score)
@@ -128,11 +131,14 @@ namespace osu.Game.Online.Leaderboards
                     topScoreStatistics.Add(new HitResultCell(result));
             }
         }
+
         private void updateTimestampLabel()
         {
             if (displayedScore != null)
             {
-                timestampLabel.Text = prefer24HourTime.Value ? $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy HH:mm}" : $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy h:mm tt}";
+                timestampLabel.Text = prefer24HourTime.Value
+                    ? $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy HH:mm}"
+                    : $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy h:mm tt}";
             }
         }
 


### PR DESCRIPTION
Fixed Leaderboard tooltip not following time format setting

- Old

![old](https://user-images.githubusercontent.com/75315940/190721704-33ccf642-d460-452c-bc64-982fa2df58f6.png)


- Fixed version (if 'Prefer 24-hour time display' is turned off)

![afbeelding](https://user-images.githubusercontent.com/75315940/190721896-a661e508-04a7-48a3-9731-6233162c4603.png)

