### PR TITLE
Disable alpha component parsing in beatmap / skin colour sections

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -306,7 +306,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                     new Color4(128, 255, 128, 255),
                     new Color4(255, 187, 255, 255),
                     new Color4(255, 177, 140, 255),
-                    new Color4(100, 100, 100, 100),
+                    new Color4(100, 100, 100, 255), // alpha is specified as 100, but should be ignored.
                 };
                 Assert.AreEqual(expectedColors.Length, comboColors.Count);
                 for (int i = 0; i < expectedColors.Length; i++)

--- a/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Skins
                     new Color4(142, 199, 255, 255),
                     new Color4(255, 128, 128, 255),
                     new Color4(128, 255, 255, 255),
-                    new Color4(100, 100, 100, 100),
+                    new Color4(100, 100, 100, 255), // alpha is specified as 100, but should be ignored.
                 };
 
                 Assert.AreEqual(expectedColors.Count, comboColors.Count);

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Beatmaps.Formats
             switch (section)
             {
                 case Section.Colours:
-                    HandleColours(output, line);
+                    HandleColours(output, line, false);
                     return;
             }
         }
@@ -93,7 +93,7 @@ namespace osu.Game.Beatmaps.Formats
             return line;
         }
 
-        protected void HandleColours<TModel>(TModel output, string line)
+        protected void HandleColours<TModel>(TModel output, string line, bool allowAlpha)
         {
             var pair = SplitKeyVal(line);
 
@@ -108,7 +108,7 @@ namespace osu.Game.Beatmaps.Formats
 
             try
             {
-                byte alpha = split.Length == 4 ? byte.Parse(split[3]) : (byte)255;
+                byte alpha = allowAlpha && split.Length == 4 ? byte.Parse(split[3]) : (byte)255;
                 colour = new Color4(byte.Parse(split[0]), byte.Parse(split[1]), byte.Parse(split[2]), alpha);
             }
             catch

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Skinning
                         break;
 
                     case string when pair.Key.StartsWith("Colour", StringComparison.Ordinal):
-                        HandleColours(currentConfig, line);
+                        HandleColours(currentConfig, line, true);
                         break;
 
                     // Custom sprite paths

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Skinning
                     // osu!catch section only has colour settings
                     // so no harm in handling the entire section
                     case Section.CatchTheBeat:
-                        HandleColours(skin, line);
+                        HandleColours(skin, line, true);
                         return;
                 }
 


### PR DESCRIPTION
Just a quick change to match stable. Beatmap / skin `[Colours]` section should not support alpha (the alpha component is ignored and set to 255 rather than the whole colour parsing failing). Other usages, like osu!catch and osu!mania do support alpha.

Not 100% on (original osu-stable) reasoning, but let's just match for now.

Addresses https://github.com/ppy/osu/discussions/20391, in which you can see lazer failing to parse the colour (due to an incorrect floating point alpha specification which was ignored by stable).