### PR TITLE
Fixes unecessary events being handled by `ModFlashlight`

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Catch.Mods
                 FlashlightPosition = playfield.CatcherArea.ToSpaceOfOtherDrawable(playfield.Catcher.DrawPosition, this);
             }
 
-            protected override void OnComboChange(ValueChangedEvent<int> e)
+            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Catch.Mods
                 : base(modFlashlight)
             {
                 this.playfield = playfield;
-                FlashlightSize = new Vector2(0, GetSizeFor(0));
+                FlashlightSize = new Vector2(0, appliedFlashlightSize);
             }
 
             protected override void Update()
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 
             public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetComboBasedSize(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }
 
             protected override string FragmentShader => "CircularFlashlight";

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Catch.Mods
                 : base(modFlashlight)
             {
                 this.playfield = playfield;
-                FlashlightSize = new Vector2(0, appliedFlashlightSize);
+                FlashlightSize = new Vector2(0, AppliedFlashlightSize);
             }
 
             protected override void Update()

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Catch.Mods
                 FlashlightPosition = playfield.CatcherArea.ToSpaceOfOtherDrawable(playfield.Catcher.DrawPosition, this);
             }
 
-            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
+            public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             public ManiaFlashlight(ManiaModFlashlight modFlashlight)
                 : base(modFlashlight)
             {
-                FlashlightSize = new Vector2(DrawWidth, GetSizeFor(0));
+                FlashlightSize = new Vector2(DrawWidth, appliedFlashlightSize);
 
                 AddLayout(flashlightProperties);
             }
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
             public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(DrawWidth, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
+                this.TransformTo(nameof(FlashlightSize), new Vector2(DrawWidth, GetComboBasedSize(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }
 
             protected override string FragmentShader => "RectangularFlashlight";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                 }
             }
 
-            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
+            public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), new Vector2(DrawWidth, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             public ManiaFlashlight(ManiaModFlashlight modFlashlight)
                 : base(modFlashlight)
             {
-                FlashlightSize = new Vector2(DrawWidth, appliedFlashlightSize);
+                FlashlightSize = new Vector2(DrawWidth, AppliedFlashlightSize);
 
                 AddLayout(flashlightProperties);
             }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                 }
             }
 
-            protected override void OnComboChange(ValueChangedEvent<int> e)
+            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), new Vector2(DrawWidth, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 return base.OnMouseMove(e);
             }
 
-            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
+            public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 followDelay = modFlashlight.FollowDelay.Value;
 
-                FlashlightSize = new Vector2(0, appliedFlashlightSize);
+                FlashlightSize = new Vector2(0, AppliedFlashlightSize);
             }
 
             public void OnSliderTrackingChange(ValueChangedEvent<bool> e)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 followDelay = modFlashlight.FollowDelay.Value;
 
-                FlashlightSize = new Vector2(0, GetSizeFor(0));
+                FlashlightSize = new Vector2(0, appliedFlashlightSize);
             }
 
             public void OnSliderTrackingChange(ValueChangedEvent<bool> e)
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetComboBasedSize(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }
 
             protected override string FragmentShader => "CircularFlashlight";

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 return base.OnMouseMove(e);
             }
 
-            protected override void OnComboChange(ValueChangedEvent<int> e)
+            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -49,20 +49,22 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 : base(modFlashlight)
             {
                 this.taikoPlayfield = taikoPlayfield;
-                FlashlightSize = getSizeFor(0);
+                FlashlightSize = getSizeVector(appliedFlashlightSize);
 
                 AddLayout(flashlightProperties);
             }
 
-            private Vector2 getSizeFor(int combo)
+            private Vector2 getSizeVector(float size)
             {
                 // Preserve flashlight size through the playfield's aspect adjustment.
-                return new Vector2(0, GetSizeFor(combo) * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
+                return new Vector2(0, size * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
             }
+
+            private Vector2 getSizeVectorForCombo(int combo) => getSizeVector(GetComboBasedSize(combo));
 
             public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
-                this.TransformTo(nameof(FlashlightSize), getSizeFor(e.NewValue), FLASHLIGHT_FADE_DURATION);
+                this.TransformTo(nameof(FlashlightSize), getSizeVectorForCombo(e.NewValue), FLASHLIGHT_FADE_DURATION);
             }
 
             protected override string FragmentShader => "CircularFlashlight";
@@ -76,7 +78,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     FlashlightPosition = ToLocalSpace(taikoPlayfield.HitTarget.ScreenSpaceDrawQuad.Centre);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
-                    FlashlightSize = getSizeFor(Combo.Value);
+                    FlashlightSize = getSizeVectorForCombo(Combo.Value);
 
                     flashlightProperties.Validate();
                 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 return new Vector2(0, GetSizeFor(combo) * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
             }
 
-            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
+            public override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), getSizeFor(e.NewValue), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 return new Vector2(0, GetSizeFor(combo) * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
             }
 
