### PR TITLE
Fix playlist overlay overflowing at high UI scales

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -24,7 +25,7 @@ namespace osu.Game.Overlays.Music
     public class PlaylistOverlay : VisibilityContainer
     {
         private const float transition_duration = 600;
-        private const float playlist_height = 510;
+        public const float PLAYLIST_HEIGHT = 510;
 
         private readonly BindableList<Live<BeatmapSetInfo>> beatmapSets = new BindableList<Live<BeatmapSetInfo>>();
 
@@ -130,7 +131,7 @@ namespace osu.Game.Overlays.Music
             filter.Search.HoldFocus = true;
             Schedule(() => filter.Search.TakeFocus());
 
-            this.ResizeTo(new Vector2(1, playlist_height), transition_duration, Easing.OutQuint);
+            this.ResizeTo(new Vector2(1, RelativeSizeAxes.HasFlagFast(Axes.Y) ? 1f : PLAYLIST_HEIGHT), transition_duration, Easing.OutQuint);
             this.FadeIn(transition_duration, Easing.OutQuint);
         }
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Overlays
         private const float transition_length = 800;
         private const float progress_height = 10;
         private const float bottom_black_area_height = 55;
+        private const float margin = 10;
 
         private Drawable background;
         private ProgressBar progressBar;
@@ -69,7 +70,7 @@ namespace osu.Game.Overlays
         public NowPlayingOverlay()
         {
             Width = 400;
-            Margin = new MarginPadding(10);
+            Margin = new MarginPadding(margin);
         }
 
         [BackgroundDependencyLoader]
@@ -194,7 +195,7 @@ namespace osu.Game.Overlays
                 LoadComponentAsync(playlist = new PlaylistOverlay
                 {
                     RelativeSizeAxes = Axes.X,
-                    Y = player_height + 10,
+                    Y = player_height + margin,
                 }, _ =>
                 {
                     dragContainer.Add(playlist);

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Overlays
 
         private Container dragContainer;
         private Container playerContainer;
+        private Container playlistContainer;
 
         protected override string PopInSampleName => "UI/now-playing-pop-in";
         protected override string PopOutSampleName => "UI/now-playing-pop-out";
@@ -83,7 +84,6 @@ namespace osu.Game.Overlays
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
                         playerContainer = new Container
@@ -183,8 +183,13 @@ namespace osu.Game.Overlays
                                 }
                             },
                         },
+                        playlistContainer = new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Y = player_height + margin,
+                        }
                     }
-                }
+                },
             };
         }
 
@@ -194,11 +199,10 @@ namespace osu.Game.Overlays
             {
                 LoadComponentAsync(playlist = new PlaylistOverlay
                 {
-                    RelativeSizeAxes = Axes.X,
-                    Y = player_height + margin,
+                    RelativeSizeAxes = Axes.Both,
                 }, _ =>
                 {
-                    dragContainer.Add(playlist);
+                    playlistContainer.Add(playlist);
 
                     playlist.State.BindValueChanged(s => playlistButton.FadeColour(s.NewValue == Visibility.Visible ? colours.Yellow : Color4.White, 200, Easing.OutQuint), true);
 
@@ -243,7 +247,18 @@ namespace osu.Game.Overlays
         {
             base.UpdateAfterChildren();
 
-            Height = dragContainer.Height;
+            playlistContainer.Height = MathF.Min(Parent.DrawHeight - margin * 3 - player_height, PlaylistOverlay.PLAYLIST_HEIGHT);
+
+            float height = player_height;
+
+            if (playlist != null)
+            {
+                height += playlist.DrawHeight;
+                if (playlist.State.Value == Visibility.Visible)
+                    height += margin;
+            }
+
+            Height = dragContainer.Height = height;
         }
 
         protected override void Update()


### PR DESCRIPTION
Fixes #9239.

This overlay uses resizing as visibility animation, so it's not possible to directly control it like `BeatmapDetails`. I used a hack with a nested container and manual height control of both `DragContainer` and playlist's container.