### PR TITLE
Fix multiplayer crashes due to incorrect download state

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
-using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -25,9 +22,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
     {
         private const double fade_time = 50;
 
-        private SpriteIcon icon;
-        private OsuSpriteText text;
-        private ProgressBar progressBar;
+        private SpriteIcon icon = null!;
+        private OsuSpriteText text = null!;
+        private ProgressBar progressBar = null!;
 
         public StateDisplay()
         {
@@ -86,7 +83,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             };
         }
 
-        private OsuColour colours;
+        private OsuColour colours = null!;
 
         public void UpdateStatus(MultiplayerUserState state, BeatmapAvailability availability)
         {
@@ -164,10 +161,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     break;
 
                 case DownloadState.Downloading:
-                    Debug.Assert(availability.DownloadProgress != null);
-
                     progressBar.FadeIn(fade_time);
-                    progressBar.CurrentTime = availability.DownloadProgress.Value;
+                    progressBar.CurrentTime = availability.DownloadProgress ?? 0;
 
                     text.Text = "downloading map";
                     icon.Icon = FontAwesome.Solid.ArrowAltCircleDown;


### PR DESCRIPTION
It should be guaranteed that progress is non-null in this case, but rather than expending effort to find why/where this is not the case (and adding server side verification, which is currently missing), it makes more sense to fallback to a very sane default value.

Closes https://github.com/ppy/osu/issues/20360.