### PR TITLE
Add argon combo colours

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -21,7 +21,6 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 using osuTK;
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -250,11 +250,9 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Test]
         public void TestHitLightingColour()
         {
-            var fruitColour = SkinConfiguration.DefaultComboColours[1];
             AddStep("enable hit lighting", () => config.SetValue(OsuSetting.HitLighting, true));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
-            AddAssert("correct hit lighting colour", () =>
-                catcher.ChildrenOfType<HitExplosion>().First()?.Entry?.ObjectColour == fruitColour);
+            AddAssert("correct hit lighting colour", () => catcher.ChildrenOfType<HitExplosion>().First()?.Entry?.ObjectColour == this.ChildrenOfType<DrawableCatchHitObject>().First().AccentColour.Value);
         }
 
         [Test]

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -44,6 +44,28 @@ namespace osu.Game.Skinning
             : base(skin, resources)
         {
             this.resources = resources;
+
+            Configuration.CustomComboColours = new List<Color4>
+            {
+                // Standard combo progression order is green - blue - red - yellow.
+                // But for whatever reason, this starts from index 1, not 0.
+                //
+                // We've added two new combo colours in argon, so to ensure the initial rotation matches,
+                // this same progression is in slots 1 - 4.
+
+                // Orange
+                new Color4(241, 116, 0, 255),
+                // Green
+                new Color4(0, 241, 53, 255),
+                // Blue
+                new Color4(0, 82, 241, 255),
+                // Red
+                new Color4(241, 0, 0, 255),
+                // Yellow
+                new Color4(232, 235, 0, 255),
+                // Purple
+                new Color4(92, 0, 241, 255),
+            };
         }
 
         public override Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Textures?.Get(componentName, wrapModeS, wrapModeT);


### PR DESCRIPTION
I'm 99% sure these are just test colours flyte was using, but they look good so let's go with them. I've added two new colours to increase the default combo colour rotation to 6. The initial ordering still matches, for whatever that's worth.