### PR TITLE
Fix mods potentially keeping reference to runtime gameplay elements

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -15,8 +15,10 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
@@ -99,6 +101,37 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
             AddUntilStep("wait for last played to update", () => getLastPlayed() != null);
+        }
+
+        [Test]
+        public void TestModReferenceNotRetained()
+        {
+            AddStep("allow fail", () => allowFail = false);
+
+            Mod[] originalMods = { new OsuModDaycore { SpeedChange = { Value = 0.8 } } };
+            Mod[] playerMods = null!;
+
+            AddStep($"Load player with mods", () => LoadPlayer(originalMods));
+            AddUntilStep("player loaded", () => Player.IsLoaded && Player.Alpha == 1);
+
+            AddStep("get mods at start of gameplay", () => playerMods = Player.Score.ScoreInfo.Mods.ToArray());
+
+            // Player creates new instance of mods during load.
+            AddAssert("player score has copied mods", () => playerMods.First(), () => Is.Not.SameAs(originalMods.First()));
+            AddAssert("player score has matching mods", () => playerMods.First(), () => Is.EqualTo(originalMods.First()));
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+
+            AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
+
+            AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
+
+            // Player creates new instance of mods after gameplay to ensure any runtime references to drawables etc. are not retained.
+            AddAssert("results screen score has copied mods", () => (Player.GetChildScreen() as ResultsScreen)?.Score.Mods.First(), () => Is.Not.SameAs(playerMods.First()));
+            AddAssert("results screen score has matching", () => (Player.GetChildScreen() as ResultsScreen)?.Score.Mods.First(), () => Is.EqualTo(playerMods.First()));
+
+            AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
+            AddUntilStep("databased score has correct mods", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID)).Mods.First(), () => Is.EqualTo(playerMods.First()));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             Mod[] originalMods = { new OsuModDaycore { SpeedChange = { Value = 0.8 } } };
             Mod[] playerMods = null!;
 
-            AddStep($"Load player with mods", () => LoadPlayer(originalMods));
+            AddStep("load player with mods", () => LoadPlayer(originalMods));
             AddUntilStep("player loaded", () => Player.IsLoaded && Player.Alpha == 1);
 
             AddStep("get mods at start of gameplay", () => playerMods = Player.Score.ScoreInfo.Mods.ToArray());

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -137,6 +137,11 @@ namespace osu.Game.Scoring
 
             clone.Statistics = new Dictionary<HitResult, int>(clone.Statistics);
             clone.MaximumStatistics = new Dictionary<HitResult, int>(clone.MaximumStatistics);
+
+            // Ensure we have fresh mods to avoid any references (ie. after gameplay).
+            clone.clearAllMods();
+            clone.ModsJson = ModsJson;
+
             clone.RealmUser = new RealmUser
             {
                 OnlineID = RealmUser.OnlineID,

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -7,7 +7,6 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
@@ -57,7 +56,9 @@ namespace osu.Game.Tests.Visual
 
         protected virtual bool Autoplay => false;
 
-        protected void LoadPlayer()
+        protected void LoadPlayer() => LoadPlayer(Array.Empty<Mod>());
+
+        protected void LoadPlayer(Mod[] mods)
         {
             var ruleset = CreatePlayerRuleset();
             Ruleset.Value = ruleset.RulesetInfo;
@@ -65,20 +66,21 @@ namespace osu.Game.Tests.Visual
             var beatmap = CreateBeatmap(ruleset.RulesetInfo);
 
             Beatmap.Value = CreateWorkingBeatmap(beatmap);
-            SelectedMods.Value = Array.Empty<Mod>();
+
+            SelectedMods.Value = mods;
 
             if (!AllowFail)
             {
                 var noFailMod = ruleset.CreateMod<ModNoFail>();
                 if (noFailMod != null)
-                    SelectedMods.Value = new[] { noFailMod };
+                    SelectedMods.Value = SelectedMods.Value.Append(noFailMod).ToArray();
             }
 
             if (Autoplay)
             {
                 var mod = ruleset.GetAutoplayMod();
                 if (mod != null)
-                    SelectedMods.Value = SelectedMods.Value.Concat(mod.Yield()).ToArray();
+                    SelectedMods.Value = SelectedMods.Value.Append(mod).ToArray();
             }
 
             Player = CreatePlayer(ruleset);


### PR DESCRIPTION
As noticed by smoogipoo during multiplayer match on the weekend.

Fixes:

![unknown](https://user-images.githubusercontent.com/191335/190944586-f0d85558-a848-4013-981b-9a4fd1ae20cb.png)
