### PR TITLE
Cleanup bindings instantiation

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
             MaxValue = 1.5f,

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -21,17 +21,11 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             MinValue = 0.5f,
             MaxValue = 1.5f,
-            Default = 1f,
-            Value = 1f,
             Precision = 0.1f
         };
 
         [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
-        public override BindableBool ComboBasedSize { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
         public override float DefaultFlashlightSize => 350;
 

--- a/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
@@ -22,10 +22,8 @@ namespace osu.Game.Rulesets.Catch.Mods
             "The combo count at which the catcher becomes completely hidden",
             SettingControlType = typeof(SettingsSlider<int, HiddenComboSlider>)
         )]
-        public override BindableInt HiddenComboCount { get; } = new BindableInt
+        public override BindableInt HiddenComboCount { get; } = new BindableInt(10)
         {
-            Default = 10,
-            Value = 10,
             MinValue = 0,
             MaxValue = 50,
         };

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -18,21 +18,15 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override Type[] IncompatibleMods => new[] { typeof(ModHidden) };
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
             MaxValue = 3f,
-            Default = 1f,
-            Value = 1f,
             Precision = 0.1f
         };
 
         [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
-        public override BindableBool ComboBasedSize { get; } = new BindableBool
-        {
-            Default = false,
-            Value = false
-        };
+        public override BindableBool ComboBasedSize { get; } = new BindableBool();
 
         public override float DefaultFlashlightSize => 50;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDeflate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDeflate.cs
@@ -19,12 +19,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Hit them at the right size!";
 
         [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
-        public override BindableNumber<float> StartScale { get; } = new BindableFloat
+        public override BindableNumber<float> StartScale { get; } = new BindableFloat(2)
         {
             MinValue = 1f,
             MaxValue = 25f,
-            Default = 2f,
-            Value = 2f,
             Precision = 0.1f,
         };
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -33,21 +33,15 @@ namespace osu.Game.Rulesets.Osu.Mods
         };
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
             MaxValue = 2f,
-            Default = 1f,
-            Value = 1f,
             Precision = 0.1f
         };
 
         [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
-        public override BindableBool ComboBasedSize { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
         public override float DefaultFlashlightSize => 180;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -19,12 +19,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Hit them at the right size!";
 
         [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
-        public override BindableNumber<float> StartScale { get; } = new BindableFloat
+        public override BindableNumber<float> StartScale { get; } = new BindableFloat(0.5f)
         {
             MinValue = 0f,
             MaxValue = 0.99f,
-            Default = 0.5f,
-            Value = 0.5f,
             Precision = 0.01f,
         };
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
@@ -27,10 +27,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             "The combo count at which the cursor becomes completely hidden",
             SettingControlType = typeof(SettingsSlider<int, HiddenComboSlider>)
         )]
-        public override BindableInt HiddenComboCount { get; } = new BindableInt
+        public override BindableInt HiddenComboCount { get; } = new BindableInt(10)
         {
-            Default = 10,
-            Value = 10,
             MinValue = 0,
             MaxValue = 50,
         };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -29,10 +29,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModTarget)).ToArray();
 
         [SettingSource("Angle sharpness", "How sharp angles should be", SettingControlType = typeof(SettingsSlider<float>))]
-        public BindableFloat AngleSharpness { get; } = new BindableFloat
+        public BindableFloat AngleSharpness { get; } = new BindableFloat(7)
         {
-            Default = 7,
-            Value = 7,
             MinValue = 1,
             MaxValue = 10,
             Precision = 0.1f

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTarget.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTarget.cs
@@ -53,11 +53,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         }).ToArray();
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> Seed { get; } = new Bindable<int?>
-        {
-            Default = null,
-            Value = null
-        };
+        public Bindable<int?> Seed { get; } = new Bindable<int?>();
 
         [SettingSource("Metronome ticks", "Whether a metronome beat should play in the background")]
         public Bindable<bool> Metronome { get; } = new BindableBool(true);

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -18,21 +18,15 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
-        public override BindableFloat SizeMultiplier { get; } = new BindableFloat
+        public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
             MaxValue = 1.5f,
