### PR TITLE
Adds mod setting `DisableFollowPoints` to the Flashlight mod

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.UI;
+
+namespace osu.Game.Rulesets.Osu.Tests.Mods
+{
+    public class TestSceneOsuModFlashlight : OsuModTestScene
+    {
+        [Test]
+        public void TestDisabledFollowPoints() => CreateModTest(new ModTestData
+        {
+            PassCondition = () => !((OsuPlayfield)Player.DrawableRuleset.Playfield).FollowPoints.IsPresent,
+            Mod = new OsuModFlashlight
+            {
+                DisableFollowPoints = { Value = true }
+            }
+        });
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -13,6 +13,8 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
@@ -49,11 +51,22 @@ namespace osu.Game.Rulesets.Osu.Mods
             Value = true
         };
 
+        [SettingSource("Disable follow points", "Disables follow points for a more rewarding experience.")]
+        public BindableBool DisableFollowPoints { get; } = new BindableBool();
+
         public override float DefaultFlashlightSize => 180;
 
         private OsuFlashlight flashlight = null!;
 
         protected override Flashlight CreateFlashlight() => flashlight = new OsuFlashlight(this);
+
+        public override void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
+        {
+            base.ApplyToDrawableRuleset(drawableRuleset);
+
+            if (DisableFollowPoints.Value)
+                ((OsuPlayfield)drawableRuleset.Playfield).FollowPoints.Hide();
+        }
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {


### PR DESCRIPTION
Based on the discussion brought up by #18905

> Maybe add a subsetting for flashlight that forces follow points off? this allows for players to choose whether they want a harder but more rewarding experience( iirc followpoints are considered for pp ) or an easier one.

This adds the option for this being possible, although the pp part should be discussed by the pp comitee and such, it is still a fun option to play with regardless.