### PR TITLE
Add very basic "argon" spinner

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
@@ -43,7 +42,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             => new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
 
         private DrawableSpinner drawableSpinner = null!;
-        private SpriteIcon spinnerSymbol => drawableSpinner.ChildrenOfType<SpriteIcon>().Single();
 
         [SetUpSteps]
         public override void SetUpSteps()
@@ -77,18 +75,12 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             double finalCumulativeTrackerRotation = 0;
             double finalTrackerRotation = 0, trackerRotationTolerance = 0;
-            double finalSpinnerSymbolRotation = 0, spinnerSymbolRotationTolerance = 0;
 
             addSeekStep(spinner_start_time + 5000);
             AddStep("retrieve disc rotation", () =>
             {
                 finalTrackerRotation = drawableSpinner.RotationTracker.Rotation;
                 trackerRotationTolerance = Math.Abs(finalTrackerRotation * 0.05f);
-            });
-            AddStep("retrieve spinner symbol rotation", () =>
-            {
-                finalSpinnerSymbolRotation = spinnerSymbol.Rotation;
-                spinnerSymbolRotationTolerance = Math.Abs(finalSpinnerSymbolRotation * 0.05f);
             });
             AddStep("retrieve cumulative disc rotation", () => finalCumulativeTrackerRotation = drawableSpinner.Result.RateAdjustedRotation);
 
@@ -98,8 +90,6 @@ namespace osu.Game.Rulesets.Osu.Tests
                 // due to the exponential damping applied we're allowing a larger margin of error of about 10%
                 // (5% relative to the final rotation value, but we're half-way through the spin).
                 () => drawableSpinner.RotationTracker.Rotation, () => Is.EqualTo(finalTrackerRotation / 2).Within(trackerRotationTolerance));
-            AddAssert("symbol rotation rewound",
-                () => spinnerSymbol.Rotation, () => Is.EqualTo(finalSpinnerSymbolRotation / 2).Within(spinnerSymbolRotationTolerance));
             AddAssert("is cumulative rotation rewound",
                 // cumulative rotation is not damped, so we're treating it as the "ground truth" and allowing a comparatively smaller margin of error.
                 () => drawableSpinner.Result.RateAdjustedRotation, () => Is.EqualTo(finalCumulativeTrackerRotation / 2).Within(100));
@@ -107,8 +97,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             addSeekStep(spinner_start_time + 5000);
             AddAssert("is disc rotation almost same",
                 () => drawableSpinner.RotationTracker.Rotation, () => Is.EqualTo(finalTrackerRotation).Within(trackerRotationTolerance));
-            AddAssert("is symbol rotation almost same",
-                () => spinnerSymbol.Rotation, () => Is.EqualTo(finalSpinnerSymbolRotation).Within(spinnerSymbolRotationTolerance));
             AddAssert("is cumulative rotation almost same",
                 () => drawableSpinner.Result.RateAdjustedRotation, () => Is.EqualTo(finalCumulativeTrackerRotation).Within(100));
         }
@@ -122,7 +110,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             addSeekStep(5000);
 
             AddAssert("disc spin direction correct", () => clockwise ? drawableSpinner.RotationTracker.Rotation > 0 : drawableSpinner.RotationTracker.Rotation < 0);