-            Default = 1f,
-            Value = 1f,
             Precision = 0.1f
         };
 
         [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
-        public override BindableBool ComboBasedSize { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
         public override float DefaultFlashlightSize => 250;
 

--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -204,31 +204,23 @@ namespace osu.Game.Tests.Online
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
-            public override BindableNumber<double> InitialRate { get; } = new BindableDouble
+            public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1.5)
             {
                 MinValue = 1,
                 MaxValue = 2,
-                Default = 1.5,
-                Value = 1.5,
                 Precision = 0.01,
             };
 
             [SettingSource("Final rate", "The speed increase to ramp towards")]
-            public override BindableNumber<double> FinalRate { get; } = new BindableDouble
+            public override BindableNumber<double> FinalRate { get; } = new BindableDouble(0.5)
             {
                 MinValue = 0,
                 MaxValue = 1,
-                Default = 0.5,
-                Value = 0.5,
                 Precision = 0.01,
             };
 
             [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
-            public override BindableBool AdjustPitch { get; } = new BindableBool
-            {
-                Default = true,
-                Value = true
-            };
+            public override BindableBool AdjustPitch { get; } = new BindableBool(true);
         }
 
         private class TestModDifficultyAdjust : ModDifficultyAdjust

--- a/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
@@ -124,31 +124,23 @@ namespace osu.Game.Tests.Online
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
-            public override BindableNumber<double> InitialRate { get; } = new BindableDouble
+            public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1.5)
             {
                 MinValue = 1,
                 MaxValue = 2,
-                Default = 1.5,
-                Value = 1.5,
                 Precision = 0.01,
             };
 
             [SettingSource("Final rate", "The speed increase to ramp towards")]
-            public override BindableNumber<double> FinalRate { get; } = new BindableDouble
+            public override BindableNumber<double> FinalRate { get; } = new BindableDouble(0.5)
             {
                 MinValue = 0,
                 MaxValue = 1,
-                Default = 0.5,
-                Value = 0.5,
                 Precision = 0.01,
             };
 
             [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
-            public override BindableBool AdjustPitch { get; } = new BindableBool
-            {
-                Default = true,
-                Value = true
-            };
+            public override BindableBool AdjustPitch { get; } = new BindableBool(true);
         }
 
         private class TestModEnum : Mod

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
@@ -29,11 +29,7 @@ namespace osu.Game.Tests.Visual.Settings
             {
                 Child = textBox = new SettingsTextBox
                 {
-                    Current = new Bindable<string>
-                    {
-                        Default = "test",
-                        Value = "test"
-                    }
+                    Current = new Bindable<string>("test")
                 };
             });
             AddUntilStep("wait for loaded", () => textBox.IsLoaded);
@@ -59,11 +55,7 @@ namespace osu.Game.Tests.Visual.Settings
             {
                 Child = textBox = new SettingsTextBox
                 {
-                    Current = new Bindable<string>
-                    {
-                        Default = "test",
-                        Value = "test"
-                    }
+                    Current = new Bindable<string>("test")
                 };
             });
             AddUntilStep("wait for loaded", () => textBox.IsLoaded);

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
@@ -67,11 +67,7 @@ namespace osu.Game.Tests.Visual.Settings
             };
 
             [SettingSource("Sample number textbox", "Textbox number entry", SettingControlType = typeof(SettingsNumberBox))]
