### PR TITLE
Add mod setting `AngleSharpness` to the random mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -120,13 +120,14 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// <param name="flowDirection">Whether the relative angle should be positive or negative.</param>
         private float getRelativeTargetAngle(float targetDistance, float offset, bool flowDirection)
         {
-            // Range 0..1
+            // Range [0.1;1]
             float angleSharpness = AngleSharpness.Value / AngleSharpness.MaxValue;
+            // Range [0;0.9]
             float angleWideness = 1 - angleSharpness;
 
-            // Range: -70..30
+            // Range: [-60;30]
             float customOffsetX = angleSharpness * 100 - 70;
-            // Range: -0.075..0.175
+            // Range: [-0.075;0.15]
             float customOffsetY = angleWideness * 0.25f - 0.075f;
 
             targetDistance += customOffsetX;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -101,7 +101,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private float getRandomOffset(float stdDev)
         {
-            // Range: [0.5;2]
+            // Range: [0.5, 2]
+            // Higher angle sharpness -> lower multiplier
             float customMultiplier = (1.5f * AngleSharpness.MaxValue - AngleSharpness.Value) / (1.5f * AngleSharpness.MaxValue - AngleSharpness.Default);
 
             return OsuHitObjectGenerationUtils.RandomGaussian(random, 0, stdDev * customMultiplier);
@@ -112,14 +113,14 @@ namespace osu.Game.Rulesets.Osu.Mods
         /// <param name="flowDirection">Whether the relative angle should be positive or negative.</param>
         private float getRelativeTargetAngle(float targetDistance, float offset, bool flowDirection)
         {
-            // Range [0.1;1]
+            // Range: [0.1, 1]
             float angleSharpness = AngleSharpness.Value / AngleSharpness.MaxValue;
-            // Range [0;0.9]
+            // Range: [0, 0.9]
             float angleWideness = 1 - angleSharpness;
 
-            // Range: [-60;30]
+            // Range: [-60, 30]
             float customOffsetX = angleSharpness * 100 - 70;
-            // Range: [-0.075;0.15]
+            // Range: [-0.075, 0.15]
             float customOffsetY = angleWideness * 0.25f - 0.075f;
 
             targetDistance += customOffsetX;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -38,16 +38,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             Precision = 0.1f
         };
 
-        [SettingSource("Angle variety", "The amount of variety in how sharp angles are", SettingControlType = typeof(SettingsSlider<float>))]
-        public BindableFloat AngleVariety { get; } = new BindableFloat
-        {
-            Default = 3,
-            Value = 3,
-            MinValue = 0,
-            MaxValue = 10,
-            Precision = 0.1f
-        };
-
         private static readonly float playfield_diagonal = OsuPlayfield.BASE_SIZE.LengthFast;
 
         private Random random = null!;
@@ -111,7 +101,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private float getRandomOffset(float stdDev)
         {
-            float customMultiplier = AngleVariety.Value / AngleVariety.Default;
+            // Range: [0.5;2]
+            float customMultiplier = (1.5f * AngleSharpness.MaxValue - AngleSharpness.Value) / (1.5f * AngleSharpness.MaxValue - AngleSharpness.Default);
+
             return OsuHitObjectGenerationUtils.RandomGaussian(random, 0, stdDev * customMultiplier);
         }
 


### PR DESCRIPTION
After the recent changes in #18769, some people from the community pointed out that the uncomfortable patterns the random mod was generating were the main reason they were using the mod, since it made maps that they thought were boring more engaging to play. This is my attempt to satisfy those players while still keeping the recent changes.

This adds 2 mod settings to the random mod.

- "Angle sharpness" - A higher angle sharpness value means that angles are generally sharper, and vice versa. It does that by adding two offsets to the angle calculation function.
- ~~"Angle variety" - Increases the "randomness" of angles by applying a multiplier to all standard deviations.~~

If those settings are left at default, the mod behaves just like before this PR (after #18769).

I tried to choose the ranges of the settings sliders in a way that makes it feel intuitive and prevents the user from choosing values that completely break the hit object generation.

With those two settings, players have the ability to choose whether they want mostly sharp angles, mostly wide angles or both.

And since graphs are cool, here's visual representation of how the minimum (`1`) and maximum (`10`) values of the `AngleSharpness` setting affect the angle calculation function.
`α(x) ..... Angle between hit objects in rad`
`x ........ Distance between hit objects`
![image](https://user-images.githubusercontent.com/47356629/190932282-fa5b9d52-0717-4443-9281-88232f08816f.png)