### PR TITLE
Removes unnecessary setting sources specifications

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Mods;
@@ -16,7 +15,6 @@ namespace osu.Game.Rulesets.Catch.Mods
     {
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
 
-        [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
@@ -24,7 +22,6 @@ namespace osu.Game.Rulesets.Catch.Mods
             Precision = 0.1f
         };
 
-        [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
         public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
         public override float DefaultFlashlightSize => 350;

--- a/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
@@ -6,8 +6,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mods;
 using osu.Framework.Utils;
-using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.UI;
 
@@ -17,11 +15,6 @@ namespace osu.Game.Rulesets.Catch.Mods
     {
         public override LocalisableString Description => "Where's the catcher?";
 
-        [SettingSource(
-            "Hidden at combo",
-            "The combo count at which the catcher becomes completely hidden",
-            SettingControlType = typeof(SettingsSlider<int, HiddenComboSlider>)
-        )]
         public override BindableInt HiddenComboCount { get; } = new BindableInt(10)
         {
             MinValue = 0,

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mods;
 using osuTK;
@@ -17,7 +16,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => new[] { typeof(ModHidden) };
 
-        [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
@@ -25,7 +23,6 @@ namespace osu.Game.Rulesets.Mania.Mods
             Precision = 0.1f
         };
 
-        [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
         public override BindableBool ComboBasedSize { get; } = new BindableBool();
 
         public override float DefaultFlashlightSize => 50;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDeflate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDeflate.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -18,7 +17,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override LocalisableString Description => "Hit them at the right size!";
 
-        [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
         public override BindableNumber<float> StartScale { get; } = new BindableFloat(2)
         {
             MinValue = 1f,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             Precision = default_follow_delay,
         };
 
-        [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
@@ -40,7 +39,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             Precision = 0.1f
         };
 
-        [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
         public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
         public override float DefaultFlashlightSize => 180;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -18,7 +17,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override LocalisableString Description => "Hit them at the right size!";
 
-        [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
         public override BindableNumber<float> StartScale { get; } = new BindableFloat(0.5f)
         {
             MinValue = 0f,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
@@ -7,8 +7,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.UI;
@@ -22,11 +20,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private PeriodTracker spinnerPeriods = null!;
 
-        [SettingSource(
-            "Hidden at combo",
-            "The combo count at which the cursor becomes completely hidden",
-            SettingControlType = typeof(SettingsSlider<int, HiddenComboSlider>)
-        )]
         public override BindableInt HiddenComboCount { get; } = new BindableInt(10)
         {
             MinValue = 0,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -20,6 +21,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => 1;
 
+        [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
         public abstract BindableNumber<float> StartScale { get; }
 
         protected virtual float EndScale => 1;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
@@ -17,7 +16,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
 
-        [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public override BindableFloat SizeMultiplier { get; } = new BindableFloat(1)
         {
             MinValue = 0.5f,
@@ -25,7 +23,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
             Precision = 0.1f
         };
 
-        [SettingSource("Change size based on combo", "Decrease the flashlight size as combo increases.")]
         public override BindableBool ComboBasedSize { get; } = new BindableBool(true);
 
         public override float DefaultFlashlightSize => 250;

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -6,7 +6,9 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
@@ -34,6 +36,11 @@ namespace osu.Game.Rulesets.Mods
 
         protected float ComboBasedAlpha;
 
+        [SettingSource(
+            "Hidden at combo",
+            "The combo count at which the cursor becomes completely hidden",
+            SettingControlType = typeof(SettingsSlider<int, HiddenComboSlider>)
+        )]
         public abstract BindableInt HiddenComboCount { get; }
 
         public ScoreRank AdjustRank(ScoreRank rank, double accuracy) => rank;

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -17,7 +16,6 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Sloooow doooown...";
         public override IconUsage? Icon => FontAwesome.Solid.ChevronCircleDown;
 
-        [SettingSource("Initial rate", "The starting speed of the track")]
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {
             MinValue = 0.51,
@@ -25,7 +23,6 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.01,
         };
 
-        [SettingSource("Final rate", "The speed increase to ramp towards")]
         public override BindableNumber<double> FinalRate { get; } = new BindableDouble(0.75)
         {
             MinValue = 0.5,
@@ -33,7 +30,6 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.01,
         };
 
-        [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
         public override BindableBool AdjustPitch { get; } = new BindableBool(true);
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModWindUp)).ToArray();

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -17,7 +16,6 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Can you keep up?";
         public override IconUsage? Icon => FontAwesome.Solid.ChevronCircleUp;
 
-        [SettingSource("Initial rate", "The starting speed of the track")]
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble(1)
         {
             MinValue = 0.5,
@@ -25,7 +23,6 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.01,
         };
 
-        [SettingSource("Final rate", "The speed increase to ramp towards")]
         public override BindableNumber<double> FinalRate { get; } = new BindableDouble(1.5)
         {
             MinValue = 0.51,
@@ -33,7 +30,6 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.01,
         };
 
-        [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
         public override BindableBool AdjustPitch { get; } = new BindableBool(true);
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModWindDown)).ToArray();


### PR DESCRIPTION
This was something noticed on https://github.com/ppy/osu/pull/20460#discussion_r980750637, there were multiple boilerplate code for `SettingSource` even though in the places were this boilerplate is applied they all inherit from a common abstract `Bindable<T>`, this change removes all the boilerplate on the mod classes.