### PR TITLE
Fix `SkinnableTestScene` sizing logic potentially failing to work

### DIFF
--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Tests.Visual
                 {
                     c.RelativeSizeAxes = Axes.None;
                     c.AutoSizeAxes = Axes.None;
+                    c.Size = Vector2.Zero;
 
                     c.RelativeSizeAxes = !autoSize ? Axes.Both : Axes.None;
                     c.AutoSizeAxes = autoSize ? Axes.Both : Axes.None;


### PR DESCRIPTION
If the relative size axes of a container changes after it has loaded, then a "relative to absolute" factor would be applied to the current size of the container, and thus the content may not display correctly if it sets axes on BDL/LoadComplete rather than constructor (e.g. `DrawableSpinner`).

Fixed by flushing out the current container size before setting new size axes.