### PR TITLE
Rename default skin to make way for new version

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             });
         }
 
-        private class TestSkin : DefaultSkin
+        private class TestSkin : DefaultSkinTriangles
         {
             public bool FlipCatcherPlate { get; set; }
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchSkinConfiguration.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             });
         }
 
-        private class TestSkin : DefaultSkinTriangles
+        private class TestSkin : TrianglesSkin
         {
             public bool FlipCatcherPlate { get; set; }
 

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyHitExplosion.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
         [BackgroundDependencyLoader]
         private void load(SkinManager skins)
         {
-            var defaultLegacySkin = skins.DefaultLegacySkin;
+            var defaultLegacySkin = skins.DefaultClassicSkin;
 
             // sprite names intentionally swapped to match stable member naming / ease of cross-referencing
             explosion1.Texture = defaultLegacySkin.GetTexture("scoreboard-explosion-2");

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Test]
         public void TestDefaultSkin()
         {
-            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = DefaultSkin.CreateInfo().ToLiveUnmanaged());
+            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged());
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaComposeScreen.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Test]
         public void TestDefaultSkin()
         {
-            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged());
+            AddStep("set default skin", () => skins.CurrentSkinInfo.Value = TrianglesSkin.CreateInfo().ToLiveUnmanaged());
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneCursorParticles.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneCursorParticles.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
             AddStep("setup default legacy skin", () =>
             {
-                skinManager.CurrentSkinInfo.Value = skinManager.DefaultLegacySkin.SkinInfo;
+                skinManager.CurrentSkinInfo.Value = skinManager.DefaultClassicSkin.SkinInfo;
             });
         });
     }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             hitCircle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
