### PR TITLE
Reduce occasions when "game is muted" notification shows

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -264,13 +264,13 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestMutedNotificationMasterVolume()
         {
-            addVolumeSteps("master volume", () => audioManager.Volume.Value = 0, () => audioManager.Volume.IsDefault);
+            addVolumeSteps("master volume", () => audioManager.Volume.Value = 0, () => audioManager.Volume.Value == 0.5);
         }
 
         [Test]
         public void TestMutedNotificationTrackVolume()
         {
-            addVolumeSteps("music volume", () => audioManager.VolumeTrack.Value = 0, () => audioManager.VolumeTrack.IsDefault);
+            addVolumeSteps("music volume", () => audioManager.VolumeTrack.Value = 0, () => audioManager.VolumeTrack.Value == 0.5);
         }
 
         [Test]

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -539,10 +539,11 @@ namespace osu.Game.Screens.Play
                     volumeOverlay.IsMuted.Value = false;
 
                     // Check values before resetting, as the user may have only had mute enabled, in which case we might not need to adjust volumes.
+                    // Note that we only restore halfway to ensure the user isn't suddenly overloaded by unexpectedly high volume.
                     if (audioManager.Volume.Value <= volume_requirement)
-                        audioManager.Volume.SetDefault();
+                        audioManager.Volume.Value = 0.5f;
                     if (audioManager.VolumeTrack.Value <= volume_requirement)
-                        audioManager.VolumeTrack.SetDefault();
+                        audioManager.VolumeTrack.Value = 0.5f;
 
                     return true;
                 };

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -502,7 +502,7 @@ namespace osu.Game.Screens.Play
 
         private int restartCount;
 
-        private const double volume_requirement = 0.05;
+        private const double volume_requirement = 0.01;
 
         private void showMuteWarningIfNeeded()
         {


### PR DESCRIPTION
Reduces the threshold to 1%, and changes clicking the notification to only increase volume level to 50%, rather than 100%.