### PR TITLE
Fix `rank_history` serialisation order dependence

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -228,7 +228,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"rank_history")]
         private APIRankHistory rankHistory
         {
-            set => statistics.RankHistory = value;
+            set => Statistics.RankHistory = value;
         }
 
         [JsonProperty("badges")]


### PR DESCRIPTION
```csharp
[network] 2022-09-26 18:18:39 [verbose]: Processing response from https://dev.ppy.sh/api/v2/me/ failed with Newtonsoft.Json.JsonSerializationException: Error setting value to 'rankHistory' on 'osu.Game.Online.API.Requests.Responses.APIUser'.
[network] 2022-09-26 18:18:39 [verbose]: ---> System.NullReferenceException: Object reference not set to an instance of an object.
[network] 2022-09-26 18:18:39 [verbose]: at osu.Game.Online.API.Requests.Responses.APIUser.set_rankHistory(APIRankHistory
value) in /tmp/osu/osu.Game/Online/API/Requests/Responses/APIUser.cs:line 231
```

Order was changed inadvertently osu-web side. They will revert the change before production deployment for backwards compatibility.