### PR TITLE
Fix editor performance being sub-par on beatmap load

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
@@ -33,8 +32,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         [Resolved]
         private OsuColour colours { get; set; }
-
-        private static readonly int highest_divisor = BindableBeatDivisor.PREDEFINED_DIVISORS.Last();
 
         public TimelineTickDisplay()
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -4,10 +4,12 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
@@ -145,6 +147,20 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                     beat++;
                 }
+            }
+
+            if (Children.Count > 512)
+            {
+                // There should always be a sanely small number of ticks rendered.
+                // If this assertion triggers, either the zoom logic is broken or a beatmap is
+                // probably doing weird things...
+                //
+                // Let's hope the latter never happens.
+                // If it does, we can choose to either fix it or ignore it as an outlier.
+                string message = $"Timeline is rendering many ticks ({Children.Count})";
+
+                Logger.Log(message);
+                Debug.Fail(message);
             }
 
             int usedDrawables = drawableIndex;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -77,20 +77,19 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.Update();
 
-            if (timeline != null)
+            if (timeline == null || !(DrawWidth > 0)) return;
+
+            (float, float) newRange = (
+                (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopLeft).X - PointVisualisation.MAX_WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X,
+                (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopRight).X + PointVisualisation.MAX_WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X);
+
+            if (visibleRange != newRange)
             {
-                var newRange = (
-                    (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopLeft).X - PointVisualisation.MAX_WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X,
-                    (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopRight).X + PointVisualisation.MAX_WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X);
+                visibleRange = newRange;
 
-                if (visibleRange != newRange)
-                {
-                    visibleRange = newRange;
-
-                    // actual regeneration only needs to occur if we've passed one of the known next min/max tick boundaries.
-                    if (nextMinTick == null || nextMaxTick == null || (visibleRange.min < nextMinTick || visibleRange.max > nextMaxTick))
-                        tickCache.Invalidate();
-                }
+                // actual regeneration only needs to occur if we've passed one of the known next min/max tick boundaries.
+                if (nextMinTick == null || nextMaxTick == null || (visibleRange.min < nextMinTick || visibleRange.max > nextMaxTick))
+                    tickCache.Invalidate();
             }
 
             if (!tickCache.IsValid)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.Update();
 
-            if (timeline == null || !(DrawWidth > 0)) return;
+            if (timeline == null || DrawWidth <= 0) return;
 
             (float, float) newRange = (
                 (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopLeft).X - PointVisualisation.MAX_WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X,

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -56,7 +56,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         protected ZoomableScrollContainer()
             : base(Direction.Horizontal)
         {
-            base.Content.Add(zoomedContent = new Container { RelativeSizeAxes = Axes.Y });
+            base.Content.Add(zoomedContent = new Container
+            {
+                RelativeSizeAxes = Axes.Y,
+                // We must hide content until SetupZoom is called.
+                // If not, a child component that relies on its DrawWidth (via RelativeSizeAxes) may see a very incorrect value
+                // momentarily, as noticed in the TimelineTickDisplay, which would render thousands of ticks incorrectly.
+                Alpha = 0,
+            });
 
             AddLayout(zoomedContentWidthCache);
         }
@@ -94,6 +101,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             maxZoom = maximum;
             CurrentZoom = zoomTarget = initial;
             isZoomSetUp = true;
+
+            zoomedContent.Show();
         }
 
         /// <summary>
@@ -118,9 +127,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 CurrentZoom = zoomTarget = newZoom;
         }
 
-        protected override void Update()
+        protected override void UpdateAfterChildren()
         {
-            base.Update();
+            base.UpdateAfterChildren();
 
             if (!zoomedContentWidthCache.IsValid)
                 updateZoomedContentWidth();


### PR DESCRIPTION
Worse for longer beatmaps. Basically every timeline tick for the whole duration of the beatmap was being loaded at startup due to changes in the zoom container logic.

I've added multiple safeties to guard against this.

Closes #20462.