### PR TITLE
Add "argon" skin judgement bubbles

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
@@ -1,14 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 
@@ -19,6 +22,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         protected readonly HitResult Result;
 
         protected SpriteText JudgementText { get; private set; } = null!;
+
+        private RingExplosion? ringExplosion;
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -42,10 +47,19 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     Origin = Anchor.Centre,
                     Text = Result.GetDescription().ToUpperInvariant(),
                     Colour = colours.ForHitResult(Result),
+                    Blending = BlendingParameters.Additive,
                     Spacing = new Vector2(5, 0),
                     Font = OsuFont.Default.With(size: 20, weight: FontWeight.Bold),
-                }
+                },
             };
+
+            if (Result.IsHit())
+            {
+                AddInternal(ringExplosion = new RingExplosion(Result)
+                {
+                    Colour = colours.ForHitResult(Result),
+                });
+            }
         }
 
         /// <summary>
@@ -78,8 +92,80 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             }
 
             this.FadeOutFromOne(800);
+
+            ringExplosion?.PlayAnimation();
         }
 
         public Drawable? GetAboveHitObjectsProxiedContent() => null;
+
+        private class RingExplosion : CompositeDrawable
+        {
+            private readonly float travel = 52;
+
+            public RingExplosion(HitResult result)
+            {
+                const float thickness = 4;
+
+                const float small_size = 9;
+                const float large_size = 14;
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                Blending = BlendingParameters.Additive;
+
+                int countSmall = 0;
+                int countLarge = 0;
+
+                switch (result)
+                {
+                    case HitResult.Meh:
+                        countSmall = 3;
+                        travel *= 0.3f;
+                        break;
+
+                    case HitResult.Ok:
+                    case HitResult.Good:
+                        countSmall = 4;
+                        travel *= 0.6f;
+                        break;
+
+                    case HitResult.Great:
+                    case HitResult.Perfect:
+                        countSmall = 4;
+                        countLarge = 4;
+                        break;
+                }
+
+                for (int i = 0; i < countSmall; i++)
+                    AddInternal(new RingPiece(thickness) { Size = new Vector2(small_size) });
+
+                for (int i = 0; i < countLarge; i++)
+                    AddInternal(new RingPiece(thickness) { Size = new Vector2(large_size) });
+            }
+
+            public void PlayAnimation()
+            {
+                foreach (var c in InternalChildren)
+                {
+                    const float start_position_ratio = 0.3f;
+
+                    float direction = RNG.NextSingle(0, 360);
+                    float distance = RNG.NextSingle(travel / 2, travel);
+
+                    c.MoveTo(new Vector2(
+                        MathF.Cos(direction) * distance * start_position_ratio,
+                        MathF.Sin(direction) * distance * start_position_ratio
+                    ));
+
+                    c.MoveTo(new Vector2(
+                        MathF.Cos(direction) * distance,
+                        MathF.Sin(direction) * distance
+                    ), 600, Easing.OutQuint);
+                }
+
+                this.FadeOutFromOne(1000, Easing.OutQuint);
+            }
+        }
     }
 }


### PR DESCRIPTION
Just a very initial pass. Don't worry too much about the design. Just want to get *something* in there to get a feel for how they are going to work.


https://user-images.githubusercontent.com/191335/191703279-f646c9dc-b1b4-441a-960b-0e18f45c19cb.mp4


https://user-images.githubusercontent.com/191335/191703448-ac9b6460-6afa-4041-baad-71aa9f542222.mp4


Am aware that the judgements are sometimes hard to see (visible response time is slower than triangles / classic) with the new argon skin's circle glow. I need to move that to the "lighting" layer to improve things, which will come as a follow-up effort.

I'm also aware that there is an existing `ParticleExplosion` class that does very similar things with a more optimal approach, but I am using slightly different tweens and would prefer it in an isolated state for now.