### PR TITLE
Fix argon reverse arrow becoming white after switching skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             };
 
             accentColour = hitObject.AccentColour.GetBoundCopy();
-            accentColour.BindValueChanged(accent => icon.Colour = accent.NewValue.Darken(4));
+            accentColour.BindValueChanged(accent => icon.Colour = accent.NewValue.Darken(4), true);
         }
     }
 }


### PR DESCRIPTION
oops