### PR TITLE
Flush toast tray on entering gameplay

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Overlays
 
             if (enabled)
                 // we want a slight delay before toggling notifications on to avoid the user becoming overwhelmed.
-                notificationsEnabler = Scheduler.AddDelayed(() => processingPosts = true, State.Value == Visibility.Visible ? 0 : 100);
+                notificationsEnabler = Scheduler.AddDelayed(() => processingPosts = true, State.Value == Visibility.Visible ? 0 : 250);
             else
                 processingPosts = false;
         }

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -115,7 +115,10 @@ namespace osu.Game.Overlays
                 // we want a slight delay before toggling notifications on to avoid the user becoming overwhelmed.
                 notificationsEnabler = Scheduler.AddDelayed(() => processingPosts = true, State.Value == Visibility.Visible ? 0 : 250);
             else
+            {
                 processingPosts = false;
+                toastTray.FlushAllToasts();
+            }
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Closes #20197.

I've also adjusted the delay after a no-notification section slightly because I felt it was too sudden with the recent reduction from 1 second.