### PR TITLE
Add "keybindings" search term to settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -19,6 +21,8 @@ namespace osu.Game.Overlays.Settings.Sections
         private readonly KeyBindingPanel keyConfig;
 
         public override LocalisableString Header => InputSettingsStrings.InputSectionHeader;
+
+        public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(new LocalisableString[] { "keybindings" });
 
         public override Drawable CreateIcon() => new SpriteIcon
         {


### PR DESCRIPTION
Every time I try to search for this section I end up writing "keyb" and get no results. This annoys me to no end and I've tried to deal with it for the greater part of 2 years, yet still unsuccessful at remembering that the game expects "bindings" or "key bindings" instead.

I think "key bindings" (already handled) / "keybindings" are both very common terms:
- https://code.visualstudio.com/docs/getstarted/keybindings ("key bindings" + "keybindings")
- https://docs.oracle.com/javase/tutorial/uiswing/misc/keybinding.html ("key bindings")
- https://help.gnome.org/users/orca/stable/howto_key_bindings.html.en ("key bindings" + "keybindings")
- https://docs.unrealengine.com/4.27/en-US/Basics/UI/KeyBindings/ ("key bindings" + "keybindings")
- https://learn.microsoft.com/en-us/office/vba/api/word.keybindings.add ("keybindings")