-            protected override void OnComboChange(ValueChangedEvent<int> e)
+            protected override void ApplyComboBasedSize(ValueChangedEvent<int> e)
             {
                 this.TransformTo(nameof(FlashlightSize), getSizeFor(e.NewValue), FLASHLIGHT_FADE_DURATION);
             }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 : base(modFlashlight)
             {
                 this.taikoPlayfield = taikoPlayfield;
-                FlashlightSize = getSizeVector(appliedFlashlightSize);
+                FlashlightSize = getSizeVector(AppliedFlashlightSize);
 
                 AddLayout(flashlightProperties);
             }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -108,19 +108,11 @@ namespace osu.Game.Rulesets.Mods
 
             public List<BreakPeriod> Breaks = new List<BreakPeriod>();
 
-            protected readonly float appliedFlashlightSize;
-
-            private readonly float defaultFlashlightSize;
-            private readonly float sizeMultiplier;
-            private readonly bool comboBasedSize;
+            protected readonly float AppliedFlashlightSize;
 
             protected Flashlight(ModFlashlight modFlashlight)
             {
-                defaultFlashlightSize = modFlashlight.DefaultFlashlightSize;
-                sizeMultiplier = modFlashlight.SizeMultiplier.Value;
-                comboBasedSize = modFlashlight.ComboBasedSize.Value;
-
-                appliedFlashlightSize = defaultFlashlightSize * sizeMultiplier;
+                AppliedFlashlightSize = modFlashlight.DefaultFlashlightSize * modFlashlight.SizeMultiplier.Value;
             }
 
             [BackgroundDependencyLoader]
@@ -154,7 +146,7 @@ namespace osu.Game.Rulesets.Mods
 
             protected float GetComboBasedSize(int combo)
             {
-                float size = appliedFlashlightSize;
+                float size = AppliedFlashlightSize;
 
                 if (combo >= 200)
                     size *= 0.8f;

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -108,6 +108,8 @@ namespace osu.Game.Rulesets.Mods
 
             public List<BreakPeriod> Breaks = new List<BreakPeriod>();
 
+            protected readonly float appliedFlashlightSize;
+
             private readonly float defaultFlashlightSize;
             private readonly float sizeMultiplier;
             private readonly bool comboBasedSize;
@@ -117,6 +119,8 @@ namespace osu.Game.Rulesets.Mods
                 defaultFlashlightSize = modFlashlight.DefaultFlashlightSize;
                 sizeMultiplier = modFlashlight.SizeMultiplier.Value;
                 comboBasedSize = modFlashlight.ComboBasedSize.Value;
+
+                appliedFlashlightSize = defaultFlashlightSize * sizeMultiplier;
             }
 
             [BackgroundDependencyLoader]
@@ -148,17 +152,14 @@ namespace osu.Game.Rulesets.Mods
 
             protected abstract string FragmentShader { get; }
 
-            protected float GetSizeFor(int combo)
+            protected float GetComboBasedSize(int combo)
             {
-                float size = defaultFlashlightSize * sizeMultiplier;
+                float size = appliedFlashlightSize;
 
-                if (comboBasedSize)
-                {
-                    if (combo >= 200)
-                        size *= 0.8f;
-                    else if (combo >= 100)
-                        size *= 0.9f;
-                }
+                if (combo >= 200)
+                    size *= 0.8f;
+                else if (combo >= 100)
+                    size *= 0.9f;
 
                 return size;
             }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -82,7 +82,9 @@ namespace osu.Game.Rulesets.Mods
             flashlight.RelativeSizeAxes = Axes.Both;
             flashlight.Colour = Color4.Black;
 
-            flashlight.Combo.BindTo(Combo);
+            if (ComboBasedSize.Value)
+                flashlight.Combo.BindTo(Combo);
+
             drawableRuleset.KeyBindingInputManager.Add(flashlight);
 
             flashlight.Breaks = drawableRuleset.Beatmap.Breaks;
@@ -123,7 +125,8 @@ namespace osu.Game.Rulesets.Mods
             {
                 base.LoadComplete();
 
-                Combo.ValueChanged += OnComboChange;
+                if (comboBasedSize)
+                    Combo.ValueChanged += ApplyComboBasedSize;
 
                 using (BeginAbsoluteSequence(0))
                 {
@@ -140,7 +143,7 @@ namespace osu.Game.Rulesets.Mods
                 }
             }
 
-            protected abstract void OnComboChange(ValueChangedEvent<int> e);
+            protected abstract void ApplyComboBasedSize(ValueChangedEvent<int> e);
 
             protected abstract string FragmentShader { get; }
 


### PR DESCRIPTION
So before this change `ModFlashlight` would constantly listen to `OnComboChange` events and call `GetSizeFor` and `TransformTo` on any combo change event, this can be seem on how `OsuModFlashlight` handled the said `OnComboChangeEvent`:
```cs
public override void OnComboChange(ValueChangedEvent<int> e)
{
    this.TransformTo(nameof(FlashlightSize), new Vector2(0, GetSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
}
```
What this pull request does is rename `OnComboChange` to `ApplyComboBasedSize` to fit the role of the method better and stop listening to these events if `ComboBasedSize` is turned off.
