### PR TITLE
Fix "argon" skin not supporting user loaded sprites in gameplay

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -11,10 +11,13 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
-    public class OsuArgonSkinTransformer : ISkin
+    public class OsuArgonSkinTransformer : ISkinTransformer
     {
+        public ISkin Skin { get; }
+
         public OsuArgonSkinTransformer(ISkin skin)
         {
+            Skin = skin;
         }
 
         public Drawable? GetDrawableComponent(ISkinComponent component)
@@ -55,15 +58,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             return null;
         }
 
-        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
-        {
-            return null;
-        }
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
 
-        public ISample? GetSample(ISampleInfo sampleInfo)
-        {
-            return null;
-        }
+        public ISample? GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
 
         public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup) where TLookup : notnull where TValue : notnull
         {

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -1,26 +1,20 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Audio.Sample;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Audio;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
-    public class OsuArgonSkinTransformer : ISkinTransformer
+    public class OsuArgonSkinTransformer : SkinTransformer
     {
-        public ISkin Skin { get; }
-
         public OsuArgonSkinTransformer(ISkin skin)
+            : base(skin)
         {
-            Skin = skin;
         }
 
-        public Drawable? GetDrawableComponent(ISkinComponent component)
+        public override Drawable? GetDrawableComponent(ISkinComponent component)
         {
             switch (component)
             {
@@ -55,16 +49,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     break;
             }
 
-            return null;
-        }
-
-        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
-
-        public ISample? GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
-
-        public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup) where TLookup : notnull where TValue : notnull
-        {
-            return null;
+            return base.GetDrawableComponent(component);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             var topProvider = source.FindProvider(s => s.GetTexture("spinner-top") != null);
 
-            if (topProvider is LegacySkinTransformer transformer && !(transformer.Skin is DefaultLegacySkin))
+            if (topProvider is ISkinTransformer transformer && !(transformer.Skin is DefaultLegacySkin))
             {
                 AddInternal(ApproachCircle = new Sprite
                 {

--- a/osu.Game/Skinning/ISkinTransformer.cs
+++ b/osu.Game/Skinning/ISkinTransformer.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// A skin transformer takes in an <see cref="ISkin"/> and applies transformations to it.
+    /// The most common use case is allowing individual rulesets to add skinnable components without directly coupling to underlying skins.
+    /// </summary>
+    public interface ISkinTransformer : ISkin
+    {
+        /// <summary>
+        /// The original skin that is being transformed.
+        /// </summary>
+        ISkin Skin { get; }
+    }
+}

--- a/osu.Game/Skinning/LegacySkinTransformer.cs
+++ b/osu.Game/Skinning/LegacySkinTransformer.cs
@@ -1,14 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System;
-using JetBrains.Annotations;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Objects.Legacy;
 using static osu.Game.Skinning.SkinConfiguration;
@@ -18,24 +11,14 @@ namespace osu.Game.Skinning
     /// <summary>
     /// Transformer used to handle support of legacy features for individual rulesets.
     /// </summary>
-    public abstract class LegacySkinTransformer : ISkinTransformer
+    public abstract class LegacySkinTransformer : SkinTransformer
     {
-        [NotNull]
-        public ISkin Skin { get; }
-
-        protected LegacySkinTransformer([NotNull] ISkin skin)
+        protected LegacySkinTransformer(ISkin skin)
+            : base(skin)
         {
-            Skin = skin ?? throw new ArgumentNullException(nameof(skin));
         }
 
-        public virtual Drawable GetDrawableComponent(ISkinComponent component) => Skin.GetDrawableComponent(component);
-
-        public Texture GetTexture(string componentName) => GetTexture(componentName, default, default);
-
-        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
-            => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
-
-        public virtual ISample GetSample(ISampleInfo sampleInfo)
+        public override ISample? GetSample(ISampleInfo sampleInfo)
         {
             if (!(sampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacySample))
                 return Skin.GetSample(sampleInfo);
@@ -44,9 +27,7 @@ namespace osu.Game.Skinning
             if (legacySample.IsLayered && playLayeredHitSounds?.Value == false)
                 return new SampleVirtual();
 
-            return Skin.GetSample(sampleInfo);
+            return base.GetSample(sampleInfo);
         }
-
-        public virtual IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => Skin.GetConfig<TLookup, TValue>(lookup);
     }
 }

--- a/osu.Game/Skinning/LegacySkinTransformer.cs
+++ b/osu.Game/Skinning/LegacySkinTransformer.cs
@@ -18,11 +18,8 @@ namespace osu.Game.Skinning
     /// <summary>
     /// Transformer used to handle support of legacy features for individual rulesets.
     /// </summary>
-    public abstract class LegacySkinTransformer : ISkin
+    public abstract class LegacySkinTransformer : ISkinTransformer
     {
-        /// <summary>
-        /// The <see cref="ISkin"/> which is being transformed.
-        /// </summary>
         [NotNull]
         public ISkin Skin { get; }
 

--- a/osu.Game/Skinning/SkinTransformer.cs
+++ b/osu.Game/Skinning/SkinTransformer.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+
+namespace osu.Game.Skinning
+{
+    public abstract class SkinTransformer : ISkinTransformer
+    {
+        public ISkin Skin { get; }
+
+        protected SkinTransformer(ISkin skin)
+        {
+            Skin = skin ?? throw new ArgumentNullException(nameof(skin));
+        }
+
+        public virtual Drawable? GetDrawableComponent(ISkinComponent component) => Skin.GetDrawableComponent(component);
+
+        public virtual Texture? GetTexture(string componentName) => GetTexture(componentName, default, default);
+
+        public virtual Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
+
+        public virtual ISample? GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
+
+        public virtual IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup) where TLookup : notnull where TValue : notnull => Skin.GetConfig<TLookup, TValue>(lookup);
+    }
+}

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Skinning
                 {
                     foreach (var skin in skins)
                     {
-                        if (skin is LegacySkinTransformer transformer && isUserSkin(transformer.Skin))
+                        if (skin is ISkinTransformer transformer && isUserSkin(transformer.Skin))
                             return transformer.Skin;
 
                         if (isUserSkin(skin))


### PR DESCRIPTION
The skin transformer lookups were very dependent on all transformers being `LegacySkinTransformer`.

This centralises the implementation and adds support for non-legacy transformers.