### PR TITLE
Adds "notes per second" limits for alternate and single-tap mods

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
@@ -70,10 +71,11 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void Update(Playfield playfield)
         {
-            var hitCircles = playfield.HitObjectContainer.Objects.Select(drawable => drawable.HitObject).OfType<HitCircle>();
-            var hitTimes = hitCircles.Select(ho => ho.StartTime);
-
-            NotesPerSecond = hitTimes.Count(time => time >= playfield.Clock.CurrentTime && time <= playfield.Clock.CurrentTime + 1e3);
+            NotesPerSecond = playfield.HitObjectContainer.Objects.OfType<DrawableHitCircle>().Count(drawable =>
+            {
+                double time = drawable.HitObject.StartTime;
+                return time >= playfield.Clock.CurrentTime && time <= playfield.Clock.CurrentTime + 1e3;
+            });
         }
 
         protected abstract bool CheckValidNewAction(OsuAction action);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -16,6 +18,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => FontAwesome.Solid.Keyboard;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModSingleTap) }).ToArray();
 
-        protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction != action;
+        [SettingSource("Notes per second for alternating", "The minimal number of notes per second that you want to be forced to alternate.")]
+        public IBindable<int> AlternateNotesPerSecond { get; } = new NotesPerSecondSetting();
+
+        protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction != action || NotesPerSecond < AlternateNotesPerSecond.Value;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -14,6 +16,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"You must only use one key!";
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAlternate) }).ToArray();
 
-        protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction == null || LastAcceptedAction == action;
+        [SettingSource("Notes per second for single tap", "The maximum number of notes per second that you want to be forced to single tap.")]
+        public IBindable<int> SingleTapNotesPerSecond { get; } = new NotesPerSecondSetting();
+
+        protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction == null || LastAcceptedAction == action || NotesPerSecond > SingleTapNotesPerSecond.Value;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Notes per second for single tap", "The maximum number of notes per second that you want to be forced to single tap.")]
         public IBindable<int> SingleTapNotesPerSecond { get; } = new NotesPerSecondSetting();
 
-        protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction == null || LastAcceptedAction == action || NotesPerSecond > SingleTapNotesPerSecond.Value;
+        protected override bool CheckValidNewAction(OsuAction action) =>
+            LastAcceptedAction == null || LastAcceptedAction == action || (!SingleTapNotesPerSecond.IsDefault && NotesPerSecond > SingleTapNotesPerSecond.Value);
     }
 }


### PR DESCRIPTION
This pull request aims to bring more customization into alternate and singletap mods.

Sometimes you don't want to be forced to alternate some kind of level of note density or either being forced to single tap some kind of note density too, that's why i am bringing this changes.

I remember someone wrote an issue requesting for this feature (I am not sure though). although it was being requested as a "minimal bpm" setting, i believe notes per second should fit this role better and is more accessible for the average user, but i can change to bpm if required.

Pull request changes
- Customize the minimal number of notes per second that you want to begin being forced to alternate with the alternate mod. 
- Customize the number of notes per second that you want to not be required to singletap with the singletap mod.