-            AddAssert("spinner symbol direction correct", () => clockwise ? spinnerSymbol.Rotation > 0 : spinnerSymbol.Rotation < 0);
         }
 
         private Replay flip(Replay scoreReplay) => new Replay

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTrianglesSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTrianglesSpinnerRotation.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Skinning;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public class TestSceneTrianglesSpinnerRotation : TestSceneOsuPlayer
+    {
+        private const double spinner_start_time = 100;
+        private const double spinner_duration = 6000;
+
+        [Resolved]
+        private SkinManager skinManager { get; set; } = null!;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        protected override bool Autoplay => true;
+
+        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new ScoreExposedPlayer();
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
+            => new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+
+        private DrawableSpinner drawableSpinner = null!;
+        private SpriteIcon spinnerSymbol => drawableSpinner.ChildrenOfType<SpriteIcon>().Single();
+
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("set triangles skin", () => skinManager.CurrentSkinInfo.Value = TrianglesSkin.CreateInfo().ToLiveUnmanaged());
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+            AddStep("retrieve spinner", () => drawableSpinner = (DrawableSpinner)Player.DrawableRuleset.Playfield.AllHitObjects.First());
+        }
+
+        [Test]
+        public void TestSymbolMiddleRewindingRotation()
+        {
+            double finalSpinnerSymbolRotation = 0, spinnerSymbolRotationTolerance = 0;
+
+            addSeekStep(spinner_start_time + 5000);
+            AddStep("retrieve spinner symbol rotation", () =>
+            {
+                finalSpinnerSymbolRotation = spinnerSymbol.Rotation;
+                spinnerSymbolRotationTolerance = Math.Abs(finalSpinnerSymbolRotation * 0.05f);
+            });
+
+            addSeekStep(spinner_start_time + 2500);
+            AddAssert("symbol rotation rewound",
+                () => spinnerSymbol.Rotation, () => Is.EqualTo(finalSpinnerSymbolRotation / 2).Within(spinnerSymbolRotationTolerance));
+
+            addSeekStep(spinner_start_time + 5000);
+            AddAssert("is symbol rotation almost same",
+                () => spinnerSymbol.Rotation, () => Is.EqualTo(finalSpinnerSymbolRotation).Within(spinnerSymbolRotationTolerance));
+        }
+
+        [Test]
+        public void TestSymbolRotationDirection([Values(true, false)] bool clockwise)
+        {
+            if (clockwise)
+                transformReplay(flip);
+
+            addSeekStep(5000);
+            AddAssert("spinner symbol direction correct", () => clockwise ? spinnerSymbol.Rotation > 0 : spinnerSymbol.Rotation < 0);
+        }
+
+        private Replay flip(Replay scoreReplay) => new Replay
+        {
+            Frames = scoreReplay
+                     .Frames
+                     .Cast<OsuReplayFrame>()
+                     .Select(replayFrame =>
+                     {
+                         var flippedPosition = new Vector2(OsuPlayfield.BASE_SIZE.X - replayFrame.Position.X, replayFrame.Position.Y);
+                         return new OsuReplayFrame(replayFrame.Time, flippedPosition, replayFrame.Actions.ToArray());
+                     })
+                     .Cast<ReplayFrame>()
+                     .ToList()
+        };
+
+        private void addSeekStep(double time)
+        {
+            AddStep($"seek to {time}", () => Player.GameplayClockContainer.Seek(time));
+            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(time).Within(100));
+        }
+
+        private void transformReplay(Func<Replay, Replay> replayTransformation) => AddStep("set replay", () =>
+        {
+            var drawableRuleset = this.ChildrenOfType<DrawableOsuRuleset>().Single();
+            var score = drawableRuleset.ReplayScore;
+            var transformedScore = new Score
+            {
+                ScoreInfo = score.ScoreInfo,
+                Replay = replayTransformation.Invoke(score.Replay)
+            };
+            drawableRuleset.SetReplayScore(transformedScore);
+        });
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            HitObjects = new List<HitObject>
+            {
+                new Spinner
+                {
+                    Position = new Vector2(256, 192),
+                    StartTime = spinner_start_time,
+                    Duration = spinner_duration
+                },
+            }
+        };
+
+        private class ScoreExposedPlayer : TestPlayer
+        {
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            public ScoreExposedPlayer()
+                : base(false, false)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -55,14 +55,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Font = OsuFont.Default.With(size: 28, weight: FontWeight.Bold),
-                    Y = -120,
+                    Y = -100,
                 },
                 spmContainer = new Container
                 {
                     Alpha = 0f,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Y = 100,
+                    Y = 60,
                     Children = new[]
                     {
                         spmCounter = new OsuSpriteText

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -1,0 +1,146 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonSpinner : CompositeDrawable
+    {
+        private DrawableSpinner drawableSpinner = null!;
+
+        private OsuSpriteText bonusCounter = null!;
+
+        private Container spmContainer = null!;
+        private OsuSpriteText spmCounter = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableHitObject)
+        {
+            RelativeSizeAxes = Axes.Both;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            drawableSpinner = (DrawableSpinner)drawableHitObject;
+
+            InternalChildren = new Drawable[]
+            {
+                bonusCounter = new OsuSpriteText
+                {
+                    Alpha = 0,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Font = OsuFont.Default.With(size: 24),
+                    Y = -120,
+                },
+                new ArgonSpinnerDisc
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                bonusCounter = new OsuSpriteText
+                {
+                    Alpha = 0,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Font = OsuFont.Default.With(size: 28, weight: FontWeight.Bold),
+                    Y = -120,
+                },
+                spmContainer = new Container
+                {
+                    Alpha = 0f,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Y = 100,
+                    Children = new[]
+                    {
+                        spmCounter = new OsuSpriteText
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Text = @"0",
+                            Font = OsuFont.Default.With(size: 28, weight: FontWeight.SemiBold)
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Text = @"SPINS PER MINUTE",
+                            Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold),
+                            Y = 30
+                        }
+                    }
+                }
+            };
+        }
+
+        private IBindable<double> gainedBonus = null!;
+        private IBindable<double> spinsPerMinute = null!;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            gainedBonus = drawableSpinner.GainedBonus.GetBoundCopy();
+            gainedBonus.BindValueChanged(bonus =>
+            {
+                bonusCounter.Text = bonus.NewValue.ToString(NumberFormatInfo.InvariantInfo);
+                bonusCounter.FadeOutFromOne(1500);
+                bonusCounter.ScaleTo(1.5f).Then().ScaleTo(1f, 1000, Easing.OutQuint);
+            });
+
+            spinsPerMinute = drawableSpinner.SpinsPerMinute.GetBoundCopy();
+            spinsPerMinute.BindValueChanged(spm =>
+            {
+                spmCounter.Text = Math.Truncate(spm.NewValue).ToString(@"#0");
+            }, true);
+
+            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
+            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!spmContainer.IsPresent && drawableSpinner.Result?.TimeStarted != null)
+                fadeCounterOnTimeStart();
+        }
+
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
+        {
+            if (!(drawableHitObject is DrawableSpinner))
+                return;
+
+            fadeCounterOnTimeStart();
+        }
+
+        private void fadeCounterOnTimeStart()
+        {
+            if (drawableSpinner.Result?.TimeStarted is double startTime)
+            {
+                using (BeginAbsoluteSequence(startTime))
+                    spmContainer.FadeIn(drawableSpinner.HitObject.TimeFadeIn);
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableSpinner.IsNotNull())
+                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinnerDisc.cs
@@ -1,0 +1,247 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Skinning.Default;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonSpinnerDisc : CompositeDrawable
+    {
+        private const float initial_scale = 1.3f;
+        private const float idle_alpha = 0.2f;
+        private const float tracking_alpha = 0.4f;
+
+        private const float idle_centre_size = 80f;
+        private const float tracking_centre_size = 40f;
+
+        private DrawableSpinner drawableSpinner = null!;
+
+        private readonly BindableBool complete = new BindableBool();
+
+        private int wholeRotationCount;
+
+        private bool checkNewRotationCount
+        {
+            get
+            {
+                int rotations = (int)(drawableSpinner.Result.RateAdjustedRotation / 360);
+
+                if (wholeRotationCount == rotations) return false;
+
+                wholeRotationCount = rotations;
+                return true;
+            }
+        }
+
+        private Container disc = null!;
+        private Container centre = null!;
+        private CircularContainer fill = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableHitObject)
+        {
+            drawableSpinner = (DrawableSpinner)drawableHitObject;
+
+            // we are slightly bigger than our parent, to clip the top and bottom of the circle
+            // this should probably be revisited when scaled spinners are a thing.
+            Scale = new Vector2(initial_scale);
+
+            InternalChildren = new Drawable[]
+            {
+                disc = new CircularContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        fill = new CircularContainer
+                        {
+                            Name = @"Fill",
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            EdgeEffect = new EdgeEffectParameters
+                            {
+                                Type = EdgeEffectType.Shadow,
+                                Colour = Colour4.FromHex("FC618F").Opacity(1f),
+                                Radius = 40,
+                            },
+                            Child = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0f,
+                                AlwaysPresent = true,
+                            }
+                        },
+                        new CircularContainer
+                        {
+                            Name = @"Ring",
+                            Masking = true,
+                            BorderColour = Color4.White,
+                            BorderThickness = 5,
+                            RelativeSizeAxes = Axes.Both,
+                            Child = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0,
+                                AlwaysPresent = true,
+                            }
+                        },
+                        new ArgonSpinnerTicks(),
+                    }
+                },
+                centre = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(idle_centre_size),
+                    Children = new[]
+                    {
+                        new RingPiece(10)
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(0.8f),
+                        },
+                        new RingPiece(3)
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(1f),
+                        }
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
+
+            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            complete.Value = Time.Current >= drawableSpinner.Result.TimeCompleted;
+
+            if (complete.Value)
+            {
+                if (checkNewRotationCount)
+                {
+                    fill.FinishTransforms(false, nameof(Alpha));
+                    fill
+                        .FadeTo(tracking_alpha + 0.2f, 60, Easing.OutExpo)
+                        .Then()
+                        .FadeTo(tracking_alpha, 250, Easing.OutQuint);
+                }
+            }
+            else
+            {
+                fill.Alpha = (float)Interpolation.Damp(fill.Alpha, drawableSpinner.RotationTracker.Tracking ? tracking_alpha : idle_alpha, 0.98f, (float)Math.Abs(Clock.ElapsedFrameTime));
+            }
+
+            if (centre.Width == idle_centre_size && drawableSpinner.Result?.TimeStarted != null)
+                updateCentrePieceSize();
+
+            const float initial_fill_scale = 0.1f;
+            float targetScale = initial_fill_scale + (0.98f - initial_fill_scale) * drawableSpinner.Progress;
+
+            fill.Scale = new Vector2((float)Interpolation.Lerp(fill.Scale.X, targetScale, Math.Clamp(Math.Abs(Time.Elapsed) / 100, 0, 1)));
+            disc.Rotation = drawableSpinner.RotationTracker.Rotation;
+        }
+
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
+        {
+            if (!(drawableHitObject is DrawableSpinner))
+                return;
+
+            Spinner spinner = drawableSpinner.HitObject;
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt))
+            {
+                this.ScaleTo(initial_scale);
+                this.RotateTo(0);
+
+                using (BeginDelayedSequence(spinner.TimePreempt / 2))
+                {
+                    // constant ambient rotation to give the spinner "spinning" character.
+                    this.RotateTo((float)(25 * spinner.Duration / 2000), spinner.TimePreempt + spinner.Duration);
+                }
+
+                using (BeginDelayedSequence(spinner.TimePreempt + spinner.Duration + drawableHitObject.Result.TimeOffset))
+                {
+                    switch (state)
+                    {
+                        case ArmedState.Hit:
+                            this.ScaleTo(initial_scale * 1.2f, 320, Easing.Out);
+                            this.RotateTo(Rotation + 180, 320);
+                            break;
+
+                        case ArmedState.Miss:
+                            this.ScaleTo(initial_scale * 0.8f, 320, Easing.In);
+                            break;
+                    }
+                }
+            }
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt))
+            {
+                centre.ScaleTo(0);
+                disc.ScaleTo(0);
+
+                using (BeginDelayedSequence(spinner.TimePreempt / 2))
+                {
+                    centre.ScaleTo(0.3f, spinner.TimePreempt / 4, Easing.OutQuint);
+                    disc.ScaleTo(0.2f, spinner.TimePreempt / 4, Easing.OutQuint);
+
+                    using (BeginDelayedSequence(spinner.TimePreempt / 2))
+                    {
+                        centre.ScaleTo(0.8f, spinner.TimePreempt / 2, Easing.OutQuint);
+                        disc.ScaleTo(1, spinner.TimePreempt / 2, Easing.OutQuint);
+                    }
+                }
+            }
+
+            if (drawableSpinner.Result?.TimeStarted != null)
+                updateCentrePieceSize();
+        }
+
+        private void updateCentrePieceSize()
+        {
+            Debug.Assert(drawableSpinner.Result?.TimeStarted != null);
+
+            Spinner spinner = drawableSpinner.HitObject;
+
+            using (BeginAbsoluteSequence(drawableSpinner.Result.TimeStarted.Value))
+                centre.ResizeTo(new Vector2(tracking_centre_size), spinner.TimePreempt / 2, Easing.OutQuint);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableSpinner.IsNotNull())
+                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinnerDisc.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public class ArgonSpinnerDisc : CompositeDrawable
     {
-        private const float initial_scale = 1.3f;
+        private const float initial_scale = 1f;
         private const float idle_alpha = 0.2f;
         private const float tracking_alpha = 0.4f;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinnerTicks.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinnerTicks.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public class ArgonSpinnerTicks : CompositeDrawable
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Origin = Anchor.Centre;
+            Anchor = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+
+            const float count = 25;
+
+            for (float i = 0; i < count; i++)
+            {
+                AddInternal(new CircularContainer
+                {
+                    RelativePositionAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 5,
+                    BorderColour = Color4.White,
+                    BorderThickness = 2f,
+                    Size = new Vector2(30, 5),
+                    Origin = Anchor.Centre,
+                    Position = new Vector2(
+                        0.5f + MathF.Sin(i / count * 2 * MathF.PI) / 2 * 0.75f,
+                        0.5f + MathF.Cos(i / count * 2 * MathF.PI) / 2 * 0.75f
+                    ),
+                    Rotation = -i / count * 360 - 120,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Colour = Colour4.White.Opacity(0.2f),
+                        Radius = 30,
+                    },
+                    Children = new[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0,
+                            AlwaysPresent = true,
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -42,6 +42,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         case OsuSkinComponents.SliderScorePoint:
                             return new ArgonSliderScorePoint();
 
+                        case OsuSkinComponents.SpinnerBody:
+                            return new ArgonSpinner();
+
                         case OsuSkinComponents.ReverseArrow:
                             return new ArgonReverseArrow();
                     }


### PR DESCRIPTION
[Source design](https://www.figma.com/file/up6guVobzpc3DZlQxWzVmv/Gameplay-Layout?node-id=2%3A1577). Metrics were mostly ballparked, the sides of the new spinner were not added due to being too complex to implement, similar to the reverse indicator on slider borders.

All animations have been directly copy-pasted from the triangles variant for simplicity, as I don't believe we will still use the same animation so there's probably no need to share them across using an abstract class or otherwise.

https://user-images.githubusercontent.com/22781491/191815624-114fe262-575e-4b40-b823-80d1c1a4e1c6.mp4

