### PR TITLE
Use `StackedEndPosition` instead of `EndPosition` to determine the jump distance in the `FlashlightEvaluator`

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/FlashlightEvaluator.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
                 if (!(currentObj.BaseObject is Spinner))
                 {
-                    double jumpDistance = (osuHitObject.StackedPosition - currentHitObject.EndPosition).Length;
+                    double jumpDistance = (osuHitObject.StackedPosition - currentHitObject.StackedEndPosition).Length;
 
                     cumulativeStrainTime += lastObj.StrainTime;
 


### PR DESCRIPTION
`EndPosition` is just the original position from the `.osu` file, while the `StackedEndPosition` is the actual in-game position after applying the stacking algorithm.

That's why I adjusted the jump distance calculation to take the `StackedEndPosition` into account.