-            Child = new SkinProvidingContainer(new DefaultSkin(null))
+            Child = new SkinProvidingContainer(new DefaultSkinTriangles(null))
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = drawableHitCircle = new DrawableHitCircle(hitCircle)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             hitCircle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
-            Child = new SkinProvidingContainer(new DefaultSkinTriangles(null))
+            Child = new SkinProvidingContainer(new TrianglesSkin(null))
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = drawableHitCircle = new DrawableHitCircle(hitCircle)

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Skins.IO
             skinManager.CurrentSkinInfo.Value.PerformRead(s =>
             {
                 Assert.IsFalse(s.Protected);
-                Assert.AreEqual(typeof(DefaultSkin), s.CreateInstance(skinManager).GetType());
+                Assert.AreEqual(typeof(DefaultSkinTriangles), s.CreateInstance(skinManager).GetType());
 
                 new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportModelTo(s, exportStream);
 
@@ -215,7 +215,7 @@ namespace osu.Game.Tests.Skins.IO
             {
                 Assert.IsFalse(s.Protected);
                 Assert.AreNotEqual(originalSkinId, s.ID);
-                Assert.AreEqual(typeof(DefaultSkin), s.CreateInstance(skinManager).GetType());
+                Assert.AreEqual(typeof(DefaultSkinTriangles), s.CreateInstance(skinManager).GetType());
             });
 
             return Task.CompletedTask;

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Tests.Skins.IO
         {
             var skinManager = osu.Dependencies.Get<SkinManager>();
 
-            skinManager.CurrentSkinInfo.Value = skinManager.DefaultLegacySkin.SkinInfo;
+            skinManager.CurrentSkinInfo.Value = skinManager.DefaultClassicSkin.SkinInfo;
 
             skinManager.EnsureMutableSkin();
 

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Skins.IO
             skinManager.CurrentSkinInfo.Value.PerformRead(s =>
             {
                 Assert.IsFalse(s.Protected);
-                Assert.AreEqual(typeof(DefaultSkinTriangles), s.CreateInstance(skinManager).GetType());
+                Assert.AreEqual(typeof(TrianglesSkin), s.CreateInstance(skinManager).GetType());
 
                 new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportModelTo(s, exportStream);
 
@@ -215,7 +215,7 @@ namespace osu.Game.Tests.Skins.IO
             {
                 Assert.IsFalse(s.Protected);
                 Assert.AreNotEqual(originalSkinId, s.ID);
-                Assert.AreEqual(typeof(DefaultSkinTriangles), s.CreateInstance(skinManager).GetType());
+                Assert.AreEqual(typeof(TrianglesSkin), s.CreateInstance(skinManager).GetType());
             });
 
             return Task.CompletedTask;

--- a/osu.Game.Tests/Visual/Gameplay/SkinnableHUDComponentTestScene.cs
+++ b/osu.Game.Tests/Visual/Gameplay/SkinnableHUDComponentTestScene.cs
@@ -1,12 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Skinning;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -19,7 +18,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             SetContents(skin =>
             {
-                var implementation = skin != null
+                var implementation = skin is not TrianglesSkin
                     ? CreateLegacyImplementation()
                     : CreateDefaultImplementation();
 

--- a/osu.Game.Tests/Visual/Gameplay/SkinnableHUDComponentTestScene.cs
+++ b/osu.Game.Tests/Visual/Gameplay/SkinnableHUDComponentTestScene.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             SetContents(skin =>
             {
-                var implementation = skin is not TrianglesSkin
+                var implementation = skin is LegacySkin
                     ? CreateLegacyImplementation()
                     : CreateDefaultImplementation();
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestEmptyLegacyBeatmapSkinFallsBack()
         {
-            CreateSkinTest(DefaultSkin.CreateInfo(), () => new LegacyBeatmapSkin(new BeatmapInfo(), null));
+            CreateSkinTest(DefaultSkinTriangles.CreateInfo(), () => new LegacyBeatmapSkin(new BeatmapInfo(), null));
             AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
             AddAssert("hud from default skin", () => AssertComponentsFromExpectedSource(SkinnableTarget.MainHUDComponents, skinManager.CurrentSkin.Value));
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestEmptyLegacyBeatmapSkinFallsBack()
         {
-            CreateSkinTest(DefaultSkinTriangles.CreateInfo(), () => new LegacyBeatmapSkin(new BeatmapInfo(), null));
+            CreateSkinTest(TrianglesSkin.CreateInfo(), () => new LegacyBeatmapSkin(new BeatmapInfo(), null));
             AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
             AddAssert("hud from default skin", () => AssertComponentsFromExpectedSource(SkinnableTarget.MainHUDComponents, skinManager.CurrentSkin.Value));
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneParticleSpewer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneParticleSpewer.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         private TestParticleSpewer createSpewer() =>
-            new TestParticleSpewer(skinManager.DefaultLegacySkin.GetTexture("star2"))
+            new TestParticleSpewer(skinManager.DefaultClassicSkin.GetTexture("star2"))
             {
                 Origin = Anchor.Centre,
                 RelativePositionAxes = Axes.Both,

--- a/osu.Game.Tests/Visual/Navigation/TestSceneEditDefaultSkin.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneEditDefaultSkin.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestEditDefaultSkin()
         {
-            AddAssert("is default skin", () => skinManager.CurrentSkinInfo.Value.ID == SkinInfo.DEFAULT_SKIN);
+            AddAssert("is default skin", () => skinManager.CurrentSkinInfo.Value.ID == SkinInfo.DEFAULT_SKIN_TRIANGLES);
 
             AddStep("open settings", () => { Game.Settings.Show(); });
 
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("open skin editor", () => skinEditor.Show());
 
             // Until step required as the skin editor may take time to load (and an extra scheduled frame for the mutable part).
-            AddUntilStep("is modified default skin", () => skinManager.CurrentSkinInfo.Value.ID != SkinInfo.DEFAULT_SKIN);
+            AddUntilStep("is modified default skin", () => skinManager.CurrentSkinInfo.Value.ID != SkinInfo.DEFAULT_SKIN_TRIANGLES);
             AddAssert("is not protected", () => skinManager.CurrentSkinInfo.Value.PerformRead(s => !s.Protected));
 
             AddUntilStep("export button enabled", () => Game.Settings.ChildrenOfType<SkinSection.ExportSkinButton>().SingleOrDefault()?.Enabled.Value == true);

--- a/osu.Game.Tests/Visual/Navigation/TestSceneEditDefaultSkin.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneEditDefaultSkin.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestEditDefaultSkin()
         {
-            AddAssert("is default skin", () => skinManager.CurrentSkinInfo.Value.ID == SkinInfo.DEFAULT_SKIN_TRIANGLES);
+            AddAssert("is default skin", () => skinManager.CurrentSkinInfo.Value.ID == SkinInfo.TRIANGLES_SKIN);
 
             AddStep("open settings", () => { Game.Settings.Show(); });
 
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("open skin editor", () => skinEditor.Show());
 
             // Until step required as the skin editor may take time to load (and an extra scheduled frame for the mutable part).
-            AddUntilStep("is modified default skin", () => skinManager.CurrentSkinInfo.Value.ID != SkinInfo.DEFAULT_SKIN_TRIANGLES);
+            AddUntilStep("is modified default skin", () => skinManager.CurrentSkinInfo.Value.ID != SkinInfo.TRIANGLES_SKIN);
             AddAssert("is not protected", () => skinManager.CurrentSkinInfo.Value.PerformRead(s => !s.Protected));
 
             AddUntilStep("export button enabled", () => Game.Settings.ChildrenOfType<SkinSection.ExportSkinButton>().SingleOrDefault()?.Enabled.Value == true);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Configuration
         {
             // UI/selection defaults
             SetDefault(OsuSetting.Ruleset, string.Empty);
-            SetDefault(OsuSetting.Skin, SkinInfo.DEFAULT_SKIN.ToString());
+            SetDefault(OsuSetting.Skin, SkinInfo.DEFAULT_SKIN_TRIANGLES.ToString());
 
             SetDefault(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Configuration
         {
             // UI/selection defaults
             SetDefault(OsuSetting.Ruleset, string.Empty);
-            SetDefault(OsuSetting.Skin, SkinInfo.DEFAULT_SKIN_TRIANGLES.ToString());
+            SetDefault(OsuSetting.Skin, SkinInfo.TRIANGLES_SKIN.ToString());
 
             SetDefault(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -69,8 +69,9 @@ namespace osu.Game.Database
         /// 22   2022-07-31    Added ModPreset.
         /// 23   2022-08-01    Added LastLocalUpdate to BeatmapInfo.
         /// 24   2022-08-22    Added MaximumStatistics to ScoreInfo.
+        /// 25   2022-09-18    Remove skins to add with new naming.
         /// </summary>
-        private const int schema_version = 24;
+        private const int schema_version = 25;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -869,6 +870,11 @@ namespace osu.Game.Database
                         });
                     }
 
+                    break;
+
+                case 25:
+                    // Remove the default skins so they can be added back by SkinManager with updated naming.
+                    migration.NewRealm.RemoveRange(migration.NewRealm.All<SkinInfo>().Where(s => s.Protected));
                     break;
             }
         }

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Overlays.Settings.Sections
             // In the future we should change this to properly handle ChangeSet events.
             dropdownItems.Clear();
 
-            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.DEFAULT_SKIN_TRIANGLES).ToLive(realm));
+            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.TRIANGLES_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.CLASSIC_SKIN).ToLive(realm));
 
             dropdownItems.Add(random_skin_info);

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -78,8 +78,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
             realmSubscription = realm.RegisterForNotifications(_ => realm.Realm.All<SkinInfo>()
                                                                          .Where(s => !s.DeletePending)
-                                                                         .OrderByDescending(s => s.Protected) // protected skins should be at the top.
-                                                                         .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
+                                                                         .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
 
             skinDropdown.Current.BindValueChanged(skin =>
             {
@@ -101,14 +100,17 @@ namespace osu.Game.Overlays.Settings.Sections
             if (!sender.Any())
                 return;
 
-            int protectedCount = sender.Count(s => s.Protected);
-
             // For simplicity repopulate the full list.
             // In the future we should change this to properly handle ChangeSet events.
             dropdownItems.Clear();
-            foreach (var skin in sender)
+
+            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.DEFAULT_SKIN_TRIANGLES).ToLive(realm));
+            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.CLASSIC_SKIN).ToLive(realm));
+
+            dropdownItems.Add(random_skin_info);
+
+            foreach (var skin in sender.Where(s => !s.Protected))
                 dropdownItems.Add(skin.ToLive(realm));
-            dropdownItems.Insert(protectedCount, random_skin_info);
 
             Schedule(() => skinDropdown.Items = dropdownItems);
         }

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.Backgrounds
 
                     case BackgroundSource.Skin:
                         // default skins should use the default background rotation, which won't be the case if a SkinBackground is created for them.
-                        if (skin.Value is DefaultSkin || skin.Value is DefaultLegacySkin)
+                        if (skin.Value is DefaultSkinTriangles || skin.Value is DefaultLegacySkin)
                             break;
 
                         newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.Backgrounds
 
                     case BackgroundSource.Skin:
                         // default skins should use the default background rotation, which won't be the case if a SkinBackground is created for them.
-                        if (skin.Value is DefaultSkinTriangles || skin.Value is DefaultLegacySkin)
+                        if (skin.Value is TrianglesSkin || skin.Value is DefaultLegacySkin)
                             break;
 
                         newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Skinning
         public static SkinInfo CreateInfo() => new SkinInfo
         {
             ID = Skinning.SkinInfo.CLASSIC_SKIN, // this is temporary until database storage is decided upon.
-            Name = "osu!classic",
+            Name = "osu! \"classic\" (2013)",
             Creator = "team osu!",
             Protected = true,
             InstantiationInfo = typeof(DefaultLegacySkin).GetInvariantInstantiationInfo()

--- a/osu.Game/Skinning/DefaultSkinTriangles.cs
+++ b/osu.Game/Skinning/DefaultSkinTriangles.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Skinning
         public static SkinInfo CreateInfo() => new SkinInfo
         {
             ID = osu.Game.Skinning.SkinInfo.DEFAULT_SKIN_TRIANGLES,
-            Name = "osu! (triangles)",
+            Name = "osu! \"triangles\" (2017)",
             Creator = "team osu!",
             Protected = true,
             InstantiationInfo = typeof(DefaultSkinTriangles).GetInvariantInstantiationInfo()

--- a/osu.Game/Skinning/DefaultSkinTriangles.cs
+++ b/osu.Game/Skinning/DefaultSkinTriangles.cs
@@ -22,26 +22,26 @@ using osuTK.Graphics;
 
 namespace osu.Game.Skinning
 {
-    public class DefaultSkin : Skin
+    public class DefaultSkinTriangles : Skin
     {
         public static SkinInfo CreateInfo() => new SkinInfo
         {
-            ID = osu.Game.Skinning.SkinInfo.DEFAULT_SKIN,
+            ID = osu.Game.Skinning.SkinInfo.DEFAULT_SKIN_TRIANGLES,
             Name = "osu! (triangles)",
             Creator = "team osu!",
             Protected = true,
-            InstantiationInfo = typeof(DefaultSkin).GetInvariantInstantiationInfo()
+            InstantiationInfo = typeof(DefaultSkinTriangles).GetInvariantInstantiationInfo()
         };
 
         private readonly IStorageResourceProvider resources;
 
-        public DefaultSkin(IStorageResourceProvider resources)
+        public DefaultSkinTriangles(IStorageResourceProvider resources)
             : this(CreateInfo(), resources)
         {
         }
 
         [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
-        public DefaultSkin(SkinInfo skin, IStorageResourceProvider resources)
+        public DefaultSkinTriangles(SkinInfo skin, IStorageResourceProvider resources)
             : base(skin, resources)
         {
             this.resources = resources;

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Skinning
                 }
             }
 
-            int lastDefaultSkinIndex = sources.IndexOf(sources.OfType<DefaultSkin>().LastOrDefault());
+            int lastDefaultSkinIndex = sources.IndexOf(sources.OfType<DefaultSkinTriangles>().LastOrDefault());
 
             // Ruleset resources should be given the ability to override game-wide defaults
             // This is achieved by placing them before the last instance of DefaultSkin.

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Skinning
                 }
             }
 
-            int lastDefaultSkinIndex = sources.IndexOf(sources.OfType<DefaultSkinTriangles>().LastOrDefault());
+            int lastDefaultSkinIndex = sources.IndexOf(sources.OfType<TrianglesSkin>().LastOrDefault());
 
             // Ruleset resources should be given the ability to override game-wide defaults
             // This is achieved by placing them before the last instance of DefaultSkin.

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -232,6 +232,9 @@ namespace osu.Game.Skinning
         {
             skin.SkinInfo.PerformWrite(s =>
             {
+                // Update for safety
+                s.InstantiationInfo = skin.GetType().GetInvariantInstantiationInfo();
+
                 // Serialise out the SkinInfo itself.
                 string skinInfoJson = JsonConvert.SerializeObject(s, new JsonSerializerSettings { Formatting = Formatting.Indented });
 

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Skinning
     [JsonObject(MemberSerialization.OptIn)]
     public class SkinInfo : RealmObject, IHasRealmFiles, IEquatable<SkinInfo>, IHasGuidPrimaryKey, ISoftDelete, IHasNamedFiles
     {
-        internal static readonly Guid DEFAULT_SKIN = new Guid("2991CFD8-2140-469A-BCB9-2EC23FBCE4AD");
+        internal static readonly Guid DEFAULT_SKIN_TRIANGLES = new Guid("2991CFD8-2140-469A-BCB9-2EC23FBCE4AD");
         internal static readonly Guid CLASSIC_SKIN = new Guid("81F02CD3-EEC6-4865-AC23-FAE26A386187");
         internal static readonly Guid RANDOM_SKIN = new Guid("D39DFEFB-477C-4372-B1EA-2BCEA5FB8908");
 

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -47,7 +47,17 @@ namespace osu.Game.Skinning
                 ? typeof(LegacySkin)
                 : Type.GetType(InstantiationInfo).AsNonNull();
 
-            return (Skin)Activator.CreateInstance(type, this, resources);
+            try
+            {
+                return (Skin)Activator.CreateInstance(type, this, resources);
+            }
+            catch
+            {
+                // This defaults to triangles to catch the case where a user has a modified triangles skin.
+                // If we ever add more default skins in the future this will need some kind of proper migration rather than
+                // a single catch.
+                return new DefaultSkinTriangles(this, resources);
+            }
         }
 
         public IList<RealmNamedFileUsage> Files { get; } = null!;

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -53,7 +53,8 @@ namespace osu.Game.Skinning
             }
             catch
             {
-                // This defaults to triangles to catch the case where a user has a modified triangles skin.
+                // Since the class was renamed from "DefaultSkin" to "TrianglesSkin", the instantiation would fail
+                // for user modified skins. This aims to amicably handle that.
                 // If we ever add more default skins in the future this will need some kind of proper migration rather than
                 // a single catch.
                 return new TrianglesSkin(this, resources);

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Skinning
     [JsonObject(MemberSerialization.OptIn)]
     public class SkinInfo : RealmObject, IHasRealmFiles, IEquatable<SkinInfo>, IHasGuidPrimaryKey, ISoftDelete, IHasNamedFiles
     {
-        internal static readonly Guid DEFAULT_SKIN_TRIANGLES = new Guid("2991CFD8-2140-469A-BCB9-2EC23FBCE4AD");
+        internal static readonly Guid TRIANGLES_SKIN = new Guid("2991CFD8-2140-469A-BCB9-2EC23FBCE4AD");
         internal static readonly Guid CLASSIC_SKIN = new Guid("81F02CD3-EEC6-4865-AC23-FAE26A386187");
         internal static readonly Guid RANDOM_SKIN = new Guid("D39DFEFB-477C-4372-B1EA-2BCEA5FB8908");
 
@@ -56,7 +56,7 @@ namespace osu.Game.Skinning
                 // This defaults to triangles to catch the case where a user has a modified triangles skin.
                 // If we ever add more default skins in the future this will need some kind of proper migration rather than
                 // a single catch.
-                return new DefaultSkinTriangles(this, resources);
+                return new TrianglesSkin(this, resources);
             }
         }
 

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.IO;
@@ -45,20 +44,18 @@ namespace osu.Game.Skinning
             var type = string.IsNullOrEmpty(InstantiationInfo)
                 // handle the case of skins imported before InstantiationInfo was added.
                 ? typeof(LegacySkin)
-                : Type.GetType(InstantiationInfo).AsNonNull();
+                : Type.GetType(InstantiationInfo);
 
-            try
+            if (type == null)
             {
-                return (Skin)Activator.CreateInstance(type, this, resources);
-            }
-            catch
-            {
-                // Since the class was renamed from "DefaultSkin" to "TrianglesSkin", the instantiation would fail
+                // Since the class was renamed from "DefaultSkin" to "TrianglesSkin", the type retrieval would fail
                 // for user modified skins. This aims to amicably handle that.
                 // If we ever add more default skins in the future this will need some kind of proper migration rather than
-                // a single catch.
+                // a single fallback.
                 return new TrianglesSkin(this, resources);
             }
+
+            return (Skin)Activator.CreateInstance(type, this, resources);
         }
 
         public IList<RealmNamedFileUsage> Files { get; } = null!;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -59,14 +59,14 @@ namespace osu.Game.Skinning
         private readonly IResourceStore<byte[]> userFiles;
 
         /// <summary>
-        /// The default skin.
+        /// The default "triangles" skin.
         /// </summary>
         public Skin DefaultSkinTriangles { get; }
 
         /// <summary>
-        /// The default legacy skin.
+        /// The default "classic" skin.
         /// </summary>
-        public Skin DefaultLegacySkin { get; }
+        public Skin DefaultClassicSkin { get; }
 
         public SkinManager(Storage storage, RealmAccess realm, GameHost host, IResourceStore<byte[]> resources, AudioManager audio, Scheduler scheduler)
             : base(storage, realm)
@@ -85,7 +85,7 @@ namespace osu.Game.Skinning
 
             var defaultSkins = new[]
             {
-                DefaultLegacySkin = new DefaultLegacySkin(this),
+                DefaultClassicSkin = new DefaultLegacySkin(this),
                 DefaultSkinTriangles = new TrianglesSkin(this),
             };
 
@@ -229,8 +229,8 @@ namespace osu.Game.Skinning
             {
                 yield return CurrentSkin.Value;
 
-                if (CurrentSkin.Value is LegacySkin && CurrentSkin.Value != DefaultLegacySkin)
-                    yield return DefaultLegacySkin;
+                if (CurrentSkin.Value is LegacySkin && CurrentSkin.Value != DefaultClassicSkin)
+                    yield return DefaultClassicSkin;
 
                 if (CurrentSkin.Value != DefaultSkinTriangles)
                     yield return DefaultSkinTriangles;
@@ -310,7 +310,7 @@ namespace osu.Game.Skinning
             if (skinInfo == null)
             {
                 if (guid == SkinInfo.CLASSIC_SKIN)
-                    skinInfo = DefaultLegacySkin.SkinInfo;
+                    skinInfo = DefaultClassicSkin.SkinInfo;
             }
 
             CurrentSkinInfo.Value = skinInfo ?? DefaultSkinTriangles.SkinInfo;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -49,9 +49,9 @@ namespace osu.Game.Skinning
 
         public readonly Bindable<Skin> CurrentSkin = new Bindable<Skin>();
 
-        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged())
+        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(TrianglesSkin.CreateInfo().ToLiveUnmanaged())
         {
-            Default = Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged()
+            Default = TrianglesSkin.CreateInfo().ToLiveUnmanaged()
         };
 
         private readonly SkinImporter skinImporter;
@@ -86,7 +86,7 @@ namespace osu.Game.Skinning
             var defaultSkins = new[]
             {
                 DefaultLegacySkin = new DefaultLegacySkin(this),
-                DefaultSkinTriangles = new DefaultSkinTriangles(this),
+                DefaultSkinTriangles = new TrianglesSkin(this),
             };
 
             // Ensure the default entries are present.
@@ -125,7 +125,7 @@ namespace osu.Game.Skinning
 
                 if (randomChoices.Length == 0)
                 {
-                    CurrentSkinInfo.Value = Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged();
+                    CurrentSkinInfo.Value = TrianglesSkin.CreateInfo().ToLiveUnmanaged();
                     return;
                 }
 
@@ -294,7 +294,7 @@ namespace osu.Game.Skinning
                 Guid currentUserSkin = CurrentSkinInfo.Value.ID;
 
                 if (items.Any(s => s.ID == currentUserSkin))
-                    scheduler.Add(() => CurrentSkinInfo.Value = Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged());
+                    scheduler.Add(() => CurrentSkinInfo.Value = TrianglesSkin.CreateInfo().ToLiveUnmanaged());
 
                 Delete(items.ToList(), silent);
             });

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -49,9 +49,9 @@ namespace osu.Game.Skinning
 
         public readonly Bindable<Skin> CurrentSkin = new Bindable<Skin>();
 
-        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged())
+        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged())
         {
-            Default = Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged()
+            Default = Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged()
         };
 
         private readonly SkinImporter skinImporter;
@@ -61,7 +61,7 @@ namespace osu.Game.Skinning
         /// <summary>
         /// The default skin.
         /// </summary>
-        public Skin DefaultSkin { get; }
+        public Skin DefaultSkinTriangles { get; }
 
         /// <summary>
         /// The default legacy skin.
@@ -86,7 +86,7 @@ namespace osu.Game.Skinning
             var defaultSkins = new[]
             {
                 DefaultLegacySkin = new DefaultLegacySkin(this),
-                DefaultSkin = new DefaultSkin(this),
+                DefaultSkinTriangles = new DefaultSkinTriangles(this),
             };
 
             // Ensure the default entries are present.
@@ -104,7 +104,7 @@ namespace osu.Game.Skinning
                 CurrentSkin.Value = skin.NewValue.PerformRead(GetSkin);
             };
 
-            CurrentSkin.Value = DefaultSkin;
+            CurrentSkin.Value = DefaultSkinTriangles;
             CurrentSkin.ValueChanged += skin =>
             {
                 if (!skin.NewValue.SkinInfo.Equals(CurrentSkinInfo.Value))
@@ -125,7 +125,7 @@ namespace osu.Game.Skinning
 
                 if (randomChoices.Length == 0)
                 {
-                    CurrentSkinInfo.Value = Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged();
+                    CurrentSkinInfo.Value = Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged();
                     return;
                 }
 
@@ -232,8 +232,8 @@ namespace osu.Game.Skinning
                 if (CurrentSkin.Value is LegacySkin && CurrentSkin.Value != DefaultLegacySkin)
                     yield return DefaultLegacySkin;
 
-                if (CurrentSkin.Value != DefaultSkin)
-                    yield return DefaultSkin;
+                if (CurrentSkin.Value != DefaultSkinTriangles)
+                    yield return DefaultSkinTriangles;
             }
         }
 
@@ -294,7 +294,7 @@ namespace osu.Game.Skinning
                 Guid currentUserSkin = CurrentSkinInfo.Value.ID;
 
                 if (items.Any(s => s.ID == currentUserSkin))
-                    scheduler.Add(() => CurrentSkinInfo.Value = Skinning.DefaultSkin.CreateInfo().ToLiveUnmanaged());
+                    scheduler.Add(() => CurrentSkinInfo.Value = Skinning.DefaultSkinTriangles.CreateInfo().ToLiveUnmanaged());
 
                 Delete(items.ToList(), silent);
             });
