### PR TITLE
Fix potential crash on game exit due to incorrect scheduling of realm change handler

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             beatmapSubscription?.Dispose();
         }
 
-        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error)
+        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error) => Schedule(() =>
         {
             currentlyLoadedBeatmaps.Text = FirstRunSetupBeatmapScreenStrings.CurrentlyLoadedBeatmaps(sender.Count);
 
@@ -139,7 +139,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                 currentlyLoadedBeatmaps.ScaleTo(1.1f)
                                        .ScaleTo(1, 1500, Easing.OutQuint);
             }
-        }
+        });
 
         private void downloadTutorial()
         {

--- a/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
+++ b/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
@@ -58,6 +58,9 @@ namespace osu.Game.Rulesets.Configuration
                 pendingWrites.Clear();
             }
 
+            if (!changed.Any())
+                return true;
+
             realm?.Write(r =>
             {
                 foreach (var c in changed)


### PR DESCRIPTION
Also noticed that the call stack resulting in this report is a configuration manager writing to realm far too often, so fixed that in c488726.