-            public Bindable<int?> IntTextBoxBindable { get; } = new Bindable<int?>
-            {
-                Default = null,
-                Value = null
-            };
+            public Bindable<int?> IntTextBoxBindable { get; } = new Bindable<int?>();
         }
 
         private enum TestEnum

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
@@ -38,16 +38,20 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         slider1 = new ExpandableSlider<float, SizeSlider<float>>
                         {
-                            Current = new BindableFloat(1.0f)
+                            Current = new BindableFloat
                             {
+                                Default = 1.0f,
+                                MinValue = 1.0f,
                                 MaxValue = 10.0f,
                                 Precision = 0.01f,
                             },
                         },
                         slider2 = new ExpandableSlider<double>
                         {
-                            Current = new BindableDouble(1.0)
+                            Current = new BindableDouble
                             {
+                                Default = 1.0,
+                                MinValue = 1.0
                                 MaxValue = 10.0,
                                 Precision = 0.01,
                             },

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
@@ -38,20 +38,16 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         slider1 = new ExpandableSlider<float, SizeSlider<float>>
                         {
-                            Current = new BindableFloat
+                            Current = new BindableFloat(1.0f)
                             {
-                                Default = 1.0f,
-                                MinValue = 1.0f,
                                 MaxValue = 10.0f,
                                 Precision = 0.01f,
                             },
                         },
                         slider2 = new ExpandableSlider<double>
                         {
-                            Current = new BindableDouble
+                            Current = new BindableDouble(1.0)
                             {
-                                Default = 1.0,
-                                MinValue = 1.0,
                                 MaxValue = 10.0,
                                 Precision = 0.01,
                             },

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneExpandingContainer.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                             Current = new BindableDouble
                             {
                                 Default = 1.0,
-                                MinValue = 1.0
+                                MinValue = 1.0,
                                 MaxValue = 10.0,
                                 Precision = 0.01,
                             },

--- a/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Beatmaps.ControlPoints
         public readonly BindableDouble SliderVelocityBindable = new BindableDouble(1)
         {
             Precision = 0.01,
-            Default = 1,
             MinValue = 0.1,
             MaxValue = 10
         };

--- a/osu.Game/Beatmaps/ControlPoints/EffectControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/EffectControlPoint.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Beatmaps.ControlPoints
         public readonly BindableDouble ScrollSpeedBindable = new BindableDouble(1)
         {
             Precision = 0.01,
-            Default = 1,
             MinValue = 0.01,
             MaxValue = 10
         };

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Beatmaps.ControlPoints
         {
             MinValue = 0,
             MaxValue = 100,
-            Default = 100
         };
 
         /// <summary>

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -49,7 +49,6 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         public readonly BindableDouble BeatLengthBindable = new BindableDouble(DEFAULT_BEAT_LENGTH)
         {
-            Default = DEFAULT_BEAT_LENGTH,
             MinValue = 6,
             MaxValue = 60000
         };

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -36,32 +36,24 @@ namespace osu.Game.Rulesets.Mods
         public override Type[] IncompatibleMods => new[] { typeof(ModRateAdjust), typeof(ModTimeRamp), typeof(ModAutoplay) };
 
         [SettingSource("Initial rate", "The starting speed of the track")]
-        public BindableNumber<double> InitialRate { get; } = new BindableDouble
+        public BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {
             MinValue = 0.5,
             MaxValue = 2,
-            Default = 1,
-            Value = 1,
             Precision = 0.01
         };
 
         [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
-        public BindableBool AdjustPitch { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public BindableBool AdjustPitch { get; } = new BindableBool(true);
 
         /// <summary>
         /// The instantaneous rate of the track.
         /// Every frame this mod will attempt to smoothly adjust this to meet <see cref="targetRate"/>.
         /// </summary>
-        public BindableNumber<double> SpeedChange { get; } = new BindableDouble
+        public BindableNumber<double> SpeedChange { get; } = new BindableDouble(1)
         {
             MinValue = min_allowable_rate,
             MaxValue = max_allowable_rate,
-            Default = 1,
-            Value = 1
         };
 
         // The two constants below denote the maximum allowable range of rates that `SpeedChange` can take.

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -18,12 +18,10 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Zoooooooooom...";
 
         [SettingSource("Speed increase", "The actual increase to apply")]
-        public override BindableNumber<double> SpeedChange { get; } = new BindableDouble
+        public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)
         {
             MinValue = 1.01,
             MaxValue = 2,
-            Default = 1.5,
-            Value = 1.5,
             Precision = 0.01,
         };
     }

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -18,12 +18,10 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Less zoom...";
 
         [SettingSource("Speed decrease", "The actual decrease to apply")]
-        public override BindableNumber<double> SpeedChange { get; } = new BindableDouble
+        public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)
         {
             MinValue = 0.5,
             MaxValue = 0.99,
-            Default = 0.75,
-            Value = 0.75,
             Precision = 0.01,
         };
     }

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -36,34 +36,20 @@ namespace osu.Game.Rulesets.Mods
         private readonly BindableNumber<int> currentCombo = new BindableInt();
 
         [SettingSource("Enable metronome", "Add a metronome beat to help you keep track of the rhythm.")]
-        public BindableBool EnableMetronome { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public BindableBool EnableMetronome { get; } = new BindableBool(true);
 
         [SettingSource("Final volume at combo", "The combo count at which point the track reaches its final volume.", SettingControlType = typeof(SettingsSlider<int, MuteComboSlider>))]
-        public BindableInt MuteComboCount { get; } = new BindableInt
+        public BindableInt MuteComboCount { get; } = new BindableInt(100)
         {
-            Default = 100,
-            Value = 100,
             MinValue = 0,
             MaxValue = 500,
         };
 
         [SettingSource("Start muted", "Increase volume as combo builds.")]
-        public BindableBool InverseMuting { get; } = new BindableBool
-        {
-            Default = false,
-            Value = false
-        };
+        public BindableBool InverseMuting { get; } = new BindableBool();
 
         [SettingSource("Mute hit sounds", "Hit sounds are also muted alongside the track.")]
-        public BindableBool AffectsHitSounds { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public BindableBool AffectsHitSounds { get; } = new BindableBool(true);
 
         protected ModMuted()
         {

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -18,10 +18,6 @@ namespace osu.Game.Rulesets.Mods
         public override double ScoreMultiplier => 1;
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]
-        public Bindable<int?> Seed { get; } = new Bindable<int?>
-        {
-            Default = null,
-            Value = null
-        };
+        public Bindable<int?> Seed { get; } = new Bindable<int?>();
     }
 }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -39,10 +39,8 @@ namespace osu.Game.Rulesets.Mods
         private double finalRateTime;
         private double beginRampTime;
 
