### PR TITLE
Add warning message in `files` folder to avoid accidental deletion

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -255,6 +256,8 @@ namespace osu.Game
 
             InitialiseFonts();
 
+            addFilesWarning();
+
             Audio.Samples.PlaybackConcurrency = SAMPLE_CONCURRENCY;
 
             dependencies.Cache(SkinManager = new SkinManager(Storage, realm, Host, Resources, Audio, Scheduler));
@@ -371,6 +374,29 @@ namespace osu.Game
 
             Ruleset.BindValueChanged(onRulesetChanged);
             Beatmap.BindValueChanged(onBeatmapChanged);
+        }
+
+        private void addFilesWarning()
+        {
+            var realmStore = new RealmFileStore(realm, Storage);
+
+            const string filename = "IMPORTANT READ ME.txt";
+
+            if (!realmStore.Storage.Exists(filename))
+            {
+                using (var stream = realmStore.Storage.CreateFileSafely(filename))
+                using (var textWriter = new StreamWriter(stream))
+                {
+                    textWriter.WriteLine(@"This folder contains all your user files (beatmaps, skins, replays etc.)");
+                    textWriter.WriteLine(@"Please do not touch or delete this folder!!");
+                    textWriter.WriteLine();
+                    textWriter.WriteLine(@"If you are really looking to completely delete user data, please delete");
+                    textWriter.WriteLine(@"the parent folder including all other files and directories");
+                    textWriter.WriteLine();
+                    textWriter.WriteLine(@"For more information on how these files are organised,");
+                    textWriter.WriteLine(@"see https://github.com/ppy/osu/wiki/User-file-storage");
+                }
+            }
         }
 
         private void onTrackChanged(WorkingBeatmap beatmap, TrackChangeDirection direction)


### PR DESCRIPTION
This is a pretty standard practice for applications that have data stored in folders where a user may accidentally determine that the content is unnecessary.

Aims to address cases like
https://github.com/ppy/osu/discussions/20394#discussioncomment-3705694. It's not the first time this has come up, and definitely won't be the last.

macOS:

![Finder 2022-09-22 at 04 18 12](https://user-images.githubusercontent.com/191335/191657476-64a7a8d8-b402-47ec-b8e4-3cd0a9053973.png)

Windows:

![Parallels Desktop 2022-09-22 at 04 18 59](https://user-images.githubusercontent.com/191335/191657553-20cd30f1-4c9d-48b4-b31e-c75884e1f36c.png)