@@ -313,7 +313,7 @@ namespace osu.Game.Skinning
                     skinInfo = DefaultLegacySkin.SkinInfo;
             }
 
-            CurrentSkinInfo.Value = skinInfo ?? DefaultSkin.SkinInfo;
+            CurrentSkinInfo.Value = skinInfo ?? DefaultSkinTriangles.SkinInfo;
         }
     }
 }

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Skinning
 
                 // Temporarily used to exclude undesirable ISkin implementations
                 static bool isUserSkin(ISkin skin)
-                    => skin.GetType() == typeof(DefaultSkin)
+                    => skin.GetType() == typeof(DefaultSkinTriangles)
                        || skin.GetType() == typeof(DefaultLegacySkin)
                        || skin.GetType() == typeof(LegacySkin);
             }

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Skinning
 
                 // Temporarily used to exclude undesirable ISkin implementations
                 static bool isUserSkin(ISkin skin)
-                    => skin.GetType() == typeof(DefaultSkinTriangles)
+                    => skin.GetType() == typeof(TrianglesSkin)
                        || skin.GetType() == typeof(DefaultLegacySkin)
                        || skin.GetType() == typeof(LegacySkin);
             }

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -22,26 +22,26 @@ using osuTK.Graphics;
 
 namespace osu.Game.Skinning
 {
-    public class DefaultSkinTriangles : Skin
+    public class TrianglesSkin : Skin
     {
         public static SkinInfo CreateInfo() => new SkinInfo
         {
-            ID = osu.Game.Skinning.SkinInfo.DEFAULT_SKIN_TRIANGLES,
+            ID = osu.Game.Skinning.SkinInfo.TRIANGLES_SKIN,
             Name = "osu! \"triangles\" (2017)",
             Creator = "team osu!",
             Protected = true,
-            InstantiationInfo = typeof(DefaultSkinTriangles).GetInvariantInstantiationInfo()
+            InstantiationInfo = typeof(TrianglesSkin).GetInvariantInstantiationInfo()
         };
 
         private readonly IStorageResourceProvider resources;
 
-        public DefaultSkinTriangles(IStorageResourceProvider resources)
+        public TrianglesSkin(IStorageResourceProvider resources)
             : this(CreateInfo(), resources)
         {
         }
 
         [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
-        public DefaultSkinTriangles(SkinInfo skin, IStorageResourceProvider resources)
+        public TrianglesSkin(SkinInfo skin, IStorageResourceProvider resources)
             : base(skin, resources)
         {
             this.resources = resources;

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual
     public abstract class SkinnableTestScene : OsuGridTestScene, IStorageResourceProvider
     {
         private Skin metricsSkin;
-        private Skin defaultSkin;
+        private Skin defaultSkinTriangles;
         private Skin specialSkin;
         private Skin oldSkin;
 
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual
             var dllStore = new DllResourceStore(GetType().Assembly);
 
             metricsSkin = new TestLegacySkin(new SkinInfo { Name = "metrics-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/metrics_skin"), this, true);
-            defaultSkin = new DefaultLegacySkin(this);
+            defaultSkinTriangles = new DefaultLegacySkin(this);
             specialSkin = new TestLegacySkin(new SkinInfo { Name = "special-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/special_skin"), this, true);
             oldSkin = new TestLegacySkin(new SkinInfo { Name = "old-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/old_skin"), this, true);
         }
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual
 
             Cell(0).Child = createProvider(null, creationFunction, beatmap);
             Cell(1).Child = createProvider(metricsSkin, creationFunction, beatmap);
-            Cell(2).Child = createProvider(defaultSkin, creationFunction, beatmap);
+            Cell(2).Child = createProvider(defaultSkinTriangles, creationFunction, beatmap);
             Cell(3).Child = createProvider(specialSkin, creationFunction, beatmap);
             Cell(4).Child = createProvider(oldSkin, creationFunction, beatmap);
         }

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -29,8 +29,9 @@ namespace osu.Game.Tests.Visual
 {
     public abstract class SkinnableTestScene : OsuGridTestScene, IStorageResourceProvider
     {
+        private TrianglesSkin trianglesSkin;
         private Skin metricsSkin;
-        private Skin trianglesSkin;
+        private Skin legacySkin;
         private Skin specialSkin;
         private Skin oldSkin;
 
@@ -47,8 +48,9 @@ namespace osu.Game.Tests.Visual
         {
             var dllStore = new DllResourceStore(GetType().Assembly);
 
+            trianglesSkin = new TrianglesSkin(this);
             metricsSkin = new TestLegacySkin(new SkinInfo { Name = "metrics-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/metrics_skin"), this, true);
-            trianglesSkin = new DefaultLegacySkin(this);
+            legacySkin = new DefaultLegacySkin(this);
             specialSkin = new TestLegacySkin(new SkinInfo { Name = "special-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/special_skin"), this, true);
             oldSkin = new TestLegacySkin(new SkinInfo { Name = "old-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/old_skin"), this, true);
         }
@@ -61,9 +63,9 @@ namespace osu.Game.Tests.Visual
 
             var beatmap = CreateBeatmapForSkinProvider();
 
-            Cell(0).Child = createProvider(null, creationFunction, beatmap);
+            Cell(0).Child = createProvider(trianglesSkin, creationFunction, beatmap);
             Cell(1).Child = createProvider(metricsSkin, creationFunction, beatmap);
-            Cell(2).Child = createProvider(trianglesSkin, creationFunction, beatmap);
+            Cell(2).Child = createProvider(legacySkin, creationFunction, beatmap);
             Cell(3).Child = createProvider(specialSkin, creationFunction, beatmap);
             Cell(4).Child = createProvider(oldSkin, creationFunction, beatmap);
         }

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual
     public abstract class SkinnableTestScene : OsuGridTestScene, IStorageResourceProvider
     {
         private Skin metricsSkin;
-        private Skin defaultSkinTriangles;
+        private Skin trianglesSkin;
         private Skin specialSkin;
         private Skin oldSkin;
 
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual
             var dllStore = new DllResourceStore(GetType().Assembly);
 
             metricsSkin = new TestLegacySkin(new SkinInfo { Name = "metrics-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/metrics_skin"), this, true);
-            defaultSkinTriangles = new DefaultLegacySkin(this);
+            trianglesSkin = new DefaultLegacySkin(this);
             specialSkin = new TestLegacySkin(new SkinInfo { Name = "special-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/special_skin"), this, true);
             oldSkin = new TestLegacySkin(new SkinInfo { Name = "old-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/old_skin"), this, true);
         }
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual
 
             Cell(0).Child = createProvider(null, creationFunction, beatmap);
             Cell(1).Child = createProvider(metricsSkin, creationFunction, beatmap);
-            Cell(2).Child = createProvider(defaultSkinTriangles, creationFunction, beatmap);
+            Cell(2).Child = createProvider(trianglesSkin, creationFunction, beatmap);
             Cell(3).Child = createProvider(specialSkin, creationFunction, beatmap);
             Cell(4).Child = createProvider(oldSkin, creationFunction, beatmap);
         }


### PR DESCRIPTION
This contains the structural changes required to slot in a new version of the default skin.

It should have no functional changes. Of note, as the class name has changed serialised skins will have the wrong name. To keep things simple, this is handled with try-catch and updated accordingly.