### PR TITLE
Fix failing multiplayer tests

### DIFF
--- a/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
@@ -9,27 +9,25 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapRequest : APIRequest<APIBeatmap>
     {
-        private readonly IBeatmapInfo beatmapInfo;
-
-        private readonly string filename;
+        public readonly IBeatmapInfo BeatmapInfo;
+        public readonly string Filename;
 
         public GetBeatmapRequest(IBeatmapInfo beatmapInfo)
         {
-            this.beatmapInfo = beatmapInfo;
-
-            filename = (beatmapInfo as BeatmapInfo)?.Path ?? string.Empty;
+            BeatmapInfo = beatmapInfo;
+            Filename = (beatmapInfo as BeatmapInfo)?.Path ?? string.Empty;
         }
 
         protected override WebRequest CreateWebRequest()
         {
             var request = base.CreateWebRequest();
 
-            if (beatmapInfo.OnlineID > 0)
-                request.AddParameter(@"id", beatmapInfo.OnlineID.ToString());
-            if (!string.IsNullOrEmpty(beatmapInfo.MD5Hash))
-                request.AddParameter(@"checksum", beatmapInfo.MD5Hash);
-            if (!string.IsNullOrEmpty(filename))
-                request.AddParameter(@"filename", filename);
+            if (BeatmapInfo.OnlineID > 0)
+                request.AddParameter(@"id", BeatmapInfo.OnlineID.ToString());
+            if (!string.IsNullOrEmpty(BeatmapInfo.MD5Hash))
+                request.AddParameter(@"checksum", BeatmapInfo.MD5Hash);
+            if (!string.IsNullOrEmpty(Filename))
+                request.AddParameter(@"filename", Filename);
 
             return request;
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -54,6 +54,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         {
             private const float disabled_alpha = 0.2f;
 
+            public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
             public Action? SettingsApplied;
 
             public OsuTextBox NameField = null!;

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -135,25 +135,15 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                     });
                     return true;
 
+                case GetBeatmapRequest getBeatmapRequest:
+                {
+                    getBeatmapRequest.TriggerSuccess(createResponseBeatmaps(getBeatmapRequest.BeatmapInfo.OnlineID).Single());
+                    return true;
+                }
+
                 case GetBeatmapsRequest getBeatmapsRequest:
                 {
-                    var result = new List<APIBeatmap>();
-
-                    foreach (int id in getBeatmapsRequest.BeatmapIds)
-                    {
-                        var baseBeatmap = beatmapManager.QueryBeatmap(b => b.OnlineID == id);
-
-                        if (baseBeatmap == null)
-                        {
-                            baseBeatmap = new TestBeatmap(new RulesetInfo { OnlineID = 0 }).BeatmapInfo;
-                            baseBeatmap.OnlineID = id;
-                            baseBeatmap.BeatmapSet!.OnlineID = id;
-                        }
-
-                        result.Add(OsuTestScene.CreateAPIBeatmap(baseBeatmap));
-                    }
-
-                    getBeatmapsRequest.TriggerSuccess(new GetBeatmapsResponse { Beatmaps = result });
+                    getBeatmapsRequest.TriggerSuccess(new GetBeatmapsResponse { Beatmaps = createResponseBeatmaps(getBeatmapsRequest.BeatmapIds.ToArray()) });
                     return true;
                 }
 
@@ -173,6 +163,27 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                     getBeatmapSetRequest.TriggerSuccess(OsuTestScene.CreateAPIBeatmapSet(baseBeatmap));
                     return true;
                 }
+            }
+
+            List<APIBeatmap> createResponseBeatmaps(params int[] beatmapIds)
+            {
+                var result = new List<APIBeatmap>();
+
+                foreach (int id in beatmapIds)
+                {
+                    var baseBeatmap = beatmapManager.QueryBeatmap(b => b.OnlineID == id);
+
+                    if (baseBeatmap == null)
+                    {
+                        baseBeatmap = new TestBeatmap(new RulesetInfo { OnlineID = 0 }).BeatmapInfo;
+                        baseBeatmap.OnlineID = id;
+                        baseBeatmap.BeatmapSet!.OnlineID = id;
+                    }
+
+                    result.Add(OsuTestScene.CreateAPIBeatmap(baseBeatmap));
+                }
+
+                return result;
             }
 
             return false;


### PR DESCRIPTION
As seen by https://teamcity.ppy.sh/test/-372987141450758820?currentProjectId=Osu&expandTestHistoryChartSection=true, multiplayer tests have been failing a lot recently. This regressed in https://github.com/ppy/osu/pull/20419.

Only the first commit (override of `IsPresent`) is relevant to fixing the issue.

The second commit is an issue I noticed along the way, which is that the following appeared in my logs:
```
[network] 2022-09-27 11:32:59 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.InvalidOperationException: DummyAPIAccess cannot process this request.)
```

Can only reproduce by running `TestCorrectModsSelectedAfterNewItemAdded` by itself.