### PR TITLE
Fix update progress notification not closing on completion

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -465,7 +465,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             base.Update();
 
-            progressingNotifications.RemoveAll(n => n.State == ProgressNotificationState.Completed);
+            progressingNotifications.RemoveAll(n => n.State == ProgressNotificationState.Completed && n.WasClosed);
 
             if (progressingNotifications.Count(n => n.State == ProgressNotificationState.Active) < 3)
             {

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -156,6 +156,7 @@ namespace osu.Game.Updater
                 switch (State)
                 {
                     case ProgressNotificationState.Cancelled:
+                    case ProgressNotificationState.Completed:
                         base.Close(runFlingAnimation);
                         break;
                 }


### PR DESCRIPTION
Since `ProgressNotification` was changed to call `Close` rather than `base.Close` in https://github.com/ppy/osu/pull/20339, update progress notification regressed as it overrides `Close` to disallow cancelling the notification, but it did not handle `Completed` state.

Test scene was also updated to no longer count a progressed notification as completed unless it has been closed as well, since that's a general behaviour for any progress notification.