### PR TITLE
Add new default "argon" skin

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -58,10 +58,11 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private Drawable testSingle(float circleSize, bool auto = false, double timeOffset = 0, Vector2? positionOffset = null)
         {
-            var drawable = createSingle(circleSize, auto, timeOffset, positionOffset);
-
             var playfield = new TestOsuPlayfield();
-            playfield.Add(drawable);
+
+            for (double t = timeOffset; t < timeOffset + 60000; t += 2000)
+                playfield.Add(createSingle(circleSize, auto, t, positionOffset));
+
             return playfield;
         }
 

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -27,6 +27,7 @@ using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.Scoring;
+using osu.Game.Rulesets.Osu.Skinning.Argon;
 using osu.Game.Rulesets.Osu.Skinning.Legacy;
 using osu.Game.Rulesets.Osu.Statistics;
 using osu.Game.Rulesets.Osu.UI;
@@ -237,6 +238,9 @@ namespace osu.Game.Rulesets.Osu
             {
                 case LegacySkin:
                     return new OsuLegacySkinTransformer(skin);
+
+                case ArgonSkin:
+                    return new OsuArgonSkinTransformer(skin);
             }
 
             return null;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonFollowCircle.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonFollowCircle : FollowCircle
+    {
+        public ArgonFollowCircle()
+        {
+            InternalChild = new CircularContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                BorderThickness = 4,
+                BorderColour = ColourInfo.GradientVertical(Colour4.FromHex("FC618F"), Colour4.FromHex("BB1A41")),
+                Blending = BlendingParameters.Additive,
+                Child = new Box
+                {
+                    Colour = ColourInfo.GradientVertical(Colour4.FromHex("FC618F"), Colour4.FromHex("BB1A41")),
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.3f,
+                }
+            };
+        }
+
+        protected override void OnSliderPress()
+        {
+            const float duration = 300f;
+
+            if (Precision.AlmostEquals(0, Alpha))
+                this.ScaleTo(1);
+
+            this.ScaleTo(DrawableSliderBall.FOLLOW_AREA, duration, Easing.OutQuint)
+                .FadeIn(duration, Easing.OutQuint);
+        }
+
+        protected override void OnSliderRelease()
+        {
+            const float duration = 150;
+
+            this.ScaleTo(DrawableSliderBall.FOLLOW_AREA * 1.2f, duration, Easing.OutQuint)
+                .FadeTo(0, duration, Easing.OutQuint);
+        }
+
+        protected override void OnSliderEnd()
+        {
+            const float duration = 300;
+
+            this.ScaleTo(1, duration, Easing.OutQuint)
+                .FadeOut(duration / 2, Easing.OutQuint);
+        }
+
+        protected override void OnSliderTick()
+        {
+            this.ScaleTo(DrawableSliderBall.FOLLOW_AREA * 1.08f, 40, Easing.OutQuint)
+                .Then()
+                .ScaleTo(DrawableSliderBall.FOLLOW_AREA, 200f, Easing.OutQuint);
+        }
+
+        protected override void OnSliderBreak()
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonJudgementPiece : CompositeDrawable, IAnimatableJudgement
+    {
+        protected readonly HitResult Result;
+
+        protected SpriteText JudgementText { get; private set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public ArgonJudgementPiece(HitResult result)
+        {
+            Result = result;
+            Origin = Anchor.Centre;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                JudgementText = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = Result.GetDescription().ToUpperInvariant(),
+                    Colour = colours.ForHitResult(Result),
+                    Spacing = new Vector2(5, 0),
+                    Font = OsuFont.Default.With(size: 20, weight: FontWeight.Bold),
+                }
+            };
+        }
+
+        /// <summary>
+        /// Plays the default animation for this judgement piece.
+        /// </summary>
+        /// <remarks>
+        /// The base implementation only handles fade (for all result types) and misses.
+        /// Individual rulesets are recommended to implement their appropriate hit animations.
+        /// </remarks>
+        public virtual void PlayAnimation()
+        {
+            switch (Result)
+            {
+                default:
+                    JudgementText
+                        .ScaleTo(Vector2.One)
+                        .ScaleTo(new Vector2(1.2f), 1800, Easing.OutQuint);
+                    break;
+
+                case HitResult.Miss:
+                    this.ScaleTo(1.6f);
+                    this.ScaleTo(1, 100, Easing.In);
+
+                    this.MoveTo(Vector2.Zero);
+                    this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                    this.RotateTo(0);
+                    this.RotateTo(40, 800, Easing.InQuint);
+                    break;
+            }
+
+            this.FadeOutFromOne(800);
+        }
+
+        public Drawable? GetAboveHitObjectsProxiedContent() => null;
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -1,0 +1,157 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Skinning.Default;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonMainCirclePiece : CompositeDrawable
+    {
+        private readonly Circle outerFill;
+        private readonly Circle outerGradient;
+        private readonly Circle innerGradient;
+        private readonly Circle innerFill;
+
+        private readonly RingPiece ring;
+        private readonly OsuSpriteText number;
+
+        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
+        private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
+
+        [Resolved]
+        private DrawableHitObject drawableObject { get; set; } = null!;
+
+        public ArgonMainCirclePiece()
+        {
+            Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
+
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            const float border_thickness = 7;
+            const float fill_thickness = 24;
+
+            InternalChildren = new Drawable[]
+            {
+                outerFill = new Circle // renders white outer border and dark fill
+                {
+                    Size = Size,
+                    Alpha = 1,
+                },
+                outerGradient = new Circle // renders the outer bright gradient
+                {
+                    Size = outerFill.Size - new Vector2(border_thickness * 3),
+                    Alpha = 1,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                innerGradient = new Circle // renders the inner bright gradient
+                {
+                    Size = outerGradient.Size - new Vector2(fill_thickness),
+                    Alpha = 1,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                innerFill = new Circle // renders the inner dark fill
+                {
+                    Size = innerGradient.Size - new Vector2(fill_thickness),
+                    Alpha = 1,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                number = new OsuSpriteText
+                {
+                    Font = OsuFont.Default.With(size: 52, weight: FontWeight.Bold),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Y = -2,
+                    Text = @"1",
+                },
+                ring = new RingPiece(border_thickness),
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
+
+            accentColour.BindTo(drawableObject.AccentColour);
+            indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            accentColour.BindValueChanged(colour =>
+            {
+                outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
+                outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
+                innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
+            }, true);
+
+            indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
+
+            drawableObject.ApplyCustomUpdateState += updateStateTransforms;
+            updateStateTransforms(drawableObject, drawableObject.State.Value);
+        }
+
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
+        {
+            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+            {
+                switch (state)
+                {
+                    case ArmedState.Hit:
+                        const double fade_out_time = 600;
+                        const double flash_in = 200;
+
+                        number.FadeOut(flash_in / 4);
+
+                        outerGradient.ResizeTo(Size, fade_out_time / 2, Easing.OutQuint);
+                        outerGradient.FadeOut(flash_in);
+
+                        innerGradient.ResizeTo(Size, fade_out_time * 2, Easing.OutQuint);
+                        innerGradient.FadeOut(flash_in);
+
+                        innerFill.ResizeTo(Size, fade_out_time * 1.5, Easing.OutQuint);
+                        innerFill.FadeOut(flash_in);
+
+                        outerFill.FadeOut(flash_in);
+
+                        ring.ResizeTo(Size + new Vector2(ring.BorderThickness * 1.5f), fade_out_time / 1.5f, Easing.OutQuint);
+                        ring.FadeOut(fade_out_time);
+
+                        using (BeginDelayedSequence(flash_in))
+                            this.FadeOut(fade_out_time, Easing.OutQuint);
+
+                        break;
+                }
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableObject.IsNotNull())
+                drawableObject.ApplyCustomUpdateState -= updateStateTransforms;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -23,7 +23,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public class ArgonMainCirclePiece : CompositeDrawable
     {
-        private readonly Circle outerFill;
+        public const float BORDER_THICKNESS = 7;
+
+        public const float OUTER_GRADIENT_SIZE = OsuHitObject.OBJECT_RADIUS * 2 - BORDER_THICKNESS * 3;
+
         private readonly Circle outerGradient;
         private readonly Circle innerGradient;
         private readonly Circle innerFill;
@@ -45,33 +48,27 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            const float border_thickness = 7;
             const float fill_thickness = 24;
 
             InternalChildren = new Drawable[]
             {
-                outerFill = new Circle // renders white outer border and dark fill
-                {
-                    Size = Size,
-                    Alpha = 1,
-                },
                 outerGradient = new Circle // renders the outer bright gradient
                 {
-                    Size = outerFill.Size - new Vector2(border_thickness * 3),
+                    Size = new Vector2(OUTER_GRADIENT_SIZE),
                     Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
                 innerGradient = new Circle // renders the inner bright gradient
                 {
-                    Size = outerGradient.Size - new Vector2(fill_thickness),
+                    Size = new Vector2(OUTER_GRADIENT_SIZE - fill_thickness),
                     Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
                 innerFill = new Circle // renders the inner dark fill
                 {
-                    Size = innerGradient.Size - new Vector2(fill_thickness),
+                    Size = new Vector2(OUTER_GRADIENT_SIZE - 2 * fill_thickness),
                     Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -85,7 +82,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     Text = @"1",
                 },
                 flash = new FlashPiece(),
-                border = new RingPiece(border_thickness),
+                border = new RingPiece(BORDER_THICKNESS),
             };
         }
 
@@ -104,7 +101,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             accentColour.BindValueChanged(colour =>
             {
-                outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
+                innerFill.Colour = colour.NewValue.Darken(4);
                 outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
                 innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
                 flash.Colour = colour.NewValue;
@@ -137,7 +134,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         // The fill layers add too much noise during the explosion animation.
                         // They will be hidden by the additive effects anyway.
-                        outerFill.FadeOut(flash_in_duration, Easing.OutQuint);
                         innerFill.FadeOut(flash_in_duration, Easing.OutQuint);
 
                         // The inner-most gradient should actually be resizing, but is only visible for

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -23,9 +23,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public class ArgonMainCirclePiece : CompositeDrawable
     {
-        public const float BORDER_THICKNESS = 7;
+        public const float BORDER_THICKNESS = (OsuHitObject.OBJECT_RADIUS * 2) * (2f / 58);
 
-        public const float OUTER_GRADIENT_SIZE = OsuHitObject.OBJECT_RADIUS * 2 - BORDER_THICKNESS * 3;
+        public const float GRADIENT_THICKNESS = BORDER_THICKNESS * 2.5f;
+
+        public const float OUTER_GRADIENT_SIZE = (OsuHitObject.OBJECT_RADIUS * 2) - BORDER_THICKNESS * 4;
+
+        public const float INNER_GRADIENT_SIZE = OUTER_GRADIENT_SIZE - GRADIENT_THICKNESS * 2;
+        public const float INNER_FILL_SIZE = INNER_GRADIENT_SIZE - GRADIENT_THICKNESS * 2;
 
         private readonly Circle outerFill;
         private readonly Circle outerGradient;
@@ -49,8 +54,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            const float fill_thickness = 24;
-
             InternalChildren = new Drawable[]
             {
                 outerFill = new Circle // renders white outer border and dark fill
@@ -67,14 +70,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 },
                 innerGradient = new Circle // renders the inner bright gradient
                 {
-                    Size = new Vector2(OUTER_GRADIENT_SIZE - fill_thickness),
+                    Size = new Vector2(INNER_GRADIENT_SIZE),
                     Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
                 innerFill = new Circle // renders the inner dark fill
                 {
-                    Size = new Vector2(OUTER_GRADIENT_SIZE - 2 * fill_thickness),
+                    Size = new Vector2(INNER_FILL_SIZE),
                     Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         public const float OUTER_GRADIENT_SIZE = OsuHitObject.OBJECT_RADIUS * 2 - BORDER_THICKNESS * 3;
 
+        private readonly Circle outerFill;
         private readonly Circle outerGradient;
         private readonly Circle innerGradient;
         private readonly Circle innerFill;
@@ -41,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         [Resolved]
         private DrawableHitObject drawableObject { get; set; } = null!;
 
-        public ArgonMainCirclePiece()
+        public ArgonMainCirclePiece(bool withOuterFill)
         {
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
@@ -52,6 +53,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             InternalChildren = new Drawable[]
             {
+                outerFill = new Circle // renders white outer border and dark fill
+                {
+                    Size = Size,
+                    Alpha = withOuterFill ? 1 : 0,
+                },
                 outerGradient = new Circle // renders the outer bright gradient
                 {
                     Size = new Vector2(OUTER_GRADIENT_SIZE),
@@ -101,7 +107,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             accentColour.BindValueChanged(colour =>
             {
-                innerFill.Colour = colour.NewValue.Darken(4);
+                outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
                 outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
                 innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
                 flash.Colour = colour.NewValue;
@@ -134,6 +140,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         // The fill layers add too much noise during the explosion animation.
                         // They will be hidden by the additive effects anyway.
+                        outerFill.FadeOut(flash_in_duration, Easing.OutQuint);
                         innerFill.FadeOut(flash_in_duration, Easing.OutQuint);
 
                         // The inner-most gradient should actually be resizing, but is only visible for

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonReverseArrow : CompositeDrawable
+    {
+        private Bindable<Color4> accentColour = null!;
+
+        private SpriteIcon icon = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject hitObject)
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
+
+            InternalChildren = new Drawable[]
+            {
+                new Circle
+                {
+                    Size = new Vector2(40, 20),
+                    Colour = Color4.White,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                icon = new SpriteIcon
+                {
+                    Icon = FontAwesome.Solid.AngleDoubleRight,
+                    Size = new Vector2(16),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+            };
+
+            accentColour = hitObject.AccentColour.GetBoundCopy();
+            accentColour.BindValueChanged(accent => icon.Colour = accent.NewValue.Darken(4));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
@@ -1,11 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
@@ -15,6 +18,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
     {
         private readonly Box fill;
         private readonly SpriteIcon icon;
+
+        private readonly Vector2 defaultIconScale = new Vector2(0.6f, 0.8f);
+
+        [Resolved(canBeNull: true)]
+        private DrawableHitObject? parentObject { get; set; }
 
         public ArgonSliderBall()
         {
@@ -37,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 icon = new SpriteIcon
                 {
                     Size = new Vector2(48),
-                    Scale = new Vector2(0.6f, 0.8f),
+                    Scale = defaultIconScale,
                     Icon = FontAwesome.Solid.AngleRight,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -45,11 +53,57 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             };
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (parentObject != null)
+            {
+                parentObject.ApplyCustomUpdateState += updateStateTransforms;
+                updateStateTransforms(parentObject, parentObject.State.Value);
+            }
+        }
+
+        private void updateStateTransforms(DrawableHitObject drawableObject, ArmedState _)
+        {
+            // Gets called by slider ticks, tails, etc., leading to duplicated
+            // animations which in this case have no visual impact (due to
+            // instant fade) but may negatively affect performance
+            if (drawableObject is not DrawableSlider)
+                return;
+
+            const float duration = 200;
+            const float icon_scale = 0.9f;
+
+            using (BeginAbsoluteSequence(drawableObject.StateUpdateTime))
+            {
+                this.FadeInFromZero(duration, Easing.OutQuint);
+                icon.ScaleTo(0).Then().ScaleTo(defaultIconScale, duration, Easing.OutElasticHalf);
+            }
+
+            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+            {
+                this.FadeOut(duration, Easing.OutQuint);
+                icon.ScaleTo(defaultIconScale * icon_scale, duration, Easing.OutQuint);
+            }
+        }
+
         protected override void Update()
         {
             base.Update();
 
-            fill.Rotation = -Rotation;
+            //undo rotation on layers which should not be rotated.
+            float appliedRotation = Parent.Rotation;
+
+            fill.Rotation = -appliedRotation;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (parentObject != null)
+                parentObject.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonSliderBall : CircularContainer
+    {
+        private readonly Box fill;
+        private readonly SpriteIcon icon;
+
+        public ArgonSliderBall()
+        {
+            Size = new Vector2(ArgonMainCirclePiece.OUTER_GRADIENT_SIZE);
+
+            Masking = true;
+
+            BorderThickness = ArgonMainCirclePiece.BORDER_THICKNESS * 2;
+            BorderColour = Color4.White;
+
+            InternalChildren = new Drawable[]
+            {
+                fill = new Box
+                {
+                    Colour = ColourInfo.GradientVertical(Colour4.FromHex("FC618F"), Colour4.FromHex("BB1A41")),
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                icon = new SpriteIcon
+                {
+                    Size = new Vector2(48),
+                    Scale = new Vector2(0.6f, 0.8f),
+                    Icon = FontAwesome.Solid.AngleRight,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            fill.Rotation = -Rotation;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             Masking = true;
 
-            BorderThickness = ArgonMainCirclePiece.BORDER_THICKNESS * 2;
+            BorderThickness = ArgonMainCirclePiece.GRADIENT_THICKNESS;
             BorderColour = Color4.White;
 
             InternalChildren = new Drawable[]

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
@@ -11,15 +11,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
     {
         protected override void LoadComplete()
         {
+            const float path_radius = ArgonMainCirclePiece.OUTER_GRADIENT_SIZE / 2;
+
             base.LoadComplete();
 
-            AccentColourBindable.BindValueChanged(accent =>
-            {
-                BorderColour = accent.NewValue;
-            }, true);
-            ScaleBindable.BindValueChanged(scale => PathRadius = ArgonMainCirclePiece.OUTER_GRADIENT_SIZE / 2 * scale.NewValue, true);
+            AccentColourBindable.BindValueChanged(accent => BorderColour = accent.NewValue, true);
+            ScaleBindable.BindValueChanged(scale => PathRadius = path_radius * scale.NewValue, true);
 
-            BorderSize = ArgonMainCirclePiece.BORDER_THICKNESS / 4;
+            // This border size thing is kind of weird, hey.
+            const float intended_thickness = ArgonMainCirclePiece.GRADIENT_THICKNESS / path_radius;
+
+            BorderSize = intended_thickness / Default.DrawableSliderPath.BORDER_PORTION;
         }
 
         protected override Default.DrawableSliderPath CreateSliderPath() => new DrawableSliderPath();

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBody.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Rulesets.Osu.Skinning.Default;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonSliderBody : PlaySliderBody
+    {
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AccentColourBindable.BindValueChanged(accent =>
+            {
+                BorderColour = accent.NewValue;
+            }, true);
+            ScaleBindable.BindValueChanged(scale => PathRadius = ArgonMainCirclePiece.OUTER_GRADIENT_SIZE / 2 * scale.NewValue, true);
+
+            BorderSize = ArgonMainCirclePiece.BORDER_THICKNESS / 4;
+        }
+
+        protected override Default.DrawableSliderPath CreateSliderPath() => new DrawableSliderPath();
+
+        private class DrawableSliderPath : Default.DrawableSliderPath
+        {
+            protected override Color4 ColourAt(float position)
+            {
+                if (CalculatedBorderPortion != 0f && position <= CalculatedBorderPortion)
+                    return BorderColour;
+
+                return AccentColour.Darken(4);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderScorePoint.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderScorePoint.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonSliderScorePoint : CircularContainer
+    {
+        private Bindable<Color4> accentColour = null!;
+
+        private const float size = 12;
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject hitObject)
+        {
+            Masking = true;
+            Origin = Anchor.Centre;
+            Size = new Vector2(size);
+            BorderThickness = 3;
+            BorderColour = Color4.White;
+            Child = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                AlwaysPresent = true,
+                Alpha = 0,
+            };
+
+            accentColour = hitObject.AccentColour.GetBoundCopy();
+            accentColour.BindValueChanged(accent => BorderColour = accent.NewValue);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class OsuArgonSkinTransformer : ISkin
+    {
+        public OsuArgonSkinTransformer(ISkin skin)
+        {
+        }
+
+        public Drawable? GetDrawableComponent(ISkinComponent component)
+        {
+            if (component is OsuSkinComponent osuComponent)
+            {
+                switch (osuComponent.Component)
+                {
+                    case OsuSkinComponents.HitCircle:
+                    case OsuSkinComponents.SliderHeadHitCircle:
+                        return new ArgonMainCirclePiece();
+                }
+            }
+
+            return null;
+        }
+
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
+        {
+            return null;
+        }
+
+        public ISample? GetSample(ISampleInfo sampleInfo)
+        {
+            return null;
+        }
+
+        public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup) where TLookup : notnull where TValue : notnull
+        {
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Argon
@@ -18,14 +19,20 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         public Drawable? GetDrawableComponent(ISkinComponent component)
         {
-            if (component is OsuSkinComponent osuComponent)
+            switch (component)
             {
-                switch (osuComponent.Component)
-                {
-                    case OsuSkinComponents.HitCircle:
-                    case OsuSkinComponents.SliderHeadHitCircle:
-                        return new ArgonMainCirclePiece();
-                }
+                case GameplaySkinComponent<HitResult> resultComponent:
+                    return new ArgonJudgementPiece(resultComponent.Component);
+
+                case OsuSkinComponent osuComponent:
+                    switch (osuComponent.Component)
+                    {
+                        case OsuSkinComponents.HitCircle:
+                        case OsuSkinComponents.SliderHeadHitCircle:
+                            return new ArgonMainCirclePiece();
+                    }
+
+                    break;
             }
 
             return null;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         case OsuSkinComponents.SliderBall:
                             return new ArgonSliderBall();
 
+                        case OsuSkinComponents.SliderFollowCircle:
+                            return new ArgonFollowCircle();
+
                         case OsuSkinComponents.SliderScorePoint:
                             return new ArgonSliderScorePoint();
 

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         case OsuSkinComponents.HitCircle:
                         case OsuSkinComponents.SliderHeadHitCircle:
                             return new ArgonMainCirclePiece();
+
+                        case OsuSkinComponents.SliderBody:
+                            return new ArgonSliderBody();
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -28,8 +28,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     switch (osuComponent.Component)
                     {
                         case OsuSkinComponents.HitCircle:
+                            return new ArgonMainCirclePiece(true);
+
                         case OsuSkinComponents.SliderHeadHitCircle:
-                            return new ArgonMainCirclePiece();
+                            return new ArgonMainCirclePiece(false);
 
                         case OsuSkinComponents.SliderBody:
                             return new ArgonSliderBody();

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -39,6 +39,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         case OsuSkinComponents.SliderScorePoint:
                             return new ArgonSliderScorePoint();
+
+                        case OsuSkinComponents.ReverseArrow:
+                            return new ArgonReverseArrow();
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -33,6 +33,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         case OsuSkinComponents.SliderBody:
                             return new ArgonSliderBody();
+
+                        case OsuSkinComponents.SliderBall:
+                            return new ArgonSliderBall();
+
+                        case OsuSkinComponents.SliderScorePoint:
+                            return new ArgonSliderScorePoint();
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
@@ -10,8 +10,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
     public abstract class DrawableSliderPath : SmoothPath
     {
-        protected const float BORDER_PORTION = 0.128f;
-        protected const float GRADIENT_PORTION = 1 - BORDER_PORTION;
+        public const float BORDER_PORTION = 0.128f;
+        public const float GRADIENT_PORTION = 1 - BORDER_PORTION;
 
         private const float border_max_size = 8f;
         private const float border_min_size = 0f;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -16,9 +16,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
     public abstract class PlaySliderBody : SnakingSliderBody
     {
-        private IBindable<float> scaleBindable;
+        protected IBindable<float> ScaleBindable { get; private set; } = null!;
+
+        protected IBindable<Color4> AccentColourBindable { get; private set; } = null!;
+
         private IBindable<int> pathVersion;
-        private IBindable<Color4> accentColour;
 
         [Resolved(CanBeNull = true)]
         private OsuRulesetConfigManager config { get; set; }
@@ -30,14 +32,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             var drawableSlider = (DrawableSlider)drawableObject;
 
-            scaleBindable = drawableSlider.ScaleBindable.GetBoundCopy();
-            scaleBindable.BindValueChanged(scale => PathRadius = OsuHitObject.OBJECT_RADIUS * scale.NewValue, true);
+            ScaleBindable = drawableSlider.ScaleBindable.GetBoundCopy();
+            ScaleBindable.BindValueChanged(scale => PathRadius = OsuHitObject.OBJECT_RADIUS * scale.NewValue, true);
 
             pathVersion = drawableSlider.PathVersion.GetBoundCopy();
             pathVersion.BindValueChanged(_ => Refresh());
 
-            accentColour = drawableObject.AccentColour.GetBoundCopy();
-            accentColour.BindValueChanged(accent => AccentColour = GetBodyAccentColour(skin, accent.NewValue), true);
+            AccentColourBindable = drawableObject.AccentColour.GetBoundCopy();
+            AccentColourBindable.BindValueChanged(accent => AccentColour = GetBodyAccentColour(skin, accent.NewValue), true);
 
             config?.BindWith(OsuRulesetSetting.SnakingInSliders, SnakingIn);
             config?.BindWith(OsuRulesetSetting.SnakingOutSliders, configSnakingOut);

--- a/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
     public class RingPiece : CircularContainer
     {
-        public RingPiece()
+        public RingPiece(float thickness = 9)
         {
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             Origin = Anchor.Centre;
 
             Masking = true;
-            BorderThickness = 9; // roughly matches slider borders and makes stacked circles distinctly visible from each other.
+            BorderThickness = thickness;
             BorderColour = Color4.White;
 
             Child = new Box

--- a/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Skins.IO
             skinManager.CurrentSkinInfo.Value.PerformRead(s =>
             {
                 Assert.IsFalse(s.Protected);
-                Assert.AreEqual(typeof(TrianglesSkin), s.CreateInstance(skinManager).GetType());
+                Assert.AreEqual(typeof(ArgonSkin), s.CreateInstance(skinManager).GetType());
 
                 new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportModelTo(s, exportStream);
 
@@ -215,7 +215,7 @@ namespace osu.Game.Tests.Skins.IO
             {
                 Assert.IsFalse(s.Protected);
                 Assert.AreNotEqual(originalSkinId, s.ID);
-                Assert.AreEqual(typeof(TrianglesSkin), s.CreateInstance(skinManager).GetType());
+                Assert.AreEqual(typeof(ArgonSkin), s.CreateInstance(skinManager).GetType());
             });
 
             return Task.CompletedTask;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -51,13 +51,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestToggleSeeking()
         {
-            DefaultSongProgress getDefaultProgress() => this.ChildrenOfType<DefaultSongProgress>().Single();
+            void applyToDefaultProgress(Action<DefaultSongProgress> action) =>
+                this.ChildrenOfType<DefaultSongProgress>().ForEach(action);
 
-            AddStep("allow seeking", () => getDefaultProgress().AllowSeeking.Value = true);
-            AddStep("hide graph", () => getDefaultProgress().ShowGraph.Value = false);
-            AddStep("disallow seeking", () => getDefaultProgress().AllowSeeking.Value = false);
-            AddStep("allow seeking", () => getDefaultProgress().AllowSeeking.Value = true);
-            AddStep("show graph", () => getDefaultProgress().ShowGraph.Value = true);
+            AddStep("allow seeking", () => applyToDefaultProgress(s => s.AllowSeeking.Value = true));
+            AddStep("hide graph", () => applyToDefaultProgress(s => s.ShowGraph.Value = false));
+            AddStep("disallow seeking", () => applyToDefaultProgress(s => s.AllowSeeking.Value = false));
+            AddStep("allow seeking", () => applyToDefaultProgress(s => s.AllowSeeking.Value = true));
+            AddStep("show graph", () => applyToDefaultProgress(s => s.ShowGraph.Value = true));
         }
 
         private void setHitObjects()

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Overlays.Settings.Sections
             // In the future we should change this to properly handle ChangeSet events.
             dropdownItems.Clear();
 
+            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.ARGON_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.TRIANGLES_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.CLASSIC_SKIN).ToLive(realm));
 

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -129,11 +129,19 @@ namespace osu.Game.Screens.Backgrounds
                     }
 
                     case BackgroundSource.Skin:
-                        // default skins should use the default background rotation, which won't be the case if a SkinBackground is created for them.
-                        if (skin.Value is TrianglesSkin || skin.Value is DefaultLegacySkin)
-                            break;
+                        switch (skin.Value)
+                        {
+                            case TrianglesSkin:
+                            case ArgonSkin:
+                            case DefaultLegacySkin:
+                                // default skins should use the default background rotation, which won't be the case if a SkinBackground is created for them.
+                                break;
 
-                        newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
+                            default:
+                                newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
+                                break;
+                        }
+
                         break;
                 }
             }

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -1,0 +1,198 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.Extensions;
+using osu.Game.IO;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Play.HUD.HitErrorMeters;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Skinning
+{
+    public class ArgonSkin : Skin
+    {
+        public static SkinInfo CreateInfo() => new SkinInfo
+        {
+            ID = osu.Game.Skinning.SkinInfo.ARGON_SKIN,
+            Name = "osu! \"argon\" (2022)",
+            Creator = "team osu!",
+            Protected = true,
+            InstantiationInfo = typeof(ArgonSkin).GetInvariantInstantiationInfo()
+        };
+
+        private readonly IStorageResourceProvider resources;
+
+        public ArgonSkin(IStorageResourceProvider resources)
+            : this(CreateInfo(), resources)
+        {
+        }
+
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
+        public ArgonSkin(SkinInfo skin, IStorageResourceProvider resources)
+            : base(skin, resources)
+        {
+            this.resources = resources;
+        }
+
+        public override Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Textures?.Get(componentName, wrapModeS, wrapModeT);
+
+        public override ISample GetSample(ISampleInfo sampleInfo)
+        {
+            foreach (string lookup in sampleInfo.LookupNames)
+            {
+                var sample = Samples?.Get(lookup) ?? resources.AudioManager?.Samples.Get(lookup);
+                if (sample != null)
+                    return sample;
+            }
+
+            return null;
+        }
+
+        public override Drawable GetDrawableComponent(ISkinComponent component)
+        {
+            if (base.GetDrawableComponent(component) is Drawable c)
+                return c;
+
+            switch (component)
+            {
+                case SkinnableTargetComponent target:
+                    switch (target.Target)
+                    {
+                        case SkinnableTarget.SongSelect:
+                            var songSelectComponents = new SkinnableTargetComponentsContainer(_ =>
+                            {
+                                // do stuff when we need to.
+                            });
+
+                            return songSelectComponents;
+
+                        case SkinnableTarget.MainHUDComponents:
+                            var skinnableTargetWrapper = new SkinnableTargetComponentsContainer(container =>
+                            {
+                                var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();
+                                var accuracy = container.OfType<DefaultAccuracyCounter>().FirstOrDefault();
+                                var combo = container.OfType<DefaultComboCounter>().FirstOrDefault();
+                                var ppCounter = container.OfType<PerformancePointsCounter>().FirstOrDefault();
+
+                                if (score != null)
+                                {
+                                    score.Anchor = Anchor.TopCentre;
+                                    score.Origin = Anchor.TopCentre;
+
+                                    // elements default to beneath the health bar
+                                    const float vertical_offset = 30;
+
+                                    const float horizontal_padding = 20;
+
+                                    score.Position = new Vector2(0, vertical_offset);
+
+                                    if (ppCounter != null)
+                                    {
+                                        ppCounter.Y = score.Position.Y + ppCounter.ScreenSpaceDeltaToParentSpace(score.ScreenSpaceDrawQuad.Size).Y - 4;
+                                        ppCounter.Origin = Anchor.TopCentre;
+                                        ppCounter.Anchor = Anchor.TopCentre;
+                                    }
+
+                                    if (accuracy != null)
+                                    {
+                                        accuracy.Position = new Vector2(-accuracy.ScreenSpaceDeltaToParentSpace(score.ScreenSpaceDrawQuad.Size).X / 2 - horizontal_padding, vertical_offset + 5);
+                                        accuracy.Origin = Anchor.TopRight;
+                                        accuracy.Anchor = Anchor.TopCentre;
+
+                                        if (combo != null)
+                                        {
+                                            combo.Position = new Vector2(accuracy.ScreenSpaceDeltaToParentSpace(score.ScreenSpaceDrawQuad.Size).X / 2 + horizontal_padding, vertical_offset + 5);
+                                            combo.Anchor = Anchor.TopCentre;
+                                        }
+                                    }
+
+                                    var hitError = container.OfType<HitErrorMeter>().FirstOrDefault();
+
+                                    if (hitError != null)
+                                    {
+                                        hitError.Anchor = Anchor.CentreLeft;
+                                        hitError.Origin = Anchor.CentreLeft;
+                                    }
+
+                                    var hitError2 = container.OfType<HitErrorMeter>().LastOrDefault();
+
+                                    if (hitError2 != null)
+                                    {
+                                        hitError2.Anchor = Anchor.CentreRight;
+                                        hitError2.Scale = new Vector2(-1, 1);
+                                        // origin flipped to match scale above.
+                                        hitError2.Origin = Anchor.CentreLeft;
+                                    }
+                                }
+                            })
+                            {
+                                Children = new Drawable[]
+                                {
+                                    new DefaultComboCounter(),
+                                    new DefaultScoreCounter(),
+                                    new DefaultAccuracyCounter(),
+                                    new DefaultHealthDisplay(),
+                                    new DefaultSongProgress(),
+                                    new BarHitErrorMeter(),
+                                    new BarHitErrorMeter(),
+                                    new PerformancePointsCounter()
+                                }
+                            };
+
+                            return skinnableTargetWrapper;
+                    }
+
+                    return null;
+            }
+
+            switch (component.LookupName)
+            {
+                // Temporary until default skin has a valid hit lighting.
+                case @"lighting":
+                    return Drawable.Empty();
+            }
+
+            if (GetTexture(component.LookupName) is Texture t)
+                return new Sprite { Texture = t };
+
+            return null;
+        }
+
+        public override IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
+        {
+            // todo: this code is pulled from LegacySkin and should not exist.
+            // will likely change based on how databased storage of skin configuration goes.
+            switch (lookup)
+            {
+                case GlobalSkinColours global:
+                    switch (global)
+                    {
+                        case GlobalSkinColours.ComboColours:
+                            return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(Configuration.ComboColours));
+                    }
+
+                    break;
+
+                case SkinComboColourLookup comboColour:
+                    return SkinUtils.As<TValue>(new Bindable<Color4>(getComboColour(Configuration, comboColour.ColourIndex)));
+            }
+
+            return null;
+        }
+
+        private static Color4 getComboColour(IHasComboColours source, int colourIndex)
+            => source.ComboColours[colourIndex % source.ComboColours.Count];
+    }
+}

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -81,6 +81,7 @@ namespace osu.Game.Skinning
                 }
             }
 
+            // TODO: check
             int lastDefaultSkinIndex = sources.IndexOf(sources.OfType<TrianglesSkin>().LastOrDefault());
 
             // Ruleset resources should be given the ability to override game-wide defaults

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Skinning
     public class SkinInfo : RealmObject, IHasRealmFiles, IEquatable<SkinInfo>, IHasGuidPrimaryKey, ISoftDelete, IHasNamedFiles
     {
         internal static readonly Guid TRIANGLES_SKIN = new Guid("2991CFD8-2140-469A-BCB9-2EC23FBCE4AD");
+        internal static readonly Guid ARGON_SKIN = new Guid("CFFA69DE-B3E3-4DEE-8563-3C4F425C05D0");
         internal static readonly Guid CLASSIC_SKIN = new Guid("81F02CD3-EEC6-4865-AC23-FAE26A386187");
         internal static readonly Guid RANDOM_SKIN = new Guid("D39DFEFB-477C-4372-B1EA-2BCEA5FB8908");
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Skinning
     [ExcludeFromDynamicCompile]
     public class SkinManager : ModelManager<SkinInfo>, ISkinSource, IStorageResourceProvider, IModelImporter<SkinInfo>
     {
+        /// <summary>
+        /// The default "classic" skin.
+        /// </summary>
+        public Skin DefaultClassicSkin { get; }
+
         private readonly AudioManager audio;
 
         private readonly Scheduler scheduler;
@@ -55,20 +60,9 @@ namespace osu.Game.Skinning
 
         private readonly IResourceStore<byte[]> userFiles;
 
-        /// <summary>
-        /// The default "triangles" skin.
-        /// </summary>
         private Skin argonSkin { get; }
 
-        /// <summary>
-        /// The default skin (old).
-        /// </summary>
         private Skin trianglesSkin { get; }
-
-        /// <summary>
-        /// The default "classic" skin.
-        /// </summary>
-        public Skin DefaultClassicSkin { get; }
 
         public SkinManager(Storage storage, RealmAccess realm, GameHost host, IResourceStore<byte[]> resources, AudioManager audio, Scheduler scheduler)
             : base(storage, realm)

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -49,10 +49,7 @@ namespace osu.Game.Skinning
 
         public readonly Bindable<Skin> CurrentSkin = new Bindable<Skin>();
 
-        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(TrianglesSkin.CreateInfo().ToLiveUnmanaged())
-        {
-            Default = TrianglesSkin.CreateInfo().ToLiveUnmanaged()
-        };
+        public readonly Bindable<Live<SkinInfo>> CurrentSkinInfo = new Bindable<Live<SkinInfo>>(ArgonSkin.CreateInfo().ToLiveUnmanaged());
 
         private readonly SkinImporter skinImporter;
 
@@ -61,7 +58,12 @@ namespace osu.Game.Skinning
         /// <summary>
         /// The default "triangles" skin.
         /// </summary>
-        public Skin DefaultSkinTriangles { get; }
+        private Skin argonSkin { get; }
+
+        /// <summary>
+        /// The default skin (old).
+        /// </summary>
+        private Skin trianglesSkin { get; }
 
         /// <summary>
         /// The default "classic" skin.
@@ -86,7 +88,8 @@ namespace osu.Game.Skinning
             var defaultSkins = new[]
             {
                 DefaultClassicSkin = new DefaultLegacySkin(this),
-                DefaultSkinTriangles = new TrianglesSkin(this),
+                trianglesSkin = new TrianglesSkin(this),
+                argonSkin = new ArgonSkin(this),
             };
 
             // Ensure the default entries are present.
@@ -104,7 +107,7 @@ namespace osu.Game.Skinning
                 CurrentSkin.Value = skin.NewValue.PerformRead(GetSkin);
             };
 
-            CurrentSkin.Value = DefaultSkinTriangles;
+            CurrentSkin.Value = argonSkin;
             CurrentSkin.ValueChanged += skin =>
             {
                 if (!skin.NewValue.SkinInfo.Equals(CurrentSkinInfo.Value))
@@ -125,7 +128,7 @@ namespace osu.Game.Skinning
 
                 if (randomChoices.Length == 0)
                 {
-                    CurrentSkinInfo.Value = TrianglesSkin.CreateInfo().ToLiveUnmanaged();
+                    CurrentSkinInfo.Value = ArgonSkin.CreateInfo().ToLiveUnmanaged();
                     return;
                 }
 
@@ -229,11 +232,15 @@ namespace osu.Game.Skinning
             {
                 yield return CurrentSkin.Value;
 
+                // Skin manager provides default fallbacks.
+                // This handles cases where a user skin doesn't have the required resources for complete display of
+                // certain elements.
+
                 if (CurrentSkin.Value is LegacySkin && CurrentSkin.Value != DefaultClassicSkin)
                     yield return DefaultClassicSkin;
 
-                if (CurrentSkin.Value != DefaultSkinTriangles)
-                    yield return DefaultSkinTriangles;
+                if (CurrentSkin.Value != trianglesSkin)
+                    yield return trianglesSkin;
             }
         }
 
@@ -294,7 +301,7 @@ namespace osu.Game.Skinning
                 Guid currentUserSkin = CurrentSkinInfo.Value.ID;
 
                 if (items.Any(s => s.ID == currentUserSkin))
-                    scheduler.Add(() => CurrentSkinInfo.Value = TrianglesSkin.CreateInfo().ToLiveUnmanaged());
+                    scheduler.Add(() => CurrentSkinInfo.Value = ArgonSkin.CreateInfo().ToLiveUnmanaged());
 
                 Delete(items.ToList(), silent);
             });
@@ -313,7 +320,7 @@ namespace osu.Game.Skinning
                     skinInfo = DefaultClassicSkin.SkinInfo;
             }
 
-            CurrentSkinInfo.Value = skinInfo ?? DefaultSkinTriangles.SkinInfo;
+            CurrentSkinInfo.Value = skinInfo ?? trianglesSkin.SkinInfo;
         }
     }
 }

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -113,6 +113,7 @@ namespace osu.Game.Skinning
                 // Temporarily used to exclude undesirable ISkin implementations
                 static bool isUserSkin(ISkin skin)
                     => skin.GetType() == typeof(TrianglesSkin)
+                       || skin.GetType() == typeof(ArgonSkin)
                        || skin.GetType() == typeof(DefaultLegacySkin)
                        || skin.GetType() == typeof(LegacySkin);
             }

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Visual
                     },
                     new OsuSpriteText
                     {
-                        Text = skin?.SkinInfo.Value.Name ?? "none",
+                        Text = skin.SkinInfo.Value.Name,
                         Scale = new Vector2(1.5f),
                         Padding = new MarginPadding(5),
                     },

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Tests.Visual
         private TrianglesSkin trianglesSkin;
         private Skin metricsSkin;
         private Skin legacySkin;
+        private Skin argonSkin;
         private Skin specialSkin;
         private Skin oldSkin;
 
@@ -48,6 +49,7 @@ namespace osu.Game.Tests.Visual
         {
             var dllStore = new DllResourceStore(GetType().Assembly);
 
+            argonSkin = new ArgonSkin(this);
             trianglesSkin = new TrianglesSkin(this);
             metricsSkin = new TestLegacySkin(new SkinInfo { Name = "metrics-skin" }, new NamespacedResourceStore<byte[]>(dllStore, "Resources/metrics_skin"), this, true);
             legacySkin = new DefaultLegacySkin(this);
@@ -63,11 +65,12 @@ namespace osu.Game.Tests.Visual
 
             var beatmap = CreateBeatmapForSkinProvider();
 
-            Cell(0).Child = createProvider(trianglesSkin, creationFunction, beatmap);
-            Cell(1).Child = createProvider(metricsSkin, creationFunction, beatmap);
-            Cell(2).Child = createProvider(legacySkin, creationFunction, beatmap);
-            Cell(3).Child = createProvider(specialSkin, creationFunction, beatmap);
-            Cell(4).Child = createProvider(oldSkin, creationFunction, beatmap);
+            Cell(0).Child = createProvider(argonSkin, creationFunction, beatmap);
+            Cell(1).Child = createProvider(trianglesSkin, creationFunction, beatmap);
+            Cell(2).Child = createProvider(metricsSkin, creationFunction, beatmap);
+            Cell(3).Child = createProvider(legacySkin, creationFunction, beatmap);
+            Cell(4).Child = createProvider(specialSkin, creationFunction, beatmap);
+            Cell(5).Child = createProvider(oldSkin, creationFunction, beatmap);
         }
 
         protected IEnumerable<Drawable> CreatedDrawables => createdDrawables;
@@ -82,10 +85,7 @@ namespace osu.Game.Tests.Visual
             OutlineBox outlineBox;
             SkinProvidingContainer skinProvider;
 
-            ISkin provider = skin;
-
-            if (provider is LegacySkin legacyProvider)
-                provider = Ruleset.Value.CreateInstance().CreateSkinTransformer(legacyProvider, beatmap);
+            ISkin provider = Ruleset.Value.CreateInstance().CreateSkinTransformer(skin, beatmap) ?? skin;
 
             var children = new Container
             {


### PR DESCRIPTION
- [x] Depends on #20354

Missing spinner, missing gradient on slider track (not even sure how to do this), missing border piece on slider reverse arrow. And probably a few other nuances. That said, I think it's ready to push this out and build on it as we go.


https://user-images.githubusercontent.com/191335/190975428-2bb854af-9151-48ca-b255-1dbcfa348956.mp4

Interested in feedback on the outer fill (currently only applied to hitcircles and not slider circles). Without it on circles, things feel too busy, but adding it to sliders as well feels a bit weird to my eye.

| Without | With |
|--|--|
| ![osu! 2022-09-19 at 07 13 07](https://user-images.githubusercontent.com/191335/190975551-91692707-e137-4d4f-a86b-d47428709817.png) | ![osu! 2022-09-19 at 07 15 58](https://user-images.githubusercontent.com/191335/190975528-b104d9fa-bf69-4c81-9baf-520612ba9e14.png) |
| ![osu! 2022-09-19 at 07 12 40](https://user-images.githubusercontent.com/191335/190975561-643ed262-0aeb-4226-9b84-d8253ef22f43.png) | ![osu! 2022-09-19 at 07 15 46](https://user-images.githubusercontent.com/191335/190975544-25846f0a-5e56-48bf-8e1a-1a251916ae50.png) |

Also to consider: should we force existing users across to argon if they are currently on triangles?