-        public BindableNumber<double> SpeedChange { get; } = new BindableDouble
+        public BindableNumber<double> SpeedChange { get; } = new BindableDouble(1)
         {
-            Default = 1,
-            Value = 1,
             Precision = 0.01,
         };
 

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -18,31 +18,23 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => FontAwesome.Solid.ChevronCircleDown;
 
         [SettingSource("Initial rate", "The starting speed of the track")]
-        public override BindableNumber<double> InitialRate { get; } = new BindableDouble
+        public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {
             MinValue = 0.51,
             MaxValue = 2,
-            Default = 1,
-            Value = 1,
             Precision = 0.01,
         };
 
         [SettingSource("Final rate", "The speed increase to ramp towards")]
-        public override BindableNumber<double> FinalRate { get; } = new BindableDouble
+        public override BindableNumber<double> FinalRate { get; } = new BindableDouble(0.75)
         {
             MinValue = 0.5,
             MaxValue = 1.99,
-            Default = 0.75,
-            Value = 0.75,
             Precision = 0.01,
         };
 
         [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
-        public override BindableBool AdjustPitch { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public override BindableBool AdjustPitch { get; } = new BindableBool(true);
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModWindUp)).ToArray();
 

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -18,31 +18,23 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => FontAwesome.Solid.ChevronCircleUp;
 
         [SettingSource("Initial rate", "The starting speed of the track")]
-        public override BindableNumber<double> InitialRate { get; } = new BindableDouble
+        public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {
             MinValue = 0.5,
             MaxValue = 1.99,
-            Default = 1,
-            Value = 1,
             Precision = 0.01,
         };
 
         [SettingSource("Final rate", "The speed increase to ramp towards")]
-        public override BindableNumber<double> FinalRate { get; } = new BindableDouble
+        public override BindableNumber<double> FinalRate { get; } = new BindableDouble(1.5)
         {
             MinValue = 0.51,
             MaxValue = 2,
-            Default = 1.5,
-            Value = 1.5,
             Precision = 0.01,
         };
 
         [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
-        public override BindableBool AdjustPitch { get; } = new BindableBool
-        {
-            Default = true,
-            Value = true
-        };
+        public override BindableBool AdjustPitch { get; } = new BindableBool(true);
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModWindDown)).ToArray();
 

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -60,7 +60,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
         /// </summary>
         protected readonly BindableDouble TimeRange = new BindableDouble(time_span_default)
         {
-            Default = time_span_default,
             MinValue = time_span_min,
             MaxValue = time_span_max
         };

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Screens.Play
 
         public readonly BindableNumber<double> UserPlaybackRate = new BindableDouble(1)
         {
-            Default = 1,
             MinValue = 0.5,
             MaxValue = 2,
             Precision = 0.1,

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public BindableDouble Current { get; } = new BindableDouble
         {
-            Default = 0,
-            Value = 0,
             MinValue = -50,
             MaxValue = 50,
             Precision = 0.1,

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public readonly Bindable<double> UserPlaybackRate = new BindableDouble(1)
         {
-            Default = 1,
             MinValue = 0.5,
             MaxValue = 2,
             Precision = 0.1,


### PR DESCRIPTION
A vast majority of `Bindable<T>`s were being instantiated using a longer way of instatiating without it being necessary, this can be seem on how the `Bindable<T>` instatiation works [here](https://github.com/ppy/osu-framework/blob/8fad02500c4ae9c8ad5b1d9460218a850c2a0700/osu.Framework/Bindables/Bindable.cs#L152).

What this pull request does is instead of:
```cs
new Bindable<T>
{
    Value = some_thing,
    Default = some_thing
};
```
We use the short way of writing the same thing
```cs
new Bindable<T>(some_thing);
```