### PR TITLE
Clamp `LifetimeStart` of `HitObject`s to their judgement windows

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         public void UpdateResult() => base.UpdateResult(true);
 
-        protected override double MaximumJudgementOffset => base.MaximumJudgementOffset * release_window_lenience;
+        public override double MaximumJudgementOffset => base.MaximumJudgementOffset * release_window_lenience;
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Origin = Anchor.Centre;
         }
 
-        protected override double MaximumJudgementOffset => DrawableSpinner.HitObject.Duration;
+        public override double MaximumJudgementOffset => DrawableSpinner.HitObject.Duration;
 
         /// <summary>
         /// Apply a judgement result.

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using NUnit.Framework;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -128,6 +129,33 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             AssertJudgementCount(2);
             AssertResult<Hit>(0, HitResult.Miss);
             AssertResult<StrongNestedHitObject>(0, HitResult.IgnoreMiss);
+        }
+
+        [Test]
+        public void TestHighVelocityHit()
+        {
+            const double hit_time = 1000;
+
+            var beatmap = CreateBeatmap(new Hit
+            {
+                Type = HitType.Centre,
+                StartTime = hit_time,
+            });
+
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 6 });
+            beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 10 });
+
+            var hitWindows = new HitWindows();
+            hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
+
+            PerformTest(new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(0),
+                new TaikoReplayFrame(hit_time - hitWindows.WindowFor(HitResult.Great), TaikoAction.LeftCentre),
+            }, beatmap);
+
+            AssertJudgementCount(1);
+            AssertResult<Hit>(0, HitResult.Ok);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Filled = HitObject.FirstTick
             });
 
-        protected override double MaximumJudgementOffset => HitObject.HitWindow;
+        public override double MaximumJudgementOffset => HitObject.HitWindow;
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -651,7 +651,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <remarks>
         /// This does not affect the time offset provided to invocations of <see cref="CheckForResult"/>.
         /// </remarks>
-        protected virtual double MaximumJudgementOffset => HitObject.HitWindows?.WindowFor(HitResult.Miss) ?? 0;
+        public virtual double MaximumJudgementOffset => HitObject.HitWindows?.WindowFor(HitResult.Miss) ?? 0;
 
         /// <summary>
         /// Applies the <see cref="Result"/> of this <see cref="DrawableHitObject"/>, notifying responders such as

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using osu.Framework.Allocation;
@@ -214,7 +215,10 @@ namespace osu.Game.Rulesets.UI.Scrolling
                     break;
             }
 
-            return scrollingInfo.Algorithm.GetDisplayStartTime(hitObject.HitObject.StartTime, originAdjustment, timeRange.Value, scrollLength);
+            double computedStartTime = scrollingInfo.Algorithm.GetDisplayStartTime(hitObject.HitObject.StartTime, originAdjustment, timeRange.Value, scrollLength);
+
+            // always load the hitobject before its first judgement offset
+            return Math.Min(hitObject.HitObject.StartTime - hitObject.MaximumJudgementOffset, computedStartTime);
         }
 
         private void updateLayoutRecursive(DrawableHitObject hitObject)


### PR DESCRIPTION
Before, if `computeOriginAdjustedLifetimeStart` deemed the `HitObject` to be on the screen for a shorter period of time than the `HitObject`'s judgement windows, its `LifetimeStart` would be set in a way that made the object unhittable if hit too early.
This happened because due to `LifetimeStart` being too big,  `MakeAlive` was called too late on the child `HitObject`, and as thus it didn't accept key inputs.
This is observable in osu!taiko gimmick ("Aspire"-like) maps that use very high note velocities to make notes near invisble.