### PR TITLE
Fix flashlight shrinking at >100x rather than starting from 100x

### DIFF
--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -132,13 +133,8 @@ namespace osu.Game.Rulesets.Mods
 
                 using (BeginAbsoluteSequence(0))
                 {
-                    foreach (var breakPeriod in Breaks)
+                    foreach (BreakPeriod breakPeriod in Breaks.Where(breakPeriod => breakPeriod.HasEffect && breakPeriod.Duration >= FLASHLIGHT_FADE_DURATION * 2))
                     {
-                        if (!breakPeriod.HasEffect)
-                            continue;
-
-                        if (breakPeriod.Duration < FLASHLIGHT_FADE_DURATION * 2) continue;
-
                         this.Delay(breakPeriod.StartTime + FLASHLIGHT_FADE_DURATION).FadeOutFromOne(FLASHLIGHT_FADE_DURATION);
                         this.Delay(breakPeriod.EndTime - FLASHLIGHT_FADE_DURATION).FadeInFromZero(FLASHLIGHT_FADE_DURATION);
                     }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -148,12 +148,11 @@ namespace osu.Game.Rulesets.Mods
             protected float GetSizeFor(int combo)
             {
                 float size = defaultFlashlightSize * sizeMultiplier;
-                int comboForSize = Math.Min(combo, flashlight_size_decrease_combo_max);
 
-                if (!comboBasedSize)
-                    comboForSize = 0;
+                if (comboBasedSize)
+                    size *= 1 - flashlight_size_decrease_with_combo_multiplier * MathF.Floor(MathF.Min(combo, flashlight_size_decrease_combo_max) / flashlight_size_decrease_combo);
 
-                return size * (1 - flashlight_size_decrease_with_combo_multiplier * MathF.Floor(MathF.Min(comboForSize, flashlight_size_decrease_combo_max) / flashlight_size_decrease_combo));
+                return size;
             }
 
             private Vector2 flashlightPosition;

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -51,11 +50,6 @@ namespace osu.Game.Rulesets.Mods
         where T : HitObject
     {
         public const double FLASHLIGHT_FADE_DURATION = 800;
-
-        private const int flashlight_size_decrease_combo = 100;
-        private const int flashlight_size_decrease_combo_max = 200;
-        private const float flashlight_size_decrease_with_combo_multiplier = 0.1f;
-
         protected readonly BindableInt Combo = new BindableInt();
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
@@ -133,8 +127,13 @@ namespace osu.Game.Rulesets.Mods
 
                 using (BeginAbsoluteSequence(0))
                 {
-                    foreach (var breakPeriod in Breaks.Where(breakPeriod => breakPeriod.HasEffect && breakPeriod.Duration >= FLASHLIGHT_FADE_DURATION * 2))
+                    foreach (var breakPeriod in Breaks)
                     {
+                        if (!breakPeriod.HasEffect)
+                            continue;
+
+                        if (breakPeriod.Duration < FLASHLIGHT_FADE_DURATION * 2) continue;
+
                         this.Delay(breakPeriod.StartTime + FLASHLIGHT_FADE_DURATION).FadeOutFromOne(FLASHLIGHT_FADE_DURATION);
                         this.Delay(breakPeriod.EndTime - FLASHLIGHT_FADE_DURATION).FadeInFromZero(FLASHLIGHT_FADE_DURATION);
                     }
@@ -150,7 +149,12 @@ namespace osu.Game.Rulesets.Mods
                 float size = defaultFlashlightSize * sizeMultiplier;
 
                 if (comboBasedSize)
-                    size *= 1 - flashlight_size_decrease_with_combo_multiplier * MathF.Floor(MathF.Min(combo, flashlight_size_decrease_combo_max) / flashlight_size_decrease_combo);
+                {
+                    if (combo > 200)
+                        size *= 0.8f;
+                    else if (combo > 100)
+                        size *= 0.9f;
+                }
 
                 return size;
             }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -50,6 +50,11 @@ namespace osu.Game.Rulesets.Mods
         where T : HitObject
     {
         public const double FLASHLIGHT_FADE_DURATION = 800;
+
+        private const int flashlight_size_decrease_combo = 100;
+        private const int last_flashlight_size_decrease_combo = 200;
+        private const float decrease_flashlight_with_combo_multiplier = 0.1f;
+
         protected readonly BindableInt Combo = new BindableInt();
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
@@ -147,16 +152,12 @@ namespace osu.Game.Rulesets.Mods
             protected float GetSizeFor(int combo)
             {
                 float size = defaultFlashlightSize * sizeMultiplier;
+                int comboForSize = Math.Min(combo, last_flashlight_size_decrease_combo);
 
-                if (comboBasedSize)
-                {
-                    if (combo > 200)
-                        size *= 0.8f;
-                    else if (combo > 100)
-                        size *= 0.9f;
-                }
+                if (!comboBasedSize)
+                    comboForSize = 0;
 
-                return size;
+                return size * (1 - decrease_flashlight_with_combo_multiplier * MathF.Floor(MathF.Min(comboForSize, last_flashlight_size_decrease_combo) / flashlight_size_decrease_combo));
             }
 
             private Vector2 flashlightPosition;

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -53,8 +53,8 @@ namespace osu.Game.Rulesets.Mods
         public const double FLASHLIGHT_FADE_DURATION = 800;
 
         private const int flashlight_size_decrease_combo = 100;
-        private const int last_flashlight_size_decrease_combo = 200;
-        private const float decrease_flashlight_with_combo_multiplier = 0.1f;
+        private const int flashlight_size_decrease_combo_max = 200;
+        private const float flashlight_size_decrease_with_combo_multiplier = 0.1f;
 
         protected readonly BindableInt Combo = new BindableInt();
 
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Mods
 
                 using (BeginAbsoluteSequence(0))
                 {
-                    foreach (BreakPeriod breakPeriod in Breaks.Where(breakPeriod => breakPeriod.HasEffect && breakPeriod.Duration >= FLASHLIGHT_FADE_DURATION * 2))
+                    foreach (var breakPeriod in Breaks.Where(breakPeriod => breakPeriod.HasEffect && breakPeriod.Duration >= FLASHLIGHT_FADE_DURATION * 2))
                     {
                         this.Delay(breakPeriod.StartTime + FLASHLIGHT_FADE_DURATION).FadeOutFromOne(FLASHLIGHT_FADE_DURATION);
                         this.Delay(breakPeriod.EndTime - FLASHLIGHT_FADE_DURATION).FadeInFromZero(FLASHLIGHT_FADE_DURATION);
@@ -148,12 +148,12 @@ namespace osu.Game.Rulesets.Mods
             protected float GetSizeFor(int combo)
             {
                 float size = defaultFlashlightSize * sizeMultiplier;
-                int comboForSize = Math.Min(combo, last_flashlight_size_decrease_combo);
+                int comboForSize = Math.Min(combo, flashlight_size_decrease_combo_max);
 
                 if (!comboBasedSize)
                     comboForSize = 0;
 
-                return size * (1 - decrease_flashlight_with_combo_multiplier * MathF.Floor(MathF.Min(comboForSize, last_flashlight_size_decrease_combo) / flashlight_size_decrease_combo));
+                return size * (1 - flashlight_size_decrease_with_combo_multiplier * MathF.Floor(MathF.Min(comboForSize, flashlight_size_decrease_combo_max) / flashlight_size_decrease_combo));
             }
 
             private Vector2 flashlightPosition;

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -150,9 +150,9 @@ namespace osu.Game.Rulesets.Mods
 
                 if (comboBasedSize)
                 {
-                    if (combo > 200)
+                    if (combo >= 200)
                         size *= 0.8f;
-                    else if (combo > 100)
+                    else if (combo >= 100)
                         size *= 0.9f;
                 }
 


### PR DESCRIPTION
 fixes when flashlight area shrinking takes place, according to https://osu.ppy.sh/wiki/en/Gameplay/Game_modifier/Flashlight shrinking should happen at 100 and 200 combo, but the if statements were checking for greater than, so the flashlight area shrinking was being delayed by 1 combo